### PR TITLE
fix(issue): [Bug]: `new-milestone --auto` exits `Status: complete` after planning without chaining into execution

### DIFF
--- a/src/headless-milestone-readiness.ts
+++ b/src/headless-milestone-readiness.ts
@@ -12,14 +12,95 @@
 // at least one slice. The notify-text signal remains a fast path; this is the
 // deciding fallback.
 
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   closeWorkflowDatabase,
   openExistingWorkflowDatabase,
 } from './resources/extensions/gsd/db-workspace.js'
+import type { MilestoneRow } from './resources/extensions/gsd/db-milestone-artifact-rows.js'
 import {
-  getActiveMilestoneFromDb,
+  getAllMilestones,
   getMilestoneSlices,
+  getSlicesByMilestoneIds,
 } from './resources/extensions/gsd/gsd-db.js'
+import { classifyMilestoneReadiness } from './resources/extensions/gsd/milestone-readiness.js'
+import {
+  buildMilestoneFileName,
+  resolveFile,
+  resolveMilestonePath,
+} from './resources/extensions/gsd/paths.js'
+import { isClosedStatus } from './resources/extensions/gsd/status-guards.js'
+
+function milestoneArtifactExistsInResolvedDir(
+  milestoneDir: string | null,
+  milestoneId: string,
+  suffix: string,
+): boolean {
+  if (!milestoneDir) return false
+  const flatPath = join(milestoneDir, buildMilestoneFileName(milestoneId, suffix))
+  return existsSync(flatPath) || resolveFile(milestoneDir, milestoneId, suffix) !== null
+}
+
+/**
+ * Mirror `buildRegistryAndFindActive` active-milestone selection: defer queued-shell
+ * milestones (queued, no context, zero slices) so a later planned milestone is
+ * treated as active instead of an older orphan shell (#1295).
+ */
+function findDerivedActiveMilestone(basePath: string): MilestoneRow | null {
+  const milestones = getAllMilestones()
+  const completeMilestoneIds = new Set<string>()
+  const parkedMilestoneIds = new Set<string>()
+
+  for (const m of milestones) {
+    if (m.status === 'parked') {
+      parkedMilestoneIds.add(m.id)
+      continue
+    }
+    if (isClosedStatus(m.status)) {
+      completeMilestoneIds.add(m.id)
+    }
+  }
+
+  const activeMilestoneIds = milestones
+    .filter((m) => !parkedMilestoneIds.has(m.id))
+    .map((m) => m.id)
+  const slicesByMilestone = getSlicesByMilestoneIds(activeMilestoneIds)
+
+  let firstDeferredQueuedShell: MilestoneRow | null = null
+  let activeMilestoneFound = false
+
+  for (const m of milestones) {
+    if (parkedMilestoneIds.has(m.id)) continue
+    if (completeMilestoneIds.has(m.id)) continue
+
+    const slices = slicesByMilestone.get(m.id) ?? []
+    const milestoneDir = resolveMilestonePath(basePath, m.id)
+    const hasContext = milestoneArtifactExistsInResolvedDir(milestoneDir, m.id, 'CONTEXT')
+    const hasDraftContext = !hasContext && milestoneArtifactExistsInResolvedDir(milestoneDir, m.id, 'CONTEXT-DRAFT')
+    const readiness = classifyMilestoneReadiness({
+      status: m.status,
+      hasContext,
+      hasDraftContext,
+      sliceCount: slices.length,
+    })
+
+    if (!activeMilestoneFound) {
+      const depsUnmet = m.depends_on.some((dep) => !completeMilestoneIds.has(dep))
+      if (depsUnmet) continue
+
+      if (readiness.kind === 'queued-shell') {
+        if (!firstDeferredQueuedShell) firstDeferredQueuedShell = m
+        continue
+      }
+
+      activeMilestoneFound = true
+      return m
+    }
+  }
+
+  return firstDeferredQueuedShell
+}
 
 /**
  * Return true when the workflow DB for `basePath` holds an executable milestone —
@@ -33,7 +114,7 @@ export function isMilestoneExecutableInDb(basePath: string): boolean {
   const opened = openExistingWorkflowDatabase(basePath)
   if (!opened.ok) return false
   try {
-    const active = getActiveMilestoneFromDb()
+    const active = findDerivedActiveMilestone(basePath)
     return active != null && getMilestoneSlices(active.id).length > 0
   } catch {
     return false

--- a/src/headless-milestone-readiness.ts
+++ b/src/headless-milestone-readiness.ts
@@ -8,9 +8,10 @@
 // yet never chains into execution (issue #1295).
 //
 // This module makes the decision authoritative by querying the workflow DB directly:
-// a milestone is executable when there is an active (non-terminal) milestone that has
-// at least one slice. The notify-text signal remains a fast path; this is the
-// deciding fallback.
+// a milestone is executable when the derived active (non-terminal) milestone has at
+// least one slice. For `new-milestone --auto`, callers can pass a pre-run snapshot
+// so the fallback only trusts readiness produced by the current planning command.
+// The notify-text signal remains a fast path; this is the deciding fallback.
 
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
@@ -31,6 +32,14 @@ import {
   resolveMilestonePath,
 } from './resources/extensions/gsd/paths.js'
 import { isClosedStatus } from './resources/extensions/gsd/status-guards.js'
+
+export interface MilestoneExecutionSnapshot {
+  milestones: Record<string, {
+    status: string
+    sliceCount: number
+    dependsOn: string[]
+  }>
+}
 
 function milestoneArtifactExistsInResolvedDir(
   milestoneDir: string | null,
@@ -102,23 +111,94 @@ function findDerivedActiveMilestone(basePath: string): MilestoneRow | null {
   return firstDeferredQueuedShell
 }
 
+function buildMilestoneExecutionSnapshot(): MilestoneExecutionSnapshot {
+  const milestones = getAllMilestones()
+  const slicesByMilestone = getSlicesByMilestoneIds(milestones.map((m) => m.id))
+  const snapshot: MilestoneExecutionSnapshot = { milestones: {} }
+
+  for (const milestone of milestones) {
+    snapshot.milestones[milestone.id] = {
+      status: milestone.status,
+      sliceCount: (slicesByMilestone.get(milestone.id) ?? []).length,
+      dependsOn: milestone.depends_on,
+    }
+  }
+
+  return snapshot
+}
+
+function milestoneSnapshotEntryChanged(
+  before: MilestoneExecutionSnapshot['milestones'][string] | undefined,
+  after: MilestoneExecutionSnapshot['milestones'][string] | undefined,
+): boolean {
+  if (!after) return false
+  if (!before) return true
+  return (
+    before.status !== after.status ||
+    before.sliceCount !== after.sliceCount ||
+    before.dependsOn.join('\0') !== after.dependsOn.join('\0')
+  )
+}
+
+/**
+ * Capture the milestone execution state before a `new-milestone --auto` run.
+ * Missing DBs are treated as an empty pre-run snapshot; unreadable DBs return
+ * null so callers can conservatively skip the DB fallback.
+ */
+export function captureMilestoneExecutionSnapshot(basePath: string): MilestoneExecutionSnapshot | null {
+  const opened = openExistingWorkflowDatabase(basePath)
+  if (!opened.ok) {
+    return opened.reason === 'missing-database' || opened.reason === 'missing-gsd-dir'
+      ? { milestones: {} }
+      : null
+  }
+  try {
+    return buildMilestoneExecutionSnapshot()
+  } catch {
+    return null
+  } finally {
+    closeWorkflowDatabase()
+  }
+}
+
+export function findExecutableMilestoneInDb(
+  basePath: string,
+  options: { changedSince?: MilestoneExecutionSnapshot } = {},
+): string | null {
+  const opened = openExistingWorkflowDatabase(basePath)
+  if (!opened.ok) return null
+  try {
+    const active = findDerivedActiveMilestone(basePath)
+    if (active == null || getMilestoneSlices(active.id).length === 0) return null
+
+    if (options.changedSince) {
+      const after = buildMilestoneExecutionSnapshot()
+      if (!milestoneSnapshotEntryChanged(options.changedSince.milestones[active.id], after.milestones[active.id])) {
+        return null
+      }
+    }
+
+    return active.id
+  } catch {
+    return null
+  } finally {
+    closeWorkflowDatabase()
+  }
+}
+
 /**
  * Return true when the workflow DB for `basePath` holds an executable milestone —
  * an active (non-terminal) milestone with at least one slice — meaning auto-mode
  * has real work to pick up.
+ * When `changedSince` is supplied, the executable milestone must also be newly
+ * created or materially changed since that snapshot.
  *
  * Never throws: returns false when the DB is missing or cannot be opened/queried,
  * so the caller can fall back to the notify-text signal.
  */
