### PR TITLE
fix(issue): [Bug]: post-execution import check blocks task completion on Convex `_generated/` imports (generated code absent on disk), pausing auto-mode

### DIFF
--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -318,12 +318,12 @@ export function checkImportResolution(
     const imports = extractRelativeImports(source);
 
     for (const { importPath, lineNum } of imports) {
-      // Framework-generated type modules may not exist on disk during post-exec
-      // checks (typically generated during framework builds/typegen). Don't
-      // block task completion on these imports.
+      // Framework/codegen-generated modules may not exist on disk during
+      // post-exec checks. Don't block task completion on these imports.
       if (
         /^\.{1,2}\/\+types\//.test(importPath) ||
-        /^(?:\.{1,2}\/)+(?:[^/]+\/)*\$types(?:$|\/)/.test(importPath)
+        /^(?:\.{1,2}\/)+(?:[^/]+\/)*\$types(?:$|\/)/.test(importPath) ||
+        /^(?:\.{1,2}\/)+(?:[^/]+\/)*_generated(?:$|\/)/.test(importPath)
       ) {
         continue;
       }

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -496,6 +496,28 @@ describe("checkImportResolution", () => {
     }
   });
 
+  test("ignores generated Convex _generated imports", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "convex"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "convex", "stagedLibraryEdits.ts"),
+      "import type { DataModel } from './_generated/dataModel';\nexport const model = {} as DataModel;"
+    );
+
+    try {
+      const task = createTask({
+        id: "T01",
+        key_files: ["convex/stagedLibraryEdits.ts"],
+      });
+
+      const results = checkImportResolution(task, [], tempDir);
+      assert.deepEqual(results, []);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("fails when import doesn't resolve", () => {
     tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Added a Convex `_generated/` import skip with regression coverage, verified by the focused post-execution checks test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1309
- [#1309 [Bug]: post-execution import check blocks task completion on Convex `_generated/` imports (generated code absent on disk), pausing auto-mode](https://github.com/open-gsd/gsd-pi/issues/1309)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1309-bug-post-execution-import-check-blocks-t-1783386960`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation bypass for known codegen import patterns only; real unresolved imports still fail.
> 
> **Overview**
> **Post-execution import resolution** no longer treats missing **Convex** `./_generated/...` modules as blocking failures when those files are not on disk yet (codegen output).
> 
> `checkImportResolution` extends the existing codegen skip list (React Router `+types`, SvelteKit `$types`) with a regex for relative paths containing `_generated`, and the comment is broadened to cover codegen generally. A unit test asserts `convex/stagedLibraryEdits.ts` importing `./_generated/dataModel` passes with an empty `_generated` folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99c41c9ebed5d20fdf5b4a8629949e7aa482580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->