### PR TITLE
refactor(daemon): split orchestrator responsibilities

### DIFF
--- a/packages/daemon/src/orchestrator-agent.ts
+++ b/packages/daemon/src/orchestrator-agent.ts
@@ -1,0 +1,162 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import type {
+  MessageParam,
+  ContentBlockParam,
+  ToolResultBlockParam,
+  ToolUseBlock,
+  TextBlock,
+} from '@anthropic-ai/sdk/resources/messages/messages';
+import {
+  ORCHESTRATOR_TOOLS,
+  executeOrchestratorTool,
+  type OrchestratorToolContext,
+} from './orchestrator-tools.js';
+
+export interface OrchestratorAgentConfig {
+  model: string;
+  max_tokens: number;
+}
+
+const SYSTEM_PROMPT = `You are GSD Control — a concise, capable orchestrator for managing GSD (Git Ship Done) coding agent sessions via Discord.
+
+You have tools to list projects, start sessions, get status, stop sessions, and inspect session details. Use them to fulfill the user's requests.
+
+Response guidelines:
+- Be terse and direct. No filler, no performed enthusiasm.
+- When reporting status, use bullet points with project name, status, duration, and cost.
+- When starting a session, confirm with the project name and session ID.
+- When stopping a session, confirm which session was stopped.
+- If something fails, say what went wrong plainly.
+- Use Discord markdown formatting (bold, code blocks) for readability.
+- Never expose internal error stack traces to the user — summarize the issue.`;
+
+const MAX_HISTORY = 30;
+const MAX_TOOL_ITERATIONS = 10;
+
+function resolveAnthropicApiKey(): string {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'ANTHROPIC_API_KEY is required. Set it in your environment or run `gsd config`.',
+    );
+  }
+  return apiKey;
+}
+
+function isAuthError(message: string): boolean {
+  return (
+    message.includes('authentication') ||
+    message.includes('apiKey') ||
+    message.includes('authToken') ||
+    message.includes('401')
+  );
+}
+
+export class OrchestratorAgent {
+  private readonly config: OrchestratorAgentConfig;
+  private readonly toolContext: OrchestratorToolContext;
+  private client: Anthropic | null;
+  private history: MessageParam[] = [];
+
+  constructor(
+    config: OrchestratorAgentConfig,
+    toolContext: OrchestratorToolContext,
+    client?: Anthropic,
+  ) {
+    this.config = config;
+    this.toolContext = toolContext;
+    this.client = client ?? null;
+  }
+
+  async run(content: string): Promise<string> {
+    this.history.push({ role: 'user', content });
+
+    try {
+      const responseText = await this.runToolLoop();
+      this.history.push({ role: 'assistant', content: responseText });
+      return responseText;
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      if (isAuthError(errorMsg)) {
+        this.client = null;
+      }
+      this.history.push({ role: 'assistant', content: '[error — see logs]' });
+      throw err;
+    } finally {
+      this.trimHistory();
+    }
+  }
+
+  getHistory(): MessageParam[] {
+    return [...this.history];
+  }
+
+  stop(): void {
+    this.history = [];
+    this.client = null;
+  }
+
+  private async getClient(): Promise<Anthropic> {
+    if (this.client) return this.client;
+    const apiKey = resolveAnthropicApiKey();
+    const { default: AnthropicSDK } = await import('@anthropic-ai/sdk');
+    this.client = new AnthropicSDK({ apiKey });
+    return this.client;
+  }
+
+  private async runToolLoop(): Promise<string> {
+    const client = await this.getClient();
+    const { model, max_tokens } = this.config;
+
+    let loopMessages: MessageParam[] = [...this.history];
+
+    for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+      const response = await client.messages.create({
+        model,
+        max_tokens,
+        system: SYSTEM_PROMPT,
+        tools: ORCHESTRATOR_TOOLS,
+        messages: loopMessages,
+      });
+
+      if (response.stop_reason !== 'tool_use') {
+        const textBlocks = response.content.filter(
+          (b): b is TextBlock => b.type === 'text',
+        );
+        return textBlocks.map((b) => b.text).join('\n') || '(No response)';
+      }
+
+      const toolUseBlocks = response.content.filter(
+        (b): b is ToolUseBlock => b.type === 'tool_use',
+      );
+
+      const toolResults: ToolResultBlockParam[] = [];
+      for (const toolUse of toolUseBlocks) {
+        const result = await executeOrchestratorTool(
+          this.toolContext,
+          toolUse.name,
+          toolUse.input as Record<string, unknown>,
+        );
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: toolUse.id,
+          content: result,
+        });
+      }
+
+      loopMessages = [
+        ...loopMessages,
+        { role: 'assistant', content: response.content as ContentBlockParam[] },
+        { role: 'user', content: toolResults },
+      ];
+    }
+
+    return 'I hit the maximum number of tool iterations. Please try a simpler request.';
+  }
+
+  private trimHistory(): void {
+    while (this.history.length > MAX_HISTORY) {
+      this.history.splice(0, 2);
+    }
+  }
+}

