### PR TITLE
fix(issue): [Bug]: On WSL with a symlinked `.gsd`, artifact verification builds a broken `../../…/home/…` path and reports a false "artifact not found on disk"

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -19,6 +19,7 @@ import {
   resolveSlicePath,
   resolveTasksDir,
   dirIsMetaOnlyLegacyMilestone,
+  normalizeRealPath,
 } from "./paths.js";
 import { milestoneIdToPhaseNum } from "./layout-policy.js";
 import { parseUnitId } from "./unit-id.js";
@@ -354,7 +355,7 @@ export function resolveSliceResearchLocation(
   if (canonicalPath && existsSync(canonicalPath)) {
     return {
       absolutePath: canonicalPath,
-      relativePath: relative(basePath, canonicalPath),
+      relativePath: relative(normalizeRealPath(basePath), canonicalPath),
     };
   }
 

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -30,6 +30,7 @@ import {
   relMilestoneFile,
   relSliceFile,
   relTaskFile,
+  normalizeRealPath,
 } from "./paths.js";
 import { invalidateAllCaches } from "./cache.js";
 import { rebuildState } from "./doctor.js";
@@ -960,7 +961,7 @@ function describeArtifactVerificationFailure(
   if (!artifactPath) {
     return `Artifact verification failed: ${unitType} "${unitId}" has no resolvable artifact path.`;
   }
-  const relPath = relative(basePath, artifactPath);
+  const relPath = relative(normalizeRealPath(basePath), artifactPath);
   if (!existsSync(artifactPath)) {
     const completionToolHint = unitType === "execute-task" && !hasTaskCompletionToolCall(agentEndMessages)
       ? " No completion tool call detected (`gsd_task_complete`/alias)."

--- a/src/resources/extensions/gsd/tests/auto-post-unit-artifact-diagnostic.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-artifact-diagnostic.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -8,6 +8,7 @@ import {
   maybeWriteParallelResearchCostSpikeBlocker,
 } from "../auto-post-unit.ts";
 import { resolveExpectedArtifactPath } from "../auto-recovery.ts";
+import { _clearGsdRootCache, clearPathCache } from "../paths.ts";
 
 test("missing execute-task artifact includes completion contract and completion-tool hint", () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-artifact-diag-"));
@@ -54,5 +55,51 @@ test("parallel research cost spike writes durable PARALLEL-BLOCKER", () => {
     assert.match(readFileSync(expected!, "utf-8"), /cost spike detected \(3\.73 vs avg 1\.02\)/);
   } finally {
     rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// ── #1238: symlinked project root must not produce a ../ path walk ────────────
+//
+// On WSL (and any layout where the project root is reached through a symlink),
+// artifact resolution canonicalizes through gsdRoot (realpathSync), so the
+// resolved artifact path lives under the REAL root while `basePath` is still the
+// symlink. Before the fix, relative(symlinkBase, realArtifactPath) walked up out
+// of the symlink (../../…/home/…) and the diagnostic reported that broken path as
+// "not found on disk". Normalizing basePath to its real path first keeps the
+// displayed path anchored at the real .gsd root.
+
+test("symlinked project root yields a clean .gsd-relative artifact path, not a ../ walk (#1238)", () => {
+  const realRoot = realpathSync(mkdtempSync(join(tmpdir(), "gsd-symlink-real-")));
+  const linkParent = realpathSync(mkdtempSync(join(tmpdir(), "gsd-symlink-link-")));
+  const linkRoot = join(linkParent, "project");
+  try {
+    // Content-bearing legacy milestone dir so plan-milestone resolves the
+    // canonical (realpath) ROADMAP path under realRoot/.gsd/milestones/M001/.
+    const milestoneDir = join(realRoot, ".gsd", "milestones", "M001");
+    mkdirSync(milestoneDir, { recursive: true });
+    writeFileSync(join(milestoneDir, "M001-CONTEXT.md"), "# context\n");
+    // The ROADMAP intentionally does not exist — this hits the "not found on
+    // disk" branch, the exact symptom in #1238.
+    symlinkSync(realRoot, linkRoot);
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    const msg = _describeArtifactVerificationFailureForTest("plan-milestone", "M001", linkRoot);
+
+    assert.match(msg, /was not found on disk after unit execution/);
+    // The displayed path must be anchored at the real .gsd root, not a broken
+    // parent-walk out of the symlinked base.
+    assert.doesNotMatch(msg, /\.\.[/\\]/, "must not contain a ../ walk out of the symlinked base");
+    assert.match(
+      msg,
+      /\.gsd[/\\]milestones[/\\]M001[/\\]M001-ROADMAP\.md/,
+      "must show the clean .gsd-relative ROADMAP path",
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(linkParent, { recursive: true, force: true });
+    rmSync(realRoot, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- Canonicalized `basePath` via `normalizeRealPath` before computing the relative artifact path in `auto-post-unit.ts` and `auto-artifact-paths.ts`, fixing the false symlinked-`.gsd` "not found" message; verified with the two related node:test suites (22 tests passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1238
- [#1238 [Bug]: On WSL with a symlinked `.gsd`, artifact verification builds a broken `../../…/home/…` path and reports a false "artifact not found on disk"](https://github.com/open-gsd/gsd-pi/issues/1238)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1238-bug-on-wsl-with-a-symlinked-gsd-artifact-1783229029`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow path-display fix in GSD auto-mode verification; no changes to auth, persistence, or artifact resolution logic beyond relative-path computation.
> 
> **Overview**
> Fixes false **artifact not found** failures and misleading paths when `.gsd` is symlinked (e.g. WSL), where `path.relative(basePath, …)` walked through `../` chains like `../../…/home/…` even though the artifact existed.
> 
> **`normalizeRealPath`** is applied to `basePath` before computing relative paths in post-unit artifact verification diagnostics (`auto-post-unit.ts`) and slice research location resolution (`auto-artifact-paths.ts`). Absolute resolution and `existsSync` behavior are unchanged; only the relative path used in messages and prompts is aligned with the real filesystem root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2337341c8cf925db851ed193ab762a5d1a2e9279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->