### PR TITLE
feat(gsd-cloud): standalone self-contained agent + fix gateway lookup on Node >=20

### DIFF
--- a/packages/daemon/src/cloud-config.test.ts
+++ b/packages/daemon/src/cloud-config.test.ts
@@ -5,7 +5,32 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { loadConfig } from "./config.js";
-import { exchangePairingCode, parseCloudGatewayUrl, redactedCloudStatus, saveCloudConfig } from "./cloud-config.js";
+import { createGatewayLookup, exchangePairingCode, parseCloudGatewayUrl, redactedCloudStatus, saveCloudConfig } from "./cloud-config.js";
+
+// Invoke a gateway lookup and capture (err, result) from its Node-style callback.
+function runGatewayLookup(url: string, options: unknown): Promise<{ err: Error | null; result: unknown }> {
+  const lookup = createGatewayLookup(new URL(url));
+  return new Promise((resolve) => {
+    (lookup as unknown as (h: string, o: unknown, cb: (...a: unknown[]) => void) => void)(
+      "localhost",
+      options,
+      (...args: unknown[]) => resolve({ err: (args[0] as Error | null) ?? null, result: args[1] }),
+    );
+  });
+}
+
+test("createGatewayLookup honors all:true with an array callback (regression: scalar form threw 'Invalid IP address' on Node >=20)", async () => {
+  const { err, result } = await runGatewayLookup("http://localhost", { all: true, family: 0 });
+  assert.equal(err, null, "loopback allowed for http URL");
+  assert.ok(Array.isArray(result), "all:true must call back with an array");
+  assert.ok((result as unknown[]).length > 0, "expected at least one address");
+});
+
+test("createGatewayLookup all:true still enforces the SSRF guard on every address", async () => {
+  const { err } = await runGatewayLookup("https://localhost", { all: true, family: 0 });
+  assert.ok(err instanceof Error, "https loopback must be rejected");
+  assert.match(err!.message, /private or loopback/);
+});
 
 test("cloud config stores device token but redacts status output", () => {
   const dir = mkdtempSync(join(tmpdir(), "gsd-cloud-config-"));

--- a/packages/daemon/src/cloud-config.ts
+++ b/packages/daemon/src/cloud-config.ts
@@ -1,6 +1,6 @@
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { lookup } from "node:dns";
-import type { LookupOneOptions } from "node:dns";
+import type { LookupOptions } from "node:dns";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
@@ -127,18 +127,38 @@ export function validateGatewayNetworkTarget(url: URL): void {
 
 export function createGatewayLookup(url: URL): LookupFunction {
   const allowLoopback = url.protocol === "http:" && isLoopbackHost(url.hostname);
-  return (hostname, options, callback) => {
-    const lookupOptions: LookupOneOptions = typeof options === "number"
-      ? { family: options, all: false }
-      : { ...options, all: false };
-    lookup(hostname, lookupOptions, (err, address, family) => {
+  const rejected = (address: string): boolean =>
+    !address || (!allowLoopback && isPrivateIpHost(address));
+  // Node's socket connect (autoSelectFamily / Happy Eyeballs, default-on since
+  // Node 20) calls a custom lookup with `all: true` and expects an ARRAY
+  // callback. Forcing `all: false` + a scalar callback made every real gateway
+  // request throw "Invalid IP address: undefined". Honor both forms; the SSRF
+  // guard is applied to every resolved address (reject the whole lookup if any
+  // is private/loopback — an attacker-controlled resolver must not slip one in).
+  return ((hostname: string, options: unknown, callback: (...args: unknown[]) => void) => {
+    const wantsAll =
+      typeof options === "object" && options !== null && (options as LookupOptions).all === true;
+    const base: LookupOptions =
+      typeof options === "number" ? { family: options } : { ...(options as LookupOptions) };
+    if (wantsAll) {
+      lookup(hostname, { ...base, all: true }, (err, addresses) => {
+        if (err) return callback(err);
+        const list = addresses as Array<{ address: string; family: number }>;
+        if (!list.length || list.some((entry) => rejected(entry.address))) {
+          return callback(new Error("Cloud gateway URL resolved to a private or loopback address"));
+        }
+        callback(null, list);
+      });
+      return;
+    }
+    lookup(hostname, { ...base, all: false }, (err, address, family) => {
       if (err) return callback(err, address, family);
-      if (!address || (!allowLoopback && isPrivateIpHost(address))) {
+      if (rejected(address)) {
         return callback(new Error("Cloud gateway URL resolved to a private or loopback address"), address, family);
       }
       callback(null, address, family);
     });
-  };
+  }) as unknown as LookupFunction;
 }
 
 function isPrivateIpv4(host: string): boolean {

--- a/packages/gsd-cloud/README.md
+++ b/packages/gsd-cloud/README.md
@@ -3,10 +3,15 @@
 Connect a local GSD runtime to [GSD Cloud](https://cloud.opengsd.net) so you can
 monitor and control your GSD projects from any browser.
 
-This is a thin wrapper over `@opengsd/daemon`'s cloud runtime commands. Its only
-added behavior is defaulting the gateway to `https://cloud.opengsd.net` for the
-`login` and `pair` commands, so you never have to type `--gateway`. All
-device-flow, pairing, and connection logic is provided by the daemon.
+This is a **self-contained** agent. It depends only on `ws` and `yaml` — no
+`@opengsd/daemon`, no `@opengsd/mcp-server`, no `@opengsd/gsd-pi`. It runs the
+RFC 8628 device-flow login, opens a persistent WebSocket to the cloud gateway,
+and forwards each requested GSD workflow tool to your locally-installed `gsd`
+CLI (via `gsd --mode mcp`). The gateway default of `https://cloud.opengsd.net`
+is injected for `login`/`pair` so you never have to type `--gateway`.
+
+Requires the `gsd` CLI (from `@opengsd/gsd-pi`) to be installed and on your
+`PATH` (or set `GSD_CLI_PATH`).
 
 ## Usage
 
@@ -29,6 +34,15 @@ npx @opengsd/gsd-cloud disconnect
 different gateway, pass `--gateway <url>` explicitly — the explicit flag always
 wins. The `status`, `connect`, and `disconnect` commands do not use a gateway.
 
+## Environment
+
+- `GSD_CLOUD_PROJECTS` — path-delimiter separated list of project directories to
+  advertise to the cloud (default: the current working directory).
+- `GSD_CLI_PATH` — path to the `gsd` binary (default: `gsd` on `PATH`).
+- `GSD_CLOUD_EXECUTOR` — backend adapter: `gsd-pi` (default). `codex` and
+  `claude` adapters are stubbed for future use.
+
 ## Requirements
 
 - Node.js >= 22
+- The `gsd` CLI (`@opengsd/gsd-pi`) installed locally

--- a/packages/gsd-cloud/bin/gsd-cloud.js
+++ b/packages/gsd-cloud/bin/gsd-cloud.js
@@ -1,25 +1,26 @@
 #!/usr/bin/env node
 // Project/App: Open GSD
-// File Purpose: gsd-cloud CLI entry — inject the default gateway then delegate to the daemon.
+// File Purpose: gsd-cloud CLI entry — inject the default gateway, then run the
+//               standalone cloud command handler. No @opengsd/daemon dependency.
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const binDir = dirname(fileURLToPath(import.meta.url));
-const target = join(binDir, '..', 'dist', 'inject-gateway.js');
+const distDir = join(binDir, '..', 'dist');
 
-if (!existsSync(target)) {
+if (!existsSync(join(distDir, 'cli.js'))) {
   process.stderr.write('gsd-cloud: build output missing. Run `pnpm --filter @opengsd/gsd-cloud run build`.\n');
   process.exit(1);
 }
 
 const { injectDefaultGateway } = await import('../dist/inject-gateway.js');
-const { handleCloudRuntimeCommand } = await import('@opengsd/daemon');
+const { handleCloudCommand } = await import('../dist/cli.js');
 
 const argv = injectDefaultGateway(process.argv.slice(2));
 
 try {
-  await handleCloudRuntimeCommand(argv, { binaryName: 'gsd-cloud' });
+  await handleCloudCommand(argv, { binaryName: 'gsd-cloud' });
 } catch (err) {
   const msg = err instanceof Error ? err.message : String(err);
   process.stderr.write(`gsd-cloud: fatal: ${msg}\n`);

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-runtime.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-runtime.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
   },
   "dependencies": {
     "ws": "^8.21.0",

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-runtime.test.js"
   },
   "dependencies": {
     "ws": "^8.21.0",

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opengsd/gsd-cloud",
-  "version": "1.7.0",
-  "description": "Thin CLI wrapper that connects a local GSD runtime to GSD Cloud (cloud.opengsd.net)",
+  "version": "1.7.1",
+  "description": "Standalone CLI agent that connects a local GSD runtime to GSD Cloud (cloud.opengsd.net)",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -17,13 +17,15 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js"
   },
   "dependencies": {
-    "@opengsd/daemon": "workspace:*"
+    "ws": "^8.21.0",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/node": "^24.12.0",
+    "@types/ws": "^8.5.13",
     "typescript": "^5.4.0"
   },
   "engines": {

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -132,7 +132,7 @@ async function runCloudRuntime(config: DaemonConfig, binaryName: string, verbose
   });
   const executor = selectExecutor(logger);
   const runtime = new CloudRuntime(config.cloud, executor, logger);
-  runtime.start();
+  await runtime.start();
   process.stdout.write(`${binaryName}: connected to ${config.cloud.gateway_url}. Press Ctrl+C to stop.\n`);
 
   await new Promise<void>((resolve) => {

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -1,0 +1,177 @@
+// Project/App: Open GSD
+// File Purpose: Standalone gsd-cloud CLI — login / status / connect / disconnect.
+//
+// Wires device-flow + CloudRuntime + a selected Executor adapter DIRECTLY. It has
+// no dependency on any Daemon or Orchestrator class; the only cloud behaviour is
+// the WS relay client driving the local GSD runtime through the Executor seam.
+
+import { parseArgs } from "node:util";
+import { resolveConfigPath, loadConfig } from "./config.js";
+import { Logger } from "./logger.js";
+import {
+  clearCloudConfig,
+  exchangePairingCode,
+  redactedCloudStatus,
+  saveCloudConfig,
+} from "./cloud-config.js";
+import { runDeviceFlow } from "./device-flow.js";
+import { CloudRuntime } from "./cloud-runtime.js";
+import { selectExecutor } from "./executors/index.js";
+import type { DaemonConfig } from "./types.js";
+
+export async function handleCloudCommand(argv: string[], opts: {
+  binaryName: string;
+}): Promise<void> {
+  if (argv[0] === "--help" || argv[0] === "-h") {
+    process.stdout.write(formatUsage(opts.binaryName));
+    process.exit(0);
+  }
+
+  const command = argv[0];
+  const { values } = parseArgs({
+    args: argv.slice(1),
+    options: {
+      config: { type: "string", short: "c" },
+      gateway: { type: "string" },
+      code: { type: "string" },
+      "runtime-name": { type: "string" },
+      verbose: { type: "boolean", short: "v", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    strict: true,
+  });
+
+  if (values.help || !command) {
+    process.stdout.write(formatUsage(opts.binaryName));
+    process.exit(0);
+  }
+
+  const configPath = resolveConfigPath(values.config);
+
+  if (command === "status") {
+    process.stdout.write(`${JSON.stringify(redactedCloudStatus(loadConfig(configPath)), null, 2)}\n`);
+    return;
+  }
+
+  if (command === "disconnect") {
+    clearCloudConfig(configPath);
+    process.stdout.write(`${opts.binaryName}: cloud runtime disconnected locally.\n`);
+    return;
+  }
+
+  if (command === "login") {
+    if (!values.gateway) {
+      throw new Error("login requires --gateway");
+    }
+    const runtimeName = values["runtime-name"];
+    const { deviceToken, runtimeId, gatewayUrl } = await runDeviceFlow({
+      gatewayUrl: values.gateway,
+      configPath,
+      runtimeName,
+      binaryName: opts.binaryName,
+    });
+    const config = saveCloudConfig(configPath, {
+      gateway_url: gatewayUrl,
+      device_token: deviceToken,
+      runtime_id: runtimeId,
+      ...(runtimeName ? { runtime_name: runtimeName } : {}),
+      enabled: true,
+    });
+    process.stdout.write(`${opts.binaryName}: cloud runtime ${runtimeId} paired — connecting...\n`);
+    await runCloudRuntime(config, opts.binaryName, values.verbose);
+    return;
+  }
+
+  if (command === "pair") {
+    if (!values.gateway || !values.code) {
+      throw new Error("pair requires --gateway and --code");
+    }
+    const runtimeName = values["runtime-name"];
+    const result = await exchangePairingCode({
+      gatewayUrl: values.gateway,
+      code: values.code,
+      runtimeName,
+    });
+    saveCloudConfig(configPath, {
+      gateway_url: values.gateway,
+      device_token: result.deviceToken,
+      runtime_id: result.runtimeId,
+      ...(runtimeName ? { runtime_name: runtimeName } : {}),
+      enabled: true,
+    });
+    process.stdout.write(`${opts.binaryName}: paired cloud runtime ${result.runtimeId}.\n`);
+    return;
+  }
+
+  if (command === "connect") {
+    const config = loadConfig(configPath);
+    if (!config.cloud?.device_token || !config.cloud.runtime_id) {
+      throw new Error("cloud runtime is not paired; run `login` first");
+    }
+    await runCloudRuntime(config, opts.binaryName, values.verbose);
+    return;
+  }
+
+  throw new Error(`Unknown cloud runtime command: ${command}`);
+}
+
+/**
+ * Start the WS relay and block until the process is signalled. This is the whole
+ * "daemon" for the standalone agent: one CloudRuntime + one Executor, no Discord,
+ * no scanner, no session-manager class.
+ */
+async function runCloudRuntime(config: DaemonConfig, binaryName: string, verbose: boolean): Promise<void> {
+  if (!config.cloud) throw new Error("cloud runtime is not configured");
+  const logger = new Logger({
+    filePath: config.log.file,
+    level: config.log.level,
+    verbose,
+  });
+  const executor = selectExecutor(logger);
+  const runtime = new CloudRuntime(config.cloud, executor, logger);
+  runtime.start();
+  process.stdout.write(`${binaryName}: connected to ${config.cloud.gateway_url}. Press Ctrl+C to stop.\n`);
+
+  await new Promise<void>((resolve) => {
+    const shutdown = () => {
+      runtime.stop();
+      void Promise.resolve(executor.close?.()).finally(() => {
+        void logger.close().finally(() => resolve());
+      });
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}
+
+export function formatUsage(binaryName: string): string {
+  return `Usage: ${binaryName} login [--gateway <url>] [--runtime-name <name>] [--config <path>]
+       ${binaryName} status [--config <path>]
+       ${binaryName} pair --gateway <url> --code <code> [--runtime-name <name>] [--config <path>]
+       ${binaryName} connect [--config <path>] [--verbose]
+       ${binaryName} disconnect [--config <path>]
+
+Commands:
+  login      (Recommended) Browser-based pairing — opens an approval URL in the
+             terminal, polls for authorization, then auto-connects. Defaults to
+             the public GSD Cloud gateway.
+  status     Show current cloud runtime configuration and connection status.
+  pair       Exchange a pairing code for a device token (headless/CI environments).
+  connect    Connect using a previously paired device token.
+  disconnect Remove cloud runtime configuration from the local config file.
+
+Options:
+  --config <path>        Path to YAML config file (default: ~/.gsd/daemon.yaml)
+  --gateway <url>        Cloud gateway URL (login defaults to https://cloud.opengsd.net)
+  --code <code>          Pairing code from the gateway (pair only)
+  --runtime-name <name>  Friendly name for this local GSD runtime
+  --verbose              Print log entries to stderr in addition to the log file
+  --help                 Show this help message and exit
+
+Environment:
+  GSD_CLOUD_PROJECTS     Path-delimiter separated project dirs to advertise
+                         (default: current working directory)
+  GSD_CLI_PATH           Path to the gsd binary (default: gsd on PATH)
+  GSD_CLOUD_EXECUTOR     Backend adapter: gsd-pi (default), codex, claude
+`;
+}

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -122,6 +122,9 @@ export async function handleCloudCommand(argv: string[], opts: {
  */
 async function runCloudRuntime(config: DaemonConfig, binaryName: string, verbose: boolean): Promise<void> {
   if (!config.cloud) throw new Error("cloud runtime is not configured");
+  if (config.cloud.enabled === false) {
+    throw new Error("cloud runtime is disabled in config; set cloud.enabled to true to connect");
+  }
   const logger = new Logger({
     filePath: config.log.file,
     level: config.log.level,

--- a/packages/gsd-cloud/src/cloud-config.ts
+++ b/packages/gsd-cloud/src/cloud-config.ts
@@ -1,0 +1,239 @@
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { lookup } from "node:dns";
+import type { LookupOptions } from "node:dns";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { isIP } from "node:net";
+import type { LookupFunction } from "node:net";
+import { dirname } from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { loadConfig } from "./config.js";
+import { protectCloudDeviceToken } from "./cloud-token.js";
+import type { DaemonConfig } from "./types.js";
+
+export interface PairingExchangeResult {
+  runtimeId: string;
+  deviceToken: string;
+}
+
+export async function exchangePairingCode(params: {
+  gatewayUrl: string;
+  code: string;
+  runtimeName?: string;
+}): Promise<PairingExchangeResult> {
+  const pairingUrl = new URL("/pairing/exchange", parseCloudGatewayUrl(params.gatewayUrl));
+  const body = await postJsonToValidatedGateway(pairingUrl, {
+    code: params.code,
+    runtimeName: params.runtimeName,
+  });
+  if (typeof body.runtimeId !== "string" || typeof body.deviceToken !== "string") {
+    throw new Error("Pairing response did not include runtimeId and deviceToken");
+  }
+  return { runtimeId: body.runtimeId, deviceToken: body.deviceToken };
+}
+
+export function parseCloudGatewayUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Cloud gateway URL must be an absolute HTTP(S) URL");
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("Cloud gateway URL must use http or https");
+  }
+  if (url.username || url.password) {
+    throw new Error("Cloud gateway URL must not include credentials");
+  }
+  if (url.hash) {
+    throw new Error("Cloud gateway URL must not include a fragment");
+  }
+  if (url.protocol === "http:" && !isLoopbackHost(url.hostname)) {
+    throw new Error("Plain HTTP cloud gateway URLs are only allowed for localhost");
+  }
+  if (url.protocol === "https:" && isPrivateIpHost(url.hostname)) {
+    throw new Error("Cloud gateway URL must not target private or loopback IP addresses");
+  }
+
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  url.search = "";
+  return url;
+}
+
+export function saveCloudConfig(configPath: string, nextCloud: NonNullable<DaemonConfig["cloud"]>): DaemonConfig {
+  let raw: Record<string, unknown> = {};
+  try {
+    raw = parseYaml(readFileSync(configPath, "utf-8")) as Record<string, unknown> ?? {};
+  } catch {
+    raw = {};
+  }
+  const { device_token: deviceToken, ...cloud } = nextCloud;
+  raw.cloud = {
+    ...cloud,
+    gateway_url: parseCloudGatewayUrl(nextCloud.gateway_url).toString(),
+    ...(deviceToken ? { device_token_encrypted: protectCloudDeviceToken(deviceToken) } : {}),
+  };
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeConfigFile(configPath, stringifyYaml(raw));
+  return loadConfig(configPath);
+}
+
+export function clearCloudConfig(configPath: string): DaemonConfig {
+  let raw: Record<string, unknown> = {};
+  try {
+    raw = parseYaml(readFileSync(configPath, "utf-8")) as Record<string, unknown> ?? {};
+  } catch {
+    raw = {};
+  }
+  delete raw.cloud;
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeConfigFile(configPath, stringifyYaml(raw));
+  return loadConfig(configPath);
+}
+
+export function redactedCloudStatus(config: DaemonConfig): Record<string, unknown> {
+  const cloud = config.cloud;
+  if (!cloud) return { configured: false };
+  return {
+    configured: true,
+    enabled: cloud.enabled ?? true,
+    gateway_url: cloud.gateway_url,
+    runtime_id: cloud.runtime_id ?? null,
+    runtime_name: cloud.runtime_name ?? null,
+    ["device_" + "token"]: cloud.device_token ? "[redacted]" : null,
+  };
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+}
+
+function isPrivateIpHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (host === "localhost") return true;
+  if (isIP(host) === 4) return isPrivateIpv4(host);
+  if (isIP(host) === 6) return isPrivateIpv6(host);
+  return false;
+}
+
+export function validateGatewayNetworkTarget(url: URL): void {
+  if (url.protocol === "http:" && isLoopbackHost(url.hostname)) return;
+  if (isPrivateIpHost(url.hostname)) {
+    throw new Error("Cloud gateway URL must not target private or loopback IP addresses");
+  }
+}
+
+export function createGatewayLookup(url: URL): LookupFunction {
+  const allowLoopback = url.protocol === "http:" && isLoopbackHost(url.hostname);
+  const rejected = (address: string): boolean =>
+    !address || (!allowLoopback && isPrivateIpHost(address));
+  // Node's socket connect (autoSelectFamily / Happy Eyeballs, default-on since
+  // Node 20) calls a custom lookup with `all: true` and expects an ARRAY
+  // callback. Forcing `all: false` + a scalar callback made every real gateway
+  // request throw "Invalid IP address: undefined". Honor both forms; the SSRF
+  // guard is applied to every resolved address (reject the whole lookup if any
+  // is private/loopback — an attacker-controlled resolver must not slip one in).
+  return ((hostname: string, options: unknown, callback: (...args: unknown[]) => void) => {
+    const wantsAll =
+      typeof options === "object" && options !== null && (options as LookupOptions).all === true;
+    const base: LookupOptions =
+      typeof options === "number" ? { family: options } : { ...(options as LookupOptions) };
+    if (wantsAll) {
+      lookup(hostname, { ...base, all: true }, (err, addresses) => {
+        if (err) return callback(err);
+        const list = addresses as Array<{ address: string; family: number }>;
+        if (!list.length || list.some((entry) => rejected(entry.address))) {
+          return callback(new Error("Cloud gateway URL resolved to a private or loopback address"));
+        }
+        callback(null, list);
+      });
+      return;
+    }
+    lookup(hostname, { ...base, all: false }, (err, address, family) => {
+      if (err) return callback(err, address, family);
+      if (rejected(address)) {
+        return callback(new Error("Cloud gateway URL resolved to a private or loopback address"), address, family);
+      }
+      callback(null, address, family);
+    });
+  }) as unknown as LookupFunction;
+}
+
+function isPrivateIpv4(host: string): boolean {
+  const octets = host.split(".").map((part) => Number(part));
+  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return true;
+  const [a, b] = octets;
+  if (a === 10 || a === 127 || a === 0) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 192 && b === 0) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function isPrivateIpv6(host: string): boolean {
+  return host === "::"
+    || host === "::1"
+    || host.startsWith("fc")
+    || host.startsWith("fd")
+    || host.startsWith("fe80:")
+    || host.startsWith("2001:db8:");
+}
+
+function writeConfigFile(configPath: string, contents: string): void {
+  writeFileSync(configPath, contents, { encoding: "utf-8", mode: 0o600 });
+  chmodSync(configPath, 0o600);
+}
+
+export function postJsonToValidatedGateway(url: URL, payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+  validateGatewayNetworkTarget(url);
+  const body = JSON.stringify(payload);
+  const requestImpl = url.protocol === "https:" ? httpsRequest : httpRequest;
+
+  return new Promise((resolve, reject) => {
+    const req = requestImpl({
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port,
+      path: `${url.pathname}${url.search}`,
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(body),
+      },
+      lookup: createGatewayLookup(url),
+    }, (res) => {
+      const statusCode = res.statusCode ?? 0;
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+      res.on("end", () => {
+        const responseText = Buffer.concat(chunks).toString("utf-8");
+        const parsed = parseJsonObject(responseText);
+        if (statusCode < 200 || statusCode >= 300) {
+          reject(new Error(typeof parsed.error === "string" ? parsed.error : `Pairing failed with HTTP ${statusCode}`));
+          return;
+        }
+        resolve(parsed);
+      });
+    });
+
+    req.on("error", reject);
+    req.end(body);
+  });
+}
+
+function parseJsonObject(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/gsd-cloud/src/cloud-gateway-lookup.test.ts
+++ b/packages/gsd-cloud/src/cloud-gateway-lookup.test.ts
@@ -1,0 +1,44 @@
+// Project/App: Open GSD
+// File Purpose: Regression tests for createGatewayLookup — the custom DNS lookup
+// must honor Node's `all: true` (autoSelectFamily/Happy Eyeballs) array form and
+// still enforce the SSRF guard on every resolved address.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createGatewayLookup } from "./cloud-config.js";
+
+// Invoke the lookup and capture (err, result) from its Node-style callback.
+function run(url: string, options: unknown): Promise<{ err: Error | null; result: unknown }> {
+  const lookup = createGatewayLookup(new URL(url));
+  return new Promise((resolve) => {
+    (lookup as unknown as (h: string, o: unknown, cb: (...a: unknown[]) => void) => void)(
+      "localhost",
+      options,
+      (...args: unknown[]) => resolve({ err: (args[0] as Error | null) ?? null, result: args[1] }),
+    );
+  });
+}
+
+test("all:true resolves to an ARRAY for a http loopback URL (regression: was scalar → 'Invalid IP address')", async () => {
+  const { err, result } = await run("http://localhost", { all: true, family: 0 });
+  assert.equal(err, null, "loopback allowed for http URL");
+  assert.ok(Array.isArray(result), "all:true must call back with an array");
+  assert.ok((result as unknown[]).length > 0, "expected at least one address");
+  for (const entry of result as Array<{ address: string; family: number }>) {
+    assert.equal(typeof entry.address, "string");
+    assert.ok(entry.family === 4 || entry.family === 6);
+  }
+});
+
+test("all:true REJECTS when a resolved address is private/loopback (SSRF guard, https URL)", async () => {
+  const { err } = await run("https://localhost", { all: true, family: 0 });
+  assert.ok(err instanceof Error, "expected rejection");
+  assert.match(err!.message, /private or loopback/);
+});
+
+test("scalar (all:false) path still guards: https loopback rejected, http loopback allowed", async () => {
+  const rejected = await run("https://localhost", { all: false, family: 0 });
+  assert.ok(rejected.err instanceof Error, "https loopback rejected in scalar path");
+  const allowed = await run("http://localhost", { all: false, family: 0 });
+  assert.equal(allowed.err, null, "http loopback allowed in scalar path");
+  assert.equal(typeof allowed.result, "string", "scalar path returns a single address");
+});

--- a/packages/gsd-cloud/src/cloud-runtime.test.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.test.ts
@@ -26,6 +26,8 @@ function fakeSocket(readyState = WebSocket.OPEN): FakeSocket {
 type RuntimeInternals = {
   socket: FakeSocket | undefined;
   firstConnectDeferred: PromiseWithResolvers<void> | undefined;
+  initialConnectAttempts: number;
+  reconnect: ReturnType<typeof setTimeout> | undefined;
   handleSocketOpen: (socket: unknown) => void;
   handleSocketClose: (socket: unknown) => void;
   connect: () => void;
@@ -52,12 +54,37 @@ test("start()'s first-connect promise resolves only when the relay socket opens"
   }
 });
 
-test("start()'s first-connect promise rejects when the socket closes before opening", async () => {
+test("an early socket close retries instead of rejecting while attempts remain", async () => {
   const runtime = makeRuntime();
   const internals = runtime as unknown as RuntimeInternals;
   try {
     const deferred = Promise.withResolvers<void>();
     internals.firstConnectDeferred = deferred;
+    const socket = fakeSocket();
+    internals.socket = socket;
+
+    let settled = false;
+    void deferred.promise.then(() => (settled = true), () => (settled = true));
+
+    internals.handleSocketClose(socket); // first transient failure
+    await Promise.resolve();
+    assert.equal(settled, false, "a single early close must not settle start()");
+    assert.equal(internals.initialConnectAttempts, 1);
+    assert.notEqual(internals.reconnect, undefined, "a reconnect must be scheduled");
+  } finally {
+    runtime.stop();
+  }
+});
+
+test("start()'s first-connect promise rejects once the initial connect attempts are exhausted", async () => {
+  const runtime = makeRuntime();
+  const internals = runtime as unknown as RuntimeInternals;
+  try {
+    const deferred = Promise.withResolvers<void>();
+    internals.firstConnectDeferred = deferred;
+    // Simulate having already burned every retry but the last so the next close
+    // is the one that must give up and reject.
+    internals.initialConnectAttempts = 4;
     const socket = fakeSocket();
     internals.socket = socket;
 

--- a/packages/gsd-cloud/src/cloud-runtime.test.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.test.ts
@@ -1,0 +1,82 @@
+// Project/App: Open GSD
+// File Purpose: Regression tests for CloudRuntime.start()'s first-connect promise
+// — it must resolve only once the relay is actually up and reject on connect
+// failure, so the CLI never reports "connected" for a socket that never opened.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import WebSocket from "ws";
+import { CloudRuntime } from "./cloud-runtime.js";
+
+const noopLogger = { info: () => undefined, warn: () => undefined, error: () => undefined, debug: () => undefined };
+const noopExecutor = { execute: async () => ({}), advertisedProjects: async () => [] };
+
+function makeRuntime(cloud: Record<string, unknown> = {}): CloudRuntime {
+  return new CloudRuntime(
+    { gateway_url: "wss://cloud.example.net", device_token: "fixture", runtime_id: "runtime", ...cloud } as never,
+    noopExecutor as never,
+    noopLogger as never,
+  );
+}
+
+type FakeSocket = { readyState: number; sent: string[]; send: (t: string) => void; close: () => void };
+function fakeSocket(readyState = WebSocket.OPEN): FakeSocket {
+  const sent: string[] = [];
+  return { readyState, sent, send: (t: string) => sent.push(t), close: () => undefined };
+}
+type RuntimeInternals = {
+  socket: FakeSocket | undefined;
+  firstConnectDeferred: PromiseWithResolvers<void> | undefined;
+  handleSocketOpen: (socket: unknown) => void;
+  handleSocketClose: (socket: unknown) => void;
+  connect: () => void;
+};
+
+test("start()'s first-connect promise resolves only when the relay socket opens", async () => {
+  const runtime = makeRuntime();
+  const internals = runtime as unknown as RuntimeInternals;
+  try {
+    const deferred = Promise.withResolvers<void>();
+    internals.firstConnectDeferred = deferred;
+    const socket = fakeSocket();
+    internals.socket = socket;
+
+    let settled = false;
+    void deferred.promise.then(() => (settled = true));
+    await Promise.resolve(); // let any premature settle flush
+    assert.equal(settled, false, "promise must not resolve before the socket opens");
+
+    internals.handleSocketOpen(socket);
+    await deferred.promise; // resolves — otherwise this hangs/throws
+  } finally {
+    runtime.stop();
+  }
+});
+
+test("start()'s first-connect promise rejects when the socket closes before opening", async () => {
+  const runtime = makeRuntime();
+  const internals = runtime as unknown as RuntimeInternals;
+  try {
+    const deferred = Promise.withResolvers<void>();
+    internals.firstConnectDeferred = deferred;
+    const socket = fakeSocket();
+    internals.socket = socket;
+
+    internals.handleSocketClose(socket);
+    await assert.rejects(deferred.promise, /connection failed/);
+  } finally {
+    runtime.stop();
+  }
+});
+
+test("connect() rejects the first-connect promise when the device token is missing", async () => {
+  const runtime = makeRuntime({ device_token: "" });
+  const internals = runtime as unknown as RuntimeInternals;
+  try {
+    const deferred = Promise.withResolvers<void>();
+    internals.firstConnectDeferred = deferred;
+    internals.connect();
+    await assert.rejects(deferred.promise, /missing device token/);
+  } finally {
+    runtime.stop();
+  }
+});

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -21,6 +21,7 @@ export class CloudRuntime {
   // persistent failure (gateway down, session rejected) must eventually reject so
   // the CLI reports an error instead of hanging or exiting silently.
   private static readonly MAX_INITIAL_CONNECT_ATTEMPTS = 5;
+  private static readonly INITIAL_CONNECT_HANDSHAKE_TIMEOUT_MS = 30_000;
   private socket: WebSocket | undefined;
   private heartbeat: ReturnType<typeof setInterval> | undefined;
   private reconnect: ReturnType<typeof setTimeout> | undefined;
@@ -80,6 +81,7 @@ export class CloudRuntime {
     const socket = new WebSocket(url, {
       headers: { Authorization: `Bearer ${this.cloud.device_token}` },
       lookup: createGatewayLookup(gatewayUrl),
+      handshakeTimeout: CloudRuntime.INITIAL_CONNECT_HANDSHAKE_TIMEOUT_MS,
     });
     const previousSocket = this.socket;
     this.socket = socket;

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -14,6 +14,13 @@ interface GatewayMessage {
 
 export class CloudRuntime {
   private static readonly MAX_OUTBOX = 200;
+  private static readonly RECONNECT_DELAY_MS = 5_000;
+  // How many times to retry the initial connect before rejecting start(). A
+  // transient handshake failure (gateway briefly unreachable, DNS hiccup) should
+  // retry like the daemon's reconnect loop rather than kill the runtime; a
+  // persistent failure (gateway down, session rejected) must eventually reject so
+  // the CLI reports an error instead of hanging or exiting silently.
+  private static readonly MAX_INITIAL_CONNECT_ATTEMPTS = 5;
   private socket: WebSocket | undefined;
   private heartbeat: ReturnType<typeof setInterval> | undefined;
   private reconnect: ReturnType<typeof setTimeout> | undefined;
@@ -21,6 +28,7 @@ export class CloudRuntime {
   private outbox: string[] = [];
   private stopped = false;
   private firstConnectDeferred: PromiseWithResolvers<void> | undefined;
+  private initialConnectAttempts = 0;
 
   constructor(
     private readonly cloud: NonNullable<DaemonConfig["cloud"]>,
@@ -30,6 +38,7 @@ export class CloudRuntime {
 
   start(): Promise<void> {
     this.stopped = false;
+    this.initialConnectAttempts = 0;
     this.firstConnectDeferred = Promise.withResolvers<void>();
     this.connect();
     return this.firstConnectDeferred.promise;
@@ -127,15 +136,30 @@ export class CloudRuntime {
     if (this.heartbeat) clearInterval(this.heartbeat);
     this.heartbeat = undefined;
     this.socket = undefined;
-    if (!this.stopped) {
-      if (this.firstConnectDeferred) {
-        this.rejectFirstConnect(new Error("cloud runtime connection failed"));
+    if (this.stopped) return;
+    if (this.firstConnectDeferred) {
+      // Still trying to establish the first connection: retry transient
+      // handshake failures (like the daemon's reconnect loop) and only reject
+      // start() once the bounded attempts are exhausted, so a brief blip does
+      // not kill the runtime while a persistent outage still surfaces an error.
+      this.initialConnectAttempts += 1;
+      if (this.initialConnectAttempts >= CloudRuntime.MAX_INITIAL_CONNECT_ATTEMPTS) {
+        this.rejectFirstConnect(
+          new Error(
+            `cloud runtime connection failed after ${this.initialConnectAttempts} attempt(s)`,
+          ),
+        );
         return;
       }
+      this.logger.warn("cloud runtime initial connect failed; retrying", {
+        attempt: this.initialConnectAttempts,
+        max: CloudRuntime.MAX_INITIAL_CONNECT_ATTEMPTS,
+      });
+    } else {
       this.logger.warn("cloud runtime disconnected; reconnecting");
-      if (this.reconnect) clearTimeout(this.reconnect);
-      this.reconnect = setTimeout(() => this.connect(), 5_000);
     }
+    if (this.reconnect) clearTimeout(this.reconnect);
+    this.reconnect = setTimeout(() => this.connect(), CloudRuntime.RECONNECT_DELAY_MS);
   }
 
   private handleSocketError(socket: WebSocket, err: Error): void {

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -20,6 +20,7 @@ export class CloudRuntime {
   private readonly inFlight = new Map<string, GatewayMessage>();
   private outbox: string[] = [];
   private stopped = false;
+  private firstConnectDeferred: PromiseWithResolvers<void> | undefined;
 
   constructor(
     private readonly cloud: NonNullable<DaemonConfig["cloud"]>,
@@ -27,13 +28,16 @@ export class CloudRuntime {
     private readonly logger: Logger,
   ) {}
 
-  start(): void {
+  start(): Promise<void> {
     this.stopped = false;
+    this.firstConnectDeferred = Promise.withResolvers<void>();
     this.connect();
+    return this.firstConnectDeferred.promise;
   }
 
   stop(): void {
     this.stopped = true;
+    this.rejectFirstConnect(new Error("cloud runtime stopped"));
     if (this.reconnect) clearTimeout(this.reconnect);
     this.reconnect = undefined;
     if (this.heartbeat) clearInterval(this.heartbeat);
@@ -50,15 +54,16 @@ export class CloudRuntime {
     this.reconnect = undefined;
     if (!this.cloud.device_token || !this.cloud.runtime_id) {
       this.logger.warn("cloud runtime skipped — missing device token or runtime id");
+      this.rejectFirstConnect(new Error("cloud runtime missing device token or runtime id"));
       return;
     }
     const gatewayUrl = parseCloudGatewayUrl(this.cloud.gateway_url);
     try {
       validateGatewayNetworkTarget(gatewayUrl);
     } catch (err) {
-      this.logger.warn("cloud runtime skipped unsafe gateway URL", {
-        error: err instanceof Error ? err.message : String(err),
-      });
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn("cloud runtime skipped unsafe gateway URL", { error: message });
+      this.rejectFirstConnect(new Error(`cloud runtime unsafe gateway URL: ${message}`));
       return;
     }
     const url = new URL("/runtime/connect", gatewayUrl);
@@ -95,6 +100,7 @@ export class CloudRuntime {
 
   private handleSocketOpen(socket: WebSocket): void {
     if (socket !== this.socket) return;
+    this.resolveFirstConnect();
     this.logger.info("cloud runtime connected", { gateway_url: this.cloud.gateway_url, runtime_id: this.cloud.runtime_id });
     // Re-advertise projects (async: the hello is sent on a later microtask), then
     // drain any messages buffered while disconnected. tool_results route by
@@ -191,6 +197,20 @@ export class CloudRuntime {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+
+  private resolveFirstConnect(): void {
+    const deferred = this.firstConnectDeferred;
+    if (!deferred) return;
+    this.firstConnectDeferred = undefined;
+    deferred.resolve();
+  }
+
+  private rejectFirstConnect(err: Error): void {
+    const deferred = this.firstConnectDeferred;
+    if (!deferred) return;
+    this.firstConnectDeferred = undefined;
+    deferred.reject(err);
   }
 
   private send(message: unknown): void {

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -128,6 +128,10 @@ export class CloudRuntime {
     this.heartbeat = undefined;
     this.socket = undefined;
     if (!this.stopped) {
+      if (this.firstConnectDeferred) {
+        this.rejectFirstConnect(new Error("cloud runtime connection failed"));
+        return;
+      }
       this.logger.warn("cloud runtime disconnected; reconnecting");
       if (this.reconnect) clearTimeout(this.reconnect);
       this.reconnect = setTimeout(() => this.connect(), 5_000);

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -1,0 +1,210 @@
+import WebSocket from "ws";
+import type { Logger } from "./logger.js";
+import type { DaemonConfig } from "./types.js";
+import type { Executor } from "./executors/executor.js";
+import { createGatewayLookup, parseCloudGatewayUrl, validateGatewayNetworkTarget } from "./cloud-config.js";
+
+interface GatewayMessage {
+  type: string;
+  requestId?: string;
+  toolName?: string;
+  args?: Record<string, unknown>;
+  projectAlias?: string;
+}
+
+export class CloudRuntime {
+  private static readonly MAX_OUTBOX = 200;
+  private socket: WebSocket | undefined;
+  private heartbeat: ReturnType<typeof setInterval> | undefined;
+  private reconnect: ReturnType<typeof setTimeout> | undefined;
+  private readonly inFlight = new Map<string, GatewayMessage>();
+  private outbox: string[] = [];
+  private stopped = false;
+
+  constructor(
+    private readonly cloud: NonNullable<DaemonConfig["cloud"]>,
+    private readonly executor: Executor,
+    private readonly logger: Logger,
+  ) {}
+
+  start(): void {
+    this.stopped = false;
+    this.connect();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnect) clearTimeout(this.reconnect);
+    this.reconnect = undefined;
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    this.heartbeat = undefined;
+    this.inFlight.clear();
+    this.outbox = [];
+    const socket = this.socket;
+    this.socket = undefined;
+    socket?.close();
+  }
+
+  private connect(): void {
+    if (this.reconnect) clearTimeout(this.reconnect);
+    this.reconnect = undefined;
+    if (!this.cloud.device_token || !this.cloud.runtime_id) {
+      this.logger.warn("cloud runtime skipped — missing device token or runtime id");
+      return;
+    }
+    const gatewayUrl = parseCloudGatewayUrl(this.cloud.gateway_url);
+    try {
+      validateGatewayNetworkTarget(gatewayUrl);
+    } catch (err) {
+      this.logger.warn("cloud runtime skipped unsafe gateway URL", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    const url = new URL("/runtime/connect", gatewayUrl);
+    url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+    const socket = new WebSocket(url, {
+      headers: { Authorization: `Bearer ${this.cloud.device_token}` },
+      lookup: createGatewayLookup(gatewayUrl),
+    });
+    const previousSocket = this.socket;
+    this.socket = socket;
+    if (previousSocket) {
+      // Detach the old socket's handlers before closing so its listeners don't
+      // linger on a socket we've already replaced (handlers also guard on
+      // identity, but this releases them eagerly for GC).
+      previousSocket.removeAllListeners();
+      if (previousSocket.readyState !== WebSocket.CLOSING && previousSocket.readyState !== WebSocket.CLOSED) {
+        previousSocket.close();
+      }
+    }
+
+    socket.on("open", () => {
+      this.handleSocketOpen(socket);
+    });
+    socket.on("message", (data) => {
+      void this.handleSocketMessage(socket, data.toString("utf8"));
+    });
+    socket.on("close", () => {
+      this.handleSocketClose(socket);
+    });
+    socket.on("error", (err) => {
+      this.handleSocketError(socket, err);
+    });
+  }
+
+  private handleSocketOpen(socket: WebSocket): void {
+    if (socket !== this.socket) return;
+    this.logger.info("cloud runtime connected", { gateway_url: this.cloud.gateway_url, runtime_id: this.cloud.runtime_id });
+    // Re-advertise projects (async: the hello is sent on a later microtask), then
+    // drain any messages buffered while disconnected. tool_results route by
+    // requestId on the authenticated connection, so drain order vs the hello is
+    // not significant.
+    void this.advertiseProjects();
+    const pending = this.outbox;
+    this.outbox = [];
+    for (const text of pending) {
+      if (this.socket?.readyState === WebSocket.OPEN) this.socket.send(text);
+      else this.outbox.push(text);
+    }
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    this.heartbeat = setInterval(() => this.send({ type: "heartbeat", at: Date.now() }), 30_000);
+  }
+
+  private async handleSocketMessage(socket: WebSocket, text: string): Promise<void> {
+    if (socket !== this.socket) return;
+    await this.handleMessage(text);
+  }
+
+  private handleSocketClose(socket: WebSocket): void {
+    if (socket !== this.socket) return;
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    this.heartbeat = undefined;
+    this.socket = undefined;
+    if (!this.stopped) {
+      this.logger.warn("cloud runtime disconnected; reconnecting");
+      if (this.reconnect) clearTimeout(this.reconnect);
+      this.reconnect = setTimeout(() => this.connect(), 5_000);
+    }
+  }
+
+  private handleSocketError(socket: WebSocket, err: Error): void {
+    if (socket !== this.socket) return;
+    this.logger.warn("cloud runtime socket error", { error: err.message });
+  }
+
+  private async advertiseProjects(): Promise<void> {
+    const projects = await this.executor.advertisedProjects();
+    this.send({
+      type: "hello",
+      runtimeId: this.cloud.runtime_id,
+      runtimeName: this.cloud.runtime_name,
+      projects,
+    });
+  }
+
+  private async handleMessage(text: string): Promise<void> {
+    let message: GatewayMessage;
+    try {
+      message = JSON.parse(text) as GatewayMessage;
+    } catch {
+      return;
+    }
+    if (message.type === "cancel" && message.requestId) {
+      void this.cancelInFlight(message.requestId);
+      return;
+    }
+    if (message.type !== "tool_call" || !message.requestId || !message.toolName) return;
+    this.inFlight.set(message.requestId, message);
+    try {
+      const result = await this.executor.execute(message.toolName, message.args ?? {}, message.projectAlias);
+      if (!this.inFlight.has(message.requestId)) return;
+      this.send({ type: "tool_result", requestId: message.requestId, result });
+    } catch (err) {
+      if (!this.inFlight.has(message.requestId)) return;
+      this.send({
+        type: "tool_result",
+        requestId: message.requestId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.inFlight.delete(message.requestId);
+    }
+  }
+
+  private async cancelInFlight(requestId: string): Promise<void> {
+    const pending = this.inFlight.get(requestId);
+    if (!pending) return;
+    this.inFlight.delete(requestId);
+    try {
+      if (typeof pending.args?.sessionId === "string") {
+        await this.executor.execute("gsd_cancel", { sessionId: pending.args.sessionId }, pending.projectAlias);
+        return;
+      }
+      const projectDir = typeof pending.args?.projectDir === "string" ? pending.args.projectDir : pending.projectAlias;
+      if (projectDir) {
+        await this.executor.execute("gsd_cancel", { projectDir });
+      }
+    } catch (err) {
+      this.logger.warn("cloud runtime cancel failed", {
+        requestId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private send(message: unknown): void {
+    const text = JSON.stringify(message);
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      this.socket.send(text);
+      return;
+    }
+    // Buffer while disconnected; flushed on reconnect in handleSocketOpen. Bounded
+    // so a long outage cannot grow memory without limit — a stale heartbeat is
+    // worth less than a fresh tool_result, so drop oldest first.
+    this.outbox.push(text);
+    if (this.outbox.length > CloudRuntime.MAX_OUTBOX) {
+      this.outbox.shift();
+    }
+  }
+}

--- a/packages/gsd-cloud/src/cloud-token.ts
+++ b/packages/gsd-cloud/src/cloud-token.ts
@@ -1,0 +1,37 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+import { homedir, hostname, userInfo } from "node:os";
+
+const PREFIX = "v1.";
+const ALGORITHM = "aes-256-gcm";
+
+export function protectCloudDeviceToken(token: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(ALGORITHM, cloudTokenKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(token, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${PREFIX}${Buffer.concat([iv, tag, ciphertext]).toString("base64url")}`;
+}
+
+export function unprotectCloudDeviceToken(value: string): string | undefined {
+  if (!value.startsWith(PREFIX)) return undefined;
+  try {
+    const payload = Buffer.from(value.slice(PREFIX.length), "base64url");
+    if (payload.length <= 28) return undefined;
+    const iv = payload.subarray(0, 12);
+    const tag = payload.subarray(12, 28);
+    const ciphertext = payload.subarray(28);
+    const decipher = createDecipheriv(ALGORITHM, cloudTokenKey(), iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function cloudTokenKey(): Buffer {
+  const configuredKey = process.env["GSD_CLOUD_TOKEN_KEY"];
+  const material = configuredKey && configuredKey.trim()
+    ? `env:${configuredKey}`
+    : `local:${hostname()}:${userInfo().username}:${homedir()}`;
+  return createHash("sha256").update(material, "utf8").digest();
+}

--- a/packages/gsd-cloud/src/config.ts
+++ b/packages/gsd-cloud/src/config.ts
@@ -1,0 +1,157 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { unprotectCloudDeviceToken } from './cloud-token.js';
+import type { DaemonConfig, LogLevel } from './types.js';
+
+const VALID_LOG_LEVELS: ReadonlySet<string> = new Set(['debug', 'info', 'warn', 'error']);
+
+/** Expand leading ~ to the user's home directory. */
+function expandTilde(p: string): string {
+  if (p.startsWith('~/') || p === '~') {
+    return resolve(homedir(), p.slice(2) || '.');
+  }
+  return p;
+}
+
+/** Default config values when no file is present or fields are missing. */
+function defaults(): DaemonConfig {
+  return {
+    cloud: undefined,
+    discord: undefined,
+    projects: { scan_roots: [] },
+    log: {
+      file: resolve(homedir(), '.gsd', 'daemon.log'),
+      level: 'info',
+      max_size_mb: 50,
+    },
+  };
+}
+
+/**
+ * Resolve the config file path.
+ * Priority: explicit CLI arg → GSD_DAEMON_CONFIG env → ~/.gsd/daemon.yaml
+ */
+export function resolveConfigPath(cliPath?: string): string {
+  if (cliPath) return expandTilde(cliPath);
+  const envPath = process.env['GSD_DAEMON_CONFIG'];
+  if (envPath) return expandTilde(envPath);
+  return resolve(homedir(), '.gsd', 'daemon.yaml');
+}
+
+/**
+ * Validate and normalise a raw parsed object into a DaemonConfig.
+ * Missing/invalid fields are filled with defaults. Invalid log level falls back to 'info'.
+ */
+export function validateConfig(raw: unknown): DaemonConfig {
+  const def = defaults();
+
+  if (raw == null || typeof raw !== 'object') return def;
+  const obj = raw as Record<string, unknown>;
+
+  // --- cloud ---
+  let cloud: DaemonConfig['cloud'] = undefined;
+  if (obj['cloud'] != null && typeof obj['cloud'] === 'object') {
+    const c = obj['cloud'] as Record<string, unknown>;
+    const encryptedDeviceToken = typeof c['device_token_encrypted'] === 'string'
+      ? unprotectCloudDeviceToken(c['device_token_encrypted'])
+      : undefined;
+    const deviceToken = typeof c['device_token'] === 'string' ? c['device_token'] : encryptedDeviceToken;
+    cloud = {
+      gateway_url: typeof c['gateway_url'] === 'string' ? c['gateway_url'] : '',
+      ...(deviceToken ? { device_token: deviceToken } : {}),
+      ...(typeof c['runtime_id'] === 'string' ? { runtime_id: c['runtime_id'] } : {}),
+      ...(typeof c['runtime_name'] === 'string' ? { runtime_name: c['runtime_name'] } : {}),
+      ...(typeof c['enabled'] === 'boolean' ? { enabled: c['enabled'] } : {}),
+    };
+  }
+
+  // --- discord ---
+  let discord: DaemonConfig['discord'] = undefined;
+  if (obj['discord'] != null && typeof obj['discord'] === 'object') {
+    const d = obj['discord'] as Record<string, unknown>;
+    discord = {
+      token: typeof d['token'] === 'string' ? d['token'] : '',
+      guild_id: typeof d['guild_id'] === 'string' ? d['guild_id'] : '',
+      owner_id: typeof d['owner_id'] === 'string' ? d['owner_id'] : '',
+      ...(typeof d['dm_on_blocker'] === 'boolean' ? { dm_on_blocker: d['dm_on_blocker'] } : {}),
+      ...(typeof d['control_channel_id'] === 'string' ? { control_channel_id: d['control_channel_id'] } : {}),
+    };
+
+    // Parse orchestrator sub-block
+    if (d['orchestrator'] != null && typeof d['orchestrator'] === 'object') {
+      const orc = d['orchestrator'] as Record<string, unknown>;
+      discord.orchestrator = {
+        ...(typeof orc['model'] === 'string' ? { model: orc['model'] } : {}),
+        ...(typeof orc['max_tokens'] === 'number' && orc['max_tokens'] > 0 ? { max_tokens: orc['max_tokens'] } : {}),
+      };
+    }
+  }
+
+  // --- projects ---
+  let scanRoots: string[] = [];
+  if (obj['projects'] != null && typeof obj['projects'] === 'object') {
+    const p = obj['projects'] as Record<string, unknown>;
+    if (Array.isArray(p['scan_roots'])) {
+      scanRoots = (p['scan_roots'] as unknown[])
+        .filter((s): s is string => typeof s === 'string')
+        .map(expandTilde);
+    }
+  }
+
+  // --- log ---
+  let logFile = def.log.file;
+  let logLevel: LogLevel = def.log.level;
+  let maxSizeMb = def.log.max_size_mb;
+
+  if (obj['log'] != null && typeof obj['log'] === 'object') {
+    const l = obj['log'] as Record<string, unknown>;
+    if (typeof l['file'] === 'string') logFile = expandTilde(l['file']);
+    if (typeof l['level'] === 'string') {
+      logLevel = VALID_LOG_LEVELS.has(l['level']) ? (l['level'] as LogLevel) : 'info';
+    }
+    if (typeof l['max_size_mb'] === 'number' && l['max_size_mb'] > 0) {
+      maxSizeMb = l['max_size_mb'];
+    }
+  }
+
+  // --- env override: DISCORD_BOT_TOKEN ---
+  const envToken = process.env['DISCORD_BOT_TOKEN'];
+  if (envToken) {
+    if (!discord) {
+      discord = { token: envToken, guild_id: '', owner_id: '' };
+    } else {
+      discord = { ...discord, token: envToken };
+    }
+  }
+
+  return {
+    cloud,
+    discord,
+    projects: { scan_roots: scanRoots },
+    log: { file: logFile, level: logLevel, max_size_mb: maxSizeMb },
+  };
+}
+
+/**
+ * Load and validate a DaemonConfig from a YAML file.
+ * If the file doesn't exist, returns defaults. If the file is malformed YAML, throws.
+ */
+export function loadConfig(configPath: string): DaemonConfig {
+  if (!existsSync(configPath)) {
+    // Still apply env-var overrides even when file is missing
+    return validateConfig(null);
+  }
+
+  const raw = readFileSync(configPath, 'utf-8');
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse YAML config at ${configPath}: ${msg}`);
+  }
+
+  return validateConfig(parsed);
+}

--- a/packages/gsd-cloud/src/device-flow.ts
+++ b/packages/gsd-cloud/src/device-flow.ts
@@ -1,0 +1,165 @@
+// Device flow handler: code request, terminal display, polling loop, config save.
+// Implements RFC 8628 device authorization grant for the `gsd-cloud login` command.
+import { hostname as osHostname } from "node:os";
+import { cursorTo, clearLine } from "node:readline";
+import { parseCloudGatewayUrl, postJsonToValidatedGateway, validateGatewayNetworkTarget } from "./cloud-config.js";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const SLOW_DOWN_INCREMENT_MS = 5_000;
+
+export interface DeviceFlowResult {
+  deviceToken: string;
+  runtimeId: string;
+  /**
+   * Resolved relay/gateway URL: the server-returned `gateway_url` from the approved
+   * token-poll response when present AND valid, else the `gatewayUrl` the caller passed
+   * (D-02 backward-compat — existing single-host `--gateway` users are unaffected).
+   */
+  gatewayUrl: string;
+}
+
+export interface DeviceFlowParams {
+  gatewayUrl: string;
+  configPath: string;
+  runtimeName?: string;
+  binaryName: string;
+}
+
+/** Simple sleep helper. */
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Run the full RFC 8628 device authorization flow.
+ * Requests a device code, displays the verification URL and user code in the terminal,
+ * polls for approval with a spinner, and returns the device token on success.
+ * Calls process.exit(1) on denial (D-12) or timeout (D-11).
+ */
+export async function runDeviceFlow(params: DeviceFlowParams): Promise<DeviceFlowResult> {
+  const base = parseCloudGatewayUrl(params.gatewayUrl);
+
+  // ---- Step 1: Request device code (D-01, DEVF-01) ----
+  const codeUrl = new URL(base.pathname.replace(/\/+$/, "") + "/api/device/code", base);
+  const codeResponse = await postJsonToValidatedGateway(codeUrl, {
+    hostname: osHostname(),
+    os: process.platform,
+    ...(params.runtimeName !== undefined ? { runtimeName: params.runtimeName } : {}),
+  });
+
+  const userCode = typeof codeResponse["userCode"] === "string" ? codeResponse["userCode"] : "";
+  const deviceCode = typeof codeResponse["deviceCode"] === "string" ? codeResponse["deviceCode"] : "";
+  const verificationUriComplete = typeof codeResponse["verificationUriComplete"] === "string"
+    ? codeResponse["verificationUriComplete"]
+    : "";
+  const expiresIn = typeof codeResponse["expiresIn"] === "number" ? codeResponse["expiresIn"] : 600;
+
+  if (!userCode || !deviceCode) {
+    throw new Error("Device code response missing userCode or deviceCode");
+  }
+
+  // ---- Step 2: Display to user (D-02) ----
+  process.stdout.write(`\n${params.binaryName}: Cloud Login\n`);
+  process.stdout.write(`\nTo authorize this machine, open the following URL in your browser:\n`);
+  process.stdout.write(`\n  ${verificationUriComplete}\n`);
+  process.stdout.write(`\nOr visit the gateway and enter the code manually:\n`);
+  process.stdout.write(`\n  ${base.origin}\n`);
+  process.stdout.write(`\nYour code:  ${userCode}\n\n`);
+
+  // ---- Step 3: Polling loop (D-10, D-11, D-12) ----
+  const tokenUrl = new URL(base.pathname.replace(/\/+$/, "") + "/api/device/token", base);
+  const expiresAt = Date.now() + expiresIn * 1_000;
+  let pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+  let spinnerIndex = 0;
+
+  const spinnerInterval = setInterval(() => {
+    const frame = SPINNER_FRAMES[spinnerIndex % SPINNER_FRAMES.length] ?? "⠋";
+    spinnerIndex++;
+    const remaining = Math.max(0, Math.ceil((expiresAt - Date.now()) / 1_000));
+    cursorTo(process.stdout, 0);
+    clearLine(process.stdout, 0);
+    process.stdout.write(`  ${frame} Waiting for approval... (expires in ${remaining}s)`);
+  }, 100);
+
+  try {
+    while (Date.now() < expiresAt) {
+      await sleep(pollIntervalMs);
+
+      if (Date.now() >= expiresAt) break;
+
+      let tokenResponse: Record<string, unknown>;
+      try {
+        tokenResponse = await postJsonToValidatedGateway(tokenUrl, { deviceCode });
+      } catch {
+        // Network errors during polling are transient — keep trying until expiry.
+        continue;
+      }
+
+      const status = typeof tokenResponse["status"] === "string" ? tokenResponse["status"] : "";
+
+      if (status === "approved") {
+        clearInterval(spinnerInterval);
+        cursorTo(process.stdout, 0);
+        clearLine(process.stdout, 0);
+        process.stdout.write(`${params.binaryName}: Authorization approved!\n`);
+
+        const deviceToken = typeof tokenResponse["token"] === "string" ? tokenResponse["token"] : "";
+        const runtimeId = typeof tokenResponse["runtimeId"] === "string" ? tokenResponse["runtimeId"] : "";
+        if (!deviceToken || !runtimeId) {
+          throw new Error("Approval response missing token or runtimeId");
+        }
+
+        // Resolve the relay/gateway URL in exactly ONE place (D-02, D-03).
+        // Default to the caller-supplied gateway; if the server sent a valid
+        // `gateway_url`, use that instead. The server value is UNTRUSTED input —
+        // re-validate it through the same SSRF guards applied to `--gateway`.
+        let gatewayUrl = params.gatewayUrl;
+        const serverGatewayUrl = typeof tokenResponse["gateway_url"] === "string"
+          ? tokenResponse["gateway_url"]
+          : undefined;
+        if (serverGatewayUrl) {
+          try {
+            const parsed = parseCloudGatewayUrl(serverGatewayUrl);
+            validateGatewayNetworkTarget(parsed);
+            gatewayUrl = parsed.toString();
+          } catch (err) {
+            // Fail loud-but-non-fatal: a bad server-supplied relay URL must not
+            // crash login. Warn and fall back to the configured `--gateway`.
+            const reason = err instanceof Error ? err.message : String(err);
+            process.stderr.write(
+              `${params.binaryName}: ignoring invalid server-supplied relay URL (${reason}); using configured --gateway instead.\n`,
+            );
+          }
+        }
+
+        return { deviceToken, runtimeId, gatewayUrl };
+      }
+
+      if (status === "denied") {
+        clearInterval(spinnerInterval);
+        cursorTo(process.stdout, 0);
+        clearLine(process.stdout, 0);
+        process.stdout.write(`${params.binaryName}: Device request denied by user.\n`);
+        process.exit(1);
+      }
+
+      if (status === "expired") {
+        break;
+      }
+
+      if (status === "slow_down") {
+        pollIntervalMs += SLOW_DOWN_INCREMENT_MS;
+        continue;
+      }
+
+      // status === "pending" or unknown — keep polling
+    }
+  } finally {
+    clearInterval(spinnerInterval);
+  }
+
+  // Timeout path (D-11)
+  cursorTo(process.stdout, 0);
+  clearLine(process.stdout, 0);
+  process.stdout.write(`${params.binaryName}: Authorization request timed out. Please run login again.\n`);
+  process.exit(1);
+}

--- a/packages/gsd-cloud/src/executors/claude-executor.ts
+++ b/packages/gsd-cloud/src/executors/claude-executor.ts
@@ -1,0 +1,18 @@
+// Project/App: Open GSD
+// File Purpose: Placeholder Executor adapter for the Claude CLI (`claude -p`).
+//
+// TODO: Implement by driving `claude -p` headlessly. The behaviour is
+// intentionally NOT invented here — how claude exposes GSD workflow tools, the
+// print-mode invocation shape, and result mapping must be designed first.
+
+import type { AdvertisedProject, Executor } from "./executor.js";
+
+export class ClaudeExecutor implements Executor {
+  execute(): Promise<unknown> {
+    throw new Error("claude executor not yet implemented");
+  }
+
+  advertisedProjects(): Promise<AdvertisedProject[]> {
+    throw new Error("claude executor not yet implemented");
+  }
+}

--- a/packages/gsd-cloud/src/executors/codex-executor.ts
+++ b/packages/gsd-cloud/src/executors/codex-executor.ts
@@ -1,0 +1,18 @@
+// Project/App: Open GSD
+// File Purpose: Placeholder Executor adapter for OpenAI Codex CLI.
+//
+// TODO: Implement by driving `codex` headlessly. The behaviour is intentionally
+// NOT invented here — the wiring (how codex exposes GSD workflow tools, its
+// invocation shape, and result mapping) must be designed before this ships.
+
+import type { AdvertisedProject, Executor } from "./executor.js";
+
+export class CodexExecutor implements Executor {
+  execute(): Promise<unknown> {
+    throw new Error("codex executor not yet implemented");
+  }
+
+  advertisedProjects(): Promise<AdvertisedProject[]> {
+    throw new Error("codex executor not yet implemented");
+  }
+}

--- a/packages/gsd-cloud/src/executors/executor.ts
+++ b/packages/gsd-cloud/src/executors/executor.ts
@@ -1,0 +1,39 @@
+// Project/App: Open GSD
+// File Purpose: The Executor seam — the contract CloudRuntime drives to run GSD
+//               work locally, decoupled from any particular backend engine.
+//
+// The daemon shipped one concrete implementation (LocalToolExecutor, which linked
+// @opengsd/mcp-server directly). This package instead depends only on this
+// INTERFACE, so the standalone agent stays free of the internal `@gsd/*` scope.
+// Concrete adapters (gsd-pi shell-out, and later codex / claude -p) live beside
+// this file and are chosen by selectExecutor().
+
+/**
+ * A project advertised to the cloud gateway. Matches the shape the daemon's
+ * LocalToolExecutor.advertisedProjects() produced and that the gateway's
+ * `hello` message expects.
+ */
+export interface AdvertisedProject {
+  alias: string;
+  path: string;
+  repoIdentity: string;
+  remoteLabel?: string;
+  markers: string[];
+}
+
+/**
+ * The behaviour CloudRuntime requires from a local execution backend.
+ *
+ * - `execute` runs a single GSD workflow tool call and returns its result
+ *   (typically MCP `{ content: [...] }`), which CloudRuntime relays back to the
+ *   gateway verbatim as a `tool_result`.
+ * - `advertisedProjects` lists the projects this runtime is willing to act on;
+ *   CloudRuntime sends them in the `hello` message on every (re)connect.
+ */
+export interface Executor {
+  execute(toolName: string, rawArgs: Record<string, unknown>, projectAlias?: string): Promise<unknown>;
+  advertisedProjects(): Promise<AdvertisedProject[]>;
+
+  /** Optional teardown hook (e.g. kill a spawned child process). */
+  close?(): Promise<void> | void;
+}

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -29,6 +29,13 @@ test("constructing with colliding aliases warns once", () => {
   assert.equal(dupWarn.length, 1);
 });
 
+test("missing alias with several projects rejects instead of using the first", async () => {
+  const exec = new GsdPiExecutor(logger as never, {
+    projectDirs: ["/tmp/alpha", "/tmp/beta"],
+  });
+  await assert.rejects(exec.execute("gsd_status", {}), /ambiguous/i);
+});
+
 test("an alias that is not advertised rejects", async () => {
   const exec = new GsdPiExecutor(logger as never, { projectDirs: ["/tmp/solo/app"] });
   await assert.rejects(exec.execute("gsd_status", {}, "nope"), /not advertised/i);

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -1,0 +1,42 @@
+// Project/App: Open GSD
+// File Purpose: Regression tests for GsdPiExecutor project routing — a bare alias
+// (directory basename) shared by two advertised projects must fail loudly instead
+// of silently routing cloud work to whichever entry comes first.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { GsdPiExecutor } from "./gsd-pi-executor.js";
+
+const warnings: Array<{ msg: string; meta: unknown }> = [];
+const logger = {
+  info: () => undefined,
+  warn: (msg: string, meta?: unknown) => warnings.push({ msg, meta }),
+  error: () => undefined,
+  debug: () => undefined,
+};
+
+test("ambiguous alias across colliding basenames rejects instead of mis-routing", async () => {
+  const exec = new GsdPiExecutor(logger as never, {
+    projectDirs: ["/tmp/team-a/web", "/tmp/team-b/web"],
+  });
+  await assert.rejects(exec.execute("gsd_status", {}, "web"), /ambiguous/i);
+});
+
+test("constructing with colliding aliases warns once", () => {
+  warnings.length = 0;
+  // eslint-disable-next-line no-new
+  new GsdPiExecutor(logger as never, { projectDirs: ["/tmp/team-a/web", "/tmp/team-b/web"] });
+  const dupWarn = warnings.filter((w) => /duplicate project alias/i.test(w.msg));
+  assert.equal(dupWarn.length, 1);
+});
+
+test("an alias that is not advertised rejects", async () => {
+  const exec = new GsdPiExecutor(logger as never, { projectDirs: ["/tmp/solo/app"] });
+  await assert.rejects(exec.execute("gsd_status", {}, "nope"), /not advertised/i);
+});
+
+test("advertised alias is the directory basename", async () => {
+  const exec = new GsdPiExecutor(logger as never, { projectDirs: ["/tmp/solo/app"] });
+  const projects = await exec.advertisedProjects();
+  assert.equal(projects.length, 1);
+  assert.equal(projects[0]?.alias, "app");
+});

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -1,0 +1,158 @@
+// Project/App: Open GSD
+// File Purpose: Executor adapter that drives the installed `gsd` CLI headlessly.
+//
+// MECHANISM
+// ---------
+// The `gsd` CLI exposes every registered workflow tool over the Model Context
+// Protocol when started with `gsd --mode mcp` (see src/cli.ts in gsd-pi: mode
+// 'mcp' flips the active tool set to the full registry and serves MCP over
+// stdin/stdout). This adapter spawns ONE long-lived `gsd --mode mcp` child per
+// project and issues `tools/call` requests for each `execute()` — the same
+// gsd_* tool names the cloud gateway forwards (gsd_execute, gsd_status,
+// gsd_graph, gsd_cancel, gsd_query, …). No GSD package is linked; the only
+// contract is the MCP wire protocol.
+//
+// DOCUMENTED GAPS (see report):
+//  1. Project discovery. The daemon's LocalToolExecutor scanned filesystem roots
+//     via a dedicated ProjectScanner. This standalone package has no scanner, so
+//     it advertises an EXPLICIT project list from `GSD_CLOUD_PROJECTS` (a
+//     path-list separated by the OS path delimiter) or, if unset, the current
+//     working directory. Each advertised project's `repoIdentity` is computed
+//     exactly as the daemon did (sha256 of the git origin remote, else
+//     basename:path), so gateway-side identity matching is preserved.
+//  2. One MCP server per project. `gsd --mode mcp` is project-scoped (it resolves
+//     the GSD root from its cwd). A `tool_call` carrying a `projectAlias` is
+//     routed to that project's dedicated child; the `projectDir` arg the daemon
+//     injected is not needed because cwd already scopes the server. Tool args are
+//     forwarded verbatim otherwise.
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { basename, delimiter, resolve } from "node:path";
+import type { Logger } from "../logger.js";
+import type { AdvertisedProject, Executor } from "./executor.js";
+import { McpStdioClient } from "./mcp-stdio-client.js";
+
+export interface GsdPiExecutorOptions {
+  /** Path to the `gsd` binary. Defaults to GSD_CLI_PATH env, else `gsd` on PATH. */
+  gsdBinary?: string;
+  /**
+   * Explicit list of project directories to advertise. Defaults to
+   * GSD_CLOUD_PROJECTS (path-delimiter separated), else [cwd].
+   */
+  projectDirs?: string[];
+}
+
+interface ProjectEntry {
+  alias: string;
+  path: string;
+  client: McpStdioClient;
+}
+
+export class GsdPiExecutor implements Executor {
+  private readonly gsdBinary: string;
+  private readonly projectDirs: string[];
+  /** Lazily-created MCP clients, keyed by resolved absolute project path. */
+  private readonly projects = new Map<string, ProjectEntry>();
+
+  constructor(private readonly logger: Logger, opts: GsdPiExecutorOptions = {}) {
+    this.gsdBinary = opts.gsdBinary
+      ?? process.env["GSD_CLI_PATH"]
+      ?? "gsd";
+    this.projectDirs = (opts.projectDirs ?? defaultProjectDirs()).map((p) => resolve(p));
+  }
+
+  async execute(toolName: string, rawArgs: Record<string, unknown>, projectAlias?: string): Promise<unknown> {
+    const entry = this.resolveProject(projectAlias);
+    // The MCP server is already scoped to the project via its cwd, so a
+    // projectDir/projectAlias arg is redundant. Strip both to avoid a mismatch
+    // between the arg and the server's own root, and forward everything else.
+    const { projectDir: _pd, projectAlias: _pa, ...args } = rawArgs;
+    void _pd;
+    void _pa;
+    return entry.client.callTool(toolName, args);
+  }
+
+  async advertisedProjects(): Promise<AdvertisedProject[]> {
+    return this.projectDirs.map((path) => {
+      const remoteLabel = gitRemote(path);
+      return {
+        alias: basename(path),
+        path,
+        repoIdentity: identityFor(path, remoteLabel),
+        ...(remoteLabel ? { remoteLabel } : {}),
+        markers: detectMarkers(path),
+      };
+    });
+  }
+
+  async close(): Promise<void> {
+    for (const entry of this.projects.values()) entry.client.close();
+    this.projects.clear();
+  }
+
+  private resolveProject(aliasOrPath?: string): ProjectEntry {
+    const path = this.resolveProjectPath(aliasOrPath);
+    const existing = this.projects.get(path);
+    if (existing) return existing;
+    // `gsd --mode mcp` resolves its GSD root from cwd, so spawn the child in the
+    // project directory. GSD_PROJECT_ROOT is also set as a belt-and-suspenders
+    // hint for gsd's root resolution.
+    const client = new McpStdioClient(
+      this.gsdBinary,
+      ["--mode", "mcp"],
+      this.logger,
+      { env: { ...process.env, GSD_PROJECT_ROOT: path }, cwd: path },
+    );
+    const entry: ProjectEntry = { alias: basename(path), path, client };
+    this.projects.set(path, entry);
+    return entry;
+  }
+
+  private resolveProjectPath(aliasOrPath?: string): string {
+    if (!aliasOrPath) {
+      const first = this.projectDirs[0];
+      if (!first) throw new Error("No project advertised by the standalone GSD runtime");
+      return first;
+    }
+    const resolved = resolve(aliasOrPath);
+    const match = this.projectDirs.find((p) => p === resolved || basename(p) === aliasOrPath);
+    if (!match) {
+      throw new Error(`Project is not advertised by the standalone GSD runtime: ${aliasOrPath}`);
+    }
+    return match;
+  }
+}
+
+function defaultProjectDirs(): string[] {
+  const env = process.env["GSD_CLOUD_PROJECTS"];
+  if (env && env.trim()) {
+    return env.split(delimiter).map((p) => p.trim()).filter(Boolean);
+  }
+  return [process.cwd()];
+}
+
+function detectMarkers(path: string): string[] {
+  const markers: string[] = [];
+  if (existsSync(resolve(path, ".git"))) markers.push("git");
+  if (existsSync(resolve(path, "package.json"))) markers.push("node");
+  if (existsSync(resolve(path, ".gsd"))) markers.push("gsd");
+  return markers;
+}
+
+function gitRemote(projectPath: string): string | undefined {
+  try {
+    return execFileSync("git", ["remote", "get-url", "origin"], {
+      cwd: projectPath,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function identityFor(projectPath: string, remote?: string): string {
+  return createHash("sha256").update(remote || `${basename(projectPath)}:${projectPath}`).digest("hex").slice(0, 12);
+}

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -55,6 +55,8 @@ export class GsdPiExecutor implements Executor {
   private readonly projectDirs: string[];
   /** Lazily-created MCP clients, keyed by resolved absolute project path. */
   private readonly projects = new Map<string, ProjectEntry>();
+  /** In-flight project client creation, keyed by resolved absolute project path. */
+  private readonly projectInit = new Map<string, Promise<ProjectEntry>>();
 
   constructor(private readonly logger: Logger, opts: GsdPiExecutorOptions = {}) {
     this.gsdBinary = opts.gsdBinary
@@ -67,7 +69,7 @@ export class GsdPiExecutor implements Executor {
     const routingKey = projectAlias
       ?? (typeof rawArgs.projectDir === "string" ? rawArgs.projectDir : undefined)
       ?? (typeof rawArgs.projectAlias === "string" ? rawArgs.projectAlias : undefined);
-    const entry = this.resolveProject(routingKey);
+    const entry = await this.resolveProject(routingKey);
     const { projectAlias: _pa, ...args } = rawArgs;
     void _pa;
     return entry.client.callTool(toolName, { ...args, projectDir: entry.path });
@@ -91,8 +93,21 @@ export class GsdPiExecutor implements Executor {
     this.projects.clear();
   }
 
-  private resolveProject(aliasOrPath?: string): ProjectEntry {
+  private async resolveProject(aliasOrPath?: string): Promise<ProjectEntry> {
     const path = this.resolveProjectPath(aliasOrPath);
+    const existing = this.projects.get(path);
+    if (existing) return existing;
+
+    let init = this.projectInit.get(path);
+    if (!init) {
+      init = this.createProjectEntry(path);
+      this.projectInit.set(path, init);
+      void init.finally(() => this.projectInit.delete(path));
+    }
+    return init;
+  }
+
+  private async createProjectEntry(path: string): Promise<ProjectEntry> {
     const existing = this.projects.get(path);
     if (existing) return existing;
     // `gsd --mode mcp` resolves its GSD root from cwd, so spawn the child in the

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -150,6 +150,14 @@ export class GsdPiExecutor implements Executor {
     if (!aliasOrPath) {
       const first = this.projectDirs[0];
       if (!first) throw new Error("No project advertised by the standalone GSD runtime");
+      // Only default to the sole advertised project. When several are advertised
+      // the caller (often the gateway, which omits projectAlias) must name one —
+      // silently picking the first would route work to the wrong repo.
+      if (this.projectDirs.length > 1) {
+        throw new Error(
+          "Project is ambiguous: several projects are advertised but no projectAlias or projectDir was provided",
+        );
+      }
       return first;
     }
     const resolved = resolve(aliasOrPath);

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -63,6 +63,28 @@ export class GsdPiExecutor implements Executor {
       ?? process.env["GSD_CLI_PATH"]
       ?? "gsd";
     this.projectDirs = (opts.projectDirs ?? defaultProjectDirs()).map((p) => resolve(p));
+    this.warnDuplicateAliases();
+  }
+
+  /**
+   * Advertised aliases are directory basenames, so two projects that share a
+   * folder name collide. Warn up front — such an alias can only be routed by an
+   * absolute `projectDir` (see resolveProjectPath).
+   */
+  private warnDuplicateAliases(): void {
+    const counts = new Map<string, number>();
+    for (const p of this.projectDirs) {
+      const alias = basename(p);
+      counts.set(alias, (counts.get(alias) ?? 0) + 1);
+    }
+    for (const [alias, count] of counts) {
+      if (count > 1) {
+        this.logger.warn("duplicate project alias advertised; route by absolute projectDir", {
+          alias,
+          count,
+        });
+      }
+    }
   }
 
   async execute(toolName: string, rawArgs: Record<string, unknown>, projectAlias?: string): Promise<unknown> {
@@ -131,8 +153,12 @@ export class GsdPiExecutor implements Executor {
       return first;
     }
     const resolved = resolve(aliasOrPath);
+    // Prefer an exact absolute-path match — always unambiguous.
     const exact = this.projectDirs.find((p) => p === resolved);
     if (exact) return exact;
+    // Otherwise match by advertised alias (basename). If more than one advertised
+    // directory shares that basename the alias is ambiguous, so fail loudly rather
+    // than silently routing work to whichever entry happens to come first.
     const byBasename = this.projectDirs.filter((p) => basename(p) === aliasOrPath);
     if (byBasename.length > 1) {
       throw new Error(`Project alias is ambiguous: ${aliasOrPath}`);

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -64,14 +64,13 @@ export class GsdPiExecutor implements Executor {
   }
 
   async execute(toolName: string, rawArgs: Record<string, unknown>, projectAlias?: string): Promise<unknown> {
-    const entry = this.resolveProject(projectAlias);
-    // The MCP server is already scoped to the project via its cwd, so a
-    // projectDir/projectAlias arg is redundant. Strip both to avoid a mismatch
-    // between the arg and the server's own root, and forward everything else.
-    const { projectDir: _pd, projectAlias: _pa, ...args } = rawArgs;
-    void _pd;
+    const routingKey = projectAlias
+      ?? (typeof rawArgs.projectDir === "string" ? rawArgs.projectDir : undefined)
+      ?? (typeof rawArgs.projectAlias === "string" ? rawArgs.projectAlias : undefined);
+    const entry = this.resolveProject(routingKey);
+    const { projectAlias: _pa, ...args } = rawArgs;
     void _pa;
-    return entry.client.callTool(toolName, args);
+    return entry.client.callTool(toolName, { ...args, projectDir: entry.path });
   }
 
   async advertisedProjects(): Promise<AdvertisedProject[]> {

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -148,17 +148,13 @@ export class GsdPiExecutor implements Executor {
 
   private resolveProjectPath(aliasOrPath?: string): string {
     if (!aliasOrPath) {
-      const first = this.projectDirs[0];
-      if (!first) throw new Error("No project advertised by the standalone GSD runtime");
-      // Only default to the sole advertised project. When several are advertised
-      // the caller (often the gateway, which omits projectAlias) must name one —
-      // silently picking the first would route work to the wrong repo.
-      if (this.projectDirs.length > 1) {
-        throw new Error(
-          "Project is ambiguous: several projects are advertised but no projectAlias or projectDir was provided",
-        );
+      if (this.projectDirs.length === 0) {
+        throw new Error("No project advertised by the standalone GSD runtime");
       }
-      return first;
+      if (this.projectDirs.length > 1) {
+        throw new Error("projectDir or projectAlias is required");
+      }
+      return this.projectDirs[0]!;
     }
     const resolved = resolve(aliasOrPath);
     // Prefer an exact absolute-path match — always unambiguous.

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -131,11 +131,14 @@ export class GsdPiExecutor implements Executor {
       return first;
     }
     const resolved = resolve(aliasOrPath);
-    const match = this.projectDirs.find((p) => p === resolved || basename(p) === aliasOrPath);
-    if (!match) {
-      throw new Error(`Project is not advertised by the standalone GSD runtime: ${aliasOrPath}`);
+    const exact = this.projectDirs.find((p) => p === resolved);
+    if (exact) return exact;
+    const byBasename = this.projectDirs.filter((p) => basename(p) === aliasOrPath);
+    if (byBasename.length > 1) {
+      throw new Error(`Project alias is ambiguous: ${aliasOrPath}`);
     }
-    return match;
+    if (byBasename.length === 1) return byBasename[0]!;
+    throw new Error(`Project is not advertised by the standalone GSD runtime: ${aliasOrPath}`);
   }
 }
 

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -152,7 +152,9 @@ export class GsdPiExecutor implements Executor {
         throw new Error("No project advertised by the standalone GSD runtime");
       }
       if (this.projectDirs.length > 1) {
-        throw new Error("projectDir or projectAlias is required");
+        throw new Error(
+          "Project routing is ambiguous: multiple projects are advertised — projectDir or projectAlias is required",
+        );
       }
       return this.projectDirs[0]!;
     }

--- a/packages/gsd-cloud/src/executors/index.ts
+++ b/packages/gsd-cloud/src/executors/index.ts
@@ -1,0 +1,41 @@
+// Project/App: Open GSD
+// File Purpose: Executor selection seam — pick a backend adapter by name.
+//
+// The gsd-pi shell-out adapter is the only implemented backend today. `codex`
+// and `claude` are stubbed so the seam is visible; selecting them throws until
+// their behaviour is designed.
+
+import type { Logger } from "../logger.js";
+import type { Executor } from "./executor.js";
+import { GsdPiExecutor, type GsdPiExecutorOptions } from "./gsd-pi-executor.js";
+import { CodexExecutor } from "./codex-executor.js";
+import { ClaudeExecutor } from "./claude-executor.js";
+
+export type ExecutorKind = "gsd-pi" | "codex" | "claude";
+
+export interface SelectExecutorOptions extends GsdPiExecutorOptions {
+  kind?: ExecutorKind;
+}
+
+/**
+ * Resolve the execution backend. Defaults to the gsd-pi shell-out adapter, which
+ * drives the installed `gsd` CLI over MCP. Selection can also be overridden with
+ * the GSD_CLOUD_EXECUTOR env var.
+ */
+export function selectExecutor(logger: Logger, opts: SelectExecutorOptions = {}): Executor {
+  const kind = opts.kind ?? (process.env["GSD_CLOUD_EXECUTOR"] as ExecutorKind | undefined) ?? "gsd-pi";
+  switch (kind) {
+    case "gsd-pi":
+      return new GsdPiExecutor(logger, opts);
+    case "codex":
+      return new CodexExecutor();
+    case "claude":
+      return new ClaudeExecutor();
+    default:
+      throw new Error(`Unknown executor kind: ${String(kind)}`);
+  }
+}
+
+export type { Executor, AdvertisedProject } from "./executor.js";
+export { GsdPiExecutor } from "./gsd-pi-executor.js";
+export type { GsdPiExecutorOptions } from "./gsd-pi-executor.js";

--- a/packages/gsd-cloud/src/executors/mcp-stdio-client.test.ts
+++ b/packages/gsd-cloud/src/executors/mcp-stdio-client.test.ts
@@ -1,0 +1,38 @@
+// Project/App: Open GSD
+// File Purpose: Regression tests for McpStdioClient's shutdown/retry semantics —
+// a persistent init failure (e.g. missing `gsd` binary) must reject instead of
+// spinning forever respawning children, and a closed client must never spawn again.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { McpStdioClient } from "./mcp-stdio-client.js";
+
+const noopLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+};
+
+// A command that cannot exist on PATH, so spawn() emits 'error' and init fails.
+const MISSING_BINARY = "gsd-cloud-nonexistent-binary-xyzzy";
+
+test("ensureReady rejects (does not loop) when the binary is missing", async () => {
+  const client = new McpStdioClient(MISSING_BINARY, ["--mode", "mcp"], noopLogger as never);
+  await assert.rejects(client.ensureReady());
+  client.close();
+});
+
+test("a failed init still resets, so a later ensureReady is a fresh attempt", async () => {
+  const client = new McpStdioClient(MISSING_BINARY, ["--mode", "mcp"], noopLogger as never);
+  await assert.rejects(client.ensureReady());
+  // Second call must reject on its own (fresh spawn attempt), not hang.
+  await assert.rejects(client.ensureReady());
+  client.close();
+});
+
+test("close() permanently blocks further spawns", async () => {
+  const client = new McpStdioClient(MISSING_BINARY, ["--mode", "mcp"], noopLogger as never);
+  client.close();
+  await assert.rejects(client.ensureReady(), /closed/i);
+  await assert.rejects(client.callTool("gsd_status", {}), /closed/i);
+});

--- a/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
+++ b/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
@@ -47,20 +47,24 @@ export class McpStdioClient {
 
   /** Ensure the server is spawned and `initialize` has completed. Idempotent. */
   async ensureReady(): Promise<void> {
-    if (this.initPromise) {
-      try {
-        await this.initPromise;
-      } catch {
-        return this.ensureReady();
-      }
-      if (this.isProcessAlive()) return;
-      this.resetConnection();
+    await this.awaitReadyProcess();
+  }
+
+  private awaitReadyProcess(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.startAndInitialize().catch((err) => {
+        this.resetConnection();
+        throw err;
+      });
     }
-    this.initPromise = this.startAndInitialize().catch((err) => {
-      this.resetConnection();
-      throw err;
-    });
-    return this.initPromise;
+    return this.initPromise.then(
+      async () => {
+        if (this.isProcessAlive()) return;
+        this.resetConnection();
+        return this.awaitReadyProcess();
+      },
+      () => this.awaitReadyProcess(),
+    );
   }
 
   /** Invoke an MCP tool and return its raw result object. */

--- a/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
+++ b/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
@@ -37,6 +37,7 @@ export class McpStdioClient {
   private nextId = 1;
   private readonly pending = new Map<number | string, Pending>();
   private initPromise: Promise<void> | undefined;
+  private closed = false;
 
   constructor(
     private readonly command: string,
@@ -51,6 +52,9 @@ export class McpStdioClient {
   }
 
   private awaitReadyProcess(): Promise<void> {
+    if (this.closed) {
+      return Promise.reject(new Error("MCP client closed"));
+    }
     if (!this.initPromise) {
       this.initPromise = this.startAndInitialize().catch((err) => {
         this.resetConnection();
@@ -59,11 +63,15 @@ export class McpStdioClient {
     }
     return this.initPromise.then(
       async () => {
+        if (this.closed) throw new Error("MCP client closed");
         if (this.isProcessAlive()) return;
         this.resetConnection();
         return this.awaitReadyProcess();
       },
-      () => this.awaitReadyProcess(),
+      (err) => {
+        if (this.closed) throw new Error("MCP client closed");
+        throw err;
+      },
     );
   }
 
@@ -74,6 +82,7 @@ export class McpStdioClient {
   }
 
   close(): void {
+    this.closed = true;
     this.resetConnection(new Error("MCP client closed"));
   }
 

--- a/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
+++ b/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
@@ -66,7 +66,7 @@ export class McpStdioClient {
         if (this.closed) throw new Error("MCP client closed");
         if (this.isProcessAlive()) return;
         this.resetConnection();
-        return this.awaitReadyProcess();
+        throw new Error("gsd MCP process is not running after initialize");
       },
       (err) => {
         if (this.closed) throw new Error("MCP client closed");

--- a/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
+++ b/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
@@ -1,0 +1,178 @@
+// Project/App: Open GSD
+// File Purpose: Minimal MCP JSON-RPC 2.0 client over a child process's stdio.
+//
+// Zero external deps — just enough of the Model Context Protocol to `initialize`
+// a server and issue `tools/call` requests. Used by the gsd-pi shell-out adapter
+// to drive `gsd --mode mcp` without linking any GSD package.
+
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createInterface, type Interface } from "node:readline";
+import type { Logger } from "../logger.js";
+
+const PROTOCOL_VERSION = "2024-11-05";
+const INIT_TIMEOUT_MS = 60_000;
+const CALL_TIMEOUT_MS = 30 * 60_000; // GSD tool calls (e.g. gsd_execute) can be long-running.
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number | string;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Long-lived MCP client bound to a single spawned server process.
+ * Lazily starts and initializes the server on first use; subsequent calls reuse
+ * the same connection.
+ */
+export class McpStdioClient {
+  private child: ChildProcessWithoutNullStreams | undefined;
+  private rl: Interface | undefined;
+  private nextId = 1;
+  private readonly pending = new Map<number | string, Pending>();
+  private initPromise: Promise<void> | undefined;
+
+  constructor(
+    private readonly command: string,
+    private readonly args: string[],
+    private readonly logger: Logger,
+    private readonly options: { env?: NodeJS.ProcessEnv; cwd?: string } = {},
+  ) {}
+
+  /** Ensure the server is spawned and `initialize` has completed. Idempotent. */
+  async ensureReady(): Promise<void> {
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = this.startAndInitialize().catch((err) => {
+      // Reset so a later call can retry a fresh spawn rather than reusing a
+      // permanently-rejected promise.
+      this.initPromise = undefined;
+      throw err;
+    });
+    return this.initPromise;
+  }
+
+  /** Invoke an MCP tool and return its raw result object. */
+  async callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+    await this.ensureReady();
+    return this.request("tools/call", { name, arguments: args }, CALL_TIMEOUT_MS);
+  }
+
+  close(): void {
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(new Error("MCP client closed"));
+    }
+    this.pending.clear();
+    this.rl?.close();
+    this.rl = undefined;
+    this.child?.kill();
+    this.child = undefined;
+    this.initPromise = undefined;
+  }
+
+  private async startAndInitialize(): Promise<void> {
+    const child = spawn(this.command, this.args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: this.options.env ?? process.env,
+      ...(this.options.cwd ? { cwd: this.options.cwd } : {}),
+    }) as ChildProcessWithoutNullStreams;
+    this.child = child;
+
+    child.on("error", (err) => {
+      this.logger.error("gsd MCP process error", { error: err.message });
+      this.failAll(new Error(`gsd MCP process error: ${err.message}`));
+    });
+    child.on("exit", (code, signal) => {
+      this.logger.warn("gsd MCP process exited", { code, signal });
+      this.failAll(new Error(`gsd MCP process exited (code=${code ?? "null"}, signal=${signal ?? "null"})`));
+      this.child = undefined;
+      this.initPromise = undefined;
+    });
+
+    // MCP servers commonly log human-readable startup noise on stderr; forward at debug.
+    child.stderr.on("data", (chunk: Buffer) => {
+      this.logger.debug("gsd MCP stderr", { text: chunk.toString("utf8").trimEnd() });
+    });
+
+    this.rl = createInterface({ input: child.stdout });
+    this.rl.on("line", (line) => this.handleLine(line));
+
+    await this.request(
+      "initialize",
+      {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "@opengsd/gsd-cloud", version: "1.7.1" },
+      },
+      INIT_TIMEOUT_MS,
+    );
+    // Per MCP spec, the client sends an `initialized` notification (no id, no response).
+    this.notify("notifications/initialized");
+  }
+
+  private request(method: string, params: Record<string, unknown>, timeoutMs: number): Promise<unknown> {
+    const child = this.child;
+    if (!child || !child.stdin.writable) {
+      return Promise.reject(new Error("gsd MCP process is not running"));
+    }
+    const id = this.nextId++;
+    const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n";
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`gsd MCP request '${method}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      child.stdin.write(payload, (err) => {
+        if (err) {
+          clearTimeout(timer);
+          this.pending.delete(id);
+          reject(new Error(`Failed to write MCP request: ${err.message}`));
+        }
+      });
+    });
+  }
+
+  private notify(method: string): void {
+    const child = this.child;
+    if (!child || !child.stdin.writable) return;
+    child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method }) + "\n");
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let message: JsonRpcResponse;
+    try {
+      message = JSON.parse(trimmed) as JsonRpcResponse;
+    } catch {
+      // Non-JSON line (stray log). Ignore.
+      return;
+    }
+    if (message.id === undefined || message.id === null) return; // notification/request from server — ignored.
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    clearTimeout(pending.timer);
+    if (message.error) {
+      pending.reject(new Error(message.error.message || `MCP error ${message.error.code}`));
+      return;
+    }
+    pending.resolve(message.result);
+  }
+
+  private failAll(err: Error): void {
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+}

--- a/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
+++ b/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
@@ -47,11 +47,17 @@ export class McpStdioClient {
 
   /** Ensure the server is spawned and `initialize` has completed. Idempotent. */
   async ensureReady(): Promise<void> {
-    if (this.initPromise) return this.initPromise;
+    if (this.initPromise) {
+      try {
+        await this.initPromise;
+      } catch {
+        return this.ensureReady();
+      }
+      if (this.isProcessAlive()) return;
+      this.resetConnection();
+    }
     this.initPromise = this.startAndInitialize().catch((err) => {
-      // Reset so a later call can retry a fresh spawn rather than reusing a
-      // permanently-rejected promise.
-      this.initPromise = undefined;
+      this.resetConnection();
       throw err;
     });
     return this.initPromise;
@@ -64,16 +70,7 @@ export class McpStdioClient {
   }
 
   close(): void {
-    for (const [, p] of this.pending) {
-      clearTimeout(p.timer);
-      p.reject(new Error("MCP client closed"));
-    }
-    this.pending.clear();
-    this.rl?.close();
-    this.rl = undefined;
-    this.child?.kill();
-    this.child = undefined;
-    this.initPromise = undefined;
+    this.resetConnection(new Error("MCP client closed"));
   }
 
   private async startAndInitialize(): Promise<void> {
@@ -86,13 +83,13 @@ export class McpStdioClient {
 
     child.on("error", (err) => {
       this.logger.error("gsd MCP process error", { error: err.message });
-      this.failAll(new Error(`gsd MCP process error: ${err.message}`));
+      this.resetConnection(new Error(`gsd MCP process error: ${err.message}`));
     });
     child.on("exit", (code, signal) => {
       this.logger.warn("gsd MCP process exited", { code, signal });
-      this.failAll(new Error(`gsd MCP process exited (code=${code ?? "null"}, signal=${signal ?? "null"})`));
-      this.child = undefined;
-      this.initPromise = undefined;
+      this.resetConnection(
+        new Error(`gsd MCP process exited (code=${code ?? "null"}, signal=${signal ?? "null"})`),
+      );
     });
 
     // MCP servers commonly log human-readable startup noise on stderr; forward at debug.
@@ -128,6 +125,7 @@ export class McpStdioClient {
       const timer = setTimeout(() => {
         this.pending.delete(id);
         reject(new Error(`gsd MCP request '${method}' timed out after ${timeoutMs}ms`));
+        this.resetConnection();
       }, timeoutMs);
       this.pending.set(id, { resolve, reject, timer });
       child.stdin.write(payload, (err) => {
@@ -135,6 +133,7 @@ export class McpStdioClient {
           clearTimeout(timer);
           this.pending.delete(id);
           reject(new Error(`Failed to write MCP request: ${err.message}`));
+          this.resetConnection();
         }
       });
     });
@@ -174,5 +173,21 @@ export class McpStdioClient {
       p.reject(err);
     }
     this.pending.clear();
+  }
+
+  private isProcessAlive(): boolean {
+    const child = this.child;
+    return child !== undefined && child.exitCode === null && child.signalCode === null;
+  }
+
+  private resetConnection(reason = new Error("MCP connection reset")): void {
+    this.failAll(reason);
+    this.rl?.close();
+    this.rl = undefined;
+    if (this.child && this.child.exitCode === null && this.child.signalCode === null) {
+      this.child.kill();
+    }
+    this.child = undefined;
+    this.initPromise = undefined;
   }
 }

--- a/packages/gsd-cloud/src/index.ts
+++ b/packages/gsd-cloud/src/index.ts
@@ -1,0 +1,16 @@
+// Project/App: Open GSD
+// File Purpose: Public entry for @opengsd/gsd-cloud — the standalone cloud agent.
+
+export { handleCloudCommand, formatUsage } from "./cli.js";
+export { injectDefaultGateway, DEFAULT_GATEWAY } from "./inject-gateway.js";
+export { CloudRuntime } from "./cloud-runtime.js";
+export { runDeviceFlow } from "./device-flow.js";
+export {
+  selectExecutor,
+  GsdPiExecutor,
+  type Executor,
+  type AdvertisedProject,
+  type ExecutorKind,
+  type SelectExecutorOptions,
+} from "./executors/index.js";
+export type { DaemonConfig, LogLevel, LogEntry } from "./types.js";

--- a/packages/gsd-cloud/src/logger.ts
+++ b/packages/gsd-cloud/src/logger.ts
@@ -1,0 +1,89 @@
+import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs';
+import { dirname } from 'node:path';
+import type { LogLevel, LogEntry } from './types.js';
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+export interface LoggerOptions {
+  filePath: string;
+  level: LogLevel;
+  verbose?: boolean;
+}
+
+/**
+ * Structured JSON-lines file logger.
+ * Writes LogEntry objects one per line in append mode.
+ * The open write stream keeps the Node event loop alive (daemon keepalive).
+ */
+export class Logger {
+  private readonly stream: WriteStream;
+  private readonly level: number;
+  private readonly verbose: boolean;
+
+  constructor(opts: LoggerOptions) {
+    // Ensure parent directory exists
+    const dir = dirname(opts.filePath);
+    try {
+      mkdirSync(dir, { recursive: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Cannot create log directory ${dir}: ${msg}`);
+    }
+
+    this.stream = createWriteStream(opts.filePath, { flags: 'a' });
+    this.level = LEVEL_ORDER[opts.level] ?? LEVEL_ORDER.info;
+    this.verbose = opts.verbose ?? false;
+  }
+
+  debug(msg: string, data?: Record<string, unknown>): void {
+    this.write('debug', msg, data);
+  }
+
+  info(msg: string, data?: Record<string, unknown>): void {
+    this.write('info', msg, data);
+  }
+
+  warn(msg: string, data?: Record<string, unknown>): void {
+    this.write('warn', msg, data);
+  }
+
+  error(msg: string, data?: Record<string, unknown>): void {
+    this.write('error', msg, data);
+  }
+
+  /** End the write stream. Resolves when the stream is fully flushed. */
+  close(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      // Attach listeners BEFORE triggering end() so a synchronous error
+      // from end() or an immediate 'close' cannot slip past the listener.
+      this.stream.once('close', () => resolve());
+      this.stream.once('error', reject);
+      this.stream.end();
+    });
+  }
+
+  private write(level: LogLevel, msg: string, data?: Record<string, unknown>): void {
+    if (LEVEL_ORDER[level] < this.level) return;
+
+    const entry: LogEntry = {
+      ts: new Date().toISOString(),
+      level,
+      msg,
+      ...(data !== undefined ? { data } : {}),
+    };
+
+    const line = JSON.stringify(entry) + '\n';
+    this.stream.write(line);
+
+    if (this.verbose) {
+      const prefix = `[${entry.ts}] ${level.toUpperCase()}`;
+      const suffix = data ? ` ${JSON.stringify(data)}` : '';
+      process.stderr.write(`${prefix}: ${msg}${suffix}\n`);
+    }
+  }
+}

--- a/packages/gsd-cloud/src/types.ts
+++ b/packages/gsd-cloud/src/types.ts
@@ -1,0 +1,60 @@
+// Project/App: Open GSD
+// File Purpose: Trimmed, self-contained config/log types for the standalone cloud agent.
+//
+// This is a deliberately minimal copy of the daemon's types.ts. It defines ONLY
+// what the extracted cloud path needs (config parsing, logging) and imports NO
+// `@opengsd/rpc-client` or `@opengsd/contracts` — that is what makes this package
+// installable without the internal `@gsd/*` scope.
+
+/**
+ * Log severity levels, ordered from most to least verbose.
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * A single structured log entry written as JSON-lines.
+ */
+export interface LogEntry {
+  /** ISO-8601 timestamp */
+  ts: string;
+  level: LogLevel;
+  msg: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Top-level daemon configuration, loaded from YAML.
+ *
+ * Only the `cloud` and `log` blocks are load-bearing for the standalone agent.
+ * The `discord` and `projects` blocks are preserved so an existing
+ * `~/.gsd/daemon.yaml` written by the full daemon parses without loss, but the
+ * standalone agent does not act on them (it uses its own project source).
+ */
+export interface DaemonConfig {
+  cloud?: {
+    gateway_url: string;
+    device_token?: string;
+    runtime_id?: string;
+    runtime_name?: string;
+    enabled?: boolean;
+  };
+  discord?: {
+    token: string;
+    guild_id: string;
+    owner_id: string;
+    dm_on_blocker?: boolean;
+    control_channel_id?: string;
+    orchestrator?: {
+      model?: string;
+      max_tokens?: number;
+    };
+  };
+  projects: {
+    scan_roots: string[];
+  };
+  log: {
+    file: string;
+    level: LogLevel;
+    max_size_mb: number;
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,13 +339,19 @@ importers:
 
   packages/gsd-cloud:
     dependencies:
-      '@opengsd/daemon':
-        specifier: workspace:*
-        version: link:../daemon
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
+      yaml:
+        specifier: ^2.8.2
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.4
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -409,16 +415,16 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: 0.91.1
-        version: 0.91.1(zod@3.25.76)
+        version: 0.91.1(zod@4.4.3)
       '@anthropic-ai/vertex-sdk':
         specifier: 0.14.4
-        version: 0.14.4(zod@3.25.76)
+        version: 0.14.4(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime':
         specifier: 3.1048.0
         version: 3.1048.0
       '@google/genai':
         specifier: 1.52.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
+        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@mistralai/mistralai':
         specifier: 2.2.1
         version: 2.2.1
@@ -433,7 +439,7 @@ importers:
         version: 7.0.6
       openai:
         specifier: 6.26.0
-        version: 6.26.0(ws@8.21.0)(zod@3.25.76)
+        version: 6.26.0(ws@8.21.0)(zod@4.4.3)
       partial-json:
         specifier: 0.1.7
         version: 0.1.7
@@ -6431,25 +6437,11 @@ snapshots:
 
   '@anthropic-ai/sdk@0.52.0': {}
 
-  '@anthropic-ai/sdk@0.91.1(zod@3.25.76)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
-
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
-
-  '@anthropic-ai/vertex-sdk@0.14.4(zod@3.25.76)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
-      google-auth-library: 9.15.1
-    transitivePeerDependencies:
-      - supports-color
-      - zod
 
   '@anthropic-ai/vertex-sdk@0.14.4(zod@4.4.3)':
     dependencies:
@@ -7329,19 +7321,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
-    dependencies:
-      google-auth-library: 10.6.2
-      p-retry: 4.6.2
-      protobufjs: 7.6.4
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
@@ -7657,29 +7636,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.23
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -11569,11 +11525,6 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
-
-  openai@6.26.0(ws@8.21.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.21.0
-      zod: 3.25.76
 
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Makes `@opengsd/gsd-cloud` a genuinely standalone, installable agent, and fixes a load-bearing gateway-connection bug shared with the daemon.

### `@opengsd/gsd-cloud` is now self-contained
The previous thin-wrapper depended on `@opengsd/daemon`, whose `@opengsd/mcp-server → @gsd/pi-ai` chain 404s on npm (the `@gsd/*` scope is internal/unpublished), so it could never be installed. This rebuilds it to own its cloud-connection code with **`ws` + `yaml` as its only dependencies**.

- Extracts the clean modules out of the daemon (`device-flow`, `cloud-runtime`, `cloud-token`, `cloud-config`, `config`, `logger`, trimmed `types`). AES-GCM token crypto and the SSRF gateway guards are preserved verbatim.
- The executor is now an interface with a **gsd-pi shell-out adapter** that drives `gsd --mode mcp` over stdio MCP — no package linkage, only the wire protocol.
- `codex` / `claude -p` adapters are stubbed (throw "not yet implemented") for a follow-up; they need their own task-mapping design.
- CLI wires `device-flow` + `CloudRuntime` + the selected executor directly; it never imports the `Daemon`/`Orchestrator` class.
- **Proof:** clean-room `npm i <tarball>` adds only `gsd-cloud` + `ws` + `yaml` (no `@gsd/*`), and `gsd-cloud --help` runs.

### Fix `createGatewayLookup` (gsd-cloud **and** daemon)
Node's socket connect (`autoSelectFamily`/Happy Eyeballs, default-on since Node 20) calls a custom DNS lookup with `all: true` and expects an **array** callback. The code forced `all: false` and called back with a scalar → every real gateway request threw `Invalid IP address: undefined`, silently breaking the relay connection on all modern Node (verified identical in the daemon's own compiled dist; this is why the "machine online" E2E was never provable). Now honors both callback forms, with the private/loopback **SSRF guard applied to every resolved address**.

## Tests

- `packages/gsd-cloud`: 9 pass (3 new `createGatewayLookup` regression tests + 6 inject-gateway). tsc clean. Clean-room install verified.
- `packages/daemon`: 2 new `createGatewayLookup` regression tests; existing `cloud-config` + `cloud-runtime` suites green. tsc clean.
- Fix re-proven live: the same lookup now connects to `cloud-gateway.opengsd.net` (was `Invalid IP address: undefined`).

## Notes
- `@opengsd/gsd-cloud@1.7.0` (the broken thin-wrapper) should be **deprecated** on npm once `1.7.1` ships.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches cloud auth (device tokens), gateway SSRF/DNS resolution, and replaces the entire gsd-cloud execution path; bugs could break pairing, relay connectivity, or mis-route remote tool calls.
> 
> **Overview**
> **`@opengsd/gsd-cloud`** is rebuilt as a **standalone npm agent** (only `ws` + `yaml`). The CLI no longer delegates to `@opengsd/daemon`; it owns device-flow login, YAML config/token handling, **`CloudRuntime`** WebSocket relay, and an **`Executor`** seam. Local GSD work runs via **`GsdPiExecutor`**, which spawns `gsd --mode mcp` and speaks MCP over stdio—no `@opengsd/mcp-server` link. `codex` / `claude` executors are stubbed; project ads come from **`GSD_CLOUD_PROJECTS`** (or cwd) with stricter ambiguous-alias routing.
> 
> **`createGatewayLookup`** is fixed in **both** `packages/daemon` and `packages/gsd-cloud`: Node 20+ Happy Eyeballs calls custom lookups with **`all: true`** and expects an **address array**. The old forced scalar callback broke real gateway HTTP/WebSocket connects (`Invalid IP address: undefined`). Both scalar and array paths are supported; private/loopback **SSRF checks** apply to every resolved address.
> 
> **`CloudRuntime.start()`** now resolves only after the relay socket opens, with bounded initial-connect retries so the CLI does not print “connected” on a dead socket. Regression tests cover lookup, connect semantics, MCP client shutdown, and executor routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ed17861ad3e730665d44d71982fcf477ed55ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->