### PR TITLE
fix(issue): [Bug]: md-importer re-import rewrites slice `completed_at` to import time — tasks are preserve-guarded (#1222/#1228), slices and milestones are not

### DIFF
--- a/src/resources/extensions/gsd/db/writers/status.ts
+++ b/src/resources/extensions/gsd/db/writers/status.ts
@@ -19,11 +19,18 @@ import { getDbOrNull } from "../engine.js";
 import { GSDError, GSD_STALE_STATE } from "../../errors.js";
 import { isClosedStatus } from "../../status-guards.js";
 
-/** A single row-level status write, discriminated by entity (the faces' arity). */
+/**
+ * A single row-level status write, discriminated by entity (the faces' arity).
+ *
+ * preserveCompletion (#1291): when true, an existing non-null completed_at on the
+ * row is kept rather than overwritten. Mirrors the task upsert's guard so a
+ * markdown re-import cannot re-stamp an already-complete slice/milestone with the
+ * current import time — the DB row is strictly richer than the plan.
+ */
 export type StatusTransition =
-  | { entity: "task"; milestoneId: string; sliceId: string; taskId: string; status: string; completedAt?: string | null }
-  | { entity: "slice"; milestoneId: string; sliceId: string; status: string; completedAt?: string | null }
-  | { entity: "milestone"; milestoneId: string; status: string; completedAt?: string | null };
+  | { entity: "task"; milestoneId: string; sliceId: string; taskId: string; status: string; completedAt?: string | null; preserveCompletion?: boolean }
+  | { entity: "slice"; milestoneId: string; sliceId: string; status: string; completedAt?: string | null; preserveCompletion?: boolean }
+  | { entity: "milestone"; milestoneId: string; status: string; completedAt?: string | null; preserveCompletion?: boolean };
 
 function requireDb() {
   const db = getDbOrNull();
@@ -44,15 +51,19 @@ function requireDb() {
 export function applyStatusTransition(t: StatusTransition): void {
   const db = requireDb();
   const completedAt = t.completedAt ?? null;
+  const preserve = t.preserveCompletion ? 1 : 0;
 
   switch (t.entity) {
     case "task":
       db.prepare(
-        `UPDATE tasks SET status = :status, completed_at = :completed_at
+        `UPDATE tasks SET status = :status,
+           completed_at = CASE WHEN :preserve_completion = 1 AND tasks.completed_at IS NOT NULL
+                               THEN tasks.completed_at ELSE :completed_at END
          WHERE milestone_id = :milestone_id AND slice_id = :slice_id AND id = :id`,
       ).run({
         ":status": t.status,
         ":completed_at": completedAt,
+        ":preserve_completion": preserve,
         ":milestone_id": t.milestoneId,
         ":slice_id": t.sliceId,
         ":id": t.taskId,
@@ -61,11 +72,14 @@ export function applyStatusTransition(t: StatusTransition): void {
 
     case "slice":
       db.prepare(
-        `UPDATE slices SET status = :status, completed_at = :completed_at
+        `UPDATE slices SET status = :status,
+           completed_at = CASE WHEN :preserve_completion = 1 AND slices.completed_at IS NOT NULL
+                               THEN slices.completed_at ELSE :completed_at END
          WHERE milestone_id = :milestone_id AND id = :id`,
       ).run({
         ":status": t.status,
         ":completed_at": completedAt,
+        ":preserve_completion": preserve,
         ":milestone_id": t.milestoneId,
         ":id": t.sliceId,
       });
@@ -80,8 +94,11 @@ export function applyStatusTransition(t: StatusTransition): void {
         );
       }
       db.prepare(
-        `UPDATE milestones SET status = :status, completed_at = :completed_at WHERE id = :id`,
-      ).run({ ":status": t.status, ":completed_at": completedAt, ":id": t.milestoneId });
+        `UPDATE milestones SET status = :status,
+           completed_at = CASE WHEN :preserve_completion = 1 AND milestones.completed_at IS NOT NULL
+                               THEN milestones.completed_at ELSE :completed_at END
+         WHERE id = :id`,
+      ).run({ ":status": t.status, ":completed_at": completedAt, ":preserve_completion": preserve, ":id": t.milestoneId });
       return;
     }
   }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -656,8 +656,8 @@ export function upsertTaskPlanning(milestoneId: string, sliceId: string, taskId:
 }
 
 
-export function updateSliceStatus(milestoneId: string, sliceId: string, status: string, completedAt?: string): void {
-  applyStatusTransition({ entity: "slice", milestoneId, sliceId, status, completedAt });
+export function updateSliceStatus(milestoneId: string, sliceId: string, status: string, completedAt?: string, preserveCompletion?: boolean): void {
+  applyStatusTransition({ entity: "slice", milestoneId, sliceId, status, completedAt, preserveCompletion });
 }
 
 export function setTaskSummaryMd(milestoneId: string, sliceId: string, taskId: string, md: string): void {
@@ -820,8 +820,8 @@ function writeMilestoneStatus(milestoneId: string, status: string, completedAt?:
  * advance planned milestones. They may not reopen a closed milestone; callers
  * must use reopenMilestoneStatus(), which is reserved for gsd_milestone_reopen.
  */
-export function updateMilestoneStatus(milestoneId: string, status: string, completedAt?: string | null): void {
-  applyStatusTransition({ entity: "milestone", milestoneId, status, completedAt });
+export function updateMilestoneStatus(milestoneId: string, status: string, completedAt?: string | null, preserveCompletion?: boolean): void {
+  applyStatusTransition({ entity: "milestone", milestoneId, status, completedAt, preserveCompletion });
 }
 
 /**

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -763,7 +763,10 @@ export function migrateHierarchyToDb(basePath: string): {
     // see the drift when no SUMMARY file exists).
     if (IMPORT_COMPLETE_STATUSES.has(milestoneStatus)) {
       const summaryPath = resolveMilestoneFile(basePath, milestoneId, 'SUMMARY');
-      updateMilestoneStatus(milestoneId, milestoneStatus, importCompletionTimestamp(summaryPath));
+      // #1291: preserve an existing completion timestamp so a re-import backfills
+      // only rows that lack one, never re-stamping an already-complete milestone
+      // with the current import time. Same guard as the task path below.
+      updateMilestoneStatus(milestoneId, milestoneStatus, importCompletionTimestamp(summaryPath), true);
     }
     counts.milestones++;
 
@@ -801,11 +804,15 @@ export function migrateHierarchyToDb(basePath: string): {
       // complete (same rationale as milestones above).
       if (IMPORT_COMPLETE_STATUSES.has(sliceStatus)) {
         const sliceSummary = resolveSliceFile(basePath, milestoneId, sliceEntry.id, 'SUMMARY');
+        // #1291: preserve an existing completion timestamp so a re-import backfills
+        // only slices that lack one, never re-stamping an already-complete slice
+        // with the current import time. Same guard as the task path below.
         updateSliceStatus(
           milestoneId,
           sliceEntry.id,
           sliceStatus,
           importCompletionTimestamp(sliceSummary),
+          true,
         );
       }
       counts.slices++;
@@ -937,11 +944,14 @@ export function migrateHierarchyToDb(basePath: string): {
         });
         if (allTasksDone && hasSliceSummary) {
           if (_getAdapter()) {
+            // #1291: preserve an existing completion timestamp — this consistency
+            // upgrade sets a completion time only when the row lacks one.
             updateSliceStatus(
               milestoneId,
               sliceEntry.id,
               'complete',
               importCompletionTimestamp(sliceSummaryPath),
+              true,
             );
             process.stderr.write(
               `gsd-migrate: ${milestoneId}/${sliceEntry.id} all tasks + slice summary complete — upgrading slice to complete\n`,

--- a/src/resources/extensions/gsd/tests/import-slice-milestone-completion-preserve.test.ts
+++ b/src/resources/extensions/gsd/tests/import-slice-milestone-completion-preserve.test.ts
@@ -1,0 +1,116 @@
+// Project/App: gsd-pi
+// File Purpose: Regression for #1291 — a full markdown re-import must NOT rewrite
+// the completed_at of an already-complete slice or milestone with the current
+// import time. The task path was fixed for this (#1222/#1228) via
+// preserveCompletionMetadata; the slice and milestone backfills in
+// migrateHierarchyToDb had no such guard, so every re-import re-stamped every
+// complete slice/milestone. The fix threads preserveCompletion through
+// updateSliceStatus/updateMilestoneStatus so an existing completed_at survives.
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  openDatabase,
+  closeDatabase,
+  getAllMilestones,
+  getMilestoneSlices,
+  updateSliceStatus,
+  updateMilestoneStatus,
+} from '../gsd-db.ts';
+import { migrateHierarchyToDb } from '../md-importer.ts';
+import { describe, test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  closeDatabase();
+  for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+  tmpDirs.length = 0;
+});
+
+function createFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-preserve-completion-'));
+  tmpDirs.push(base);
+  return base;
+}
+
+function writeFile(base: string, relativePath: string, content: string): void {
+  const full = join(base, '.gsd', relativePath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, content);
+}
+
+// All slices [x] → milestone imports complete, slices import complete.
+const ROADMAP_ALL_DONE = `# M001: Finished Milestone
+
+**Vision:** Done work.
+
+## Slices
+
+- [x] **S01: First Slice** \`risk:low\` \`depends:[]\`
+  > After this: Done.
+
+- [x] **S02: Second Slice** \`risk:medium\` \`depends:[S01]\`
+  > After this: Also done.
+`;
+
+const REAL_S01 = '2026-07-05T19:52:04.672Z';
+const REAL_S02 = '2026-07-05T20:36:51.313Z';
+const REAL_M001 = '2026-07-05T21:00:00.000Z';
+
+describe('migrateHierarchyToDb: re-import preserves existing completion timestamps (#1291)', () => {
+  test('a re-import does not rewrite already-complete slice completed_at', () => {
+    const base = createFixtureBase();
+    writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_ALL_DONE);
+
+    openDatabase(join(base, '.gsd', 'gsd.db'));
+    migrateHierarchyToDb(base);
+
+    // Simulate the durable completion timestamps the real run wrote hours apart.
+    updateSliceStatus('M001', 'S01', 'complete', REAL_S01);
+    updateSliceStatus('M001', 'S02', 'complete', REAL_S02);
+
+    // A second full re-import (the class of event that bit the reporter).
+    migrateHierarchyToDb(base);
+
+    const slices = getMilestoneSlices('M001');
+    const s01 = slices.find((s) => s.id === 'S01')!;
+    const s02 = slices.find((s) => s.id === 'S02')!;
+    assert.equal(s01.completed_at, REAL_S01, 'S01 completed_at must survive re-import unchanged');
+    assert.equal(s02.completed_at, REAL_S02, 'S02 completed_at must survive re-import unchanged');
+  });
+
+  test('a re-import does not rewrite an already-complete milestone completed_at', () => {
+    const base = createFixtureBase();
+    writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_ALL_DONE);
+
+    openDatabase(join(base, '.gsd', 'gsd.db'));
+    migrateHierarchyToDb(base);
+
+    updateMilestoneStatus('M001', 'complete', REAL_M001);
+
+    migrateHierarchyToDb(base);
+
+    const m001 = getAllMilestones().find((m) => m.id === 'M001')!;
+    assert.equal(m001.completed_at, REAL_M001, 'M001 completed_at must survive re-import unchanged');
+  });
+
+  test('an initial import of a complete slice still backfills a completed_at when the row has none', () => {
+    // The guard preserves an existing timestamp but must not suppress the
+    // legitimate first-time backfill for a slice imported as complete.
+    const base = createFixtureBase();
+    writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_ALL_DONE);
+
+    openDatabase(join(base, '.gsd', 'gsd.db'));
+    migrateHierarchyToDb(base);
+
+    const slices = getMilestoneSlices('M001');
+    for (const s of slices) {
+      assert.ok(s.completed_at, `complete slice ${s.id} should receive a backfilled completed_at on first import`);
+    }
+    const m001 = getAllMilestones().find((m) => m.id === 'M001')!;
+    assert.ok(m001.completed_at, 'complete milestone should receive a backfilled completed_at on first import');
+  });
+});


### PR DESCRIPTION
## Summary
- Added a `preserveCompletion` guard to the slice/milestone status writers and set it on the md-importer backfills so re-imports no longer rewrite existing `completed_at`, verified by a new 3-case regression test plus 63 passing related tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1291
- [#1291 [Bug]: md-importer re-import rewrites slice `completed_at` to import time — tasks are preserve-guarded (#1222/#1228), slices and milestones are not](https://github.com/open-gsd/gsd-pi/issues/1291)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1291-bug-md-importer-re-import-rewrites-slice-1783362526`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional API flag defaults to prior overwrite behavior; only the markdown import path opts in, limiting blast radius to completion metadata on re-import.
> 
> **Overview**
> Fixes **#1291**: full markdown re-imports were overwriting `completed_at` on already-complete slices and milestones with the current import time, while tasks were already protected via `preserveCompletionMetadata`.
> 
> **`preserveCompletion`** is added on `StatusTransition` and implemented in `applyStatusTransition` so `completed_at` is only updated when the row has no timestamp or the flag is off. **`updateSliceStatus`** and **`updateMilestoneStatus`** accept an optional fifth argument and forward it to the status writer.
> 
> **`migrateHierarchyToDb`** passes `preserveCompletion: true` on milestone/slice completion backfills and on the “all tasks + slice summary” slice upgrade path, matching the task re-import behavior.
> 
> A **three-case regression test** covers re-import preservation for slices and milestones and confirms first-time backfill still runs when `completed_at` is null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d802ce75d809e6d392c8a5564410949af485075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->