--- a/packages/daemon/src/orchestrator-tools.ts
+++ b/packages/daemon/src/orchestrator-tools.ts
@@ -1,0 +1,177 @@
+import { z } from 'zod';
+import type { Tool } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { SessionManager } from './session-manager.js';
+import type { ProjectInfo, ManagedSession } from './types.js';
+import type { Logger } from './logger.js';
+
+export interface OrchestratorToolContext {
+  sessionManager: SessionManager;
+  scanProjects: () => Promise<ProjectInfo[]>;
+  logger: Logger;
+}
+
+export const ORCHESTRATOR_TOOLS: Tool[] = [
+  {
+    name: 'list_projects',
+    description: 'List all detected projects across configured scan roots. Returns project names, paths, and detected markers (git, node, gsd, etc.).',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'start_session',
+    description: 'Start a new GSD auto-mode session for a project. Provide the absolute project path. Optionally provide a command to run instead of the default "/gsd auto".',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        projectPath: { type: 'string', description: 'Absolute path to the project directory' },
+        command: { type: 'string', description: 'Optional command to send instead of "/gsd auto"' },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'get_status',
+    description: 'Get the current status of all active GSD sessions. Shows project name, status, duration, and cost for each.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'stop_session',
+    description: 'Stop a running GSD session. Provide a session ID or project name — fuzzy matching is used to find the session.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        identifier: { type: 'string', description: 'Session ID or project name to match' },
+      },
+      required: ['identifier'],
+    },
+  },
+  {
+    name: 'get_session_detail',
+    description: 'Get detailed information about a specific session including cost breakdown, recent events, pending blockers, and error state.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        sessionId: { type: 'string', description: 'The session ID to inspect' },
+      },
+      required: ['sessionId'],
+    },
+  },
+];
+
+const StartSessionInput = z.object({
+  projectPath: z.string(),
+  command: z.string().optional(),
+});
+
+const StopSessionInput = z.object({
+  identifier: z.string(),
+});
+
+const GetSessionDetailInput = z.object({
+  sessionId: z.string(),
+});
+
+export async function executeOrchestratorTool(
+  context: OrchestratorToolContext,
+  name: string,
+  input: Record<string, unknown>,
+): Promise<string> {
+  try {
+    switch (name) {
+      case 'list_projects':
+        return await listProjects(context);
+      case 'start_session':
+        return await startSession(context, input);
+      case 'get_status':
+        return getStatus(context);
+      case 'get_session_detail':
+        return getSessionDetail(context, input);
+      case 'stop_session':
+        return await stopSession(context, input);
+      default:
+        return `Unknown tool: ${name}`;
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    context.logger.error('tool execution error', { tool: name, error: msg });
+    return `Error: ${msg}`;
+  }
+}
+
+async function listProjects(context: OrchestratorToolContext): Promise<string> {
+  const projects = await context.scanProjects();
+  if (projects.length === 0) return 'No projects found.';
+  return JSON.stringify(
+    projects.map((p) => ({ name: p.name, path: p.path, markers: p.markers })),
+    null,
+    2,
+  );
+}
+
+async function startSession(
+  context: OrchestratorToolContext,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const parsed = StartSessionInput.parse(input);
+  const sessionId = await context.sessionManager.startSession({
+    projectDir: parsed.projectPath,
+    command: parsed.command,
+  });
+  return `Session started: ${sessionId} for ${parsed.projectPath}`;
+}
+
+function getStatus(context: OrchestratorToolContext): string {
+  const sessions = context.sessionManager.getAllSessions();
+  if (sessions.length === 0) return 'No active sessions.';
+
+  return sessions
+    .map((s: ManagedSession) => {
+      const durationMin = Math.floor((Date.now() - s.startTime) / 60_000);
+      const cost = s.cost.totalCost.toFixed(4);
+      return `• ${s.projectName} — ${s.status} (${durationMin}m, $${cost})`;
+    })
+    .join('\n');
+}
+
+async function stopSession(
+  context: OrchestratorToolContext,
+  input: Record<string, unknown>,
+): Promise<string> {
+  const parsed = StopSessionInput.parse(input);
+  const { identifier } = parsed;
+
+  const byId = context.sessionManager.getSession(identifier);
+  if (byId) {
+    await context.sessionManager.cancelSession(identifier);
+    return `Stopped session ${identifier} (${byId.projectName})`;
+  }
+
+  const normalizedIdentifier = identifier.toLowerCase();
+  const match = context.sessionManager.getAllSessions().find(
+    (s: ManagedSession) =>
+      s.projectName.toLowerCase().includes(normalizedIdentifier) ||
+      s.projectDir.toLowerCase().includes(normalizedIdentifier),
+  );
+  if (match) {
+    await context.sessionManager.cancelSession(match.sessionId);
+    return `Stopped session ${match.sessionId} (${match.projectName})`;
+  }
+
+  return `No session found matching "${identifier}"`;
+}
+
+function getSessionDetail(
+  context: OrchestratorToolContext,
+  input: Record<string, unknown>,
+): string {
+  const parsed = GetSessionDetailInput.parse(input);
+  const result = context.sessionManager.getResult(parsed.sessionId);
+  return JSON.stringify(result, null, 2);
+}

--- a/packages/daemon/src/orchestrator.test.ts
+++ b/packages/daemon/src/orchestrator.test.ts
@@ -297,8 +297,31 @@ describe('Orchestrator', () => {
 
       assert.equal(msg.sentMessages.length, 1);
       assert.equal(msg.sentMessages[0], 'Here are your projects');
-      // The tool was called (2 create calls: tool_use + end_turn)
       assert.equal(mockClient.createCallCount, 2);
+
+      const finalMessages = mockClient.lastCreateParams?.messages as Array<{ role: string; content: unknown }>;
+      const toolResultMessage = finalMessages.at(-1);
+      assert.equal(toolResultMessage?.role, 'user');
+
+      const toolResults = toolResultMessage?.content as Array<{
+        type: string;
+        tool_use_id: string;
+        content: string;
+      }>;
+      assert.equal(toolResults.length, 1);
+      assert.match(toolResults[0]!.tool_use_id, /^toolu_/);
+      assert.equal(toolResults[0]!.type, 'tool_result');
+      assert.equal(
+        toolResults[0]!.content,
+        JSON.stringify(
+          [
+            { name: 'alpha', path: '/home/user/alpha', markers: ['git', 'node', 'gsd'] },
+            { name: 'bravo', path: '/home/user/bravo', markers: ['git', 'rust'] },
+          ],
+          null,
+          2,
+        ),
+      );
     });
   });
 

