### PR TITLE
fix(issue): [Bug]: `reconcileMergedMilestonesFromJournal` runs unguarded DB writes during auto-start bootstrap while its sibling reconciler is wrapped and warns

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -205,35 +205,43 @@ export function reconcileProjectMilestonesFromDisk(basePath: string): number {
 export function reconcileMergedMilestonesFromJournal(basePath: string): number {
   if (!isDbAvailable()) return 0;
 
-  const mergedAtByMilestone = new Map<string, string>();
-  for (const entry of queryJournal(basePath, { eventType: "worktree-merged" })) {
-    const data = entry.data ?? {};
-    const milestoneId = typeof data.milestoneId === "string" ? data.milestoneId : null;
-    if (!milestoneId) continue;
-    if (data.conflict === true) continue;
+  try {
+    const mergedAtByMilestone = new Map<string, string>();
+    for (const entry of queryJournal(basePath, { eventType: "worktree-merged" })) {
+      const data = entry.data ?? {};
+      const milestoneId = typeof data.milestoneId === "string" ? data.milestoneId : null;
+      if (!milestoneId) continue;
+      if (data.conflict === true) continue;
 
-    const endedAt = typeof data.endedAt === "string" ? data.endedAt : entry.ts;
-    const previous = mergedAtByMilestone.get(milestoneId);
-    if (!previous || endedAt > previous) mergedAtByMilestone.set(milestoneId, endedAt);
-  }
-
-  let closed = 0;
-  for (const [milestoneId, completedAt] of mergedAtByMilestone) {
-    const existing = getMilestone(milestoneId);
-    if (!existing) {
-      insertMilestone({ id: milestoneId, title: milestoneId, status: "complete" });
-      updateMilestoneStatus(milestoneId, "complete", completedAt);
-      closed++;
-      continue;
+      const endedAt = typeof data.endedAt === "string" ? data.endedAt : entry.ts;
+      const previous = mergedAtByMilestone.get(milestoneId);
+      if (!previous || endedAt > previous) mergedAtByMilestone.set(milestoneId, endedAt);
     }
-    if (!isClosedStatus(existing.status)) {
-      updateMilestoneStatus(milestoneId, "complete", completedAt);
-      closed++;
-    }
-  }
 
-  if (closed > 0) invalidateAllCaches();
-  return closed;
+    let closed = 0;
+    for (const [milestoneId, completedAt] of mergedAtByMilestone) {
+      const existing = getMilestone(milestoneId);
+      if (!existing) {
+        insertMilestone({ id: milestoneId, title: milestoneId, status: "complete" });
+        updateMilestoneStatus(milestoneId, "complete", completedAt);
+        closed++;
+        continue;
+      }
+      if (!isClosedStatus(existing.status)) {
+        updateMilestoneStatus(milestoneId, "complete", completedAt);
+        closed++;
+      }
+    }
+
+    if (closed > 0) invalidateAllCaches();
+    return closed;
+  } catch (err) {
+    logWarning(
+      "bootstrap",
+      `merged-milestone journal reconciliation failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return 0;
+  }
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/auto-start-project-milestone-reconcile.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-project-milestone-reconcile.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { closeDatabase, getAllMilestones, getMilestone, insertMilestone, isDbAvailable, openDatabase } from "../gsd-db.ts";
+import { _getAdapter, closeDatabase, getAllMilestones, getMilestone, insertMilestone, isDbAvailable, openDatabase } from "../gsd-db.ts";
 import { reconcileMergedMilestonesFromJournal, reconcileProjectMilestonesFromDisk } from "../auto-start.ts";
 import { emitWorktreeMerged } from "../worktree-telemetry.ts";
 
@@ -64,6 +64,34 @@ test("#5389: bootstrap reconciles PROJECT.md milestones that are missing from DB
     assert.equal(byId.get("M001")?.status, "complete");
     assert.equal(byId.get("M002")?.status, "queued");
     assert.equal(byId.get("M003")?.status, "queued");
+  } finally {
+    if (isDbAvailable()) closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("#1236: bootstrap merged-milestone reconciliation degrades to a warning instead of aborting when the DB is degraded", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-merged-reconcile-degraded-"));
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Merged Milestone", status: "active" });
+
+    emitWorktreeMerged(base, "M001", { reason: "milestone-complete", conflict: false });
+
+    // Simulate a degraded DB: the connection stays "available" (isDbAvailable()
+    // remains true because the handle is non-null), but the milestones table is
+    // gone, so the reconciler's DB access throws partway through bootstrap.
+    _getAdapter()!.exec("DROP TABLE milestones");
+    assert.equal(isDbAvailable(), true);
+
+    // Regression (#1236): this reconciler was previously unguarded, so a
+    // degraded-DB failure threw and aborted the rest of `/gsd auto` bootstrap.
+    // It must now catch, warn, and return 0, matching its sibling
+    // reconcileProjectMilestonesFromDisk. Reaching the assertion proves it did
+    // not throw.
+    const closed = reconcileMergedMilestonesFromJournal(base);
+    assert.equal(closed, 0);
   } finally {
     if (isDbAvailable()) closeDatabase();
     rmSync(base, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Wrapped `reconcileMergedMilestonesFromJournal`'s body in try/catch + `logWarning` to match its sibling so a degraded-DB write failure no longer aborts `/gsd auto` bootstrap; verified via the existing reconciler test suite (2 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1236
- [#1236 [Bug]: `reconcileMergedMilestonesFromJournal` runs unguarded DB writes during auto-start bootstrap while its sibling reconciler is wrapped and warns](https://github.com/open-gsd/gsd-pi/issues/1236)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1236-bug-reconcilemergedmilestonesfromjournal-1783228669`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive error handling only; success-path behavior is unchanged and failures degrade to a warning plus no reconciled closes.
> 
> **Overview**
> **`reconcileMergedMilestonesFromJournal`** now wraps its journal scan and DB writes in **`try/catch`**, logging a **`bootstrap`** warning and returning **`0`** on failure—matching **`reconcileProjectMilestonesFromDisk`**.
> 
> That way a degraded DB or journal error during **`/gsd auto`** bootstrap no longer throws and aborts the rest of startup; reconciliation is skipped defensively instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2954366d9e5e0dde0c27f7c8d579c0e0b125558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->