### PR TITLE
fix(issue): Forensics Report — Projection Sync Ghost-SHA in gsd-pi

### DIFF
--- a/src/resources/extensions/gsd/compat/compat-marker.ts
+++ b/src/resources/extensions/gsd/compat/compat-marker.ts
@@ -148,6 +148,53 @@ export function writeCompatMarker(basePath: string, marker: CompatMarker): void 
   renameSync(tmp, path);
 }
 
+/**
+ * Remove projection entries whose backing file no longer exists on disk.
+ *
+ * gsd-pi never deletes marker entries on its own: both drift detectors skip
+ * files missing from disk (`if (!existsSync(abs)) continue;`) and the write-time
+ * flush only ever adds or refreshes entries. So when a phase directory is
+ * renamed or removed (e.g. `phases/29-new-milestone-m029/` →
+ * `phases/29-frontend-code-debt-cleanup/`), the old projection paths linger in
+ * `.compat.json` forever as phantom entries pointing at directories that no
+ * longer exist (#1257). They never reconcile, and `.compat.json` keeps drifting
+ * from disk reality so `git status` stops being a reliable proxy for "did the
+ * engine touch my plans?".
+ *
+ * This prunes those orphaned entries across the `.gsd/` projections and the
+ * `.planning/` projections/passthrough maps. It is safe: a missing-file entry is
+ * inert (every detector already ignores it), and if the file is later
+ * re-projected the write-time flush / unseeded-file detection re-seeds an
+ * accurate baseline.
+ *
+ * Returns the number of entries removed; when nothing is orphaned the marker is
+ * left untouched (no needless write, no `lastProjectedAt` churn).
+ */
+export function pruneOrphanedProjectionEntries(basePath: string): number {
+  if (!existsSync(compatMarkerPath(basePath))) return 0;
+
+  const marker = readCompatMarker(basePath);
+  let removed = 0;
+
+  const pruneMap = (map: Record<string, ProjectionEntry>, root: string): void => {
+    for (const relPath of Object.keys(map)) {
+      if (!existsSync(join(basePath, root, relPath))) {
+        delete map[relPath];
+        removed++;
+      }
+    }
+  };
+
+  pruneMap(marker.projections, ".gsd");
+  if (marker.planning) {
+    pruneMap(marker.planning.projections, ".planning");
+    pruneMap(marker.planning.passthrough, ".planning");
+  }
+
+  if (removed > 0) writeCompatMarker(basePath, marker);
+  return removed;
+}
+
 function quarantine(basePath: string, raw: string): void {
   const path = compatMarkerPath(basePath);
   const badPath = `${path}.bad-${Date.now()}`;

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -73,6 +73,20 @@ export async function reconcileBeforeDispatch(
   if (!deps.dryRun) {
     const { capturePlanningCompatIfNeeded } = await import("../compat/planning-compat.js");
     await capturePlanningCompatIfNeeded(basePath);
+
+    // Self-heal phantom projection entries (#1257): a renamed/removed phase
+    // directory leaves stale `.compat.json` projection paths that no detector
+    // ever prunes (they all skip missing files), so the marker drifts from disk
+    // reality permanently. Drop entries whose backing file is gone before the
+    // detect passes run. Gated on !dryRun to keep detection read-only.
+    const { pruneOrphanedProjectionEntries } = await import("../compat/compat-marker.js");
+    const prunedCount = pruneOrphanedProjectionEntries(basePath);
+    if (prunedCount > 0) {
+      logWarning(
+        "reconcile",
+        `pruned ${prunedCount} orphaned projection entr${prunedCount === 1 ? "y" : "ies"} from .compat.json (backing file no longer on disk)`,
+      );
+    }
   }
 
   for (let pass = 0; pass < MAX_PASSES; pass++) {

--- a/src/resources/extensions/gsd/tests/compat-marker.test.ts
+++ b/src/resources/extensions/gsd/tests/compat-marker.test.ts
@@ -12,6 +12,7 @@ import {
   writeCompatMarker,
   normalizeForHash,
   computeProjectionSha,
+  pruneOrphanedProjectionEntries,
   EMPTY_MARKER,
   compatMarkerPath,
 } from "../compat/compat-marker.ts";
@@ -102,4 +103,88 @@ test("computeProjectionSha is stable for cosmetically different but equivalent c
 test("compatMarkerPath resolves under .gsd", () => {
   const base = makeTmpBase();
   assert.equal(compatMarkerPath(base), join(base, ".gsd", ".compat.json"));
+});
+
+test("pruneOrphanedProjectionEntries drops entries whose backing file is gone (#1257)", () => {
+  const base = makeTmpBase();
+  // Live projection: file exists on disk.
+  const liveRel = "phases/29-frontend-code-debt-cleanup/29-ROADMAP.md";
+  mkdirSync(join(base, ".gsd", "phases", "29-frontend-code-debt-cleanup"), { recursive: true });
+  writeFileSync(join(base, ".gsd", liveRel), "# M029\n", "utf-8");
+  // Phantom projection: directory was renamed, file no longer exists.
+  const ghostRel = "phases/29-new-milestone-m029/29-ROADMAP.md";
+
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-07-05T05:35:19.379Z",
+    projections: {
+      [liveRel]: { sha: "live000000000000", entities: ["M029"] },
+      [ghostRel]: { sha: "ghost00000000000", entities: ["M029"] },
+    },
+    piVersion: "1.4.0",
+  });
+
+  const removed = pruneOrphanedProjectionEntries(base);
+  assert.equal(removed, 1);
+
+  const marker = readCompatMarker(base);
+  assert.ok(marker.projections[liveRel], "live projection must survive");
+  assert.equal(marker.projections[ghostRel], undefined, "phantom projection must be pruned");
+});
+
+test("pruneOrphanedProjectionEntries also prunes .planning projections/passthrough", () => {
+  const base = makeTmpBase();
+  mkdirSync(join(base, ".planning"), { recursive: true });
+  writeFileSync(join(base, ".planning", "ROADMAP.md"), "# roadmap\n", "utf-8");
+
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-07-05T05:35:19.379Z",
+    projections: {},
+    planning: {
+      active: true,
+      layout: "flat-phases",
+      projections: {
+        "ROADMAP.md": { sha: "live000000000000", entities: [] },
+        "gone/PLAN.md": { sha: "ghost00000000000", entities: [] },
+      },
+      passthrough: {
+        "gone/PATTERNS.md": { sha: "ghost11111111111", entities: [] },
+      },
+    },
+    piVersion: "1.4.0",
+  });
+
+  const removed = pruneOrphanedProjectionEntries(base);
+  assert.equal(removed, 2);
+
+  const marker = readCompatMarker(base);
+  assert.ok(marker.planning!.projections["ROADMAP.md"], "live planning projection must survive");
+  assert.equal(marker.planning!.projections["gone/PLAN.md"], undefined);
+  assert.equal(marker.planning!.passthrough["gone/PATTERNS.md"], undefined);
+});
+
+test("pruneOrphanedProjectionEntries is a no-op when nothing is orphaned", () => {
+  const base = makeTmpBase();
+  const rel = "phases/01-phase/01-01-PLAN.md";
+  mkdirSync(join(base, ".gsd", "phases", "01-phase"), { recursive: true });
+  writeFileSync(join(base, ".gsd", rel), "# plan\n", "utf-8");
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-07-05T05:35:19.379Z",
+    projections: { [rel]: { sha: "abc000000000000", entities: ["M001"] } },
+    piVersion: "1.4.0",
+  });
+
+  assert.equal(pruneOrphanedProjectionEntries(base), 0);
+});
+
+test("pruneOrphanedProjectionEntries returns 0 and writes nothing when marker is missing", () => {
+  const base = makeTmpBase();
+  assert.equal(pruneOrphanedProjectionEntries(base), 0);
+  const files = readdirSync(join(base, ".gsd"));
+  assert.ok(!files.includes(".compat.json"), "must not create a marker where none existed");
 });


