### PR TITLE
fix(issue): [Bug]: Unattended `gsd headless auto` has no resumer for the parallel/slice_parallel worker pause signal → terminal exit 10 after the first unit

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -56,7 +56,7 @@ import { normalizeWorktreePathForCompare } from "./worktree-root.js";
 import { isDbAvailable, getTask, getSlice, getMilestone, getMilestoneSlices, updateTaskStatus, _getAdapter, getVerificationEvidence } from "./gsd-db.js";
 import { getWorkflowDatabasePath, refreshWorkflowDatabaseFromDisk } from "./db-workspace.js";
 import { renderPlanCheckboxes, renderRoadmapFromDb, roadmapRenderMarksSliceDone } from "./markdown-renderer.js";
-import { consumeSignal } from "./session-status-io.js";
+import { awaitWorkerResume, consumeSignal } from "./session-status-io.js";
 import {
   checkPostUnitHooks,
   consumeHookFailure,
@@ -1279,8 +1279,27 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         return "dispatched";
       }
       if (signal.signal === "pause") {
-        await pauseAuto(ctx, pi);
-        return "dispatched";
+        // A worker `pause` is a *temporary* coordination request: the docs
+        // contract (docs/user-docs/parallel-orchestration.md) is "finish current
+        // unit, wait" followed by a matching `resume`. Only the interactive
+        // dashboard runtime owns a resumer — unattended `gsd headless auto` does
+        // not — so a terminal pauseAuto() here strands the worker at exit 10
+        // (BLOCKED) after its first unit, with nothing able to lift it (#1273).
+        // Wait for the coordinator to resume (or stop) us instead. If no resumer
+        // lifts the pause within the window, degrade to in-process serialization
+        // and continue the dispatch loop rather than halting the run forever.
+        const resumeOutcome = await awaitWorkerResume(s.basePath, milestoneLock);
+        if (resumeOutcome === "stop") {
+          await stopAuto(ctx, pi);
+          return "dispatched";
+        }
+        if (resumeOutcome === "timeout") {
+          logWarning(
+            "parallel",
+            `pause signal for ${milestoneLock} was not resumed (no headless resumer, #1273); continuing dispatch`,
+          );
+        }
+        // "resume" or "timeout": fall through and continue post-unit processing.
       }
     }
   }

--- a/src/resources/extensions/gsd/session-status-io.ts
+++ b/src/resources/extensions/gsd/session-status-io.ts
@@ -48,6 +48,11 @@ const PARALLEL_DIR = "parallel";
 const STATUS_SUFFIX = ".status.json";
 const SIGNAL_SUFFIX = ".signal.json";
 const DEFAULT_STALE_TIMEOUT_MS = 30_000;
+// How long a paused worker waits for the coordinator to lift the pause before
+// it degrades to in-process serialization (#1273). Kept below the stale
+// timeout so the wait never races the coordinator's liveness detection.
+const DEFAULT_RESUME_WAIT_MS = 10_000;
+const DEFAULT_RESUME_POLL_MS = 250;
 
 function isSessionStatus(data: unknown): data is SessionStatus {
   return data !== null && typeof data === "object" && "milestoneId" in data && "pid" in data;
@@ -141,6 +146,35 @@ export function consumeSignal(basePath: string, milestoneId: string): SignalMess
     try { unlinkSync(p); } catch { /* non-fatal */ }
   }
   return msg;
+}
+
+/**
+ * Wait for a coordinator to lift a `pause` on a worker by sending `resume`
+ * (or `stop`). Polls the signal file until one of those arrives or the timeout
+ * elapses. Intervening `pause`/`rebase` signals are consumed and ignored so a
+ * repeated pause doesn't reset the wait.
+ *
+ * A worker's `pause` is only ever lifted by the interactive/dashboard resumer;
+ * unattended `gsd headless auto` owns no resumer, so callers use the `"timeout"`
+ * result to degrade to in-process serialization instead of stranding the worker
+ * at a terminal pause it cannot resume (#1273).
+ */
+export async function awaitWorkerResume(
+  basePath: string,
+  milestoneId: string,
+  opts: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<"resume" | "stop" | "timeout"> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_RESUME_WAIT_MS;
+  const pollMs = opts.pollMs ?? DEFAULT_RESUME_POLL_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const msg = consumeSignal(basePath, milestoneId);
+    if (msg?.signal === "resume") return "resume";
+    if (msg?.signal === "stop") return "stop";
+    if (Date.now() >= deadline) return "timeout";
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
 }
 
 // ─── Stale Detection ───────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/worker-resume-wait.test.ts
