### PR TITLE
fix(issue): [Bug]: `migrateHierarchyToDb` imports a `[sketch]` slice's stub PLAN tasks as real DB rows, flipping planning→executing

### DIFF
--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -810,8 +810,13 @@ export function migrateHierarchyToDb(basePath: string): {
       }
       counts.slices++;
 
-      // Insert tasks from parsed plan
-      if (!plan) continue;
+      // Insert tasks from parsed plan.
+      // Sketch slices carry only a stub PLAN until refined; do not seed DB
+      // tasks from a placeholder <tasks> block (would falsely flip
+      // planning -> executing before the slice is decomposed). Once the
+      // `[sketch]` badge is removed by a real plan-slice, tasks import
+      // normally on the next pass. (#1286)
+      if (!plan || sliceEntry.isSketch) continue;
 
       for (const taskEntry of plan.tasks) {
         // Per K002: use 'complete' not 'done'

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -169,6 +169,9 @@ export function scanMarkdownHierarchy(basePath: string): HierarchyScan {
 
     for (const slice of roadmap.slices) {
       scan.slices.add(`${milestoneId}/${slice.id}`);
+      // Sketch slices carry only a stub PLAN until refined; match migrateHierarchyToDb
+      // and do not count placeholder tasks from the <tasks> block (#1286).
+      if (slice.isSketch) continue;
       const planPath = resolveSliceFile(basePath, milestoneId, slice.id, "PLAN");
       if (!planPath || !existsSync(planPath)) continue;
       const plan = parsePlan(readFileSync(planPath, "utf-8"));

--- a/src/resources/extensions/gsd/tests/db-authority-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/db-authority-regression.test.ts
@@ -17,7 +17,7 @@ import {
   openDatabase,
 } from "../gsd-db.ts";
 import { migrateHierarchyToDb } from "../md-importer.ts";
-import { checkMarkdownHierarchyAgainstDb } from "../migration-auto-check.ts";
+import { checkMarkdownHierarchyAgainstDb, countMarkdownHierarchy } from "../migration-auto-check.ts";
 import { queryDecisions } from "../context-store.ts";
 import { deriveStateFromDb, invalidateStateCache } from "../state.ts";
 import type { Requirement } from "../types.ts";
@@ -205,4 +205,79 @@ test("explicit markdown import remains opt-in and is not run by startup mismatch
   assert.deepEqual(imported, { milestones: 1, slices: 1, tasks: 1 });
   assert.equal(getAllMilestones().length, 1);
   assert.equal(getSliceTasks("M001", "S01").length, 1);
+});
+
+// #1286: migrateHierarchyToDb skips a `[sketch]` slice's stub PLAN tasks, so
+// scanMarkdownHierarchy must skip counting them too. Otherwise the markdown
+// scan claims task rows the DB authoritatively omits, and the startup drift
+// check perpetually reports recovery-required / recommends
+// `/gsd recover --confirm` — which re-skips the stub tasks and never converges.
+test("sketch slice stub tasks are not treated as markdown/DB drift", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  const sketchSliceDir = join(milestoneDir, "slices", "S01");
+  const realSliceDir = join(milestoneDir, "slices", "S02");
+  mkdirSync(sketchSliceDir, { recursive: true });
+  mkdirSync(realSliceDir, { recursive: true });
+
+  // S01 is a sketch (badge before risk, per ADR-011 render); S02 is refined.
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    [
+      "# M001: Sketch Drift",
+      "",
+      "**Vision:** Sketch stub tasks must not count as drift",
+      "",
+      "## Slices",
+      "- [ ] **S01: Sketch Slice** `[sketch]` `risk:low` `depends:[]`",
+      "  > After this: Sketch decomposed.",
+      "",
+      "- [ ] **S02: Real Slice** `risk:low` `depends:[]`",
+      "  > After this: Real work done.",
+      "",
+    ].join("\n"),
+  );
+  // The sketch slice still carries a stub PLAN with a placeholder <tasks> block.
+  writeFileSync(
+    join(sketchSliceDir, "S01-PLAN.md"),
+    [
+      "# S01: Sketch Slice",
+      "",
+      "**Goal:** Placeholder.",
+      "",
+      "## Tasks",
+      "- [ ] **T01: Plan 01**",
+      "  Stub placeholder task.",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(realSliceDir, "S02-PLAN.md"),
+    [
+      "# S02: Real Slice",
+      "",
+      "**Goal:** Real work.",
+      "",
+      "## Tasks",
+      "- [ ] **T01: Task** `est:5m`",
+      "",
+    ].join("\n"),
+  );
+
+  openProjectDb(base);
+  // The importer seeds S02's task but skips S01's stub (1 task total).
+  const imported = migrateHierarchyToDb(base);
+  assert.deepEqual(imported, { milestones: 1, slices: 2, tasks: 1 });
+  assert.equal(getSliceTasks("M001", "S01").length, 0, "sketch slice seeds no tasks");
+  assert.equal(getSliceTasks("M001", "S02").length, 1, "real slice seeds its task");
+
+  // The markdown scan must mirror the importer: the sketch stub task is not
+  // counted, so markdown (1 task) matches the DB (1 task) and the check is
+  // in-sync rather than recommending a recover that would never converge.
+  assert.deepEqual(countMarkdownHierarchy(base), { milestones: 1, slices: 2, tasks: 1 });
+  const check = await checkMarkdownHierarchyAgainstDb(base);
+  assert.equal(check.action, "none", "sketch stub tasks must not be flagged as drift");
+  assert.equal(check.reason, "in-sync");
 });

--- a/src/resources/extensions/gsd/tests/migrate-hierarchy.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-hierarchy.test.ts
@@ -427,3 +427,56 @@ test('migrate-hier: demo text extracted', () => {
     }
 });
 