### PR DESCRIPTION
## Summary
- Added `pruneOrphanedProjectionEntries` and wired it into pre-dispatch reconcile to drop phantom `.compat.json` projection entries whose backing files no longer exist after phase-directory renames; verified via new and existing compat-marker/reconciliation unit tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1257
- [#1257 Forensics Report — Projection Sync Ghost-SHA in gsd-pi](https://github.com/open-gsd/gsd-pi/issues/1257)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1257-forensics-report-projection-sync-ghost-s-1783255527`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted self-heal on compat marker metadata before reconcile; skips dry-run and only deletes entries for missing files, with unit test coverage.
> 
> **Overview**
> Fixes **ghost-SHA drift** in `.gsd/.compat.json` when phase directories are renamed or removed: stale projection paths used to linger forever because drift detectors skip missing files and never delete marker entries.
> 
> Adds **`pruneOrphanedProjectionEntries`**, which removes marker entries whose backing files are gone under `.gsd/` projections and `.planning/` projections/passthrough. It only rewrites the marker when something was removed (no-op otherwise).
> 
> **`reconcileBeforeDispatch`** runs this prune step after planning capture and before drift detection (skipped in `dryRun`), and logs a warning when entries are removed.
> 
> Unit tests cover `.gsd` phantoms, `.planning` maps, no-op cases, and missing-marker behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f577119d47b4a6b94abef0630a5e57b603ce071c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->