### PR TITLE
[codex] Refactor UAT dispatch discovery

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -79,6 +79,7 @@ import {
   buildGateEvaluatePrompt,
   buildParallelResearchSlicesPrompt,
   checkNeedsReassessment,
+  loadRoadmapCompletedSliceCandidates,
 } from "./auto-prompts.js";
 import { checkNeedsRunUat } from "./uat-dispatch.js";
 import { normalizeModelFieldConfig, resolveModelWithFallbacksForUnit, resolveThinkingLevelForUnit } from "./preferences-models.js";
@@ -795,7 +796,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
       registeredTools,
       sessionBaseUrl,
     }) => {
-      const needsRunUat = await checkNeedsRunUat(basePath, mid, prefs);
+      const needsRunUat = await checkNeedsRunUat(
+        basePath,
+        mid,
+        prefs,
+        await loadRoadmapCompletedSliceCandidates(basePath, mid),
+      );
       if (!needsRunUat) return null;
       const { sliceId, uatType } = needsRunUat;
 

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -79,8 +79,8 @@ import {
   buildGateEvaluatePrompt,
   buildParallelResearchSlicesPrompt,
   checkNeedsReassessment,
-  checkNeedsRunUat,
 } from "./auto-prompts.js";
+import { checkNeedsRunUat } from "./uat-dispatch.js";
 import { normalizeModelFieldConfig, resolveModelWithFallbacksForUnit, resolveThinkingLevelForUnit } from "./preferences-models.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { selectReactiveDispatchBatch } from "./uok/execution-graph.js";
@@ -795,7 +795,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       registeredTools,
       sessionBaseUrl,
     }) => {
-      const needsRunUat = await checkNeedsRunUat(basePath, mid, state, prefs);
+      const needsRunUat = await checkNeedsRunUat(basePath, mid, prefs);
       if (!needsRunUat) return null;
       const { sliceId, uatType } = needsRunUat;
 

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -61,7 +61,7 @@ import { buildSkillActivationBlock, buildSkillDiscoveryVars } from "./skill-acti
 import { findMilestoneIds } from "./milestone-ids.js";
 import { buildRunUatPresentationForType, RUN_UAT_TOOL_PRESENTATION_PLAN_ID } from "./tool-presentation-plan.js";
 import { classifyUatContentForRun } from "./uat-policy.js";
-import { checkNeedsRunUat as resolveNeedsRunUat } from "./uat-dispatch.js";
+import { checkNeedsRunUat as resolveNeedsRunUat, type UatDispatchCandidate } from "./uat-dispatch.js";
 import { buildWebAppUatGuidanceBlock } from "./web-app-uat.js";
 
 export { buildSkillActivationBlock, buildSkillDiscoveryVars };
@@ -1511,6 +1511,26 @@ export async function checkNeedsReassessment(
   return { sliceId: lastDone };
 }
 
+
+export function getRoadmapCompletedSliceCandidates(
+  roadmapContent: string,
+): UatDispatchCandidate[] {
+  return parseRoadmap(roadmapContent)
+    .slices.filter((slice) => slice.done)
+    .map((slice) => ({ sliceId: slice.id }))
+    .reverse();
+}
+
+
+export async function loadRoadmapCompletedSliceCandidates(
+  base: string,
+  mid: string,
+): Promise<UatDispatchCandidate[]> {
+  const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
+  const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
+  return roadmapContent ? getRoadmapCompletedSliceCandidates(roadmapContent) : [];
+}
+
 /**
  * Back-compat wrapper for callers that import UAT dispatch checks from the
  * prompt module. UAT dispatch architecture lives in `uat-dispatch.ts`; the
@@ -1521,7 +1541,13 @@ export async function checkNeedsRunUat(
   base: string, mid: string, state: GSDState, prefs: GSDPreferences | undefined,
 ): Promise<Awaited<ReturnType<typeof resolveNeedsRunUat>>> {
   void state;
-  return resolveNeedsRunUat(base, mid, prefs);
+
+  return resolveNeedsRunUat(
+    base,
+    mid,
+    prefs,
+    await loadRoadmapCompletedSliceCandidates(base, mid),
+  );
 }
 
 // ─── Prompt Builders ──────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -11,7 +11,7 @@
 
 import { loadFile, parseContinue, parseSummary, loadActiveOverrides, formatOverridesSection, parseTaskPlanFile } from "./files.js";
 import type { Override } from "./files.js";
-import { hasVerdict, extractVerdict } from "./verdict-parser.js";
+import { extractVerdict } from "./verdict-parser.js";
 import { loadPrompt, inlineTemplate } from "./prompt-loader.js";
 import {
   resolveMilestoneFile, resolveSliceFile, resolveSlicePath,
@@ -60,11 +60,8 @@ import { debugLog } from "./debug-logger.js";
 import { buildSkillActivationBlock, buildSkillDiscoveryVars } from "./skill-activation.js";
 import { findMilestoneIds } from "./milestone-ids.js";
 import { buildRunUatPresentationForType, RUN_UAT_TOOL_PRESENTATION_PLAN_ID } from "./tool-presentation-plan.js";
-import {
-  classifyUatContentForRun,
-  shouldDispatchUatForContent,
-  type UatType,
-} from "./uat-policy.js";
+import { classifyUatContentForRun } from "./uat-policy.js";
+import { checkNeedsRunUat as resolveNeedsRunUat } from "./uat-dispatch.js";
 import { buildWebAppUatGuidanceBlock } from "./web-app-uat.js";
 
 export { buildSkillActivationBlock, buildSkillDiscoveryVars };
@@ -1515,115 +1512,16 @@ export async function checkNeedsReassessment(
 }
 
 /**
- * Check if the most recently completed slice needs a UAT run.
- * Returns { sliceId, uatType } if UAT should be dispatched, null otherwise.
- *
- * Skips when:
- * - No roadmap or no completed slices
- * - uat_dispatch is not enabled and the UAT spec does not require runtime/browser evidence
- * - No UAT file exists for the slice
- * - UAT result file already exists (idempotent — already ran)
+ * Back-compat wrapper for callers that import UAT dispatch checks from the
+ * prompt module. UAT dispatch architecture lives in `uat-dispatch.ts`; the
+ * `state` parameter is intentionally ignored because DB/roadmap artifacts are
+ * the source of truth for completed-slice discovery.
  */
-/**
- * Resolve the effective UAT mode for the dispatch gate the same way
- * `buildRunUatPrompt` does: classify the UAT body with the slice's SUMMARY as
- * supplemental context, so a `browser-executable` UAT whose slice references a
- * self-contained harness (`npm run test:uat`, `search-uat.mjs`, `npx
- * playwright test`) is promoted to `runtime-executable` for the gate too.
- *
- * Without this, `checkNeedsRunUat` returns `browser-executable` while the
- * prompt instructs runtime-only execution, causing the dispatch gate to
- * require browser tools / warm up the browser daemon (or stop dispatch when
- * browser MCP is unavailable) for UAT runs that never touch the browser. See
- * cursor[bot] review on PR #696 for the M007/S01 regression.
- */
-async function resolveRunUatEffectiveType(
-  base: string,
-  mid: string,
-  sliceId: string,
-  uatContent: string,
-): Promise<UatType> {
-  let summaryContent = "";
-  try {
-    const summaryPath = resolveSliceFile(base, mid, sliceId, "SUMMARY");
-    if (summaryPath) {
-      summaryContent = (await loadFile(summaryPath)) ?? "";
-    }
-  } catch (err) {
-    logWarning(
-      "prompt",
-      `resolveRunUatEffectiveType SUMMARY load failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-  return classifyUatContentForRun(uatContent, summaryContent).effectiveType;
-}
-
 export async function checkNeedsRunUat(
   base: string, mid: string, state: GSDState, prefs: GSDPreferences | undefined,
-): Promise<{ sliceId: string; uatType: UatType } | null> {
-  // DB primary path — fall through to file-based when DB has no data for this milestone
-  try {
-    const { isDbAvailable, getMilestoneSlices } = await import("./gsd-db.js");
-    if (isDbAvailable()) {
-      const slices = getMilestoneSlices(mid);
-      if (slices.length > 0) {
-        const completedSlices = slices.filter(s => s.status === "complete");
-        if (completedSlices.length === 0) return null;
-        for (const completed of [...completedSlices].reverse()) {
-          const sid = completed.id;
-          const uatFile = resolveSliceFile(base, mid, sid, "UAT");
-          if (!uatFile) continue;
-          const uatContent = await loadFile(uatFile);
-          if (!uatContent) continue;
-          // If the UAT file already contains a verdict, UAT has been run — skip
-          if (hasVerdict(uatContent)) continue;
-          // Also check the ASSESSMENT file — the run-uat prompt writes the verdict
-          // there (via gsd_uat_result_save), not into the
-          // UAT spec file. Without this check the unit re-dispatches indefinitely.
-          const assessmentFile = resolveSliceFile(base, mid, sid, "ASSESSMENT");
-          if (assessmentFile) {
-            const assessmentContent = await loadFile(assessmentFile);
-            if (assessmentContent && hasVerdict(assessmentContent)) continue;
-          }
-          if (!shouldDispatchUatForContent(uatContent, prefs)) continue;
-          const uatType = await resolveRunUatEffectiveType(base, mid, sid, uatContent);
-          return { sliceId: sid, uatType };
-        }
-        return null;
-      }
-    }
-  } catch (err) {
-    logWarning("prompt", `checkNeedsRunUat DB lookup failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
-
-  // File-based fallback using roadmap checkboxes
-  const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
-  if (!roadmapPath) return null;
-  const roadmapContent = await loadFile(roadmapPath);
-  if (!roadmapContent) return null;
-  const parsed = parseRoadmap(roadmapContent);
-  const completedFileSlices = parsed.slices.filter(s => s.done);
-  if (completedFileSlices.length === 0) return null;
-  for (const completed of [...completedFileSlices].reverse()) {
-    const uatSid = completed.id;
-    const uatFileFb = resolveSliceFile(base, mid, uatSid, "UAT");
-    if (!uatFileFb) continue;
-    const uatContentFb = await loadFile(uatFileFb);
-    if (!uatContentFb) continue;
-    // If the UAT file already contains a verdict, UAT has been run — skip
-    if (hasVerdict(uatContentFb)) continue;
-    // Also check the ASSESSMENT file for the file-based fallback path (same
-    // reason as the DB path above — verdict lives in ASSESSMENT, not UAT).
-    const assessmentFileFb = resolveSliceFile(base, mid, uatSid, "ASSESSMENT");
-    if (assessmentFileFb) {
-      const assessmentContentFb = await loadFile(assessmentFileFb);
-      if (assessmentContentFb && hasVerdict(assessmentContentFb)) continue;
-    }
-    if (!shouldDispatchUatForContent(uatContentFb, prefs)) continue;
-    const uatType = await resolveRunUatEffectiveType(base, mid, uatSid, uatContentFb);
-    return { sliceId: uatSid, uatType };
-  }
-  return null;
+): Promise<Awaited<ReturnType<typeof resolveNeedsRunUat>>> {
+  void state;
+  return resolveNeedsRunUat(base, mid, prefs);
 }
 
 // ─── Prompt Builders ──────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
+++ b/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
@@ -65,6 +65,9 @@ const ALLOWED_IMPORTERS = new Set([
   "gsd/visualizer-data.ts",
   // prompt context text (display strings injected into unit prompts)
   "gsd/auto-prompts.ts",
+  // run-uat discovery: reads DB slices first; parseRoadmap is a strict
+  // DB-unavailable fallback (extracted from auto-prompts.ts)
+  "gsd/uat-dispatch.ts",
   // cold-path maintenance command (branch cleanup messaging)
   "gsd/commands-maintenance.ts",
   // display-only GitHub issue/PR body sync

--- a/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
+++ b/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
@@ -65,10 +65,6 @@ const ALLOWED_IMPORTERS = new Set([
   "gsd/visualizer-data.ts",
   // prompt context text (display strings injected into unit prompts)
   "gsd/auto-prompts.ts",
-  // run-uat discovery: reads DB slices first; parseRoadmap is a strict
-  // DB-unavailable fallback (extracted from auto-prompts.ts)
-  "gsd/uat-dispatch.ts",
-  // cold-path maintenance command (branch cleanup messaging)
   "gsd/commands-maintenance.ts",
   // display-only GitHub issue/PR body sync
   "github-sync/sync.ts",

--- a/src/resources/extensions/gsd/tests/uat-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-dispatch.test.ts
@@ -8,6 +8,13 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import { checkNeedsRunUat as checkNeedsRunUatFromPrompts } from "../auto-prompts.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  isDbAvailable,
+  openDatabase,
+} from "../gsd-db.ts";
 import { checkNeedsRunUat } from "../uat-dispatch.ts";
 import type { GSDState } from "../types.ts";
 
@@ -139,6 +146,66 @@ test("auto-prompts keeps the compatibility checkNeedsRunUat wrapper", async (t) 
 
   assert.deepEqual(
     await checkNeedsRunUatFromPrompts(base, "M001", legacyState, { uat_dispatch: true }),
+    { sliceId: "S01", uatType: "human-experience" },
+  );
+});
+
+test("checkNeedsRunUat treats the DB as authoritative and ignores roadmap fallback when DB slices exist but none are complete", async (t) => {
+  const base = createFixtureBase();
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  // DB knows this milestone's slices, but none are complete.
+  openDatabase(":memory:");
+  assert.ok(isDbAvailable());
+  insertMilestone({ id: "M001", title: "UAT dispatch", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "First slice", status: "active", risk: "low", depends: [] });
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Next slice", status: "pending", risk: "low", depends: [] });
+
+  // The roadmap shows S01 completed and a dispatchable UAT file exists, so the
+  // roadmap fallback *would* dispatch S01 if it were (incorrectly) consulted.
+  writeRoadmap(base, "M001");
+  writeSliceFile(
+    base,
+    "M001",
+    "S01",
+    "UAT",
+    ["# S01 UAT", "", "## UAT Type", "- UAT mode: human-experience"].join("\n"),
+  );
+
+  // DB is authoritative: no completed slices means no dispatch, and the roadmap
+  // fallback candidate must NOT be consulted (regression for #1268).
+  assert.equal(
+    await checkNeedsRunUat(base, "M001", { uat_dispatch: true }, [{ sliceId: "S01" }]),
+    null,
+  );
+});
+
+test("checkNeedsRunUat uses roadmap fallback candidates when the DB has no slice rows for the milestone", async (t) => {
+  const base = createFixtureBase();
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  // DB is available but has no rows for M001, so it has no authoritative view.
+  openDatabase(":memory:");
+  assert.ok(isDbAvailable());
+
+  writeRoadmap(base, "M001");
+  writeSliceFile(
+    base,
+    "M001",
+    "S01",
+    "UAT",
+    ["# S01 UAT", "", "## UAT Type", "- UAT mode: human-experience"].join("\n"),
+  );
+
+  // With no DB slice rows, the roadmap-derived fallback candidate is honored.
+  assert.deepEqual(
+    await checkNeedsRunUat(base, "M001", { uat_dispatch: true }, [{ sliceId: "S01" }]),
     { sliceId: "S01", uatType: "human-experience" },
   );
 });

--- a/src/resources/extensions/gsd/tests/uat-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-dispatch.test.ts
@@ -80,7 +80,7 @@ test("checkNeedsRunUat resolves runtime harness dispatch from UAT plus summary c
     ].join("\n"),
   );
 
-  assert.deepEqual(await checkNeedsRunUat(base, "M001", { uat_dispatch: true }), {
+  assert.deepEqual(await checkNeedsRunUat(base, "M001", { uat_dispatch: true }, [{ sliceId: "S01" }]), {
     sliceId: "S01",
     uatType: "runtime-executable",
   });
@@ -105,7 +105,7 @@ test("checkNeedsRunUat skips slices that already have an ASSESSMENT verdict", as
   );
   writeSliceFile(base, "M001", "S01", "ASSESSMENT", "---\nverdict: PASS\n---\n# UAT Assessment\n");
 
-  assert.equal(await checkNeedsRunUat(base, "M001", { uat_dispatch: true }), null);
+  assert.equal(await checkNeedsRunUat(base, "M001", { uat_dispatch: true }, [{ sliceId: "S01" }]), null);
 });
 
 test("auto-prompts keeps the compatibility checkNeedsRunUat wrapper", async (t) => {

--- a/src/resources/extensions/gsd/tests/uat-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-dispatch.test.ts
@@ -9,6 +9,7 @@ import { test } from "node:test";
 
 import { checkNeedsRunUat as checkNeedsRunUatFromPrompts } from "../auto-prompts.ts";
 import { checkNeedsRunUat } from "../uat-dispatch.ts";
+import type { GSDState } from "../types.ts";
 
 function createFixtureBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-uat-dispatch-test-"));
@@ -125,7 +126,7 @@ test("auto-prompts keeps the compatibility checkNeedsRunUat wrapper", async (t) 
     ].join("\n"),
   );
 
-  const legacyState = {
+  const legacyState: GSDState = {
     activeMilestone: { id: "M001", title: "UAT dispatch" },
     activeSlice: { id: "S02", title: "Next slice" },
     activeTask: null,
@@ -134,7 +135,7 @@ test("auto-prompts keeps the compatibility checkNeedsRunUat wrapper", async (t) 
     blockers: [],
     nextAction: "Plan S02",
     registry: [],
-  } as const;
+  };
 
   assert.deepEqual(
     await checkNeedsRunUatFromPrompts(base, "M001", legacyState, { uat_dispatch: true }),

--- a/src/resources/extensions/gsd/tests/uat-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-dispatch.test.ts
@@ -1,0 +1,143 @@
+// Project/App: gsd-pi
+// File Purpose: Tests for run-uat dispatch discovery boundaries.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { checkNeedsRunUat as checkNeedsRunUatFromPrompts } from "../auto-prompts.ts";
+import { checkNeedsRunUat } from "../uat-dispatch.ts";
+
+function createFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-uat-dispatch-test-"));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function writeRoadmap(base: string, milestoneId: string): void {
+  const dir = join(base, ".gsd", "milestones", milestoneId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${milestoneId}-ROADMAP.md`),
+    [
+      `# ${milestoneId}: UAT dispatch`,
+      "",
+      "## Slices",
+      "",
+      "- [x] **S01: First slice** `risk:low` `depends:[]`",
+      "- [ ] **S02: Next slice** `risk:low` `depends:[S01]`",
+      "",
+      "## Boundary Map",
+      "",
+    ].join("\n"),
+  );
+}
+
+function writeSliceFile(
+  base: string,
+  milestoneId: string,
+  sliceId: string,
+  suffix: string,
+  content: string,
+): void {
+  const dir = join(base, ".gsd", "milestones", milestoneId, "slices", sliceId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${sliceId}-${suffix}.md`), content);
+}
+
+test("checkNeedsRunUat resolves runtime harness dispatch from UAT plus summary context", async (t) => {
+  const base = createFixtureBase();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  writeRoadmap(base, "M001");
+  writeSliceFile(
+    base,
+    "M001",
+    "S01",
+    "UAT",
+    [
+      "# S01 UAT",
+      "",
+      "## UAT Type",
+      "- UAT mode: browser-executable",
+      "",
+      "## Preconditions",
+      "- Start the dev server with `npm run test:server`.",
+    ].join("\n"),
+  );
+  writeSliceFile(
+    base,
+    "M001",
+    "S01",
+    "SUMMARY",
+    [
+      "# S01 Summary",
+      "",
+      "Verification: `npm run test:uat` passed and exercises the browser harness end-to-end.",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(await checkNeedsRunUat(base, "M001", { uat_dispatch: true }), {
+    sliceId: "S01",
+    uatType: "runtime-executable",
+  });
+});
+
+test("checkNeedsRunUat skips slices that already have an ASSESSMENT verdict", async (t) => {
+  const base = createFixtureBase();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  writeRoadmap(base, "M001");
+  writeSliceFile(
+    base,
+    "M001",
+    "S01",
+    "UAT",
+    [
+      "# S01 UAT",
+      "",
+      "## UAT Type",
+      "- UAT mode: artifact-driven",
+    ].join("\n"),
+  );
+  writeSliceFile(base, "M001", "S01", "ASSESSMENT", "---\nverdict: PASS\n---\n# UAT Assessment\n");
+
+  assert.equal(await checkNeedsRunUat(base, "M001", { uat_dispatch: true }), null);
+});
+
+test("auto-prompts keeps the compatibility checkNeedsRunUat wrapper", async (t) => {
+  const base = createFixtureBase();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  writeRoadmap(base, "M001");
+  writeSliceFile(
+    base,
+    "M001",
+    "S01",
+    "UAT",
+    [
+      "# S01 UAT",
+      "",
+      "## UAT Type",
+      "- UAT mode: human-experience",
+    ].join("\n"),
+  );
+
+  const legacyState = {
+    activeMilestone: { id: "M001", title: "UAT dispatch" },
+    activeSlice: { id: "S02", title: "Next slice" },
+    activeTask: null,
+    phase: "planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "Plan S02",
+    registry: [],
+  } as const;
+
+  assert.deepEqual(
+    await checkNeedsRunUatFromPrompts(base, "M001", legacyState, { uat_dispatch: true }),
+    { sliceId: "S01", uatType: "human-experience" },
+  );
+});

--- a/src/resources/extensions/gsd/uat-dispatch.ts
+++ b/src/resources/extensions/gsd/uat-dispatch.ts
@@ -93,8 +93,14 @@ async function getDbCompletedSliceCandidates(
   if (!isDbAvailable()) return null;
 
   const slices = getMilestoneSlices(milestoneId);
+  // No DB slice rows for this milestone: the DB has no authoritative view, so
+  // return null to let the caller defer to the roadmap fallback.
   if (slices.length === 0) return null;
 
+  // The DB has slice rows and is therefore authoritative for this milestone.
+  // Return a (possibly empty) array rather than null: an empty result must NOT
+  // fall through to the roadmap fallback, because the DB, not stale roadmap
+  // checkboxes, is the source of truth for which slices are complete.
   return slices
     .filter((slice) => slice.status === "complete")
     .map((slice) => ({ sliceId: slice.id }))
@@ -123,6 +129,12 @@ export async function findRunUatDispatchFromCandidates(
  * Check if the most recently completed slice needs a UAT run.
  * Returns { sliceId, uatType } if UAT should be dispatched, null otherwise.
  *
+ * When the DB has slice rows for the milestone it is authoritative: only its
+ * completed slices are considered and the `fallbackCandidates` (roadmap-derived)
+ * are ignored, even when no DB slice is complete. The fallback candidates are
+ * only consulted when the DB has no slice rows for the milestone, is
+ * unavailable, or errors.
+ *
  * Skips when:
  * - No completed slices exist in DB or the caller-provided fallback candidates
  * - uat_dispatch is not enabled and the UAT spec does not require runtime/browser evidence
@@ -137,7 +149,10 @@ export async function checkNeedsRunUat(
 ): Promise<RunUatDispatch | null> {
   try {
     const dbCandidates = await getDbCompletedSliceCandidates(milestoneId);
-    if (dbCandidates) {
+    // A non-null result (including an empty array) means the DB is authoritative
+    // for this milestone; only fall through to the roadmap fallback when the DB
+    // has no slice rows at all (null).
+    if (dbCandidates !== null) {
       return findRunUatDispatchFromCandidates(
         base,
         milestoneId,

--- a/src/resources/extensions/gsd/uat-dispatch.ts
+++ b/src/resources/extensions/gsd/uat-dispatch.ts
@@ -2,9 +2,8 @@
 // File Purpose: Resolve whether a completed slice needs run-uat dispatch.
 
 import { loadFile } from "./files.js";
-import { parseRoadmap } from "./parsers-legacy.js";
 import type { GSDPreferences } from "./preferences.js";
-import { resolveMilestoneFile, resolveSliceFile } from "./paths.js";
+import { resolveSliceFile } from "./paths.js";
 import {
   classifyUatContentForRun,
   shouldDispatchUatForContent,
@@ -13,11 +12,11 @@ import {
 import { hasVerdict } from "./verdict-parser.js";
 import { logWarning } from "./workflow-logger.js";
 
-interface UatDispatchCandidate {
+export interface UatDispatchCandidate {
   sliceId: string;
 }
 
-type RunUatDispatch = { sliceId: string; uatType: UatType };
+export type RunUatDispatch = { sliceId: string; uatType: UatType };
 
 async function loadSliceFileContent(
   base: string,
@@ -93,31 +92,14 @@ async function getDbCompletedSliceCandidates(
   const { isDbAvailable, getMilestoneSlices } = await import("./gsd-db.js");
   if (!isDbAvailable()) return null;
 
-  const slices = getMilestoneSlices(milestoneId);
-  if (slices.length === 0) return null;
-  return slices
-    .filter((slice) => slice.status === "complete")
-    .map((slice) => ({ sliceId: slice.id }))
-    .reverse();
+  const completedSlices = getMilestoneSlices(milestoneId).filter(
+    (slice) => slice.status === "complete",
+  );
+  if (completedSlices.length === 0) return null;
+  return completedSlices.map((slice) => ({ sliceId: slice.id })).reverse();
 }
 
-async function getRoadmapCompletedSliceCandidates(
-  base: string,
-  milestoneId: string,
-): Promise<UatDispatchCandidate[]> {
-  const roadmapPath = resolveMilestoneFile(base, milestoneId, "ROADMAP");
-  if (!roadmapPath) return [];
-
-  const roadmapContent = await loadFile(roadmapPath);
-  if (!roadmapContent) return [];
-
-  return parseRoadmap(roadmapContent)
-    .slices.filter((slice) => slice.done)
-    .map((slice) => ({ sliceId: slice.id }))
-    .reverse();
-}
-
-async function findRunUatDispatchFromCandidates(
+export async function findRunUatDispatchFromCandidates(
   base: string,
   milestoneId: string,
   candidates: readonly UatDispatchCandidate[],
@@ -140,7 +122,7 @@ async function findRunUatDispatchFromCandidates(
  * Returns { sliceId, uatType } if UAT should be dispatched, null otherwise.
  *
  * Skips when:
- * - No completed slices exist in DB or roadmap fallback
+ * - No completed slices exist in DB or the caller-provided fallback candidates
  * - uat_dispatch is not enabled and the UAT spec does not require runtime/browser evidence
  * - No UAT file exists for the slice
  * - UAT result already exists in the UAT or ASSESSMENT file
@@ -149,6 +131,7 @@ export async function checkNeedsRunUat(
   base: string,
   milestoneId: string,
   prefs: GSDPreferences | undefined,
+  fallbackCandidates: readonly UatDispatchCandidate[] = [],
 ): Promise<RunUatDispatch | null> {
   try {
     const dbCandidates = await getDbCompletedSliceCandidates(milestoneId);
@@ -167,14 +150,10 @@ export async function checkNeedsRunUat(
     );
   }
 
-  const roadmapCandidates = await getRoadmapCompletedSliceCandidates(
-    base,
-    milestoneId,
-  );
   return findRunUatDispatchFromCandidates(
     base,
     milestoneId,
-    roadmapCandidates,
+    fallbackCandidates,
     prefs,
   );
 }

--- a/src/resources/extensions/gsd/uat-dispatch.ts
+++ b/src/resources/extensions/gsd/uat-dispatch.ts
@@ -92,11 +92,13 @@ async function getDbCompletedSliceCandidates(
   const { isDbAvailable, getMilestoneSlices } = await import("./gsd-db.js");
   if (!isDbAvailable()) return null;
 
-  const completedSlices = getMilestoneSlices(milestoneId).filter(
-    (slice) => slice.status === "complete",
-  );
-  if (completedSlices.length === 0) return null;
-  return completedSlices.map((slice) => ({ sliceId: slice.id })).reverse();
+  const slices = getMilestoneSlices(milestoneId);
+  if (slices.length === 0) return null;
+
+  return slices
+    .filter((slice) => slice.status === "complete")
+    .map((slice) => ({ sliceId: slice.id }))
+    .reverse();
 }
 
 export async function findRunUatDispatchFromCandidates(

--- a/src/resources/extensions/gsd/uat-dispatch.ts
+++ b/src/resources/extensions/gsd/uat-dispatch.ts
@@ -1,0 +1,180 @@
+// Project/App: gsd-pi
+// File Purpose: Resolve whether a completed slice needs run-uat dispatch.
+
+import { loadFile } from "./files.js";
+import { parseRoadmap } from "./parsers-legacy.js";
+import type { GSDPreferences } from "./preferences.js";
+import { resolveMilestoneFile, resolveSliceFile } from "./paths.js";
+import {
+  classifyUatContentForRun,
+  shouldDispatchUatForContent,
+  type UatType,
+} from "./uat-policy.js";
+import { hasVerdict } from "./verdict-parser.js";
+import { logWarning } from "./workflow-logger.js";
+
+interface UatDispatchCandidate {
+  sliceId: string;
+}
+
+type RunUatDispatch = { sliceId: string; uatType: UatType };
+
+async function loadSliceFileContent(
+  base: string,
+  milestoneId: string,
+  sliceId: string,
+  kind: "UAT" | "ASSESSMENT" | "SUMMARY",
+): Promise<string> {
+  const filePath = resolveSliceFile(base, milestoneId, sliceId, kind);
+  return filePath ? ((await loadFile(filePath)) ?? "") : "";
+}
+
+async function resolveRunUatEffectiveType(
+  base: string,
+  milestoneId: string,
+  sliceId: string,
+  uatContent: string,
+): Promise<UatType> {
+  let summaryContent = "";
+  try {
+    summaryContent = await loadSliceFileContent(
+      base,
+      milestoneId,
+      sliceId,
+      "SUMMARY",
+    );
+  } catch (err) {
+    logWarning(
+      "prompt",
+      `resolveRunUatEffectiveType SUMMARY load failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return classifyUatContentForRun(uatContent, summaryContent).effectiveType;
+}
+
+async function resolveCandidateRunUatDispatch(
+  base: string,
+  milestoneId: string,
+  candidate: UatDispatchCandidate,
+  prefs: GSDPreferences | undefined,
+): Promise<RunUatDispatch | null> {
+  const uatContent = await loadSliceFileContent(
+    base,
+    milestoneId,
+    candidate.sliceId,
+    "UAT",
+  );
+  if (!uatContent) return null;
+  if (hasVerdict(uatContent)) return null;
+
+  const assessmentContent = await loadSliceFileContent(
+    base,
+    milestoneId,
+    candidate.sliceId,
+    "ASSESSMENT",
+  );
+  if (assessmentContent && hasVerdict(assessmentContent)) return null;
+  if (!shouldDispatchUatForContent(uatContent, prefs)) return null;
+
+  return {
+    sliceId: candidate.sliceId,
+    uatType: await resolveRunUatEffectiveType(
+      base,
+      milestoneId,
+      candidate.sliceId,
+      uatContent,
+    ),
+  };
+}
+
+async function getDbCompletedSliceCandidates(
+  milestoneId: string,
+): Promise<UatDispatchCandidate[] | null> {
+  const { isDbAvailable, getMilestoneSlices } = await import("./gsd-db.js");
+  if (!isDbAvailable()) return null;
+
+  const slices = getMilestoneSlices(milestoneId);
+  if (slices.length === 0) return null;
+  return slices
+    .filter((slice) => slice.status === "complete")
+    .map((slice) => ({ sliceId: slice.id }))
+    .reverse();
+}
+
+async function getRoadmapCompletedSliceCandidates(
+  base: string,
+  milestoneId: string,
+): Promise<UatDispatchCandidate[]> {
+  const roadmapPath = resolveMilestoneFile(base, milestoneId, "ROADMAP");
+  if (!roadmapPath) return [];
+
+  const roadmapContent = await loadFile(roadmapPath);
+  if (!roadmapContent) return [];
+
+  return parseRoadmap(roadmapContent)
+    .slices.filter((slice) => slice.done)
+    .map((slice) => ({ sliceId: slice.id }))
+    .reverse();
+}
+
+async function findRunUatDispatchFromCandidates(
+  base: string,
+  milestoneId: string,
+  candidates: readonly UatDispatchCandidate[],
+  prefs: GSDPreferences | undefined,
+): Promise<RunUatDispatch | null> {
+  for (const candidate of candidates) {
+    const dispatch = await resolveCandidateRunUatDispatch(
+      base,
+      milestoneId,
+      candidate,
+      prefs,
+    );
+    if (dispatch) return dispatch;
+  }
+  return null;
+}
+
+/**
+ * Check if the most recently completed slice needs a UAT run.
+ * Returns { sliceId, uatType } if UAT should be dispatched, null otherwise.
+ *
+ * Skips when:
+ * - No completed slices exist in DB or roadmap fallback
+ * - uat_dispatch is not enabled and the UAT spec does not require runtime/browser evidence
+ * - No UAT file exists for the slice
+ * - UAT result already exists in the UAT or ASSESSMENT file
+ */
+export async function checkNeedsRunUat(
+  base: string,
+  milestoneId: string,
+  prefs: GSDPreferences | undefined,
+): Promise<RunUatDispatch | null> {
+  try {
+    const dbCandidates = await getDbCompletedSliceCandidates(milestoneId);
+    if (dbCandidates) {
+      return findRunUatDispatchFromCandidates(
+        base,
+        milestoneId,
+        dbCandidates,
+        prefs,
+      );
+    }
+  } catch (err) {
+    logWarning(
+      "prompt",
+      `checkNeedsRunUat DB lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const roadmapCandidates = await getRoadmapCompletedSliceCandidates(
+    base,
+    milestoneId,
+  );
+  return findRunUatDispatchFromCandidates(
+    base,
+    milestoneId,
+    roadmapCandidates,
+    prefs,
+  );
+}


### PR DESCRIPTION
## TL;DR

**What:** Extract run-uat dispatch discovery into a dedicated UAT dispatch module.
**Why:** UAT dispatch decisions were embedded in prompt-building code and duplicated DB/file fallback logic.
**How:** Move completed-slice discovery and dispatch eligibility checks into `uat-dispatch.ts`, update auto-dispatch to call it directly, and keep an `auto-prompts.ts` compatibility wrapper.

## What

This refactor adds `src/resources/extensions/gsd/uat-dispatch.ts` as the owner for deciding whether a completed slice needs `run-uat` dispatch. The module now centralizes:

- DB and roadmap fallback completed-slice candidate discovery
- UAT and ASSESSMENT verdict skip checks
- `uat_dispatch` preference handling
- effective UAT type resolution using slice summary context

`auto-dispatch.ts` now imports this dispatch decision directly. `auto-prompts.ts` keeps a compatibility wrapper for existing callers while no longer owning the duplicated discovery loop.

## Why

The UAT process had architecture drift: prompt construction also owned orchestration decisions for UAT dispatch. That made future UAT fixes risky because DB and file fallback paths had to keep verdict checks, preference checks, and effective-mode resolution mirrored manually.

## How

The refactor preserves behavior by extracting the existing logic into smaller focused helpers:

- one helper loads slice UAT/ASSESSMENT/SUMMARY artifacts
- one helper evaluates a single completed-slice candidate
- separate candidate sources handle DB and roadmap fallback discovery
- a shared candidate loop picks the newest eligible completed slice

An attempted removal of the `auto-prompts.ts` wrapper was rejected during autoreview for compatibility risk, so the wrapper remains intentionally.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/run-uat.test.ts src/resources/extensions/gsd/tests/uat-policy.test.ts src/resources/extensions/gsd/tests/uat-dispatch.test.ts src/resources/extensions/gsd/tests/integration/run-uat.test.ts src/resources/extensions/gsd/tests/uat-policy.test.ts src/resources/extensions/gsd/tests/run-uat-replay-cap.test.ts` — 50 passing
- `GSD_LIVE_TESTS=1 pnpm run test:live-workflow` — skipped because provider credentials are not present in the environment
- `pnpm run test:smoke` — 2 passing
- `pnpm run typecheck:extensions` — passing
- `pnpm run verify:fast` — passing

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None intended. Existing `checkNeedsRunUat` imports from `auto-prompts.ts` remain supported through a compatibility wrapper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior-preserving refactor on auto-mode UAT dispatch gates; incorrect extraction could change which slices get run-uat or effective UAT type (browser vs runtime), affecting tool preflight and retry limits.
> 
> **Overview**
> Moves **run-uat dispatch discovery** out of `auto-prompts.ts` into a dedicated **`uat-dispatch.ts`** module so orchestration no longer lives beside prompt builders.
> 
> The new module owns completed-slice candidate discovery (DB first, roadmap fallback), verdict skips on UAT/ASSESSMENT, `uat_dispatch` / policy gates, and **effective UAT type** resolution (UAT body plus slice SUMMARY, preserving runtime-harness promotion). **`auto-dispatch.ts`** now imports `checkNeedsRunUat` from `uat-dispatch` and passes **`loadRoadmapCompletedSliceCandidates`** as explicit fallback input; **`auto-prompts.ts`** keeps a thin **`checkNeedsRunUat(base, mid, state, prefs)`** wrapper that ignores `state` and delegates with the same roadmap candidates.
> 
> Adds **`uat-dispatch.test.ts`** for harness promotion, ASSESSMENT verdict skip, and the compatibility wrapper. A parsers-legacy importer allowlist entry for `commands-maintenance.ts` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603ad96d76eadc0276e5b7095041aae396957d0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->