### PR TITLE
fix(issue): [Bug]: headless auto/next idles forever when a queued pre-planning milestone routes to an interactive menu

### DIFF
--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -13,6 +13,7 @@
 
 import {
   isBlockedNoticeMessage,
+  isInteractiveMenuUnavailableNotice,
   isManualResolutionNotice,
   isPauseNotice,
   isTerminalNotice,
@@ -74,7 +75,8 @@ export function mapStatusToExitCode(status: string): number {
  *   "Auto-mode paused..."
  *   "Step-mode paused..."
  * plus bootstrap-time manual-resolution failures that return before auto-mode
- * can emit a formal pause/stop notification.
+ * can emit a formal pause/stop notification, plus interactive menus that could
+ * not render headlessly (a dead-end that returns without dispatching). (#1294)
  *
  * Does NOT match progress notifications that happen to contain words like
  * "complete" or "stopped" (e.g., "Override resolved — rewrite-docs completed",
@@ -122,7 +124,16 @@ export function isTerminalNotification(event: Record<string, unknown>): boolean 
   if (isBlockingCommandBlock(event)) return true
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
   const message = String(event.message ?? '').toLowerCase()
-  return isTerminalNotice(message) || isPauseNotice(message) || isManualResolutionNotice(message)
+  // A menu that could not render headlessly is a terminal dead-end: the
+  // extension already returned without dispatching, so nothing else will fire.
+  // Resolve the run (as blocked, via isBlockedNotification) instead of idling
+  // forever waiting for a completion signal. (#1294)
+  return (
+    isTerminalNotice(message) ||
+    isPauseNotice(message) ||
+    isManualResolutionNotice(message) ||
+    isInteractiveMenuUnavailableNotice(message)
+  )
 }
 
 export function isBlockedNotification(event: Record<string, unknown>): boolean {

--- a/src/resources/extensions/gsd/command-feedback.ts
+++ b/src/resources/extensions/gsd/command-feedback.ts
@@ -96,22 +96,29 @@ export function notifyDiscussNeedsInteractiveMenu(
   });
 }
 
-/** Hub picker for /gsd queue (reorder vs add) is unavailable. */
+/**
+ * Hub picker for /gsd queue (reorder vs add) is unavailable.
+ *
+ * Unlike the other picker-guidance notices, /gsd queue does NOT dead-end here:
+ * the caller falls through to the add-work flow, which runs headlessly. So this
+ * notice must avoid the "did not start:" picker-failure phrasing — the headless
+ * host classifies that as a blocked dead-end (see stop-notice.ts / #1294) and
+ * would exit 10 before the add-work run starts.
+ */
 export function notifyQueueHubNeedsInteractiveMenu(
   ctx: ExtensionCommandContext,
   reason: string,
 ): void {
-  notifyPickerCommandNeedsInteractiveMenu(ctx, {
-    command: "/gsd queue",
-    reason,
-    alternatives: [
-      "Add-work flow can run headless — continuing with queue discussion.",
-    ],
-    hints: [
-      "/gsd queue — run from the GSD TUI to reorder pending milestones",
-      "/gsd status — see milestone order and phase",
-    ],
-  });
+  ctx.ui.notify(
+    [
+      `/gsd queue reorder menu needs an interactive session (${reason}).`,
+      "Continuing headless with the add-work flow.",
+      "",
+      "  • /gsd queue — run from the GSD TUI to reorder pending milestones",
+      "  • /gsd status — see milestone order and phase",
+    ].join("\n"),
+    "warning",
+  );
 }
 
 /** /gsd, /gsd new-milestone, /gsd new-project wizard menus. */

--- a/src/resources/extensions/gsd/stop-notice.ts
+++ b/src/resources/extensions/gsd/stop-notice.ts
@@ -67,15 +67,19 @@ export function isNonBlockingPauseNotice(message: string): boolean {
 }
 
 /**
- * A next-action menu that could not render in a non-interactive (headless / RPC)
- * session. Wording originates from `notifyCommandMenuUnavailable` in
- * next-action-ui.ts / command-feedback.ts. Headless `auto`/`next` cannot answer
- * such a menu, so the run has dead-ended and needs operator intervention.
- * Classify it as blocked so the headless host exits 10 instead of idling forever
- * waiting for a completion signal that never comes. (#1294)
+ * A picker / next-action menu that could not render in a non-interactive
+ * (headless / RPC) session. Both wordings originate from the menu-unavailable
+ * helpers (`notifyCommandMenuUnavailable` and `notifyPickerCommandNeedsInteractiveMenu`
+ * in next-action-ui.ts / command-feedback.ts). Headless `auto`/`next` cannot
+ * answer such a menu, so the run has dead-ended and needs operator intervention.
+ * Classify it as blocked so the headless host exits 10 instead of idling
+ * forever waiting for a completion signal that never comes. (#1294)
  */
 export function isInteractiveMenuUnavailableNotice(message: string): boolean {
-  return message.includes("menu could not be shown in this session");
+  return (
+    message.includes("menu could not be shown in this session") ||
+    message.includes("did not start:")
+  );
 }
 
 export function isBlockedNoticeMessage(message: string): boolean {

--- a/src/resources/extensions/gsd/stop-notice.ts
+++ b/src/resources/extensions/gsd/stop-notice.ts
@@ -66,10 +66,27 @@ export function isNonBlockingPauseNotice(message: string): boolean {
   return message.includes("idempotent advance: unit already active");
 }
 
+/**
+ * A picker / next-action menu that could not render in a non-interactive
+ * (headless / RPC) session. Both wordings originate from the menu-unavailable
+ * helpers (`notifyCommandMenuUnavailable` and `notifyPickerCommandNeedsInteractiveMenu`
+ * in next-action-ui.ts / command-feedback.ts). Headless `auto`/`next` cannot
+ * answer such a menu, so the run has dead-ended and needs operator intervention.
+ * Classify it as blocked so the headless host exits 10 instead of idling
+ * forever waiting for a completion signal that never comes. (#1294)
+ */
+export function isInteractiveMenuUnavailableNotice(message: string): boolean {
+  return (
+    message.includes("menu could not be shown in this session") ||
+    message.includes("did not start:")
+  );
+}
+
 export function isBlockedNoticeMessage(message: string): boolean {
   return (
     message.includes("blocked:") ||
     (isPauseNotice(message) && !isNonBlockingPauseNotice(message)) ||
-    isManualResolutionNotice(message)
+    isManualResolutionNotice(message) ||
+    isInteractiveMenuUnavailableNotice(message)
   );
 }

--- a/src/resources/extensions/gsd/stop-notice.ts
+++ b/src/resources/extensions/gsd/stop-notice.ts
@@ -67,19 +67,15 @@ export function isNonBlockingPauseNotice(message: string): boolean {
 }
 
 /**
- * A picker / next-action menu that could not render in a non-interactive
- * (headless / RPC) session. Both wordings originate from the menu-unavailable
- * helpers (`notifyCommandMenuUnavailable` and `notifyPickerCommandNeedsInteractiveMenu`
- * in next-action-ui.ts / command-feedback.ts). Headless `auto`/`next` cannot
- * answer such a menu, so the run has dead-ended and needs operator intervention.
- * Classify it as blocked so the headless host exits 10 instead of idling
- * forever waiting for a completion signal that never comes. (#1294)
+ * A next-action menu that could not render in a non-interactive (headless / RPC)
+ * session. Wording originates from `notifyCommandMenuUnavailable` in
+ * next-action-ui.ts / command-feedback.ts. Headless `auto`/`next` cannot answer
+ * such a menu, so the run has dead-ended and needs operator intervention.
+ * Classify it as blocked so the headless host exits 10 instead of idling forever
+ * waiting for a completion signal that never comes. (#1294)
  */
 export function isInteractiveMenuUnavailableNotice(message: string): boolean {
-  return (
-    message.includes("menu could not be shown in this session") ||
-    message.includes("did not start:")
-  );
+  return message.includes("menu could not be shown in this session");
 }
 
 export function isBlockedNoticeMessage(message: string): boolean {

--- a/src/resources/extensions/gsd/tests/command-feedback.test.ts
+++ b/src/resources/extensions/gsd/tests/command-feedback.test.ts
@@ -11,6 +11,7 @@ import {
   notifySmartEntryNeedsInteractiveMenu,
   requiresInteractiveMenu,
 } from "../command-feedback.js";
+import { isBlockedNoticeMessage, isInteractiveMenuUnavailableNotice } from "../stop-notice.js";
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 function makeCtx(overrides: {
@@ -86,6 +87,17 @@ describe("notifyQueueHubNeedsInteractiveMenu", () => {
     const notes = (ctx as typeof ctx & { _notifications: Array<{ message: string }> })._notifications;
     assert.match(notes[0]!.message, /\/gsd queue/);
     assert.match(notes[0]!.message, /reorder/i);
+  });
+
+  // /gsd queue continues headless with the add-work flow after this notice, so
+  // it must NOT be classified as a blocked dead-end (would exit 10 early). (#1294)
+  it("emits a notice the headless host does not treat as a dead-end", () => {
+    const ctx = makeCtx({ hasUI: false });
+    notifyQueueHubNeedsInteractiveMenu(ctx, "this session has no interactive menu");
+    const notes = (ctx as typeof ctx & { _notifications: Array<{ message: string }> })._notifications;
+    const message = notes[0]!.message.toLowerCase();
+    assert.equal(isInteractiveMenuUnavailableNotice(message), false);
+    assert.equal(isBlockedNoticeMessage(message), false);
   });
 });
 

--- a/src/resources/extensions/gsd/tests/stop-notice.test.ts
+++ b/src/resources/extensions/gsd/tests/stop-notice.test.ts
@@ -14,6 +14,7 @@ import {
   isPauseNotice,
   isBlockedNoticeMessage,
   isManualResolutionNotice,
+  isInteractiveMenuUnavailableNotice,
   PAUSED_NOTICE_PREFIXES,
   TERMINAL_NOTICE_PREFIXES,
 } from "../stop-notice.js";
@@ -60,6 +61,22 @@ describe("emitter↔detector round-trip", () => {
     const message = "merge conflict — resolve manually and re-run /gsd auto";
     assert.ok(isManualResolutionNotice(message));
     assert.ok(isBlockedNoticeMessage(message));
+  });
+
+  test("un-showable menu notices classify as blocked (#1294)", () => {
+    // Emitted verbatim by notifyCommandMenuUnavailable (next-action-ui.ts / command-feedback.ts).
+    const menuUnavailable =
+      "gsd — m002: editorial hn menu could not be shown in this session.\nrun /gsd when ready.";
+    assert.ok(isInteractiveMenuUnavailableNotice(menuUnavailable));
+    assert.ok(isBlockedNoticeMessage(menuUnavailable));
+
+    // Emitted by notifyPickerCommandNeedsInteractiveMenu (command-feedback.ts).
+    const pickerGuidance = "/gsd did not start: milestone menu needs an interactive session";
+    assert.ok(isInteractiveMenuUnavailableNotice(pickerGuidance));
+    assert.ok(isBlockedNoticeMessage(pickerGuidance));
+
+    // Unrelated notices are not swept up.
+    assert.equal(isInteractiveMenuUnavailableNotice("auto-mode complete"), false);
   });
 
   test("terminal prefixes cover the known stop vocabulary", () => {

--- a/src/resources/extensions/gsd/tests/stop-notice.test.ts
+++ b/src/resources/extensions/gsd/tests/stop-notice.test.ts
@@ -70,10 +70,10 @@ describe("emitter↔detector round-trip", () => {
     assert.ok(isInteractiveMenuUnavailableNotice(menuUnavailable));
     assert.ok(isBlockedNoticeMessage(menuUnavailable));
 
-    // Picker guidance may continue after notifying (e.g. headless queue add-work).
-    const pickerGuidance = "/gsd queue did not start: this session has no interactive menu";
-    assert.equal(isInteractiveMenuUnavailableNotice(pickerGuidance), false);
-    assert.equal(isBlockedNoticeMessage(pickerGuidance), false);
+    // Emitted by notifyPickerCommandNeedsInteractiveMenu (command-feedback.ts).
+    const pickerGuidance = "/gsd did not start: milestone menu needs an interactive session";
+    assert.ok(isInteractiveMenuUnavailableNotice(pickerGuidance));
+    assert.ok(isBlockedNoticeMessage(pickerGuidance));
 
     // Unrelated notices are not swept up.
     assert.equal(isInteractiveMenuUnavailableNotice("auto-mode complete"), false);

--- a/src/resources/extensions/gsd/tests/stop-notice.test.ts
+++ b/src/resources/extensions/gsd/tests/stop-notice.test.ts
@@ -70,10 +70,10 @@ describe("emitter↔detector round-trip", () => {
     assert.ok(isInteractiveMenuUnavailableNotice(menuUnavailable));
     assert.ok(isBlockedNoticeMessage(menuUnavailable));
 
-    // Emitted by notifyPickerCommandNeedsInteractiveMenu (command-feedback.ts).
-    const pickerGuidance = "/gsd did not start: milestone menu needs an interactive session";
-    assert.ok(isInteractiveMenuUnavailableNotice(pickerGuidance));
-    assert.ok(isBlockedNoticeMessage(pickerGuidance));
+    // Picker guidance may continue after notifying (e.g. headless queue add-work).
+    const pickerGuidance = "/gsd queue did not start: this session has no interactive menu";
+    assert.equal(isInteractiveMenuUnavailableNotice(pickerGuidance), false);
+    assert.equal(isBlockedNoticeMessage(pickerGuidance), false);
 
     // Unrelated notices are not swept up.
     assert.equal(isInteractiveMenuUnavailableNotice("auto-mode complete"), false);

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -277,6 +277,19 @@ test('isBlockedNotification: avoids blocked text without blocked marker', () => 
   assert.equal(isBlockedNotification(makeNotify('The request was blocked by the firewall')), false)
 })
 
+test('un-showable menu notifications are terminal and blocked (#1294)', () => {
+  // Verbatim shape from notifyCommandMenuUnavailable — the pre-planning menu route
+  // that previously idled forever in headless auto/next.
+  const menu = makeNotify('GSD — M002: Editorial HN menu could not be shown in this session.\nRun /gsd when ready.')
+  assert.equal(isTerminalNotification(menu), true)
+  assert.equal(isBlockedNotification(menu), true)
+
+  // Picker-guidance shape from notifyPickerCommandNeedsInteractiveMenu.
+  const picker = makeNotify('/gsd did not start: milestone menu needs an interactive session')
+  assert.equal(isTerminalNotification(picker), true)
+  assert.equal(isBlockedNotification(picker), true)
+})
+
 test('isInteractiveHeadlessTool: ask_user_questions is interactive', () => {
   assert.equal(isInteractiveHeadlessTool('ask_user_questions'), true)
 })

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -284,10 +284,10 @@ test('un-showable menu notifications are terminal and blocked (#1294)', () => {
   assert.equal(isTerminalNotification(menu), true)
   assert.equal(isBlockedNotification(menu), true)
 
-  // Queue hub picker guidance is non-terminal — add-work continues after the warning.
-  const queueHub = makeNotify('/gsd queue did not start: this session has no interactive menu')
-  assert.equal(isTerminalNotification(queueHub), false)
-  assert.equal(isBlockedNotification(queueHub), false)
+  // Picker-guidance shape from notifyPickerCommandNeedsInteractiveMenu.
+  const picker = makeNotify('/gsd did not start: milestone menu needs an interactive session')
+  assert.equal(isTerminalNotification(picker), true)
+  assert.equal(isBlockedNotification(picker), true)
 })
 
 test('isInteractiveHeadlessTool: ask_user_questions is interactive', () => {

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -284,10 +284,10 @@ test('un-showable menu notifications are terminal and blocked (#1294)', () => {
   assert.equal(isTerminalNotification(menu), true)
   assert.equal(isBlockedNotification(menu), true)
 
-  // Picker-guidance shape from notifyPickerCommandNeedsInteractiveMenu.
-  const picker = makeNotify('/gsd did not start: milestone menu needs an interactive session')
-  assert.equal(isTerminalNotification(picker), true)
-  assert.equal(isBlockedNotification(picker), true)
+  // Queue hub picker guidance is non-terminal — add-work continues after the warning.
+  const queueHub = makeNotify('/gsd queue did not start: this session has no interactive menu')
+  assert.equal(isTerminalNotification(queueHub), false)
+  assert.equal(isBlockedNotification(queueHub), false)
 })
 
 test('isInteractiveHeadlessTool: ask_user_questions is interactive', () => {


### PR DESCRIPTION
## Summary
- Classified headless "menu could not be shown" notices as terminal+blocked so `gsd auto`/`next` exits 10 instead of idling forever on an un-showable pre-planning menu; verified with new unit tests (53 pass) and a clean typecheck of the changed files.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1294
- [#1294 [Bug]: headless auto/next idles forever when a queued pre-planning milestone routes to an interactive menu](https://github.com/open-gsd/gsd-pi/issues/1294)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1294-bug-headless-auto-next-idles-forever-whe-1783360796`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes headless completion and exit-code behavior for notify messages; misclassification could cause premature exit 10 or renewed idle hangs, though queue is explicitly carved out and tests lock the strings.
> 
> **Overview**
> Fixes headless **`gsd auto` / `next`** hanging indefinitely when a pre-planning milestone routes to a menu that cannot render without a TUI.
> 
> **Stop-notice / headless host:** Adds **`isInteractiveMenuUnavailableNotice`** for notify text like *"menu could not be shown in this session"* and *"did not start:"*. Those signals are treated as **terminal** and **blocked**, so the headless run resolves with **exit 10** instead of waiting for a completion event that never arrives.
> 
> **`/gsd queue` exception:** **`notifyQueueHubNeedsInteractiveMenu`** no longer uses the shared *"did not start:"* picker wording, because queue **continues headlessly** into add-work after the reorder notice. The new copy is explicitly **not** classified as a dead-end.
> 
> Unit tests cover classification and the queue notice shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63704c23094a8c443e4a124ca5070e37916fba3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->