### PR TITLE
fix(issue): complete-slice's reopen reason never reaches the re-dispatched execute-task (follow-up to #1225)

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -2725,6 +2725,26 @@ export async function buildExecuteTaskPrompt(
   let phaseAnchorSection = planAnchor ? formatAnchorForPrompt(planAnchor) : "";
   trackPromptContext(contextTelemetry, "plan-anchor", phaseAnchorSection ? "inline" : "skipped", phaseAnchorSection, phaseAnchorSection ? undefined : "missing");
 
+  // #1272: inject a pending reopen reason into this task's prompt. When a gate
+  // (e.g. complete-slice's full-suite run) reopened the task via gsd_task_reopen
+  // with a diagnosis, surface it here so the re-dispatched executor fixes the
+  // regression instead of re-running the original (green) scoped verify. Claim
+  // is one-shot (artifact deleted on read). Not feature-gated — a reopened task
+  // must always know why. Prepended so it sits above the plan anchor.
+  try {
+    const { claimReopenReasonForInjection } = await import("./reopen-reason.js");
+    const reopenClaimed = claimReopenReasonForInjection(base, mid, sid, tid);
+    if (reopenClaimed) {
+      const block = reopenClaimed.injectionBlock + "\n\n---\n\n";
+      phaseAnchorSection = phaseAnchorSection
+        ? `${block}${phaseAnchorSection}`
+        : block;
+      trackPromptContext(contextTelemetry, "reopen-reason", "inline", reopenClaimed.injectionBlock);
+    }
+  } catch (reopenErr) {
+    logWarning("prompt", `reopen reason injection failed: ${(reopenErr as Error).message}`);
+  }
+
   // ADR-011 Phase 2: inject any resolved-but-unapplied escalation override
   // into this task's prompt. Claim is atomic via DB UPDATE WHERE IS NULL, so
   // if a parallel build already injected it, we skip. Feature-gated by

--- a/src/resources/extensions/gsd/reopen-reason.ts
+++ b/src/resources/extensions/gsd/reopen-reason.ts
@@ -1,0 +1,109 @@
+// Project/App: gsd-pi
+// File Purpose: Persist a reopened task's failure diagnosis and inject it into the re-dispatched execute-task prompt.
+// GSD Extension — follow-up to #1225 (#1272)
+//
+// When complete-slice's gate reopens a task via gsd_task_reopen, the operator
+// supplies a `reason` explaining exactly what the full-suite gate caught and
+// how to fix it. That reason previously only landed in the workflow event log
+// (audit trail) and never reached the re-dispatched executor, so the executor
+// re-ran the original (green) verify and re-completed the task without touching
+// the regression. This module is the "inject unresolved context into the next
+// dispatch" mechanism for reopen reasons — a lightweight, file-based sibling of
+// escalation.js#claimOverrideForInjection, keyed by (milestone, slice, task).
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+import { legacyMilestonesDir, resolveSlicePath, resolveTasksDir } from "./paths.js";
+import { atomicWriteSync } from "./atomic-write.js";
+import { logWarning } from "./workflow-logger.js";
+
+interface ReopenReasonArtifact {
+  version: 1;
+  milestoneId: string;
+  sliceId: string;
+  taskId: string;
+  reason: string;
+  createdAt: string;
+}
+
+/**
+ * Canonical reopen-reason artifact path, parallel to T##-SUMMARY.md and
+ * T##-ESCALATION.json:
+ *   .gsd/milestones/{M}/slices/{S}/tasks/{T}-REOPEN.json
+ * Flat-phase: the artifact sits directly in the phase dir. Legacy layouts
+ * without a tasks/ subdir return null (caller degrades gracefully).
+ */
+export function reopenReasonArtifactPath(
+  basePath: string, milestoneId: string, sliceId: string, taskId: string,
+): string | null {
+  const tDir = resolveTasksDir(basePath, milestoneId, sliceId);
+  if (tDir) return join(tDir, `${taskId}-REOPEN.json`);
+  if (existsSync(legacyMilestonesDir(basePath))) return null;
+  const phaseDir = resolveSlicePath(basePath, milestoneId, sliceId);
+  if (!phaseDir) return null;
+  return join(phaseDir, `${taskId}-REOPEN.json`);
+}
+
+/**
+ * Persist the reopen reason so the next execute-task dispatch can surface it.
+ * A no-op when the reason is empty or the artifact path cannot be resolved —
+ * reopen itself must still succeed even if we cannot attach context.
+ */
+export function writeReopenReason(
+  basePath: string, milestoneId: string, sliceId: string, taskId: string, reason: string,
+): void {
+  const trimmed = reason.trim();
+  if (!trimmed) return;
+  const path = reopenReasonArtifactPath(basePath, milestoneId, sliceId, taskId);
+  if (!path) {
+    logWarning("tool", `reopen-reason: cannot resolve artifact path for ${milestoneId}/${sliceId}/${taskId}; reopen reason not attached to next dispatch`);
+    return;
+  }
+  const artifact: ReopenReasonArtifact = {
+    version: 1,
+    milestoneId, sliceId, taskId,
+    reason: trimmed,
+    createdAt: new Date().toISOString(),
+  };
+  mkdirSync(join(path, ".."), { recursive: true });
+  atomicWriteSync(path, JSON.stringify(artifact, null, 2));
+}
+
+/**
+ * If a reopen reason is pending for this task, claim it (one-shot: the artifact
+ * is deleted on read) and return the markdown block to prepend to the executor's
+ * prompt. Returns null when nothing is pending or the artifact is malformed.
+ */
+export function claimReopenReasonForInjection(
+  basePath: string, milestoneId: string, sliceId: string, taskId: string,
+): { injectionBlock: string } | null {
+  const path = reopenReasonArtifactPath(basePath, milestoneId, sliceId, taskId);
+  if (!path || !existsSync(path)) return null;
+  let art: ReopenReasonArtifact | null = null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<ReopenReasonArtifact>;
+    if (parsed && parsed.version === 1 && typeof parsed.reason === "string" && parsed.reason.trim()) {
+      art = parsed as ReopenReasonArtifact;
+    }
+  } catch {
+    art = null;
+  }
+  // Claim (delete) regardless of validity so a malformed artifact doesn't
+  // wedge every future dispatch of this task.
+  try { unlinkSync(path); } catch { /* already gone */ }
+  if (!art) return null;
+  return { injectionBlock: formatReopenReasonBlock(art) };
+}
+
+function formatReopenReasonBlock(art: ReopenReasonArtifact): string {
+  return [
+    `## Reopened — Reason (from ${art.taskId})`,
+    "",
+    "This task was previously marked complete but a downstream gate (e.g. complete-slice's full-suite run) reopened it. The verify command in your task plan passed in isolation — it did **not** catch the regression below. Do **not** call `gsd_task_complete` until you have reproduced and fixed exactly what this diagnosis describes, then re-run the specific failing command it names (not just the original scoped verify).",
+    "",
+    "**Diagnosis / fix instructions from the gate:**",
+    "",
+    art.reason.trim(),
+  ].join("\n");
+}