-export function isMilestoneExecutableInDb(basePath: string): boolean {
-  const opened = openExistingWorkflowDatabase(basePath)
-  if (!opened.ok) return false
-  try {
-    const active = findDerivedActiveMilestone(basePath)
-    return active != null && getMilestoneSlices(active.id).length > 0
-  } catch {
-    return false
-  } finally {
-    closeWorkflowDatabase()
-  }
+export function isMilestoneExecutableInDb(
+  basePath: string,
+  options: { changedSince?: MilestoneExecutionSnapshot } = {},
+): boolean {
+  return findExecutableMilestoneInDb(basePath, options) != null
 }

--- a/src/headless-milestone-readiness.ts
+++ b/src/headless-milestone-readiness.ts
@@ -1,0 +1,43 @@
+// Project/App Name: gsd-pi + DB-authoritative milestone readiness for `--auto` chaining
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+//
+// The `new-milestone --auto` chain decision historically hinged on regex-matching
+// a specific notify string ("Milestone <id> ready."), which is only emitted on one
+// of several planning success paths. Any run that finishes planning through a
+// different branch — or takes an early-return handoff path — completes successfully
+// yet never chains into execution (issue #1295).
+//
+// This module makes the decision authoritative by querying the workflow DB directly:
+// a milestone is executable when there is an active (non-terminal) milestone that has
+// at least one slice. The notify-text signal remains a fast path; this is the
+// deciding fallback.
+
+import {
+  closeWorkflowDatabase,
+  openExistingWorkflowDatabase,
+} from './resources/extensions/gsd/db-workspace.js'
+import {
+  getActiveMilestoneFromDb,
+  getMilestoneSlices,
+} from './resources/extensions/gsd/gsd-db.js'
+
+/**
+ * Return true when the workflow DB for `basePath` holds an executable milestone —
+ * an active (non-terminal) milestone with at least one slice — meaning auto-mode
+ * has real work to pick up.
+ *
+ * Never throws: returns false when the DB is missing or cannot be opened/queried,
+ * so the caller can fall back to the notify-text signal.
+ */
+export function isMilestoneExecutableInDb(basePath: string): boolean {
+  const opened = openExistingWorkflowDatabase(basePath)
+  if (!opened.ok) return false
+  try {
+    const active = getActiveMilestoneFromDb()
+    return active != null && getMilestoneSlices(active.id).length > 0
+  } catch {
+    return false
+  } finally {
+    closeWorkflowDatabase()
+  }
+}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -61,7 +61,10 @@ import {
   loadContext,
   bootstrapGsdProject,
 } from './headless-context.js'
-import { isMilestoneExecutableInDb } from './headless-milestone-readiness.js'
+import {
+  captureMilestoneExecutionSnapshot,
+  isMilestoneExecutableInDb,
+} from './headless-milestone-readiness.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -976,6 +979,10 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     })
   }
 
