### PR TITLE
fix(issue): [Bug]: `resolveGsdPathContract` opens the workflow DB through an unresolved `.gsd` symlink, causing a wrong SQLite journal mode and `SQLITE_READONLY_DBMOVED` on WSL

### DIFF
--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -379,21 +379,26 @@ export function resolveGsdPathContract(
   const resolvedWorkRoot = resolve(workRoot || process.cwd());
   const isWorktree = isGsdWorktreePath(resolvedWorkRoot);
   if (isWorktree && !originalProjectRoot?.trim()) {
-    const projectGsd = resolveExternalStateProjectGsdFromWorktreePath(resolvedWorkRoot);
-    if (projectGsd) {
+    const rawProjectGsd = resolveExternalStateProjectGsdFromWorktreePath(resolvedWorkRoot);
+    if (rawProjectGsd) {
+      // Canonicalize the `.gsd` root so the DB path matches what every other
+      // accessor (gsdRoot/gsdProjectionRoot) returns — otherwise an unresolved
+      // symlink (e.g. `/mnt/c/.../.gsd` → native ext4 on WSL) selects the wrong
+      // journal mode and yields a fragile, move-prone handle. See issue #1239.
+      const projectGsd = normalizeRealPath(rawProjectGsd);
       return {
         projectRoot: dirname(dirname(projectGsd)),
         workRoot: resolvedWorkRoot,
         projectGsd,
-        worktreeGsd: join(resolvedWorkRoot, ".gsd"),
+        worktreeGsd: normalizeRealPath(join(resolvedWorkRoot, ".gsd")),
         projectDb: join(projectGsd, "gsd.db"),
         isWorktree,
       };
     }
   }
   const projectRoot = resolve(resolveWorktreeProjectRoot(resolvedWorkRoot, originalProjectRoot));
-  const projectGsd = join(projectRoot, ".gsd");
-  const worktreeGsd = isWorktree ? join(resolvedWorkRoot, ".gsd") : null;
+  const projectGsd = normalizeRealPath(join(projectRoot, ".gsd"));
+  const worktreeGsd = isWorktree ? normalizeRealPath(join(resolvedWorkRoot, ".gsd")) : null;
 
   return {
     projectRoot,

--- a/src/resources/extensions/gsd/tests/integration/paths.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, rmSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
@@ -9,6 +9,7 @@ import {
   gsdProjectionRoot,
   gsdRoot,
   milestonesDir,
+  resolveGsdPathContract,
   resolveSliceFile,
   resolveTaskFile,
   _clearGsdRootCache,
@@ -187,5 +188,69 @@ describe('paths', () => {
         "flat-phase TID-SUMMARY.md at phase root is found even when slices/S01/ exists",
       );
     } finally { cleanup(root); }
+  });
+
+  test('Case 10: resolveGsdPathContract canonicalizes a symlinked .gsd root (regression #1239)', () => {
+    // WSL / external-state shape: `<projectRoot>/.gsd` is a symlink pointing at a
+    // real directory on another volume. Before #1239 the DB path was built from
+    // the unresolved symlink, so the workflow SQLite handle opened through a
+    // move-prone path and could pick the wrong journal mode / SQLITE_READONLY_DBMOVED.
+    const root = tmp();
+    try {
+      const realState = join(root, "real-state"); // canonical symlink target
+      mkdirSync(join(realState, "milestones"), { recursive: true });
+      const projectRoot = join(root, "project");
+      mkdirSync(projectRoot, { recursive: true });
+      symlinkSync(realState, join(projectRoot, ".gsd"), "dir");
+
+      _clearGsdRootCache();
+      const contract = resolveGsdPathContract(projectRoot);
+
+      const canonicalGsd = realpathSync.native(join(projectRoot, ".gsd"));
+      assert.deepStrictEqual(contract.projectGsd, canonicalGsd,
+        "projectGsd is the realpath'd target, not the unresolved .gsd symlink");
+      assert.deepStrictEqual(contract.projectDb, join(canonicalGsd, "gsd.db"),
+        "projectDb is built from the canonical .gsd root");
+      assert.deepStrictEqual(contract.projectGsd, gsdProjectionRoot(projectRoot),
+        "projectGsd agrees with gsdProjectionRoot on the canonical root");
+      assert.notStrictEqual(contract.projectDb, join(projectRoot, ".gsd", "gsd.db"),
+        "regression #1239: DB must not open through the unresolved .gsd symlink");
+    } finally { cleanup(root); }
+  });
+
+  test('Case 11: resolveGsdPathContract canonicalizes the external-state worktree DB path through a symlinked store (regression #1239)', () => {
+    const root = tmp();
+    const originalStateDir = process.env.GSD_STATE_DIR;
+    try {
+      const stateDir = join(root, "state");
+      process.env.GSD_STATE_DIR = stateDir;
+
+      // The external-state project store `<state>/projects/<hash>` is itself a
+      // symlink to a real directory on another volume (the WSL `.gsd` shape).
+      const realProjectGsd = join(root, "real-projects", "abc123");
+      mkdirSync(realProjectGsd, { recursive: true });
+      mkdirSync(join(stateDir, "projects"), { recursive: true });
+      const storeSymlink = join(stateDir, "projects", "abc123");
+      symlinkSync(realProjectGsd, storeSymlink, "dir");
+
+      const wtRoot = join(storeSymlink, "worktrees", "M002");
+      mkdirSync(join(wtRoot, ".gsd"), { recursive: true });
+
+      _clearGsdRootCache();
+      const contract = resolveGsdPathContract(wtRoot);
+
+      const canonicalStore = realpathSync.native(storeSymlink);
+      assert.ok(contract.isWorktree, "recognized as an external-state worktree layout");
+      assert.deepStrictEqual(contract.projectGsd, canonicalStore,
+        "projectGsd is the realpath'd project store, not the unresolved symlink");
+      assert.deepStrictEqual(contract.projectDb, join(canonicalStore, "gsd.db"),
+        "projectDb is built from the canonical project store");
+      assert.notStrictEqual(contract.projectDb, join(storeSymlink, "gsd.db"),
+        "regression #1239: DB must not open through the unresolved external-state symlink");
+    } finally {
+      if (originalStateDir === undefined) delete process.env.GSD_STATE_DIR;
+      else process.env.GSD_STATE_DIR = originalStateDir;
+      cleanup(root);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Canonicalized the `.gsd` roots via `normalizeRealPath` in both `resolveGsdPathContract` return blocks so the workflow DB opens through the realpath'd path; verified with a symlink-based tsx test showing `projectGsd`/`projectDb` now match `realpathSync.native`.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1239
- [#1239 [Bug]: `resolveGsdPathContract` opens the workflow DB through an unresolved `.gsd` symlink, causing a wrong SQLite journal mode and `SQLITE_READONLY_DBMOVED` on WSL](https://github.com/open-gsd/gsd-pi/issues/1239)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1239-bug-resolvegsdpathcontract-opens-the-wor-1783229389`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow path-resolution change aligned with existing `normalizeRealPath` usage elsewhere; low blast radius beyond DB open paths on symlinked `.gsd` layouts.
> 
> **Overview**
> **`resolveGsdPathContract`** now runs **`projectGsd`** and **`worktreeGsd`** through **`normalizeRealPath`** (native realpath) in both return paths—worktree discovery and the default project-root branch—so **`projectDb`** is built from the same canonical `.gsd` root as **`gsdRoot`** / **`gsdProjectionRoot`**.
> 
> This fixes opening the workflow SQLite DB through an unresolved symlink (e.g. WSL `/mnt/c/.../.gsd` pointing at native ext4), which could pick the wrong journal mode and surface **`SQLITE_READONLY_DBMOVED`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9548e06bebca29704648de53f475483b8df51c40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->