### PR TITLE
fix(issue): [Bug]: Interrupted web_search turn persists an orphaned server_tool_use → 400 "without a corresponding web_search_tool_result block" on replay

### DIFF
--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -1094,6 +1094,20 @@ function convertMessages(
 			}
 		} else if (msg.role === "assistant") {
 			const blocks: ContentBlockParam[] = [];
+			const pairedServerToolUseIds = new Set<string>();
+			const followingWebSearchResultIds = new Set<string>();
+
+			for (let j = msg.content.length - 1; j >= 0; j--) {
+				const block = msg.content[j];
+				if (block.type === "serverToolUse") {
+					if (followingWebSearchResultIds.has(block.id)) {
+						pairedServerToolUseIds.add(block.id);
+					}
+				} else if (block.type === "webSearchResult") {
+					followingWebSearchResultIds.add(block.toolUseId);
+				}
+			}
+			const emittedServerToolUseIds = new Set<string>();
 
 			for (const block of msg.content) {
 				if (block.type === "text") {
@@ -1135,6 +1149,8 @@ function convertMessages(
 						input: block.arguments ?? {},
 					});
 				} else if (block.type === "serverToolUse") {
+					if (!pairedServerToolUseIds.has(block.id)) continue;
+					emittedServerToolUseIds.add(block.id);
 					blocks.push({
 						type: "server_tool_use",
 						id: block.id,
@@ -1143,6 +1159,7 @@ function convertMessages(
 						...(block.caller ? { caller: block.caller } : {}),
 					} as ContentBlockParam);
 				} else if (block.type === "webSearchResult") {
+					if (!emittedServerToolUseIds.has(block.toolUseId)) continue;
 					blocks.push({
 						type: "web_search_tool_result",
 						tool_use_id: block.toolUseId,

--- a/packages/pi-ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/pi-ai/test/anthropic-sse-parsing.test.ts
@@ -440,4 +440,81 @@ describe("Anthropic raw SSE parsing", () => {
 			],
 		});
 	});
+
+	it("drops unpaired native web search blocks from assistant history", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const webSearchContent = [
+			{
+				type: "web_search_result",
+				title: "Example",
+				url: "https://example.com",
+				encrypted_content: "encrypted-result",
+			},
+		];
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: "Search the web.",
+					timestamp: Date.now(),
+				},
+				{
+					role: "assistant",
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					content: [
+						{ type: "text", text: "Starting search." },
+						{ type: "serverToolUse", id: "srv_orphan", name: "web_search", input: { query: "orphaned" } },
+						{ type: "webSearchResult", toolUseId: "srv_stray", content: webSearchContent },
+						{ type: "webSearchResult", toolUseId: "srv_out_of_order", content: webSearchContent },
+						{ type: "serverToolUse", id: "srv_out_of_order", name: "web_search", input: { query: "late" } },
+						{ type: "serverToolUse", id: "srv_paired", name: "web_search", input: { query: "gsd" } },
+						{ type: "webSearchResult", toolUseId: "srv_paired", content: webSearchContent },
+						{ type: "text", text: "Found one result." },
+					],
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: Date.now(),
+				},
+				{
+					role: "user",
+					content: "Continue.",
+					timestamp: Date.now(),
+				},
+			],
+		};
+		const capture: { params?: any } = {};
+		const stream = streamAnthropic(model, context, {
+			client: createCapturingAnthropicClient(createSseResponse(minimalAnthropicEvents), capture),
+		});
+
+		await stream.result();
+
+		expect(capture.params.messages[1]).toEqual({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Starting search." },
+				{
+					type: "server_tool_use",
+					id: "srv_paired",
+					name: "web_search",
+					input: { query: "gsd" },
+				},
+				{
+					type: "web_search_tool_result",
+					tool_use_id: "srv_paired",
+					content: webSearchContent,
+				},
+				{ type: "text", text: "Found one result." },
+			],
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Fixed Anthropic native web search history replay by dropping unpaired blocks and added a focused regression test; whitespace verification passed while vitest was blocked by missing dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1330
- [#1330 [Bug]: Interrupted web_search turn persists an orphaned server_tool_use → 400 "without a corresponding web_search_tool_result block" on replay](https://github.com/open-gsd/gsd-pi/issues/1330)

## User
- @mirogers-jha

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1330-bug-interrupted-web-search-turn-persists-1783449249`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Anthropic message conversion for native web search replay; paired blocks behave as before, with a focused test.
> 
> **Overview**
> Fixes **Anthropic 400 errors** when continuing a chat after an interrupted native `web_search` turn left orphaned `server_tool_use` / `web_search_tool_result` blocks in persisted assistant history.
> 
> `convertMessages` now **pre-scans** assistant content (back-to-front) to find `serverToolUse` IDs that have a matching `webSearchResult` later in the array, then **omits** unpaired blocks when building API params. Stray results without an emitted `server_tool_use` are skipped as well. A regression test asserts only the correctly paired blocks are replayed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3385413f1d6d46d1142ac5a5c0960cd15d95c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->