### PR TITLE
fix(issue): [Bug] reconcile triggers mass re-projection of all historical PLAN.md files, resetting completed task checkboxes to unchecked

### DIFF
--- a/src/resources/extensions/gsd/migrate/planning-writer.ts
+++ b/src/resources/extensions/gsd/migrate/planning-writer.ts
@@ -11,6 +11,7 @@ import { join, relative } from "node:path";
 
 import { getAllMilestones, getMilestoneSlices, getSliceTasks } from "../gsd-db.js";
 import { saveFile } from "../files.js";
+import { isClosedStatus } from "../status-guards.js";
 import type { PlanningLayout } from "../compat/compat-marker.js";
 import {
   applyPlanningProjectionWrites,
@@ -104,7 +105,7 @@ function formatPlanningPlan(
   phaseNum: number,
   planNum: number,
   title: string,
-  tasks: Array<{ id: string; title: string; estimate?: string }>,
+  tasks: Array<{ id: string; title: string; estimate?: string; done?: boolean }>,
 ): string {
   const lines: string[] = [];
   lines.push(`# ${pad(phaseNum)}-${pad(planNum)}: ${title}`, "");
@@ -115,7 +116,11 @@ function formatPlanningPlan(
   lines.push("<tasks>");
   for (const t of tasks) {
     const est = t.estimate ? ` _(${t.estimate})_` : "";
-    lines.push(`- [ ] **${t.id}**: ${t.title}${est}`);
+    // Render the checkbox from the task's DB status so a DB→.planning
+    // projection preserves completion. Hardcoding `[ ]` here silently reset
+    // every completed historical task to unchecked on each reconcile (#1276).
+    const box = t.done ? "[x]" : "[ ]";
+    lines.push(`- ${box} **${t.id}**: ${t.title}${est}`);
   }
   lines.push("</tasks>");
   lines.push("");
@@ -173,7 +178,7 @@ export async function writePlanningDirectory(
 
       const tasks = getSliceTasks(milestone.id, slice.id);
       const isDone =
-        tasks.length > 0 && tasks.every((t) => t.status === "complete");
+        tasks.length > 0 && tasks.every((t) => isClosedStatus(t.status));
       roadmapEntries.push({
         number: phaseNum,
         title: slice.title || slice.id,
@@ -204,6 +209,7 @@ export async function writePlanningDirectory(
                 id: task.id,
                 title: task.title || task.id,
                 estimate: task.estimate || undefined,
+                done: isClosedStatus(task.status),
               },
             ]),
           );

--- a/src/resources/extensions/gsd/tests/planning-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-writer.test.ts
@@ -8,7 +8,7 @@ import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
 import { writePlanningDirectory } from "../migrate/planning-writer.ts";
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask } from "../gsd-db.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, updateTaskStatus } from "../gsd-db.ts";
 
 const tmpDirs: string[] = [];
 function makeTmp(): string {
@@ -63,6 +63,23 @@ test("writePlanningDirectory emits phase plan file with XML structure", async ()
   // Planning plans use XML tags per parsers.ts extractXmlTag
   assert.match(plan, /<objective>/);
   assert.match(plan, /<tasks>/);
+});
+
+test("writePlanningDirectory renders completed task checkboxes as [x] (#1276)", async () => {
+  const base = makeTmp();
+  updateTaskStatus("M001", "S01", "T01", "complete");
+  await writePlanningDirectory(base, "flat-phases");
+
+  const phaseDir = readdirSync(join(base, ".planning", "phases"), { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)[0]!;
+  const planFile = readdirSync(join(base, ".planning", "phases", phaseDir))
+    .filter((f) => f.endsWith("PLAN.md"))[0]!;
+  const plan = readFileSync(join(base, ".planning", "phases", phaseDir, planFile), "utf-8");
+  assert.match(plan, /- \[x\] \*\*T01\*\*/, "completed task should project as [x], not [ ]");
+
+  const roadmap = readFileSync(join(base, ".planning", "ROADMAP.md"), "utf-8");
+  assert.match(roadmap, /- \[x\] 01 —/, "phase with all tasks complete should be [x] in ROADMAP");
 });
 
 test("writePlanningDirectory is idempotent: writing twice produces stable content", async () => {


### PR DESCRIPTION
## Summary
- Fixed `formatPlanningPlan` to render task checkboxes from DB status (using `isClosedStatus`) instead of hardcoding `[ ]`, preventing reconcile from resetting completed historical PLAN.md checkboxes; verified with a new regression test and the full planning projection test suites (19/19 pass).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1276
- [#1276 [Bug] reconcile triggers mass re-projection of all historical PLAN.md files, resetting completed task checkboxes to unchecked](https://github.com/open-gsd/gsd-pi/issues/1276)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1276-bug-reconcile-triggers-mass-re-projectio-1783323037`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized projection-writer fix with a regression test; no auth, security, or data-schema changes.
> 
> **Overview**
> Fixes reconcile re-projection wiping historical **PLAN.md** completion: `formatPlanningPlan` now emits `[x]`/`[ ]` from each task’s DB status via **`isClosedStatus`**, instead of always writing unchecked boxes.
> 
> Phase “done” in **ROADMAP.md** uses the same closed-status helper (not only `complete`). Adds a regression test that marks a task complete and asserts **PLAN.md** and **ROADMAP** show `[x]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdcfbde8c4a4c7584f2e41dd5eacb646324f665b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->