### PR TITLE
fix(issue): Post-unit hook gate ignores valid artifacts in .gsd/phases layout

### DIFF
--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -24,6 +24,7 @@ import { resolvePostUnitHooks, resolvePreDispatchHooks } from "./preferences.js"
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { parseUnitId } from "./unit-id.js";
+import { resolveMilestonePath } from "./paths.js";
 import { queryJournal, type JournalEntry } from "./journal.js";
 import { readUnitRuntimeRecord, type UnitRuntimePhase } from "./unit-runtime.js";
 import { extractFrontmatterVerdict } from "./verdict-parser.js";
@@ -32,13 +33,43 @@ import { extractFrontmatterVerdict } from "./verdict-parser.js";
 
 export function resolveHookArtifactPath(basePath: string, unitId: string, artifactName: string): string {
   const { milestone, slice, task } = parseUnitId(unitId);
+
+  // Prefer the active phase directory (flat-phase layout: .gsd/phases/<NN>-.../).
+  // Configured gate artifacts are canonical phase-level files (e.g.
+  // BROWSER-RUNTIME-EVIDENCE.md), so resolve the exact declared name first,
+  // then a task-prefixed variant for retry sentinels / rework briefs.
+  const candidates: string[] = [];
+  const phaseDir = resolveMilestonePath(basePath, milestone);
+  if (phaseDir) {
+    candidates.push(join(phaseDir, artifactName));
+    if (task !== undefined) {
+      candidates.push(join(phaseDir, `${task}-${artifactName}`));
+    }
+  }
+
+  // Legacy nested layout fallbacks (.gsd/milestones/<M>/slices/<S>/tasks/...).
+  const legacyBase = join(basePath, ".gsd", "milestones", milestone);
+  let legacyDefault: string;
   if (task !== undefined && slice !== undefined) {
-    return join(basePath, ".gsd", "milestones", milestone, "slices", slice, "tasks", `${task}-${artifactName}`);
+    legacyDefault = join(legacyBase, "slices", slice, "tasks", `${task}-${artifactName}`);
+    candidates.push(legacyDefault);
+    candidates.push(join(legacyBase, "slices", slice, "tasks", artifactName));
+    candidates.push(join(legacyBase, "slices", slice, artifactName));
+  } else if (slice !== undefined) {
+    legacyDefault = join(legacyBase, "slices", slice, artifactName);
+    candidates.push(legacyDefault);
+  } else {
+    legacyDefault = join(legacyBase, artifactName);
   }
-  if (slice !== undefined) {
-    return join(basePath, ".gsd", "milestones", milestone, "slices", slice, artifactName);
-  }
-  return join(basePath, ".gsd", "milestones", milestone, artifactName);
+  candidates.push(join(legacyBase, artifactName));
+
+  const existing = candidates.find((candidate) => existsSync(candidate));
+  if (existing) return existing;
+
+  // Nothing on disk yet: prefer the active phase path when the phase dir is
+  // known, otherwise fall back to the legacy default (preserves pre-flat-phase
+  // behavior for missing-artifact diagnostics).
+  return phaseDir ? join(phaseDir, artifactName) : legacyDefault;
 }
 
 // ─── Dispatch Rule Conversion ──────────────────────────────────────────────

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -22,7 +22,7 @@ import type {
 } from "./types.js";
 import { resolvePostUnitHooks, resolvePreDispatchHooks } from "./preferences.js";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { parseUnitId } from "./unit-id.js";
 import { resolveMilestonePath } from "./paths.js";
 import { queryJournal, type JournalEntry } from "./journal.js";
