### PR TITLE
refactor(browser-tools): guard managed daemon connection lifecycle

### DIFF
--- a/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
+++ b/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
@@ -406,6 +406,7 @@ export class ManagedGsdBrowserConnectionPool {
   private readonly connect: ConnectManagedGsdBrowser;
   private readonly closeConnection: CloseManagedGsdBrowserConnection;
   private generation = 0;
+  private closing = false;
 
   constructor(
     connect: ConnectManagedGsdBrowser,
@@ -427,6 +428,10 @@ export class ManagedGsdBrowserConnectionPool {
     launch: GsdBrowserMcpLaunchConfig,
     signal?: AbortSignal,
   ): Promise<ManagedConnection> {
+    if (this.closing) {
+      return Promise.reject(new Error("gsd-browser connection pool is closing"));
+    }
+
     const key = buildConnectionKey(launch);
     const existing = this.connections.get(key);
     if (existing) return Promise.resolve(existing);
@@ -439,7 +444,7 @@ export class ManagedGsdBrowserConnectionPool {
     const connectionSignal = combineAbortSignals(abortController.signal, signal);
     const connectionPromise = this.connect(launch, connectionSignal)
       .then(async (connection) => {
-        if (this.generation !== generation) {
+        if (this.closing || this.generation !== generation) {
           await this.closeConnection(connection);
           throw new Error("gsd-browser connection closed during startup");
         }
@@ -457,6 +462,7 @@ export class ManagedGsdBrowserConnectionPool {
   }
 
   async closeAll(): Promise<void> {
+    this.closing = true;
     this.generation += 1;
 
     const activeConnections = Array.from(this.connections.values());
@@ -477,7 +483,12 @@ export class ManagedGsdBrowserConnectionPool {
       }
     });
 
-    await Promise.allSettled([...closingActive, ...closingPending]);
+    try {
+      await Promise.allSettled([...closingActive, ...closingPending]);
+    } finally {
+      this.closing = false;
+      this.generation += 1;
+    }
   }
 }
 

--- a/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
+++ b/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
@@ -32,6 +32,13 @@ interface ManagedConnection {
   launch: GsdBrowserMcpLaunchConfig;
 }
 
+type ConnectManagedGsdBrowser = (
+  launch: GsdBrowserMcpLaunchConfig,
+  signal?: AbortSignal,
+) => Promise<ManagedConnection>;
+
+type CloseManagedGsdBrowserConnection = (connection: ManagedConnection) => Promise<void>;
+
 interface McpContentItem {
   type: string;
   text?: string;
@@ -69,8 +76,6 @@ interface ManagedBrowserToolSpec {
   compatibility?: { producesImages?: boolean };
 }
 
-const connections = new Map<string, ManagedConnection>();
-const pendingConnections = new Map<string, Promise<ManagedConnection>>();
 const DEFAULT_MAX_LINES = 2_000;
 const DEFAULT_MAX_BYTES = 50 * 1024;
 const MCP_CALL_TIMEOUT_MS = 60_000;
@@ -368,6 +373,82 @@ function buildConnectionKey(launch: GsdBrowserMcpLaunchConfig): string {
   });
 }
 
+export class ManagedGsdBrowserConnectionPool {
+  private readonly connections = new Map<string, ManagedConnection>();
+  private readonly pendingConnections = new Map<string, Promise<ManagedConnection>>();
+  private readonly connect: ConnectManagedGsdBrowser;
+  private readonly closeConnection: CloseManagedGsdBrowserConnection;
+  private generation = 0;
+
+  constructor(
+    connect: ConnectManagedGsdBrowser,
+    closeConnection: CloseManagedGsdBrowserConnection,
+  ) {
+    this.connect = connect;
+    this.closeConnection = closeConnection;
+  }
+
+  get activeCount(): number {
+    return this.connections.size;
+  }
+
+  get pendingCount(): number {
+    return this.pendingConnections.size;
+  }
+
+  getOrConnect(
+    launch: GsdBrowserMcpLaunchConfig,
+    signal?: AbortSignal,
+  ): Promise<ManagedConnection> {
+    const key = buildConnectionKey(launch);
+    const existing = this.connections.get(key);
+    if (existing) return Promise.resolve(existing);
+
+    const pending = this.pendingConnections.get(key);
+    if (pending) return pending;
+
+    const generation = this.generation;
+    const connectionPromise = this.connect(launch, signal)
+      .then(async (connection) => {
+        if (this.generation !== generation) {
+          await this.closeConnection(connection);
+          throw new Error("gsd-browser connection closed during startup");
+        }
+        this.connections.set(key, connection);
+        return connection;
+      })
+      .finally(() => {
+        if (this.pendingConnections.get(key) === connectionPromise) {
+          this.pendingConnections.delete(key);
+        }
+      });
+
+    this.pendingConnections.set(key, connectionPromise);
+    return connectionPromise;
+  }
+
+  async closeAll(): Promise<void> {
+    this.generation += 1;
+
+    const activeConnections = Array.from(this.connections.values());
+    const pendingConnections = Array.from(this.pendingConnections.values());
+    this.connections.clear();
+    this.pendingConnections.clear();
+
+    const closingActive = activeConnections.map((connection) => this.closeConnection(connection));
+    const closingPending = pendingConnections.map(async (pending) => {
+      try {
+        const connection = await pending;
+        await this.closeConnection(connection);
+      } catch {
+        // Failed or invalidated connection attempts have already cleaned up.
+      }
+    });
+
+    await Promise.allSettled([...closingActive, ...closingPending]);
+  }
+}
+
 async function connectManagedGsdBrowser(
   launch: GsdBrowserMcpLaunchConfig,
   signal?: AbortSignal,
@@ -399,6 +480,24 @@ async function connectManagedGsdBrowser(
   }
 }
 
+async function closeManagedGsdBrowserConnection(connection: ManagedConnection): Promise<void> {
+  try {
+    await connection.client.close();
+  } catch {
+    // Best-effort cleanup.
+  }
+  try {
+    await connection.transport.close();
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+const connectionPool = new ManagedGsdBrowserConnectionPool(
+  connectManagedGsdBrowser,
+  closeManagedGsdBrowserConnection,
+);
+
 async function getOrConnectManagedGsdBrowser(
   ctx?: ExtensionContext,
   signal?: AbortSignal,
@@ -406,22 +505,7 @@ async function getOrConnectManagedGsdBrowser(
   const launch = resolveGsdBrowserMcpLaunchConfig(resolveProjectRoot(ctx), process.env, {
     sessionSuffix: resolveManagedSessionSuffix(ctx),
   });
-  const key = buildConnectionKey(launch);
-  const existing = connections.get(key);
-  if (existing) return existing;
-
-  const pending = pendingConnections.get(key);
-  if (pending) return pending;
-
-  const connectionPromise = connectManagedGsdBrowser(launch, signal);
-  pendingConnections.set(key, connectionPromise);
-  try {
-    const connection = await connectionPromise;
-    connections.set(key, connection);
-    return connection;
-  } finally {
-    pendingConnections.delete(key);
-  }
+  return connectionPool.getOrConnect(launch, signal);
 }
 
 function isUnknownMcpToolError(error: unknown): boolean {
@@ -743,21 +827,7 @@ export function registerManagedGsdBrowserTools(pi: ExtensionAPI): void {
 }
 
 export async function closeManagedGsdBrowser(): Promise<void> {
-  const closing = Array.from(connections.entries()).map(async ([key, connection]) => {
-    try {
-      await connection.client.close();
-    } catch {
-      // Best-effort cleanup.
-    }
-    try {
-      await connection.transport.close();
-    } catch {
-      // Best-effort cleanup.
-    }
-    connections.delete(key);
-  });
-  await Promise.allSettled(closing);
-  pendingConnections.clear();
+  await connectionPool.closeAll();
 }
 
 export async function _resetManagedGsdBrowserForTest(): Promise<void> {

--- a/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
+++ b/src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts
@@ -39,6 +39,11 @@ type ConnectManagedGsdBrowser = (
 
 type CloseManagedGsdBrowserConnection = (connection: ManagedConnection) => Promise<void>;
 
+interface PendingManagedConnection {
+  promise: Promise<ManagedConnection>;
+  abortController: AbortController;
+}
+
 interface McpContentItem {
   type: string;
   text?: string;
@@ -373,9 +378,31 @@ function buildConnectionKey(launch: GsdBrowserMcpLaunchConfig): string {
   });
 }
 
+function combineAbortSignals(
+  poolSignal: AbortSignal,
+  callerSignal?: AbortSignal,
+): AbortSignal {
+  if (!callerSignal) return poolSignal;
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any([poolSignal, callerSignal]);
+  }
+
+  const controller = new AbortController();
+  const abort = (): void => {
+    if (!controller.signal.aborted) controller.abort();
+  };
+  if (poolSignal.aborted || callerSignal.aborted) {
+    abort();
+  } else {
+    poolSignal.addEventListener("abort", abort, { once: true });
+    callerSignal.addEventListener("abort", abort, { once: true });
+  }
+  return controller.signal;
+}
+
 export class ManagedGsdBrowserConnectionPool {
   private readonly connections = new Map<string, ManagedConnection>();
-  private readonly pendingConnections = new Map<string, Promise<ManagedConnection>>();
+  private readonly pendingConnections = new Map<string, PendingManagedConnection>();
   private readonly connect: ConnectManagedGsdBrowser;
   private readonly closeConnection: CloseManagedGsdBrowserConnection;
   private generation = 0;
@@ -405,10 +432,12 @@ export class ManagedGsdBrowserConnectionPool {
     if (existing) return Promise.resolve(existing);
 
     const pending = this.pendingConnections.get(key);
-    if (pending) return pending;
+    if (pending) return pending.promise;
 
     const generation = this.generation;
-    const connectionPromise = this.connect(launch, signal)
+    const abortController = new AbortController();
+    const connectionSignal = combineAbortSignals(abortController.signal, signal);
+    const connectionPromise = this.connect(launch, connectionSignal)
       .then(async (connection) => {
         if (this.generation !== generation) {
           await this.closeConnection(connection);
@@ -418,12 +447,12 @@ export class ManagedGsdBrowserConnectionPool {
         return connection;
       })
       .finally(() => {
-        if (this.pendingConnections.get(key) === connectionPromise) {
+        if (this.pendingConnections.get(key)?.promise === connectionPromise) {
           this.pendingConnections.delete(key);
         }
       });
 
-    this.pendingConnections.set(key, connectionPromise);
+    this.pendingConnections.set(key, { promise: connectionPromise, abortController });
     return connectionPromise;
   }
 
@@ -434,11 +463,14 @@ export class ManagedGsdBrowserConnectionPool {
     const pendingConnections = Array.from(this.pendingConnections.values());
     this.connections.clear();
     this.pendingConnections.clear();
+    for (const pending of pendingConnections) {
+      pending.abortController.abort();
+    }
 
     const closingActive = activeConnections.map((connection) => this.closeConnection(connection));
     const closingPending = pendingConnections.map(async (pending) => {
       try {
-        const connection = await pending;
+        const connection = await pending.promise;
         await this.closeConnection(connection);
       } catch {
         // Failed or invalidated connection attempts have already cleaned up.

--- a/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
@@ -133,6 +133,36 @@ describe("ManagedGsdBrowserConnectionPool", () => {
     assert.equal(pool.activeCount, 0);
     assert.equal(pool.pendingCount, 0);
   });
+
+  it("rejects new connection attempts started while the pool is closing", async () => {
+    let resolveConnect;
+    let connectCount = 0;
+    const pool = new ManagedGsdBrowserConnectionPool(async () => {
+      connectCount += 1;
+      return new Promise((resolve) => {
+        resolveConnect = resolve;
+      });
+    }, async () => {});
+
+    const pending = pool.getOrConnect(makeLaunchConfig());
+    const closedPool = pool.closeAll();
+
+    // A caller that arrives during the in-flight closeAll must not open a new
+    // connection that could survive shutdown.
+    await assert.rejects(
+      pool.getOrConnect(makeLaunchConfig()),
+      /closing/,
+      "getOrConnect must reject while the pool is closing",
+    );
+
+    resolveConnect({ id: "pending-connection" });
+    await assert.rejects(pending, /closed during startup/);
+    await closedPool;
+
+    assert.equal(connectCount, 1, "no second connection is started during shutdown");
+    assert.equal(pool.activeCount, 0);
+    assert.equal(pool.pendingCount, 0);
+  });
 });
 
 describe("contract tool translations", () => {

--- a/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 const {
   MANAGED_BROWSER_TOOL_SPECS,
   MANAGED_GSD_BROWSER_TOOL_NAMES,
+  ManagedGsdBrowserConnectionPool,
   findMissingContractCoverage,
   normalizeManagedArgs,
   registerManagedGsdBrowserTools,
@@ -69,6 +70,44 @@ describe("findMissingContractCoverage", () => {
   it("reports translated tools when a required MCP tool is missing", () => {
     const served = GSD_BROWSER_SERVED_TOOLS.filter((name) => name !== "browser_batch");
     assert.deepEqual(findMissingContractCoverage(served), ["browser_click", "browser_type", "browser_batch"]);
+  });
+});
+
+describe("ManagedGsdBrowserConnectionPool", () => {
+  it("closes a pending connection that resolves after the pool is closed", async () => {
+    const closed = [];
+    let resolveConnect;
+    const pool = new ManagedGsdBrowserConnectionPool(async () => {
+      return new Promise((resolve) => {
+        resolveConnect = resolve;
+      });
+    }, async (connection) => {
+      closed.push(connection.id);
+    });
+
+    const launch = {
+      command: "gsd-browser",
+      args: ["mcp"],
+      cwd: "/tmp/example-project",
+      projectRoot: "/tmp/example-project",
+      serverName: "gsd-browser",
+      sessionName: "test-session",
+    };
+
+    const pending = pool.getOrConnect(launch);
+    const closedPool = pool.closeAll();
+    resolveConnect({ id: "late-connection" });
+
+    await assert.rejects(
+      pending,
+      /closed during startup/,
+      "pending callers must not receive a reusable connection after close",
+    );
+    await closedPool;
+
+    assert.deepEqual(closed, ["late-connection"]);
+    assert.equal(pool.activeCount, 0);
+    assert.equal(pool.pendingCount, 0);
   });
 });
 

--- a/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs
@@ -30,6 +30,17 @@ const GSD_BROWSER_SERVED_TOOLS = [
   "browser_act",
 ];
 
+function makeLaunchConfig() {
+  return {
+    command: "gsd-browser",
+    args: ["mcp"],
+    cwd: "/tmp/example-project",
+    projectRoot: "/tmp/example-project",
+    serverName: "gsd-browser",
+    sessionName: "test-session",
+  };
+}
+
 describe("registerManagedGsdBrowserTools", () => {
   it("registers the curated Pi browser contract", () => {
     const tools = [];
@@ -85,14 +96,7 @@ describe("ManagedGsdBrowserConnectionPool", () => {
       closed.push(connection.id);
     });
 
-    const launch = {
-      command: "gsd-browser",
-      args: ["mcp"],
-      cwd: "/tmp/example-project",
-      projectRoot: "/tmp/example-project",
-      serverName: "gsd-browser",
-      sessionName: "test-session",
-    };
+    const launch = makeLaunchConfig();
 
     const pending = pool.getOrConnect(launch);
     const closedPool = pool.closeAll();
@@ -106,6 +110,26 @@ describe("ManagedGsdBrowserConnectionPool", () => {
     await closedPool;
 
     assert.deepEqual(closed, ["late-connection"]);
+    assert.equal(pool.activeCount, 0);
+    assert.equal(pool.pendingCount, 0);
+  });
+
+  it("aborts pending connection attempts when the pool is closed", async () => {
+    let receivedSignal;
+    const pool = new ManagedGsdBrowserConnectionPool(async (_launch, signal) => {
+      receivedSignal = signal;
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("connect aborted")), { once: true });
+      });
+    }, async () => {});
+
+    const pending = pool.getOrConnect(makeLaunchConfig());
+    const closedPool = pool.closeAll();
+
+    await assert.rejects(pending, /connect aborted/);
+    await closedPool;
+
+    assert.equal(receivedSignal?.aborted, true);
     assert.equal(pool.activeCount, 0);
     assert.equal(pool.pendingCount, 0);
   });


### PR DESCRIPTION
## TL;DR

**What:** Guard the managed gsd-browser connection pool against late connection resolution and pending daemon starts during shutdown.
**Why:** A pending daemon connection can resolve or continue after the pool has already been closed, leaving lifecycle ownership ambiguous.
**How:** Track pool closure state, close late-resolving connections, abort pending start attempts on shutdown, and cover both races with focused browser-tools regression tests.

## What

This refactors the managed gsd-browser connection lifecycle in `src/resources/extensions/browser-tools/engine/managed-gsd-browser.ts` and adds test coverage in `src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs`.

The connection pool now treats shutdown as authoritative even when a pending connection promise resolves later. If the pool closes while connection creation is in flight, the resolved connection is immediately closed and not retained as the active pool connection. Pending connection attempts also receive an abort signal when the pool closes.

## Why

The managed browser daemon pool owns the daemon connection lifecycle. Before this change, a connection that resolved after `close()` could escape that lifecycle and remain open after the pool had been shut down. Pending start attempts also had no pool-owned cancellation path, creating confusing start/stop behavior and risking daemon lifecycle leaks across browser-tool sessions.

## How

The pool now tracks pending connections with their own abort controllers. Caller cancellation is combined with pool cancellation, and `closeAll()` aborts pending starts while still closing any late-resolving connection. Regression tests simulate both races: a connection resolving after shutdown and a connection attempt aborted by shutdown.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-timeout=10000 src/resources/extensions/browser-tools/tests/managed-gsd-browser-tools.test.mjs`
- `./node_modules/.bin/tsc --noEmit --project tsconfig.extensions.json`
- `git diff --check`

## Breaking changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes managed browser daemon connect/disconnect behavior during session teardown; incorrect pooling could leave MCP child processes running or break tool calls, but scope is limited to browser-tools lifecycle.
> 
> **Overview**
> **Replaces module-level connection maps with a `ManagedGsdBrowserConnectionPool`** that owns managed gsd-browser MCP client lifecycle. `getOrConnectManagedGsdBrowser` and `closeManagedGsdBrowser` now route through a single pool instance.
> 
> **Shutdown is authoritative during in-flight connects.** `closeAll()` sets a closing flag, bumps a generation counter, aborts pending starts (each pending attempt gets its own `AbortController`, merged with caller `AbortSignal` via `combineAbortSignals`), and closes active connections. If a connect finishes after close or after a generation change, the new connection is torn down immediately and callers get **"closed during startup"** instead of a pooled handle. New `getOrConnect` calls while closing reject with **"connection pool is closing"**.
> 
> **Adds focused regression tests** for late resolution after `closeAll`, abort of pending connects, and rejecting concurrent connect attempts during shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff28dc09351748f3c893ad006685edbc15f064d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->