+  // ─── Test (i): Sketch slice stub tasks are not seeded (#1286) ─────────
+
+test('migrate-hier: sketch slice stub PLAN tasks are not imported', () => {
+    const base = createFixtureBase();
+    try {
+      // S01 is a sketch (badge before risk, per ADR-011 render); its PLAN is a
+      // stub with a placeholder <tasks> block. S02 is a real, refined slice.
+      const roadmap = `# M001: Test Milestone
+
+**Vision:** Sketch slices must not seed DB tasks.
+
+## Slices
+
+- [ ] **S01: Sketch Slice** \`[sketch]\` \`risk:low\` \`depends:[]\`
+  > After this: Sketch decomposed.
+
+- [ ] **S02: Real Slice** \`risk:low\` \`depends:[]\`
+  > After this: Real work done.
+`;
+      const sketchPlan = `# S01: Sketch Slice
+
+**Goal:** Placeholder.
+
+## Tasks
+
+- [ ] **T01: Plan 01**
+  Stub placeholder task.
+`;
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', roadmap);
+      writeFile(base, 'milestones/M001/slices/S01/S01-PLAN.md', sketchPlan);
+      writeFile(base, 'milestones/M001/slices/S02/S02-PLAN.md', PLAN_S02_1_TASK);
+
+      openDatabase(':memory:');
+      const counts = migrateHierarchyToDb(base);
+
+      const slices = getMilestoneSlices('M001');
+      assert.deepStrictEqual(slices.length, 2, 'sketch: 2 slices inserted');
+      assert.deepStrictEqual(slices[0]!.is_sketch, 1, 'sketch: S01 preserves is_sketch flag');
+
+      const s01Tasks = getSliceTasks('M001', 'S01');
+      assert.deepStrictEqual(s01Tasks.length, 0, 'sketch: no stub tasks seeded for sketch slice S01');
+
+      const s02Tasks = getSliceTasks('M001', 'S02');
+      assert.deepStrictEqual(s02Tasks.length, 1, 'sketch: real slice S02 still imports its task');
+      assert.deepStrictEqual(counts.tasks, 1, 'sketch: only the non-sketch slice contributes tasks');
+
+      closeDatabase();
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+});
+

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -420,6 +420,59 @@ test("migration auto-check still reports real drift with scratch dirs excluded f
   }
 });
 
