### PR TITLE
fix(issue): [Feature Request]: gsd-browser daemon has no automatic teardown — orphaned Chrome process survives session/task completion

### DIFF
--- a/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/gsd-browser-launch-config.test.mjs
@@ -9,6 +9,7 @@ import { dirname, join } from "node:path";
 const {
   resolveBundledGsdBrowserCliPath,
   resolveGsdBrowserDaemonStartInvocation,
+  resolveGsdBrowserDaemonStopInvocation,
   resolveGsdBrowserMcpLaunchConfig,
 } = await import("../../shared/gsd-browser-cli.ts");
 
@@ -176,6 +177,24 @@ describe("resolveGsdBrowserDaemonStartInvocation", () => {
     assert.deepEqual(
       daemon.args.slice(0, daemon.args.indexOf("--session")),
       [...launch.args.slice(0, launch.args.indexOf("mcp")), "daemon", "start"],
+    );
+  });
+});
+
+describe("resolveGsdBrowserDaemonStopInvocation", () => {
+  it("mirrors MCP session and identity flags with daemon stop", () => {
+    const launch = resolveGsdBrowserMcpLaunchConfig("/tmp/example-project", {});
+    const daemon = resolveGsdBrowserDaemonStopInvocation("/tmp/example-project", {});
+
+    assert.equal(daemon.command, launch.command);
+    assert.equal(daemon.cwd, launch.cwd);
+    assert.deepEqual(
+      daemon.args.slice(daemon.args.indexOf("--session")),
+      launch.args.slice(launch.args.indexOf("--session")),
+    );
+    assert.deepEqual(
+      daemon.args.slice(0, daemon.args.indexOf("--session")),
+      [...launch.args.slice(0, launch.args.indexOf("mcp")), "daemon", "stop"],
     );
   });
 });

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -185,6 +185,7 @@ import { enterAutoWorktree, isInAutoWorktree } from "./auto-worktree-entry.js";
 import { getAutoWorktreePath } from "./auto-worktree-path-resolution.js";
 import { checkResourcesStale, readResourceVersion } from "./auto-worktree-resource-version.js";
 import { escapeStaleWorktree } from "./auto-worktree-runtime-cleanup.js";
+import { teardownWarmedBrowserDaemons } from "./browser-daemon-auto-prep.js";
 import { getAutoWorktreeOriginalBase } from "./auto-worktree-session-registry.js";
 import { syncWorktreeStateBack } from "./auto-worktree-sync.js";
 import { teardownAutoWorktree } from "./auto-worktree-teardown.js";
