### PR TITLE
fix(issue): [Bug]: hook / supervisor / reactive-subagent `model` object form silently ignores its `thinking` sub-field

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1460,7 +1460,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const subagentModelConfig = normalizeModelFieldConfig(reactiveConfig?.subagent_model)
         ?? resolveModelWithFallbacksForUnit("subagent");
       const subagentModel = subagentModelConfig?.primary;
-      const subagentThinking = resolveThinkingLevelForUnit("subagent");
+      // Prefer the per-field `thinking` carried on `reactive_execution.subagent_model`'s
+      // object form over the phase-bucket `subagent` level (#1269).
+      const subagentThinking = subagentModelConfig?.thinking ?? resolveThinkingLevelForUnit("subagent");
       // Default-on safety threshold: only activate reactive dispatch when at
       // least N tasks are ready. Users who explicitly enabled reactive_execution
       // keep the legacy threshold of 2 (matches the prior "any parallelism is

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -298,7 +298,10 @@ export async function applySupervisorModelIfConfigured(
     if (isModelUnavailable(basePath, match.provider, match.id)) continue;
     try {
       if (await pi.setModel(match, { persist: false })) {
-        applyThinkingLevelForModel(pi, pi.getThinkingLevel(), match, ctx);
+        // Prefer the per-field `thinking` from `auto_supervisor.model`'s object
+        // form over the session level so a configured supervisor level actually
+        // applies (#1269).
+        applyThinkingLevelForModel(pi, modelConfig.thinking ?? pi.getThinkingLevel(), match, ctx);
         return;
       }
     } catch (err) {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -116,7 +116,7 @@ import {
 } from "./auto-tool-tracking.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
-import { selectAndApplyModel, resolveModelId, clearToolBaseline, isModelUnavailable } from "./auto-model-selection.js";
+import { selectAndApplyModel, resolveModelId, clearToolBaseline, isModelUnavailable, applyThinkingLevelForModel } from "./auto-model-selection.js";
 import { resolveModelWithFallbacksForUnit } from "./preferences-models.js";
 import { resetRoutingHistory, recordOutcome } from "./routing-history.js";
 import {
@@ -3190,6 +3190,13 @@ export async function dispatchHookUnit(
       if (isModelUnavailable(targetBasePath, match.provider, match.id)) continue;
       try {
         if (await pi.setModel(match)) {
+          // The manual trigger path bypasses selectAndApplyModel, so apply the
+          // hook's per-field `thinking` (from `post_unit_hooks[].model`'s object
+          // form) here against the just-set model rather than leaving the hook at
+          // the session level (#1269). Absent → session level, unchanged.
+          if (hookModelConfig?.thinking) {
+            applyThinkingLevelForModel(pi, hookModelConfig.thinking, match, ctx);
+          }
           applied = true;
           break;
         }

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -110,7 +110,14 @@ export function normalizeModelFieldConfig(
   const primary = field.provider && !field.model.includes("/")
     ? `${field.provider}/${field.model}`
     : field.model;
-  return { primary, fallbacks: field.fallbacks ?? [] };
+  // Carry the per-field `thinking` sub-field through so the dispatch site can
+  // prefer it over the session/floor level, mirroring phase-inline thinking
+  // (#1269). `undefined` is preserved as absent so behavior is unchanged.
+  return {
+    primary,
+    fallbacks: field.fallbacks ?? [],
+    ...(field.thinking ? { thinking: field.thinking } : {}),
+  };
 }
 
 /**
@@ -192,6 +199,14 @@ export function resolveThinkingLevelForUnit(
   basePath?: string,
   availableModelIds?: string[],
 ): GSDThinkingLevel | undefined {
+  // Single-field configs — `auto_supervisor.model` and `post_unit_hooks[].model`
+  // — carry their own inline `thinking` on the object model form and have no
+  // phase-bucket chain, so the walk below never covers them. Resolve their
+  // per-field level directly (#1269).
+  if (unitType === "supervisor" || unitType.startsWith("hook/")) {
+    return resolveModelWithFallbacksForUnit(unitType, basePath, availableModelIds)?.thinking;
+  }
+
   const loadOpts = availableModelIds !== undefined ? { availableModelIds } : undefined;
   const prefs = loadEffectiveGSDPreferences(basePath, loadOpts)?.preferences;
   if (!prefs) return undefined;

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -312,6 +312,13 @@ export interface GSDModelConfigV2 {
 export interface ResolvedModelConfig {
   primary: string;
   fallbacks: string[];
+  /**
+   * Per-field reasoning level carried from the object model form's `thinking`
+   * sub-field (e.g. `{ model, thinking: high }` on `post_unit_hooks[].model`,
+   * `auto_supervisor.model`, or `reactive_execution.subagent_model`). Applied at
+   * the dispatch site in preference to the session/floor level (#1269).
+   */
+  thinking?: GSDThinkingLevel;
 }
 
 export type SkillDiscoveryMode = "auto" | "suggest" | "off";

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -52,6 +52,7 @@ function sanitizeModelField(
   raw: unknown,
   label: string,
   errors: string[],
+  warnings?: string[],
 ): string | GSDPhaseModelConfig | undefined {
   if (raw === undefined) return undefined;
   if (typeof raw === "string") {
@@ -76,6 +77,20 @@ function sanitizeModelField(
     if (obj.fallbacks !== undefined) {
       const fallbacks = normalizeStringArray(obj.fallbacks);
       if (fallbacks.length > 0) sanitized.fallbacks = fallbacks;
+    }
+    // Preserve the object form's `thinking` sub-field so the dispatch site can
+    // pin the hook/supervisor/subagent reasoning level (#1269). An illegal level
+    // is warned-and-stripped, mirroring inline per-phase thinking, so a typo can't
+    // reach the resolver and be treated as explicit configuration.
+    if (obj.thinking !== undefined) {
+      if (VALID_THINKING_LEVELS.has(obj.thinking as GSDThinkingLevel)) {
+        sanitized.thinking = obj.thinking as GSDThinkingLevel;
+      } else {
+        warnings?.push(
+          `${label} thinking "${String(obj.thinking)}" is not a valid thinking level ` +
+          `(off, minimal, low, medium, high, xhigh) — ignored`,
+        );
+      }
     }
     return sanitized;
   }
@@ -524,7 +539,7 @@ export function validatePreferences(preferences: GSDPreferences): {
       // Other supervisor fields pass through unchanged.
       const supervisor = { ...preferences.auto_supervisor };
       if (supervisor.model !== undefined) {
-        supervisor.model = sanitizeModelField(supervisor.model, "auto_supervisor.model", errors);
+        supervisor.model = sanitizeModelField(supervisor.model, "auto_supervisor.model", errors, warnings);
       }
       validated.auto_supervisor = supervisor;
     } else {
@@ -618,7 +633,7 @@ export function validatePreferences(preferences: GSDPreferences): {
         const mc = typeof hook.max_cycles === "number" ? hook.max_cycles : Number(hook.max_cycles);
         validHook.max_cycles = Number.isFinite(mc) ? Math.max(1, Math.min(10, Math.round(mc))) : 1;
       }
-      const hookModel = sanitizeModelField(hook.model, `post_unit_hooks "${name}" model`, errors);
+      const hookModel = sanitizeModelField(hook.model, `post_unit_hooks "${name}" model`, errors, warnings);
       if (hookModel !== undefined) {
         validHook.model = hookModel;
       }
@@ -1076,6 +1091,7 @@ export function validatePreferences(preferences: GSDPreferences): {
         re.subagent_model,
         "reactive_execution.subagent_model",
         errors,
+        warnings,
       );
       if (subagentModel !== undefined) {
         validRe.subagent_model = subagentModel;

--- a/src/resources/extensions/gsd/tests/single-field-model-thinking.test.ts
+++ b/src/resources/extensions/gsd/tests/single-field-model-thinking.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression tests for #1269 — the object model form's `thinking` sub-field on
+ * the three single-model fields (`post_unit_hooks[].model`,
+ * `auto_supervisor.model`, and `reactive_execution.subagent_model`) was
+ * silently dropped after validation/normalization, so a configured
+ * hook/supervisor/subagent reasoning level never applied.
+ *
+ * These exercise the real preference pipeline through the exported runtime APIs:
+ *   sanitize   → validatePreferences
+ *   normalize  → normalizeModelFieldConfig
+ *   resolve    → resolveThinkingLevelForUnit  (supervisor + hook/* early path)
+ *
+ * The `supervisor` and `hook/*` unit types have no phase-bucket chain, so the
+ * pre-#1269 resolver walk never covered them and returned `undefined`.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { validatePreferences } from "../preferences-validation.ts";
+import { normalizeModelFieldConfig, resolveThinkingLevelForUnit } from "../preferences-models.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+/** Read the per-field `thinking` off a validated/normalized model config. */
+function thinkingOf(model: unknown): string | undefined {
+  return (model as { thinking?: string } | undefined)?.thinking;
+}
+
+/** Write a project-level `.gsd/PREFERENCES.md` and run `fn` with its basePath. */
+function withProjectPreferences<T>(frontmatter: string, fn: (basePath: string) => T): T {
+  const base = mkdtempSync(join(tmpdir(), "gsd-1269-thinking-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "PREFERENCES.md"), `---\n${frontmatter}\n---\n`, "utf-8");
+  invalidateAllCaches();
+  try {
+    return fn(base);
+  } finally {
+    invalidateAllCaches();
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+// ── sanitize: validatePreferences preserves a valid object-form thinking ──────
+
+test("validatePreferences preserves auto_supervisor.model object-form thinking", () => {
+  const { preferences, errors } = validatePreferences({
+    auto_supervisor: { model: { model: "supervisor-model", thinking: "high" } },
+  });
+  assert.equal(errors.length, 0);
+  assert.equal(thinkingOf(preferences.auto_supervisor?.model), "high");
+});
+
+test("validatePreferences preserves post_unit_hooks[].model object-form thinking", () => {
+  const { preferences, errors } = validatePreferences({
+    post_unit_hooks: [
+      {
+        name: "code-review",
+        after: ["execute-task"],
+        prompt: "Review the diff",
+        model: { model: "hook-model", thinking: "low" },
+      },
+    ],
+  });
+  assert.equal(errors.length, 0);
+  assert.equal(thinkingOf(preferences.post_unit_hooks?.[0]?.model), "low");
+});
+
+test("validatePreferences preserves reactive_execution.subagent_model object-form thinking", () => {
+  const { preferences, errors } = validatePreferences({
+    reactive_execution: {
+      enabled: true,
+      max_parallel: 2,
+      isolation_mode: "same-tree",
+      subagent_model: { model: "subagent-model", thinking: "medium" },
+    },
+  });
+  assert.equal(errors.length, 0);
+  assert.equal(thinkingOf(preferences.reactive_execution?.subagent_model), "medium");
+});
+
+// ── sanitize: an invalid thinking level is warned and stripped ────────────────
+
+test("validatePreferences warns and strips an invalid object-form thinking level", () => {
+  const { preferences, errors, warnings } = validatePreferences({
+    auto_supervisor: { model: { model: "supervisor-model", thinking: "ludicrous" } },
+  });
+  // The model survives; only the bogus thinking is dropped, so a typo can never
+  // reach the resolver and masquerade as explicit configuration.
+  assert.equal(errors.length, 0);
+  assert.equal(thinkingOf(preferences.auto_supervisor?.model), undefined);
+  assert.ok(
+    warnings.some((w) => w.includes("auto_supervisor.model") && w.includes("thinking")),
+    `expected a thinking warning, got: ${JSON.stringify(warnings)}`,
+  );
+});
+
+// ── normalize: normalizeModelFieldConfig carries thinking through ─────────────
+
+test("normalizeModelFieldConfig carries object-form thinking through", () => {
+  const config = normalizeModelFieldConfig({ model: "hook-model", thinking: "xhigh" });
+  assert.equal(config?.primary, "hook-model");
+  assert.equal(config?.thinking, "xhigh");
+});
+
+test("normalizeModelFieldConfig leaves thinking absent when omitted", () => {
+  const fromObject = normalizeModelFieldConfig({ model: "hook-model" });
+  assert.equal(fromObject?.primary, "hook-model");
+  assert.equal(fromObject?.thinking, undefined);
+
+  const fromString = normalizeModelFieldConfig("hook-model");
+  assert.equal(fromString?.primary, "hook-model");
+  assert.equal(fromString?.thinking, undefined);
+});
+
+// ── resolve: the single-field unit types surface their per-field thinking ──────
+
+test("resolveThinkingLevelForUnit('supervisor') returns auto_supervisor.model thinking", () => {
+  withProjectPreferences(
+    ["auto_supervisor:", "  model:", "    model: supervisor-model", "    thinking: high"].join("\n"),
+    (base) => {
+      assert.equal(resolveThinkingLevelForUnit("supervisor", base), "high");
+    },
+  );
+});
+
+test("resolveThinkingLevelForUnit('hook/<name>') returns the matching hook model thinking", () => {
+  withProjectPreferences(
+    [
+      "post_unit_hooks:",
+      "  - name: code-review",
+      "    after:",
+      "      - execute-task",
+      "    prompt: Review the diff",
+      "    model:",
+      "      model: hook-model",
+      "      thinking: low",
+    ].join("\n"),
+    (base) => {
+      assert.equal(resolveThinkingLevelForUnit("hook/code-review", base), "low");
+    },
+  );
+});
+
+test("resolveThinkingLevelForUnit('supervisor') stays undefined when thinking is omitted", () => {
+  // Bare-string model form carries no thinking → dispatch falls back to the
+  // session/floor level, unchanged from pre-#1269 behavior.
+  withProjectPreferences(
+    ["auto_supervisor:", "  model: supervisor-model"].join("\n"),
+    (base) => {
+      assert.equal(resolveThinkingLevelForUnit("supervisor", base), undefined);
+    },
+  );
+});

--- a/src/resources/extensions/gsd/tests/single-field-model-thinking.test.ts
+++ b/src/resources/extensions/gsd/tests/single-field-model-thinking.test.ts
@@ -86,7 +86,7 @@ test("validatePreferences preserves reactive_execution.subagent_model object-for
 test("validatePreferences warns and strips an invalid object-form thinking level", () => {
   const { preferences, errors, warnings } = validatePreferences({
     auto_supervisor: { model: { model: "supervisor-model", thinking: "ludicrous" } },
-  });
+  } as never);
   // The model survives; only the bogus thinking is dropped, so a typo can never
   // reach the resolver and masquerade as explicit configuration.
   assert.equal(errors.length, 0);


### PR DESCRIPTION
## Summary
- Preserved the object-form `thinking` sub-field end-to-end for `post_unit_hooks[].model`, `auto_supervisor.model`, and `reactive_execution.subagent_model` (type + sanitize + normalize + resolve + three apply sites), verified with the model/thinking unit suites (49 passing) and a runtime resolution check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1269
- [#1269 [Bug]: hook / supervisor / reactive-subagent `model` object form silently ignores its `thinking` sub-field](https://github.com/open-gsd/gsd-pi/issues/1269)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1269-bug-hook-supervisor-reactive-subagent-mo-1783266111`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted preference plumbing and dispatch-time thinking application with absent-field fallbacks unchanged; no auth or data-path changes.
> 
> **Overview**
> Fixes **#1269** so `{ model, thinking, … }` on `post_unit_hooks[].model`, `auto_supervisor.model`, and `reactive_execution.subagent_model` is no longer dropped after validation/normalization.
> 
> **Pipeline:** `sanitizeModelField` keeps a valid `thinking` level (invalid values are warned and stripped). `normalizeModelFieldConfig` and `ResolvedModelConfig` carry it through. `resolveThinkingLevelForUnit` reads inline `thinking` directly for `supervisor` and `hook/*` units that do not use the phase-bucket chain.
> 
> **Dispatch:** Per-field `thinking` is preferred over session/phase-bucket levels at three sites—the supervisor model setter, reactive-execute prompt building (`subagentThinking`), and the manual post-unit hook model path in `auto.ts` (which bypasses `selectAndApplyModel`).
> 
> When `thinking` is omitted, behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0678efd2fa2edd1bdadf46b4115b0714d1b9daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->