+test("migration auto-check excludes sketch slice stub tasks from the markdown scan (#1286)", () => {
+  const base = makeBase();
+  try {
+    // S01 is a sketch (`[sketch]` badge): its PLAN is a stub carrying a
+    // placeholder <tasks> block until refinement. migrateHierarchyToDb skips
+    // seeding those stub tasks, so the markdown scan must skip them too — else
+    // the stub inflates the markdown count and reports false drift against a DB
+    // that (correctly) holds zero tasks for the sketch slice.
+    const roadmap = `# M001: Test Milestone
+
+**Vision:** Sketch slices must not inflate markdown task counts.
+
+## Slices
+
+- [ ] **S01: Sketch Slice** \`[sketch]\` \`risk:low\` \`depends:[]\`
+  > After this: Sketch decomposed.
+
+- [ ] **S02: Real Slice** \`risk:low\` \`depends:[]\`
+  > After this: Real work done.
+`;
+    const sketchPlan = `# S01: Sketch Slice
+
+**Goal:** Placeholder.
+
+## Tasks
+
+- [ ] **T01: Plan 01**
+  Stub placeholder task.
+`;
+    const realPlan = `# S02: Real Slice
+
+**Goal:** Real work.
+
+## Tasks
+
+- [ ] **T01: Real Task**
+  Real work.
+`;
+    const milestoneDir = join(base, ".gsd", "milestones", "M001");
+    mkdirSync(join(milestoneDir, "slices", "S01"), { recursive: true });
+    mkdirSync(join(milestoneDir, "slices", "S02"), { recursive: true });
+    writeFileSync(join(milestoneDir, "M001-ROADMAP.md"), roadmap);
+    writeFileSync(join(milestoneDir, "slices", "S01", "S01-PLAN.md"), sketchPlan);
+    writeFileSync(join(milestoneDir, "slices", "S02", "S02-PLAN.md"), realPlan);
+
+    // Both slices count, but only the refined slice contributes a task; the
+    // sketch stub task is excluded, matching migrateHierarchyToDb.
+    assert.deepEqual(countMarkdownHierarchy(base), { milestones: 1, slices: 2, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("migration auto-check still compares a roadmapless milestone that HAS a DB row", async () => {
   const base = makeBase();
   try {


### PR DESCRIPTION
## Summary
- Gated the `migrateHierarchyToDb` task loop with `sliceEntry.isSketch` so sketch slices' stub PLAN tasks aren't seeded as real DB rows, added a regression test, and verified with the importer/reconcile suites.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1286
- [#1286 [Bug]: `migrateHierarchyToDb` imports a `[sketch]` slice's stub PLAN tasks as real DB rows, flipping planning→executing](https://github.com/open-gsd/gsd-pi/issues/1286)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1286-bug-migratehierarchytodb-imports-a-sketc-1783353236`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted guard on markdown→DB import and hierarchy scanning; behavior change is limited to sketch slices and is covered by new tests.
> 
> **Overview**
> Fixes **#1286**: roadmap slices marked **`[sketch]`** (ADR-011) can still have a placeholder **PLAN** with stub **Tasks**, which **`migrateHierarchyToDb`** was importing as real task rows and could push workflow from planning into executing too early.
> 
> **`migrateHierarchyToDb`** still inserts sketch slices (including **`is_sketch`**), but **skips the task loop** when **`sliceEntry.isSketch`** is set. Refined slices keep importing tasks as before; after **`plan-slice`** removes the sketch badge, a later import picks up real tasks.
> 
> **`scanMarkdownHierarchy`** in migration auto-check applies the same rule so markdown task counts are not inflated by sketch stub tasks, avoiding **false drift** vs a DB that correctly has zero tasks for that slice.
> 
> Regression coverage in **`migrate-hierarchy.test.ts`** and **`migration-auto-check.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9518a1d215061d4ce8aded4e7b344f978f480641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->