### PR TITLE
fix(issue): [Bug]: A task-less (sketch) slice acquires a phantom "Plan NN" task after a `.planning` projection round-trip, causing auto-mode to skip planning

### DIFF
--- a/src/resources/extensions/gsd/migrate/planning-writer.ts
+++ b/src/resources/extensions/gsd/migrate/planning-writer.ts
@@ -181,17 +181,14 @@ export async function writePlanningDirectory(
       });
 
       if (tasks.length === 0) {
-        // Empty phase — write a single placeholder plan so the dir isn't empty.
-        const planPath = join(phaseDir, `${pad(phaseNum)}-01-PLAN.md`);
-        await saveFile(
-          planPath,
-          formatPlanningPlan(phaseNum, 1, slice.title || slice.id, []),
-        );
-        paths.push(planPath);
-        projectionWrites.push({
-          relPath: toPlanningRel(planPath),
-          entities: [`${milestone.id}/${slice.id}`],
-        });
+        // Sketch / undecomposed slice — zero tasks. Do NOT emit an ingestible
+        // *-PLAN.md here: the reverse transform maps one GSDTask per plan file
+        // (transformer.ts mapSlice), so a placeholder would materialize a
+        // phantom "Plan NN" task and flip the slice from "needs planning" to
+        // "has a planned task", causing auto-mode to skip planning (issue #1285).
+        // The phase dir is already created (mkdirSync above) and the slice is
+        // listed in ROADMAP.md, so it round-trips with tasks = [] — the correct
+        // sketch-slice shape.
       } else {
         for (let ti = 0; ti < tasks.length; ti++) {
           const task = tasks[ti]!;
@@ -217,19 +214,14 @@ export async function writePlanningDirectory(
     }
   }
 
-  // If no slices produced any phases, write a single empty phase so ROADMAP.md
-  // isn't blank and the layout is still discoverable.
+  // If no slices produced any phases, emit a single empty phase dir + ROADMAP
+  // entry so the layout stays discoverable. Do NOT write a placeholder
+  // *-PLAN.md — an ingestible plan file would round-trip into a phantom task
+  // (see the tasks.length === 0 branch above, issue #1285).
   if (roadmapEntries.length === 0) {
     const phaseDirName = `${pad(1)}-milestone`;
     const phaseDir = join(root, "phases", phaseDirName);
     mkdirSync(phaseDir, { recursive: true });
-    const planPath = join(phaseDir, `${pad(1)}-01-PLAN.md`);
-    await saveFile(planPath, formatPlanningPlan(1, 1, milestones[0]!.title || milestones[0]!.id, []));
-    paths.push(planPath);
-    projectionWrites.push({
-      relPath: toPlanningRel(planPath),
-      entities: [milestones[0]!.id],
-    });
     roadmapEntries.push({ number: 1, title: milestones[0]!.title || milestones[0]!.id, done: false });
   }
 

--- a/src/resources/extensions/gsd/tests/planning-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-writer.test.ts
@@ -75,6 +75,35 @@ test("writePlanningDirectory is idempotent: writing twice produces stable conten
   assert.equal(roadmap2, roadmap1);
 });
 
+test("writePlanningDirectory does not emit an ingestible PLAN.md for a task-less (sketch) slice", async () => {
+  // Regression for #1285: a milestone-level sketch slice has zero DB tasks.
+  // The projection must not write a placeholder NN-01-PLAN.md — the reverse
+  // transform maps one task per plan file, so a placeholder would materialize
+  // a phantom "Plan NN" task and make auto-mode skip planning.
+  const base = makeTmp();
+  insertSlice({
+    milestoneId: "M001", id: "S02", title: "Sketch slice", status: "pending",
+    risk: "medium", depends: ["S01"], demo: "designed", sequence: 2,
+  });
+  // S02 intentionally has no tasks.
+
+  await writePlanningDirectory(base, "flat-phases");
+
+  const phaseDirs = readdirSync(join(base, ".planning", "phases"), { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  const sketchDir = phaseDirs.find((d) => /^02-/.test(d));
+  assert.ok(sketchDir, `expected a 02- phase dir for the sketch slice, got ${JSON.stringify(phaseDirs)}`);
+
+  const planFiles = readdirSync(join(base, ".planning", "phases", sketchDir!))
+    .filter((f) => f.endsWith("PLAN.md"));
+  assert.equal(planFiles.length, 0, `sketch slice should have no PLAN.md, got ${JSON.stringify(planFiles)}`);
+
+  // The slice remains discoverable via ROADMAP.md.
+  const roadmap = readFileSync(join(base, ".planning", "ROADMAP.md"), "utf-8");
+  assert.match(roadmap, /Sketch slice/);
+});
+
 test("writePlanningDirectory throws for unsupported layouts", async () => {
   const base = makeTmp();
   await assert.rejects(() => writePlanningDirectory(base, "multi-milestone"), /not yet supported/);


### PR DESCRIPTION
## Summary
- Stopped `writePlanningDirectory` from emitting a placeholder `*-PLAN.md` for task-less sketch slices (which round-tripped into a phantom "Plan NN" task); verified with the planning-writer, round-trip, and flat-phase test suites plus a new regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1285
- [#1285 [Bug]: A task-less (sketch) slice acquires a phantom "Plan NN" task after a `.planning` projection round-trip, causing auto-mode to skip planning](https://github.com/open-gsd/gsd-pi/issues/1285)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1285-bug-a-task-less-sketch-slice-acquires-a--1783362571`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to planning projection output for empty slices; behavior is covered by a new regression test with no auth or data-model changes.
> 
> **Overview**
> Fixes a **`.planning` projection round-trip bug** where task-less (sketch) slices incorrectly gained a phantom **"Plan NN"** task, so **auto-mode treated them as already planned** and skipped planning.
> 
> **`writePlanningDirectory`** no longer writes ingestible placeholder `*-PLAN.md` files when a slice has **zero DB tasks** or when **no phases** would otherwise be emitted. It still creates the **phase directory** and **ROADMAP.md** entry so sketch slices stay discoverable with **`tasks = []`** on re-import.
> 
> Adds a **regression test** asserting sketch slices get a phase folder but **no** `PLAN.md` files, while the slice title remains in the roadmap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4338ced84615411c409cff05b01af0e8d28f7d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->