@@ -40,7 +40,9 @@ export function resolveHookArtifactPath(basePath: string, unitId: string, artifa
   // then a task-prefixed variant for retry sentinels / rework briefs.
   const candidates: string[] = [];
   const phaseDir = resolveMilestonePath(basePath, milestone);
-  if (phaseDir) {
+  const isFlatPhaseDir = phaseDir !== null
+    && !(dirname(phaseDir).endsWith("/milestones") || dirname(phaseDir).endsWith("\\milestones"));
+  if (isFlatPhaseDir) {
     candidates.push(join(phaseDir, artifactName));
     if (task !== undefined) {
       candidates.push(join(phaseDir, `${task}-${artifactName}`));
@@ -69,7 +71,7 @@ export function resolveHookArtifactPath(basePath: string, unitId: string, artifa
   // Nothing on disk yet: prefer the active phase path when the phase dir is
   // known, otherwise fall back to the legacy default (preserves pre-flat-phase
   // behavior for missing-artifact diagnostics).
-  return phaseDir ? join(phaseDir, artifactName) : legacyDefault;
+  return isFlatPhaseDir ? join(phaseDir!, artifactName) : legacyDefault;
 }
 
 // ─── Dispatch Rule Conversion ──────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/rule-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/rule-registry.test.ts
@@ -587,4 +587,54 @@ describe("resolveHookArtifactPath", () => {
       rmSync(tempGsdHome, { recursive: true, force: true });
     }
   });
+
+  test("legacy: nested task artifact wins over a milestone-root file of the same name", () => {
+    const originalGsdHome = process.env.GSD_HOME;
+    const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-legacy-root-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-hook-home-"));
+    try {
+      process.env.GSD_HOME = tempGsdHome;
+      const milestoneDir = join(projectRoot, ".gsd", "milestones", "M050");
+      const tasksDir = join(milestoneDir, "slices", "S02", "tasks");
+      mkdirSync(tasksDir, { recursive: true });
+      // The correct task-scoped artifact lives in the nested slices/tasks tree.
+      const nestedPath = join(tasksDir, "T01-REVIEW.md");
+      writeFileSync(nestedPath, "---\nverdict: pass\n---\n", "utf-8");
+      // A same-named decoy at the legacy milestone root must NOT win — before the
+      // fix, resolveMilestonePath returned the milestone root and it was probed
+      // ahead of the nested task path (#1264 Bugbot follow-up).
+      writeFileSync(join(milestoneDir, "REVIEW.md"), "---\nverdict: failed\n---\n", "utf-8");
+
+      const resolved = resolveHookArtifactPath(projectRoot, "M050/S02/T01", "REVIEW.md");
+      assert.equal(resolved, nestedPath, "task-scoped legacy path wins over the milestone-root file");
+    } finally {
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
+  });
+
+  test("legacy: missing-artifact fallback points at the nested task path, not the milestone root", () => {
+    const originalGsdHome = process.env.GSD_HOME;
+    const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-legacy-miss-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-hook-home-"));
+    try {
+      process.env.GSD_HOME = tempGsdHome;
+      const milestoneDir = join(projectRoot, ".gsd", "milestones", "M050");
+      mkdirSync(milestoneDir, { recursive: true });
+      // Content-bearing legacy milestone dir (a non-META file) so resolveMilestonePath
+      // returns it, but the requested gate artifact does not exist anywhere.
+      writeFileSync(join(milestoneDir, "M050-ROADMAP.md"), "# roadmap\n", "utf-8");
+
+      const resolved = resolveHookArtifactPath(projectRoot, "M050/S02/T01", "REVIEW.md");
+      const expected = join(milestoneDir, "slices", "S02", "tasks", "T01-REVIEW.md");
+      assert.equal(resolved, expected, "diagnostic fallback uses the nested task path for a legacy task-scoped unit");
+    } finally {
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/resources/extensions/gsd/tests/rule-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/rule-registry.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'node:assert/strict';
 import { test, describe, beforeEach } from "node:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { emitJournalEvent } from "../journal.ts";
@@ -542,5 +542,49 @@ describe("RuleRegistry", () => {
 
     assert.deepStrictEqual(result.action, "stop", "result is a stop action");
     assert.deepStrictEqual(result.matchedRule, "<no-match>", "matchedRule is '<no-match>' on fallback");
+  });
+});
+
+describe("resolveHookArtifactPath", () => {
+  test("resolves a phase-level artifact from the .gsd/phases layout", () => {
+    const originalGsdHome = process.env.GSD_HOME;
+    const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-phase-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-hook-home-"));
+    try {
+      process.env.GSD_HOME = tempGsdHome;
+      const phaseDir = join(realpathSync(projectRoot), ".gsd", "phases", "50-some-phase");
+      mkdirSync(phaseDir, { recursive: true });
+      const artifactPath = join(phaseDir, "BROWSER-RUNTIME-EVIDENCE.md");
+      writeFileSync(artifactPath, "---\nverdict: advisory\n---\n", "utf-8");
+
+      const resolved = resolveHookArtifactPath(projectRoot, "M050/S02/T01", "BROWSER-RUNTIME-EVIDENCE.md");
+      assert.equal(resolved, artifactPath, "resolves the canonical phase-level artifact");
+    } finally {
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to the legacy milestones/slices/tasks layout", () => {
+    const originalGsdHome = process.env.GSD_HOME;
+    const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-legacy-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-hook-home-"));
+    try {
+      process.env.GSD_HOME = tempGsdHome;
+      const tasksDir = join(projectRoot, ".gsd", "milestones", "M050", "slices", "S02", "tasks");
+      mkdirSync(tasksDir, { recursive: true });
+      const artifactPath = join(tasksDir, "T01-REVIEW.md");
+      writeFileSync(artifactPath, "---\nverdict: pass\n---\n", "utf-8");
+
+      const resolved = resolveHookArtifactPath(projectRoot, "M050/S02/T01", "REVIEW.md");
+      assert.equal(resolved, artifactPath, "resolves the task-prefixed legacy artifact");
+    } finally {
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Made `resolveHookArtifactPath` candidate-based so it finds phase-level gate artifacts in `.gsd/phases/<NN>-.../` before legacy `.gsd/milestones/...` paths; verified with two new regression tests and the existing hook test suites (all pass).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1264
- [#1264 Post-unit hook gate ignores valid artifacts in .gsd/phases layout](https://github.com/open-gsd/gsd-pi/issues/1264)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1264-post-unit-hook-gate-ignores-valid-artifa-1783262655`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized path-resolution change with explicit legacy fallbacks and new tests; no auth or data-handling impact.
> 
> **Overview**
> **`resolveHookArtifactPath`** no longer assumes only the legacy `.gsd/milestones/.../slices/.../tasks/` tree. It builds an ordered list of candidate paths, checks **flat-phase** directories under `.gsd/phases/<NN>-.../` first (canonical phase-level gate files like `BROWSER-RUNTIME-EVIDENCE.md`, plus optional `{task}-` prefixed names), then legacy slice/task variants, and returns the first path that exists on disk.
> 
> When nothing exists yet, it returns the phase-level path when a flat phase dir is known; otherwise it keeps the previous legacy default so missing-artifact diagnostics stay the same for older layouts.
> 
> Two regression tests cover the phases layout and legacy fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90dba397fc291eaa01c8d71b3f88aaee0b6c0c71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->