### PR TITLE
fix(issue): New milestone re-interviews user: worktree misses flat-phase CONTEXT.md, pre-planning dispatch re-fires discuss-milestone

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1095,10 +1095,11 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "pre-planning (no context) → discuss-milestone",
-    match: async ({ state, mid, midTitle, basePath, prefs, structuredQuestionsAvailable }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, session, structuredQuestionsAvailable }) => {
       if (state.phase !== "pre-planning") return null;
       if (isRegistryMilestoneComplete(state, mid)) return null;
-      const contextFile = resolveMilestoneFile(basePath, mid, "CONTEXT");
+      const contextBasePath = resolveWorktreeProjectRoot(basePath, session?.originalBasePath);
+      const contextFile = resolveMilestoneFile(contextBasePath, mid, "CONTEXT");
       const hasContext = !!(contextFile && (await loadFile(contextFile)));
       if (hasContext) return null; // fall through to next rule
       if (prefs?.planning_depth === "deep") return null;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1099,7 +1099,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (state.phase !== "pre-planning") return null;
       if (isRegistryMilestoneComplete(state, mid)) return null;
       const contextBasePath = resolveWorktreeProjectRoot(basePath, session?.originalBasePath);
-      const contextFile = resolveMilestoneFile(contextBasePath, mid, "CONTEXT");
+      const contextFile =
+        resolveMilestoneFile(basePath, mid, "CONTEXT") ??
+        (contextBasePath !== basePath ? resolveMilestoneFile(contextBasePath, mid, "CONTEXT") : null);
       const hasContext = !!(contextFile && (await loadFile(contextFile)));
       if (hasContext) return null; // fall through to next rule
       if (prefs?.planning_depth === "deep") return null;

--- a/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
@@ -146,6 +146,30 @@ test("dispatch-rule-coverage: pre-planning, no CONTEXT → discuss-milestone", a
   );
 });
 