--- a/packages/daemon/src/orchestrator.ts
+++ b/packages/daemon/src/orchestrator.ts
@@ -1,52 +1,17 @@
 /**
- * Orchestrator — LLM-powered agent for the #gsd-control Discord channel.
+ * Orchestrator — Discord-facing controller for the #gsd-control channel.
  *
- * Receives Discord messages, maintains conversation history, calls the
- * Anthropic messages API with 5 tool definitions (list_projects, start_session,
- * get_status, stop_session, get_session_detail), and sends the LLM's response
- * back to Discord.
- *
- * Uses the standard messages.create() tool-use loop (not betaZodTool helpers,
- * which don't exist in SDK v0.52). Zod schemas are used for input validation
- * at the tool execution layer.
+ * Receives Discord messages, filters them by channel/owner/bot guards, delegates
+ * valid user content to OrchestratorAgent, and sends the response back to Discord.
  */
 
 import type Anthropic from '@anthropic-ai/sdk';
-import type {
-  MessageParam,
-  ContentBlockParam,
-  ToolResultBlockParam,
-  ToolUseBlock,
-  TextBlock,
-} from '@anthropic-ai/sdk/resources/messages/messages';
+import type { MessageParam } from '@anthropic-ai/sdk/resources/messages/messages';
 import type { SessionManager } from './session-manager.js';
 import type { ChannelManager } from './channel-manager.js';
 import type { ProjectInfo } from './types.js';
 import type { Logger } from './logger.js';
