### PR TITLE
perf(gsd): batch plan-v2 task queries and skip unchanged graph writes

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -37,7 +37,7 @@ commit `58dc840f`. Plans 018–024 planned against commit `7cca07ae`.
 | 018 | Ship @opengsd/gsd-cloud built, tested, and guarded against empty publishes | P0 | M | — | DONE |
 | 019 | Refuse token-less web mode on non-loopback hosts | P1 | S | — | DONE |
 | 020 | Add request timeouts to cloud pairing HTTP helper (both copies) | P1 | S | — | TODO |
-| 021 | Batch plan-v2 graph compile + skip unchanged writes (dispatch hot path) | P2 | S | — | TODO |
+| 021 | Batch plan-v2 graph compile + skip unchanged writes (dispatch hot path) | P2 | S | — | DONE |
 | 022 | Test gsd-cloud device-flow polling and SSRF gateway guards | P2 | M | 018 | TODO |
 | 023 | ADR: decide the flat-phase layout migration completion path | P2 | M | — | TODO |
 | 024 | Dependency & dead-code hygiene (hono, daemon SDK, ajv, chart.tsx) | P2 | S | — | TODO |

--- a/src/resources/extensions/gsd/tests/uok-plan-v2-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-plan-v2-wiring.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -237,6 +237,98 @@ test("plan-v2 ensure rejects empty executable graph", () => {
   assert.equal(compiled.ok, false);
   assert.match(compiled.reason ?? "", /compiled graph is empty/i);
   assert.equal(isEmptyPlanV2GraphResult(compiled), true);
+});
+
+function seedMultiSliceRows(): void {
+  insertMilestone({ id: MILESTONE_ID, title: "Milestone", status: "active" });
+  const slices: Array<[string, number, Array<[string, number]>]> = [
+    ["S01", 1, [["T01", 1], ["T02", 2]]],
+    ["S02", 2, [["T03", 1], ["T04", 2]]],
+  ];
+  for (const [sid, sseq, tasks] of slices) {
+    insertSlice({ id: sid, milestoneId: MILESTONE_ID, title: `Slice ${sid}`, status: "in_progress", sequence: sseq });
+    for (const [tid, tseq] of tasks) {
+      insertTask({
+        id: tid,
+        milestoneId: MILESTONE_ID,
+        sliceId: sid,
+        title: `Task ${tid}`,
+        status: "pending",
+        keyFiles: [`src/${tid}.ts`],
+        sequence: tseq,
+      });
+    }
+  }
+}
+
+test("plan-v2 batched compile preserves node ids, order, and count", () => {
+  const basePath = createBasePath();
+  seedMultiSliceRows();
+  writeMilestoneFile(basePath, "CONTEXT", "Finalized context.");
+
+  const compiled = ensurePlanV2Graph(basePath, buildState("executing"));
+  assert.equal(compiled.ok, true);
+
+  const graph = JSON.parse(readFileSync(compiled.graphPath ?? "", "utf-8")) as {
+    nodes: Array<{ id: string }>;
+  };
+  assert.deepEqual(
+    graph.nodes.map((n) => n.id),
+    [
+      "execute-task:M001:S01:T01",
+      "execute-task:M001:S01:T02",
+      "complete-slice:M001:S01",
+      "execute-task:M001:S02:T03",
+      "execute-task:M001:S02:T04",
+      "complete-slice:M001:S02",
+    ],
+  );
+});
+
+test("plan-v2 skips the disk write when the graph is unchanged", () => {
+  const basePath = createBasePath();
+  seedMultiSliceRows();
+  writeMilestoneFile(basePath, "CONTEXT", "Finalized context.");
+
+  const first = ensurePlanV2Graph(basePath, buildState("executing"));
+  assert.equal(first.ok, true);
+  const graphPath = first.graphPath ?? "";
+  const before = readFileSync(graphPath, "utf-8");
+
+  // Backdate mtime so a rewrite is detectable even within the same millisecond.
+  utimesSync(graphPath, 1000, 1000);
+  const backdatedMtime = statSync(graphPath).mtimeMs;
+
+  const second = ensurePlanV2Graph(basePath, buildState("executing"));
+  assert.equal(second.ok, true);
+  assert.equal(statSync(graphPath).mtimeMs, backdatedMtime, "identical state must not rewrite the graph");
+  assert.equal(readFileSync(graphPath, "utf-8"), before);
+});
+
+test("plan-v2 rewrites the graph when it changes", () => {
+  const basePath = createBasePath();
+  seedMultiSliceRows();
+  writeMilestoneFile(basePath, "CONTEXT", "Finalized context.");
+
+  const first = ensurePlanV2Graph(basePath, buildState("executing"));
+  const graphPath = first.graphPath ?? "";
+  const before = readFileSync(graphPath, "utf-8");
+  utimesSync(graphPath, 1000, 1000);
+
+  insertTask({
+    id: "T05",
+    milestoneId: MILESTONE_ID,
+    sliceId: "S02",
+    title: "Added task",
+    status: "pending",
+    keyFiles: ["src/T05.ts"],
+    sequence: 3,
+  });
+
+  const second = ensurePlanV2Graph(basePath, buildState("executing"));
+  assert.equal(second.ok, true);
+  assert.notEqual(statSync(graphPath).mtimeMs, 1000000, "changed graph must rewrite");
+  assert.notEqual(readFileSync(graphPath, "utf-8"), before);
 });
 
 test("plan-v2 allows empty graph for milestone terminal phases", () => {

--- a/src/resources/extensions/gsd/uok/plan-v2.ts
+++ b/src/resources/extensions/gsd/uok/plan-v2.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 
 import type { GSDState, Phase } from "../types.js";
 import { gsdRoot, resolveMilestoneFile, resolveSliceFile } from "../paths.js";
-import { isDbAvailable, getMilestoneSlices, getSliceTasks } from "../gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getTasksBySliceIds } from "../gsd-db.js";
 import type { SliceRow } from "../db-task-slice-rows.js";
 import type { UokGraphNode } from "./contracts.js";
 
@@ -37,6 +37,19 @@ export interface PlanV2CompileResult {
 
 function graphOutputPath(basePath: string): string {
   return join(gsdRoot(basePath), "runtime", "uok-plan-v2-graph.json");
+}
+
+// True when the on-disk graph matches `output` ignoring the volatile `compiledAt`
+// stamp, so redundant recompiles on the dispatch hot path skip the disk write.
+function graphBodyUnchanged(outPath: string, output: Record<string, unknown>): boolean {
+  try {
+    const existing = JSON.parse(readFileSync(outPath, "utf-8")) as Record<string, unknown>;
+    const { compiledAt: _existingStamp, ...existingBody } = existing;
+    const { compiledAt: _outputStamp, ...outputBody } = output;
+    return JSON.stringify(existingBody) === JSON.stringify(outputBody);
+  } catch {
+    return false; // Missing, unreadable, or corrupt — write.
+  }
 }
 
 function hasFileContent(path: string | null): boolean {
@@ -120,9 +133,11 @@ export function compileUnitGraphFromState(basePath: string, state: GSDState): Pl
     };
   }
 
+  const tasksBySlice = getTasksBySliceIds(slices.map((slice) => ({ milestoneId: mid, sliceId: slice.id })));
+
   for (const slice of slices) {
     const sid = slice.id;
-    const tasks = getSliceTasks(mid, sid)
+    const tasks = (tasksBySlice.get(`${mid}\0${sid}`) ?? [])
       .sort((a, b) => Number(a.sequence ?? 0) - Number(b.sequence ?? 0));
 
     let previousTaskNodeId: string | null = null;
@@ -174,7 +189,9 @@ export function compileUnitGraphFromState(basePath: string, state: GSDState): Pl
 
   const outPath = graphOutputPath(basePath);
   mkdirSync(join(gsdRoot(basePath), "runtime"), { recursive: true });
-  writeFileSync(outPath, JSON.stringify(output, null, 2) + "\n", "utf-8");
+  if (!graphBodyUnchanged(outPath, output)) {
+    writeFileSync(outPath, JSON.stringify(output, null, 2) + "\n", "utf-8");
+  }
 
   return {
     ok: true,


### PR DESCRIPTION
## TL;DR

**What:** Batch the plan-v2 unit-graph task queries into one lookup and skip rewriting the graph file when its content is unchanged.
**Why:** The plan-v2 gate runs before nearly every auto-mode dispatch, paying an N+1 (one query per slice) plus a full serialize + disk write every time.
**How:** Reuse the existing `getTasksBySliceIds` batch and gate the write on a content compare (ignoring the volatile `compiledAt` stamp).

## What

- `src/resources/extensions/gsd/uok/plan-v2.ts` — `compileUnitGraphFromState` now fetches all tasks via one `getTasksBySliceIds` call instead of `getSliceTasks` per slice; the disk write is gated by a new `graphBodyUnchanged` helper.
- `src/resources/extensions/gsd/tests/uok-plan-v2-wiring.test.ts` — adds equivalence (node ids/order/count), skip-unchanged-write, and rewrite-on-change cases.

## Why

`pre-dispatch.ts` calls `ensurePlanV2Graph` on `executing`/`summarizing`/`validating-milestone`/`completing-milestone` (planV2 defaults on). For an 8-slice milestone that's 9 SQLite queries plus a full JSON serialize + `runtime/uok-plan-v2-graph.json` rewrite on every one of dozens of dispatches, even when nothing changed.

## How

- One batched `getTasksBySliceIds` lookup keyed `${milestoneId}\0${sliceId}`; the existing per-slice `.sort` is preserved so task order is byte-identical.
- Write is skipped when the on-disk graph matches the freshly compiled body. The output stamps a fresh `compiledAt` on every call, so a naive whole-string compare would never match — `graphBodyUnchanged` compares the body with `compiledAt` stripped from both sides. `compiledAt` has no consumers, so leaving the old stamp on disk is harmless.

Same fix family as #014 (which added `getTasksBySliceIds`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only changes to graph compilation with behavioral tests; graph semantics and gate logic are unchanged aside from fewer queries and conditional writes.
> 
> **Overview**
> **Plan-v2 graph compilation** on the auto-mode pre-dispatch path now does one batched SQLite lookup for all slice tasks via `getTasksBySliceIds` instead of `getSliceTasks` per slice, cutting N+1 queries on milestones with many slices.
> 
> **Disk I/O** is skipped when the compiled graph body matches what is already in `runtime/uok-plan-v2-graph.json`; comparison strips the volatile `compiledAt` field so repeated dispatches with unchanged workflow state do not rewrite the file.
> 
> Tests cover multi-slice node id/order/count equivalence, unchanged-state mtime preservation, and rewrite when a new task is inserted. `plans/README.md` records plan 021 as DONE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8c69f09b23aefbba12c6c6ae4b9464b553c0b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->