### PR TITLE
refactor(uok): harden kernel audit orchestration

### DIFF
--- a/src/resources/extensions/gsd/activity-log.ts
+++ b/src/resources/extensions/gsd/activity-log.ts
@@ -138,7 +138,7 @@ export function saveActivityLog(
     state.nextSeq += 1;
     state.lastSnapshotKeyByUnit.set(unitKey, key);
 
-    if (isUnifiedAuditEnabled()) {
+    if (isUnifiedAuditEnabled(basePath)) {
       emitUokAuditEvent(
         basePath,
         buildAuditEnvelope({

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -142,7 +142,7 @@ export function emitJournalEvent(basePath: string, entry: JournalEntry): void {
     // Silent failure — journal must never break auto-mode
   }
 
-  if (!isUnifiedAuditEnabled()) return;
+  if (!isUnifiedAuditEnabled(basePath)) return;
   try {
     const causedBy = entry.causedBy
       ? `${entry.causedBy.flowId}:${entry.causedBy.seq}`

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -265,7 +265,7 @@ export function snapshotUnitMetrics(
   }
   saveLedger(basePath, ledger);
 
-  if (isUnifiedAuditEnabled()) {
+  if (isUnifiedAuditEnabled(basePath)) {
     emitUokAuditEvent(
       basePath,
       buildAuditEnvelope({
@@ -458,7 +458,7 @@ export function snapshotUnitMetricsByScope(
   }
   saveLedger(base, scopedLedger);
 
-  if (isUnifiedAuditEnabled()) {
+  if (isUnifiedAuditEnabled(base)) {
     emitUokAuditEvent(
       base,
       buildAuditEnvelope({

--- a/src/resources/extensions/gsd/tests/uok-gate-runner.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gate-runner.test.ts
@@ -3,14 +3,20 @@ import assert from "node:assert/strict";
 
 import { closeDatabase, openDatabase, _getAdapter } from "../gsd-db.ts";
 import { UokGateRunner } from "../uok/gate-runner.ts";
+import {
+  clearUnifiedAuditOverrideForTests,
+  setUnifiedAuditEnabled,
+} from "../uok/audit-toggle.ts";
 
 test.beforeEach(() => {
+  setUnifiedAuditEnabled(true);
   closeDatabase();
   const ok = openDatabase(":memory:");
   assert.equal(ok, true);
 });
 
 test.afterEach(() => {
+  clearUnifiedAuditOverrideForTests();
   closeDatabase();
 });
 
@@ -67,6 +73,39 @@ test("uok gate runner returns manual-attention for unknown gate id", async () =>
 
   assert.equal(result.outcome, "manual-attention");
   assert.equal(result.failureClass, "unknown");
+});
+
+test("uok gate runner emits audit by default for standalone callers", async () => {
+  clearUnifiedAuditOverrideForTests();
+  const runner = new UokGateRunner();
+  await runner.run("standalone-missing-gate", {
+    basePath: process.cwd(),
+    traceId: "trace-standalone",
+    turnId: "turn-standalone",
+  });
+
+  const adapter = _getAdapter();
+  const rows = adapter?.prepare(
+    "SELECT type FROM audit_events WHERE trace_id = 'trace-standalone'",
+  ).all() ?? [];
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.["type"], "gate-run");
+});
+
+test("uok gate runner skips audit when unified audit is explicitly disabled", async () => {
+  setUnifiedAuditEnabled(false);
+  const runner = new UokGateRunner();
+  await runner.run("disabled-audit-missing-gate", {
+    basePath: process.cwd(),
+    traceId: "trace-disabled-audit",
+    turnId: "turn-disabled-audit",
+  });
+
+  const adapter = _getAdapter();
+  const rows = adapter?.prepare(
+    "SELECT type FROM audit_events WHERE trace_id = 'trace-disabled-audit'",
+  ).all() ?? [];
+  assert.equal(rows.length, 0);
 });
 
 // Regression tests for #4950

--- a/src/resources/extensions/gsd/tests/uok-kernel-path.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-kernel-path.test.ts
@@ -1,6 +1,5 @@
 // Project/App: gsd-pi
-// File Purpose: Verifies UOK kernel path selection, legacy fallback telemetry,
-// and that a failing telemetry-only audit emit never aborts orchestration.
+// File Purpose: Verifies UOK kernel path selection and legacy fallback telemetry.
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -15,7 +14,15 @@ import type { LoopDeps } from "../auto/loop-deps.ts";
 import { gsdRoot } from "../paths.ts";
 import type { GSDPreferences } from "../preferences.ts";
 import { getLegacyTelemetry, resetLegacyTelemetry } from "../legacy-telemetry.ts";
-import { closeDatabase, openDatabase, _getAdapter } from "../gsd-db.ts";
+import { _getAdapter, closeDatabase, openDatabase } from "../gsd-db.ts";
+import { UokGateRunner } from "../uok/gate-runner.ts";
+import { applyModelPolicyFilter } from "../uok/model-policy.ts";
+import {
+  clearUnifiedAuditOverrideForTests,
+  isUnifiedAuditEnabled,
+  setUnifiedAuditEnabled,
+} from "../uok/audit-toggle.ts";
+import { writeEscalationArtifact } from "../escalation.ts";
 import { peekLogs, _resetLogs } from "../workflow-logger.ts";
 
 function makeBasePath(): string {
@@ -107,7 +114,8 @@ test("runAutoLoopWithUok uses kernel path by default and records uok-kernel pari
     assert.ok(args.calls.kernelDeps);
     assert.notEqual(args.calls.kernelDeps, args.deps);
     assert.ok(args.calls.kernelDeps?.uokObserver);
-    assert.equal(process.env.GSD_UOK_AUDIT_UNIFIED, "0");
+    assert.equal(isUnifiedAuditEnabled(), true);
+    assert.equal(isUnifiedAuditEnabled(basePath), false);
 
     const events = readParityEvents(basePath);
     assert.equal(events.length, 2);
@@ -118,6 +126,37 @@ test("runAutoLoopWithUok uses kernel path by default and records uok-kernel pari
     assert.equal(events[1]?.status, "ok");
     assert.equal(getLegacyTelemetry()["legacy.uokFallbackUsed"], 0);
   } finally {
+    resetLegacyTelemetry();
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
+test("runAutoLoopWithUok keeps audit disabled for legacy-wrapper while restoring process override", async () => {
+  const basePath = makeBasePath();
+  clearUnifiedAuditOverrideForTests();
+  try {
+    resetLegacyTelemetry();
+    const args = makeArgs(basePath, {
+      uok: {
+        enabled: false,
+        audit_unified: { enabled: false },
+      },
+    });
+    await runAutoLoopWithUok(args);
+
+    assert.equal(args.calls.kernel, 0);
+    assert.equal(args.calls.legacy, 1);
+    assert.equal(isUnifiedAuditEnabled(), true);
+    assert.equal(isUnifiedAuditEnabled(basePath), false);
+
+    const events = readParityEvents(basePath);
+    assert.equal(events.length, 2);
+    assert.equal(events[0]?.path, "legacy-wrapper");
+    assert.equal(events[1]?.path, "legacy-wrapper");
+    assert.equal(events[1]?.status, "ok");
+    assert.equal(getLegacyTelemetry()["legacy.uokFallbackUsed"], 1);
+  } finally {
+    clearUnifiedAuditOverrideForTests();
     resetLegacyTelemetry();
     rmSync(basePath, { recursive: true, force: true });
   }
@@ -180,18 +219,12 @@ test("runAutoLoopWithUok respects GSD_UOK_FORCE_LEGACY emergency switch", async 
   }
 });
 
-test("runAutoLoopWithUok does not abort when the uok-kernel-enter audit emit fails (regression #1233)", async () => {
+test("runAutoLoopWithUok records error exit and restores previous audit override when kernel fails", async () => {
   const basePath = makeBasePath();
-  mkdirSync(join(basePath, ".gsd"), { recursive: true });
-  const previousAuditEnv = process.env.GSD_UOK_AUDIT_UNIFIED;
-  // Open a real DB so emitUokAuditEvent takes the authoritative write branch,
-  // then drop audit_events so that write throws — the on-disk analogue of a DB
-  // handle that is open but not writable, exactly the #1233 failure mode.
-  assert.equal(openDatabase(join(basePath, ".gsd", "gsd.db")), true, "DB must open for this scenario");
-  _getAdapter()!.exec("DROP TABLE audit_events");
+  clearUnifiedAuditOverrideForTests();
+  setUnifiedAuditEnabled(false);
   try {
     resetLegacyTelemetry();
-    _resetLogs();
     const args = makeArgs(basePath, {
       uok: {
         enabled: true,
@@ -199,36 +232,171 @@ test("runAutoLoopWithUok does not abort when the uok-kernel-enter audit emit fai
         gitops: { enabled: false },
       },
     });
+    args.runKernelLoop = async (_ctx, _pi, _s, loopDeps): Promise<void> => {
+      args.calls.kernel += 1;
+      args.calls.kernelDeps = loopDeps;
+      throw new Error("kernel exploded");
+    };
 
-    // Before the fix, the telemetry-only kernel-enter emit propagated the DB
-    // write error and aborted /gsd auto before the loop ever ran. It must now
-    // resolve and let orchestration proceed.
-    await runAutoLoopWithUok(args);
+    await assert.rejects(
+      () => runAutoLoopWithUok(args),
+      /kernel exploded/,
+    );
 
-    assert.equal(args.calls.kernel, 1, "kernel loop must still run after a failed audit emit");
+    assert.equal(args.calls.kernel, 1);
     assert.equal(args.calls.legacy, 0);
+    assert.equal(isUnifiedAuditEnabled(), false);
 
-    // A clean enter + exit parity pair proves the loop ran to completion.
     const events = readParityEvents(basePath);
     assert.equal(events.length, 2);
     assert.equal(events[0]?.phase, "enter");
     assert.equal(events[1]?.phase, "exit");
-    assert.equal(events[1]?.status, "ok");
-
-    // The failure must be recorded as a non-fatal warning, not silently lost.
-    const warned = peekLogs().some(
-      (e) =>
-        e.severity === "warn" &&
-        e.component === "db" &&
-        /uok-kernel-enter audit emit failed/u.test(e.message),
-    );
-    assert.ok(warned, "a non-fatal db warning must be recorded for the failed audit emit");
+    assert.equal(events[1]?.status, "error");
+    assert.match(String(events[1]?.error), /kernel exploded/);
   } finally {
-    closeDatabase();
-    _resetLogs();
+    clearUnifiedAuditOverrideForTests();
     resetLegacyTelemetry();
-    if (previousAuditEnv === undefined) delete process.env.GSD_UOK_AUDIT_UNIFIED;
-    else process.env.GSD_UOK_AUDIT_UNIFIED = previousAuditEnv;
     rmSync(basePath, { recursive: true, force: true });
   }
+});
+
+test("runAutoLoopWithUok treats kernel-enter audit failures as telemetry-only", async (t) => {
+  const basePath = makeBasePath();
+  const dbPath = join(basePath, ".gsd", "gsd.db");
+  clearUnifiedAuditOverrideForTests();
+  _resetLogs();
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+  assert.equal(openDatabase(dbPath), true, "DB must open for this scenario");
+  t.after(() => {
+    clearUnifiedAuditOverrideForTests();
+    closeDatabase();
+    _resetLogs();
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  _getAdapter()!.exec("DROP TABLE audit_events");
+
+  const args = makeArgs(basePath, {
+    uok: {
+      enabled: true,
+      audit_unified: { enabled: true },
+      gitops: { enabled: false },
+    },
+  });
+  args.runKernelLoop = async (_ctx, _pi, _s, loopDeps): Promise<void> => {
+    args.calls.kernel += 1;
+    args.calls.kernelDeps = loopDeps;
+    const observer = loopDeps.uokObserver;
+    assert.ok(observer, "kernel path must still install a turn observer");
+    observer.onTurnStart({
+      basePath,
+      traceId: "trace-audit-down",
+      turnId: "turn-audit-down",
+      iteration: 1,
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      startedAt: new Date().toISOString(),
+    });
+    observer.onTurnResult({
+      traceId: "trace-audit-down",
+      turnId: "turn-audit-down",
+      iteration: 1,
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      status: "completed",
+      failureClass: "none",
+      phaseResults: [],
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    });
+
+    const gateRunner = new UokGateRunner();
+    gateRunner.register({
+      id: "test-gate",
+      type: "policy",
+      execute: async () => ({
+        outcome: "pass",
+        failureClass: "none",
+        rationale: "ok",
+      }),
+    });
+    await gateRunner.run("test-gate", {
+      basePath,
+      traceId: "trace-audit-down",
+      turnId: "turn-audit-down",
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+    });
+
+    const filtered = applyModelPolicyFilter(
+      [{ id: "model-a", provider: "openai", api: "responses" }],
+      {
+        basePath,
+        traceId: "trace-audit-down",
+        turnId: "turn-audit-down",
+        unitType: "execute-task",
+      },
+    );
+    assert.equal(filtered.eligible.length, 1);
+
+    mkdirSync(join(basePath, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), {
+      recursive: true,
+    });
+    writeEscalationArtifact(basePath, {
+      version: 1,
+      taskId: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      question: "Choose a path",
+      options: [
+        { id: "a", label: "A", tradeoffs: "First path" },
+        { id: "b", label: "B", tradeoffs: "Second path" },
+      ],
+      recommendation: "a",
+      recommendationRationale: "Test recommendation",
+      continueWithDefault: false,
+      createdAt: new Date().toISOString(),
+    });
+  };
+
+  await runAutoLoopWithUok(args);
+
+  assert.equal(args.calls.kernel, 1);
+  assert.equal(args.calls.legacy, 0);
+
+  const events = readParityEvents(basePath);
+  assert.equal(events.length, 3);
+  assert.equal(events[0]?.phase, "enter");
+  assert.equal(events[1]?.phase, "telemetry-error");
+  assert.equal(events[1]?.telemetry, "uok-kernel-enter");
+  assert.equal(events[2]?.phase, "exit");
+  assert.equal(events[2]?.status, "ok");
+  assert.equal(isUnifiedAuditEnabled(), true);
+  assert.equal(isUnifiedAuditEnabled(basePath), false);
+  assert.ok(
+    peekLogs().some(entry =>
+      entry.severity === "warn" &&
+      entry.component === "db" &&
+      entry.message.includes("uok-kernel-enter audit emit failed"),
+    ),
+    "degraded audit path should emit a non-fatal warning",
+  );
+
+  assert.doesNotThrow(() => {
+    writeEscalationArtifact(basePath, {
+      version: 1,
+      taskId: "T02",
+      sliceId: "S01",
+      milestoneId: "M001",
+      question: "Continue?",
+      options: [
+        { id: "yes", label: "Yes", tradeoffs: "Continue" },
+        { id: "no", label: "No", tradeoffs: "Stop" },
+      ],
+      recommendation: "yes",
+      recommendationRationale: "Audit stayed disabled after degraded enter",
+      continueWithDefault: true,
+      createdAt: new Date().toISOString(),
+    });
+  });
 });

--- a/src/resources/extensions/gsd/tests/uok-model-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-model-policy.test.ts
@@ -12,8 +12,13 @@ import {
   registerToolCompatibility,
   resetToolCompatibilityRegistry,
 } from "@gsd/pi-coding-agent";
+import {
+  clearUnifiedAuditOverrideForTests,
+  setUnifiedAuditEnabled,
+} from "../uok/audit-toggle.ts";
 
 test.afterEach(() => {
+  clearUnifiedAuditOverrideForTests();
   resetToolCompatibilityRegistry();
 });
 
@@ -32,6 +37,7 @@ test("uok model policy builds requirement vectors from unit metadata", () => {
 test("uok model policy enforces provider/api/tool constraints and emits decision audit events", () => {
   const basePath = mkdtempSync(join(tmpdir(), "gsd-uok-model-policy-"));
   try {
+    setUnifiedAuditEnabled(true);
     mkdirSync(join(basePath, ".gsd"), { recursive: true });
     registerToolCompatibility("screenshot", { producesImages: true });
 

--- a/src/resources/extensions/gsd/uok/audit-toggle.ts
+++ b/src/resources/extensions/gsd/uok/audit-toggle.ts
@@ -1,9 +1,39 @@
 const AUDIT_ENV_KEY = "GSD_UOK_AUDIT_UNIFIED";
+const suppressedBasePaths = new Set<string>();
 
 export function setUnifiedAuditEnabled(enabled: boolean): void {
   process.env[AUDIT_ENV_KEY] = enabled ? "1" : "0";
 }
 
-export function isUnifiedAuditEnabled(): boolean {
-  return process.env[AUDIT_ENV_KEY] === "1";
+export function setUnifiedAuditSuppressedForBasePath(basePath: string, suppressed: boolean): void {
+  if (suppressed) {
+    suppressedBasePaths.add(basePath);
+    return;
+  }
+  suppressedBasePaths.delete(basePath);
+}
+
+export function isUnifiedAuditEnabled(basePath?: string): boolean {
+  if (basePath && suppressedBasePaths.has(basePath)) return false;
+  return process.env[AUDIT_ENV_KEY] !== "0";
+}
+
+export function getUnifiedAuditOverride(): boolean | undefined {
+  const raw = process.env[AUDIT_ENV_KEY];
+  if (raw === "0") return false;
+  if (raw === "1") return true;
+  return undefined;
+}
+
+export function restoreUnifiedAuditOverride(override: boolean | undefined): void {
+  if (override === undefined) {
+    delete process.env[AUDIT_ENV_KEY];
+    return;
+  }
+  setUnifiedAuditEnabled(override);
+}
+
+export function clearUnifiedAuditOverrideForTests(): void {
+  delete process.env[AUDIT_ENV_KEY];
+  suppressedBasePaths.clear();
 }

--- a/src/resources/extensions/gsd/uok/audit.ts
+++ b/src/resources/extensions/gsd/uok/audit.ts
@@ -9,6 +9,7 @@ import { withFileLockSync } from "../file-lock.js";
 import { gsdRoot } from "../paths.js";
 import { isDbAvailable, insertAuditEvent } from "../gsd-db.js";
 import { CURRENT_UOK_CONTRACT_VERSION, validateAuditEvent, type AuditEventEnvelope } from "./contracts.js";
+import { isUnifiedAuditEnabled } from "./audit-toggle.js";
 
 function auditLogPath(basePath: string): string {
   return join(gsdRoot(basePath), "audit", "events.jsonl");
@@ -42,6 +43,7 @@ export function buildAuditEnvelope(args: {
 export function emitUokAuditEvent(basePath: string, event: AuditEventEnvelope): void {
   // Drop writes from a turn superseded by timeout recovery / cancellation.
   if (isStaleWrite("uok-audit")) return;
+  if (!isUnifiedAuditEnabled(basePath)) return;
   const validation = validateAuditEvent(event);
   if (!validation.ok) {
     throw new Error(`Invalid UOK audit event: ${validation.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ")}`);

--- a/src/resources/extensions/gsd/uok/gate-runner.ts
+++ b/src/resources/extensions/gsd/uok/gate-runner.ts
@@ -1,6 +1,7 @@
 import type { FailureClass, GateResult } from "./contracts.js";
 import { insertGateRun } from "../gsd-db.js";
 import { buildAuditEnvelope, emitUokAuditEvent } from "./audit.js";
+import { isUnifiedAuditEnabled } from "./audit-toggle.js";
 
 export interface GateRunnerContext {
   basePath: string;
@@ -37,6 +38,29 @@ const RETRY_MATRIX: Record<FailureClass, number> = {
   "manual-attention": 0,
   unknown: 0,
 };
+
+function emitGateAuditIfEnabled(ctx: GateRunnerContext, result: GateResult): void {
+  if (!isUnifiedAuditEnabled(ctx.basePath)) return;
+
+  emitUokAuditEvent(
+    ctx.basePath,
+    buildAuditEnvelope({
+      traceId: ctx.traceId,
+      turnId: ctx.turnId,
+      category: "gate",
+      type: "gate-run",
+      payload: {
+        gateId: result.gateId,
+        gateType: result.gateType,
+        outcome: result.outcome,
+        failureClass: result.failureClass,
+        attempt: result.attempt,
+        maxAttempts: result.maxAttempts,
+        retryable: result.retryable,
+      },
+    }),
+  );
+}
 
 export class UokGateRunner {
   private readonly registry = new Map<string, GateExecutionInput>();
@@ -85,24 +109,7 @@ export class UokGateRunner {
         evaluatedAt: unknownResult.evaluatedAt,
       });
 
-      emitUokAuditEvent(
-        ctx.basePath,
-        buildAuditEnvelope({
-          traceId: ctx.traceId,
-          turnId: ctx.turnId,
-          category: "gate",
-          type: "gate-run",
-          payload: {
-            gateId: unknownResult.gateId,
-            gateType: unknownResult.gateType,
-            outcome: unknownResult.outcome,
-            failureClass: unknownResult.failureClass,
-            attempt: unknownResult.attempt,
-            maxAttempts: unknownResult.maxAttempts,
-            retryable: unknownResult.retryable,
-          },
-        }),
-      );
+      emitGateAuditIfEnabled(ctx, unknownResult);
 
       return unknownResult;
     }
@@ -170,24 +177,7 @@ export class UokGateRunner {
         evaluatedAt: final.evaluatedAt,
       });
 
-      emitUokAuditEvent(
-        ctx.basePath,
-        buildAuditEnvelope({
-          traceId: ctx.traceId,
-          turnId: ctx.turnId,
-          category: "gate",
-          type: "gate-run",
-          payload: {
-            gateId: final.gateId,
-            gateType: final.gateType,
-            outcome: final.outcome,
-            failureClass: final.failureClass,
-            attempt: final.attempt,
-            maxAttempts: final.maxAttempts,
-            retryable: final.retryable,
-          },
-        }),
-      );
+      emitGateAuditIfEnabled(ctx, final);
 
       if (!retryable) break;
     }

--- a/src/resources/extensions/gsd/uok/gitops.ts
+++ b/src/resources/extensions/gsd/uok/gitops.ts
@@ -1,6 +1,7 @@
 import { isDbAvailable, upsertTurnGitTransaction } from "../gsd-db.js";
 import type { TurnCloseoutRecord } from "./contracts.js";
 import { buildAuditEnvelope, emitUokAuditEvent } from "./audit.js";
+import { isUnifiedAuditEnabled } from "./audit-toggle.js";
 
 export type TurnGitStage = "turn-start" | "stage" | "checkpoint" | "publish" | "record";
 
@@ -34,24 +35,26 @@ export function writeTurnGitTransaction(args: GitTxArgs): void {
     updatedAt: new Date().toISOString(),
   });
 
-  emitUokAuditEvent(
-    args.basePath,
-    buildAuditEnvelope({
-      traceId: args.traceId,
-      turnId: args.turnId,
-      category: "gitops",
-      type: `turn-git-${args.stage}`,
-      payload: {
-        unitType: args.unitType,
-        unitId: args.unitId,
-        action: args.action,
-        push: args.push,
-        status: args.status,
-        error: args.error,
-        ...(args.metadata ?? {}),
-      },
-    }),
-  );
+  if (isUnifiedAuditEnabled(args.basePath)) {
+    emitUokAuditEvent(
+      args.basePath,
+      buildAuditEnvelope({
+        traceId: args.traceId,
+        turnId: args.turnId,
+        category: "gitops",
+        type: `turn-git-${args.stage}`,
+        payload: {
+          unitType: args.unitType,
+          unitId: args.unitId,
+          action: args.action,
+          push: args.push,
+          status: args.status,
+          error: args.error,
+          ...(args.metadata ?? {}),
+        },
+      }),
+    );
+  }
 }
 
 export function writeTurnCloseoutGitRecord(

--- a/src/resources/extensions/gsd/uok/kernel.ts
+++ b/src/resources/extensions/gsd/uok/kernel.ts
@@ -8,8 +8,13 @@ import type { AutoSession } from "../auto/session.js";
 import type { LoopDeps } from "../auto/loop-deps.js";
 import { gsdRoot } from "../paths.js";
 import { buildAuditEnvelope, emitUokAuditEvent } from "./audit.js";
-import { setUnifiedAuditEnabled } from "./audit-toggle.js";
-import { resolveUokFlags } from "./flags.js";
+import {
+  getUnifiedAuditOverride,
+  restoreUnifiedAuditOverride,
+  setUnifiedAuditEnabled,
+  setUnifiedAuditSuppressedForBasePath,
+} from "./audit-toggle.js";
+import { resolveUokFlags, type UokFlags } from "./flags.js";
 import { createTurnObserver } from "./loop-adapter.js";
 import { incrementLegacyTelemetry } from "../legacy-telemetry.js";
 import { logWarning } from "../workflow-logger.js";
@@ -46,90 +51,195 @@ function writeParityEvent(basePath: string, event: Record<string, unknown>): voi
   }
 }
 
+type UokKernelPathLabel = "uok-kernel" | "legacy-wrapper" | "legacy-fallback";
+
+interface UokKernelRunPlan {
+  flags: UokFlags;
+  pathLabel: UokKernelPathLabel;
+  traceId: string;
+  useKernel: boolean;
+}
+
 function resolveKernelPathLabel(
-  flags: ReturnType<typeof resolveUokFlags>,
-): "uok-kernel" | "legacy-wrapper" | "legacy-fallback" {
+  flags: UokFlags,
+): UokKernelPathLabel {
   if (flags.legacyFallback) return "legacy-fallback";
   return flags.enabled ? "uok-kernel" : "legacy-wrapper";
 }
 
-export async function runAutoLoopWithUok(args: RunAutoLoopWithUokArgs): Promise<void> {
-  const { ctx, pi, s, deps, runKernelLoop, runLegacyLoop } = args;
-  const prefs = deps.loadEffectiveGSDPreferences()?.preferences;
-  const flags = resolveUokFlags(prefs);
-  setUnifiedAuditEnabled(flags.auditUnified);
+function createUokKernelRunPlan(input: {
+  preferences: ReturnType<LoopDeps["loadEffectiveGSDPreferences"]> | undefined;
+  autoStartTime?: unknown;
+}): UokKernelRunPlan {
+  const flags = resolveUokFlags(input.preferences?.preferences);
   const pathLabel = resolveKernelPathLabel(flags);
-  if (pathLabel !== "uok-kernel") {
-    incrementLegacyTelemetry("legacy.uokFallbackUsed");
-  }
-
-  writeParityEvent(s.basePath, {
-    ts: new Date().toISOString(),
-    path: pathLabel,
+  return {
     flags,
-    phase: "enter",
-  });
+    pathLabel,
+    traceId: `session:${String(input.autoStartTime || Date.now())}`,
+    useKernel: flags.enabled,
+  };
+}
 
-  if (flags.auditUnified) {
-    try {
-      emitUokAuditEvent(
-        s.basePath,
-        buildAuditEnvelope({
-          traceId: `session:${String(s.autoStartTime || Date.now())}`,
-          category: "orchestration",
-          type: "uok-kernel-enter",
-          payload: {
-            flags,
-            sessionId: ctx.sessionManager?.getSessionId?.(),
-          },
-        }),
-      );
-    } catch (err) {
-      // Telemetry/observability must never abort orchestration. Matches the
-      // best-effort semantics of the parity event above and the JSONL sink
-      // inside emitUokAuditEvent.
-      logWarning(
-        "db",
-        `uok-kernel-enter audit emit failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }
+interface KernelAuditStateController {
+  apply(enabled: boolean): void;
+  restore(): void;
+}
 
-  const decoratedDeps: LoopDeps = flags.enabled
-    ? {
-        ...deps,
-        uokObserver: createTurnObserver({
-          basePath: s.basePath,
-          gitAction: flags.gitopsTurnAction,
-          gitPush: flags.gitopsTurnPush,
-          enableAudit: flags.auditUnified,
-          enableGitops: flags.gitops,
-        }),
-      }
-    : deps;
+function createKernelAuditStateController(basePath: string): KernelAuditStateController {
+  const previousAuditOverride = getUnifiedAuditOverride();
+  return {
+    apply(enabled): void {
+      setUnifiedAuditSuppressedForBasePath(basePath, !enabled);
+      setUnifiedAuditEnabled(enabled);
+    },
+    restore(): void {
+      restoreUnifiedAuditOverride(previousAuditOverride);
+    },
+  };
+}
+
+function emitKernelEnterAudit(input: {
+  basePath: string;
+  plan: UokKernelRunPlan;
+  sessionId?: string;
+}): boolean {
+  if (!input.plan.flags.auditUnified) return true;
 
   try {
-    if (flags.enabled) {
-      await runKernelLoop(ctx, pi, s, decoratedDeps);
-    } else {
-      await runLegacyLoop(ctx, pi, s, deps);
+    emitUokAuditEvent(
+      input.basePath,
+      buildAuditEnvelope({
+        traceId: input.plan.traceId,
+        category: "orchestration",
+        type: "uok-kernel-enter",
+        payload: {
+          flags: input.plan.flags,
+          sessionId: input.sessionId,
+        },
+      }),
+    );
+    return true;
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    writeParityEvent(input.basePath, {
+      ts: new Date().toISOString(),
+      path: input.plan.pathLabel,
+      flags: input.plan.flags,
+      phase: "telemetry-error",
+      telemetry: "uok-kernel-enter",
+      error: errorMessage,
+    });
+    logWarning("db", `uok-kernel-enter audit emit failed (non-fatal): ${errorMessage}`);
+    return false;
+  }
+}
+
+function decorateLoopDepsForKernel(input: {
+  deps: LoopDeps;
+  basePath: string;
+  plan: UokKernelRunPlan;
+  auditHealthy: boolean;
+}): LoopDeps {
+  if (!input.plan.useKernel) return input.deps;
+
+  return {
+    ...input.deps,
+    uokObserver: createTurnObserver({
+      basePath: input.basePath,
+      gitAction: input.plan.flags.gitopsTurnAction,
+      gitPush: input.plan.flags.gitopsTurnPush,
+      enableAudit: input.plan.flags.auditUnified && input.auditHealthy,
+      enableGitops: input.plan.flags.gitops,
+    }),
+  };
+}
+
+async function executeKernelRunPlan(input: {
+  plan: UokKernelRunPlan;
+  ctx: ExtensionContext;
+  pi: ExtensionAPI;
+  s: AutoSession;
+  deps: LoopDeps;
+  kernelDeps: LoopDeps;
+  runKernelLoop: RunAutoLoopWithUokArgs["runKernelLoop"];
+  runLegacyLoop: RunAutoLoopWithUokArgs["runLegacyLoop"];
+}): Promise<void> {
+  if (input.plan.useKernel) {
+    await input.runKernelLoop(input.ctx, input.pi, input.s, input.kernelDeps);
+    return;
+  }
+  await input.runLegacyLoop(input.ctx, input.pi, input.s, input.deps);
+}
+
+export async function runAutoLoopWithUok(args: RunAutoLoopWithUokArgs): Promise<void> {
+  const { ctx, pi, s, deps, runKernelLoop, runLegacyLoop } = args;
+  const auditState = createKernelAuditStateController(s.basePath);
+  let plan: UokKernelRunPlan | null = null;
+
+  try {
+    plan = createUokKernelRunPlan({
+      preferences: deps.loadEffectiveGSDPreferences(),
+      autoStartTime: s.autoStartTime,
+    });
+    auditState.apply(plan.flags.auditUnified);
+
+    if (plan.pathLabel !== "uok-kernel") {
+      incrementLegacyTelemetry("legacy.uokFallbackUsed");
     }
+
     writeParityEvent(s.basePath, {
       ts: new Date().toISOString(),
-      path: pathLabel,
-      flags,
+      path: plan.pathLabel,
+      flags: plan.flags,
+      phase: "enter",
+    });
+
+    const auditHealthy = emitKernelEnterAudit({
+      basePath: s.basePath,
+      plan,
+      sessionId: ctx.sessionManager?.getSessionId?.(),
+    });
+    auditState.apply(plan.flags.auditUnified && auditHealthy);
+
+    const kernelDeps = decorateLoopDepsForKernel({
+      deps,
+      basePath: s.basePath,
+      plan,
+      auditHealthy,
+    });
+
+    await executeKernelRunPlan({
+      plan,
+      ctx,
+      pi,
+      s,
+      deps,
+      kernelDeps,
+      runKernelLoop,
+      runLegacyLoop,
+    });
+
+    writeParityEvent(s.basePath, {
+      ts: new Date().toISOString(),
+      path: plan.pathLabel,
+      flags: plan.flags,
       phase: "exit",
       status: "ok",
     });
   } catch (err) {
-    writeParityEvent(s.basePath, {
-      ts: new Date().toISOString(),
-      path: pathLabel,
-      flags,
-      phase: "exit",
-      status: "error",
-      error: err instanceof Error ? err.message : String(err),
-    });
+    if (plan) {
+      writeParityEvent(s.basePath, {
+        ts: new Date().toISOString(),
+        path: plan.pathLabel,
+        flags: plan.flags,
+        phase: "exit",
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     throw err;
+  } finally {
+    auditState.restore();
   }
 }

--- a/src/resources/extensions/gsd/uok/model-policy.ts
+++ b/src/resources/extensions/gsd/uok/model-policy.ts
@@ -1,6 +1,7 @@
 import type { TaskMetadata } from "../complexity-classifier.js";
 import { computeTaskRequirements, filterToolsForProvider } from "../model-router.js";
 import { buildAuditEnvelope, emitUokAuditEvent } from "./audit.js";
+import { isUnifiedAuditEnabled } from "./audit-toggle.js";
 
 export interface ModelCandidate {
   id: string;
@@ -83,23 +84,25 @@ export function applyModelPolicyFilter<T extends ModelCandidate>(
     };
     decisions.push(decision);
 
-    emitUokAuditEvent(
-      options.basePath,
-      buildAuditEnvelope({
-        traceId: options.traceId,
-        turnId: options.turnId,
-        category: "model-policy",
-        type: allowed ? "model-policy-allow" : "model-policy-deny",
-        payload: {
-          modelId: model.id,
-          provider: model.provider,
-          api: model.api,
-          reason,
-          unitType: options.unitType,
-          requirements,
-        },
-      }),
-    );
+    if (isUnifiedAuditEnabled(options.basePath)) {
+      emitUokAuditEvent(
+        options.basePath,
+        buildAuditEnvelope({
+          traceId: options.traceId,
+          turnId: options.turnId,
+          category: "model-policy",
+          type: allowed ? "model-policy-allow" : "model-policy-deny",
+          payload: {
+            modelId: model.id,
+            provider: model.provider,
+            api: model.api,
+            reason,
+            unitType: options.unitType,
+            requirements,
+          },
+        }),
+      );
+    }
 
     if (allowed) eligible.push(model);
   }

--- a/src/resources/extensions/gsd/workflow-event-ledger.ts
+++ b/src/resources/extensions/gsd/workflow-event-ledger.ts
@@ -105,7 +105,7 @@ export function writeWorktreeEventLog(
 }
 
 function emitWorkflowEventAudit(basePath: string, event: WorkflowEvent): void {
-  if (!isUnifiedAuditEnabled()) return;
+  if (!isUnifiedAuditEnabled(basePath)) return;
   try {
     const normalized = normalizeWorkflowEventCommand(event.cmd) ?? "unknown";
     emitUokAuditEvent(

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -302,7 +302,7 @@ function _push(
     _buffer.shift();
   }
 
-  if (_auditBasePath && isUnifiedAuditEnabled()) {
+  if (_auditBasePath && isUnifiedAuditEnabled(_auditBasePath)) {
     try {
       emitUokAuditEvent(
         _auditBasePath,


### PR DESCRIPTION
## TL;DR

**What:** Refactors uOK kernel orchestration into an explicit run plan, audit-state controller, dependency decoration, and execution boundary.
**Why:** Kernel-enter audit failures should degrade to telemetry without aborting auto-mode or leaking audit state across workspaces.
**How:** Scope unified-audit suppression by workspace, preserve parity diagnostics, make audit degradation explicit, and add regression coverage around degraded audit flows.

## What

- Adds an explicit uOK kernel run plan for path selection, flags, and trace metadata.
- Encapsulates temporary unified-audit state changes so the prior override is restored after each run.
- Keeps `uok-kernel-enter` audit failures telemetry-only while disabling downstream unified-audit writes for the affected workspace.
- Updates uOK gate runner, model-policy, gitops, and workflow logging/audit adapters to respect explicit audit enablement.
- Expands uOK kernel tests around default kernel behavior, legacy fallback, error exits, and degraded audit flows.

## Why

The uOK kernel path should remain resilient when the authoritative audit sink is degraded. A failure writing the kernel-enter audit event must not abort `/gsd auto`, and any temporary audit suppression should be scoped to the current workspace instead of affecting unrelated work.

## How

The kernel wrapper now builds a single run plan, applies audit state through a controller, emits parity events for enter/error/exit, and decorates loop dependencies with an observer only when the kernel path is active. If the kernel-enter audit write fails, the wrapper records a parity `telemetry-error`, logs a non-fatal DB warning, suppresses downstream unified-audit writes for that base path, and still runs the kernel loop.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/uok-kernel-path.test.ts src/resources/extensions/gsd/tests/uok-audit.test.ts src/resources/extensions/gsd/tests/uok-audit-unified.test.ts src/resources/extensions/gsd/tests/uok-loop-adapter-writer.test.ts src/resources/extensions/gsd/tests/uok-gate-runner.test.ts src/resources/extensions/gsd/tests/uok-model-policy.test.ts src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts`
- `./node_modules/.bin/tsc --noEmit --project tsconfig.extensions.json`
- `git diff --check origin/main..HEAD`
- `GSD_LIVE_TESTS=1 GSD_SMOKE_BINARY="$(pwd)/dist/loader.js" node --experimental-strip-types tests/live-workflow/run.ts` — skipped because no provider credentials were present.

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785849820&installation_id=134682257&pr_number=1262&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1262&signature=bf0bfed33f0997343df5baaa0b3dc7f2524196fc831d67113403b7456ff86cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration and audit gating defaults (env no longer requires explicit `1` for enablement) and temporarily mutates process-level audit env during kernel runs; regressions could miss audit events or affect concurrent workspaces.
> 
> **Overview**
> **Unified audit** is now gated with an optional workspace `basePath`: per-path suppression can disable writes for one project without turning off audit globally, and `emitUokAuditEvent` no-op’s when audit is off for that path. Call sites (activity log, journal, metrics, gates, gitops, model policy, workflow ledger/logger) pass `basePath` into the toggle.
> 
> The **UOK kernel wrapper** is split into a run plan, an audit-state controller (apply preference, restore prior `GSD_UOK_AUDIT_UNIFIED` in `finally`), enter/exit parity events, and kernel-only loop-deps decoration. If **`uok-kernel-enter`** fails to persist, orchestration continues: a parity `telemetry-error` is recorded, a non-fatal DB warning is logged, and unified audit stays suppressed for that workspace for the rest of the run (observer audit gated on “healthy” enter).
> 
> **Tests** cover standalone gate audit defaults, explicit disable, legacy-wrapper audit scoping, kernel error exits with override restore, and the degraded-audit path (gates/model policy/escalation still run without further audit writes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72c410a4b07ec07bf62b1904993d428a26e04e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->