### PR TITLE
fix(issue): [Bug]: `sketchFlagHandler` clears `is_sketch` on mere PLAN-file existence, including a stub or leftover PLAN

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
@@ -8,13 +8,14 @@
 //      sketch slices to plan-slice, which writes PLAN.md but leaves
 //      is_sketch=1 — the next reconciliation pass clears it.
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 import {
   getSketchedSliceIds,
   isDbAvailable,
   setSliceSketchFlag,
 } from "../../gsd-db.js";
+import { parsePlan } from "../../parsers-legacy.js";
 import { resolveSliceFile } from "../../paths.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
@@ -31,11 +32,35 @@ export function detectStaleSketchFlags(
 
   const sliceIds = getSketchedSliceIds(mid);
   return sliceIds
-    .filter((sid) => {
-      const planPath = resolveSliceFile(ctx.basePath, mid, sid, "PLAN");
-      return planPath !== null && existsSync(planPath);
-    })
+    .filter((sid) => sketchIsPlanned(ctx.basePath, mid, sid))
     .map((sid) => ({ kind: "stale-sketch-flag" as const, mid, sid }));
+}
+
+/**
+ * A sketch slice counts as "planned" (so its is_sketch flag may be cleared)
+ * only when it has a *real* plan on disk — not merely any PLAN file.
+ *
+ * File existence alone (#1287) is too weak: a stub/placeholder PLAN, a
+ * crash-leftover, or a projection round-trip that emits synthetic "Plan NN"
+ * task titles (migrate/transformer.buildTaskTitle) all satisfy existsSync yet
+ * were never actually refined. Clearing the flag for one strips the `refining`
+ * guard in phase derivation and lets a phantom task drive dispatch.
+ *
+ * A legitimate plan-slice always decomposes into >= 1 genuine task, so require
+ * at least one non-placeholder task. This is strictly stricter than the old
+ * existence check — the documented crash-recovery scenarios (a real plan-slice
+ * that wrote its tasks) still clear, a bare stub no longer does.
+ */
+function sketchIsPlanned(basePath: string, mid: string, sid: string): boolean {
+  const planPath = resolveSliceFile(basePath, mid, sid, "PLAN");
+  if (planPath === null || !existsSync(planPath)) return false;
+  try {
+    const plan = parsePlan(readFileSync(planPath, "utf-8"));
+    return plan.tasks.some((t) => !/^Plan\s+\d+$/i.test(t.title.trim()));
+  } catch {
+    // A PLAN we cannot parse is not a trustworthy "planning done" signal.
+    return false;
+  }
 }
 
 export function repairStaleSketchFlag(record: SketchFlagDrift): void {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
@@ -37,6 +37,21 @@ export function detectStaleSketchFlags(
 }
 
 /**
+ * True when a task title is a synthetic placeholder emitted by a projection
+ * round-trip rather than a real, refined task. `migrate/transformer.buildTaskTitle`
+ * produces two shapes when a plan was never decomposed:
+ *   - `Plan NN`            (fallback when phase/plan frontmatter is absent)
+ *   - `${phase} ${plan}`   (e.g. `00 01`, `00 03b`, `29-auth-system 01`)
+ * Neither carries genuine planning intent, so both must be treated as stubs.
+ */
+function isPlaceholderTaskTitle(title: string): boolean {
+  const t = title.trim();
+  if (/^Plan\s+\d+[a-z]*$/i.test(t)) return true;
+  // buildTaskTitle returns `${phase} ${plan}` when frontmatter has both fields.
+  return /^[\w-]+\s+\d+[a-z]*$/i.test(t);
+}
+
+/**
  * A sketch slice counts as "planned" (so its is_sketch flag may be cleared)
  * only when it has a *real* plan on disk — not merely any PLAN file.
  *
@@ -61,19 +76,6 @@ function sketchIsPlanned(basePath: string, mid: string, sid: string): boolean {
     // A PLAN we cannot parse is not a trustworthy "planning done" signal.
     return false;
   }
-}
-
-/**
- * True when a task title is a synthetic placeholder emitted by a projection
- * round-trip rather than a real, refined task. `migrate/transformer.buildTaskTitle`
- * produces two shapes when a plan was never decomposed:
- *   - `Plan NN`            (fallback when phase/plan frontmatter is absent)
- *   - `${phase} ${plan}`   (e.g. `00 01` — two numeric tokens)
- * Neither carries genuine planning intent, so both must be treated as stubs.
- */
-function isPlaceholderTaskTitle(title: string): boolean {
-  const trimmed = title.trim();
-  return /^Plan\s+\d+$/i.test(trimmed) || /^\d+\s+\d+$/.test(trimmed);
 }
 
 export function repairStaleSketchFlag(record: SketchFlagDrift): void {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
@@ -41,7 +41,7 @@ export function detectStaleSketchFlags(
  * only when it has a *real* plan on disk — not merely any PLAN file.
  *
  * File existence alone (#1287) is too weak: a stub/placeholder PLAN, a
- * crash-leftover, or a projection round-trip that emits synthetic "Plan NN"
+ * crash-leftover, or a projection round-trip that emits synthetic placeholder
  * task titles (migrate/transformer.buildTaskTitle) all satisfy existsSync yet
  * were never actually refined. Clearing the flag for one strips the `refining`
  * guard in phase derivation and lets a phantom task drive dispatch.
@@ -56,11 +56,24 @@ function sketchIsPlanned(basePath: string, mid: string, sid: string): boolean {
   if (planPath === null || !existsSync(planPath)) return false;
   try {
     const plan = parsePlan(readFileSync(planPath, "utf-8"));
-    return plan.tasks.some((t) => !/^Plan\s+\d+$/i.test(t.title.trim()));
+    return plan.tasks.some((t) => !isPlaceholderTaskTitle(t.title));
   } catch {
     // A PLAN we cannot parse is not a trustworthy "planning done" signal.
     return false;
   }
+}
+
+/**
+ * True when a task title is a synthetic placeholder emitted by a projection
+ * round-trip rather than a real, refined task. `migrate/transformer.buildTaskTitle`
+ * produces two shapes when a plan was never decomposed:
+ *   - `Plan NN`            (fallback when phase/plan frontmatter is absent)
+ *   - `${phase} ${plan}`   (e.g. `00 01` — two numeric tokens)
+ * Neither carries genuine planning intent, so both must be treated as stubs.
+ */
+function isPlaceholderTaskTitle(title: string): boolean {
+  const trimmed = title.trim();
+  return /^Plan\s+\d+$/i.test(trimmed) || /^\d+\s+\d+$/.test(trimmed);
 }
 
 export function repairStaleSketchFlag(record: SketchFlagDrift): void {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
@@ -48,7 +48,9 @@ function isPlaceholderTaskTitle(title: string): boolean {
   const t = title.trim();
   if (/^Plan\s+\d+[a-z]*$/i.test(t)) return true;
   // buildTaskTitle returns `${phase} ${plan}` when frontmatter has both fields.
-  return /^[\w-]+\s+\d+[a-z]*$/i.test(t);
+  // Phase slugs are digit-led (e.g. `00`, `29-auth-system`); require that so
+  // legitimate titles like `Step 1` are not misclassified as stubs.
+  return /^\d[\w-]*\s+\d+[a-z]*$/i.test(t);
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
+++ b/src/resources/extensions/gsd/tests/parsers-legacy-importers.test.ts
@@ -47,6 +47,9 @@ const ALLOWED_IMPORTERS = new Set([
   "gsd/migration-auto-check.ts",
   // drift detection: compares markdown projection against DB by design
   "gsd/state-reconciliation/drift/roadmap.ts",
+  // drift detection: reads PLAN.md tasks to distinguish a real plan from a
+  // stub before clearing a stale is_sketch flag (#1287)
+  "gsd/state-reconciliation/drift/sketch-flag.ts",
   // stale-render detection + render verification helpers over rendered output
   "gsd/markdown-renderer.ts",
   // pre-migration fallback: deriveState must work before the DB exists

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -76,6 +76,21 @@ function writeS01Artifacts(base: string): void {
   writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"), "# S01 Summary\n");
 }
 
+// A *real* decomposed PLAN (>= 1 genuine task). #1287: the stale-sketch-flag
+// detector requires a real plan — not a bare stub — before clearing is_sketch.
+function realPlanContent(sliceId: string): string {
+  return [
+    `# ${sliceId}: Feature`,
+    "",
+    "**Goal:** Ship the feature",
+    "",
+    "## Tasks",
+    "",
+    "- [ ] **T01: Build the feature** `est:1h`",
+    "",
+  ].join("\n");
+}
+
 function cleanup(base: string, originalCwd: string): void {
   try { closeDatabase(); } catch { /* noop */ }
   process.chdir(originalCwd);
@@ -185,7 +200,7 @@ test("ADR-011: existing PLAN + stale sketch flag heals via reconcileBeforeDispat
   writePreferences(base, "phases:\n  progressive_planning: true");
   writeFileSync(
     join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
-    "# S02 Plan\n",
+    realPlanContent("S02"),
   );
   process.chdir(base);
 
@@ -252,7 +267,7 @@ test("ADR-011: reconcileBeforeDispatch auto-heals stale sketch flag when PLAN ex
   // Simulate plan-slice completion where PLAN exists but is_sketch was not flipped.
   writeFileSync(
     join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
-    "# S02 Plan\n",
+    realPlanContent("S02"),
   );
   process.chdir(base);
 
@@ -282,7 +297,7 @@ test("ADR-011: deriveState stays pure across worktree/canonical-root; healing be
   writePreferences(base, "phases:\n  skip_research: false");
   writeFileSync(
     join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
-    "# S02 Plan\n",
+    realPlanContent("S02"),
   );
   const worktreePath = join(base, "worker");
   mkdirSync(worktreePath, { recursive: true });

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -107,11 +107,11 @@ test("ADR-017 (#5700): sketch-flag drift detected and repaired end-to-end", asyn
     sketchScope: "limited",
   });
 
-  // Simulate the post-crash scenario: PLAN.md exists on disk but the
-  // is_sketch flag is still 1.
+  // Simulate the post-crash scenario: a *real* PLAN.md (a decomposed task)
+  // exists on disk but the is_sketch flag is still 1.
   writeFileSync(
     join(base, ".gsd", "phases", "01-test", "01-02-PLAN.md"),
-    "# S02 Plan\n",
+    makeStalePlanContent("S02", [{ id: "T01", title: "Build the feature", done: false }]),
   );
   assert.equal(getSlice("M001", "S02")?.is_sketch, 1, "pre: flagged as sketch");
 
@@ -129,6 +129,56 @@ test("ADR-017 (#5700): sketch-flag drift detected and repaired end-to-end", asyn
     assert.equal(result.repaired[0].mid, "M001");
     assert.equal(result.repaired[0].sid, "S02");
   }
+});
+
+test("#1287: stub/placeholder PLAN does NOT clear the sketch flag", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({
+    id: "S02",
+    milestoneId: "M001",
+    title: "Feature",
+    status: "pending",
+    risk: "medium",
+    depends: [],
+    demo: "S02 demo.",
+    sequence: 1,
+    isSketch: true,
+    sketchScope: "limited",
+  });
+
+  const planPath = join(base, ".gsd", "phases", "01-test", "01-02-PLAN.md");
+
+  // A bare stub PLAN (no decomposed tasks) must not clear the flag.
+  writeFileSync(planPath, "# S02 Plan\n");
+  clearRendererCaches();
+  let state = makeState({ activeMilestone: { id: "M001", title: "Test" } });
+  let result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => state,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 1, "stub PLAN: flag stays set");
+  assert.equal(result.repaired.length, 0, "stub PLAN: no repair");
+
+  // A projection round-trip stub whose only task is a synthetic "Plan NN"
+  // placeholder (migrate/transformer.buildTaskTitle) must also not clear it.
+  writeFileSync(
+    planPath,
+    makeStalePlanContent("S02", [{ id: "T01", title: "Plan 01", done: false }]),
+  );
+  clearRendererCaches();
+  state = makeState({ activeMilestone: { id: "M001", title: "Test" } });
+  result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => state,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 1, "placeholder task: flag stays set");
+  assert.equal(result.repaired.length, 0, "placeholder task: no repair");
 });
 
 test("ADR-017 (#5700): repair failure throws ReconciliationFailedError with shape", async () => {
@@ -1977,7 +2027,7 @@ test("deriveState is pure: stale sketch healed only via reconcileBeforeDispatch"
   });
   writeFileSync(
     join(base, ".gsd", "phases", "01-test", "01-02-PLAN.md"),
-    "# S02 Plan\n",
+    makeStalePlanContent("S02", [{ id: "T01", title: "Build the feature", done: false }]),
   );
 
   const { deriveState } = await import("../state.ts");

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -202,6 +202,49 @@ test("#1287: stub/placeholder PLAN does NOT clear the sketch flag", async (t) =>
   assert.equal(result.repaired.length, 0, "phase/plan placeholder task: no repair");
 });
 
+test("#1288: real tasks shaped like `word + number` still clear the sketch flag", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({
+    id: "S02",
+    milestoneId: "M001",
+    title: "Feature",
+    status: "pending",
+    risk: "medium",
+    depends: [],
+    demo: "S02 demo.",
+    sequence: 1,
+    isSketch: true,
+    sketchScope: "limited",
+  });
+
+  const planPath = join(base, ".gsd", "phases", "01-test", "01-02-PLAN.md");
+
+  // `Step 1` / `RFC 1234` match the loose `word + number` shape but are genuine
+  // decomposed tasks. buildTaskTitle only emits `${phase} ${plan}` with a
+  // digit-led phase, so these must NOT be read as placeholders (#1288): a real
+  // plan-slice like this must still clear the stale is_sketch flag.
+  writeFileSync(
+    planPath,
+    makeStalePlanContent("S02", [
+      { id: "T01", title: "Step 1", done: false },
+      { id: "T02", title: "RFC 1234", done: false },
+    ]),
+  );
+  clearRendererCaches();
+  const state = makeState({ activeMilestone: { id: "M001", title: "Test" } });
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => state,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "real task titles: flag cleared");
+  assert.equal(result.repaired.length, 1, "real task titles: repaired once");
+});
+
 test("ADR-017 (#5700): repair failure throws ReconciliationFailedError with shape", async () => {
   const seenDrift: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
   const handler: DriftHandler = {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -179,6 +179,27 @@ test("#1287: stub/placeholder PLAN does NOT clear the sketch flag", async (t) =>
   assert.equal(result.ok, true);
   assert.equal(getSlice("M001", "S02")?.is_sketch, 1, "placeholder task: flag stays set");
   assert.equal(result.repaired.length, 0, "placeholder task: no repair");
+
+  // buildTaskTitle also emits `${phase} ${plan}` (e.g. "00 01") when the plan
+  // frontmatter carries phase/plan. This projected placeholder must not clear
+  // the flag either.
+  writeFileSync(
+    planPath,
+    makeStalePlanContent("S02", [{ id: "T01", title: "00 01", done: false }]),
+  );
+  clearRendererCaches();
+  state = makeState({ activeMilestone: { id: "M001", title: "Test" } });
+  result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => state,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(
+    getSlice("M001", "S02")?.is_sketch,
+    1,
+    "phase/plan placeholder task: flag stays set",
+  );
+  assert.equal(result.repaired.length, 0, "phase/plan placeholder task: no repair");
 });
 
 test("ADR-017 (#5700): repair failure throws ReconciliationFailedError with shape", async () => {


### PR DESCRIPTION
## Summary
- Strengthened the stale-sketch-flag detector to require a real (non-placeholder) planned task before clearing `is_sketch`, verified via focused drift and progressive-planning test suites (88 tests passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1287
- [#1287 [Bug]: `sketchFlagHandler` clears `is_sketch` on mere PLAN-file existence, including a stub or leftover PLAN](https://github.com/open-gsd/gsd-pi/issues/1287)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1287-bug-sketchflaghandler-clears-is-sketch-o-1783352516`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `is_sketch` is cleared before dispatch, which gates refining vs planning; incorrect placeholder matching could leave flags stuck or clear too early, but scope is limited to sketch reconciliation.
> 
> **Overview**
> Fixes **#1287**: the ADR-017 **stale-sketch-flag** drift handler no longer treats any on-disk PLAN as proof that refinement finished.
> 
> **Detection** now reads and parses the slice PLAN and only treats the slice as planned when there is **at least one task whose title is not a synthetic placeholder** (`Plan NN` or digit-led `${phase} ${plan}` shapes from projection round-trips). Bare stubs, unparseable PLANs, and placeholder-only plans **do not** clear `is_sketch`, so phase derivation keeps the **refining** guard and dispatch does not advance on phantom plans.
> 
> **Tests** use decomposed PLAN fixtures for heal scenarios and add **#1287** coverage for stub PLANs and both placeholder title patterns; progressive-planning heal tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5346f7a778d8d89604bb034a9d0b1d8ddf207671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->