### PR TITLE
fix(issue): [Bug]: `gsd headless verdict pass --rationale "..."` unusable — headless argv parser silently swallows unrecognized flags before slash-command assembly

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -233,6 +233,12 @@ export function parseHeadlessArgs(argv: string[]): HeadlessOptions {
         options.resumeSession = args[++i]
       } else if (arg === '--bare') {
         options.bare = true
+      } else {
+        // Unrecognized flag: pass it through to the slash command verbatim
+        // instead of silently dropping it. This lets subcommand flags such as
+        // `verdict pass --rationale "..."` reach the assembled slash command
+        // (#1297). Known headless flags above still win regardless of position.
+        options.commandArgs.push(arg)
       }
     } else if (options.command === 'auto') {
       options.command = arg

--- a/src/tests/headless-cli-surface.test.ts
+++ b/src/tests/headless-cli-surface.test.ts
@@ -106,6 +106,9 @@ function parseHeadlessArgs(argv: string[]): HeadlessOptions {
         options.resumeSession = args[++i]
       } else if (arg === '--bare') {
         options.bare = true
+      } else {
+        // Unrecognized flag: pass through to the slash command (#1297)
+        options.commandArgs.push(arg)
       }
     } else if (options.command === 'auto') {
       options.command = arg
@@ -422,4 +425,20 @@ test('--bare does not affect other flags', () => {
   assert.equal(opts.timeout, 60000)
   assert.equal(opts.resumeSession, 'sess-abc')
   assert.equal(opts.command, 'auto')
+})
+
+// ─── Unrecognized subcommand flags pass through (#1297) ────────────────────
+
+test('unknown subcommand flag passes through to commandArgs', () => {
+  const opts = parseHeadlessArgs([
+    'node', 'gsd', 'headless',
+    'verdict', 'pass',
+    '--rationale', 'key-gated live UAT unavailable',
+  ])
+  assert.equal(opts.command, 'verdict')
+  assert.deepEqual(opts.commandArgs, [
+    'pass',
+    '--rationale',
+    'key-gated live UAT unavailable',
+  ])
 })


### PR DESCRIPTION
## Summary
- Added an unknown-flag fallthrough in parseHeadlessArgs so subcommand flags like `--rationale` pass through to the slash command instead of being dropped; verified with the headless CLI surface unit suite (39/39 pass) plus a new regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1297
- [#1297 [Bug]: `gsd headless verdict pass --rationale "..."` unusable — headless argv parser silently swallows unrecognized flags before slash-command assembly](https://github.com/open-gsd/gsd-pi/issues/1297)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1297-bug-gsd-headless-verdict-pass-rationale--1783362601`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI argument parsing change with a targeted regression test; no auth, data, or runtime orchestration logic touched.
> 
> **Overview**
> Fixes **`gsd headless verdict pass --rationale "..."`** and similar invocations where subcommand flags were **silently dropped** during argv parsing.
> 
> **`parseHeadlessArgs`** now treats any `--` token that is not a known headless option as part of the target slash command: it appends the flag (and leaves following positional values on the normal path) into **`commandArgs`**, so **`buildHeadlessSlashCommand`** can emit something like `/gsd verdict pass --rationale ...`. Documented headless flags (`--timeout`, `--bare`, etc.) are unchanged and still take precedence.
> 
> A **regression test** in the headless CLI surface suite mirrors the same parser logic and asserts the `verdict` / `pass` / `--rationale` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569f4b31590847817eb0082234619cf74dde7fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->