+  const preRunMilestoneSnapshot = isNewMilestone && options.auto
+    ? captureMilestoneExecutionSnapshot(process.cwd())
+    : null
+
   // Send the command
   const command = buildHeadlessSlashCommand(options)
   if (!options.json) {
@@ -999,11 +1006,14 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   // string) is only a fast path — it fires on just one of several planning
   // success branches, so "planning succeeded" frequently does not imply the
   // "ready" text was emitted. When the fast path misses, fall back to querying
-  // the created milestone's readiness directly and chain if it is executable
+  // the milestone readiness changed by this command and chain if it is executable
   // (issue #1295).
+  const dbMilestoneReady = preRunMilestoneSnapshot
+    ? isMilestoneExecutableInDb(process.cwd(), { changedSince: preRunMilestoneSnapshot })
+    : false
   const shouldChainAuto =
     isNewMilestone && options.auto && !blocked && exitCode === EXIT_SUCCESS &&
-    (milestoneReady || isMilestoneExecutableInDb(process.cwd()))
+    (milestoneReady || dbMilestoneReady)
   if (shouldChainAuto) {
     if (!options.json) {
       process.stderr.write('[headless] Milestone ready — chaining into auto-mode...\n')

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -61,6 +61,7 @@ import {
   loadContext,
   bootstrapGsdProject,
 } from './headless-context.js'
+import { isMilestoneExecutableInDb } from './headless-milestone-readiness.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -992,8 +993,18 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     await completionPromise
   }
 
-  // Auto-mode chaining: if --auto and milestone creation succeeded, send /gsd auto
-  if (isNewMilestone && options.auto && milestoneReady && !blocked && exitCode === EXIT_SUCCESS) {
+  // Auto-mode chaining: if --auto and milestone creation succeeded, send /gsd auto.
+  //
+  // The chain decision is DB-authoritative. `milestoneReady` (regex on a notify
+  // string) is only a fast path — it fires on just one of several planning
+  // success branches, so "planning succeeded" frequently does not imply the
+  // "ready" text was emitted. When the fast path misses, fall back to querying
+  // the created milestone's readiness directly and chain if it is executable
+  // (issue #1295).
+  const shouldChainAuto =
+    isNewMilestone && options.auto && !blocked && exitCode === EXIT_SUCCESS &&
+    (milestoneReady || isMilestoneExecutableInDb(process.cwd()))
+  if (shouldChainAuto) {
     if (!options.json) {
       process.stderr.write('[headless] Milestone ready — chaining into auto-mode...\n')
     }

--- a/src/tests/headless-milestone-readiness.test.ts
+++ b/src/tests/headless-milestone-readiness.test.ts
@@ -18,7 +18,10 @@ import {
   insertMilestone,
   insertSlice,
 } from "../resources/extensions/gsd/gsd-db.ts";
-import { isMilestoneExecutableInDb } from "../headless-milestone-readiness.ts";
+import {
+  captureMilestoneExecutionSnapshot,
+  isMilestoneExecutableInDb,
+} from "../headless-milestone-readiness.ts";
 
 function makeProject(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-milestone-readiness-"));
@@ -64,6 +67,50 @@ test("not executable when the only milestone is terminal", () => {
     closeDatabase();
 
     assert.equal(isMilestoneExecutableInDb(base), false);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("changed-since fallback skips queued shells and sees a newly planned milestone", () => {
+  const base = makeProject();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "m1", title: "Leftover shell", status: "queued" });
+    closeDatabase();
+
+    const before = captureMilestoneExecutionSnapshot(base);
+    assert.ok(before);
+
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "m2", title: "New executable milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "m2", title: "Slice one" });
+    closeDatabase();
+
+    assert.equal(isMilestoneExecutableInDb(base, { changedSince: before }), true);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("changed-since fallback does not reuse an older active milestone for a new shell", () => {
+  const base = makeProject();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "m1", title: "Existing active milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "m1", title: "Existing slice" });
+    closeDatabase();
+
+    const before = captureMilestoneExecutionSnapshot(base);
+    assert.ok(before);
+
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "m2", title: "New shell", status: "queued" });
+    closeDatabase();
+
+    assert.equal(isMilestoneExecutableInDb(base, { changedSince: before }), false);
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });

--- a/src/tests/headless-milestone-readiness.test.ts
+++ b/src/tests/headless-milestone-readiness.test.ts
@@ -1,0 +1,80 @@
+// Project/App Name: gsd-pi + DB-authoritative milestone readiness tests (#1295)
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+//
+// Verifies the `--auto` chain fallback: after new-milestone planning writes
+// slices, the milestone is executable in the DB even when the "Milestone <id>
+// ready." notify string was never emitted. This is the signal that keeps the
+// chain firing when the notify-text regex misses.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+} from "../resources/extensions/gsd/gsd-db.ts";
+import { isMilestoneExecutableInDb } from "../headless-milestone-readiness.ts";
+
+function makeProject(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-milestone-readiness-"));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+test("executable when an active milestone has slices (chain fires)", () => {
+  const base = makeProject();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "m1", title: "New milestone", status: "queued" });
+    insertSlice({ id: "S01", milestoneId: "m1", title: "Slice one" });
+    closeDatabase();
+
+    assert.equal(isMilestoneExecutableInDb(base), true);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("not executable when the milestone has no slices (planning incomplete)", () => {
+  const base = makeProject();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "m1", title: "Shell", status: "queued" });
+    closeDatabase();
+
+    assert.equal(isMilestoneExecutableInDb(base), false);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("not executable when the only milestone is terminal", () => {
+  const base = makeProject();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "m1", title: "Done", status: "complete" });
+    insertSlice({ id: "S01", milestoneId: "m1", title: "Slice one", status: "complete" });
+    closeDatabase();
+
+    assert.equal(isMilestoneExecutableInDb(base), false);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("returns false (no throw) when no DB exists", () => {
+  const base = makeProject();
+  try {
+    assert.equal(isMilestoneExecutableInDb(base), false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Made `new-milestone --auto` chaining DB-authoritative via a new `isMilestoneExecutableInDb` fallback so planning success reliably chains into execution; verified with new unit tests and a clean `build:core`.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1295
- [#1295 [Bug]: `new-milestone --auto` exits `Status: complete` after planning without chaining into execution](https://github.com/open-gsd/gsd-pi/issues/1295)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1295-bug-new-milestone-auto-exits-status-comp-1783362579`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes headless orchestration and workflow DB reads for auto chaining; logic is guarded by snapshots and tests but affects when long-running auto-mode starts.
> 
> **Overview**
> Fixes **`new-milestone --auto`** stopping after planning with `Status: complete` instead of continuing into **`/gsd auto`** when planning succeeds but the **"Milestone &lt;id&gt; ready."** notify string is never emitted.
> 
> **`headless.ts`** still treats that notify as a fast path, but after a successful planning run it also checks the workflow DB: chain when **`milestoneReady || dbMilestoneReady`**. For auto runs it captures a **pre-run milestone snapshot** so the DB fallback only counts milestones **newly created or materially changed** by the current command (avoids chaining on stale executable state).
> 
> New **`headless-milestone-readiness`** module opens the workflow DB, picks the derived active milestone (same queued-shell deferral as **`buildRegistryAndFindActive`**), and requires at least one slice. **`headless-milestone-readiness.test.ts`** covers executable vs incomplete/terminal cases, `changedSince` behavior, and missing DB handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ad1cd441dc6aa1c74f6e43bf309da88c50d6b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->