### PR TITLE
fix(issue): [Bug]: auto-start's DB gate only checks that the database opened, not that it is writable, so a read-only handle passes and fails minutes later with an opaque error

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -76,7 +76,7 @@ import { initRoutingHistory } from "./routing-history.js";
 import { restoreHookState, resetHookState, reconcileRestoredHookDispatch } from "./post-unit-hooks.js";
 import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactive.js";
 import { snapshotSkills } from "./skill-discovery.js";
-import { isDbAvailable, getMilestone, getAllMilestones, insertMilestone, updateMilestoneStatus } from "./gsd-db.js";
+import { isDbAvailable, probeDbWritable, getMilestone, getAllMilestones, insertMilestone, updateMilestoneStatus } from "./gsd-db.js";
 import {
   getWorkflowDatabaseStatus,
   openExistingWorkflowDatabase,
@@ -1788,6 +1788,23 @@ export async function bootstrapAutoSession(
         "error",
       );
       return releaseLockAndReturn();
+    }
+
+    // Gate: confirm the handle is actually writable, not just open. A
+    // schema-current DB does zero writes during open, so a read-only /
+    // DBMOVED handle otherwise passes the check above and only fails much
+    // later at the first authoritative write (the uok-kernel-enter audit)
+    // with an opaque "readonly database" error (#1234).
+    if (existsSync(gsdDbPath) && isDbAvailable()) {
+      const writable = probeDbWritable();
+      if (!writable.ok) {
+        const detail = writable.detail ? ` (${writable.detail})` : "";
+        ctx.ui.notify(
+          `SQLite database is not writable: ${gsdDbPath}.${detail} Check file/WAL permissions or reopen a stale handle before running auto-mode.`,
+          "error",
+        );
+        return releaseLockAndReturn();
+      }
     }
 
     // Initialize metrics

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -860,3 +860,39 @@ export function getDb(): DbAdapter {
 export function getDbOrNull(): DbAdapter | null {
   return currentDb;
 }
+
+export interface DbWritableProbeResult {
+  ok: boolean;
+  detail?: string;
+}
+
+/**
+ * Confirm the open handle can actually write, not just that it opened.
+ *
+ * A schema-current database performs zero writes during open, so a handle that
+ * opened successfully but is not writable (read-only file, WAL/SHM permission
+ * mismatch, or a stale/moved handle → SQLITE_READONLY_DBMOVED) otherwise passes
+ * the open-only availability check and only fails much later at the first real
+ * write. The probe forces a genuine page write by re-writing the current
+ * `PRAGMA user_version` value back inside an IMMEDIATE transaction: a bare
+ * `BEGIN IMMEDIATE; ROLLBACK` is not sufficient because a moved handle does not
+ * fail until a page is actually dirtied. The value is unchanged, so the probe
+ * is idempotent, and the transaction is rolled back so nothing persists.
+ */
+export function probeDbWritable(): DbWritableProbeResult {
+  const db = currentDb;
+  if (!db) return { ok: false, detail: "No database is open." };
+  try {
+    const row = db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined;
+    const current = typeof row?.user_version === "number" ? row.user_version : 0;
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      db.exec(`PRAGMA user_version = ${current}`);
+    } finally {
+      db.exec("ROLLBACK");
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, detail: (err as Error).message };
+  }
+}

--- a/src/resources/extensions/gsd/tests/db-writable-probe.test.ts
+++ b/src/resources/extensions/gsd/tests/db-writable-probe.test.ts
@@ -1,0 +1,66 @@
+// gsd-pi — DB writability probe regression tests (#1234).
+//
+// Auto-start's DB gate only checked that the provider opened, not that the
+// handle can actually write. A schema-current DB does zero writes during open,
+// so a read-only / DBMOVED handle passed the open-only check and failed much
+// later at the first authoritative write with an opaque "readonly database"
+// error. `probeDbWritable` forces a real page write so that failure class is
+// caught at the natural checkpoint.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openDatabase, closeDatabase, probeDbWritable, _getAdapter } from "../gsd-db.ts";
+import type { DbAdapter } from "../db-adapter.ts";
+
+function makeBase(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-db-writable-probe-"));
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  return dir;
+}
+
+test("probeDbWritable succeeds against a freshly opened writable database", () => {
+  const base = makeBase();
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  try {
+    assert.deepEqual(probeDbWritable(), { ok: true });
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("probeDbWritable reports not-ok with detail when no database is open", () => {
+  closeDatabase();
+  const result = probeDbWritable();
+  assert.equal(result.ok, false);
+  assert.match(result.detail ?? "", /No database is open/u);
+});
+
+test("probeDbWritable reports not-ok when the page write fails (simulating a read-only handle)", () => {
+  const base = makeBase();
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  const adapter = _getAdapter() as DbAdapter;
+  assert.ok(adapter);
+
+  // The read (prepare/get) still works; only the page-dirtying write throws,
+  // mirroring SQLITE_READONLY_DBMOVED which fails once a page is dirtied.
+  const origExec = adapter.exec.bind(adapter);
+  adapter.exec = (sql: string): void => {
+    if (sql.includes("user_version =")) throw new Error("attempt to write a readonly database");
+    return origExec(sql);
+  };
+
+  try {
+    const result = probeDbWritable();
+    assert.equal(result.ok, false);
+    assert.match(result.detail ?? "", /readonly database/u);
+  } finally {
+    adapter.exec = origExec;
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Added a page-writing `probeDbWritable()` and an auto-start gate that aborts with a clear "database is not writable" message when the DB opens read-only/moved; verified with new probe tests, the existing gate test, and a clean extensions typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1234
- [#1234 [Bug]: auto-start's DB gate only checks that the database opened, not that it is writable, so a read-only handle passes and fails minutes later with an opaque error](https://github.com/open-gsd/gsd-pi/issues/1234)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1234-bug-auto-start-s-db-gate-only-checks-tha-1783262666`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bootstrap-only guard with a rolled-back probe write; no change to normal DB write paths beyond the new startup check.
> 
> **Overview**
> Auto-start used to treat a successful DB open as enough to continue, but a schema-current database can open without writing anything—so read-only files, WAL permission problems, or stale **DBMOVED** handles still passed and only failed later with an opaque readonly error.
> 
> This PR adds **`probeDbWritable()`**, which rewrites the current `PRAGMA user_version` inside `BEGIN IMMEDIATE` and rolls back, forcing a real page write that catches those cases. **`bootstrapAutoSession`** now runs that probe after the existing open gate and aborts with a clear “database is not writable” message (including SQLite detail) instead of starting auto-mode. Regression tests cover writable DB, no open handle, and simulated read-only write failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1129b8a162749dbe4c4579408c1ab0c31aeb0157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->