### PR TITLE
fix(issue): [Bug]: `--print` mode discards `process.exitCode` set by commands/extensions — unconditional `process.exit(0)` after `runPrintMode`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import chalk from 'chalk'
 import { checkForGsdBrowserUpdates, checkForUpdates } from './update-check.js'
 import { shouldBypassManagedResourceMismatchGate } from './cli-policy.js'
 import { shouldRedirectAutoToHeadless } from './cli-auto-routing.js'
+import { resolvePrintModeExitCode } from './print-mode-exit.js'
 import { printHelp, printSubcommandHelp } from './help-text.js'
 import { applySecurityOverrides } from './security-overrides.js'
 import { validateConfiguredModel } from './startup-model-validation.js'
@@ -778,7 +779,7 @@ if (isPrintMode) {
   // Honor any exit code a slash command or extension handler set during the
   // turn (e.g. a machine-readable verdict for headless orchestrators); default
   // to 0 when none was set.
-  process.exit(process.exitCode ?? 0)
+  process.exit(resolvePrintModeExitCode(process.exitCode))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -775,7 +775,10 @@ if (isPrintMode) {
     mode: mode as 'text' | 'json',
     messages: cliFlags.messages,
   })
-  process.exit(0)
+  // Honor any exit code a slash command or extension handler set during the
+  // turn (e.g. a machine-readable verdict for headless orchestrators); default
+  // to 0 when none was set.
+  process.exit(process.exitCode ?? 0)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/print-mode-exit.ts
+++ b/src/print-mode-exit.ts
@@ -1,0 +1,14 @@
+/**
+ * Resolve the process exit code the CLI should use after `runPrintMode`
+ * completes.
+ *
+ * Print mode previously always exited 0, discarding any `process.exitCode` a
+ * slash command or extension handler set during the turn (e.g. a machine
+ * readable verdict for a headless orchestrator). Honor a code that was set;
+ * default to 0 when none was.
+ *
+ * Regression: #1293
+ */
+export function resolvePrintModeExitCode(exitCode: NodeJS.Process['exitCode']) {
+  return exitCode ?? 0
+}

--- a/src/tests/print-mode-exit.test.ts
+++ b/src/tests/print-mode-exit.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression tests for #1293 — `--print` mode must not discard a
+ * `process.exitCode` set by a slash command or extension handler.
+ *
+ * The print-mode branch in src/cli.ts used to call `process.exit(0)`
+ * unconditionally, forcing a success exit even when a handler had signalled
+ * failure (or a custom verdict) via `process.exitCode`. It now resolves the
+ * final code through `resolvePrintModeExitCode`, which honors a set code and
+ * defaults to 0.
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { resolvePrintModeExitCode } from '../print-mode-exit.js'
+
+test('defaults to 0 when no exit code was set (#1293)', () => {
+  assert.equal(resolvePrintModeExitCode(undefined), 0)
+})
+
+test('preserves an explicit success code of 0', () => {
+  assert.equal(resolvePrintModeExitCode(0), 0)
+})
+
+test('propagates a non-zero exit code set by a handler (#1293)', () => {
+  assert.equal(resolvePrintModeExitCode(1), 1)
+  assert.equal(resolvePrintModeExitCode(2), 2)
+  assert.equal(resolvePrintModeExitCode(42), 42)
+})


### PR DESCRIPTION
## Summary
- Changed print-mode's trailing `process.exit(0)` to `process.exit(process.exitCode ?? 0)` in src/cli.ts so handler-set exit codes propagate; verified via tsc typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1293
- [#1293 [Bug]: `--print` mode discards `process.exitCode` set by commands/extensions — unconditional `process.exit(0)` after `runPrintMode`](https://github.com/open-gsd/gsd-pi/issues/1293)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1293-bug-print-mode-discards-process-exitcode-1783361634`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI exit-behavior fix with a dedicated helper and unit tests; no auth, data, or session logic changes.
> 
> **Overview**
> **Print mode** (`--print` / text/json modes) no longer forces exit code **0** after `runPrintMode` finishes. It now exits with whatever **`process.exitCode`** a slash command or extension set during the turn, or **0** if none was set.
> 
> The logic lives in **`resolvePrintModeExitCode`** (`src/print-mode-exit.ts`), used from the print-mode branch in `cli.ts`. Regression tests cover undefined, 0, and non-zero codes (**#1293**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1b60f8f8bbe9d937fa532a8368d43bf9d483496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->