### PR TITLE
fix(issue): [Bug]: marker-key mismatch triggers repeated whole-tree re-imports + leaked `.gsd-backups/migrate-*` dirs — reproduced on a real (non-symlinked) `.gsd`

### DIFF
--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -83,6 +83,39 @@ function expectedPhaseDirs(basePath: string): string[] {
   );
 }
 
+/**
+ * Return the most-recent existing `.gsd-backups/migrate-<ts>/` snapshot, or null.
+ *
+ * The flat-phase migration can re-fire on later dispatches when the legacy
+ * `.gsd/milestones/` layout reappears (e.g. a marker-key mismatch re-triggers a
+ * whole-tree re-import — issue #1292). The DB was already reconciled from that
+ * tree before the backup step runs, so re-snapshotting an identical legacy tree
+ * on every dispatch only leaks a fresh `migrate-<ts>/` directory each time. When
+ * a prior snapshot already exists we reuse it as the rollback fallback instead
+ * of creating a duplicate, bounding the accumulation to one recovery copy.
+ */
+function existingMigrateBackup(basePath: string): string | null {
+  const backupRoot = join(basePath, ".gsd-backups");
+  if (!existsSync(backupRoot)) return null;
+  try {
+    let latest: { path: string; mtimeMs: number } | null = null;
+    for (const entry of readdirSync(backupRoot)) {
+      if (!entry.startsWith("migrate-")) continue;
+      const dirPath = join(backupRoot, entry);
+      try {
+        const st = statSync(dirPath);
+        if (!st.isDirectory()) continue;
+        if (!latest || st.mtimeMs > latest.mtimeMs) latest = { path: dirPath, mtimeMs: st.mtimeMs };
+      } catch {
+        // Non-fatal: skip unreadable entries.
+      }
+    }
+    return latest?.path ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function hasLegacyMilestoneSubdirs(dirPath: string): boolean {
   if (!existsSync(dirPath)) return false;
   try {
@@ -245,15 +278,31 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
 
   let backupDir = migratingPath;
   if (!resumingInterrupted) {
-    // 2. Backup (only reached when the DB has rows and migration will proceed)
-    const ts = Date.now();
-    backupDir = join(basePath, ".gsd-backups", `migrate-${ts}`);
-    try {
-      mkdirSync(join(basePath, ".gsd-backups"), { recursive: true });
-      cpSync(milestonesPath, backupDir, { recursive: true });
-    } catch (err) {
-      logWarning("migration", `flat-phase migration backup failed: ${(err as Error).message}`);
-      throw err;
+    // 2. Backup (only reached when the DB has rows and migration will proceed).
+    // migrateFromMarkdown above already reconciled the legacy tree into the DB,
+    // so its content is safely persisted. If a prior successful migration
+    // already snapshotted the legacy tree, a re-fire of this gate (issue #1292:
+    // marker-key mismatch re-importing the whole tree at dispatch boundaries)
+    // must not leak a fresh .gsd-backups/migrate-<ts>/ every dispatch. Treat it
+    // as a marker-refresh re-projection: reuse the existing snapshot as the
+    // rollback fallback instead of creating a duplicate.
+    const priorBackup = existingMigrateBackup(basePath);
+    if (priorBackup) {
+      backupDir = priorBackup;
+      logWarning(
+        "migration",
+        `flat-phase migration re-fired; reusing existing backup ${priorBackup} instead of re-snapshotting (issue #1292)`,
+      );
+    } else {
+      const ts = Date.now();
+      backupDir = join(basePath, ".gsd-backups", `migrate-${ts}`);
+      try {
+        mkdirSync(join(basePath, ".gsd-backups"), { recursive: true });
+        cpSync(milestonesPath, backupDir, { recursive: true });
+      } catch (err) {
+        logWarning("migration", `flat-phase migration backup failed: ${(err as Error).message}`);
+        throw err;
+      }
     }
 
     if (existsSync(migratingPath)) {

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -105,6 +105,7 @@ function existingMigrateBackup(basePath: string): string | null {
       try {
         const st = statSync(dirPath);
         if (!st.isDirectory()) continue;
+        if (!hasLegacyMilestoneSubdirs(dirPath)) continue;
         if (!latest || st.mtimeMs > latest.mtimeMs) latest = { path: dirPath, mtimeMs: st.mtimeMs };
       } catch {
         // Non-fatal: skip unreadable entries.

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -132,6 +132,7 @@ function rollbackPartialMigration(
   basePath: string,
   backupDir: string,
   migratingPath?: string,
+  backupCreatedThisRun = true,
 ): void {
   // Remove the partially-written phases/ dir.
   try {
@@ -147,7 +148,8 @@ function rollbackPartialMigration(
   // preserved migrating tree (the sole surviving data source) and must never be
   // removed here. Deleting the backup after a successful rollback keeps the gate
   // from leaking one .gsd-backups/migrate-<ts>/ per session_start.
-  const isDisposableBackup = Boolean(backupDir) && backupDir !== migratingPath;
+  const isDisposableBackup =
+    Boolean(backupDir) && backupDir !== migratingPath && backupCreatedThisRun;
   const cleanupBackup = (): void => {
     if (!isDisposableBackup || !existsSync(backupDir)) return;
     try {
@@ -278,6 +280,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
   }
 
   let backupDir = migratingPath;
+  let backupCreatedThisRun = false;
   if (!resumingInterrupted) {
     // 2. Backup (only reached when the DB has rows and migration will proceed).
     // migrateFromMarkdown above already reconciled the legacy tree into the DB,
@@ -300,6 +303,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
       try {
         mkdirSync(join(basePath, ".gsd-backups"), { recursive: true });
         cpSync(milestonesPath, backupDir, { recursive: true });
+        backupCreatedThisRun = true;
       } catch (err) {
         logWarning("migration", `flat-phase migration backup failed: ${(err as Error).message}`);
         throw err;
@@ -327,7 +331,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
     removePathWithRetries(phasesPath);
   } catch (err) {
     logWarning("migration", `failed to clear stale phases/ before render: ${(err as Error).message}`);
-    rollbackPartialMigration(basePath, backupDir, migratingPath);
+    rollbackPartialMigration(basePath, backupDir, migratingPath, backupCreatedThisRun);
     throw err;
   }
 
@@ -349,7 +353,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
     }
   } catch (err) {
     logWarning("migration", `flat-phase render failed: ${(err as Error).message}`);
-    rollbackPartialMigration(basePath, backupDir, migratingPath);
+    rollbackPartialMigration(basePath, backupDir, migratingPath, backupCreatedThisRun);
     throw err;
   }
 
@@ -359,7 +363,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
       "migration",
       `flat-phase render had ${renderResult.errors.length} error(s): ${renderResult.errors.join("; ")}`,
     );
-    rollbackPartialMigration(basePath, backupDir, migratingPath);
+    rollbackPartialMigration(basePath, backupDir, migratingPath, backupCreatedThisRun);
     throw new Error(
       `flat-phase migration render failed: ${renderResult.errors.slice(0, 3).join("; ")}`,
     );
@@ -372,7 +376,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
       "migration",
       `flat-phase migration missing ${missingPhaseDirs.length} expected phase dir(s): ${missingPhaseDirs.join(", ")}`,
     );
-    rollbackPartialMigration(basePath, backupDir, migratingPath);
+    rollbackPartialMigration(basePath, backupDir, migratingPath, backupCreatedThisRun);
     throw new Error("flat-phase migration verification failed: missing rendered phase directories");
   }
   if (db.slices > 0 && renderResult.rendered === 0) {
@@ -380,7 +384,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
       "migration",
       "flat-phase migration verification failed: render produced no artifacts for populated DB",
     );
-    rollbackPartialMigration(basePath, backupDir, migratingPath);
+    rollbackPartialMigration(basePath, backupDir, migratingPath, backupCreatedThisRun);
     throw new Error("flat-phase migration verification failed: no artifacts rendered");
   }
 
@@ -390,7 +394,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
     deleteArtifactsByPathPrefix("milestones/");
   } catch (err) {
     logWarning("migration", `flat-phase migration could not prune legacy artifact rows: ${(err as Error).message}`);
-    rollbackPartialMigration(basePath, backupDir, migratingPath);
+    rollbackPartialMigration(basePath, backupDir, migratingPath, backupCreatedThisRun);
     throw err;
   }
 

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -199,6 +199,26 @@ test("migrateToFlatPhase is idempotent (second run is a no-op)", async () => {
   assert.equal(backups.length, 1, "should only have one backup");
 });
 
+test("re-fired migration reuses the existing backup instead of leaking a new migrate-* dir (#1292)", async () => {
+  const base = makeTmp();
+  await migrateToFlatPhase(base);
+  const backupRoot = join(base, ".gsd-backups");
+  const firstBackups = readdirSync(backupRoot).filter((d) => d.startsWith("migrate-"));
+  assert.equal(firstBackups.length, 1, "first migration snapshots exactly one backup");
+
+  // Simulate the re-fire: the legacy .gsd/milestones/ layout reappears (e.g. a
+  // marker-key mismatch re-imports the whole tree). The DB rows still exist, so
+  // the migration gate proceeds again — it must not snapshot a second backup.
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01"), { recursive: true });
+  assert.equal(needsFlatPhaseMigration(base), true, "reappeared legacy layout re-triggers migration");
+
+  await migrateToFlatPhase(base);
+
+  const afterBackups = readdirSync(backupRoot).filter((d) => d.startsWith("migrate-"));
+  assert.deepEqual(afterBackups, firstBackups, "re-fire must not leak a second migrate-* backup");
+  assert.equal(existsSync(join(base, ".gsd", "milestones")), false, "legacy milestones/ removed again");
+});
+
 test("migrateToFlatPhase preserves slice sidecar artifacts and skips recovery placeholder PLAN", async () => {
   const base = makeTmp({ withTask: false });
   const legacySliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -219,6 +219,34 @@ test("re-fired migration reuses the existing backup instead of leaking a new mig
   assert.equal(existsSync(join(base, ".gsd", "milestones")), false, "legacy milestones/ removed again");
 });
 
+test("rollback after a re-fired migration preserves the reused migrate-* backup", async (t) => {
+  const base = makeTmp();
+  await migrateToFlatPhase(base);
+  const backupRoot = join(base, ".gsd-backups");
+  const firstBackups = readdirSync(backupRoot).filter((d) => d.startsWith("migrate-"));
+  assert.equal(firstBackups.length, 1, "first migration snapshots exactly one backup");
+
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01"), { recursive: true });
+  const milestonesPath = join(base, ".gsd", "milestones");
+  const phasesPath = join(base, ".gsd", "phases");
+
+  const restoreFsOps = _setFlatPhaseMigrationFsOpsForTest({
+    rmSync(target, opts) {
+      if (target === phasesPath) {
+        throw Object.assign(new Error("simulated locked phases/"), { code: "EPERM" });
+      }
+      return rmSync(target, opts as never);
+    },
+  });
+  t.after(restoreFsOps);
+
+  await assert.rejects(migrateToFlatPhase(base), /simulated locked/);
+
+  const afterBackups = readdirSync(backupRoot).filter((d) => d.startsWith("migrate-"));
+  assert.deepEqual(afterBackups, firstBackups, "rollback must preserve the reused backup");
+  assert.ok(existsSync(milestonesPath), "legacy milestones/ should be restored on rollback");
+});
+
 test("migrateToFlatPhase preserves slice sidecar artifacts and skips recovery placeholder PLAN", async () => {
   const base = makeTmp({ withTask: false });
   const legacySliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -247,6 +247,31 @@ test("rollback after a re-fired migration preserves the reused migrate-* backup"
   assert.ok(existsSync(milestonesPath), "legacy milestones/ should be restored on rollback");
 });
 
+test("migration ignores an empty/partial leftover backup and writes a complete one (#1292)", async () => {
+  const base = makeTmp();
+
+  // Simulate a prior first-time backup that crashed mid-cpSync: an empty
+  // migrate-<ts>/ leftover with no milestones/ content. It is the newest entry,
+  // so mtime-based selection would reuse it as the rollback copy if content were
+  // not validated — silently retaining a recovery copy missing the legacy tree.
+  const backupRoot = join(base, ".gsd-backups");
+  const emptyLeftover = join(backupRoot, "migrate-crashed");
+  mkdirSync(emptyLeftover, { recursive: true });
+
+  await migrateToFlatPhase(base);
+
+  assert.ok(existsSync(join(base, ".gsd", "phases", "01-foundation")), "flat phase should render");
+  // The empty leftover must not have been reused; a fresh, content-bearing
+  // backup that actually captured the legacy milestones/ tree must be created.
+  const contentBackups = readdirSync(backupRoot)
+    .filter((d) => d.startsWith("migrate-"))
+    .filter((d) => existsSync(join(backupRoot, d, "M001")));
+  assert.ok(
+    contentBackups.length >= 1,
+    "a complete backup containing the legacy milestones/ tree must be created, not the empty leftover",
+  );
+});
+
 test("migrateToFlatPhase preserves slice sidecar artifacts and skips recovery placeholder PLAN", async () => {
   const base = makeTmp({ withTask: false });
   const legacySliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");


### PR DESCRIPTION
## Summary
- Stopped the `.gsd-backups/migrate-*` leak by making flat-phase migration reuse an existing backup instead of re-snapshotting on every re-fire, verified with a new regression test (14/14 migration tests pass).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1292
- [#1292 [Bug]: marker-key mismatch triggers repeated whole-tree re-imports + leaked `.gsd-backups/migrate-*` dirs — reproduced on a real (non-symlinked) `.gsd`](https://github.com/open-gsd/gsd-pi/issues/1292)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1292-bug-marker-key-mismatch-triggers-repeate-1783362534`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to flat-phase migration backup/rollback on disk; behavior is guarded by new regression tests and does not touch auth or remote data.
> 
> **Overview**
> Fixes **accumulating `.gsd-backups/migrate-*` directories** when flat-phase migration runs again after legacy `.gsd/milestones/` reappears (e.g. marker-key mismatch re-import at dispatch boundaries — #1292).
> 
> **`migrateToFlatPhase`** now calls **`existingMigrateBackup`** to pick the newest prior `migrate-*` snapshot that still looks like a legacy tree. If one exists, that path is used as the rollback fallback and **no new `cpSync` backup** is created; otherwise behavior is unchanged. **`rollbackPartialMigration`** takes **`backupCreatedThisRun`** so rollback only deletes a disposable backup when this run actually created it—reused snapshots are kept for recovery.
> 
> Regression tests cover a re-fired migration (still only one backup) and rollback after re-fire (reused backup preserved, `milestones/` restored).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c51d2af98ba3378dc727d3e8f30cd0e5ce3ff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->