### PR TITLE
fix(issue): [Bug]: /gsd discuss <milestone-id> emits misleading 'not discussable' when milestone is absent from ROADMAP or uses unique-suffix ID

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -864,6 +864,13 @@ export function getDiscussableFutureMilestones<T extends { id: string; status: s
   );
 }
 
+function findDiscussTargetMilestone(
+  registry: GSDState["registry"],
+  milestoneId: string,
+): GSDState["registry"][number] | undefined {
+  return registry.find((m) => m.id === milestoneId || m.id.startsWith(`${milestoneId}-`));
+}
+
 function getStructuredQuestionsAvailability(
   pi: ExtensionAPI,
   ctx: ExtensionContext | undefined,
@@ -1333,12 +1340,23 @@ export async function showDiscuss(
     if (slash > 0) {
       const mid = target.slice(0, slash);
       const sid = target.slice(slash + 1);
-      const targetMilestone = state.registry.find((m) => m.id === mid);
-      if (!targetMilestone || targetMilestone.status === "complete" || targetMilestone.status === "parked") {
-        ctx.ui.notify(`Milestone ${mid} is not discussable.`, "warning");
+      const targetMilestone = findDiscussTargetMilestone(state.registry, mid);
+      if (!targetMilestone) {
+        ctx.ui.notify(
+          `Milestone ${mid} was not found in the roadmap. Use /gsd new-milestone to add it, or /gsd status to see available milestones.`,
+          "warning",
+        );
         return;
       }
-      const slices = await loadDiscussNormSlices(basePath, mid);
+      if (targetMilestone.status === "complete") {
+        ctx.ui.notify(`Milestone ${targetMilestone.id} is already complete.`, "info");
+        return;
+      }
+      if (targetMilestone.status === "parked") {
+        ctx.ui.notify(`Milestone ${targetMilestone.id} is parked. Run /gsd unpark ${targetMilestone.id} to reactivate.`, "warning");
+        return;
+      }
+      const slices = await loadDiscussNormSlices(basePath, targetMilestone.id);
       const chosen = slices.find((s) => s.id.toUpperCase() === sid.toUpperCase());
       if (!chosen) {
         ctx.ui.notify(`Slice ${target} was not found in discussable slices.`, "warning");
@@ -1348,10 +1366,10 @@ export async function showDiscuss(
         ctx.ui.notify(`Slice ${target} is already complete; nothing to discuss.`, "info");
         return;
       }
-      const discussBasePath = resolveDiscussSliceBasePath(basePath, mid);
-      const contextFile = resolveSliceFile(discussBasePath, mid, sid, "CONTEXT");
+      const discussBasePath = resolveDiscussSliceBasePath(basePath, targetMilestone.id);
+      const contextFile = resolveSliceFile(discussBasePath, targetMilestone.id, sid, "CONTEXT");
       const sqAvail = getStructuredQuestionsAvailability(pi, ctx);
-      const prompt = await buildDiscussSlicePrompt(mid, sid, chosen.title, discussBasePath, {
+      const prompt = await buildDiscussSlicePrompt(targetMilestone.id, sid, chosen.title, discussBasePath, {
         rediscuss: !!contextFile,
         structuredQuestionsAvailable: sqAvail,
       });
@@ -1359,9 +1377,20 @@ export async function showDiscuss(
       return;
     }
 
-    const targetMilestone = state.registry.find((m) => m.id === target);
-    if (!targetMilestone || targetMilestone.status === "complete" || targetMilestone.status === "parked") {
-      ctx.ui.notify(`Milestone ${target} is not discussable.`, "warning");
+    const targetMilestone = findDiscussTargetMilestone(state.registry, target);
+    if (!targetMilestone) {
+      ctx.ui.notify(
+        `Milestone ${target} was not found in the roadmap. Use /gsd new-milestone to add it, or /gsd status to see available milestones.`,
+        "warning",
+      );
+      return;
+    }
+    if (targetMilestone.status === "complete") {
+      ctx.ui.notify(`Milestone ${targetMilestone.id} is already complete.`, "info");
+      return;
+    }
+    if (targetMilestone.status === "parked") {
+      ctx.ui.notify(`Milestone ${targetMilestone.id} is parked. Run /gsd unpark ${targetMilestone.id} to reactivate.`, "warning");
       return;
     }
     await dispatchDiscussForMilestone(ctx, pi, basePath, targetMilestone.id, targetMilestone.title, {});

--- a/src/resources/extensions/gsd/tests/discuss-routing-fixes.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-routing-fixes.test.ts
@@ -80,6 +80,43 @@ function makeDiscussCtx(notifications: Array<{ message: string; level?: string }
   };
 }
 
+async function runDiscussTargetFixture(
+  target: string,
+  milestones: Array<{ id: string; title?: string; status?: string }>,
+  writeArtifacts?: (base: string) => void,
+) {
+  const base = mkdtempSync(join(tmpdir(), "gsd-discuss-target-"));
+  const notifications: Array<{ message: string; level?: string }> = [];
+  const harness = makeDiscussPi();
+  try {
+    mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+    writeArtifacts?.(base);
+    const dbPath = join(base, ".gsd", "gsd.db");
+    assert.equal(openDatabase(dbPath), true);
+    for (const milestone of milestones) {
+      insertMilestone(milestone);
+    }
+
+    await showDiscuss(
+      makeDiscussCtx(notifications) as any,
+      harness.pi as any,
+      base,
+      { target },
+    );
+
+    return {
+      notifications: [...notifications],
+      sent: [...harness.sent],
+    };
+  } finally {
+    harness.restore();
+    if (isDbAvailable()) closeDatabase();
+    invalidateStateCache();
+    clearGuidedUnitContext();
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
 describe("discuss target normalization", () => {
   test("canonicalizes milestone and slice casing", () => {
     assert.equal(normalizeDiscussTarget("m014"), "M014");
@@ -87,6 +124,92 @@ describe("discuss target normalization", () => {
     assert.equal(normalizeDiscussTarget("m014/s03"), "M014/S03");
     assert.equal(_parseDiscussArgsForTest("m014").target, "M014");
     assert.equal(_parseDiscussArgsForTest("--slice m014/s03").target, "M014/S03");
+  });
+});
+
+describe("showDiscuss targeted milestone guardrails (#1320)", () => {
+  test("missing, complete, and parked milestone targets get actionable messages", async () => {
+    const cases = [
+      {
+        target: "M006",
+        milestones: [{ id: "M005", title: "Current", status: "active" }],
+        level: "warning",
+        message: /Milestone M006 was not found in the roadmap\. Use \/gsd new-milestone to add it, or \/gsd status to see available milestones\./,
+      },
+      {
+        target: "M006/S01",
+        milestones: [{ id: "M005", title: "Current", status: "active" }],
+        level: "warning",
+        message: /Milestone M006 was not found in the roadmap\. Use \/gsd new-milestone to add it, or \/gsd status to see available milestones\./,
+      },
+      {
+        target: "M006",
+        milestones: [{ id: "M006", title: "Done", status: "complete" }],
+        level: "info",
+        message: /Milestone M006 is already complete\./,
+      },
+      {
+        target: "M006/S01",
+        milestones: [{ id: "M006", title: "Done", status: "complete" }],
+        level: "info",
+        message: /Milestone M006 is already complete\./,
+      },
+      {
+        target: "M006",
+        milestones: [{ id: "M006", title: "Deferred", status: "parked" }],
+        level: "warning",
+        message: /Milestone M006 is parked\. Run \/gsd unpark M006 to reactivate\./,
+      },
+      {
+        target: "M006/S01",
+        milestones: [{ id: "M006", title: "Deferred", status: "parked" }],
+        level: "warning",
+        message: /Milestone M006 is parked\. Run \/gsd unpark M006 to reactivate\./,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const result = await runDiscussTargetFixture(testCase.target, testCase.milestones);
+      assert.equal(result.sent.length, 0, `${testCase.target} must not dispatch`);
+      assert.equal(result.notifications.length, 1, `${testCase.target} must emit one notification`);
+      assert.equal(result.notifications[0]?.level, testCase.level);
+      assert.match(result.notifications[0]?.message ?? "", testCase.message);
+      assert.doesNotMatch(result.notifications[0]?.message ?? "", /not discussable/i);
+    }
+  });
+
+  test("bare milestone targets match unique-suffix milestone IDs", async () => {
+    const result = await runDiscussTargetFixture("M006", [
+      { id: "M006-abc123", title: "Unique milestone", status: "active" },
+    ]);
+
+    assert.equal(result.notifications.length, 0);
+    assert.equal(result.sent.length, 1, "bare ID must dispatch the suffixed milestone");
+    assert.match(String(result.sent[0]?.content), /M006-abc123|Unique milestone|guided-discuss-milestone/i);
+  });
+
+  test("bare slice targets match unique-suffix milestone IDs", async () => {
+    const result = await runDiscussTargetFixture(
+      "M006/S01",
+      [{ id: "M006-abc123", title: "Unique milestone", status: "active" }],
+      (base) => {
+        mkdirSync(join(base, ".gsd", "milestones", "M006-abc123"), { recursive: true });
+        writeFileSync(
+          join(base, ".gsd", "milestones", "M006-abc123", "M006-abc123-ROADMAP.md"),
+          `# M006-abc123 Roadmap
+
+## Slices
+- [ ] **S01: Unique slice** \`risk:medium\` \`depends:[]\`
+  > After this: the suffixed milestone slice can be discussed
+`,
+          "utf-8",
+        );
+      },
+    );
+
+    assert.equal(result.notifications.length, 0);
+    assert.equal(result.sent.length, 1, "bare ID slice target must dispatch through the suffixed milestone");
+    assert.match(String(result.sent[0]?.content), /M006-abc123|S01|Unique slice|guided-discuss-slice/i);
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixed targeted discuss milestone guardrails and suffix-ID matching with focused regression coverage and static verification.

## Bugs Addressed
- [x] **Collapsed milestone state warnings are not actionable**
- [x] **Bare milestone IDs do not match unique-suffix IDs**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1320
- [#1320 [Bug]: /gsd discuss <milestone-id> emits misleading 'not discussable' when milestone is absent from ROADMAP or uses unique-suffix ID](https://github.com/open-gsd/gsd-pi/issues/1320)

## User
- @birdypme

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1320-bug-gsd-discuss-milestone-id-emits-misle-1783435205`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized routing and UX in `showDiscuss` with regression tests; no auth or data-model changes.
> 
> **Overview**
> Fixes **targeted** `/gsd discuss` when users pass a milestone or slice ID that does not line up cleanly with registry entries.
> 
> **Milestone resolution:** Adds `findDiscussTargetMilestone` so a bare ID like `M006` can match suffixed registry IDs such as `M006-abc123`. Slice and milestone discuss flows then use that **canonical** milestone ID for roadmap loading, artifact paths, and workflow dispatch.
> 
> **Clearer guardrails:** Replaces the single vague “not discussable” warning with separate outcomes—missing milestone (points to `/gsd new-milestone` or `/gsd status`), already complete, or parked (suggests `/gsd unpark`).
> 
> **Tests:** Regression coverage in `discuss-routing-fixes.test.ts` for those messages, suffix-ID matching, and ensuring invalid targets do not dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044d9170bf747b8d16f79de34af53a5f66b44823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->