### PR TITLE
fix(issue): unregistered-milestone false positive: flat-phase ID extractor derives bare M### from descriptive slug, missing suffixed DB row (M###-abcdef)

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
@@ -7,8 +7,8 @@
 
 import { existsSync } from "node:fs";
 
-import { getMilestone, isDbAvailable } from "../../gsd-db.js";
-import { findMilestoneIds } from "../../milestone-ids.js";
+import { getAllMilestones, getMilestone, isDbAvailable } from "../../gsd-db.js";
+import { findMilestoneIds, parseMilestoneId } from "../../milestone-ids.js";
 import { resolveMilestoneFile, resolveMilestonePath } from "../../paths.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
@@ -29,6 +29,26 @@ function milestoneHasContent(basePath: string, milestoneId: string): boolean {
   );
 }
 
+/**
+ * A directory extracted to a bare `M{NNN}` id is not unregistered when the
+ * milestone is actually registered under a `unique_milestone_ids` suffixed id
+ * (`M{NNN}-<suffix>`) for the same sequence number. The flat-phase extractor in
+ * `milestone-ids` cannot recover the suffix from a descriptive slug (e.g.
+ * `07-v40fmq-m007-...-footer-system`), so it falls through to the bare `M007`.
+ * Probing the DB for a suffixed row on that sequence resolves the directory to
+ * its registered identity instead of firing a false-positive drift (issue
+ * #1281).
+ */
+function hasRegisteredSuffixedVariant(milestoneId: string): boolean {
+  const { suffix, num } = parseMilestoneId(milestoneId);
+  // Only bare, well-formed `M{NNN}` ids can be ambiguous with a suffixed row.
+  if (suffix || num === 0) return false;
+  return getAllMilestones().some((m) => {
+    const parsed = parseMilestoneId(m.id);
+    return parsed.num === num && parsed.suffix !== undefined;
+  });
+}
+
 export function detectUnregisteredMilestoneDrift(
   _state: GSDState,
   ctx: DriftContext,
@@ -38,6 +58,7 @@ export function detectUnregisteredMilestoneDrift(
   const drifts: UnregisteredMilestoneDrift[] = [];
   for (const milestoneId of findMilestoneIds(ctx.basePath)) {
     if (getMilestone(milestoneId)) continue;
+    if (hasRegisteredSuffixedVariant(milestoneId)) continue;
     if (!milestoneHasContent(ctx.basePath, milestoneId)) continue;
     drifts.push({ kind: "unregistered-milestone", milestoneId });
   }
@@ -45,35 +66,61 @@ export function detectUnregisteredMilestoneDrift(
 }
 
 /**
- * Repair intentionally fails closed. The project-root DB is authoritative at
- * runtime; markdown-only milestones must be reconciled through an explicit,
- * operator-controlled action so operators opt into changing canonical state.
- *
- * The hint deliberately leads with the *targeted*, non-destructive options. The
- * common cause of this drift is a directory left under an old ID after a
- * `unique_milestone_ids` rename, where the right fix is to rename (move) the
- * directory — not a full DB reimport. `/gsd recover --confirm` is a destructive
- * clear-and-reimport of the entire DB and is offered only as a last resort, so
- * users do not reach for it expecting a targeted repair (see issue #826).
+ * The recovery hint deliberately leads with the *targeted*, non-destructive
+ * options. The common cause of this drift is a directory left under an old ID
+ * after a `unique_milestone_ids` rename, where the right fix is to rename (move)
+ * the directory — not a full DB reimport. `/gsd recover --confirm` is a
+ * destructive clear-and-reimport of the entire DB and is offered only as a last
+ * resort, so users do not reach for it expecting a targeted repair (see issue
+ * #826).
+ */
+function unregisteredMilestoneGuidance(
+  record: UnregisteredMilestoneDrift,
+  ctx: DriftContext,
+): string {
+  const dir = resolveMilestonePath(ctx.basePath, record.milestoneId);
+  const dirHint = dir ?? `the .gsd directory for ${record.milestoneId}`;
+  return (
+    `Milestone ${record.milestoneId} exists only as markdown projection ` +
+    "(on-disk ROADMAP/CONTEXT/SUMMARY with no authoritative DB row). " +
+    "Runtime reconciliation will not import markdown into the DB. Choose one:\n" +
+    `  • Rename: if this directory is the same milestone under an old ID (e.g. a unique_milestone_ids rename), move \`${dirHint}\` to the current ID's directory and re-run.\n` +
+    `  • Discard: if this milestone is no longer relevant, delete \`${dirHint}\` and re-run.\n` +
+    "  • Last resort: `/gsd recover --confirm` performs a destructive full DB clear-and-reimport — it does NOT do a targeted import and can replace or duplicate existing DB milestones."
+  );
+}
+
+/**
+ * Terminal blocker for an unregistered milestone. The project-root DB is
+ * authoritative at runtime; markdown-only milestones must be reconciled through
+ * an explicit, operator-controlled action so operators opt into changing
+ * canonical state. Exposing this as a `blocker` (matching the `artifact-db`
+ * convention) surfaces the drift as a pause-with-hint that gates dispatch,
+ * instead of a guaranteed repair throw that escalates auto-mode health to red
+ * (see issue #1281).
+ */
+export function describeUnregisteredMilestoneBlocker(
+  record: UnregisteredMilestoneDrift,
+  ctx: DriftContext,
+): string {
+  return unregisteredMilestoneGuidance(record, ctx);
+}
+
+/**
+ * Repair intentionally fails closed. Retained as a defensive fallback for the
+ * reconciliation engine; in practice `blocker` short-circuits this drift into a
+ * non-fatal pause before repair is ever attempted.
  */
 export function repairUnregisteredMilestone(
   record: UnregisteredMilestoneDrift,
   ctx: DriftContext,
 ): void {
-  const dir = resolveMilestonePath(ctx.basePath, record.milestoneId);
-  const dirHint = dir ?? `the .gsd directory for ${record.milestoneId}`;
-  throw new Error(
-    `Milestone ${record.milestoneId} exists only as markdown projection ` +
-      "(on-disk ROADMAP/CONTEXT/SUMMARY with no authoritative DB row). " +
-      "Runtime reconciliation will not import markdown into the DB. Choose one:\n" +
-      `  • Rename: if this directory is the same milestone under an old ID (e.g. a unique_milestone_ids rename), move \`${dirHint}\` to the current ID's directory and re-run.\n` +
-      `  • Discard: if this milestone is no longer relevant, delete \`${dirHint}\` and re-run.\n` +
-      "  • Last resort: `/gsd recover --confirm` performs a destructive full DB clear-and-reimport — it does NOT do a targeted import and can replace or duplicate existing DB milestones.",
-  );
+  throw new Error(unregisteredMilestoneGuidance(record, ctx));
 }
 
 export const unregisteredMilestoneHandler: DriftHandler<UnregisteredMilestoneDrift> = {
   kind: "unregistered-milestone",
   detect: detectUnregisteredMilestoneDrift,
+  blocker: describeUnregisteredMilestoneBlocker,
   repair: repairUnregisteredMilestone,
 };

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1032,7 +1032,7 @@ test("ADR-017 (#5703): live worker lock is not cleared", async (t) => {
 
 // ─── #5704: unregistered-milestone drift ────────────────────────────────────
 
-test("ADR-017 (#5704): unregistered-milestone drift fails closed without importing markdown", async (t) => {
+test("ADR-017 (#5704/#1281): unregistered-milestone drift pauses with a hint instead of hard-escalating", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-projmd-"));
   const milestoneDir = join(base, ".gsd", "phases", "42-test");
   mkdirSync(milestoneDir, { recursive: true });
@@ -1059,27 +1059,65 @@ test("ADR-017 (#5704): unregistered-milestone drift fails closed without importi
   // Pre-condition: filesystem has the milestone, DB does NOT.
   assert.equal(getMilestone("M042"), null, "pre: DB has no row for M042");
 
-  await assert.rejects(
-    reconcileBeforeDispatch(base, {
-      invalidateStateCache: () => {},
-      deriveState: async () => makeState(),
-    }),
-    (err: unknown) => {
-      assert.ok(err instanceof ReconciliationFailedError);
-      assert.match(String(err.message), /unregistered-milestone/);
-      assert.equal(err.failures[0]?.drift.kind, "unregistered-milestone");
-      assert.match(String(err.failures[0]?.cause), /M042/);
-      assert.match(String(err.failures[0]?.cause), /markdown projection/);
-      // Hint leads with targeted, non-destructive actions (rename/discard)...
-      assert.match(String(err.failures[0]?.cause), /Rename/);
-      assert.match(String(err.failures[0]?.cause), /Discard/);
-      // ...and reframes recover as a destructive last resort, not the fix (#826).
-      assert.match(String(err.failures[0]?.cause), /\/gsd recover/);
-      assert.match(String(err.failures[0]?.cause), /last resort/i);
-      return true;
-    },
-  );
+  // #1281: the handler exposes a `blocker`, so reconciliation returns a
+  // non-fatal pause-with-hint (ok:true + blocker) rather than throwing.
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+  assert.equal(result.ok, true);
+  const blocker = result.blockers.find((b) => /M042/.test(b));
+  assert.ok(blocker, "expected an M042 unregistered-milestone blocker");
+  assert.match(blocker!, /markdown projection/);
+  // Hint leads with targeted, non-destructive actions (rename/discard)...
+  assert.match(blocker!, /Rename/);
+  assert.match(blocker!, /Discard/);
+  // ...and reframes recover as a destructive last resort, not the fix (#826).
+  assert.match(blocker!, /\/gsd recover/);
+  assert.match(blocker!, /last resort/i);
+  // Runtime never imports markdown into the DB.
   assert.equal(getMilestone("M042"), null, "post: DB still has no row for M042");
+});
+
+test("#1281: descriptive flat-phase dir registered under a suffixed id → no false-positive drift", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-1281-suffix-"));
+  // Descriptive slug the flat-phase extractor cannot recover the suffix from →
+  // it derives the bare `M007`, which has no DB row.
+  const milestoneDir = join(base, ".gsd", "phases", "07-v40fmq-m007-v40fmq-navigation-footer-system");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(
+    join(milestoneDir, "M007-v40fmq-ROADMAP.md"),
+    [
+      "# M007: Navigation Footer System",
+      "",
+      "**Vision:** Verify no false-positive unregistered-milestone drift",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Foundation** `risk:medium` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  // The milestone IS registered — under the unique_milestone_ids suffixed id.
+  insertMilestone({ id: "M007-v40fmq", title: "Navigation Footer System", status: "complete" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.blockers.some((b) => /unregistered/i.test(b) || /M007/.test(b)),
+    false,
+    "bare M007 derived from the slug must resolve to the registered M007-v40fmq row",
+  );
 });
 
 test("ADR-017 (#5704): registered milestone (DB row present) → no drift", async (t) => {


### PR DESCRIPTION
## Summary
- Fixed the flat-phase extractor false positive by probing the DB for a suffixed milestone variant in the drift detector and gave the unregistered-milestone handler a blocker so it pauses-with-hint instead of escalating; verified with typecheck, build, and the reconciliation-drift + milestone-id test suites.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1281
- [#1281 unregistered-milestone false positive: flat-phase ID extractor derives bare M### from descriptive slug, missing suffixed DB row (M###-abcdef)](https://github.com/open-gsd/gsd-pi/issues/1281)

## User
- @klajdo-f

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1281-unregistered-milestone-false-positive-fl-1783337995`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-dispatch reconciliation gating and drift detection for milestones; wrong suffixed matching could hide real drift, but scope is limited to the unregistered-milestone handler and existing repair/blocker patterns.
> 
> **Overview**
> Fixes **false-positive** `unregistered-milestone` drift when flat-phase directories resolve to a bare `M###` id but the milestone is registered as `M###-<suffix>` in the DB. Detection now skips drift if any suffixed row shares that sequence number.
> 
> **Unregistered-milestone** handling now exposes a **`blocker`** (shared recovery guidance via `unregisteredMilestoneGuidance`) so reconciliation returns **`ok: true`** with a pause hint instead of throwing and hard-escalating auto-mode health. Repair still fails closed as a fallback.
> 
> Tests were updated for the blocker behavior and add coverage for the descriptive-slug / suffixed-DB case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd446bf732e1958d346a9d321962f9322328b39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->