+test("dispatch-rule-coverage: pre-planning worktree sees project-root CONTEXT", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-wt-context-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const projectPhaseDir = join(tmp, ".gsd", "phases", "01-foundation");
+  mkdirSync(projectPhaseDir, { recursive: true });
+  writeFileSync(join(projectPhaseDir, "01-CONTEXT.md"), "# Context\n");
+
+  const worktree = join(tmp, ".gsd", "worktrees", "M001");
+  mkdirSync(join(worktree, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(
+    join(worktree, ".gsd", "milestones", "M001", "M001-META.json"),
+    '{"branch":"milestone/M001"}',
+  );
+
+  const rule = DISPATCH_RULES.find(
+    (candidate) => candidate.name === "pre-planning (no context) → discuss-milestone",
+  );
+  assert.ok(rule, "pre-planning missing-context rule should exist");
+
+  const result = await rule.match(makeCtx(worktree, makeState({ phase: "pre-planning" })));
+  assert.equal(result, null, "project-root CONTEXT must prevent a second discuss-milestone dispatch");
+});
+
 test("dispatch-rule-coverage: pre-planning, has CONTEXT, no RESEARCH → research-milestone", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-res-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
@@ -170,6 +170,31 @@ test("dispatch-rule-coverage: pre-planning worktree sees project-root CONTEXT", 
   assert.equal(result, null, "project-root CONTEXT must prevent a second discuss-milestone dispatch");
 });
 
+test("dispatch-rule-coverage: pre-planning worktree sees worktree-only CONTEXT", async (t) => {
+  // Mirror image of the project-root test: discuss-milestone mirrors CONTEXT into
+  // the worktree's own .gsd, and it may not yet exist at the project root (the
+  // worktree→root sync deliberately does not flow markdown projections back).
+  // A project-root-only check would miss it and re-fire discuss-milestone.
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-wt-only-context-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  // No CONTEXT at the project root — only the milestone dir exists there.
+  mkdirSync(join(tmp, ".gsd", "phases"), { recursive: true });
+
+  const worktree = join(tmp, ".gsd", "worktrees", "M001");
+  const worktreePhaseDir = join(worktree, ".gsd", "phases", "01-foundation");
+  mkdirSync(worktreePhaseDir, { recursive: true });
+  writeFileSync(join(worktreePhaseDir, "01-CONTEXT.md"), "# WT Context\n");
+
+  const rule = DISPATCH_RULES.find(
+    (candidate) => candidate.name === "pre-planning (no context) → discuss-milestone",
+  );
+  assert.ok(rule, "pre-planning missing-context rule should exist");
+
+  const result = await rule.match(makeCtx(worktree, makeState({ phase: "pre-planning" })));
+  assert.equal(result, null, "worktree-only CONTEXT must prevent a second discuss-milestone dispatch");
+});
+
 test("dispatch-rule-coverage: pre-planning, has CONTEXT, no RESEARCH → research-milestone", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-res-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
@@ -97,6 +97,42 @@ test("projectRootToWorktree forwards root PROJECT.md into isolated worktrees", (
   }
 });
 
+test("projectRootToWorktree projects flat-phase discuss artifacts before dispatch", () => {
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const worktree = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(join(worktree, ".gsd", "phases", "01-foundation"), { recursive: true });
+
+    const projectPhaseDir = join(dir, ".gsd", "phases", "01-foundation");
+    mkdirSync(projectPhaseDir, { recursive: true });
+    writeFileSync(join(projectPhaseDir, "01-CONTEXT.md"), "# M001 Context\n");
+    writeFileSync(join(projectPhaseDir, "01-DISCUSSION.md"), "# M001 Discussion\n");
+
+    const metaDir = join(dir, ".gsd", "milestones", "M001");
+    mkdirSync(metaDir, { recursive: true });
+    writeFileSync(join(metaDir, "M001-META.json"), '{"branch":"milestone/M001"}');
+
+    const workspace = createWorkspace(worktree);
+    const scope = scopeMilestone(workspace, "M001");
+    new WorktreeStateProjection().projectRootToWorktree(scope);
+
+    assert.ok(
+      existsSync(join(worktree, ".gsd", "milestones", "M001", "M001-META.json")),
+      "milestone metadata is projected into the worktree",
+    );
+    assert.ok(
+      existsSync(join(worktree, ".gsd", "phases", "01-foundation", "01-CONTEXT.md")),
+      "flat-phase CONTEXT.md is projected into the worktree",
+    );
+    assert.ok(
+      existsSync(join(worktree, ".gsd", "phases", "01-foundation", "01-DISCUSSION.md")),
+      "flat-phase DISCUSSION.md is projected into the worktree",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test("projectRootToWorktree projects prior-milestone slice/task SUMMARY.md, not just top-level files", () => {
   // Regression: a worktree opened for the CURRENT milestone (M002) must also
   // receive the full subtree of OTHER, already-completed milestones (M001) so

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -179,6 +179,14 @@ function syncOtherMilestoneArtifacts(
   }
 }
 
+function syncFlatPhaseArtifacts(prGsd: string, wtGsd: string): void {
+  safeCopyRecursive(
+    join(prGsd, "phases"),
+    join(wtGsd, "phases"),
+    { force: false },
+  );
+}
+
 /**
  * Root-level .gsd/ files copied from worktree back to project root for
  * post-merge diagnostics. Markdown projections are NOT in this list — DB
@@ -253,6 +261,10 @@ export function _projectRootToWorktreeImpl(
   // Root PROJECT/REQUIREMENTS/DECISIONS projections must be readable from a
   // worktree-bound unit; the project root remains authoritative.
   syncRootProjectionFilesToWorktree(prGsd, wtGsd);
+
+  // Flat-phase artifacts (phases/NN-slug/NN-CONTEXT.md, NN-DISCUSSION.md,
+  // ROADMAP, etc.) must be available before the first worktree dispatch.
+  syncFlatPhaseArtifacts(prGsd, wtGsd);
 
   // Copy milestone directory from project root to worktree — additive only.
   // force:false prevents cpSync from overwriting existing worktree files.


### PR DESCRIPTION
## Summary
- Fixed worktree milestone CONTEXT lookup and flat-phase artifact projection, with diff checks passing and tests blocked by missing offline dependencies.

## Bugs Addressed
- [x] **Dispatch checks missing worktree CONTEXT and re-interviews user**
- [x] **Worktree sync omits flat-phase discuss artifacts**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1308
- [#1308 New milestone re-interviews user: worktree misses flat-phase CONTEXT.md, pre-planning dispatch re-fires discuss-milestone](https://github.com/open-gsd/gsd-pi/issues/1308)

## User
- @DragonSigh

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1308-new-milestone-re-interviews-user-worktre-1783392213`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode dispatch gating and worktree→root projection sync; incorrect path resolution could still skip or duplicate discuss-milestone, though behavior is covered by new tests and uses additive `force: false` copies.
> 
> **Overview**
> Fixes **new milestones re-interviewing the user** when auto-mode runs inside a milestone worktree and milestone **CONTEXT** exists only under the project root’s flat-phase layout (`phases/…/NN-CONTEXT.md`).
> 
> The **pre-planning (no context) → discuss-milestone** rule now resolves the canonical project root via `resolveWorktreeProjectRoot` (using `session.originalBasePath` when present) and treats CONTEXT as present if it exists on either the worktree `basePath` or that project root.
> 
> **Worktree state projection** adds additive sync of the entire `.gsd/phases/` tree from project root to worktree during `projectRootToWorktree`, so discuss artifacts like CONTEXT and DISCUSSION are on the worktree filesystem before the first unit dispatch—not only visible through the dispatch fallback.
> 
> New tests cover the dispatch rule behavior from a worktree with project-root-only CONTEXT and flat-phase projection into the worktree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4951ec45481ba4e1fbcef0e556c6b04a099f1a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->