### PR TITLE
fix(issue): Hook and singleton model fields silently ignore fallbacks[] — a transient provider trip hard-fails (and can pause) an auto-mode run

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1428,11 +1428,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const sTitle = state.activeSlice.title;
       if (resolveSliceFile(basePath, mid, sid, "REACTIVE-BLOCKER")) return null;
       const maxParallel = reactiveConfig?.max_parallel ?? 2;
-      // `subagent_model` accepts the phase-bucket object form (#1229); use its
-      // primary here (the reactive subagent model is embedded in the dispatch
-      // prompt rather than set as the session model).
-      const subagentModel = normalizeModelFieldConfig(reactiveConfig?.subagent_model)?.primary
-        ?? resolveModelWithFallbacksForUnit("subagent")?.primary;
+      // `subagent_model` accepts the phase-bucket object form (#1229); honor the
+      // full primary→fallbacks chain in the dispatch prompt (the reactive
+      // subagent model is embedded there rather than set as the session model).
+      const subagentModelConfig = normalizeModelFieldConfig(reactiveConfig?.subagent_model)
+        ?? resolveModelWithFallbacksForUnit("subagent");
+      const subagentModel = subagentModelConfig?.primary;
       const subagentThinking = resolveThinkingLevelForUnit("subagent");
       // Default-on safety threshold: only activate reactive dispatch when at
       // least N tasks are ready. Users who explicitly enabled reactive_execution
