### PR TITLE
perf(gsd): reduce parallel-path DB churn (batch eligibility queries, one monitor open per tick)

### DIFF
--- a/src/resources/extensions/gsd/parallel-eligibility.ts
+++ b/src/resources/extensions/gsd/parallel-eligibility.ts
@@ -8,7 +8,7 @@
 import { deriveState } from "./state.js";
 import { resolveMilestoneFile, resolveSliceFile } from "./paths.js";
 import { findMilestoneIds } from "./guided-flow.js";
-import { isDbAvailable, getMilestoneSlices, getSliceTasks } from "./gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getTasksBySliceIds } from "./gsd-db.js";
 import { openExistingWorkflowDatabase } from "./db-workspace.js";
 import type { MilestoneRegistryEntry } from "./types.js";
 
@@ -40,10 +40,11 @@ async function collectTouchedFiles(
   const files = new Set<string>();
 
   if (isDbAvailable()) {
-    // DB path: query slices and their tasks for file lists
+    // DB path: query slices and their tasks for file lists (one batched task
+    // query instead of one per slice; file order is irrelevant here — Set dedup)
     const slices = getMilestoneSlices(milestoneId);
-    for (const slice of slices) {
-      const tasks = getSliceTasks(milestoneId, slice.id);
+    const tasksBySlice = getTasksBySliceIds(slices.map((slice) => ({ milestoneId, sliceId: slice.id })));
+    for (const tasks of tasksBySlice.values()) {
       for (const task of tasks) {
         if (Array.isArray(task.files)) {
           for (const f of task.files) {

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -72,6 +72,7 @@ interface WorkerView {
   totalSlices: number;
   doneSlices: number;
   slices: SliceProgress[];
+  completions: string[];
   errors: string[];
 }
 
@@ -143,14 +144,21 @@ function discoverWorkers(basePath: string): string[] {
   return [...mids].sort();
 }
 
-function querySliceProgress(basePath: string, mid: string, workRoot: string = worktreePathFor(basePath, mid)): SliceProgress[] {
+// Slice progress + recent completions share one DB connection per worker per
+// tick. Opening the isolated worker DB twice per refresh (once for each) was
+// pure churn on the 5s interval.
+function queryWorkerProgress(
+  basePath: string,
+  mid: string,
+  workRoot: string = worktreePathFor(basePath, mid),
+): { slices: SliceProgress[]; completions: string[] } {
   const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
-  if (!existsSync(dbPath)) return [];
+  if (!existsSync(dbPath)) return { slices: [], completions: [] };
 
   const db = openWorkflowDatabaseIsolated(dbPath);
-  if (!db) return [];
+  if (!db) return { slices: [], completions: [] };
   try {
-    const rows = db.prepare(
+    const sliceRows = db.prepare(
       `SELECT
          s.id AS id,
          s.status AS status,
@@ -162,14 +170,32 @@ function querySliceProgress(basePath: string, mid: string, workRoot: string = wo
        GROUP BY s.id
        ORDER BY s.id`,
     ).all({ ":mid": mid });
-    return rows.map((row) => ({
+    const slices = sliceRows.map((row) => ({
       id: String(row["id"] ?? ""),
       status: String(row["status"] ?? ""),
       total: Number(row["total"] ?? 0),
       done: Number(row["done"] ?? 0),
     }));
+
+    const completionRows = db.prepare(
+      `SELECT id, slice_id, one_liner
+       FROM tasks
+       WHERE milestone_id=:mid
+         AND status='complete'
+         AND completed_at IS NOT NULL
+       ORDER BY completed_at DESC
+       LIMIT 5`,
+    ).all({ ":mid": mid });
+    const completions = completionRows.map((row) => {
+      const taskId = String(row["id"] ?? "");
+      const sliceId = String(row["slice_id"] ?? "");
+      const oneLiner = String(row["one_liner"] ?? "");
+      return `✓ ${mid}/${sliceId}/${taskId}${oneLiner ? ": " + oneLiner : ""}`;
+    });
+
+    return { slices, completions };
   } catch {
-    return [];
+    return { slices: [], completions: [] };
   } finally {
     try { db.close(); } catch { /* ignore */ }
   }
@@ -276,36 +302,6 @@ function extractCostFromNdjson(basePath: string, mid: string): number {
   }
 }
 
-function queryRecentCompletions(basePath: string, mid: string): string[] {
-  const workRoot = worktreePathFor(basePath, mid);
-  const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
-  if (!existsSync(dbPath)) return [];
-
-  const db = openWorkflowDatabaseIsolated(dbPath);
-  if (!db) return [];
-  try {
-    const rows = db.prepare(
-      `SELECT id, slice_id, one_liner
-       FROM tasks
-       WHERE milestone_id=:mid
-         AND status='complete'
-         AND completed_at IS NOT NULL
-       ORDER BY completed_at DESC
-       LIMIT 5`,
-    ).all({ ":mid": mid });
-    return rows.map((row) => {
-      const taskId = String(row["id"] ?? "");
-      const sliceId = String(row["slice_id"] ?? "");
-      const oneLiner = String(row["one_liner"] ?? "");
-      return `✓ ${mid}/${sliceId}/${taskId}${oneLiner ? ": " + oneLiner : ""}`;
-    });
-  } catch {
-    return [];
-  } finally {
-    try { db.close(); } catch { /* ignore */ }
-  }
-}
-
 function collectWorkerData(basePath: string): WorkerView[] {
   const mids = discoverWorkers(basePath);
   const parallelDir = join(basePath, ".gsd", "parallel");
@@ -317,7 +313,7 @@ function collectWorkerData(basePath: string): WorkerView[] {
     const workRoot = worktreePathFor(basePath, mid);
     const status = readJsonSafe<StatusJson>(join(parallelDir, `${mid}.status.json`));
     const lock = readJsonSafe<AutoLock>(join(workRoot, ".gsd", "auto.lock"));
-    const slices = querySliceProgress(basePath, mid, workRoot);
+    const { slices, completions } = queryWorkerProgress(basePath, mid, workRoot);
 
     const pid = lock?.pid || status?.pid || 0;
     const alive = pid ? isPidAlive(pid) : false;
@@ -378,6 +374,7 @@ function collectWorkerData(basePath: string): WorkerView[] {
       totalSlices: slices.length,
       doneSlices,
       slices,
+      completions,
       errors,
     });
   }
@@ -443,10 +440,10 @@ export class ParallelMonitorOverlay {
     if (this.disposed) return;
     this.workers = collectWorkerData(this.basePath);
 
-    // Collect completion events
+    // Collect completion events (already read during collectWorkerData's single
+    // DB open per worker — no second connection here).
     for (const wk of this.workers) {
-      const completions = queryRecentCompletions(this.basePath, wk.mid);
-      for (const evt of completions) {
+      for (const evt of wk.completions) {
         if (!this.events.includes(evt)) this.events.push(evt);
       }
     }

--- a/src/resources/extensions/gsd/tests/parallel-eligibility-file-overlap.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-eligibility-file-overlap.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression tests for batched touched-file collection in parallel eligibility.
+ *
+ * `collectTouchedFiles` used to run one `getSliceTasks` query per slice (N+1);
+ * it now issues a single `getTasksBySliceIds` batch and dedups paths into a
+ * Set. These tests pin the observable contract of that path through the public
+ * `analyzeParallelEligibility` API:
+ *   1. files are collected from EVERY slice of a milestone, not just the first
+ *      (a file present only in a non-first slice must still drive overlap), and
+ *   2. a path repeated across a milestone's slices is deduped (Set semantics),
+ *      so it appears once in the cross-milestone overlap.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { analyzeParallelEligibility } from "../parallel-eligibility.ts";
+import { invalidateStateCache } from "../state.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+} from "../gsd-db.ts";
+
+// ─── Fixture Helpers ───────────────────────────────────────────────────────
+
+function createFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-parallel-elig-overlap-"));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function writeMilestoneFile(base: string, milestoneId: string, filename: string, content: string): void {
+  const filePath = join(base, ".gsd", "milestones", milestoneId, filename);
+  mkdirSync(join(filePath, ".."), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+/**
+ * Write the on-disk planning artifacts that make a milestone eligible
+ * (CONTEXT + ROADMAP listing its slices + a PLAN per slice). Mirrors the
+ * proven-eligible setup used by parallel-eligibility-ghost.test.ts.
+ */
+function writeEligibleMilestoneFiles(base: string, milestoneId: string, sliceIds: string[]): void {
+  writeMilestoneFile(base, milestoneId, `${milestoneId}-CONTEXT.md`, `# ${milestoneId}: Fixture\n\nBatch fixture.`);
+  const roadmapSlices = sliceIds
+    .map((sid) => `- [ ] **${sid}: Slice ${sid}** \`risk:low\` \`depends:[]\`\n  > Slice ${sid}.`)
+    .join("\n");
+  writeMilestoneFile(
+    base,
+    milestoneId,
+    `${milestoneId}-ROADMAP.md`,
+    `# ${milestoneId}: Fixture\n\n## Slices\n\n${roadmapSlices}\n`,
+  );
+  for (const sid of sliceIds) {
+    writeMilestoneFile(
+      base,
+      milestoneId,
+      `slices/${sid}/${sid}-PLAN.md`,
+      `# ${sid}: Slice ${sid}\n\n**Goal:** Do ${sid}.\n**Demo:** Done.\n\n## Tasks\n\n- [ ] **T01: Task** \`est:10m\`\n  Do it.\n`,
+    );
+  }
+}
+
+function cleanup(base: string): void {
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe("parallel-eligibility: batched touched-file collection", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = createFixtureBase();
+    openDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    cleanup(base);
+    invalidateStateCache();
+  });
+
+  test("collects files from every slice (batch) and dedups repeated paths", async () => {
+    // M001 spans two slices. `src/shared.ts` appears in BOTH slices (dedup
+    // target); `src/beta.ts` appears ONLY in the second slice S02 (proves the
+    // batch covers non-first slices). `src/alpha.ts` is unique to M001.
+    writeEligibleMilestoneFiles(base, "M001", ["S01", "S02"]);
+    insertMilestone({ id: "M001", title: "M001: Fixture", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice S01", status: "active", risk: "low", depends: [], sequence: 1 });
+    insertSlice({ id: "S02", milestoneId: "M001", title: "Slice S02", status: "active", risk: "low", depends: [], sequence: 2 });
+    insertTask({
+      id: "T01", sliceId: "S01", milestoneId: "M001", title: "S01 task", status: "pending",
+      planning: { files: ["src/alpha.ts", "src/shared.ts"] },
+    });
+    insertTask({
+      id: "T01", sliceId: "S02", milestoneId: "M001", title: "S02 task", status: "pending",
+      planning: { files: ["src/shared.ts", "src/beta.ts"] },
+    });
+
+    // M002 overlaps M001 on both `src/shared.ts` and `src/beta.ts`.
+    writeEligibleMilestoneFiles(base, "M002", ["S01"]);
+    insertMilestone({ id: "M002", title: "M002: Fixture", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M002", title: "Slice S01", status: "active", risk: "low", depends: [], sequence: 1 });
+    insertTask({
+      id: "T01", sliceId: "S01", milestoneId: "M002", title: "S01 task", status: "pending",
+      planning: { files: ["src/shared.ts", "src/beta.ts"] },
+    });
+
+    invalidateStateCache();
+    const result = await analyzeParallelEligibility(base);
+
+    // Both milestones must be eligible so Rule 3 (file overlap) runs on them.
+    assert.ok(result.eligible.find((e) => e.milestoneId === "M001"), "M001 should be eligible");
+    assert.ok(result.eligible.find((e) => e.milestoneId === "M002"), "M002 should be eligible");
+
+    const overlap = result.fileOverlaps.find(
+      (o) =>
+        (o.mid1 === "M001" && o.mid2 === "M002") ||
+        (o.mid1 === "M002" && o.mid2 === "M001"),
+    );
+    assert.ok(overlap, "M001 and M002 must be reported as overlapping");
+
+    // `src/beta.ts` lives only in M001's SECOND slice — its presence proves the
+    // batched query collected tasks from every slice, not just the first.
+    assert.ok(
+      overlap!.files.includes("src/beta.ts"),
+      "overlap must include src/beta.ts (only present in M001's non-first slice S02)",
+    );
+    assert.ok(overlap!.files.includes("src/shared.ts"), "overlap must include src/shared.ts");
+
+    // `src/shared.ts` appears in both of M001's slices but must be deduped to a
+    // single entry (Set collection), so the sorted overlap is exactly these two.
+    assert.deepEqual(
+      [...overlap!.files].sort(),
+      ["src/beta.ts", "src/shared.ts"],
+      "overlap files must be deduped and limited to the shared paths",
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tests/parallel-monitor-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-monitor-overlay.test.ts
@@ -108,6 +108,65 @@ describe("parallel-monitor-overlay", () => {
     }
   });
 
+  it("merged worker query renders slice progress and completions across multiple slices", async () => {
+    // Regression guard for the single-open merge: queryWorkerProgress now
+    // returns { slices, completions } from ONE connection per worker per tick.
+    // A worker spanning two slices, each with a completed task, must still
+    // surface every slice's progress AND both completions (previously two
+    // separate DB opens produced these).
+    const base = mkdtempSync(join(tmpdir(), "gsd-parallel-overlay-multi-"));
+
+    try {
+      mkdirSync(join(base, ".gsd", "parallel"), { recursive: true });
+      assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+      insertMilestone({ id: "M001", title: "Multi-slice Fixture" });
+      insertSlice({ milestoneId: "M001", id: "S01", title: "First", status: "pending", sequence: 1 });
+      insertSlice({ milestoneId: "M001", id: "S02", title: "Second", status: "pending", sequence: 2 });
+      insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", status: "complete", oneLiner: "alpha done", sequence: 1 });
+      insertTask({ milestoneId: "M001", sliceId: "S01", id: "T02", status: "pending", sequence: 2 });
+      insertTask({ milestoneId: "M001", sliceId: "S02", id: "T01", status: "complete", oneLiner: "beta done", sequence: 1 });
+      insertTask({ milestoneId: "M001", sliceId: "S02", id: "T02", status: "pending", sequence: 2 });
+      closeDatabase();
+
+      writeFileSync(
+        join(base, ".gsd", "parallel", "M001.status.json"),
+        JSON.stringify({
+          milestoneId: "M001",
+          pid: process.pid,
+          state: "running",
+          cost: 0,
+          lastHeartbeat: Date.now(),
+          startedAt: Date.now() - 30_000,
+          worktreePath: join(base, ".gsd-worktrees", "M001"),
+        }),
+        "utf-8",
+      );
+
+      const mod = await import("../parallel-monitor-overlay.js");
+      const mockTui = { requestRender: () => {} };
+      const mockTheme = {
+        fg: (_color: string, text: string) => text,
+        bold: (text: string) => text,
+      };
+      const overlay = new mod.ParallelMonitorOverlay(mockTui, mockTheme as any, () => {}, base);
+
+      try {
+        const joined = overlay.render(120).join("\n");
+        // Both slices' progress must come from the single merged query.
+        assert.match(joined, /S01:1\/2/, "S01 progress should render from the merged query");
+        assert.match(joined, /S02:1\/2/, "S02 progress should render from the merged query");
+        // Completions for tasks in both slices ride along on the same DB open.
+        assert.match(joined, /S01\/T01: alpha done/, "S01 completion should render");
+        assert.match(joined, /S02\/T01: beta done/, "S02 completion should render");
+      } finally {
+        overlay.dispose();
+      }
+    } finally {
+      try { closeDatabase(); } catch { /* already closed */ }
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
   it("progressBar generates correct width", async () => {
     // Dynamic import to test the module loads cleanly
     const mod = await import("../parallel-monitor-overlay.js");


### PR DESCRIPTION
## TL;DR

**What:** Remove two N+1/redundant-connection patterns on the parallel-milestone paths.
**Why:** Both re-open or re-query the DB per slice/worker when a single batched read suffices.
**How:** Batch the eligibility task queries, and merge the monitor overlay's two per-worker DB opens into one.

## What

- `src/resources/extensions/gsd/parallel-eligibility.ts` — `collectTouchedFiles` replaces its per-slice `getSliceTasks` loop with one `getTasksBySliceIds` batch.
- `src/resources/extensions/gsd/parallel-monitor-overlay.ts` — `querySliceProgress` and `queryRecentCompletions` merge into a single `queryWorkerProgress` that opens the isolated worker DB once per worker per refresh; `WorkerView` now carries `completions`.

## Why

- Eligibility analysis ran one query per slice to collect touched files — the same N+1 shape as #014/#1325, on the milestone-parallelism analysis path.
- The monitor overlay opened each worker's isolated DB **twice** on every 5s refresh: once in `collectWorkerData` for slice progress, again in `refresh` for recent completions. Pure connection churn scaling with worker count.

## How

- Eligibility: file paths dedup into a `Set`, so order is irrelevant — no sort needed, just iterate the batched map's values.
- Overlay: `queryWorkerProgress` runs both the slice-progress and recent-completions queries on one open connection and returns `{ slices, completions }`; completions ride along on `WorkerView` so `refresh` reads `wk.completions` instead of re-opening. Behavior-preserving — the existing overlay test's completions-rendering assertion still passes.

Same fix family as #1325; split into its own PR (one concern) since it touches the parallel-monitor path, not the dispatch hot path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only query batching and connection reuse on monitoring/eligibility paths; no auth, writes, or dispatch logic changes.
> 
> **Overview**
> Cuts redundant SQLite work on parallel-milestone tooling without changing eligibility or monitor semantics.
> 
> **Parallel eligibility** — `collectTouchedFiles` no longer calls `getSliceTasks` once per slice; it batches all slice pairs through `getTasksBySliceIds` and still dedupes paths into a `Set`.
> 
> **Parallel monitor overlay** — Replaces separate `querySliceProgress` and `queryRecentCompletions` (each opening the worker’s isolated DB) with **`queryWorkerProgress`**, which runs slice-progress and recent-completion SQL on **one connection per worker per 5s refresh**. Completions ride on `WorkerView`; `refresh` reads `wk.completions` instead of opening the DB again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc2c962007cc9c1eeb15861a51493ca34549fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->