@@ -1488,6 +1489,17 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
   } catch (err) {
     /* best-effort — mirror stopAuto cleanup */
     logWarning("session", `lock cleanup failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
+  }
+
+  // Symmetric teardown for the browser-UAT warm-up preflight (#1259): stop any
+  // gsd-browser daemon this session started so the Chrome process does not
+  // linger after the loop exits. Re-warms on the next browser-backed run-uat.
+  try {
+    for (const { projectRoot, error } of teardownWarmedBrowserDaemons()) {
+      logWarning("session", `gsd-browser daemon stop failed for ${projectRoot}: ${error}`, { file: "auto.ts" });
+    }
+  } catch (err) {
+    logWarning("session", `browser daemon teardown failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
   }
 
   // A transient provider-error pause intentionally leaves the paused badge

--- a/src/resources/extensions/gsd/browser-daemon-auto-prep.ts
+++ b/src/resources/extensions/gsd/browser-daemon-auto-prep.ts
@@ -9,10 +9,19 @@ import {
 import {
   resolveGsdBrowserCliAvailability,
   resolveGsdBrowserDaemonStartInvocation,
+  resolveGsdBrowserDaemonStopInvocation,
 } from "../shared/gsd-browser-cli.js";
 import { uatTypeIncludesBrowser, type UatType } from "./uat-policy.js";
 
 const DEFAULT_DAEMON_START_TIMEOUT_MS = 30_000;
+const DEFAULT_DAEMON_STOP_TIMEOUT_MS = 15_000;
+
+/**
+ * Project roots whose gsd-browser daemon this process warmed via
+ * {@link prepareBrowserDaemonForUat}. Teardown only stops daemons we actually
+ * started, so non-browser auto-mode sessions never spawn a stray `daemon stop`.
+ */
+const warmedDaemonProjectRoots = new Set<string>();
 
 function isEnvDisabled(value: string | undefined): boolean {
   if (!value) return false;
@@ -102,7 +111,74 @@ export function prepareBrowserDaemonForUat(ctx: BrowserDaemonWarmContext): strin
   if (!shouldWarmBrowserDaemonForUat(ctx)) return null;
 
   const result = ensureBrowserDaemonStarted(ctx.projectRoot, { env: ctx.env });
-  if (result.ok) return null;
+  if (result.ok) {
+    warmedDaemonProjectRoots.add(resolve(ctx.projectRoot));
+    return null;
+  }
 
   return `Cannot dispatch browser-backed run-uat: gsd-browser daemon failed to start (${result.error}). Ensure Chrome/Chromium is installed, run \`gsd-browser daemon health\` with the project session flags from .mcp.json, or set GSD_BROWSER_PATH to a Chromium binary.`;
+}
+
+/**
+ * Best-effort stop of a gsd-browser session daemon warmed for browser UAT.
+ * Mirrors {@link ensureBrowserDaemonStarted}; returns the failure detail rather
+ * than throwing so teardown can stay non-fatal.
+ */
+export function stopBrowserDaemon(
+  projectRoot: string,
+  options: { env?: NodeJS.ProcessEnv; timeoutMs?: number } = {},
+): { ok: true } | { ok: false; error: string } {
+  const env = options.env ?? process.env;
+  const availability = resolveGsdBrowserCliAvailability(env);
+  if (!availability.available) {
+    return { ok: false, error: availability.detail };
+  }
+
+  let invocation: ReturnType<typeof resolveGsdBrowserDaemonStopInvocation>;
+  try {
+    invocation = resolveGsdBrowserDaemonStopInvocation(projectRoot, env);
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  try {
+    execFileSync(invocation.command, invocation.args, {
+      cwd: invocation.cwd,
+      env: { ...process.env, ...env, ...(invocation.env ?? {}) },
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: options.timeoutMs ?? DEFAULT_DAEMON_STOP_TIMEOUT_MS,
+      encoding: "utf-8",
+    });
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Tear down every gsd-browser daemon this process warmed for browser UAT,
+ * clearing the tracked set. Called on auto-mode loop exit so the Chrome process
+ * does not survive session/task completion (mirrors the warm-up preflight).
+ * Best-effort: returns the project roots whose stop failed for logging.
+ */
+export function teardownWarmedBrowserDaemons(
+  options: { env?: NodeJS.ProcessEnv } = {},
+): { projectRoot: string; error: string }[] {
+  if (warmedDaemonProjectRoots.size === 0) return [];
+
+  const failures: { projectRoot: string; error: string }[] = [];
+  for (const projectRoot of warmedDaemonProjectRoots) {
+    const result = stopBrowserDaemon(projectRoot, { env: options.env });
+    if (!result.ok) {
+      failures.push({ projectRoot, error: result.error });
+    }
+  }
+  warmedDaemonProjectRoots.clear();
+  return failures;
 }

--- a/src/resources/extensions/gsd/tests/browser-daemon-auto-prep.test.ts
+++ b/src/resources/extensions/gsd/tests/browser-daemon-auto-prep.test.ts
@@ -4,6 +4,8 @@ import assert from "node:assert/strict";
 import {
   prepareBrowserDaemonForUat,
   shouldWarmBrowserDaemonForUat,
+  stopBrowserDaemon,
+  teardownWarmedBrowserDaemons,
 } from "../browser-daemon-auto-prep.ts";
 import { commitBrowserEngineResolution } from "../../browser-tools/engine/selection.ts";
 import { resolveGsdBrowserCliAvailability } from "../../shared/gsd-browser-cli.ts";
@@ -141,4 +143,28 @@ test("prepareBrowserDaemonForUat returns actionable error when daemon start fail
   });
 
   assert.match(error ?? "", /gsd-browser daemon failed to start/i);
+});
+
+test("stopBrowserDaemon reports failure when the gsd-browser CLI is missing", () => {
+  const result = stopBrowserDaemon("/tmp/example-project", {
+    env: { GSD_BROWSER_MCP_COMMAND: "/definitely/missing/gsd-browser" },
+  });
+
+  assert.equal(result.ok, false);
+});
+
+test("teardownWarmedBrowserDaemons is a no-op when nothing was warmed", () => {
+  // A failed warm-up must not register a project root for teardown.
+  prepareBrowserDaemonForUat({
+    uatType: "browser-executable",
+    sessionProvider: "claude-code",
+    sessionAuthMode: "externalCli",
+    projectRoot: "/tmp/example-project",
+    env: {
+      ...GSD_BROWSER_ENGINE,
+      GSD_BROWSER_MCP_COMMAND: "/definitely/missing/gsd-browser",
+    },
+  });
+
+  assert.deepEqual(teardownWarmedBrowserDaemons(), []);
 });

--- a/src/resources/extensions/shared/gsd-browser-cli.ts
+++ b/src/resources/extensions/shared/gsd-browser-cli.ts
@@ -355,14 +355,16 @@ export function resolveGsdBrowserMcpLaunchConfig(
 }
 
 /**
- * CLI invocation that starts the gsd-browser session daemon with the same
- * session and identity flags as {@link resolveGsdBrowserMcpLaunchConfig}, so
- * browser UAT can warm Chrome/CDP before the first MCP navigation.
+ * CLI invocation that runs a `daemon <action>` command against the gsd-browser
+ * session daemon with the same session and identity flags as
+ * {@link resolveGsdBrowserMcpLaunchConfig}, so start (warm-up) and stop
+ * (teardown) address the exact same managed daemon.
  */
-export function resolveGsdBrowserDaemonStartInvocation(
+function resolveGsdBrowserDaemonInvocation(
+  action: "start" | "stop",
   projectRoot: string,
-  env: NodeJS.ProcessEnv = process.env,
-  options: GsdBrowserMcpLaunchOptions = {},
+  env: NodeJS.ProcessEnv,
+  options: GsdBrowserMcpLaunchOptions,
 ): Pick<GsdBrowserMcpLaunchConfig, "command" | "args" | "cwd" | "env"> {
   const launch = resolveGsdBrowserMcpLaunchConfig(projectRoot, env, options);
   const mcpIndex = launch.args.indexOf("mcp");
@@ -374,8 +376,34 @@ export function resolveGsdBrowserDaemonStartInvocation(
   const sessionFlags = launch.args.slice(mcpIndex + 1);
   return {
     command: launch.command,
-    args: [...prefix, "daemon", "start", ...sessionFlags],
+    args: [...prefix, "daemon", action, ...sessionFlags],
     cwd: launch.cwd,
     ...(launch.env ? { env: launch.env } : {}),
   };
+}
+
+/**
+ * CLI invocation that starts the gsd-browser session daemon with the same
+ * session and identity flags as {@link resolveGsdBrowserMcpLaunchConfig}, so
+ * browser UAT can warm Chrome/CDP before the first MCP navigation.
+ */
+export function resolveGsdBrowserDaemonStartInvocation(
+  projectRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+  options: GsdBrowserMcpLaunchOptions = {},
+): Pick<GsdBrowserMcpLaunchConfig, "command" | "args" | "cwd" | "env"> {
+  return resolveGsdBrowserDaemonInvocation("start", projectRoot, env, options);
+}
+
+/**
+ * CLI invocation that stops the gsd-browser session daemon warmed for browser
+ * UAT, so the Chrome process is torn down instead of lingering after the
+ * triggering task/session ends.
+ */
+export function resolveGsdBrowserDaemonStopInvocation(
+  projectRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+  options: GsdBrowserMcpLaunchOptions = {},
+): Pick<GsdBrowserMcpLaunchConfig, "command" | "args" | "cwd" | "env"> {
+  return resolveGsdBrowserDaemonInvocation("stop", projectRoot, env, options);
 }


### PR DESCRIPTION
## Summary
- Added a symmetric gsd-browser daemon teardown (stop invocation + `teardownWarmedBrowserDaemons`) wired into auto-mode's `cleanupAfterLoopExit` so warmed Chrome processes are stopped on loop exit; verified via the changed-src test runner (23 pass) and extensions typecheck (no new errors).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1259
- [#1259 [Feature Request]: gsd-browser daemon has no automatic teardown — orphaned Chrome process survives session/task completion](https://github.com/open-gsd/gsd-pi/issues/1259)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1259-feature-request-gsd-browser-daemon-has-n-1783300219`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort teardown on loop exit with tracking limited to successful warm-ups; failures are logged only and do not block cleanup.
> 
> **Overview**
> Fixes **orphaned Chrome** after browser UAT by pairing the existing warm-up with automatic **daemon stop** when auto-mode exits.
> 
> **CLI:** `resolveGsdBrowserDaemonStopInvocation` shares the same session/identity flags as MCP launch and `daemon start` via a refactored `resolveGsdBrowserDaemonInvocation("start" | "stop", ...)`.
> 
> **Runtime:** Successful UAT warm-up registers the project root; `stopBrowserDaemon` / `teardownWarmedBrowserDaemons` run best-effort `daemon stop` only for those roots (failed warm-ups are not tracked). **`cleanupAfterLoopExit`** in auto-mode invokes teardown and logs failures without blocking shutdown.
> 
> **Tests** mirror start/stop CLI parity and cover missing CLI, empty teardown, and failed warm-up not registering teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 780ec44e1dda821f877da0db250c7f13d6dcd8ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->