### PR TITLE
fix(issue): [Bug]: auto-mode declares "All milestones complete" despite FAIL UAT, an undispatched artifact-driven UAT backfilled as PASS, and a no-artifact validate-milestone (M030 forensics)

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -308,12 +308,21 @@ export async function readUatGateVerdict(
       return null;
     }
 
-    const assessmentVerdict = extractVerdict(assessmentContent);
-    if (assessmentVerdict) {
-      return {
-        verdict: assessmentVerdict,
-        uatType: uatType ?? extractUatType(assessmentContent),
-      };
+    // Backfilled assessments (#1258) are placeholders created during milestone
+    // validation for completed slices that never produced a real UAT ASSESSMENT
+    // (e.g. artifact-driven UAT that was never dispatched). Their fabricated
+    // verdict must not be treated as a genuine UAT sign-off — otherwise "never
+    // checked" is silently read as "passed". Skip the placeholder and fall
+    // through to the authoritative run-uat DB row (which stays null unless a
+    // real UAT was actually recorded).
+    if (assessmentScope !== BACKFILL_ASSESSMENT_SCOPE) {
+      const assessmentVerdict = extractVerdict(assessmentContent);
+      if (assessmentVerdict) {
+        return {
+          verdict: assessmentVerdict,
+          uatType: uatType ?? extractUatType(assessmentContent),
+        };
+      }
     }
   }
 
@@ -489,17 +498,28 @@ function stripGsdPrefix(path: string): string {
   return path.startsWith(".gsd/") ? path.slice(".gsd/".length) : path;
 }
 