--- a/src/resources/extensions/gsd/tests/reopen-reason.test.ts
+++ b/src/resources/extensions/gsd/tests/reopen-reason.test.ts
@@ -1,0 +1,117 @@
+// GSD — reopen-reason injection tests (#1272)
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+} from '../gsd-db.ts';
+import { handleReopenTask } from '../tools/reopen-task.ts';
+import {
+  reopenReasonArtifactPath,
+  writeReopenReason,
+  claimReopenReasonForInjection,
+} from '../reopen-reason.ts';
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-reopen-reason-'));
+  mkdirSync(join(base, '.gsd', 'milestones', 'M001', 'slices', 'S01', 'tasks'), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+function seedCompleteTask(): void {
+  insertMilestone({ id: 'M001', title: 'Test Milestone', status: 'active' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice', status: 'in_progress' });
+  insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Task One', status: 'complete' });
+}
+
+test('writeReopenReason then claim: injects the reason, then is one-shot', () => {
+  const base = makeTmpBase();
+  try {
+    const reason = 'T01 shifted the descendants count to 12. Fix: update the assertion to 12.';
+    writeReopenReason(base, 'M001', 'S01', 'T01', reason);
+
+    const path = reopenReasonArtifactPath(base, 'M001', 'S01', 'T01')!;
+    assert.ok(existsSync(path), 'artifact should be written');
+
+    const claimed = claimReopenReasonForInjection(base, 'M001', 'S01', 'T01');
+    assert.ok(claimed, 'first claim should return an injection block');
+    assert.match(claimed!.injectionBlock, /Reopened — Reason/);
+    assert.match(claimed!.injectionBlock, /descendants count to 12/);
+    assert.ok(!existsSync(path), 'artifact should be deleted after claim (one-shot)');
+
+    const second = claimReopenReasonForInjection(base, 'M001', 'S01', 'T01');
+    assert.equal(second, null, 'second claim should return null');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('claimReopenReasonForInjection: returns null when nothing pending', () => {
+  const base = makeTmpBase();
+  try {
+    assert.equal(claimReopenReasonForInjection(base, 'M001', 'S01', 'T01'), null);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('writeReopenReason: empty/whitespace reason is a no-op', () => {
+  const base = makeTmpBase();
+  try {
+    writeReopenReason(base, 'M001', 'S01', 'T01', '   ');
+    const path = reopenReasonArtifactPath(base, 'M001', 'S01', 'T01')!;
+    assert.ok(!existsSync(path), 'no artifact should be written for an empty reason');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handleReopenTask: persists a claimable reopen reason when reason is provided', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+  try {
+    seedCompleteTask();
+
+    const result = await handleReopenTask({
+      milestoneId: 'M001',
+      sliceId: 'S01',
+      taskId: 'T01',
+      reason: 'Full suite caught NavNodeTest regression — update count assertion to 12.',
+    }, base);
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+    const claimed = claimReopenReasonForInjection(base, 'M001', 'S01', 'T01');
+    assert.ok(claimed, 'reopen reason should be claimable after handleReopenTask');
+    assert.match(claimed!.injectionBlock, /NavNodeTest regression/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handleReopenTask: no reason provided leaves nothing to claim', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+  try {
+    seedCompleteTask();
+
+    await handleReopenTask({ milestoneId: 'M001', sliceId: 'S01', taskId: 'T01' }, base);
+
+    assert.equal(claimReopenReasonForInjection(base, 'M001', 'S01', 'T01'), null);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tools/reopen-task.ts
+++ b/src/resources/extensions/gsd/tools/reopen-task.ts
@@ -23,6 +23,7 @@ import { flushWorkflowProjections } from "../projection-flush.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
+import { writeReopenReason } from "../reopen-reason.js";
 import { existsSync, unlinkSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
 import { resolveTasksDir, resolveSlicePath, clearPathCache } from "../paths.js";
@@ -124,6 +125,20 @@ export async function handleReopenTask(
     logWarning("tool", `reopen-task artifact cleanup warning: ${(cleanupErr as Error).message}`);
   }
   clearPathCache();
+
+  // ── Persist the reopen reason for the next execute-task dispatch (#1272) ──
+  // Without this, the re-dispatched executor receives the original task plan
+  // and verify command with zero signal that it was reopened — it re-runs the
+  // (still-green) scoped verify and re-completes the task, never touching the
+  // regression the gate actually caught. buildExecuteTaskPrompt claims this
+  // artifact and prepends the diagnosis to the next dispatch.
+  if (params.reason && params.reason.trim() !== "") {
+    try {
+      writeReopenReason(basePath, params.milestoneId, params.sliceId, params.taskId, params.reason);
+    } catch (reasonErr) {
+      logWarning("tool", `reopen-task reason persistence warning: ${(reasonErr as Error).message}`);
+    }
+  }
 
   // ── Post-mutation hook ───────────────────────────────────────────────────
   try {


### PR DESCRIPTION
## Summary
- Persist gsd_task_reopen's reason as a claimable artifact and inject it into the next execute-task prompt so reopened tasks fix the diagnosed regression; verified via new/existing reopen tests (13/13), prompt/escalation tests (75/75), and a clean extensions typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1272
- [#1272 complete-slice's reopen reason never reaches the re-dispatched execute-task (follow-up to #1225)](https://github.com/open-gsd/gsd-pi/issues/1272)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1272-complete-slice-s-reopen-reason-never-rea-1783300214`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the execute-task and reopen-task paths that drive workflow correctness; scope is narrow with graceful fallbacks and no auth/data-model changes.
> 
> **Overview**
> **Fixes reopened tasks ignoring gate diagnoses** — when `gsd_task_reopen` (e.g. from complete-slice’s full-suite gate) supplied a `reason`, it only hit the event log; the re-dispatched executor still saw the original plan and could pass scoped verify without fixing the regression.
> 
> Adds a file-based **`reopen-reason`** flow (patterned after escalation claim): `handleReopenTask` writes `{taskId}-REOPEN.json` when a non-empty reason is given; **`buildExecuteTaskPrompt`** claims it once (artifact deleted on read) and prepends a **“Reopened — Reason”** block above the plan anchor, telling the executor to fix the named failure before `gsd_task_complete`. Injection is always on for reopened tasks (not feature-gated). Reopen still succeeds if persistence fails.
> 
> New unit/integration tests cover write/claim one-shot behavior and reopen-with/without reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa02bd9cefe2426061b6db49d62e69daab8a0d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->