### PR TITLE
test(gsd-cloud): cover device-flow polling and SSRF gateway guards

### DIFF
--- a/docs/dev/ADR-045-flat-phase-layout-completion.md
+++ b/docs/dev/ADR-045-flat-phase-layout-completion.md
@@ -1,0 +1,251 @@
+<!-- Project/App: gsd-pi -->
+<!-- File Purpose: ADR (proposed) for completing the flat-phase projection layout migration — records why the legacy/flat coexistence seam is the top recurring bug source, proposes single-sourced layout detection (Option B) as stage 1 toward a forced migration (Option A), and specifies the re-enable path for the disabled stale-render drift detector. -->
+
+# ADR-045: Flat-Phase Layout Migration Completion
+
+**Status:** Proposed — maintainer decision required before any code follows
+**Date:** 2026-07-07
+**Author:** GSD architecture review
+**Related:** ADR-017 (state reconciliation, drift-driven), ADR-035 (projection dirty scope), `CONTEXT.md` Drift / Drift catalog / Worktree State Projection terms, and issues [#852](https://github.com/open-gsd/gsd-pi/issues/852), [#1303](https://github.com/open-gsd/gsd-pi/issues/1303), [#1305](https://github.com/open-gsd/gsd-pi/issues/1305), [#1313](https://github.com/open-gsd/gsd-pi/issues/1313), [#1316](https://github.com/open-gsd/gsd-pi/issues/1316)
+
+## Context
+
+The v1.4.0 "flat-phase" projection layout migration is still half-finished at
+v1.8.1. Two on-disk projection layouts coexist:
+
+- **Legacy:** `milestones/<MID>/…` (and nested `slices/<SID>/…`).
+- **Flat-phase:** `phases/NN-slug/NN-CONTEXT.md`, `NN-ROADMAP.md`, etc.
+
+The DB remains the single source of truth; both trees are projections of it
+(ADR-017). The problem is not the two layouts — it is *how the code decides
+which layout a project is in*, and the fact that that decision is neither
+single-sourced nor reliable.
+
+### The coexistence contract today
+
+**1. One-time startup migration.** `flat-phase-migration.ts` runs on startup
+"when the legacy structure is detected" and moves content from `milestones/…`
+into `phases/…`. It is best-effort and non-mandatory: a project can run
+indefinitely in the legacy layout, and a project can end up *partially*
+migrated (some content moved, some not) if the migration is interrupted or the
+detection misfires.
+
+**2. Runtime filesystem-sniffed detection.** There is no persisted layout flag.
+Every consumer re-derives the layout at runtime by looking at the disk. The
+authority is `isLegacyMilestonesLayout(basePath)` in `paths.ts:659`, which
+delegates to `legacyMilestonesHasSubdirs` (`paths.ts:598`): the project is
+"legacy" iff `milestones/` exists and contains at least one *content-bearing*
+subdirectory (`dirIsContentBearingLegacyMilestone`, `paths.ts:621`).
+
+**3. The metadata-dir poisoning — and its partial mitigation.**
+`git-service.ts` stores each milestone's integration-branch metadata at
+`milestones/<MID>/<MID>-META.json` (`milestoneMetaPath`, `git-service.ts:392`)
+and creates that directory with `mkdirSync(join(gsdRoot(basePath),
+"milestones", milestoneId), { recursive: true })` (`git-service.ts:454`) —
+**even in flat-phase projects.** Naively, that `milestones/<MID>/` directory
+would flip `isLegacyMilestonesLayout` to `true` and route artifact resolution
+to the wrong path (`milestones/<MID>/<MID>-CONTEXT.md` instead of
+`phases/NN-slug/NN-CONTEXT.md`), trapping units in a finalize-retry loop
+(the #852 follow-up).
+
+A **partial mitigation already exists** in `paths.ts` and the ADR must be read
+against the *current* state, not the pre-mitigation one:
+
+- `dirIsContentBearingLegacyMilestone` (`paths.ts:621`) now excludes
+  `*-META.json`-only directories (a `milestones/<MID>/` holding only metadata
+  no longer counts as legacy content), and also excludes *empty* scaffolding
+  subdirectories (e.g. an empty `slices/` created alongside the META file).
+- `dirIsMetaOnlyLegacyMilestone` (`paths.ts:649`) lets
+  `resolveProjectMilestonePath` skip META-only dirs during path resolution.
+
+This mitigation reduces the poisoning but does not remove its root cause: the
+integration-branch metadata still lives *inside* the `milestones/<MID>/` tree
+whose presence is the layout-detection signal. Detection therefore remains a
+heuristic sniff of a directory that a second, unrelated subsystem writes into.
+
+**4. The drift alarm is switched off.** The architecture's core projection
+drift detector, `detectStaleRenders` in `markdown-renderer.ts:1020`, is
+hard-wired to `return []`. Its own TODO explains why (verbatim):
+
+```ts
+export function detectStaleRenders(basePath: string): StaleEntry[] {
+  // TODO(flat-phase): stale-render detection is temporarily fully disabled.
+  // The isLegacyMilestonesLayout gate is unreliable: git-service.ts creates
+  // milestones/<mid>/ directories for integration-branch metadata even in
+  // flat-phase projects, making the gate fire true and then producing false
+  // stale-render drift in the second reconcile cycle → ReconciliationFailedError
+  // → auto-mode blocked (exit 10) for multi-slice/remediation e2e scenarios.
+  // Re-enable after path construction is unified and the metadata dir is
+  // decoupled from the layout-detection signal.
+  return [];
+}
+```
+
+The real implementation survives as `detectStaleRendersImpl`
+(`markdown-renderer.ts:1032`) but is never called from the reconcile path. Per
+the Drift catalog, stale-render is a known-repairable Drift class; with the
+detector stubbed, **projection drift between the DB and the `.planning/`/`.gsd/`
+markdown is invisible** until a downstream failure surfaces it.
+
+### The bug cluster this seam produces
+
+The legacy/flat coexistence seam is the single largest recurring bug source in
+recent history. Shipped fixes traceable to it, all within days of this ADR:
+
+| Issue | Symptom | Seam mechanism |
+|---|---|---|
+| [#1316](https://github.com/open-gsd/gsd-pi/issues/1316) | `renderAssessmentFromDb` wrote a flat-phase filename into a legacy `slices/<SID>/` dir → reassess-roadmap verification broke | render target chose wrong layout |
+| [#1313](https://github.com/open-gsd/gsd-pi/issues/1313) | Worktree sync missed the flat-phase `CONTEXT.md` → user re-interviewed, discuss-milestone re-fired | Worktree State Projection missed a flat-phase artifact path |
+| [#1305](https://github.com/open-gsd/gsd-pi/issues/1305) | Marker-key mismatch → repeated whole-tree re-imports + leaked `.gsd-backups/migrate-*` dirs | migration re-fired; backup rollback reused/deleted dirs |
+| [#1303](https://github.com/open-gsd/gsd-pi/issues/1303) | Re-import rewrote slice `completed_at` to import time | importer round-trip against the wrong layout |
+| [#852](https://github.com/open-gsd/gsd-pi/issues/852) (follow-up) | META-only `milestones/<MID>/` flipped detection to legacy → finalize-retry loop | metadata dir poisoned layout detection |
+
+### Inventory: how widely the layout branch spreads
+
+The layout distinction is not localized. **13 non-test source files** under
+`src/resources/extensions/gsd/` consult `isLegacyMilestonesLayout` /
+`legacyMilestones*` independently (verified at commit `7cca07ae`; see the
+Appendix for the per-file line-level breakdown). Each is an independent site
+that can drift out of agreement with the others — which is exactly the failure
+mode behind #1316 (renderer disagreed with the resolved dir).
+
+## Decision (proposed)
+
+Three options. The recommendation is **A-via-B**: adopt Option B now as a
+mechanical, testable stage 1, and treat Option A as the release-gated stage 2
+that B is a prerequisite for.
+
+### Option A — Complete the migration (end state)
+
+Make the startup migration **mandatory and verified**: on detecting a legacy
+tree, migrate to flat-phase behind a success gate and a backup (reusing
+`flat-phase-migration.ts` machinery), refusing to proceed on a failed/partial
+migration rather than limping on in a mixed state. After N releases in which
+every reachable project has been force-migrated, **delete the legacy branches**
+across the 13 files and drop `parsers-legacy.js` from the hot path, then
+re-enable `detectStaleRendersImpl` behind the e2e fixtures the TODO names.
+
+- **Benefit:** one layout, one code path, detector re-enabled, the entire bug
+  cluster's root cause removed.
+- **Risk: HIGH.** Existing users have on-disk legacy trees. A forced migration
+  cannot be rolled back casually. #1305 is the cautionary tale: its leaked and
+  reused `.gsd-backups/migrate-*` dirs show exactly where a backup/rollback
+  contract goes wrong. Option A **must** specify that contract (see
+  Consequences) before any code.
+
+### Option B — Single detection authority, keep coexistence (stage 1)
+
+Do not delete anything yet. Instead:
+
+1. **Extract ONE shared layout-detection module** that renderer, importer,
+   git-service, doctor, and the auto path all call. `paths.ts` is the natural
+   owner — `isLegacyMilestonesLayout` already lives there; the work is making
+   the other 12 files route through a single entry point instead of each
+   re-deriving from `legacyMilestonesDir` + `existsSync`.
+2. **Move integration-branch META storage OUT of `milestones/<MID>/`** — e.g.
+   to `.gsd/runtime/<MID>-META.json` or another dot-path the detector ignores —
+   so metadata **can never** poison layout detection. This removes the root
+   cause the `paths.ts` mitigation only papers over, and requires a small
+   read-time fallback so existing on-disk META files are still found.
+3. **Re-enable stale-render detection** once detection is single-sourced and
+   the metadata dir is decoupled — the two preconditions the TODO names.
+
+- **Benefit:** kills the poisoning root cause and the multi-site drift, is
+  mechanical and unit-testable, and is a **prerequisite for A anyway** (A's
+  "unify path construction" step is exactly B's step 1).
+- **Risk: LOW–MEDIUM.** Mechanical refactor plus a metadata-location change
+  with a read-time fallback; no forced data migration.
+
+### Option C — Status quo
+
+Keep the coexistence seam and the disabled detector. The bug list above is the
+argument against it: the seam has produced at least five shipped fixes in days,
+and the DB-is-source-of-truth invariant currently ships **without** its
+projection drift detection. "Do nothing" means continuing to pay that tax and
+continuing to fly blind on projection drift. Not recommended.
+
+### Recommendation
+
+**Adopt Option B now; stage Option A behind a maintainer-approved release
+plan.** B is safe, testable, and required by A. A delivers the real end state
+(one code path, detector on) but carries the on-disk-migration risk that needs
+an explicit backup/rollback contract and a release-count decision only a
+maintainer can make.
+
+## Consequences
+
+**Re-enabling `detectStaleRenders` restores the Drift catalog's stale-render
+entry.** Projection drift between the DB and its `.planning/`/`.gsd/` markdown
+becomes visible again and auto-repairable, instead of surfacing only as a
+downstream failure. This is the invariant ADR-017 assumes and ADR-035 scopes.
+
+**The false-positive risk the stub was hiding is real and must be fenced.** The
+TODO's failure mode was: detector fires true on a poisoned layout →
+false stale-render Drift in the second reconcile cycle → `ReconciliationFailedError`
+→ auto-mode blocked (exit 10) for multi-slice and remediation scenarios.
+Re-enable is therefore **gated on**:
+
+- Detection single-sourced (Option B step 1), so the detector and the resolved
+  render target can never disagree.
+- Metadata decoupled from the detection signal (Option B step 2), so a
+  `milestones/<MID>/` created for META never reads as legacy content.
+- **E2e fixtures existing first** for the exact scenarios the TODO names:
+  multi-slice reconcile and remediation reconcile, each asserting zero
+  false-positive stale-render Drift across two reconcile cycles.
+
+**Option A's forced migration needs a rollback/backup contract** — the
+highest-value thing for a reviewer to scrutinize. Learning from #1305:
+
+- Backups must be **uniquely named per attempt** and never reused across a
+  re-fired migration (the #1305 marker-key/backup-reuse defect).
+- A failed migration must roll back to the backup **without deleting a backup
+  that a prior attempt still owns**, and must leave the project in a single,
+  coherent layout — never a half-migrated tree.
+- Leaked `.gsd-backups/migrate-*` dirs must be cleaned on success and
+  detectable on failure.
+
+## Trigger / staging
+
+- **Stage 1 — Option B (mechanical, testable, no maintainer gate beyond
+  approving this ADR).** Single detection authority + relocate git-service META
+  storage + e2e fixtures + re-enable `detectStaleRendersImpl`. Each is
+  separately plannable as a code plan.
+- **Stage 2 — Option A (release-gated).** Mandatory verified migration, then —
+  after the agreed release count — delete the legacy branches across the 13
+  files and drop `parsers-legacy.js` from the hot path.
+
+**Open questions a maintainer must answer before Stage 2:**
+
+1. What is the minimum supported upgrade path — can a user on a pre-v1.4.0
+   legacy tree upgrade directly, or is a stepping-stone release required?
+2. How many releases must the forced migration ship (every project observed
+   migrated) before legacy-branch deletion is safe?
+3. Where does relocated integration-branch META live (`.gsd/runtime/` vs.
+   another dot-path), and what is the read-time fallback window for existing
+   on-disk `milestones/<MID>/<MID>-META.json` files?
+
+## Appendix — Layout-branch inventory (verified at `7cca07ae`)
+
+`grep -rln "isLegacyMilestonesLayout\|legacyMilestones"
+src/resources/extensions/gsd --include="*.ts"` (excluding tests) → **13 files**.
+Each is an independent site that re-derives or acts on the layout distinction:
+
+| File | Line(s) | Decision it drives |
+|---|---|---|
+| `paths.ts` | 598, 621, 649, 659 | **Layout-detection authority** — `isLegacyMilestonesLayout`, the content-bearing/META-only heuristics, `legacyMilestonesDir` |
+| `markdown-renderer.ts` | 179–182, 528–531, 1020, 1216–1217 | **Render target** — which layout to project into; also the disabled `detectStaleRenders` stub (1020) |
+| `md-importer.ts` | 366 | **Import source** — reads legacy dir when importing markdown back to DB |
+| `migrate/transformer.ts` | 426–432 | **Migration transform** — filters legacy milestones carrying phases |
+| `auto.ts` | 3083–3084, 3098 | **Path resolution** — auto-loop resolves legacy base + layout flag |
+| `auto-artifact-paths.ts` | 48–50 | **Path resolution** — worktree `.gsd` vs root anchoring (comment-documented divergence from `legacyMilestonesDir`) |
+| `guided-flow.ts` | 413–415, 2162 | **Path resolution** — prefers legacy milestone dirs when present |
+| `bootstrap/register-hooks.ts` | 865, 911 | **Path resolution** — hook artifact scanning across both layouts |
+| `triage-resolution.ts` | 342 | **Path resolution** — legacy base for triage artifacts |
+| `reopen-reason.ts` | 42 | **Gate** — returns null (skips) when a legacy tree exists |
+| `escalation.ts` | 42 | **Gate** — returns null (skips) when a legacy tree exists |
+| `doctor.ts` | 145–146, 247–248 | **Verification** — health checks probe both `milestonesDir` and `legacyMilestonesDir` |
+| `doctor-state-checks.ts` | 338 | **Verification** — skips a state check unless a legacy dir exists |
+
+Bug-history evidence (`git log --grep`): #1316 (`5b106193`), #1313 (`bef0e8ff`),
+#1305 (`ae3fb966`), #1303 (`92efa014`), #852 (`fd9116e8` + follow-up guards in
+`paths.ts`).

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/cloud-runtime.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
   },
   "dependencies": {
     "ws": "^8.21.0",

--- a/packages/gsd-cloud/src/cloud-config.test.ts
+++ b/packages/gsd-cloud/src/cloud-config.test.ts
@@ -1,10 +1,80 @@
 // Project/App: Open GSD
-// File Purpose: Regression tests for postJsonToValidatedGateway's request
-// timeout — a hung gateway must reject rather than hang the pairing/device flow.
+// File Purpose: Tests for the cloud gateway config module. Two independent suites:
+//   1. SSRF-guard matrix for parseCloudGatewayUrl / validateGatewayNetworkTarget —
+//      loosening any branch (plain-HTTP carve-out, private/loopback IP rejection,
+//      protocol/credential/fragment checks) turns a case red.
+//   2. postJsonToValidatedGateway's request timeout — a hung gateway must reject
+//      rather than hang the pairing/device flow.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createServer, type RequestListener } from "node:http";
-import { postJsonToValidatedGateway } from "./cloud-config.js";
+import {
+  parseCloudGatewayUrl,
+  validateGatewayNetworkTarget,
+  postJsonToValidatedGateway,
+} from "./cloud-config.js";
+
+// Each rejected case pairs an untrusted input with the substring the guard must
+// report — so a message change is deliberate, not accidental.
+const REJECTED: Array<{ input: string; message: RegExp }> = [
+  // Plain HTTP is only allowed for loopback hosts.
+  { input: "http://evil.example", message: /only allowed for localhost/ },
+  // RFC1918 private ranges over HTTPS.
+  { input: "https://10.0.0.1", message: /private or loopback/ },
+  { input: "https://192.168.1.1", message: /private or loopback/ },
+  { input: "https://172.16.0.1", message: /private or loopback/ },
+  // Link-local / cloud metadata endpoint.
+  { input: "https://169.254.169.254", message: /private or loopback/ },
+  // Loopback over HTTPS (IPv4 and IPv6 forms) and the localhost hostname.
+  { input: "https://127.0.0.1", message: /private or loopback/ },
+  { input: "https://[::1]", message: /private or loopback/ },
+  { input: "https://localhost", message: /private or loopback/ },
+  // Non-HTTP protocol.
+  { input: "ftp://gateway.example", message: /must use http or https/ },
+  // Embedded credentials / fragments are rejected outright.
+  { input: "https://user:pass@gateway.example", message: /must not include credentials/ },
+  { input: "https://gateway.example/#frag", message: /must not include a fragment/ },
+  // Unparseable / non-absolute inputs.
+  { input: "", message: /absolute HTTP\(S\) URL/ },
+  { input: "not a url", message: /absolute HTTP\(S\) URL/ },
+];
+
+for (const { input, message } of REJECTED) {
+  test(`parseCloudGatewayUrl rejects ${JSON.stringify(input)}`, () => {
+    assert.throws(() => parseCloudGatewayUrl(input), message);
+  });
+}
+
+// Accepted: a public HTTPS host and the documented local-dev plain-HTTP loopback carve-out.
+const ACCEPTED: Array<{ input: string; hostname: string; protocol: string }> = [
+  { input: "https://cloud-gateway.opengsd.net", hostname: "cloud-gateway.opengsd.net", protocol: "https:" },
+  { input: "http://localhost:8787", hostname: "localhost", protocol: "http:" },
+  { input: "http://127.0.0.1:8787", hostname: "127.0.0.1", protocol: "http:" },
+];
+
+for (const { input, hostname, protocol } of ACCEPTED) {
+  test(`parseCloudGatewayUrl accepts ${JSON.stringify(input)}`, () => {
+    const url = parseCloudGatewayUrl(input);
+    assert.equal(url.hostname, hostname);
+    assert.equal(url.protocol, protocol);
+    // Round-trips to a usable absolute URL for the same host.
+    assert.equal(new URL(url.toString()).hostname, hostname);
+  });
+}
+
+// validateGatewayNetworkTarget is the request-time defense-in-depth guard applied to
+// already-constructed URLs (device code/token endpoints). Cover its branches directly.
+test("validateGatewayNetworkTarget rejects private/loopback targets", () => {
+  assert.throws(() => validateGatewayNetworkTarget(new URL("https://169.254.169.254")), /private or loopback/);
+  assert.throws(() => validateGatewayNetworkTarget(new URL("https://10.0.0.1")), /private or loopback/);
+  assert.throws(() => validateGatewayNetworkTarget(new URL("https://[::1]")), /private or loopback/);
+});
+
+test("validateGatewayNetworkTarget allows a public HTTPS host and http loopback", () => {
+  assert.doesNotThrow(() => validateGatewayNetworkTarget(new URL("https://cloud-gateway.opengsd.net")));
+  assert.doesNotThrow(() => validateGatewayNetworkTarget(new URL("http://localhost:8787")));
+  assert.doesNotThrow(() => validateGatewayNetworkTarget(new URL("http://127.0.0.1:8787")));
+});
 
 // Start a loopback server, returning its base URL; skips the test under sandbox EPERM.
 async function listenLoopback(

--- a/packages/gsd-cloud/src/device-flow.test.ts
+++ b/packages/gsd-cloud/src/device-flow.test.ts
@@ -1,0 +1,187 @@
+// Project/App: Open GSD
+// File Purpose: Drive runDeviceFlow against a loopback HTTP server to cover the RFC 8628
+// poll state machine (pending→approved), the missing-token guard, and re-validation of the
+// UNTRUSTED server-supplied gateway_url (valid wins / invalid falls back without crashing).
+//
+// The denied and expired paths are intentionally NOT tested here: runDeviceFlow calls
+// process.exit(1) on both (D-11/D-12), which an in-process node:test cannot survive.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import { runDeviceFlow } from "./device-flow.js";
+import { parseCloudGatewayUrl } from "./cloud-config.js";
+
+// runDeviceFlow requires a configPath but never reads it (saving is the caller's job),
+// so a constant avoids pointless per-test tmp-dir I/O.
+const CONFIG_PATH = "unused-by-runDeviceFlow.yaml";
+
+/** Returns the JSON body /api/device/token should answer with on POST number `callCount` (1-based). */
+type TokenResponder = (callCount: number) => Record<string, unknown>;
+
+/**
+ * Stand up a loopback HTTP server implementing both device-flow endpoints. Counts token
+ * POSTs so the poll loop's progression can be asserted; `tokenResponder` shapes each reply.
+ */
+function startDeviceServer(tokenResponder: TokenResponder): Promise<{ server: Server; baseUrl: string; tokenCalls: () => number }> {
+  let tokenCalls = 0;
+  const server = createServer((req, res) => {
+    req.setEncoding("utf8");
+    req.on("data", () => { /* body drained; contents are not asserted */ });
+    req.on("end", () => {
+      if (req.url === "/api/device/code") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({
+          userCode: "ABCD-1234",
+          deviceCode: "device-code-fixture",
+          verificationUriComplete: "https://example.test/verify",
+          // Short-lived so the timeout path is bounded if a test ever fails to approve.
+          expiresIn: 30,
+        }));
+        return;
+      }
+      if (req.url === "/api/device/token") {
+        tokenCalls += 1;
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(tokenResponder(tokenCalls)));
+        return;
+      }
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "not found" }));
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address !== "object") {
+        reject(new Error("failed to bind loopback test server"));
+        return;
+      }
+      resolve({ server, baseUrl: `http://127.0.0.1:${address.port}`, tokenCalls: () => tokenCalls });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+}
+
+/** Silence spinner stdout noise and capture stderr so the invalid-URL warning can be asserted. */
+function silenceOutput(): { restore: () => void; stderr: () => string } {
+  const originalOut = process.stdout.write.bind(process.stdout);
+  const originalErr = process.stderr.write.bind(process.stderr);
+  let capturedErr = "";
+  (process.stdout as unknown as { write: typeof process.stdout.write }).write = (() => true) as typeof process.stdout.write;
+  (process.stderr as unknown as { write: typeof process.stderr.write }).write = ((chunk: unknown) => {
+    capturedErr += typeof chunk === "string" ? chunk : String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  return {
+    restore: () => {
+      (process.stdout as unknown as { write: typeof process.stdout.write }).write = originalOut;
+      (process.stderr as unknown as { write: typeof process.stderr.write }).write = originalErr;
+    },
+    stderr: () => capturedErr,
+  };
+}
+
+/** Run the flow against a server, always silencing output and closing the server. */
+async function drive(
+  tokenResponder: TokenResponder,
+  assertResult: (result: Awaited<ReturnType<typeof runDeviceFlow>>, ctx: { baseUrl: string; tokenCalls: () => number; stderr: string }) => void,
+  t: { skip: (msg: string) => void },
+): Promise<void> {
+  let started: { server: Server; baseUrl: string; tokenCalls: () => number };
+  try {
+    started = await startDeviceServer(tokenResponder);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EPERM") {
+      t.skip("loopback listen is blocked in this sandbox");
+      return;
+    }
+    throw err;
+  }
+  const out = silenceOutput();
+  try {
+    const result = await runDeviceFlow({
+      gatewayUrl: started.baseUrl,
+      configPath: CONFIG_PATH,
+      binaryName: "gsd",
+    });
+    out.restore();
+    assertResult(result, { baseUrl: started.baseUrl, tokenCalls: started.tokenCalls, stderr: out.stderr() });
+  } finally {
+    out.restore();
+    await closeServer(started.server);
+  }
+}
+
+test("immediate approval resolves with token, runtimeId, and the passed --gateway", async (t) => {
+  await drive(
+    () => ({ status: "approved", token: "tok", runtimeId: "rt" }),
+    (result, ctx) => {
+      assert.equal(result.deviceToken, "tok");
+      assert.equal(result.runtimeId, "rt");
+      assert.equal(result.gatewayUrl, ctx.baseUrl);
+    },
+    t,
+  );
+});
+
+test("pending then approved keeps polling until approval", async (t) => {
+  await drive(
+    (call) => (call < 2 ? { status: "pending" } : { status: "approved", token: "tok", runtimeId: "rt" }),
+    (result, ctx) => {
+      assert.equal(result.deviceToken, "tok");
+      assert.ok(ctx.tokenCalls() >= 2, `expected >=2 token polls, saw ${ctx.tokenCalls()}`);
+    },
+    t,
+  );
+});
+
+test("a VALID server-supplied gateway_url wins over the passed --gateway", async (t) => {
+  const serverGateway = "https://relay.opengsd.net";
+  await drive(
+    () => ({ status: "approved", token: "tok", runtimeId: "rt", gateway_url: serverGateway }),
+    (result) => {
+      // Mirror the code's own resolution: parse + toString normalization.
+      assert.equal(result.gatewayUrl, parseCloudGatewayUrl(serverGateway).toString());
+    },
+    t,
+  );
+});
+
+test("an INVALID server-supplied gateway_url falls back to --gateway without throwing", async (t) => {
+  await drive(
+    () => ({ status: "approved", token: "tok", runtimeId: "rt", gateway_url: "https://169.254.169.254" }),
+    (result, ctx) => {
+      assert.equal(result.gatewayUrl, ctx.baseUrl);
+      assert.match(ctx.stderr, /ignoring invalid server-supplied relay URL/);
+    },
+    t,
+  );
+});
+
+test("approval missing token/runtimeId rejects", async (t) => {
+  let started: { server: Server; baseUrl: string; tokenCalls: () => number };
+  try {
+    started = await startDeviceServer(() => ({ status: "approved", runtimeId: "rt" }));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EPERM") {
+      t.skip("loopback listen is blocked in this sandbox");
+      return;
+    }
+    throw err;
+  }
+  const out = silenceOutput();
+  try {
+    await assert.rejects(
+      runDeviceFlow({ gatewayUrl: started.baseUrl, configPath: CONFIG_PATH, binaryName: "gsd" }),
+      /missing token or runtimeId/,
+    );
+  } finally {
+    out.restore();
+    await closeServer(started.server);
+  }
+});

--- a/plans/022-gsd-cloud-pairing-ssrf-tests.md
+++ b/plans/022-gsd-cloud-pairing-ssrf-tests.md
@@ -1,0 +1,204 @@
+# Plan 022: Test gsd-cloud's device-flow polling and SSRF gateway guards
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 7cca07ae..HEAD -- packages/gsd-cloud/src/device-flow.ts packages/gsd-cloud/src/cloud-config.ts packages/gsd-cloud/package.json`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW (tests only)
+- **Depends on**: plans/018-ship-gsd-cloud-built-and-tested.md (so these tests actually run in CI); plans/020-cloud-pairing-http-timeouts.md if it landed (it adds a `timeoutMs` param to the helper — harmless here)
+- **Category**: tests
+- **Planned at**: commit `7cca07ae`, 2026-07-07
+
+## Why this matters
+
+`packages/gsd-cloud` is the security boundary for pairing a local machine to
+GSD Cloud, and its two most security-critical modules have zero direct tests:
+
+- `device-flow.ts` implements the full RFC 8628 device-authorization flow — the
+  poll state machine (pending / approved / denied / expired), and the
+  re-validation of the **server-supplied** `gateway_url` (untrusted input that,
+  if accepted unchecked, would let a compromised gateway redirect all future
+  relay traffic). No test in the package references it.
+- `cloud-config.ts` exports the SSRF guards (`parseCloudGatewayUrl`,
+  `validateGatewayNetworkTarget`, and the private `isPrivateIpHost`) that stop
+  a malicious `--gateway` from pointing pairing/token traffic at
+  `169.254.x.x`/`127.0.0.1`/RFC1918 ranges. The package's only test file,
+  `cloud-gateway-lookup.test.ts`, imports **just** `createGatewayLookup`; an
+  accidental loosening of the protocol check or private-IP matching would not
+  fail any test.
+
+The daemon package already tests its equivalent device flow with a loopback
+HTTP server (`packages/daemon/src/device-flow.test.ts`) — this plan brings
+gsd-cloud to parity using the same harness pattern.
+
+## Current state
+
+Files and roles:
+
+- `packages/gsd-cloud/src/device-flow.ts` — `runDeviceFlow(params)`. Key facts from reading it:
+  - Requests `/api/device/code`, expects `{ userCode, deviceCode, verificationUriComplete, expiresIn }`; throws if `userCode`/`deviceCode` missing.
+  - Polls `/api/device/token` with `{ deviceCode }`; poll-loop network errors are swallowed and retried until expiry.
+  - On `status === "approved"`: requires `token` + `runtimeId` (throws if missing); if the response carries `gateway_url`, it is re-validated via `parseCloudGatewayUrl` + `validateGatewayNetworkTarget` — an INVALID value warns to stderr and falls back to the caller's `params.gatewayUrl`; a VALID value replaces it. Returns `{ deviceToken, runtimeId, gatewayUrl }`.
+  - On `status === "denied"` and on expiry it clears the spinner and (per the doc comment) **calls `process.exit(1)`** — read the tail of the file (past line 140) to confirm exact behavior before writing those cases.
+  - Writes spinner frames to `process.stdout` on a 100ms interval during polling.
+- `packages/gsd-cloud/src/cloud-config.ts` — `parseCloudGatewayUrl` (line ~35: rejects plain-HTTP for non-localhost, rejects HTTPS private/loopback IP hosts), `isPrivateIpHost` (line ~113, not exported), `validateGatewayNetworkTarget` (line ~121), `exchangePairingCode` (line ~19), `postJsonToValidatedGateway` (line ~198).
+- `packages/gsd-cloud/src/cloud-gateway-lookup.test.ts` — the package's assertion style (node:test, `assert/strict`, `// Project/App:` two-line header).
+- `packages/daemon/src/device-flow.test.ts` — THE harness to copy. Its `startDeviceServer` helper stands up a loopback `node:http` server implementing `/api/device/code` and `/api/device/token`, parameterized by what `gateway_url` the token response carries. First ~35 lines:
+
+```ts
+// Device-flow gateway_url resolution tests: server-valid-wins, absent-falls-back,
+// invalid-falls-back-no-throw. Drives runDeviceFlow against a local loopback HTTP server.
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+...
+function startDeviceServer(gatewayCase: GatewayCase): Promise<{ server: Server; baseUrl: string }> {
+  const server = createServer((req, res) => {
+    ...
+      if (req.url === "/api/device/code") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({
+          userCode: "ABCD-1234",
+          deviceCode: "device-code-fixture",
+          verificationUriComplete: "https://example.test/verify?code=ABCD-1234",
+          expiresIn: 600,
+```
+
+- `packages/gsd-cloud/package.json` — `test` script lists compiled test files explicitly; new files must be appended:
+
+```json
+"test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-runtime.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
+```
+
+Conventions: double quotes, semicolons, `// Project/App:` + `// File Purpose:`
+two-line headers on new files, `node:test` + `assert/strict`. IMPORTANT: the
+SSRF guard permits plain HTTP only for localhost, so loopback `http://127.0.0.1:<port>`
+test servers are valid targets (this is exactly how the daemon tests work).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build + run package tests | `pnpm --filter @opengsd/gsd-cloud run test` | exit 0, all pass |
+| Run one compiled test file | `pnpm --filter @opengsd/gsd-cloud run build && node --test packages/gsd-cloud/dist/device-flow.test.js` | all pass |
+
+## Scope
+
+**In scope**:
+
+- `packages/gsd-cloud/src/device-flow.test.ts` (create)
+- `packages/gsd-cloud/src/cloud-config.test.ts` (create — if plan 020 already created it, extend it)
+- `packages/gsd-cloud/package.json` (append the two compiled test files to the `test` script)
+
+**Out of scope**:
+
+- Any production source change in `device-flow.ts` / `cloud-config.ts`. If a behavior looks wrong while testing, STOP and report — do not "fix" production code in a test plan. Exception: if `process.exit(1)` on denial/expiry makes those paths untestable in-process, note it in the report; do NOT refactor to injectable exit in this plan.
+- `packages/daemon/**` — its flow is already tested.
+- `cloud-token.ts` — worth testing later; kept out to keep this plan bounded (recorded in `plans/README.md`).
+
+## Git workflow
+
+- Branch: `advisor/022-gsd-cloud-pairing-ssrf-tests`
+- Conventional Commit, e.g. `test(gsd-cloud): cover device-flow polling and SSRF gateway guards`
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: SSRF-guard unit tests (`cloud-config.test.ts`)
+
+Create `packages/gsd-cloud/src/cloud-config.test.ts` with a table-driven matrix
+over `parseCloudGatewayUrl` (and `validateGatewayNetworkTarget` where a URL
+parses but the target must be rejected). First READ `cloud-config.ts` lines
+35–130 to confirm which function rejects which case, then assert at minimum:
+
+Rejected (assert `throws`, and match the error message the code actually uses):
+- `http://evil.example` (plain HTTP, non-localhost)
+- `https://10.0.0.1`, `https://192.168.1.1`, `https://172.16.0.1` (RFC1918)
+- `https://169.254.169.254` (link-local / cloud metadata)
+- `https://127.0.0.1`, `https://[::1]` (loopback over HTTPS)
+- `ftp://gateway.example` or similar non-HTTP protocol
+- empty string / garbage (`"not a url"`)
+
+Accepted (assert no throw, and the returned `URL` round-trips):
+- `https://cloud-gateway.opengsd.net`
+- `http://localhost:8787` and `http://127.0.0.1:8787` (the documented local-dev carve-out — confirm the exact allowed forms from the code first)
+
+`isPrivateIpHost` is unexported — cover it through the public functions; do not
+export it just for tests (this package has no `_xxxForTest` seam convention yet,
+and the public surface reaches every branch via the matrix above).
+
+**Verify**: `pnpm --filter @opengsd/gsd-cloud run build && node --test packages/gsd-cloud/dist/cloud-config.test.js` → all pass.
+
+### Step 2: Device-flow tests (`device-flow.test.ts`)
+
+Create `packages/gsd-cloud/src/device-flow.test.ts`, porting the
+`startDeviceServer` harness from `packages/daemon/src/device-flow.test.ts`
+(adapt imports/params to gsd-cloud's `runDeviceFlow` signature — read
+`DeviceFlowParams` first; it includes `gatewayUrl` and `binaryName` and
+optional `runtimeName`). To keep tests fast, have `/api/device/code` return a
+small `expiresIn` (e.g. 5) — the poll interval constant is
+`DEFAULT_POLL_INTERVAL_MS`; read its value first and, if it makes tests slow
+(>2s), have the token endpoint approve on the first poll.
+
+Cases:
+
+1. **Immediate approval**: token endpoint returns `{ status: "approved", token: "tok", runtimeId: "rt" }` → resolves with `{ deviceToken: "tok", runtimeId: "rt", gatewayUrl: <params.gatewayUrl> }`.
+2. **Pending then approved**: first token call returns `{ status: "pending" }` (or whatever non-approved status the code treats as continue — read the loop), second returns approved → resolves; assert the server saw ≥2 token POSTs.
+3. **Server-supplied VALID `gateway_url` wins**: approved response carries `gateway_url: "https://relay.opengsd.net"` → result `gatewayUrl` equals that value (normalized via `parseCloudGatewayUrl(...).toString()` — mirror the daemon test's expectation style).
+4. **Server-supplied INVALID `gateway_url` falls back**: approved response carries `gateway_url: "https://169.254.169.254"` → result `gatewayUrl` equals `params.gatewayUrl`, and the run does not throw (the code warns on stderr and continues).
+5. **Approval response missing token/runtimeId throws**: approved status with no `token` → rejects with `/missing token or runtimeId/`.
+
+Do NOT test the denied/expired paths if they call `process.exit(1)` (confirmed
+by reading the file tail) — an in-process `node:test` cannot survive that.
+Instead add a comment in the test file noting the exclusion and why.
+
+Silence spinner noise if it pollutes test output: the spinner writes via
+`process.stdout` `cursorTo`/`clearLine` — if that breaks in a non-TTY test
+environment, that is a STOP condition (report it as a real bug: device flow
+assumed a TTY), not something to patch around.
+
+**Verify**: `node --test packages/gsd-cloud/dist/device-flow.test.js` (after build) → all 5 pass in < 30s.
+
+### Step 3: Wire the new files into the package test script
+
+Append `dist/cloud-config.test.js dist/device-flow.test.js` to the `test`
+script's file list in `packages/gsd-cloud/package.json`.
+
+**Verify**: `pnpm --filter @opengsd/gsd-cloud run test` → exit 0; output shows tests from BOTH new files plus the 5 pre-existing files.
+
+## Test plan
+
+This plan IS the test plan: ~11+ new tests across two files. Pattern files:
+`packages/daemon/src/device-flow.test.ts` (harness),
+`packages/gsd-cloud/src/cloud-gateway-lookup.test.ts` (style).
+
+## Done criteria
+
+- [ ] `packages/gsd-cloud/src/cloud-config.test.ts` exists; SSRF matrix covers ≥6 rejected + ≥2 accepted URLs
+- [ ] `packages/gsd-cloud/src/device-flow.test.ts` exists; the 5 cases above pass
+- [ ] `pnpm --filter @opengsd/gsd-cloud run test` → exit 0 and runs both new files
+- [ ] No production source files modified (`git status`)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- Any test reveals a real behavioral bug (e.g. an invalid server `gateway_url` is accepted, a private IP passes the guard, the spinner crashes in non-TTY) — report the bug with the failing test; do not change production code.
+- `runDeviceFlow`'s signature or the endpoint paths differ from Current state.
+- The poll loop cannot be made to complete in <30s per test without production changes.
+
+## Maintenance notes
+
+- When plan 018 lands, these tests run on every CI push — they are the regression net for the pairing security boundary.
+- Follow-ups deferred and recorded in the index: `cloud-token.ts` tests; making denial/expiry testable via an injectable exit seam (would need a maintainer decision on adding a `ForTest` seam to this package); daemon `orchestrator-agent.ts`/`cloud-cli.ts` coverage.
+- Reviewer: check the SSRF matrix against `cloud-config.ts`'s actual branches — the value of this suite is that loosening ANY branch turns a test red.

--- a/plans/README.md
+++ b/plans/README.md
@@ -38,7 +38,7 @@ commit `58dc840f`. Plans 018–024 planned against commit `7cca07ae`.
 | 019 | Refuse token-less web mode on non-loopback hosts | P1 | S | — | DONE |
 | 020 | Add request timeouts to cloud pairing HTTP helper (both copies) | P1 | S | — | DONE |
 | 021 | Batch plan-v2 graph compile + skip unchanged writes (dispatch hot path) | P2 | S | — | DONE |
-| 022 | Test gsd-cloud device-flow polling and SSRF gateway guards | P2 | M | 018 | TODO |
+| 022 | Test gsd-cloud device-flow polling and SSRF gateway guards | P2 | M | 018 | DONE |
 | 023 | ADR: decide the flat-phase layout migration completion path | P2 | M | — | TODO |
 | 024 | Dependency & dead-code hygiene (hono, daemon SDK, ajv, chart.tsx) | P2 | S | — | TODO |
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -39,7 +39,7 @@ commit `58dc840f`. Plans 018–024 planned against commit `7cca07ae`.
 | 020 | Add request timeouts to cloud pairing HTTP helper (both copies) | P1 | S | — | DONE |
 | 021 | Batch plan-v2 graph compile + skip unchanged writes (dispatch hot path) | P2 | S | — | DONE |
 | 022 | Test gsd-cloud device-flow polling and SSRF gateway guards | P2 | M | 018 | DONE |
-| 023 | ADR: decide the flat-phase layout migration completion path | P2 | M | — | TODO |
+| 023 | ADR: decide the flat-phase layout migration completion path | P2 | M | — | DONE |
 | 024 | Dependency & dead-code hygiene (hono, daemon SDK, ajv, chart.tsx) | P2 | S | — | TODO |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`


### PR DESCRIPTION
## What

Adds the first direct tests for `packages/gsd-cloud`'s two most security-critical, previously-untested modules in the device-pairing boundary. **Tests only — no production source changed.**

### `cloud-config.test.ts` — SSRF guard matrix
Table-driven coverage of `parseCloudGatewayUrl` and `validateGatewayNetworkTarget`:
- **13 rejected:** plain-HTTP non-localhost, RFC1918 (`10/8`, `192.168/16`, `172.16/12`), `169.254` link-local/metadata, HTTPS loopback (`127.0.0.1`, `[::1]`, `localhost`), non-HTTP protocol, embedded credentials, fragment, empty/garbage.
- **3 accepted:** public HTTPS host, `http://localhost`, `http://127.0.0.1` (the documented local-dev carve-out).

The point of the matrix: loosening **any** guard branch turns a case red. `isPrivateIpHost` stays unexported and is covered through the public surface (this package has no `ForTest` seam convention).

### `device-flow.test.ts` — RFC 8628 poll state machine
Ports the loopback-HTTP harness from `packages/daemon/src/device-flow.test.ts` to drive `runDeviceFlow` through five cases:
1. Immediate approval → resolves with token/runtimeId and the passed `--gateway`.
2. Pending → approved (asserts ≥2 token polls).
3. A **valid** server-supplied `gateway_url` wins over `--gateway`.
4. An **invalid** server-supplied `gateway_url` (private IP) falls back to `--gateway` without throwing (asserts the stderr warning) — the untrusted-input re-validation path.
5. Approval missing `token`/`runtimeId` rejects.

The `denied`/`expired` paths call `process.exit(1)` and are deliberately not tested (an in-process `node:test` cannot survive that); the exclusion is documented in the file header.

## Why

`gsd-cloud` is the security boundary for pairing a local machine to GSD Cloud, and these two modules had **zero** direct tests. An accidental loosening of the protocol check, the private-IP matching, or the server-`gateway_url` re-validation would previously have failed no test. This suite is the regression net for that boundary.

## Notes

- Both compiled files are wired into the package `test` script.
- Device-flow tests use real timers — each pays `runDeviceFlow`'s fixed 5s pre-poll sleep (~30s for the file). There's no injectable timer seam and adding one is out of scope; mocking timers would break the global stdout/stderr capture the invalid-URL assertion relies on.

## Verification

`pnpm --filter @opengsd/gsd-cloud run test` → exit 0, **40 pass / 0 fail** (both new files included).

Follow-ups deferred (tracked in `plans/README.md` / plan 022): `cloud-token.ts` tests, and an injectable-exit seam to make the denied/expired paths testable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production changes to pairing or layout code; new tests only exercise existing SSRF and device-flow behavior. ADR and plan index updates are non-runtime.
> 
> **Overview**
> Adds **tests-only** coverage for the GSD Cloud pairing boundary in `@opengsd/gsd-cloud`, and registers both compiled suites in the package **`test`** script so CI runs them with the existing cloud tests.
> 
> **`cloud-config.test.ts`** exercises `parseCloudGatewayUrl` and `validateGatewayNetworkTarget` with a table-driven matrix (rejected private/loopback/metadata URLs, non-HTTP, credentials, fragments; accepted public HTTPS and loopback HTTP).
> 
> **`device-flow.test.ts`** drives `runDeviceFlow` against a loopback HTTP server (daemon-style harness): immediate and pending→approved polling, trusted vs untrusted server `gateway_url` resolution, and missing token/runtimeId rejection; denied/expired paths stay untested because they call `process.exit(1)`.
> 
> The same diff also lands **plan 022** and marks it DONE in **`plans/README.md`**, plus **ADR-045** (proposed flat-phase layout migration completion — documentation only, no extension code changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c37e44a0949ba163c2823bf5ed908f2a076d5e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->