+// Scope marker for assessments fabricated by the milestone-validation backfill
+// (#1258). It keeps these placeholders distinguishable from genuine `run-uat`
+// sign-offs so `readUatGateVerdict` never mistakes "never checked" for "passed".
+const BACKFILL_ASSESSMENT_SCOPE = "backfill";
+
 function persistSliceAssessmentBackfill(
   assessmentRelPath: string,
   mid: string,
   sliceId: string,
   content: string,
+  fabricated: boolean,
 ): void {
   const artifactPath = stripGsdPrefix(assessmentRelPath);
   const existingAssessment =
     getAssessment(assessmentRelPath) ??
     getAssessment(artifactPath);
-  const scope = stringField(existingAssessment, "scope") ?? "run-uat";
+  // A newly fabricated placeholder is filed under a distinct scope; a pre-existing
+  // on-disk ASSESSMENT keeps its real scope (default `run-uat`) so genuine
+  // sign-offs are still honored.
+  const scope = fabricated
+    ? BACKFILL_ASSESSMENT_SCOPE
+    : stringField(existingAssessment, "scope") ?? "run-uat";
   const status = stringField(existingAssessment, "status") ??
     extractVerdict(content)?.toLowerCase() ??
     "unknown";
@@ -548,19 +568,25 @@ function backfillMissingAssessmentsFromSummaries(basePath: string, mid: string):
       "---",
       `sliceId: ${sliceId}`,
       "verdict: PASS",
+      // Distinguishing marker (#1258): this ASSESSMENT was fabricated to satisfy
+      // the per-slice artifact requirement, NOT produced by a real UAT run. It
+      // must not be read as a genuine UAT sign-off.
+      "backfilled: true",
+      "verified: false",
       `date: ${now}`,
       "---",
       "",
       `# Assessment — ${sliceId}`,
       "",
       "Auto-created during milestone validation because this completed slice had a SUMMARY but no ASSESSMENT artifact.",
+      "This is a placeholder: no UAT was executed for this slice, so its verdict is not an independent sign-off.",
       "No additional reassessment changes were detected in this backfill step.",
       "",
     ].join("\n") : readFileSync(assessmentPath, "utf-8");
 
     if (isDbAvailable()) {
       try {
-        persistSliceAssessmentBackfill(assessmentRelPath, mid, sliceId, content);
+        persistSliceAssessmentBackfill(assessmentRelPath, mid, sliceId, content, didCreateAssessment);
       } catch (err) {
         logWarning("dispatch", `failed to backfill assessment DB rows for ${mid}/${sliceId}: ${(err as Error).message}`);
       }

--- a/src/resources/extensions/gsd/tests/read-uat-gate-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/read-uat-gate-verdict.test.ts
@@ -160,6 +160,60 @@ describe('readUatGateVerdict — DB fallback for orphaned ASSESSMENT', () => {
     assert.equal(result, null, 'roadmap-scoped assessments must not satisfy the UAT gate');
   });
 
+  test('a backfilled assessment does NOT satisfy the UAT gate (#1258)', async () => {
+    // The milestone-validation backfill fabricates a `verdict: PASS` ASSESSMENT
+    // for completed slices that never produced a real UAT result (e.g.
+    // artifact-driven UAT that was never dispatched). Filed under scope
+    // 'backfill', that placeholder must never be read as a genuine UAT sign-off —
+    // otherwise "never checked" is silently treated as "passed". Even with the
+    // fabricated file present on disk, the gate must fall through to the
+    // authoritative run-uat row (absent here) and return null.
+    const file = canonicalAssessmentPath(basePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, RUNTIME_PASS_BODY);
+    insertAssessment({
+      path: `.gsd/milestones/${MID}/slices/${SLICE}/${SLICE}-ASSESSMENT.md`,
+      milestoneId: MID,
+      sliceId: SLICE,
+      status: 'pass',
+      scope: 'backfill',
+      fullContent: RUNTIME_PASS_BODY,
+    });
+
+    const result = await readUatGateVerdict(basePath, MID, SLICE);
+
+    assert.equal(result, null, 'backfilled assessments must not satisfy the UAT gate');
+  });
+
+  test('a genuine run-uat row still resolves even when a backfilled file exists (#1258)', async () => {
+    // If a real UAT was later recorded, its authoritative run-uat row must win
+    // over the fabricated placeholder rather than being masked by it.
+    const file = canonicalAssessmentPath(basePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, RUNTIME_PASS_BODY);
+    insertAssessment({
+      path: `.gsd/milestones/${MID}/slices/${SLICE}/${SLICE}-ASSESSMENT.md`,
+      milestoneId: MID,
+      sliceId: SLICE,
+      status: 'pass',
+      scope: 'backfill',
+      fullContent: RUNTIME_PASS_BODY,
+    });
+    insertAssessment({
+      path: `.gsd/phases/01-some-feature/01-01-ASSESSMENT.md`,
+      milestoneId: MID,
+      sliceId: SLICE,
+      status: 'pass',
+      scope: 'run-uat',
+      fullContent: RUNTIME_PASS_BODY,
+    });
+
+    const result = await readUatGateVerdict(basePath, MID, SLICE);
+
+    assert.ok(result, 'a genuine run-uat sign-off must resolve');
+    assert.equal(result!.verdict, 'pass');
+  });
+
   test('returns null when no assessment and no file exist (fallback does not hallucinate)', async () => {
     const result = await readUatGateVerdict(basePath, MID, SLICE);
     assert.equal(result, null);

--- a/src/resources/extensions/gsd/tests/skipped-validation-db-atomicity.test.ts
+++ b/src/resources/extensions/gsd/tests/skipped-validation-db-atomicity.test.ts
@@ -52,7 +52,12 @@ test("skipped validation dispatch persists the validation file and DB assessment
     const artifactPath = "milestones/M001/slices/S01/S01-ASSESSMENT.md";
     const assessmentPath = `.gsd/${artifactPath}`;
     assert.equal(getArtifact(artifactPath)?.artifact_type, "ASSESSMENT");
-    assert.equal(getAssessment(assessmentPath)?.scope, "run-uat");
+    // #1258: the per-slice ASSESSMENT fabricated by the pre-validation backfill
+    // is a placeholder (no UAT ever ran for this slice), so it is filed under the
+    // `backfill` scope — never `run-uat` — so `readUatGateVerdict` cannot mistake
+    // it for a genuine UAT sign-off. Its verdict body stays PASS to satisfy the
+    // MV02 artifact-existence requirement.
+    assert.equal(getAssessment(assessmentPath)?.scope, "backfill");
     assert.equal(getAssessment(assessmentPath)?.status, "pass");
     assert.equal(
       getLatestAssessmentByScope("M001", "milestone-validation")?.status,


### PR DESCRIPTION
## Summary
- Marked milestone-validation backfill ASSESSMENTs with a distinct `backfill` scope/frontmatter so `readUatGateVerdict` no longer reads fabricated placeholders as genuine UAT PASSes; verified with new and existing gate tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1258
- [#1258 [Bug]: auto-mode declares "All milestones complete" despite FAIL UAT, an undispatched artifact-driven UAT backfilled as PASS, and a no-artifact validate-milestone (M030 forensics)](https://github.com/open-gsd/gsd-pi/issues/1258)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1258-bug-auto-mode-declares-all-milestones-co-1783262653`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes UAT gate resolution used for milestone closeout and auto-mode progression; scope is narrow and covered by new gate tests, but incorrect scope handling could still block or allow closure incorrectly.
> 
> **Overview**
> Fixes auto-mode treating milestone-validation **fabricated** `verdict: PASS` ASSESSMENT files as real UAT sign-offs when a slice never ran UAT.
> 
> **`readUatGateVerdict`** now skips on-disk verdict parsing when the path-keyed assessment row has scope **`backfill`**, then continues to the existing **`run-uat`** DB lookup so “never checked” stays **null** instead of **pass**.
> 
> **`backfillMissingAssessmentsFromSummaries`** tags newly created placeholders with scope **`backfill`**, frontmatter **`backfilled: true`** / **`verified: false`**, and clearer placeholder copy; **`persistSliceAssessmentBackfill`** only applies the backfill scope when the file was newly fabricated so pre-existing genuine assessments keep **`run-uat`**.
> 
> Regression tests cover backfill rows not satisfying the gate and a real **`run-uat`** row still resolving when a backfill file exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346cc31385098677d66542cc5f6c2cee59fae74f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->