@@ -1522,7 +1523,13 @@ export const DISPATCH_RULES: DispatchRule[] = [
             selected,
             basePath,
             subagentModel,
-            { sessionContextWindow, modelRegistry, sessionProvider, subagentThinking },
+            {
+              sessionContextWindow,
+              modelRegistry,
+              sessionProvider,
+              subagentThinking,
+              subagentModelFallbacks: subagentModelConfig?.fallbacks,
+            },
           ),
         };
       } catch (err) {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -81,7 +81,7 @@ import {
   checkNeedsReassessment,
   checkNeedsRunUat,
 } from "./auto-prompts.js";
-import { resolveModelWithFallbacksForUnit, resolveThinkingLevelForUnit } from "./preferences-models.js";
+import { normalizeModelFieldConfig, resolveModelWithFallbacksForUnit, resolveThinkingLevelForUnit } from "./preferences-models.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { selectReactiveDispatchBatch } from "./uok/execution-graph.js";
 import { getMilestonePipelineVariant } from "./milestone-scope-classifier.js";
@@ -1428,7 +1428,11 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const sTitle = state.activeSlice.title;
       if (resolveSliceFile(basePath, mid, sid, "REACTIVE-BLOCKER")) return null;
       const maxParallel = reactiveConfig?.max_parallel ?? 2;
-      const subagentModel = reactiveConfig?.subagent_model ?? resolveModelWithFallbacksForUnit("subagent")?.primary;
+      // `subagent_model` accepts the phase-bucket object form (#1229); use its
+      // primary here (the reactive subagent model is embedded in the dispatch
+      // prompt rather than set as the session model).
+      const subagentModel = normalizeModelFieldConfig(reactiveConfig?.subagent_model)?.primary
+        ?? resolveModelWithFallbacksForUnit("subagent")?.primary;
       const subagentThinking = resolveThinkingLevelForUnit("subagent");
       // Default-on safety threshold: only activate reactive dispatch when at
       // least N tasks are ready. Users who explicitly enabled reactive_execution

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -298,8 +298,12 @@ export async function applySupervisorModelIfConfigured(
     if (isModelUnavailable(basePath, match.provider, match.id)) continue;
     try {
       if (await pi.setModel(match, { persist: false })) return;
-    } catch {
+    } catch (err) {
       // Non-fatal — try the next fallback.
+      logWarning(
+        "dispatch",
+        `supervisor model set failed for ${candidate}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 }

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -273,7 +273,7 @@ function buildModelPolicyBlockReasons(
   }];
 }
 
-function isModelUnavailable(
+export function isModelUnavailable(
   basePath: string,
   provider: string | undefined,
   id: string | undefined,

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -282,6 +282,28 @@ export function isModelUnavailable(
     isModelTemporarilyUnavailable(basePath, provider, id);
 }
 
+/** Apply `auto_supervisor.model`, walking configured fallbacks on unavailability (#1229). */
+export async function applySupervisorModelIfConfigured(
+  ctx: ExtensionContext,
+  pi: ExtensionAPI,
+  basePath: string,
+): Promise<void> {
+  const modelConfig = resolveModelWithFallbacksForUnit("supervisor", basePath);
+  if (!modelConfig) return;
+
+  const availableModels = ctx.modelRegistry.getAvailable();
+  for (const candidate of [modelConfig.primary, ...modelConfig.fallbacks]) {
+    const match = resolveModelId(candidate, availableModels, ctx.model?.provider);
+    if (!match) continue;
+    if (isModelUnavailable(basePath, match.provider, match.id)) continue;
+    try {
+      if (await pi.setModel(match, { persist: false })) return;
+    } catch {
+      // Non-fatal — try the next fallback.
+    }
+  }
+}
+
 function restoreToolBaseline(pi: ExtensionAPI): void {
   const key = pi as unknown as object;
   const baseline = TOOL_BASELINE.get(key);

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -297,7 +297,10 @@ export async function applySupervisorModelIfConfigured(
     if (!match) continue;
     if (isModelUnavailable(basePath, match.provider, match.id)) continue;
     try {
-      if (await pi.setModel(match, { persist: false })) return;
+      if (await pi.setModel(match, { persist: false })) {
+        applyThinkingLevelForModel(pi, pi.getThinkingLevel(), match, ctx);
+        return;
+      }
     } catch (err) {
       // Non-fatal — try the next fallback.
       logWarning(

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -3909,9 +3909,15 @@ export async function buildReassessRoadmapPrompt(
  * that instructs the coordinator how to dispatch a `subagent` call. Either or
  * both may be absent (ADR-026 / #508).
  */
-function subagentCallSuffix(model?: string, thinking?: string): string {
+function subagentCallSuffix(model?: string, thinking?: string, fallbacks?: string[]): string {
   const parts: string[] = [];
-  if (model) parts.push(`model: "${model}"`);
+  if (model) {
+    let modelHint = `model: "${model}"`;
+    if (fallbacks && fallbacks.length > 0) {
+      modelHint += ` (fallbacks, in order: ${fallbacks.map((f) => `"${f}"`).join(", ")})`;
+    }
+    parts.push(modelHint);
+  }
   if (thinking) parts.push(`thinking: "${thinking}"`);
   return parts.length > 0 ? ` with ${parts.join(" and ")}` : "";
 }
@@ -3922,7 +3928,13 @@ export async function buildReactiveExecutePrompt(
   subagentModel?: string,
   // Reasoning effort travels inside opts here (not as a positional param) so
   // existing positional `opts` callers don't shift (#508).
-  opts?: { sessionContextWindow?: number; modelRegistry?: MinimalModelRegistry; sessionProvider?: string; subagentThinking?: string },
+  opts?: {
+    sessionContextWindow?: number;
+    modelRegistry?: MinimalModelRegistry;
+    sessionProvider?: string;
+    subagentThinking?: string;
+    subagentModelFallbacks?: string[];
+  },
 ): Promise<string> {
   const { loadSliceTaskIO, deriveTaskGraph, graphMetrics } = await import("./reactive-graph.js");
 
@@ -4019,7 +4031,11 @@ export async function buildReactiveExecutePrompt(
       `When done, say: "Task ${tid} complete."`,
     ].join("\n");
 
-    const modelSuffix = subagentCallSuffix(subagentModel, opts?.subagentThinking);
+    const modelSuffix = subagentCallSuffix(
+      subagentModel,
+      opts?.subagentThinking,
+      opts?.subagentModelFallbacks,
+    );
     subagentSections.push([
       `### ${tid}: ${tTitle}`,
       "",

--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -22,6 +22,7 @@ import { existsSync } from "node:fs";
 import { bumpAndResolveSynthetic } from "./auto/resolve.js";
 import { finalizeProjectResearchTimeout } from "./project-research-policy.js";
 import { applySupervisorModelIfConfigured } from "./auto-model-selection.js";
+import { getInFlightToolCount } from "./auto-tool-tracking.js";
 
 export interface RecoveryContext {
   basePath: string;
@@ -123,14 +124,17 @@ export async function recoverTimedOutUnit(
             "If full completion is impossible, write the partial artifact/state needed for recovery and make the blocker explicit.",
           ];
 
-      await applySupervisorModelIfConfigured(ctx, pi, basePath);
+      const recoveryTrigger = getInFlightToolCount() === 0;
+      if (recoveryTrigger) {
+        await applySupervisorModelIfConfigured(ctx, pi, basePath);
+      }
       pi.sendMessage(
         {
           customType: "gsd-auto-timeout-recovery",
           display: verbose,
           content: steeringLines.join("\n"),
         },
-        { triggerTurn: true, deliverAs: "steer" },
+        { triggerTurn: recoveryTrigger, deliverAs: "steer" },
       );
       ctx.ui.notify(
         `${reason === "idle" ? "Idle" : "Timeout"} recovery: steering ${unitType} ${unitId} to finish durable output (attempt ${attemptNumber}, session ${recoveryAttempts + 1}/${maxRecoveryAttempts}).`,
@@ -251,14 +255,17 @@ export async function recoverTimedOutUnit(
           "If blocked, write the partial artifact and explicitly record the blocker instead of going silent.",
         ];
 
-    await applySupervisorModelIfConfigured(ctx, pi, basePath);
+    const recoveryTrigger = getInFlightToolCount() === 0;
+    if (recoveryTrigger) {
+      await applySupervisorModelIfConfigured(ctx, pi, basePath);
+    }
     pi.sendMessage(
       {
         customType: "gsd-auto-timeout-recovery",
         display: verbose,
         content: steeringLines.join("\n"),
       },
-      { triggerTurn: true, deliverAs: "steer" },
+      { triggerTurn: recoveryTrigger, deliverAs: "steer" },
     );
     ctx.ui.notify(
       `${reason === "idle" ? "Idle" : "Timeout"} recovery: steering ${unitType} ${unitId} to produce ${expected} (attempt ${attemptNumber}, session ${recoveryAttempts + 1}/${maxRecoveryAttempts}).`,

--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -21,6 +21,7 @@ import { existsSync } from "node:fs";
 
 import { bumpAndResolveSynthetic } from "./auto/resolve.js";
 import { finalizeProjectResearchTimeout } from "./project-research-policy.js";
+import { applySupervisorModelIfConfigured } from "./auto-model-selection.js";
 
 export interface RecoveryContext {
   basePath: string;
@@ -122,6 +123,7 @@ export async function recoverTimedOutUnit(
             "If full completion is impossible, write the partial artifact/state needed for recovery and make the blocker explicit.",
           ];
 
+      await applySupervisorModelIfConfigured(ctx, pi, basePath);
       pi.sendMessage(
         {
           customType: "gsd-auto-timeout-recovery",
@@ -249,6 +251,7 @@ export async function recoverTimedOutUnit(
           "If blocked, write the partial artifact and explicitly record the blocker instead of going silent.",
         ];
 
+    await applySupervisorModelIfConfigured(ctx, pi, basePath);
     pi.sendMessage(
       {
         customType: "gsd-auto-timeout-recovery",

--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -170,7 +170,9 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
     // Triggering during active tool calls causes tool results to be skipped
     // with "Skipped due to queued user message", leading to provider errors (#3512).
     const softTrigger = getInFlightToolCount() === 0;
-    await applySupervisorModelIfConfigured(ctx, pi, s.basePath);
+    if (softTrigger) {
+      await applySupervisorModelIfConfigured(ctx, pi, s.basePath);
+    }
     pi.sendMessage(
       {
         customType: "gsd-auto-wrapup",
@@ -384,7 +386,9 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
 
     // Only trigger a new turn if no tools are currently in flight (#3512).
     const contextTrigger = getInFlightToolCount() === 0;
-    await applySupervisorModelIfConfigured(ctx, pi, s.basePath);
+    if (contextTrigger) {
+      await applySupervisorModelIfConfigured(ctx, pi, s.basePath);
+    }
     pi.sendMessage(
       {
         customType: "gsd-auto-wrapup",

--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -19,6 +19,7 @@ import {
   hasInteractiveToolInFlight,
 } from "./auto-tool-tracking.js";
 import { detectWorkingTreeActivity } from "./auto-supervisor.js";
+import { applySupervisorModelIfConfigured } from "./auto-model-selection.js";
 import { closeoutUnit, type CloseoutOptions } from "./auto-unit-closeout.js";
 import { saveActivityLog } from "./activity-log.js";
 import { recoverTimedOutUnit, type RecoveryContext } from "./auto-timeout-recovery.js";
@@ -158,7 +159,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
       : idleTimeoutMs;
 
   // ── 1. Soft timeout warning ──
-  s.wrapupWarningHandle = setTimeout(() => {
+  s.wrapupWarningHandle = setTimeout(async () => {
     s.wrapupWarningHandle = null;
     if (!s.active || !s.currentUnit) return;
     writeUnitRuntimeRecord(s.basePath, unitType, unitId, s.currentUnit.startedAt, {
@@ -169,6 +170,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
     // Triggering during active tool calls causes tool results to be skipped
     // with "Skipped due to queued user message", leading to provider errors (#3512).
     const softTrigger = getInFlightToolCount() === 0;
+    await applySupervisorModelIfConfigured(ctx, pi, s.basePath);
     pi.sendMessage(
       {
         customType: "gsd-auto-wrapup",
@@ -351,7 +353,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
     ctx.model?.provider,
   );
   const continueHereThreshold = computeBudgets(executorContextWindow).continueThresholdPercent;
-  s.continueHereHandle = setInterval(() => {
+  s.continueHereHandle = setInterval(async () => {
     if (!s.active || !s.currentUnit || !s.cmdCtx) return;
     const runtime = readUnitRuntimeRecord(s.basePath, unitType, unitId);
     if (runtime?.continueHereFired) return;
@@ -382,6 +384,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
 
     // Only trigger a new turn if no tools are currently in flight (#3512).
     const contextTrigger = getInFlightToolCount() === 0;
+    await applySupervisorModelIfConfigured(ctx, pi, s.basePath);
     pi.sendMessage(
       {
         customType: "gsd-auto-wrapup",

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -3154,9 +3154,10 @@ export async function dispatchHookUnit(
       // selectAndApplyModel, which consults the same blocked-models store (#1229).
       if (isModelUnavailable(targetBasePath, match.provider, match.id)) continue;
       try {
-        await pi.setModel(match);
-        applied = true;
-        break;
+        if (await pi.setModel(match)) {
+          applied = true;
+          break;
+        }
       } catch (err) {
         /* non-fatal — try the next fallback */
         logWarning("dispatch", `hook model set failed for ${candidate}: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -117,6 +117,7 @@ import {
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
 import { selectAndApplyModel, resolveModelId, clearToolBaseline } from "./auto-model-selection.js";
+import { resolveModelWithFallbacksForUnit } from "./preferences-models.js";
 import { resetRoutingHistory, recordOutcome } from "./routing-history.js";
 import {
   checkPostUnitHooks,
@@ -3123,19 +3124,43 @@ export async function dispatchHookUnit(
     workspaceRoot: s.basePath,
   });
 
-  if (hookModel) {
-    const availableModels = ctx.modelRegistry.getAvailable();
-    const match = resolveModelId(hookModel, availableModels, ctx.model?.provider);
-    if (match) {
+  // Resolve the hook's model honoring the configured `fallbacks[]` chain
+  // (#1229). The manual trigger path bypasses selectAndApplyModel, so resolve
+  // the primary→fallbacks order here and apply the first candidate available in
+  // the registry — a blocked or unconfigured primary then transparently drops
+  // to a fallback instead of silently reverting to the session model.
+  const availableModels = ctx.modelRegistry.getAvailable();
+  const availableModelIds = availableModels.map(
+    (m: { provider: string; id: string }) => `${m.provider}/${m.id}`,
+  );
+  const hookModelConfig = resolveModelWithFallbacksForUnit(
+    hookUnitType,
+    targetBasePath,
+    availableModelIds,
+  );
+  const modelCandidates = hookModelConfig
+    ? [hookModelConfig.primary, ...hookModelConfig.fallbacks]
+    : hookModel
+      ? [hookModel]
+      : [];
+  if (modelCandidates.length > 0) {
+    let applied = false;
+    for (const candidate of modelCandidates) {
+      const match = resolveModelId(candidate, availableModels, ctx.model?.provider);
+      if (!match) continue;
       try {
         await pi.setModel(match);
+        applied = true;
+        break;
       } catch (err) {
-        /* non-fatal */
-        logWarning("dispatch", `hook model set failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
+        /* non-fatal — try the next fallback */
+        logWarning("dispatch", `hook model set failed for ${candidate}: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
       }
-    } else {
+    }
+    if (!applied) {
       ctx.ui.notify(
-        `Hook model "${hookModel}" not found in available models. Falling back to current session model. ` +
+        `Hook model${modelCandidates.length > 1 ? "s" : ""} "${modelCandidates.join(", ")}" not available. ` +
+        `Falling back to current session model. ` +
         `Ensure the model is defined in models.json and has auth configured.`,
         "warning",
       );

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -116,7 +116,7 @@ import {
 } from "./auto-tool-tracking.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
-import { selectAndApplyModel, resolveModelId, clearToolBaseline } from "./auto-model-selection.js";
+import { selectAndApplyModel, resolveModelId, clearToolBaseline, isModelUnavailable } from "./auto-model-selection.js";
 import { resolveModelWithFallbacksForUnit } from "./preferences-models.js";
 import { resetRoutingHistory, recordOutcome } from "./routing-history.js";
 import {
@@ -3148,6 +3148,11 @@ export async function dispatchHookUnit(
     for (const candidate of modelCandidates) {
       const match = resolveModelId(candidate, availableModels, ctx.model?.provider);
       if (!match) continue;
+      // Skip models the runtime has marked blocked or temporarily unavailable
+      // (e.g. a primary that just tripped a provider limit) so the configured
+      // fallbacks[] chain actually engages — parity with auto-mode's
+      // selectAndApplyModel, which consults the same blocked-models store (#1229).
+      if (isModelUnavailable(targetBasePath, match.provider, match.id)) continue;
       try {
         await pi.setModel(match);
         applied = true;

--- a/src/resources/extensions/gsd/config-overlay.ts
+++ b/src/resources/extensions/gsd/config-overlay.ts
@@ -150,7 +150,13 @@ function collectConfigSections(options?: CollectConfigOptions): ConfigSection[] 
   if (prefs?.auto_supervisor) {
     const sup = resolveAutoSupervisorConfig();
     const supRows: ConfigSection["rows"] = [];
-    if (sup.model) supRows.push({ label: "Model", value: sup.model });
+    if (sup.model) {
+      let modelVal = sup.model;
+      if (sup.modelFallbacks && sup.modelFallbacks.length > 0) {
+        modelVal += ` \u2192 ${sup.modelFallbacks.join(" \u2192 ")}`;
+      }
+      supRows.push({ label: "Model", value: modelVal });
+    }
     supRows.push({ label: "Soft timeout", value: `${sup.soft_timeout_minutes}m` });
     supRows.push({ label: "Idle timeout", value: `${sup.idle_timeout_minutes}m` });
     supRows.push({ label: "Stalled tool timeout", value: `${sup.stalled_tool_timeout_minutes}m` });

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -138,7 +138,7 @@ Diagnostics record the file path, scope (global/project), severity (error/warnin
   - `off` — skill discovery is disabled entirely.
 
 - `auto_supervisor`: configures the auto-mode supervisor that monitors agent progress and enforces timeouts. Keys:
-  - `model`: model ID to use for the supervisor process (defaults to the currently active model).
+  - `model`: model to use for the supervisor process (defaults to the currently active model). Accepts a bare model ID **or** the same `{ model, provider?, fallbacks? }` object form as `models.<phase>`, so it honors `fallbacks[]` on a transient provider trip.
   - `soft_timeout_minutes`: minutes before the supervisor issues a soft warning (default: 20).
   - `idle_timeout_minutes`: minutes of inactivity before the supervisor intervenes (default: 10).
   - `hard_timeout_minutes`: minutes before the supervisor forces termination (default: 30).
@@ -228,7 +228,7 @@ In `"parent"` mode, slice/task `targetRepositories` default to the declared chil
   - `enabled`: boolean — set `false` to force sequential task execution. Default: `true`.
   - `max_parallel`: number — maximum tasks to dispatch in one batch, range `1`-`8`. Default: `2`.
   - `isolation_mode`: `"same-tree"` — currently the only supported value.
-  - `subagent_model`: string — optional model override for reactive task subagents. Falls back to the `models.subagent` routing when omitted.
+  - `subagent_model`: optional model override for reactive task subagents. Accepts a bare model ID **or** the `{ model, provider?, fallbacks? }` object form (parity with `models.<phase>`). Falls back to the `models.subagent` routing when omitted.
 
 - `remote_questions`: route interactive questions to Slack/Discord for headless auto-mode. Keys:
   - `channel`: `"slack"` or `"discord"` — channel type.
@@ -326,7 +326,7 @@ In `"parent"` mode, slice/task `targetRepositories` default to the declared chil
   - `after`: string[] — unit types that trigger this hook (e.g., `["execute-task"]`).
   - `prompt`: string — prompt sent to the LLM. Supports `{milestoneId}`, `{sliceId}`, `{taskId}` substitutions.
   - `max_cycles`: number — max times this hook fires per trigger (default: 1, max: 10).
-  - `model`: string — optional model override.
+  - `model`: optional model override. Accepts a bare model ID **or** the same `{ model, provider?, fallbacks? }` object form as `models.<phase>`. With `fallbacks[]`, a transient trip of the primary provider falls back to the next entry instead of hard-failing the hook — which, for a `blocking` hook with `on_block: { action: pause }`, would otherwise pause the whole run.
   - `artifact`: string — expected output file name (relative to task/slice dir). Hook is skipped if file already exists (idempotent).
   - `criticality`: `"advisory"` or `"blocking"` — advisory preserves current best-effort behavior; blocking requires clean hook completion plus a valid outcome verdict before auto-mode advances. Default: `"advisory"`.
   - `retry_on`: string — if this file is produced instead of the artifact, re-run the trigger unit then re-run hooks.

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -23,7 +23,7 @@ import type {
   GSDModelPhaseKey,
   GSDThinkingConfig,
   ResolvedModelConfig,
-  AutoSupervisorConfig,
+  ResolvedAutoSupervisorConfig,
 } from "./preferences-types.js";
 import { clearGSDPreferencesCache, loadEffectiveGSDPreferences, getGlobalGSDPreferencesPath } from "./preferences.js";
 import { getUnitPhaseChain } from "./unit-registry.js";
@@ -452,7 +452,7 @@ export function resolveDynamicRoutingConfig(): DynamicRoutingConfig {
   };
 }
 
-export function resolveAutoSupervisorConfig(): AutoSupervisorConfig {
+export function resolveAutoSupervisorConfig(): ResolvedAutoSupervisorConfig {
   const prefs = loadEffectiveGSDPreferences();
   const configured = prefs?.preferences.auto_supervisor ?? {};
 

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -87,12 +87,45 @@ function resolveWinningPhase(
 }
 
 /**
+ * Normalize a single model field into a {@link ResolvedModelConfig}.
+ *
+ * Accepts either the legacy bare-string form or the extended object form
+ * (`{ model, provider?, fallbacks? }`). This is the shared normalization used
+ * for phase buckets so sibling single-model fields — `post_unit_hooks[].model`,
+ * `auto_supervisor.model`, and `reactive_execution.subagent_model` — honor
+ * `fallbacks[]` identically rather than accepting a bare string only (#1229).
+ *
+ * Returns undefined for an unset, blank, or model-less field.
+ */
+export function normalizeModelFieldConfig(
+  field: string | GSDPhaseModelConfig | undefined,
+): ResolvedModelConfig | undefined {
+  if (!field) return undefined;
+  if (typeof field === "string") {
+    return field.trim() ? { primary: field, fallbacks: [] } : undefined;
+  }
+  if (!field.model) return undefined;
+  // When provider is explicitly set, prepend it to the model ID so the
+  // resolution code in auto.ts can do an explicit provider match.
+  const primary = field.provider && !field.model.includes("/")
+    ? `${field.provider}/${field.model}`
+    : field.model;
+  return { primary, fallbacks: field.fallbacks ?? [] };
+}
+
+/**
  * Resolve model and fallbacks for a given auto-mode unit type.
  * Returns the primary model and ordered fallbacks, or undefined if not configured.
  *
  * Supports both legacy string format and extended object format:
  * - Legacy: `planning: claude-opus-4-6`
  * - Extended: `planning: { model: claude-opus-4-6, fallbacks: [glm-5, minimax-m2.5] }`
+ *
+ * Hook unit types (`hook/<name>`) resolve against the matching
+ * `post_unit_hooks[]` entry's `model` field so hook sessions honor the same
+ * `fallbacks[]` chain as phase buckets — the recovery path can then switch to
+ * a fallback provider instead of hard-failing (and potentially pausing) the
+ * run on a transient provider trip (#1229).
  */
 export function resolveModelWithFallbacksForUnit(
   unitType: string,
@@ -107,27 +140,21 @@ export function resolveModelWithFallbacksForUnit(
     ...(skipProfileDefaults ? { skipProfileDefaults: true } : {}),
   };
   const prefs = loadEffectiveGSDPreferences(basePath, loadOpts);
+
+  // Hook sessions resolve against their own `post_unit_hooks[].model` field,
+  // which now shares the phase-bucket object form (#1229).
+  if (unitType.startsWith("hook/")) {
+    const hookName = unitType.slice("hook/".length);
+    const hooks = prefs?.preferences?.post_unit_hooks;
+    const hook = Array.isArray(hooks) ? hooks.find((h) => h.name === hookName) : undefined;
+    return normalizeModelFieldConfig(hook?.model);
+  }
+
   const chain = phaseChainForUnit(unitType);
   if (!chain) return undefined;
   const winner = resolveWinningPhase(prefs?.preferences?.models as GSDModelConfigV2 | undefined, chain);
   if (!winner) return undefined;
-  const phaseConfig = winner.config;
-
-  // Normalize: string -> { model, fallbacks: [] }
-  if (typeof phaseConfig === "string") {
-    return { primary: phaseConfig, fallbacks: [] };
-  }
-
-  // When provider is explicitly set, prepend it to the model ID so the
-  // resolution code in auto.ts can do an explicit provider match.
-  const primary = phaseConfig.provider && !phaseConfig.model.includes("/")
-    ? `${phaseConfig.provider}/${phaseConfig.model}`
-    : phaseConfig.model;
-
-  return {
-    primary,
-    fallbacks: phaseConfig.fallbacks ?? [],
-  };
+  return normalizeModelFieldConfig(winner.config);
 }
 
 /**
@@ -429,12 +456,16 @@ export function resolveAutoSupervisorConfig(): AutoSupervisorConfig {
   const prefs = loadEffectiveGSDPreferences();
   const configured = prefs?.preferences.auto_supervisor ?? {};
 
+  // `model` accepts the same object form as phase buckets (#1229); normalize to
+  // the primary model ID for the single-string consumer.
+  const model = normalizeModelFieldConfig(configured.model)?.primary;
+
   return {
     soft_timeout_minutes: configured.soft_timeout_minutes ?? 20,
     idle_timeout_minutes: configured.idle_timeout_minutes ?? 10,
     hard_timeout_minutes: configured.hard_timeout_minutes ?? 30,
     stalled_tool_timeout_minutes: configured.stalled_tool_timeout_minutes ?? 5,
-    ...(configured.model ? { model: configured.model } : {}),
+    ...(model ? { model } : {}),
   };
 }
 

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -126,6 +126,9 @@ export function normalizeModelFieldConfig(
  * `fallbacks[]` chain as phase buckets — the recovery path can then switch to
  * a fallback provider instead of hard-failing (and potentially pausing) the
  * run on a transient provider trip (#1229).
+ *
+ * The synthetic `supervisor` unit type resolves against `auto_supervisor.model`
+ * for supervisor interventions (wrap-up warnings, timeout recovery).
  */
 export function resolveModelWithFallbacksForUnit(
   unitType: string,
@@ -140,6 +143,11 @@ export function resolveModelWithFallbacksForUnit(
     ...(skipProfileDefaults ? { skipProfileDefaults: true } : {}),
   };
   const prefs = loadEffectiveGSDPreferences(basePath, loadOpts);
+
+  // Supervisor interventions resolve against `auto_supervisor.model` (#1229).
+  if (unitType === "supervisor") {
+    return normalizeModelFieldConfig(prefs?.preferences?.auto_supervisor?.model);
+  }
 
   // Hook sessions resolve against their own `post_unit_hooks[].model` field,
   // which now shares the phase-bucket object form (#1229).
@@ -456,16 +464,16 @@ export function resolveAutoSupervisorConfig(): ResolvedAutoSupervisorConfig {
   const prefs = loadEffectiveGSDPreferences();
   const configured = prefs?.preferences.auto_supervisor ?? {};
 
-  // `model` accepts the same object form as phase buckets (#1229); normalize to
-  // the primary model ID for the single-string consumer.
-  const model = normalizeModelFieldConfig(configured.model)?.primary;
+  const modelConfig = normalizeModelFieldConfig(configured.model);
 
   return {
     soft_timeout_minutes: configured.soft_timeout_minutes ?? 20,
     idle_timeout_minutes: configured.idle_timeout_minutes ?? 10,
     hard_timeout_minutes: configured.hard_timeout_minutes ?? 30,
     stalled_tool_timeout_minutes: configured.stalled_tool_timeout_minutes ?? 5,
-    ...(model ? { model } : {}),
+    ...(modelConfig
+      ? { model: modelConfig.primary, modelFallbacks: modelConfig.fallbacks }
+      : {}),
   };
 }
 

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -336,6 +336,16 @@ export interface AutoSupervisorConfig {
   stalled_tool_timeout_minutes?: number;
 }
 
+/**
+ * The supervisor config after resolution by `resolveAutoSupervisorConfig`.
+ * Identical to {@link AutoSupervisorConfig} except `model` is always the
+ * normalized primary model ID string — the object form accepted in preferences
+ * is collapsed to its primary during resolution (#1229).
+ */
+export type ResolvedAutoSupervisorConfig = Omit<AutoSupervisorConfig, "model"> & {
+  model?: string;
+};
+
 export interface RemoteQuestionsConfig {
   channel: "slack" | "discord" | "telegram";
   channel_id: string | number;

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -317,7 +317,12 @@ export interface ResolvedModelConfig {
 export type SkillDiscoveryMode = "auto" | "suggest" | "off";
 
 export interface AutoSupervisorConfig {
-  model?: string;
+  /**
+   * Model ID for the supervisor process. Accepts a bare model ID or the
+   * extended `{ model, provider?, fallbacks? }` object form for parity with
+   * phase buckets (#1229). Resolution normalizes it to the primary model ID.
+   */
+  model?: string | GSDPhaseModelConfig;
   soft_timeout_minutes?: number;
   idle_timeout_minutes?: number;
   hard_timeout_minutes?: number;

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -339,11 +339,12 @@ export interface AutoSupervisorConfig {
 /**
  * The supervisor config after resolution by `resolveAutoSupervisorConfig`.
  * Identical to {@link AutoSupervisorConfig} except `model` is always the
- * normalized primary model ID string — the object form accepted in preferences
- * is collapsed to its primary during resolution (#1229).
+ * normalized primary model ID string and `modelFallbacks` carries the ordered
+ * fallback chain from the object form accepted in preferences (#1229).
  */
 export type ResolvedAutoSupervisorConfig = Omit<AutoSupervisorConfig, "model"> & {
   model?: string;
+  modelFallbacks?: string[];
 };
 
 export interface RemoteQuestionsConfig {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -55,7 +55,12 @@ function sanitizeModelField(
 ): string | GSDPhaseModelConfig | undefined {
   if (raw === undefined) return undefined;
   if (typeof raw === "string") {
-    return raw.trim() ? raw.trim() : undefined;
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      errors.push(`${label} must not be an empty string`);
+      return undefined;
+    }
+    return trimmed;
   }
   if (raw && typeof raw === "object") {
     const obj = raw as Record<string, unknown>;

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -22,6 +22,7 @@ import {
   SKILL_ACTIONS,
   type WorkflowMode,
   type GSDPreferences,
+  type GSDPhaseModelConfig,
   type GSDSkillRule,
   type GSDThinkingLevel,
 } from "./preferences-types.js";
@@ -41,6 +42,42 @@ const VALID_UOK_TURN_ACTIONS = new Set<"commit" | "snapshot" | "status-only">([
   "snapshot",
   "status-only",
 ]);
+/**
+ * Sanitize a single model field that accepts either a bare model ID or the
+ * extended `{ model, provider?, fallbacks? }` object form used by phase buckets
+ * (#1229). Returns the sanitized value, or undefined when unset/invalid (in
+ * which case an error describing `label` is pushed onto `errors`).
+ */
+function sanitizeModelField(
+  raw: unknown,
+  label: string,
+  errors: string[],
+): string | GSDPhaseModelConfig | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw === "string") {
+    return raw.trim() ? raw.trim() : undefined;
+  }
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    const model = typeof obj.model === "string" ? obj.model.trim() : "";
+    if (!model) {
+      errors.push(`${label} object form requires a non-empty "model"`);
+      return undefined;
+    }
+    const sanitized: GSDPhaseModelConfig = { model };
+    if (typeof obj.provider === "string" && obj.provider.trim()) {
+      sanitized.provider = obj.provider.trim();
+    }
+    if (obj.fallbacks !== undefined) {
+      const fallbacks = normalizeStringArray(obj.fallbacks);
+      if (fallbacks.length > 0) sanitized.fallbacks = fallbacks;
+    }
+    return sanitized;
+  }
+  errors.push(`${label} must be a string or an object with a "model" field`);
+  return undefined;
+}
+
 const VALID_POST_UNIT_HOOK_CRITICALITIES = new Set(["advisory", "blocking"]);
 const VALID_POST_UNIT_HOOK_ON_BLOCK_ACTIONS = new Set([
   "retry-unit",
@@ -568,8 +605,9 @@ export function validatePreferences(preferences: GSDPreferences): {
         const mc = typeof hook.max_cycles === "number" ? hook.max_cycles : Number(hook.max_cycles);
         validHook.max_cycles = Number.isFinite(mc) ? Math.max(1, Math.min(10, Math.round(mc))) : 1;
       }
-      if (typeof hook.model === "string" && hook.model.trim()) {
-        validHook.model = hook.model.trim();
+      const hookModel = sanitizeModelField(hook.model, `post_unit_hooks "${name}" model`, errors);
+      if (hookModel !== undefined) {
+        validHook.model = hookModel;
       }
       if (typeof hook.artifact === "string" && hook.artifact.trim()) {
         validHook.artifact = hook.artifact.trim();
@@ -1021,12 +1059,13 @@ export function validatePreferences(preferences: GSDPreferences): {
         }
       }
 
-      if (re.subagent_model !== undefined) {
-        if (typeof re.subagent_model === "string" && re.subagent_model.length > 0) {
-          validRe.subagent_model = re.subagent_model;
-        } else {
-          errors.push("reactive_execution.subagent_model must be a non-empty string");
-        }
+      const subagentModel = sanitizeModelField(
+        re.subagent_model,
+        "reactive_execution.subagent_model",
+        errors,
+      );
+      if (subagentModel !== undefined) {
+        validRe.subagent_model = subagentModel;
       }
 
       const knownReKeys = new Set(["enabled", "max_parallel", "isolation_mode", "subagent_model"]);

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -513,7 +513,15 @@ export function validatePreferences(preferences: GSDPreferences): {
   // ─── Auto Supervisor ────────────────────────────────────────────────
   if (preferences.auto_supervisor !== undefined) {
     if (preferences.auto_supervisor && typeof preferences.auto_supervisor === "object") {
-      validated.auto_supervisor = preferences.auto_supervisor;
+      // Validate `model` through the shared sanitizer so the
+      // `{ model, provider?, fallbacks? }` object form is rejected on the same
+      // terms as its post_unit_hooks / reactive_execution siblings (#1229).
+      // Other supervisor fields pass through unchanged.
+      const supervisor = { ...preferences.auto_supervisor };
+      if (supervisor.model !== undefined) {
+        supervisor.model = sanitizeModelField(supervisor.model, "auto_supervisor.model", errors);
+      }
+      validated.auto_supervisor = supervisor;
     } else {
       errors.push("auto_supervisor must be an object");
     }

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -21,7 +21,6 @@ import type {
   PostUnitHookOutcomeVerdict,
 } from "./types.js";
 import { resolvePostUnitHooks, resolvePreDispatchHooks } from "./preferences.js";
-import { normalizeModelFieldConfig } from "./preferences-models.js";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { parseUnitId } from "./unit-id.js";
@@ -1016,7 +1015,10 @@ export class RuleRegistry {
     return {
       hookName: hook.name,
       prompt,
-      model: normalizeModelFieldConfig(hook.model)?.primary,
+      // Model selection (including fallbacks[]) is resolved by dispatchHookUnit
+      // via resolveModelWithFallbacksForUnit for the `hook/<name>` unit type,
+      // matching the auto-mode path. Emitting the primary-only model here would
+      // discard the configured fallback chain (#1229).
       unitType: `hook/${hook.name}`,
       unitId,
     };

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -376,10 +376,8 @@ export class RuleRegistry {
     return {
       hookName: config.name,
       prompt,
-      // Object-form `model` resolves to its primary here; the recovery path
-      // resolves the full fallback chain via resolveModelWithFallbacksForUnit
-      // for the `hook/<name>` unit type (#1229).
-      model: normalizeModelFieldConfig(config.model)?.primary,
+      // Model selection (including fallbacks[]) is handled by
+      // resolveModelWithFallbacksForUnit for the `hook/<name>` unit type (#1229).
       unitType: `hook/${config.name}`,
       unitId: triggerUnitId,
     };

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -21,6 +21,7 @@ import type {
   PostUnitHookOutcomeVerdict,
 } from "./types.js";
 import { resolvePostUnitHooks, resolvePreDispatchHooks } from "./preferences.js";
+import { normalizeModelFieldConfig } from "./preferences-models.js";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { parseUnitId } from "./unit-id.js";
@@ -375,7 +376,10 @@ export class RuleRegistry {
     return {
       hookName: config.name,
       prompt,
-      model: config.model,
+      // Object-form `model` resolves to its primary here; the recovery path
+      // resolves the full fallback chain via resolveModelWithFallbacksForUnit
+      // for the `hook/<name>` unit type (#1229).
+      model: normalizeModelFieldConfig(config.model)?.primary,
       unitType: `hook/${config.name}`,
       unitId: triggerUnitId,
     };
@@ -1014,7 +1018,7 @@ export class RuleRegistry {
     return {
       hookName: hook.name,
       prompt,
-      model: hook.model,
+      model: normalizeModelFieldConfig(hook.model)?.primary,
       unitType: `hook/${hook.name}`,
       unitId,
     };

--- a/src/resources/extensions/gsd/tests/auto-timeout-recovery-supervisor-inflight-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-timeout-recovery-supervisor-inflight-guard.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Idle/hard timeout recovery honors the in-flight-tool guard (#1229 follow-up).
+ *
+ * `recoverTimedOutUnit` steers a still-running unit with `deliverAs: "steer"`
+ * and, before that, may swap the session model via
+ * `applySupervisorModelIfConfigured`. Swapping the model and triggering a turn
+ * while non-interactive tool calls are still open skips tool results and trips
+ * provider errors (#3512) — the same failure the soft wrap-up and continue-here
+ * timers guard against. This test pins that the idle and hard steering branches
+ * gate both the model swap and `triggerTurn` on `getInFlightToolCount() === 0`.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { recoverTimedOutUnit, type RecoveryContext } from "../auto-timeout-recovery.ts";
+import { clearGSDPreferencesCache } from "../preferences.ts";
+import {
+  markToolStart,
+  markToolEnd,
+  clearInFlightTools,
+} from "../auto-tool-tracking.ts";
+
+const SUPERVISOR_PREFS = [
+  "auto_supervisor:",
+  "  soft_timeout_minutes: 1",
+  "  idle_timeout_minutes: 100",
+  "  hard_timeout_minutes: 100",
+  "  model:",
+  "    model: supervisor-primary",
+  "    fallbacks: [supervisor-fb]",
+];
+
+interface Harness {
+  home: string;
+  base: string;
+  ctx: any;
+  pi: any;
+  rctx: RecoveryContext;
+  setModelCalls: unknown[][];
+  sendMessageCalls: unknown[][];
+}
+
+function makeHarness(): Harness {
+  const home = mkdtempSync(join(tmpdir(), "gsd-recovery-guard-home-"));
+  const base = mkdtempSync(join(tmpdir(), "gsd-recovery-guard-base-"));
+  process.env.GSD_HOME = home;
+  writeFileSync(join(home, "preferences.md"), ["---", ...SUPERVISOR_PREFS, "---", ""].join("\n"));
+  clearGSDPreferencesCache();
+
+  const setModelCalls: unknown[][] = [];
+  const sendMessageCalls: unknown[][] = [];
+
+  const ctx = {
+    ui: { notify: () => {} },
+    model: { provider: "anthropic" },
+    modelRegistry: {
+      getAvailable: () => [
+        { id: "supervisor-primary", provider: "anthropic" },
+        { id: "supervisor-fb", provider: "anthropic" },
+      ],
+    },
+  } as any;
+
+  const pi = {
+    sendMessage: (...args: unknown[]) => {
+      sendMessageCalls.push(args);
+    },
+    setModel: async (...args: unknown[]) => {
+      setModelCalls.push(args);
+      return true;
+    },
+    getThinkingLevel: () => "off",
+    setThinkingLevel: () => {},
+  } as any;
+
+  const rctx: RecoveryContext = {
+    basePath: base,
+    verbose: false,
+    currentUnitStartedAt: 1234,
+    unitRecoveryCount: new Map(),
+  };
+
+  return { home, base, ctx, pi, rctx, setModelCalls, sendMessageCalls };
+}
+
+function cleanup(h: Harness): void {
+  clearInFlightTools();
+  clearGSDPreferencesCache();
+  delete process.env.GSD_HOME;
+  rmSync(h.home, { recursive: true, force: true });
+  rmSync(h.base, { recursive: true, force: true });
+}
+
+// "discuss-project" resolves to a PROJECT.md that never exists in the temp base,
+// so recovery skips the "already on disk" shortcut and reaches the steering
+// branch with recoveryAttempts (0) < maxRecoveryAttempts.
+for (const reason of ["idle", "hard"] as const) {
+  test(`${reason} recovery skips the supervisor model swap while a tool is in flight`, async () => {
+    const h = makeHarness();
+    try {
+      markToolStart("call-1", true, "some_tool");
+
+      const outcome = await recoverTimedOutUnit(
+        h.ctx,
+        h.pi,
+        "discuss-project",
+        "P01",
+        reason,
+        h.rctx,
+      );
+
+      assert.equal(outcome, "recovered");
+      assert.equal(
+        h.setModelCalls.length,
+        0,
+        "model must NOT swap while a tool is in flight",
+      );
+      assert.equal(h.sendMessageCalls.length, 1, "steer message still sent (queued)");
+      const opts = h.sendMessageCalls[0][1] as { triggerTurn?: boolean; deliverAs?: string };
+      assert.equal(opts.triggerTurn, false, "turn is not triggered mid-tool-call");
+      assert.equal(opts.deliverAs, "steer");
+
+      markToolEnd("call-1");
+    } finally {
+      cleanup(h);
+    }
+  });
+
+  test(`${reason} recovery applies the supervisor model swap when no tools are in flight`, async () => {
+    const h = makeHarness();
+    try {
+      const outcome = await recoverTimedOutUnit(
+        h.ctx,
+        h.pi,
+        "discuss-project",
+        "P01",
+        reason,
+        h.rctx,
+      );
+
+      assert.equal(outcome, "recovered");
+      assert.equal(h.setModelCalls.length, 1, "model swaps to the supervisor model");
+      assert.deepEqual(
+        h.setModelCalls[0][0],
+        { id: "supervisor-primary", provider: "anthropic" },
+        "swaps to the configured supervisor primary",
+      );
+      assert.equal(h.sendMessageCalls.length, 1);
+      const opts = h.sendMessageCalls[0][1] as { triggerTurn?: boolean };
+      assert.equal(opts.triggerTurn, true, "turn is triggered when no tools are open");
+    } finally {
+      cleanup(h);
+    }
+  });
+}

--- a/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-hooks.test.ts
@@ -454,4 +454,45 @@ test('triggerHookManually: with configured hook', () => {
   }
 });
 
+// ─── Hook dispatch results omit a primary-only model (#1229) ───────────────
+// Both the auto-mode (checkPostUnitHooks → _startHook) and manual
+// (triggerHookManually) dispatch paths must NOT carry a resolved primary model
+// on the dispatch result. Emitting the primary alone discards the configured
+// fallbacks[] chain: the auto path would re-apply it over a fallback already
+// selected by selectAndApplyModel, and the manual path (dispatchHookUnit) now
+// resolves the full chain itself. The dispatch result therefore leaves `model`
+// unset so downstream resolution honors fallbacks.
+test('Dispatch results omit primary-only model so fallbacks survive (#1229)', () => {
+  resetHookState();
+  const base = createFixtureBase();
+  try {
+    writeHookPreferences(base, `  - name: code-review
+    after:
+      - execute-task
+    prompt: Review the change
+    artifact: REVIEW-PASS.md
+    model:
+      model: primary-model
+      fallbacks:
+        - fallback-a
+        - fallback-b
+`);
+
+    const autoDispatch = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.ok(autoDispatch, "auto-mode dispatches the configured hook");
+    assert.equal(autoDispatch.unitType, "hook/code-review", "auto dispatch is hook-prefixed");
+    assert.equal(autoDispatch.model, undefined, "auto dispatch does not carry a primary-only model");
+
+    resetHookState();
+
+    const manualDispatch = triggerHookManually("code-review", "execute-task", "M001/S01/T01", base);
+    assert.ok(manualDispatch, "manual trigger dispatches the configured hook");
+    assert.equal(manualDispatch.unitType, "hook/code-review", "manual dispatch is hook-prefixed");
+    assert.equal(manualDispatch.model, undefined, "manual dispatch does not carry a primary-only model");
+  } finally {
+    resetHookState();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 });

--- a/src/resources/extensions/gsd/tests/sibling-model-fallbacks.test.ts
+++ b/src/resources/extensions/gsd/tests/sibling-model-fallbacks.test.ts
@@ -163,3 +163,21 @@ test("validatePreferences rejects a model-less object form", () => {
   } as never);
   assert.ok(errors.some((e) => e.includes('requires a non-empty "model"')));
 });
+
+test("validatePreferences accepts object-form auto_supervisor.model", () => {
+  const { preferences: validated, errors } = validatePreferences({
+    auto_supervisor: { model: { model: "sup-primary", fallbacks: ["sup-fb"] } },
+  } as never);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(validated.auto_supervisor?.model, { model: "sup-primary", fallbacks: ["sup-fb"] });
+});
+
+test("validatePreferences rejects a model-less auto_supervisor.model object", () => {
+  const { errors } = validatePreferences({
+    auto_supervisor: { model: { fallbacks: ["sup-fb"] } },
+  } as never);
+  assert.ok(
+    errors.some((e) => e.includes("auto_supervisor.model") && e.includes('requires a non-empty "model"')),
+    `expected supervisor model error, got: ${JSON.stringify(errors)}`,
+  );
+});

--- a/src/resources/extensions/gsd/tests/sibling-model-fallbacks.test.ts
+++ b/src/resources/extensions/gsd/tests/sibling-model-fallbacks.test.ts
@@ -118,7 +118,7 @@ test("hook/<name> resolves undefined when the hook has no model", () => {
 
 // ─── auto_supervisor.model ───────────────────────────────────────────────────
 
-test("auto_supervisor.model object form normalizes to its primary", () => {
+test("auto_supervisor.model object form resolves with fallbacks", () => {
   withPreferences(
     [
       "auto_supervisor:",
@@ -127,7 +127,13 @@ test("auto_supervisor.model object form normalizes to its primary", () => {
       "    fallbacks: [supervisor-fb]",
     ],
     () => {
-      assert.equal(resolveAutoSupervisorConfig().model, "supervisor-primary");
+      assert.deepEqual(resolveModelWithFallbacksForUnit("supervisor"), {
+        primary: "supervisor-primary",
+        fallbacks: ["supervisor-fb"],
+      });
+      const supervisor = resolveAutoSupervisorConfig();
+      assert.equal(supervisor.model, "supervisor-primary");
+      assert.deepEqual(supervisor.modelFallbacks, ["supervisor-fb"]);
     },
   );
 });

--- a/src/resources/extensions/gsd/tests/sibling-model-fallbacks.test.ts
+++ b/src/resources/extensions/gsd/tests/sibling-model-fallbacks.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Sibling single-model fields honor `fallbacks[]` (#1229).
+ *
+ * `post_unit_hooks[].model`, `auto_supervisor.model`, and
+ * `reactive_execution.subagent_model` accept the same
+ * `{ model, provider?, fallbacks? }` object form as `models.<phase>` so a
+ * transient provider trip falls back to the next entry instead of hard-failing
+ * (and, for a blocking hook, pausing the whole auto-mode run).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  normalizeModelFieldConfig,
+  resolveModelWithFallbacksForUnit,
+  resolveAutoSupervisorConfig,
+} from "../preferences-models.ts";
+import { validatePreferences } from "../preferences-validation.ts";
+
+function withPreferences<T>(frontmatter: string[], fn: () => T): T {
+  const oldHome = process.env.GSD_HOME;
+  const home = mkdtempSync(join(tmpdir(), "gsd-sibling-models-"));
+  try {
+    process.env.GSD_HOME = home;
+    writeFileSync(join(home, "preferences.md"), ["---", ...frontmatter, "---", ""].join("\n"));
+    return fn();
+  } finally {
+    if (oldHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+// ─── normalizeModelFieldConfig ───────────────────────────────────────────────
+
+test("normalizeModelFieldConfig: bare string → primary with empty fallbacks", () => {
+  assert.deepEqual(normalizeModelFieldConfig("my-model"), { primary: "my-model", fallbacks: [] });
+});
+
+test("normalizeModelFieldConfig: object form carries fallbacks", () => {
+  assert.deepEqual(
+    normalizeModelFieldConfig({ model: "primary", fallbacks: ["fb-1", "fb-2"] }),
+    { primary: "primary", fallbacks: ["fb-1", "fb-2"] },
+  );
+});
+
+test("normalizeModelFieldConfig: provider prefix is prepended to bare model", () => {
+  assert.deepEqual(
+    normalizeModelFieldConfig({ model: "gpt-5.4", provider: "openai-codex" }),
+    { primary: "openai-codex/gpt-5.4", fallbacks: [] },
+  );
+});
+
+test("normalizeModelFieldConfig: unset / blank / model-less → undefined", () => {
+  assert.equal(normalizeModelFieldConfig(undefined), undefined);
+  assert.equal(normalizeModelFieldConfig("   "), undefined);
+  assert.equal(normalizeModelFieldConfig({ model: "" }), undefined);
+});
+
+// ─── post_unit_hooks[].model fallback resolution ─────────────────────────────
+
+test("hook/<name> resolves the hook's object-form model with fallbacks", () => {
+  withPreferences(
+    [
+      "post_unit_hooks:",
+      "  - name: plan-review",
+      "    after: [plan-slice]",
+      "    prompt: review the plan",
+      "    model:",
+      "      model: primary-model",
+      "      fallbacks:",
+      "        - fallback-a",
+      "        - fallback-b",
+    ],
+    () => {
+      const resolved = resolveModelWithFallbacksForUnit("hook/plan-review");
+      assert.deepEqual(resolved, { primary: "primary-model", fallbacks: ["fallback-a", "fallback-b"] });
+    },
+  );
+});
+
+test("hook/<name> still resolves the legacy bare-string model form", () => {
+  withPreferences(
+    [
+      "post_unit_hooks:",
+      "  - name: plan-review",
+      "    after: [plan-slice]",
+      "    prompt: review the plan",
+      "    model: solo-model",
+    ],
+    () => {
+      assert.deepEqual(
+        resolveModelWithFallbacksForUnit("hook/plan-review"),
+        { primary: "solo-model", fallbacks: [] },
+      );
+    },
+  );
+});
+
+test("hook/<name> resolves undefined when the hook has no model", () => {
+  withPreferences(
+    [
+      "post_unit_hooks:",
+      "  - name: plan-review",
+      "    after: [plan-slice]",
+      "    prompt: review the plan",
+    ],
+    () => {
+      assert.equal(resolveModelWithFallbacksForUnit("hook/plan-review"), undefined);
+      assert.equal(resolveModelWithFallbacksForUnit("hook/unknown-hook"), undefined);
+    },
+  );
+});
+
+// ─── auto_supervisor.model ───────────────────────────────────────────────────
+
+test("auto_supervisor.model object form normalizes to its primary", () => {
+  withPreferences(
+    [
+      "auto_supervisor:",
+      "  model:",
+      "    model: supervisor-primary",
+      "    fallbacks: [supervisor-fb]",
+    ],
+    () => {
+      assert.equal(resolveAutoSupervisorConfig().model, "supervisor-primary");
+    },
+  );
+});
+
+// ─── validation accepts the object form ──────────────────────────────────────
+
+test("validatePreferences accepts object-form hook and subagent models", () => {
+  const { preferences: validated, errors } = validatePreferences({
+    post_unit_hooks: [
+      {
+        name: "plan-review",
+        after: ["plan-slice"],
+        prompt: "review",
+        model: { model: "primary", fallbacks: ["fb-1"] },
+      },
+    ],
+    reactive_execution: {
+      enabled: true,
+      subagent_model: { model: "sub-primary", fallbacks: ["sub-fb"] },
+    },
+  } as never);
+
+  assert.deepEqual(errors, []);
+  assert.deepEqual(validated.post_unit_hooks?.[0].model, { model: "primary", fallbacks: ["fb-1"] });
+  assert.deepEqual(validated.reactive_execution?.subagent_model, { model: "sub-primary", fallbacks: ["sub-fb"] });
+});
+
+test("validatePreferences rejects a model-less object form", () => {
+  const { errors } = validatePreferences({
+    post_unit_hooks: [
+      { name: "plan-review", after: ["plan-slice"], prompt: "review", model: { fallbacks: ["fb"] } },
+    ],
+  } as never);
+  assert.ok(errors.some((e) => e.includes('requires a non-empty "model"')));
+});

--- a/src/resources/extensions/gsd/tests/supervisor-model-swap-inflight-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/supervisor-model-swap-inflight-guard.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Supervisor model swap honors the in-flight-tool guard (#1229 follow-up).
+ *
+ * The wrap-up soft-timeout timer gates `triggerTurn` on there being no tools
+ * in flight — sending a turn mid-tool-call skips tool results and trips
+ * provider errors (#3512). The supervisor model swap
+ * (`applySupervisorModelIfConfigured`) must honor the identical guard: swapping
+ * the session model while tool calls are still open risks the same provider
+ * errors, so it must only run when the timer will actually trigger a turn.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mock } from "node:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { startUnitSupervision, type SupervisionContext } from "../auto-timers.ts";
+import { clearGSDPreferencesCache } from "../preferences.ts";
+import {
+  markToolStart,
+  markToolEnd,
+  clearInFlightTools,
+} from "../auto-tool-tracking.ts";
+
+const SUPERVISOR_PREFS = [
+  "auto_supervisor:",
+  "  soft_timeout_minutes: 1",
+  "  idle_timeout_minutes: 100",
+  "  hard_timeout_minutes: 100",
+  "  model:",
+  "    model: supervisor-primary",
+  "    fallbacks: [supervisor-fb]",
+];
+
+interface Harness {
+  home: string;
+  base: string;
+  ctx: any;
+  pi: any;
+  s: any;
+  sctx: SupervisionContext;
+  setModelCalls: unknown[][];
+  sendMessageCalls: unknown[][];
+}
+
+function makeHarness(): Harness {
+  const home = mkdtempSync(join(tmpdir(), "gsd-supervisor-guard-home-"));
+  const base = mkdtempSync(join(tmpdir(), "gsd-supervisor-guard-base-"));
+  process.env.GSD_HOME = home;
+  writeFileSync(join(home, "preferences.md"), ["---", ...SUPERVISOR_PREFS, "---", ""].join("\n"));
+  clearGSDPreferencesCache();
+
+  const setModelCalls: unknown[][] = [];
+  const sendMessageCalls: unknown[][] = [];
+
+  const ctx = {
+    ui: { notify: () => {} },
+    model: { provider: "anthropic" },
+    modelRegistry: {
+      getAvailable: () => [
+        { id: "supervisor-primary", provider: "anthropic" },
+        { id: "supervisor-fb", provider: "anthropic" },
+      ],
+    },
+  } as any;
+
+  const pi = {
+    sendMessage: (...args: unknown[]) => {
+      sendMessageCalls.push(args);
+    },
+    setModel: async (...args: unknown[]) => {
+      setModelCalls.push(args);
+      return true;
+    },
+    getThinkingLevel: () => "off",
+    setThinkingLevel: () => {},
+  } as any;
+
+  const s = {
+    active: true,
+    verbose: false,
+    basePath: base,
+    currentUnit: { type: "task", id: "T01", startedAt: 1234 },
+    cmdCtx: undefined,
+    wrapupWarningHandle: null,
+    idleWatchdogHandle: null,
+    unitTimeoutHandle: null,
+    continueHereHandle: null,
+  } as any;
+
+  const sctx: SupervisionContext = {
+    s,
+    ctx,
+    pi,
+    unitType: "task",
+    unitId: "T01",
+    prefs: undefined,
+    buildSnapshotOpts: () => ({}) as any,
+    buildRecoveryContext: () => ({}) as any,
+    pauseAuto: async () => {},
+  };
+
+  return { home, base, ctx, pi, s, sctx, setModelCalls, sendMessageCalls };
+}
+
+function cleanup(h: Harness): void {
+  clearInFlightTools();
+  clearGSDPreferencesCache();
+  delete process.env.GSD_HOME;
+  rmSync(h.home, { recursive: true, force: true });
+  rmSync(h.base, { recursive: true, force: true });
+}
+
+/** Neutralize every timer except the soft-timeout wrap-up so only it fires. */
+function isolateSoftTimeout(s: any): void {
+  if (s.idleWatchdogHandle) clearInterval(s.idleWatchdogHandle);
+  if (s.unitTimeoutHandle) clearTimeout(s.unitTimeoutHandle);
+  if (s.continueHereHandle) clearInterval(s.continueHereHandle);
+}
+
+/** Flush the soft-timeout callback's chained awaits. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+test("soft-timeout skips the supervisor model swap while a tool is in flight", async () => {
+  const h = makeHarness();
+  mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"], now: 0 });
+  try {
+    startUnitSupervision(h.sctx);
+    isolateSoftTimeout(h.s);
+
+    // A tool is still executing when the soft timeout fires.
+    markToolStart("call-1", true, "some_tool");
+
+    mock.timers.tick(60_000);
+    await flush();
+
+    assert.equal(
+      h.setModelCalls.length,
+      0,
+      "model must NOT swap while a tool is in flight",
+    );
+    assert.equal(h.sendMessageCalls.length, 1, "wrap-up message still sent (queued)");
+    const opts = h.sendMessageCalls[0][1] as { triggerTurn?: boolean };
+    assert.equal(opts.triggerTurn, false, "turn is not triggered mid-tool-call");
+
+    markToolEnd("call-1");
+  } finally {
+    mock.timers.reset();
+    cleanup(h);
+  }
+});
+
+test("soft-timeout applies the supervisor model swap when no tools are in flight", async () => {
+  const h = makeHarness();
+  mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"], now: 0 });
+  try {
+    startUnitSupervision(h.sctx);
+    isolateSoftTimeout(h.s);
+
+    // No tools in flight — the timer will trigger a turn, so the model swaps.
+    mock.timers.tick(60_000);
+    await flush();
+
+    assert.equal(h.setModelCalls.length, 1, "model swaps to the supervisor model");
+    assert.deepEqual(
+      h.setModelCalls[0][0],
+      { id: "supervisor-primary", provider: "anthropic" },
+      "swaps to the configured supervisor primary",
+    );
+    assert.equal(h.sendMessageCalls.length, 1);
+    const opts = h.sendMessageCalls[0][1] as { triggerTurn?: boolean };
+    assert.equal(opts.triggerTurn, true, "turn is triggered when no tools are open");
+  } finally {
+    mock.timers.reset();
+    cleanup(h);
+  }
+});

--- a/src/resources/extensions/gsd/tests/supervisor-model-swap-thinking-clamp.test.ts
+++ b/src/resources/extensions/gsd/tests/supervisor-model-swap-thinking-clamp.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Supervisor model swap reclamps the reasoning level (#1229 follow-up).
+ *
+ * Hook overrides in `unit-phase.ts` reapply `applyThinkingLevelForModel` after a
+ * model swap so the session's reasoning effort is re-clamped to what the newly
+ * selected model supports (ADR-026). `applySupervisorModelIfConfigured` swaps
+ * the session model for supervisor interventions (wrap-up, context-budget,
+ * timeout recovery) and must do the same — otherwise a level that was valid for
+ * the prior model can reach the provider on the steered turn.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { applySupervisorModelIfConfigured } from "../auto-model-selection.ts";
+import { clearGSDPreferencesCache } from "../preferences.ts";
+
+const SUPERVISOR_PREFS = [
+  "auto_supervisor:",
+  "  model:",
+  "    model: supervisor-primary",
+  "    fallbacks: [supervisor-fb]",
+];
+
+interface Harness {
+  home: string;
+  base: string;
+  ctx: any;
+  pi: any;
+  setModelCalls: unknown[][];
+  setThinkingCalls: unknown[];
+  order: string[];
+}
+
+function makeHarness(): Harness {
+  const home = mkdtempSync(join(tmpdir(), "gsd-supervisor-clamp-home-"));
+  const base = mkdtempSync(join(tmpdir(), "gsd-supervisor-clamp-base-"));
+  process.env.GSD_HOME = home;
+  writeFileSync(join(home, "preferences.md"), ["---", ...SUPERVISOR_PREFS, "---", ""].join("\n"));
+  clearGSDPreferencesCache();
+
+  const setModelCalls: unknown[][] = [];
+  const setThinkingCalls: unknown[] = [];
+  const order: string[] = [];
+
+  const ctx = {
+    ui: { notify: () => {} },
+    model: { provider: "anthropic" },
+    modelRegistry: {
+      getAvailable: () => [
+        { id: "supervisor-primary", provider: "anthropic" },
+        { id: "supervisor-fb", provider: "anthropic" },
+      ],
+    },
+  } as any;
+
+  const pi = {
+    setModel: async (...args: unknown[]) => {
+      setModelCalls.push(args);
+      order.push("setModel");
+      return true;
+    },
+    getThinkingLevel: () => "high",
+    setThinkingLevel: (level: unknown) => {
+      setThinkingCalls.push(level);
+      order.push("setThinkingLevel");
+    },
+  } as any;
+
+  return { home, base, ctx, pi, setModelCalls, setThinkingCalls, order };
+}
+
+function cleanup(h: Harness): void {
+  clearGSDPreferencesCache();
+  delete process.env.GSD_HOME;
+  rmSync(h.home, { recursive: true, force: true });
+  rmSync(h.base, { recursive: true, force: true });
+}
+
+test("supervisor swap reapplies the thinking level after selecting the model", async () => {
+  const h = makeHarness();
+  try {
+    await applySupervisorModelIfConfigured(h.ctx, h.pi, h.base);
+
+    assert.equal(h.setModelCalls.length, 1, "model swaps to the supervisor model");
+    assert.deepEqual(
+      h.setModelCalls[0][0],
+      { id: "supervisor-primary", provider: "anthropic" },
+      "swaps to the configured supervisor primary",
+    );
+    assert.equal(
+      h.setThinkingCalls.length,
+      1,
+      "thinking level is reclamped exactly once after the swap",
+    );
+    assert.deepEqual(
+      h.order,
+      ["setModel", "setThinkingLevel"],
+      "reclamp happens after setModel, matching the hook-override pattern",
+    );
+  } finally {
+    cleanup(h);
+  }
+});
+
+test("supervisor swap does not touch the thinking level when no model is configured", async () => {
+  const h = makeHarness();
+  // Overwrite prefs with no auto_supervisor.model.
+  writeFileSync(join(h.home, "preferences.md"), ["---", "auto_supervisor:", "  soft_timeout_minutes: 1", "---", ""].join("\n"));
+  clearGSDPreferencesCache();
+  try {
+    await applySupervisorModelIfConfigured(h.ctx, h.pi, h.base);
+
+    assert.equal(h.setModelCalls.length, 0, "no swap without a configured supervisor model");
+    assert.equal(h.setThinkingCalls.length, 0, "thinking level untouched when nothing swaps");
+  } finally {
+    cleanup(h);
+  }
+});

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -2,6 +2,11 @@
 // Types consumed by state derivation, file parsing, and status display.
 // Pure interfaces — no logic, no runtime dependencies.
 
+// Type-only import (erased at compile time — no runtime dependency): sibling
+// single-model fields share the phase-bucket object form so they honor
+// `fallbacks[]` (#1229).
+import type { GSDPhaseModelConfig } from "./preferences-types.js";
+
 // ─── Enums & Literal Unions ────────────────────────────────────────────────
 
 export type RiskLevel = "low" | "medium" | "high";
@@ -303,8 +308,13 @@ export interface PostUnitHookConfig {
   prompt: string;
   /** Max times this hook can fire for the same trigger unit. Default 1, max 10. */
   max_cycles?: number;
-  /** Model override for hook sessions. */
-  model?: string;
+  /**
+   * Model override for hook sessions. Accepts a bare model ID or the extended
+   * `{ model, provider?, fallbacks? }` object form so a transient trip of the
+   * primary provider falls back to the next entry instead of hard-failing the
+   * hook (#1229).
+   */
+  model?: string | GSDPhaseModelConfig;
   /** Expected output file name (relative to task/slice dir). Used for idempotency — skip if exists. */
   artifact?: string;
   /** Whether the hook is advisory or blocks unit advancement. Default advisory. */
@@ -607,8 +617,12 @@ export interface ReactiveExecutionConfig {
   max_parallel: number;
   /** Isolation mode for parallel tasks within a slice. Currently only "same-tree" is supported. */
   isolation_mode: "same-tree";
-  /** Optional model override for subagents spawned during parallel execution. */
-  subagent_model?: string;
+  /**
+   * Optional model override for subagents spawned during parallel execution.
+   * Accepts a bare model ID or the extended `{ model, provider?, fallbacks? }`
+   * object form for parity with phase buckets (#1229).
+   */
+  subagent_model?: string | GSDPhaseModelConfig;
 }
 
 /** Per-slice reactive execution runtime state, persisted to disk. */


### PR DESCRIPTION
## Summary
- Routed `post_unit_hooks[].model`, `auto_supervisor.model`, and `reactive_execution.subagent_model` through shared `{model, fallbacks}` normalization so hooks honor fallback chains; verified with a new 10-case test plus existing hook/reactive suites and a clean extensions typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1229
- [#1229 Hook and singleton model fields silently ignore fallbacks[] — a transient provider trip hard-fails (and can pause) an auto-mode run](https://github.com/open-gsd/gsd-pi/issues/1229)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1229-hook-and-singleton-model-fields-silently-1783229744`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode model selection for hooks, supervisor steering, and reactive subagents; mitigated by fallback parity with phase buckets, in-flight tool guards, and new regression tests.
> 
> **Overview**
> Extends **singleton model preference fields** (`post_unit_hooks[].model`, `auto_supervisor.model`, `reactive_execution.subagent_model`) to accept the same bare ID or `{ model, provider?, fallbacks? }` shape as `models.<phase>`, with shared `normalizeModelFieldConfig` and validation.
> 
> **Hook and manual dispatch** resolve `hook/<name>` through the full primary→fallback chain (skipping blocked/unavailable models) instead of applying a primary-only override from dispatch results. **Reactive parallel dispatch** passes the normalized subagent model plus fallbacks into the reactive-execute prompt.
> 
> **Supervisor interventions** (soft timeout, context budget, idle/hard timeout recovery) can swap to `auto_supervisor.model` via new `applySupervisorModelIfConfigured`, with thinking reclamped after the swap. Model swap and `triggerTurn` only run when **no tools are in flight**, matching the existing #3512 guard. Config overlay and docs describe fallback chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7a7b11adac66cd6f343db96af81e3b149ba1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->