### PR TITLE
docs(adr): propose flat-phase layout completion path (ADR-045)

### DIFF
--- a/docs/dev/ADR-045-flat-phase-layout-completion.md
+++ b/docs/dev/ADR-045-flat-phase-layout-completion.md
@@ -1,0 +1,251 @@
+<!-- Project/App: gsd-pi -->
+<!-- File Purpose: ADR (proposed) for completing the flat-phase projection layout migration — records why the legacy/flat coexistence seam is the top recurring bug source, proposes single-sourced layout detection (Option B) as stage 1 toward a forced migration (Option A), and specifies the re-enable path for the disabled stale-render drift detector. -->
+
+# ADR-045: Flat-Phase Layout Migration Completion
+
+**Status:** Proposed — maintainer decision required before any code follows
+**Date:** 2026-07-07
+**Author:** GSD architecture review
+**Related:** ADR-017 (state reconciliation, drift-driven), ADR-035 (projection dirty scope), `CONTEXT.md` Drift / Drift catalog / Worktree State Projection terms, and issues [#852](https://github.com/open-gsd/gsd-pi/issues/852), [#1303](https://github.com/open-gsd/gsd-pi/issues/1303), [#1305](https://github.com/open-gsd/gsd-pi/issues/1305), [#1313](https://github.com/open-gsd/gsd-pi/issues/1313), [#1316](https://github.com/open-gsd/gsd-pi/issues/1316)
+
+## Context
+
+The v1.4.0 "flat-phase" projection layout migration is still half-finished at
+v1.8.1. Two on-disk projection layouts coexist:
+
+- **Legacy:** `milestones/<MID>/…` (and nested `slices/<SID>/…`).
+- **Flat-phase:** `phases/NN-slug/NN-CONTEXT.md`, `NN-ROADMAP.md`, etc.
+
+The DB remains the single source of truth; both trees are projections of it
+(ADR-017). The problem is not the two layouts — it is *how the code decides
+which layout a project is in*, and the fact that that decision is neither
+single-sourced nor reliable.
+
+### The coexistence contract today
+
+**1. One-time startup migration.** `flat-phase-migration.ts` runs on startup
+"when the legacy structure is detected" and moves content from `milestones/…`
+into `phases/…`. It is best-effort and non-mandatory: a project can run
+indefinitely in the legacy layout, and a project can end up *partially*
+migrated (some content moved, some not) if the migration is interrupted or the
+detection misfires.
+
+**2. Runtime filesystem-sniffed detection.** There is no persisted layout flag.
+Every consumer re-derives the layout at runtime by looking at the disk. The
+authority is `isLegacyMilestonesLayout(basePath)` in `paths.ts:659`, which
+delegates to `legacyMilestonesHasSubdirs` (`paths.ts:598`): the project is
+"legacy" iff `milestones/` exists and contains at least one *content-bearing*
+subdirectory (`dirIsContentBearingLegacyMilestone`, `paths.ts:621`).
+
+**3. The metadata-dir poisoning — and its partial mitigation.**
+`git-service.ts` stores each milestone's integration-branch metadata at
+`milestones/<MID>/<MID>-META.json` (`milestoneMetaPath`, `git-service.ts:392`)
+and creates that directory with `mkdirSync(join(gsdRoot(basePath),
+"milestones", milestoneId), { recursive: true })` (`git-service.ts:454`) —
+**even in flat-phase projects.** Naively, that `milestones/<MID>/` directory
+would flip `isLegacyMilestonesLayout` to `true` and route artifact resolution
+to the wrong path (`milestones/<MID>/<MID>-CONTEXT.md` instead of
+`phases/NN-slug/NN-CONTEXT.md`), trapping units in a finalize-retry loop
+(the #852 follow-up).
+
+A **partial mitigation already exists** in `paths.ts` and the ADR must be read
+against the *current* state, not the pre-mitigation one:
+
+- `dirIsContentBearingLegacyMilestone` (`paths.ts:621`) now excludes
+  `*-META.json`-only directories (a `milestones/<MID>/` holding only metadata
+  no longer counts as legacy content), and also excludes *empty* scaffolding
+  subdirectories (e.g. an empty `slices/` created alongside the META file).
+- `dirIsMetaOnlyLegacyMilestone` (`paths.ts:649`) lets
+  `resolveProjectMilestonePath` skip META-only dirs during path resolution.
+
+This mitigation reduces the poisoning but does not remove its root cause: the
+integration-branch metadata still lives *inside* the `milestones/<MID>/` tree
+whose presence is the layout-detection signal. Detection therefore remains a
+heuristic sniff of a directory that a second, unrelated subsystem writes into.
+
+**4. The drift alarm is switched off.** The architecture's core projection
+drift detector, `detectStaleRenders` in `markdown-renderer.ts:1020`, is
+hard-wired to `return []`. Its own TODO explains why (verbatim):
+
+```ts
+export function detectStaleRenders(basePath: string): StaleEntry[] {
+  // TODO(flat-phase): stale-render detection is temporarily fully disabled.
+  // The isLegacyMilestonesLayout gate is unreliable: git-service.ts creates
+  // milestones/<mid>/ directories for integration-branch metadata even in
+  // flat-phase projects, making the gate fire true and then producing false
+  // stale-render drift in the second reconcile cycle → ReconciliationFailedError
+  // → auto-mode blocked (exit 10) for multi-slice/remediation e2e scenarios.
+  // Re-enable after path construction is unified and the metadata dir is
+  // decoupled from the layout-detection signal.
+  return [];
+}
+```
+
+The real implementation survives as `detectStaleRendersImpl`
+(`markdown-renderer.ts:1032`) but is never called from the reconcile path. Per
+the Drift catalog, stale-render is a known-repairable Drift class; with the
+detector stubbed, **projection drift between the DB and the `.planning/`/`.gsd/`
+markdown is invisible** until a downstream failure surfaces it.
+
+### The bug cluster this seam produces
+
+The legacy/flat coexistence seam is the single largest recurring bug source in
+recent history. Shipped fixes traceable to it, all within days of this ADR:
+
+| Issue | Symptom | Seam mechanism |
+|---|---|---|
+| [#1316](https://github.com/open-gsd/gsd-pi/issues/1316) | `renderAssessmentFromDb` wrote a flat-phase filename into a legacy `slices/<SID>/` dir → reassess-roadmap verification broke | render target chose wrong layout |
+| [#1313](https://github.com/open-gsd/gsd-pi/issues/1313) | Worktree sync missed the flat-phase `CONTEXT.md` → user re-interviewed, discuss-milestone re-fired | Worktree State Projection missed a flat-phase artifact path |
+| [#1305](https://github.com/open-gsd/gsd-pi/issues/1305) | Marker-key mismatch → repeated whole-tree re-imports + leaked `.gsd-backups/migrate-*` dirs | migration re-fired; backup rollback reused/deleted dirs |
+| [#1303](https://github.com/open-gsd/gsd-pi/issues/1303) | Re-import rewrote slice `completed_at` to import time | importer round-trip against the wrong layout |
+| [#852](https://github.com/open-gsd/gsd-pi/issues/852) (follow-up) | META-only `milestones/<MID>/` flipped detection to legacy → finalize-retry loop | metadata dir poisoned layout detection |
+
+### Inventory: how widely the layout branch spreads
+
+The layout distinction is not localized. **13 non-test source files** under
+`src/resources/extensions/gsd/` consult `isLegacyMilestonesLayout` /
+`legacyMilestones*` independently (verified at commit `7cca07ae`; see the
+Appendix for the per-file line-level breakdown). Each is an independent site
+that can drift out of agreement with the others — which is exactly the failure
+mode behind #1316 (renderer disagreed with the resolved dir).
+
+## Decision (proposed)
+
+Three options. The recommendation is **A-via-B**: adopt Option B now as a
+mechanical, testable stage 1, and treat Option A as the release-gated stage 2
+that B is a prerequisite for.
+
+### Option A — Complete the migration (end state)
+
+Make the startup migration **mandatory and verified**: on detecting a legacy
+tree, migrate to flat-phase behind a success gate and a backup (reusing
+`flat-phase-migration.ts` machinery), refusing to proceed on a failed/partial
+migration rather than limping on in a mixed state. After N releases in which
+every reachable project has been force-migrated, **delete the legacy branches**
+across the 13 files and drop `parsers-legacy.js` from the hot path, then
+re-enable `detectStaleRendersImpl` behind the e2e fixtures the TODO names.
+
+- **Benefit:** one layout, one code path, detector re-enabled, the entire bug
+  cluster's root cause removed.
+- **Risk: HIGH.** Existing users have on-disk legacy trees. A forced migration
+  cannot be rolled back casually. #1305 is the cautionary tale: its leaked and
+  reused `.gsd-backups/migrate-*` dirs show exactly where a backup/rollback
+  contract goes wrong. Option A **must** specify that contract (see
+  Consequences) before any code.
+
+### Option B — Single detection authority, keep coexistence (stage 1)
+
+Do not delete anything yet. Instead:
+
+1. **Extract ONE shared layout-detection module** that renderer, importer,
+   git-service, doctor, and the auto path all call. `paths.ts` is the natural
+   owner — `isLegacyMilestonesLayout` already lives there; the work is making
+   the other 12 files route through a single entry point instead of each
+   re-deriving from `legacyMilestonesDir` + `existsSync`.
+2. **Move integration-branch META storage OUT of `milestones/<MID>/`** — e.g.
+   to `.gsd/runtime/<MID>-META.json` or another dot-path the detector ignores —
+   so metadata **can never** poison layout detection. This removes the root
+   cause the `paths.ts` mitigation only papers over, and requires a small
+   read-time fallback so existing on-disk META files are still found.
+3. **Re-enable stale-render detection** once detection is single-sourced and
+   the metadata dir is decoupled — the two preconditions the TODO names.
+
+- **Benefit:** kills the poisoning root cause and the multi-site drift, is
+  mechanical and unit-testable, and is a **prerequisite for A anyway** (A's
+  "unify path construction" step is exactly B's step 1).
+- **Risk: LOW–MEDIUM.** Mechanical refactor plus a metadata-location change
+  with a read-time fallback; no forced data migration.
+
+### Option C — Status quo
+
+Keep the coexistence seam and the disabled detector. The bug list above is the
+argument against it: the seam has produced at least five shipped fixes in days,
+and the DB-is-source-of-truth invariant currently ships **without** its
+projection drift detection. "Do nothing" means continuing to pay that tax and
+continuing to fly blind on projection drift. Not recommended.
+
+### Recommendation
+
+**Adopt Option B now; stage Option A behind a maintainer-approved release
+plan.** B is safe, testable, and required by A. A delivers the real end state
+(one code path, detector on) but carries the on-disk-migration risk that needs
+an explicit backup/rollback contract and a release-count decision only a
+maintainer can make.
+
+## Consequences
+
+**Re-enabling `detectStaleRenders` restores the Drift catalog's stale-render
+entry.** Projection drift between the DB and its `.planning/`/`.gsd/` markdown
+becomes visible again and auto-repairable, instead of surfacing only as a
+downstream failure. This is the invariant ADR-017 assumes and ADR-035 scopes.
+
+**The false-positive risk the stub was hiding is real and must be fenced.** The
+TODO's failure mode was: detector fires true on a poisoned layout →
+false stale-render Drift in the second reconcile cycle → `ReconciliationFailedError`
+→ auto-mode blocked (exit 10) for multi-slice and remediation scenarios.
+Re-enable is therefore **gated on**:
+
+- Detection single-sourced (Option B step 1), so the detector and the resolved
+  render target can never disagree.
+- Metadata decoupled from the detection signal (Option B step 2), so a
+  `milestones/<MID>/` created for META never reads as legacy content.
+- **E2e fixtures existing first** for the exact scenarios the TODO names:
+  multi-slice reconcile and remediation reconcile, each asserting zero
+  false-positive stale-render Drift across two reconcile cycles.
+
+**Option A's forced migration needs a rollback/backup contract** — the
+highest-value thing for a reviewer to scrutinize. Learning from #1305:
+
+- Backups must be **uniquely named per attempt** and never reused across a
+  re-fired migration (the #1305 marker-key/backup-reuse defect).
+- A failed migration must roll back to the backup **without deleting a backup
+  that a prior attempt still owns**, and must leave the project in a single,
+  coherent layout — never a half-migrated tree.
+- Leaked `.gsd-backups/migrate-*` dirs must be cleaned on success and
+  detectable on failure.
+
+## Trigger / staging
+
+- **Stage 1 — Option B (mechanical, testable, no maintainer gate beyond
+  approving this ADR).** Single detection authority + relocate git-service META
+  storage + e2e fixtures + re-enable `detectStaleRendersImpl`. Each is
+  separately plannable as a code plan.
+- **Stage 2 — Option A (release-gated).** Mandatory verified migration, then —
+  after the agreed release count — delete the legacy branches across the 13
+  files and drop `parsers-legacy.js` from the hot path.
+
+**Open questions a maintainer must answer before Stage 2:**
+
+1. What is the minimum supported upgrade path — can a user on a pre-v1.4.0
+   legacy tree upgrade directly, or is a stepping-stone release required?
+2. How many releases must the forced migration ship (every project observed
+   migrated) before legacy-branch deletion is safe?
+3. Where does relocated integration-branch META live (`.gsd/runtime/` vs.
+   another dot-path), and what is the read-time fallback window for existing
+   on-disk `milestones/<MID>/<MID>-META.json` files?
+
+## Appendix — Layout-branch inventory (verified at `7cca07ae`)
+
+`grep -rln "isLegacyMilestonesLayout\|legacyMilestones"
+src/resources/extensions/gsd --include="*.ts"` (excluding tests) → **13 files**.
+Each is an independent site that re-derives or acts on the layout distinction:
+
+| File | Line(s) | Decision it drives |
+|---|---|---|
+| `paths.ts` | 598, 621, 649, 659 | **Layout-detection authority** — `isLegacyMilestonesLayout`, the content-bearing/META-only heuristics, `legacyMilestonesDir` |
+| `markdown-renderer.ts` | 179–182, 528–531, 1020, 1216–1217 | **Render target** — which layout to project into; also the disabled `detectStaleRenders` stub (1020) |
+| `md-importer.ts` | 366 | **Import source** — reads legacy dir when importing markdown back to DB |
+| `migrate/transformer.ts` | 426–432 | **Migration transform** — filters legacy milestones carrying phases |
+| `auto.ts` | 3083–3084, 3098 | **Path resolution** — auto-loop resolves legacy base + layout flag |
+| `auto-artifact-paths.ts` | 48–50 | **Path resolution** — worktree `.gsd` vs root anchoring (comment-documented divergence from `legacyMilestonesDir`) |
+| `guided-flow.ts` | 413–415, 2162 | **Path resolution** — prefers legacy milestone dirs when present |
+| `bootstrap/register-hooks.ts` | 865, 911 | **Path resolution** — hook artifact scanning across both layouts |
+| `triage-resolution.ts` | 342 | **Path resolution** — legacy base for triage artifacts |
+| `reopen-reason.ts` | 42 | **Gate** — returns null (skips) when a legacy tree exists |
+| `escalation.ts` | 42 | **Gate** — returns null (skips) when a legacy tree exists |
+| `doctor.ts` | 145–146, 247–248 | **Verification** — health checks probe both `milestonesDir` and `legacyMilestonesDir` |
+| `doctor-state-checks.ts` | 338 | **Verification** — skips a state check unless a legacy dir exists |
+
+Bug-history evidence (`git log --grep`): #1316 (`5b106193`), #1313 (`bef0e8ff`),
+#1305 (`ae3fb966`), #1303 (`92efa014`), #852 (`fd9116e8` + follow-up guards in
+`paths.ts`).

--- a/plans/README.md
+++ b/plans/README.md
@@ -7,7 +7,14 @@ order below unless dependencies say otherwise. Each executor: read the plan full
 before starting, honor its STOP conditions, and update your row when done.
 
 Plans 001–008 planned against commit `2c63ab9d`. Plans 009–017 planned against
-commit `58dc840f`.
+commit `58dc840f`. Plans 018–024 added 2026-07-07 from a deep re-audit (8
+category agents over the 548 commits / 573 files changed since `58dc840f`,
+findings lead-verified against HEAD `7cca07ae`); that session ran
+non-interactively, so the top findings by leverage were planned by default.
+Executors ran 018–022 the same day on per-plan `advisor/*` branches (unmerged;
+018→019→020 are stacked). NOTE: plan files 018/023/024 were restored after the
+originals — untracked in this shared checkout — were lost during executor
+branch switches; commit new plan files promptly to avoid a repeat.
 
 ## Execution order & status
 
@@ -30,7 +37,14 @@ commit `58dc840f`.
 | 015 | Bound the Discord message-batcher buffer | P2 | S | — | DONE |
 | 016 | Override undici (via discord.js) & protobufjs to patched versions | P2 | S | — | DONE |
 | 017 | Doc & DX quick fixes (ADR pointer, dev env-vars, fast-test path) | P3 | S | — | DONE |
-| 022 | Test gsd-cloud device-flow polling & SSRF gateway guards | P2 | M | 018 | DONE |
+| 018 | Ship @opengsd/gsd-cloud built, tested, and guarded against empty publishes | P0 | M | — | DONE (branch `advisor/018-…`, unmerged) |
+| 019 | Refuse token-less web mode on non-loopback hosts | P1 | S | — | DONE (branch `advisor/019-…`, stacked on 018, unmerged) |
+| 020 | Add request timeouts to cloud pairing HTTP helper (both copies) | P1 | S | — | DONE (branch `advisor/020-…`, stacked on 019, unmerged) |
+| 021 | Batch plan-v2 graph compile + skip unchanged writes (dispatch hot path) | P2 | S | — | DONE (branch `advisor/021-…`, unmerged) |
+| 022 | Test gsd-cloud device-flow polling & SSRF gateway guards | P2 | M | 018 | DONE (branch `advisor/022-…`, unmerged) |
+| 023 | ADR: decide the flat-phase layout migration completion path | P2 | M | — | DONE (branch `advisor/023-…`, ADR-045, unmerged) |
+| 024 | Dependency & dead-code hygiene (hono, daemon SDK, ajv, chart.tsx) | P2 | S | — | TODO |
+| 025 | Parallel-monitor/eligibility DB hygiene (executed ad hoc from the unplanned list; no plan file) | P3 | S | — | DONE (branch `advisor/025-…`, unmerged) |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`
 (2026-07-01). Notable deviations recorded in the plan files: 009 skipped the
@@ -42,6 +56,10 @@ previously-orphaned `message-batcher.test.js` into the daemon test script.
 - **008 depends on 001, 002, 003** because extracting the auto-loop phase modules will move the orchestrator's Worktree Safety call, the dispatch-history rehydration contract, and the session-timeout counter handling. Landing those behavior changes first avoids merge conflicts and makes the extraction diff smaller and safer.
 - **004, 005, 006, 007 are independent** of each other and of 008, but should be completed before 008 if they touch `auto/phases.ts` or the orchestrator (005 source-grep tests do not; 006 tests `unit-closeout.ts`; 007 touches `packages/mcp-server`).
 - **009–017 are all independent** of each other and of 001–008. Recommended order is by priority then leverage: security first (009, 010), then the correctness fixes that prevent silent data loss (011, 012, 013), then perf (014, 015), then the dependency pin (016) and docs (017). 011 and 015 both touch the daemon but different files (`cloud-runtime.ts` vs `message-batcher.ts`) — no conflict.
+- **022 depends on 018** (its tests only run in CI once 018 wires the cloud packages' test scripts in). Both are done on branches; merge 018 (or the 018→019→020 stack) before or with 022.
+- **Merging the 2026-07-07 branches**: `advisor/020` contains 018+019+020 (stacked); `advisor/021`, `advisor/022`, `advisor/025` are independent of the stack. 021 and 025 both touch gsd-extension query paths but different files.
+- **023 is document-only** (ADR). The migration code work it proposes is NOT planned yet — it needs maintainer approval of the ADR first (CONTRIBUTING requires an RFC/ADR for this territory).
+- **024 touches `packages/daemon/package.json`** (SDK bump) — land after the 018-stack merges to avoid manifest conflicts.
 
 ## Findings surviving verification but NOT planned this round
 
@@ -56,6 +74,36 @@ larger/looser scope, or already partly mitigated. Recorded so they aren't lost.
 - **Dashboard polls `/api/visualizer` every 30s without change detection** (`web/components/gsd/dashboard.tsx:144`): a 10s server-side cache already blunts the subprocess cost; adding ETag/`304` is a clean follow-up, not urgent.
 - **Three doc systems drift** (`docs/`, `gitbook/`, `mintlify-docs/`): `docs/user-docs/` is canonical (most active); gitbook/mintlify may be stale. Auditing and consolidating is an L-effort docs initiative.
 - **Two near-identical RPC client copies** (`packages/rpc-client` vs `packages/gsd-agent-modes/src/modes/rpc`): genuine duplication (it caused the 1000-vs-5000ms shutdown drift plan 012 fixes at both sites). De-duping is worthwhile but a deliberate refactor — surface to maintainers before doing it, given VISION's "no cosmetic refactors" rule.
+
+### From the 2026-07-07 deep audit (verified at `7cca07ae`)
+
+- **Discord orchestrator messages run concurrently against shared history** (`packages/daemon/src/daemon.ts:104` `void this.orchestrator.handleMessage(...)`; `orchestrator-agent.ts` `run()` mutates `this.history` unserialized): two near-simultaneous owner messages can interleave pushes and produce a non-alternating history the Anthropic API rejects (400). Fix is a per-agent promise-chain queue — S effort; plan when Discord control sees real concurrent use.
+- **Daemon session-manager `Promise.race` timers never cleared** (`packages/daemon/src/session-manager.ts:471` `timeout()` has no `clearTimeout`/`.unref()`): two orphaned 30s timers per successful session start keep the event loop alive and delay clean exit. S fix (return the handle, clear in `finally`).
+- **Run-manager directory names collide at second resolution** (`src/resources/extensions/gsd/run-manager.ts:52` `makeTimestamp` strips ms; `mkdirSync(recursive)` + unconditional writes at `:87–104`): two runs of the same definition within one second silently overwrite each other's DEFINITION/GRAPH/PARAMS. S fix (ms or random suffix, or non-recursive mkdir + retry on EEXIST).
+- **`json-persistence.ts` leaves `.tmp.<hex>` litter when rename fails** (`saveJsonFile`/`saveJsonFileCompact`/`writeJsonFileAtomic` swallow errors without unlinking the temp; sibling `atomic-write.ts:118,149` does clean up): S consistency fix.
+- **`atomic-write.ts` renames without fsync** — rename protects against torn files, not data loss on power failure; the doc comment overstates the guarantee. Callers are best-effort ledgers, so this is an investigate/soften-the-comment item, not a blanket fsync.
+- **Gateway auth is O(N_tokens × scrypt) per request** (`packages/cloud-mcp-gateway/src/auth-store.ts:208` `findSecretEntry` runs scrypt per stored record on every `/mcp` request and WS upgrade): CPU-DoS lever that grows with the device-token set. Fine at today's single-user scale; index by HMAC-of-secret for O(1) lookup before multi-user/team use (pairs with the team-sharing direction item).
+- **gsd-cloud device-token at-rest key derives from hostname+username+homedir** (`packages/gsd-cloud/src/cloud-token.ts:31–37`): device-binding obfuscation, not secret storage — anyone who can read the config on-host can decrypt. Document honestly; prefer OS keychain where available; rotate any token from a synced/committed config.
+- **Local SQLite reconcile interpolates paths/table names into SQL** (`db/writers/reconcile.ts:112,119`, `db-schema-metadata.ts:13`): internal-only inputs today (latent, not reachable); bind the ATTACH path and allowlist table names when next touching that code.
+- **Parallel-orchestration I/O leftovers** (siblings of plans 021/025 — 025 already fixed the monitor's double connection and the eligibility N+1): `parallel-orchestrator.ts:992+1004` reads/parses every session-status file twice per refresh; worker status files are atomically rewritten per `message_end`/`notify` event (`:820`, `:839`) even when unchanged. Both S.
+- **Daemon `orchestrator-agent.ts`/`orchestrator-tools.ts`/`cloud-cli.ts`/`cloud-token.ts` untested** (changed this window, no matching tests); **pi-ai `tool-result-content.ts` + Bedrock provider changes** need a coverage check (possibly covered transitively). Follow `packages/daemon/src/orchestrator.test.ts` / `device-flow.test.ts` patterns.
+- **zod dual-major** (daemon+web on v3; root/mcp-server/gateway on v4 — both bundled, AI-SDK peers double-instantiated) and **typebox dual-package** (`@sinclair/typebox@0.34` in 44 main-src files vs `typebox@1.x` in the vendored pi packages — same library, incompatible types, both shipped): each is an M migration needing a spike + fixture-gated typecheck pass; surface to maintainers first (VISION bans churn without measurable value; the typebox seam-crossing is the strongest argument).
+- **highlight.js 10.7.3** (2021-era, renders untrusted tool output) → bump to ^11 after verifying registered language aliases; **workspace version-range drift** (ws/typescript/@types/node/chalk floors differ) → consider a pnpm catalog; **`better-sqlite3` fallback provider is undeclared** — it try-requires gracefully (verified), so by-design-adjacent; an `optionalDependencies` entry would make the fallback real for users who don't already have it.
+- **Hermes CI has no lint/type gate and only tests Python 3.12** despite a 3.10 floor (`integrations/hermes/pyproject.toml:11` vs `.github/workflows/hermes-integration.yml:65–76`): add ruff (+3.10 matrix leg) — S.
+- **`build:core` compiles `@opengsd/contracts` three times** (build:core → build:contracts; build:pi → build:contracts; build:pi-coding-agent → build:contracts) and `hermes-integration.yml` rebuilds core without reusing `ci.yml` artifacts: S dedupe / M artifact sharing.
+- **Repo-root `screenshot-context-breakdown.jpg`** is git-tracked but NOT published (root `files` allowlist excludes it — verified). Repo-cleanliness only.
+
+## Direction options (2026-07-07 — maintainer decisions, not ranked against bugs)
+
+Grounded in repo evidence; a selected one becomes a design/spike plan, not a
+build-everything plan. Effort estimates are coarse.
+
+1. **Finish the flat-phase migration** — plan 023 writes the ADR (the drift alarm `detectStaleRenders` is still hard-disabled at 1.8.1 while the seam shipped #1303/#1305/#1313/#1316 within six days).
+2. **Team sharing + RBAC for GSD Cloud — build or formally defer**: promised twice in the product brief; zero backing code (`auth-store.ts`/`runtime-registry.ts` model single-user only; grep for team/org/rbac/tenant across gateway+gsd-cloud → 0 non-test hits). Multi-machine is delivered; multi-user is absent. A record-schema + gateway-ownership-seam ADR is the cheap first step. L (coarse).
+3. **Linux systemd service packaging for the daemon**: the brief requires macOS AND Linux service install; only `launchd.ts` exists (`packages/daemon/src/cli.ts` wires install/uninstall/status exclusively to launchd). A `systemd.ts` mirroring the launchd trio + a platform switch is a bounded M.
+4. **Bidirectional GitHub sync**: `github-sync` is export-only (all ops are `ghCreate*/ghClose*/ghAddComment`; zero inbound reads). Spike a read-only `github-sync import` preview (issues → milestone/task mapping) to surface the DB-single-writer conflict questions first. M–L (coarse).
+5. **Productize the repo's own triage/PR-risk automation as an extension**: `scripts/{ai-triage-policy,issue-dedupe,pr-risk-check,issue-lifecycle}.mjs` (~950 proven lines) solve friction every gsd user with a GitHub repo has; extension host + `gh` wrapper already exist. Spike: wrap `pr-risk-check.mjs` behind a `/pr-risk` command. M (coarse).
+6. **Implement (or cut) the stubbed Codex/Claude cloud executors**: `packages/gsd-cloud/src/executors/{codex,claude}-executor.ts` throw "not yet implemented" while the `Executor` seam, registry, README docs, and a full reference impl (`gsd-pi-executor.ts`) all exist — `GSD_CLOUD_EXECUTOR=codex` currently only throws. One adapter spike validates the tool-exposure/result-mapping contract. M per adapter (coarse).
 
 ## Findings considered and rejected
 
@@ -72,4 +120,15 @@ larger/looser scope, or already partly mitigated. Recorded so they aren't lost.
 - **Detached GitHub milestone sync unawaited**: labeled "best-effort detached sync" and covered by `recovery-finalize-logs.test.ts`; by design. Rejected.
 - **Pre-merge-check shell-injection**: the tokenizer feeds `execFileSync(binary, args)` with no `shell:true`, so shell metacharacters are inert. Rejected.
 - **Per-message WebSocket auth / Hono CORS / Hono path-traversal advisories**: the gateway uses raw `http.createServer` (no Hono CORS/serve-static middleware reachable), and the WS connection is bearer-authenticated at connect over WSS; the specific exploit paths are unreachable. Rejected (undici DoS via discord.js is real and IS planned — see 016).
-- **Stale-render detection tests skipped / flat-phase migration "incomplete"**: `detectStaleRenders` is intentionally disabled during the shipping v1.4.0 flat-phase migration (documented design), not an accidental coverage hole. Tracked as direction (finish the migration), not a bug.
+- **Stale-render detection tests skipped / flat-phase migration "incomplete"**: `detectStaleRenders` is intentionally disabled during the shipping v1.4.0 flat-phase migration (documented design), not an accidental coverage hole. Tracked as direction (finish the migration), not a bug. *2026-07-07 update: still disabled three minor versions later with fresh bug fallout — escalated to plan 023 (ADR).*
+
+### Rejected in the 2026-07-07 deep audit
+
+- **"32 source files branch on legacy layout"**: over-counted — the verified grep (non-test, `isLegacyMilestonesLayout|legacyMilestones`) finds **13** files. Still material; correct count recorded in plan 023.
+- **"`better-sqlite3` branch will throw at runtime"**: false — `db-provider.ts` try-requires and degrades with an actionable stderr message. Downgraded to an `optionalDependencies` suggestion (see unplanned list).
+- **hono advisories as a reachable security finding**: the gateway uses raw `node:http`; no hono middleware executes. The override is planned in 024 as hygiene, not as a vulnerability fix.
+- **gsd-cloud "ws+zod only" manifest drift**: it ships `ws`+`yaml` (no zod) — cosmetic mismatch with the design note, no leakage; not a finding.
+- **Studio Electron lag**: `studio/` is private/0.0.0 and outside the pnpm workspace; Electron 41 + React 19 are current. Not a finding.
+- **worktree-cli split and migrate-command split (#1314) leaving orphaned logic**: both verified clean — typed delegation, single importer chains, no duplicated copies.
+- **Hermes tests not in CI**: false — `hermes-integration.yml:76` runs pytest on hermes-touching pushes. (The missing lint/type gate IS recorded, above.)
+- **`@modelcontextprotocol/sdk`, Next 16, React 19, Playwright, discord.js 14, Electron 41, Rust crates**: all current lines, no EOL exposure. No action.


### PR DESCRIPTION
## What

Adds **ADR-045** — a proposed decision document for finishing the half-done v1.4.0 flat-phase projection layout migration (still at v1.8.1). Document-only; no source changes.

Plan: `plans/023-flat-phase-layout-adr.md`.

## Why

The legacy/flat coexistence seam is the single largest recurring bug source in recent history — #1316, #1313, #1305, #1303, and the #852 follow-up all trace to it, shipped within days of each other. The core projection drift detector (`detectStaleRenders`) is hard-wired to `return []` because of this seam, so the DB-is-source-of-truth invariant currently ships without its drift detection. `CONTRIBUTING.md` requires an ADR/RFC before code in this territory — this is that ADR.

## Recommendation

**A-via-B**: adopt Option B (single layout-detection authority + relocate git-service integration-branch META out of `milestones/<MID>/` + re-enable `detectStaleRendersImpl` behind e2e fixtures) as the mechanical stage 1, then stage Option A's forced verified migration + legacy-branch deletion behind a maintainer-approved release plan, with the #1305-informed backup/rollback contract as the reviewer's highest-value scrutiny point.

## Verification (document-only)

- Every `file:line` citation cross-checked against HEAD via `sed -n` (`paths.ts:598/621/649/659`, `git-service.ts:392/454`, `markdown-renderer.ts:1020/1032`).
- 13-file layout-branch inventory appendix, one row per grep hit (baseline verified at `7cca07ae`).
- No `.ts` files modified.
- `plans/README.md` status row updated to DONE.

## Notes

- Stacked on `advisor/022` (PR #1327) — retarget to `main` once that merges.
- Follow-up code work (Option B extraction, e2e fixtures, detector re-enable, Option A migration) is intentionally NOT planned here — it needs maintainer approval of the ADR first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and planning index updates only; no application code, migrations, or detector behavior changes in this PR.
> 
> **Overview**
> Adds **ADR-045** (proposed) documenting why the legacy vs flat-phase projection layout seam keeps causing bugs and how to finish the migration **without changing runtime code**.
> 
> The ADR frames today’s failure modes: filesystem-sniffed layout detection spread across **13** extension files, `git-service` META dirs under `milestones/<MID>/` poisoning detection (partially mitigated in `paths.ts`), and **`detectStaleRenders` stubbed to `return []`** so stale-render drift is invisible. It recommends **Option B first** (single detection authority, relocate META out of `milestones/`, re-enable detection behind e2e gates), then **Option A** (mandatory verified migration and legacy branch removal) with an explicit backup/rollback contract informed by #1305.
> 
> **`plans/README.md`** is expanded for the 2026-07-07 deep audit: plans **018–025** (status, branch notes, dependencies), a long **unplanned findings** backlog, **direction options** for maintainers (flat-phase ADR is item 1), and corrected/rejected audit claims (e.g. **13** layout-branch files, not 32). Plan **023** is marked DONE as document-only; follow-on implementation waits on ADR approval per CONTRIBUTING.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48fe9807da76c24eb660a880f88347eb091a2169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->