+++ b/src/resources/extensions/gsd/tests/worker-resume-wait.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests: awaitWorkerResume — headless worker pause survives without a resumer.
+ *
+ * Regression for #1273: a worker `pause` used to call a terminal pauseAuto()
+ * that exited the process with BLOCKED (10). On the headless path there is no
+ * resumer to send the matching `resume`, so the worker was stranded after its
+ * first unit. awaitWorkerResume lets the worker wait for the coordinator to lift
+ * the pause and, when no resumer responds, report "timeout" so the caller can
+ * degrade to in-process serialization instead of halting forever.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { awaitWorkerResume, sendSignal } from "../session-status-io.ts";
+
+function makeBase(): { base: string; cleanup: () => void } {
+  const base = mkdtempSync(join(tmpdir(), "gsd-worker-resume-"));
+  mkdirSync(join(base, ".gsd", "parallel"), { recursive: true });
+  return { base, cleanup: () => rmSync(base, { recursive: true, force: true }) };
+}
+
+describe("awaitWorkerResume", () => {
+  it("returns 'resume' when the coordinator sends resume", async () => {
+    const { base, cleanup } = makeBase();
+    try {
+      sendSignal(base, "M001", "resume");
+      const outcome = await awaitWorkerResume(base, "M001", { timeoutMs: 500, pollMs: 20 });
+      assert.equal(outcome, "resume");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("returns 'stop' when the coordinator sends stop", async () => {
+    const { base, cleanup } = makeBase();
+    try {
+      sendSignal(base, "M001", "stop");
+      const outcome = await awaitWorkerResume(base, "M001", { timeoutMs: 500, pollMs: 20 });
+      assert.equal(outcome, "stop");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("returns 'timeout' when no resumer lifts the pause (headless, #1273)", async () => {
+    const { base, cleanup } = makeBase();
+    try {
+      const outcome = await awaitWorkerResume(base, "M001", { timeoutMs: 100, pollMs: 20 });
+      assert.equal(outcome, "timeout");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("ignores a repeated pause and still resumes when resume arrives", async () => {
+    const { base, cleanup } = makeBase();
+    try {
+      // A duplicate pause must not be treated as a resume, nor reset the wait.
+      sendSignal(base, "M001", "pause");
+      const waiting = awaitWorkerResume(base, "M001", { timeoutMs: 1000, pollMs: 20 });
+      // Deliver the resume shortly after the pause is consumed and ignored.
+      setTimeout(() => sendSignal(base, "M001", "resume"), 60);
+      const outcome = await waiting;
+      assert.equal(outcome, "resume");
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Made a headless parallel/slice worker's `pause` signal non-terminal — it now waits for the coordinator's `resume`/`stop` and degrades to in-process serialization (continues dispatch) when no resumer lifts it, instead of exiting 10 (BLOCKED) after the first unit; verified with a new unit test and the existing parallel/post-unit test suites.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1273
- [#1273 [Bug]: Unattended `gsd headless auto` has no resumer for the parallel/slice_parallel worker pause signal → terminal exit 10 after the first unit](https://github.com/open-gsd/gsd-pi/issues/1273)

## User
- @GoatInAHat

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1273-bug-unattended-gsd-headless-auto-has-no--1783300206`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes parallel worker post-unit control flow in auto-post-unit; wrong timeout or signal handling could affect coordinator/worker coordination, but scope is narrow and covered by new unit tests.
> 
> **Overview**
> Fixes **#1273**: parallel workers under `GSD_MILESTONE_LOCK` used to call **`pauseAuto()`** on a coordinator **`pause`** signal, which ended the run at exit **10 (BLOCKED)**. Unattended **`gsd headless auto`** has no dashboard resumer to send **`resume`**, so the worker stopped after the first unit.
> 
> **`postUnitPreVerification`** now treats **`pause`** as temporary coordination: it **`awaitWorkerResume`**s (polls `.gsd/parallel` signal files) for **`resume`** or **`stop`**. **`stop`** still stops auto; **`resume`** or a **timeout** (default 10s, no resumer) logs a warning and **continues dispatch** instead of halting.
> 
> New **`awaitWorkerResume`** in **`session-status-io.ts`** implements the poll loop; repeated **`pause`/`rebase`** signals are consumed without resetting the wait. **`worker-resume-wait.test.ts`** covers resume, stop, timeout, and duplicate pause behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4feb741c534dd94901d9792a1df8bb031e3e0d51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->