### PR TITLE
fix(issue): [Bug]: During `/gsd discuss`, the agent's clarifying/explanatory replies are dropped — the user sees only the elicitation popups

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -2252,6 +2252,7 @@ export function streamViaClaudeCode(
 interface SdkAttemptMessageState {
 	builder: PartialMessageBuilder | null;
 	intermediateToolBlocks: AssistantMessage["content"];
+	intermediateTextBlocks: AssistantMessage["content"];
 	toolResultsById: Map<string, ExternalToolResultPayload>;
 	toolCompletionTargetsById: Map<string, { partial: AssistantMessage; contentIndex: number }>;
 	emittedExternalToolResultIds: Set<string>;
@@ -2261,6 +2262,7 @@ function createSdkAttemptMessageState(): SdkAttemptMessageState {
 	return {
 		builder: null,
 		intermediateToolBlocks: [],
+		intermediateTextBlocks: [],
 		toolResultsById: new Map<string, ExternalToolResultPayload>(),
 		toolCompletionTargetsById: new Map<string, { partial: AssistantMessage; contentIndex: number }>(),
 		emittedExternalToolResultIds: new Set<string>(),
@@ -2402,6 +2404,7 @@ async function pumpSdkMessages(
 				let {
 					builder,
 					intermediateToolBlocks,
+					intermediateTextBlocks,
 					toolResultsById,
 					toolCompletionTargetsById,
 					emittedExternalToolResultIds,
@@ -2542,8 +2545,14 @@ async function pumpSdkMessages(
 								for (const [contentIndex, block] of builder.message.content.entries()) {
 									if (block.type === "text" && block.text) {
 										lastTextContent = block.text;
+										// Accumulate completed prose in order — a multi-question
+										// turn commits [prose][elicitation] segments across several
+										// synthetic-user boundaries, and overwriting a single
+										// scalar would drop every explanation but the last.
+										intermediateTextBlocks.push({ type: "text", text: block.text });
 									} else if (block.type === "thinking" && block.thinking) {
 										lastThinkingContent = block.thinking;
+										intermediateTextBlocks.push({ type: "thinking", thinking: block.thinking });
 									} else if (block.type === "toolCall" || block.type === "serverToolUse") {
 										// Collect tool blocks for externalToolExecution rendering
 										intermediateToolBlocks.push(block);
@@ -2641,6 +2650,7 @@ async function pumpSdkMessages(
 							const result = msg as SDKResultMessage;
 							const finalContent = buildFinalAssistantContent({
 								intermediateToolBlocks,
+								intermediateTextBlocks,
 								pendingContent: builder?.message.content,
 								toolResultsById,
 								lastThinkingContent,

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1365,6 +1365,47 @@ describe("stream-adapter — Claude Code external tool results", () => {
 		});
 		assert.deepEqual(finalContent[1], { type: "text", text: "Read complete." });
 	});
+
+	test("buildFinalAssistantContent keeps every prose segment across successive elicitation boundaries (#1284)", () => {
+		// A multi-question /gsd discuss turn: [prose A][Q1][prose B][Q2][prose C].
+		// Prose A and B are committed at synthetic-user boundaries (intermediate),
+		// prose C is still in the builder (pending) when `result` arrives.
+		const finalContent = buildFinalAssistantContent({
+			intermediateToolBlocks: [
+				{ type: "toolCall", id: "q1", name: "ask_user_questions", arguments: {} } as any,
+				{ type: "toolCall", id: "q2", name: "ask_user_questions", arguments: {} } as any,
+			],
+			intermediateTextBlocks: [
+				{ type: "text", text: "prose A" },
+				{ type: "text", text: "prose B" },
+			],
+			pendingContent: [{ type: "text", text: "prose C" }],
+			toolResultsById: new Map(),
+		});
+
+		const textBlocks = finalContent.filter((b) => b.type === "text").map((b) => (b as any).text);
+		assert.deepEqual(textBlocks, ["prose A", "prose B", "prose C"]);
+	});
+
+	test("buildFinalAssistantContent does not duplicate the last prose when the turn ends on an elicitation (#1284)", () => {
+		// [prose A][Q1][prose B][Q2] — builder was reset at the final boundary, so
+		// pendingContent is empty and lastTextContent still holds "prose B".
+		const finalContent = buildFinalAssistantContent({
+			intermediateToolBlocks: [
+				{ type: "toolCall", id: "q1", name: "ask_user_questions", arguments: {} } as any,
+				{ type: "toolCall", id: "q2", name: "ask_user_questions", arguments: {} } as any,
+			],
+			intermediateTextBlocks: [
+				{ type: "text", text: "prose A" },
+				{ type: "text", text: "prose B" },
+			],
+			toolResultsById: new Map(),
+			lastTextContent: "prose B",
+		});
+
+		const textBlocks = finalContent.filter((b) => b.type === "text").map((b) => (b as any).text);
+		assert.deepEqual(textBlocks, ["prose A", "prose B"]);
+	});
 });
 
 describe("claude-code-cli — Claude Fable 5 Opus-tier support", () => {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1406,6 +1406,26 @@ describe("stream-adapter — Claude Code external tool results", () => {
 		const textBlocks = finalContent.filter((b) => b.type === "text").map((b) => (b as any).text);
 		assert.deepEqual(textBlocks, ["prose A", "prose B"]);
 	});
+
+	test("buildFinalAssistantContent emits scalar fallback prose/thinking not captured in the accumulator", () => {
+		// A non-streaming `assistant` SDK message sets lastText/lastThinkingContent
+		// only (never pushed to intermediateTextBlocks). With pendingContent empty
+		// and intermediate blocks present, the fallback must still be emitted.
+		const finalContent = buildFinalAssistantContent({
+			intermediateToolBlocks: [
+				{ type: "toolCall", id: "q1", name: "ask_user_questions", arguments: {} } as any,
+			],
+			intermediateTextBlocks: [{ type: "text", text: "prose A" }],
+			toolResultsById: new Map(),
+			lastThinkingContent: "final thinking",
+			lastTextContent: "final prose",
+		});
+
+		const textBlocks = finalContent.filter((b) => b.type === "text").map((b) => (b as any).text);
+		const thinkingBlocks = finalContent.filter((b) => b.type === "thinking").map((b) => (b as any).thinking);
+		assert.deepEqual(textBlocks, ["prose A", "final prose"]);
+		assert.deepEqual(thinkingBlocks, ["final thinking"]);
+	});
 });
 
 describe("claude-code-cli — Claude Fable 5 Opus-tier support", () => {

--- a/src/resources/extensions/claude-code-cli/turn-assembler.ts
+++ b/src/resources/extensions/claude-code-cli/turn-assembler.ts
@@ -275,12 +275,30 @@ export function buildFinalAssistantContent(params: {
 				finalContent.push(block);
 			}
 		}
-	} else if (intermediateTextBlocks.length === 0) {
+	} else {
+		// No builder content survived to this turn boundary, so fall back to the
+		// last scalar thinking/text captured off the stream. When the turn ends
+		// on an elicitation these scalars just mirror the final intermediate
+		// block (they are overwritten at each synthetic-user boundary), so only
+		// emit them when they carry content not already accumulated — otherwise
+		// a non-streaming `assistant` message's prose/thinking is silently lost.
+		const lastBlockOfType = (type: "text" | "thinking") => {
+			for (let i = intermediateTextBlocks.length - 1; i >= 0; i--) {
+				if (intermediateTextBlocks[i].type === type) return intermediateTextBlocks[i];
+			}
+			return undefined;
+		};
 		if (params.lastThinkingContent) {
-			finalContent.push({ type: "thinking", thinking: params.lastThinkingContent });
+			const lastThinking = lastBlockOfType("thinking") as { thinking?: string } | undefined;
+			if (lastThinking?.thinking !== params.lastThinkingContent) {
+				finalContent.push({ type: "thinking", thinking: params.lastThinkingContent });
+			}
 		}
 		if (params.lastTextContent) {
-			finalContent.push({ type: "text", text: params.lastTextContent });
+			const lastText = lastBlockOfType("text") as { text?: string } | undefined;
+			if (lastText?.text !== params.lastTextContent) {
+				finalContent.push({ type: "text", text: params.lastTextContent });
+			}
 		}
 	}
 

--- a/src/resources/extensions/claude-code-cli/turn-assembler.ts
+++ b/src/resources/extensions/claude-code-cli/turn-assembler.ts
@@ -244,6 +244,7 @@ export function shouldSuppressDuplicateToolUnavailableBlock(
  */
 export function buildFinalAssistantContent(params: {
 	intermediateToolBlocks: AssistantMessage["content"];
+	intermediateTextBlocks?: AssistantMessage["content"];
 	pendingContent?: AssistantMessage["content"];
 	toolResultsById: ReadonlyMap<string, ExternalToolResultPayload>;
 	lastThinkingContent?: string;
@@ -259,13 +260,22 @@ export function buildFinalAssistantContent(params: {
 	const finalContent: AssistantMessage["content"] = mergedToolBlocks.filter(
 		(block) => !shouldSuppressDuplicateToolUnavailableBlock(block, mergedToolBlocks),
 	);
+	// Emit prose/thinking captured at earlier turn-boundaries (each successive
+	// `ask_user_questions` elicitation completes a turn) before the final
+	// segment. Capturing these in an ordered accumulator — symmetric with
+	// `intermediateToolBlocks` — is what keeps intermediate explanations from
+	// being collapsed to a single overwritten scalar and silently dropped.
+	const intermediateTextBlocks = params.intermediateTextBlocks ?? [];
+	for (const block of intermediateTextBlocks) {
+		finalContent.push(block);
+	}
 	if (params.pendingContent && params.pendingContent.length > 0) {
 		for (const block of params.pendingContent) {
 			if (block.type === "text" || block.type === "thinking") {
 				finalContent.push(block);
 			}
 		}
-	} else {
+	} else if (intermediateTextBlocks.length === 0) {
 		if (params.lastThinkingContent) {
 			finalContent.push({ type: "thinking", thinking: params.lastThinkingContent });
 		}


### PR DESCRIPTION
## Summary
- Made external-CLI provider accumulate intermediate assistant prose in an ordered array instead of overwriting a single scalar so `/gsd discuss` no longer drops explanations between elicitations; verified with 204/204 passing stream-adapter tests including two new #1284 cases.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1284
- [#1284 [Bug]: During `/gsd discuss`, the agent's clarifying/explanatory replies are dropped — the user sees only the elicitation popups](https://github.com/open-gsd/gsd-pi/issues/1284)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1284-bug-during-gsd-discuss-the-agent-s-clari-1783362544`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Claude Code CLI final message assembly with targeted unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **`/gsd discuss`** turns where only elicitation popups appeared and **clarifying prose between `ask_user_questions` calls was dropped**.
> 
> The Claude Code stream adapter now **accumulates text/thinking blocks at each synthetic `user` turn boundary** in `intermediateTextBlocks` (parallel to tool blocks) instead of keeping a single overwritten `lastTextContent` scalar. **`buildFinalAssistantContent`** appends those segments in order, then pending builder content, and only uses scalar fallbacks when they are **not duplicates** of the last accumulated block—so multi-segment turns stay intact without double-emitting when the turn ends on an elicitation.
> 
> Adds **stream-adapter tests** for the #1284 scenarios and non-streaming scalar fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c432b0c3d2b16d577b056eb844d37827c078d7c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->