-import {
-  ORCHESTRATOR_TOOLS,
-  executeOrchestratorTool,
-  type OrchestratorToolContext,
-} from './orchestrator-tools.js';
-
-// ---------------------------------------------------------------------------
-// API key resolution — requires ANTHROPIC_API_KEY env var
-// Anthropic OAuth removed per TOS compliance (see docs/user-docs/claude-code-auth-compliance.md)
-// ---------------------------------------------------------------------------
-
-function resolveAnthropicApiKey(): string {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      'ANTHROPIC_API_KEY is required. Set it in your environment or run `gsd config`.',
-    );
-  }
-  return apiKey;
-}
-
-// ---------------------------------------------------------------------------
-// Configuration
-// ---------------------------------------------------------------------------
+import { OrchestratorAgent } from './orchestrator-agent.js';
 
 export interface OrchestratorConfig {
   model: string;
@@ -63,79 +28,27 @@ export interface OrchestratorDeps {
   ownerId: string;
 }
 
-// ---------------------------------------------------------------------------
-// System Prompt
-// ---------------------------------------------------------------------------
-
-const SYSTEM_PROMPT = `You are GSD Control — a concise, capable orchestrator for managing GSD (Git Ship Done) coding agent sessions via Discord.
-
-You have tools to list projects, start sessions, get status, stop sessions, and inspect session details. Use them to fulfill the user's requests.
-
-Response guidelines:
-- Be terse and direct. No filler, no performed enthusiasm.
-- When reporting status, use bullet points with project name, status, duration, and cost.
-- When starting a session, confirm with the project name and session ID.
-- When stopping a session, confirm which session was stopped.
-- If something fails, say what went wrong plainly.
-- Use Discord markdown formatting (bold, code blocks) for readability.
-- Never expose internal error stack traces to the user — summarize the issue.`;
-
-// ---------------------------------------------------------------------------
-// Conversation History Cap
-// ---------------------------------------------------------------------------
-
-const MAX_HISTORY = 30;
-
-// ---------------------------------------------------------------------------
-// Orchestrator
-// ---------------------------------------------------------------------------
-
 export class Orchestrator {
   private readonly deps: OrchestratorDeps;
-  private readonly toolContext: OrchestratorToolContext;
-  private client: Anthropic | null;
-  private history: MessageParam[] = [];
+  private readonly agent: OrchestratorAgent;
 
-  /**
-   * @param deps - orchestrator dependencies (session manager, channel manager, etc.)
-   * @param client - optional Anthropic client for testability; if omitted, created from env
-   */
   constructor(deps: OrchestratorDeps, client?: Anthropic) {
     this.deps = deps;
-    this.toolContext = {
-      sessionManager: deps.sessionManager,
-      scanProjects: deps.scanProjects,
-      logger: deps.logger,
-    };
-    this.client = client ?? null;
+    this.agent = new OrchestratorAgent(
+      { model: deps.config.model, max_tokens: deps.config.max_tokens },
+      {
+        sessionManager: deps.sessionManager,
+        scanProjects: deps.scanProjects,
+        logger: deps.logger,
+      },
+      client,
+    );
   }
 
-  /**
-   * Lazily initialise the Anthropic client. Dynamic import handles K007 module resolution.
-   * Requires ANTHROPIC_API_KEY environment variable.
-   */
-  private async getClient(): Promise<Anthropic> {
-    if (this.client) return this.client;
-    const apiKey = resolveAnthropicApiKey();
-    const { default: AnthropicSDK } = await import('@anthropic-ai/sdk');
-    this.client = new AnthropicSDK({ apiKey });
-    return this.client;
-  }
-
-  /**
-   * Handle an incoming Discord message. Entry point called by the bot's
-   * message handler for every message in every channel.
-   *
-   * Guards: ignores bot messages, non-owner messages, and non-control-channel messages.
-   */
   async handleMessage(message: DiscordMessageLike): Promise<void> {
-    // Ignore bot messages
     if (message.author.bot) return;
-
-    // Ignore non-control-channel messages
     if (message.channelId !== this.deps.config.control_channel_id) return;
 
-    // Auth guard — only the owner can use the orchestrator
     if (message.author.id !== this.deps.ownerId) {
       this.deps.logger.debug('orchestrator auth rejected', { userId: message.author.id });
       return;
@@ -150,16 +63,10 @@ export class Orchestrator {
       contentLength: content.length,
     });
 
-    // Append user message to history
-    this.history.push({ role: 'user', content });
-
     try {
-      // Show typing indicator while processing
       await message.channel.sendTyping().catch(() => {});
 
-      const responseText = await this.runAgentLoop();
-
-      // Send response to Discord
+      const responseText = await this.agent.run(content);
       await message.channel.send(responseText);
 
       this.deps.logger.info('orchestrator response sent', {
@@ -169,18 +76,12 @@ export class Orchestrator {
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
 
-      // Invalidate cached client on auth errors so next call re-resolves OAuth token
-      if (errorMsg.includes('authentication') || errorMsg.includes('apiKey') || errorMsg.includes('authToken') || errorMsg.includes('401')) {
-        this.client = null;
-      }
-
       this.deps.logger.error('orchestrator error', {
         error: errorMsg,
         userId: message.author.id,
         channelId: message.channelId,
       });
 
-      // Send error feedback to Discord
       try {
         await message.channel.send('⚠️ Something went wrong processing your request.');
       } catch (sendErr) {
@@ -188,119 +89,18 @@ export class Orchestrator {
           error: sendErr instanceof Error ? sendErr.message : String(sendErr),
         });
       }
-
-      // Still append a synthetic assistant message so history stays paired
-      this.history.push({ role: 'assistant', content: '[error — see logs]' });
-    }
-
-    this.trimHistory();
-  }
-
-  /**
-   * Run the tool-use loop: call messages.create(), execute any tool calls,
-   * feed results back, repeat until the model produces a final text response.
-   */
-  private async runAgentLoop(): Promise<string> {
-    const client = await this.getClient();
-    const { model, max_tokens } = this.deps.config;
-
-    let loopMessages: MessageParam[] = [...this.history];
-    const maxIterations = 10; // safety valve
-
-    for (let i = 0; i < maxIterations; i++) {
-      const response = await client.messages.create({
-        model,
-        max_tokens,
-        system: SYSTEM_PROMPT,
-        tools: ORCHESTRATOR_TOOLS,
-        messages: loopMessages,
-      });
-
-      // If the model stopped for end_turn (no tool calls), extract text and return
-      if (response.stop_reason === 'end_turn' || response.stop_reason !== 'tool_use') {
-        const textBlocks = response.content.filter(
-          (b): b is TextBlock => b.type === 'text',
-        );
-        const finalText = textBlocks.map((b) => b.text).join('\n') || '(No response)';
-
-        // Append assistant message to conversation history
-        this.history.push({ role: 'assistant', content: finalText });
-
-        return finalText;
-      }
-
-      // Model wants to use tools — execute them all
-      const toolUseBlocks = response.content.filter(
-        (b): b is ToolUseBlock => b.type === 'tool_use',
-      );
-
-      // Build tool results
-      const toolResults: ToolResultBlockParam[] = [];
-      for (const toolUse of toolUseBlocks) {
-        const result = await executeOrchestratorTool(
-          this.toolContext,
-          toolUse.name,
-          toolUse.input as Record<string, unknown>,
-        );
-        toolResults.push({
-          type: 'tool_result',
-          tool_use_id: toolUse.id,
-          content: result,
-        });
-      }
-
-      // Append the assistant message (with tool_use blocks) and user tool_result message
-      loopMessages = [
-        ...loopMessages,
-        { role: 'assistant', content: response.content as ContentBlockParam[] },
-        { role: 'user', content: toolResults },
-      ];
-    }
-
-    // If we hit max iterations, return a fallback
-    return 'I hit the maximum number of tool iterations. Please try a simpler request.';
-  }
-
-
-  // ---------------------------------------------------------------------------
-  // History management
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Trim conversation history to MAX_HISTORY entries.
-   * Removes the oldest user+assistant pair from the front to keep pairs aligned.
-   */
-  private trimHistory(): void {
-    while (this.history.length > MAX_HISTORY) {
-      // Remove from front — two messages at a time to keep user/assistant pairs
-      this.history.splice(0, 2);
     }
   }
 
-  /**
-   * Return a copy of the conversation history (for debugging / observability).
-   */
   getHistory(): MessageParam[] {
-    return [...this.history];
+    return this.agent.getHistory();
   }
 
-  /**
-   * Stop the orchestrator — clears history and nulls client reference.
-   */
   stop(): void {
-    this.history = [];
-    this.client = null;
+    this.agent.stop();
   }
 }
 
-// ---------------------------------------------------------------------------
-// Discord message type (minimal interface for testability)
-// ---------------------------------------------------------------------------
-
-/**
- * Minimal Discord message interface — avoids importing discord.js directly,
- * making the orchestrator testable without full discord.js mocking.
- */
 export interface DiscordMessageLike {
   author: { id: string; bot: boolean };
   channelId: string;

--- a/packages/daemon/src/orchestrator.ts
+++ b/packages/daemon/src/orchestrator.ts
@@ -11,20 +11,23 @@
  * at the tool execution layer.
  */
 
-import { z } from 'zod';
 import type Anthropic from '@anthropic-ai/sdk';
 import type {
   MessageParam,
   ContentBlockParam,
-  Tool,
   ToolResultBlockParam,
   ToolUseBlock,
   TextBlock,
 } from '@anthropic-ai/sdk/resources/messages/messages';
 import type { SessionManager } from './session-manager.js';
 import type { ChannelManager } from './channel-manager.js';
-import type { ProjectInfo, ManagedSession } from './types.js';
+import type { ProjectInfo } from './types.js';
 import type { Logger } from './logger.js';
+import {
+  ORCHESTRATOR_TOOLS,
+  executeOrchestratorTool,
+  type OrchestratorToolContext,
+} from './orchestrator-tools.js';
 
 // ---------------------------------------------------------------------------
 // API key resolution — requires ANTHROPIC_API_KEY env var
@@ -78,82 +81,6 @@ Response guidelines:
 - Never expose internal error stack traces to the user — summarize the issue.`;
 
 // ---------------------------------------------------------------------------
-// Tool Definitions (Anthropic API format)
-// ---------------------------------------------------------------------------
-
-const TOOLS: Tool[] = [
-  {
-    name: 'list_projects',
-    description: 'List all detected projects across configured scan roots. Returns project names, paths, and detected markers (git, node, gsd, etc.).',
-    input_schema: {
-      type: 'object' as const,
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: 'start_session',
-    description: 'Start a new GSD auto-mode session for a project. Provide the absolute project path. Optionally provide a command to run instead of the default "/gsd auto".',
-    input_schema: {
-      type: 'object' as const,
-      properties: {
-        projectPath: { type: 'string', description: 'Absolute path to the project directory' },
-        command: { type: 'string', description: 'Optional command to send instead of "/gsd auto"' },
-      },
-      required: ['projectPath'],
-    },
-  },
-  {
-    name: 'get_status',
-    description: 'Get the current status of all active GSD sessions. Shows project name, status, duration, and cost for each.',
-    input_schema: {
-      type: 'object' as const,
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: 'stop_session',
-    description: 'Stop a running GSD session. Provide a session ID or project name — fuzzy matching is used to find the session.',
-    input_schema: {
-      type: 'object' as const,
-      properties: {
-        identifier: { type: 'string', description: 'Session ID or project name to match' },
-      },
-      required: ['identifier'],
-    },
-  },
-  {
-    name: 'get_session_detail',
-    description: 'Get detailed information about a specific session including cost breakdown, recent events, pending blockers, and error state.',
-    input_schema: {
-      type: 'object' as const,
-      properties: {
-        sessionId: { type: 'string', description: 'The session ID to inspect' },
-      },
-      required: ['sessionId'],
-    },
-  },
-];
-
-// ---------------------------------------------------------------------------
-// Zod schemas for tool input validation
-// ---------------------------------------------------------------------------
-
-const StartSessionInput = z.object({
-  projectPath: z.string(),
-  command: z.string().optional(),
-});
-
-const StopSessionInput = z.object({
-  identifier: z.string(),
-});
-
-const GetSessionDetailInput = z.object({
-  sessionId: z.string(),
-});
-
-// ---------------------------------------------------------------------------
 // Conversation History Cap
 // ---------------------------------------------------------------------------
 
@@ -165,6 +92,7 @@ const MAX_HISTORY = 30;
 
 export class Orchestrator {
   private readonly deps: OrchestratorDeps;
+  private readonly toolContext: OrchestratorToolContext;
   private client: Anthropic | null;
   private history: MessageParam[] = [];
 
@@ -174,6 +102,11 @@ export class Orchestrator {
    */
   constructor(deps: OrchestratorDeps, client?: Anthropic) {
     this.deps = deps;
+    this.toolContext = {
+      sessionManager: deps.sessionManager,
+      scanProjects: deps.scanProjects,
+      logger: deps.logger,
+    };
     this.client = client ?? null;
   }
 
@@ -279,7 +212,7 @@ export class Orchestrator {
         model,
         max_tokens,
         system: SYSTEM_PROMPT,
-        tools: TOOLS,
+        tools: ORCHESTRATOR_TOOLS,
         messages: loopMessages,
       });
 
@@ -304,7 +237,11 @@ export class Orchestrator {
       // Build tool results
       const toolResults: ToolResultBlockParam[] = [];
       for (const toolUse of toolUseBlocks) {
-        const result = await this.executeTool(toolUse.name, toolUse.input as Record<string, unknown>);
+        const result = await executeOrchestratorTool(
+          this.toolContext,
+          toolUse.name,
+          toolUse.input as Record<string, unknown>,
+        );
         toolResults.push({
           type: 'tool_result',
           tool_use_id: toolUse.id,
@@ -324,100 +261,6 @@ export class Orchestrator {
     return 'I hit the maximum number of tool iterations. Please try a simpler request.';
   }
 
-  /**
-   * Execute a single tool by name. Returns a string result for the LLM.
-   * All errors are caught and returned as error strings (the LLM can reason about them).
-   */
-  private async executeTool(name: string, input: Record<string, unknown>): Promise<string> {
-    try {
-      switch (name) {
-        case 'list_projects':
-          return await this.toolListProjects();
-        case 'start_session':
-          return await this.toolStartSession(input);
-        case 'get_status':
-          return this.toolGetStatus();
-        case 'get_session_detail':
-          return this.toolGetSessionDetail(input);
-        case 'stop_session':
-          return await this.toolStopSession(input);
-        default:
-          return `Unknown tool: ${name}`;
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.deps.logger.error('tool execution error', { tool: name, error: msg });
-      return `Error: ${msg}`;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Tool implementations
-  // ---------------------------------------------------------------------------
-
-  private async toolListProjects(): Promise<string> {
-    const projects = await this.deps.scanProjects();
-    if (projects.length === 0) return 'No projects found.';
-    return JSON.stringify(
-      projects.map((p) => ({ name: p.name, path: p.path, markers: p.markers })),
-      null,
-      2,
-    );
-  }
-
-  private async toolStartSession(input: Record<string, unknown>): Promise<string> {
-    const parsed = StartSessionInput.parse(input);
-    const sessionId = await this.deps.sessionManager.startSession({
-      projectDir: parsed.projectPath,
-      command: parsed.command,
-    });
-    return `Session started: ${sessionId} for ${parsed.projectPath}`;
-  }
-
-  private toolGetStatus(): string {
-    const sessions = this.deps.sessionManager.getAllSessions();
-    if (sessions.length === 0) return 'No active sessions.';
-
-    return sessions
-      .map((s: ManagedSession) => {
-        const durationMin = Math.floor((Date.now() - s.startTime) / 60_000);
-        const cost = s.cost.totalCost.toFixed(4);
-        return `• ${s.projectName} — ${s.status} (${durationMin}m, $${cost})`;
-      })
-      .join('\n');
-  }
-
-  private async toolStopSession(input: Record<string, unknown>): Promise<string> {
-    const parsed = StopSessionInput.parse(input);
-    const { identifier } = parsed;
-
-    // Try exact sessionId match first
-    const byId = this.deps.sessionManager.getSession(identifier);
-    if (byId) {
-      await this.deps.sessionManager.cancelSession(identifier);
-      return `Stopped session ${identifier} (${byId.projectName})`;
-    }
-
-    // Fuzzy match by project name
-    const all = this.deps.sessionManager.getAllSessions();
-    const match = all.find(
-      (s: ManagedSession) =>
-        s.projectName.toLowerCase().includes(identifier.toLowerCase()) ||
-        s.projectDir.toLowerCase().includes(identifier.toLowerCase()),
-    );
-    if (match) {
-      await this.deps.sessionManager.cancelSession(match.sessionId);
-      return `Stopped session ${match.sessionId} (${match.projectName})`;
-    }
-
-    return `No session found matching "${identifier}"`;
-  }
-
-  private toolGetSessionDetail(input: Record<string, unknown>): string {
-    const parsed = GetSessionDetailInput.parse(input);
-    const result = this.deps.sessionManager.getResult(parsed.sessionId);
-    return JSON.stringify(result, null, 2);
-  }
 
   // ---------------------------------------------------------------------------
   // History management


### PR DESCRIPTION
## TL;DR

**What:** Refactors the daemon Discord orchestrator into separate controller, agent loop, and tool-execution modules.
**Why:** The previous orchestrator mixed Discord routing, Anthropic tool-loop state, tool schemas, validation, and session operations in one file, making the architecture harder to reason about and test.
**How:** Extract tool definitions/execution into `orchestrator-tools.ts`, move Anthropic client/history/system-prompt/tool-loop ownership into `OrchestratorAgent`, and leave `Orchestrator` as the Discord-facing controller.

## What

- Adds `packages/daemon/src/orchestrator-tools.ts` for Anthropic tool definitions, Zod input validation, and tool execution.
- Adds `packages/daemon/src/orchestrator-agent.ts` for Anthropic client lifecycle, conversation history, system prompt, and the tool-use loop.
- Reduces `packages/daemon/src/orchestrator.ts` to message filtering, owner/channel guards, logging, typing indicator, response send, and error reply.
- Strengthens `packages/daemon/src/orchestrator.test.ts` to assert the actual tool-result payload is fed back into the model loop.

## Why

The daemon orchestrator had several responsibilities in one module. This change keeps behavior the same while making architectural boundaries explicit:

- Discord/controller concerns live in `Orchestrator`.
- LLM loop/history/client concerns live in `OrchestratorAgent`.
- Tool schema/validation/session operations live in `orchestrator-tools.ts`.

That split makes future changes easier to review without changing the public `Orchestrator` surface.

## How

The public `Orchestrator` constructor, `handleMessage`, `getHistory`, and `stop` behavior are preserved. Internally, `Orchestrator` constructs an `OrchestratorAgent` with the model config and a tool context. The agent owns the same history trimming, auth-error client invalidation, max tool-iteration fallback, and Anthropic messages loop as before. Tool execution still catches and returns tool errors as model-readable strings.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Validation

- `pnpm --filter @opengsd/daemon build`
- `node --test packages/daemon/dist/orchestrator.test.js`
- `pnpm --filter @opengsd/daemon test`
- Sabotage check: temporarily returned a fake tool result from the agent loop; the orchestrator test failed on the intended tool-result assertion, then passed after restore.
`no-mistakes axi run --intent ...` was attempted, but the local no-mistakes CLI returned `error: "no run started for \"codex/refactor-daemon-orchestrator\": no previous run for branch codex/refactor-daemon-orchestrator"`. Focused build/test gates above passed.

## Breaking changes

None.
