### PR TITLE
fix(gsd-db): refuse newer-schema DBs, harden version detection, close DB before migration restore

### DIFF
--- a/gitbook/reference/troubleshooting.md
+++ b/gitbook/reference/troubleshooting.md
@@ -36,6 +36,32 @@ gsd --version
 
 If the old package was installed with `sudo npm install -g`, use `sudo npm uninstall -g gsd-pi` first. pnpm can only remove packages that pnpm installed.
 
+### Startup refuses a newer database schema
+
+GSD exits before startup with an error like:
+
+```text
+gsd.db schema is v30, newer than the v29 this gsd-pi supports. Update gsd-pi (npm i -g @opengsd/gsd-pi) before opening this project.
+```
+
+The version numbers may differ. This means `.gsd/gsd.db` was already opened or migrated by a newer `gsd-pi` binary, and the running binary is too old to safely read or write that database.
+
+**Fix:** Upgrade the `gsd` binary that will open this project, then retry from the project root:
+
+```bash
+npm install -g @opengsd/gsd-pi@latest
+gsd --version
+```
+
+If you use pnpm globals, run:
+
+```bash
+pnpm add -g @opengsd/gsd-pi@latest
+gsd --version
+```
+
+Do not delete `.gsd/gsd.db` to bypass this refusal. If `gsd --version` still shows an old version, check `command -v gsd` for a stale global install or PATH shadowing, then remove the old install as described above.
+
 ### pnpm global bin directory is not in PATH
 
 pnpm global commands fail with `The configured global bin directory ... is not in PATH`.

--- a/mintlify-docs/guides/troubleshooting.mdx
+++ b/mintlify-docs/guides/troubleshooting.mdx
@@ -46,6 +46,32 @@ This check is not auto-fixable. `/gsd doctor fix` will not rewrite either side b
     If the old package was installed with `sudo npm install -g`, use `sudo npm uninstall -g gsd-pi` first. pnpm can only remove packages that pnpm installed.
   </Accordion>
 
+  <Accordion title="Startup refuses a newer database schema">
+    **Symptoms:** GSD exits before startup with an error like:
+
+    ```text
+    gsd.db schema is v30, newer than the v29 this gsd-pi supports. Update gsd-pi (npm i -g @opengsd/gsd-pi) before opening this project.
+    ```
+
+    The version numbers may differ. This means `.gsd/gsd.db` was already opened or migrated by a newer `gsd-pi` binary, and the running binary is too old to safely read or write that database.
+
+    **Fix:** Upgrade the `gsd` binary that will open this project, then retry from the project root:
+
+    ```bash
+    npm install -g @opengsd/gsd-pi@latest
+    gsd --version
+    ```
+
+    If you use pnpm globals, run:
+
+    ```bash
+    pnpm add -g @opengsd/gsd-pi@latest
+    gsd --version
+    ```
+
+    Do not delete `.gsd/gsd.db` to bypass this refusal. If `gsd --version` still shows an old version, check `command -v gsd` for a stale global install or PATH shadowing, then remove the old install as described above.
+  </Accordion>
+
   <Accordion title="pnpm global bin directory is not in PATH">
     **Cause:** pnpm refuses global package operations until its configured global bin directory is available in your shell.
 

--- a/plans/026-schema-version-and-migration-safety.md
+++ b/plans/026-schema-version-and-migration-safety.md
@@ -1,0 +1,377 @@
+# Plan 026: Refuse newer-schema DBs, harden version detection, and close the DB before migration restore
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat f095797f..HEAD -- src/resources/extensions/gsd/db/engine.ts src/resources/extensions/gsd/db-schema-metadata.ts src/resources/extensions/gsd/migrate/execution.ts src/resources/extensions/gsd/workflow-migration.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: LOW–MED
+- **Depends on**: none
+- **Category**: bug + migration + tests
+- **Planned at**: commit `f095797f`, 2026-07-07
+
+## Why this matters
+
+The SQLite DB at `.gsd/gsd.db` is the single source of truth for the GSD
+workflow engine (markdown under `.planning/`/`.gsd/` is projection-only). The
+schema-migration machinery has three verified gaps that can corrupt or
+split-brain that authoritative store:
+
+1. **No "DB newer than this binary" guard.** `migrateSchema` returns early when
+   `currentVersion >= SCHEMA_VERSION` and the caller proceeds to read/write. An
+   older gsd-pi (a stale global install, a not-yet-updated worktree, a
+   background observer process) that opens a DB already migrated by a newer
+   binary silently operates on a schema it does not understand. Multi-version
+   coexistence is real in this codebase: sibling git worktrees share the same
+   DB file (see `tests/worktree-db-same-file.test.ts`).
+2. **Version-detection edge cases.** `getCurrentSchemaVersion` reads
+   `MAX(version)` — on an empty `schema_version` table SQLite returns a row
+   whose value is `NULL`, so the function returns `null` coerced as `number`,
+   not `0`. Separately, `initSchema` treats *any* DB with an empty
+   `schema_version` table as a fresh install and stamps it `SCHEMA_VERSION`
+   (29) without running a single migration — if a legacy DB with real data but
+   no version rows ever reaches this path, it is permanently mis-stamped as
+   fully migrated and later throws "no such column" at first query.
+3. **Migration restore swaps the DB file under a live connection.** In
+   `executeMigrationWrite`, the import transaction commits to the target
+   `gsd.db`; if a *later* step (verification/readiness/audit) throws, the catch
+   calls `restoreMigrationTarget`, which `rmSync`s the whole `.gsd/` dir and
+   copies the backup back — with no `closeWorkflowDatabase()` first. The
+   process (and the workspace connection cache) still holds a handle to the
+   deleted inode: subsequent reads see the stale migrated data and the first
+   write fails with `SQLITE_READONLY_DBMOVED`.
+
+Finally, the single most important upgrade guarantee — that a mid-migration
+failure rolls back to the original schema version — has **no test**: the
+BEGIN/COMMIT/ROLLBACK wrapper in `migrateSchema` is never driven through a
+failing step, and the `needsAutoMigration`/`validateMigration` gates in
+`workflow-migration.ts` have zero test references.
+
+## Current state
+
+Files and roles:
+
+- `src/resources/extensions/gsd/db/engine.ts` — DB open, pragmas, base schema,
+  `migrateSchema` runner. `SCHEMA_VERSION = 29` at line 96.
+- `src/resources/extensions/gsd/db-schema-metadata.ts` — `getCurrentSchemaVersion`,
+  `recordSchemaVersion`, `ensureColumn`.
+- `src/resources/extensions/gsd/migrate/execution.ts` — `executeMigrationWrite`
+  (the `.planning → .gsd` migration write pipeline).
+- `src/resources/extensions/gsd/migrate/safety.ts` — `prepareMigrationTarget` /
+  `restoreMigrationTarget`; already imports `closeWorkflowDatabase` from
+  `../db-workspace.js` (line 10) and calls it at line 158.
+- `src/resources/extensions/gsd/workflow-migration.ts` — `needsAutoMigration`
+  (line 20), `validateMigration` (line 254).
+
+Excerpt — `db/engine.ts` (~line 186), the early return with no `>` branch:
+
+```ts
+function migrateSchema(db: DbAdapter, dbPath: string | null): void {
+  const currentVersion = getCurrentSchemaVersion(db);
+  if (currentVersion >= SCHEMA_VERSION) return;
+
+  backupDatabaseBeforeMigration(db, dbPath, currentVersion, { ... });
+
+  db.exec("BEGIN");
+  try {
+    if (currentVersion < 2) {
+      applyMigrationV2Artifacts(db);
+      recordSchemaVersion(db, 2);
+```
+
+Excerpt — `db/engine.ts` `initSchema` (~lines 109–132), the fresh-stamp path:
+
+```ts
+    const existing = db.prepare("SELECT count(*) as cnt FROM schema_version").get();
+    if (existing && (existing["cnt"] as number) === 0) {
+      createCoordinationTablesV24(db);
+      createRuntimeKvTableV25(db);
+      // ... index creation ...
+      recordSchemaVersion(db, SCHEMA_VERSION);
+    }
+```
+
+Excerpt — `db-schema-metadata.ts:21-24`, the `MAX(version)`-is-NULL quirk:
+
+```ts
+export function getCurrentSchemaVersion(db: DbAdapter): number {
+  const row = db.prepare("SELECT MAX(version) as v FROM schema_version").get();
+  return row ? (row["v"] as number) : 0;
+}
+```
+
+Excerpt — `migrate/execution.ts:98-131`, the restore-under-open-handle path:
+
+```ts
+  const backup = prepareMigrationTarget(targetRoot);
+  try {
+    const written = await writeGSDDirectory(project, targetRoot);
+    const legacyArchive = await archiveLegacyPlanningDirectory(sourcePath, targetRoot);
+    const imported = await importWrittenMigrationToDb(targetRoot, preview);   // COMMITS to target gsd.db
+    const verification = await verifyMigrationProjection(targetRoot, preview);
+    verification.dbReadiness = await assertMigrationDbReadiness(targetRoot, preview);
+    const audit = await writeMigrationAudit({ ... });
+    return { backup, written, imported, legacyArchive, verification, audit };
+  } catch (error) {
+    restoreMigrationTarget(backup);   // rmSync + cpSync with NO DB close
+    throw error;
+  }
+```
+
+Conventions to match:
+
+- Two-line file-purpose headers on new files; 2-space indent; single quotes in
+  `src/resources/extensions/gsd/*.ts` (match the file you edit).
+- Test-only seams are exported with an underscore prefix and `ForTest` suffix —
+  exemplar: `_isLikelyWslDrvFsPathForTest` already exists in `db/engine.ts`
+  (used at line ~98).
+- Errors at startup gates print remediation and fail loudly; empty catches
+  carry an intent comment.
+- Tests: `node:test`, in `src/resources/extensions/gsd/tests/*.test.ts`,
+  compiled to `dist-test/` before running.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Typecheck | `pnpm run typecheck:extensions` | exit 0 |
+| Compile tests | `pnpm run test:compile` | exit 0 |
+| Run one test file | `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/<name>.test.js` | all pass |
+| Targeted existing suites | run `db-engine-logs`, `db-migration-steps`, `db-migration-steps.integration`, `gsd-db`, `migrate-safety-audit` (if present), `flat-phase-migration` test files via the single-file command | all pass |
+
+Do NOT run the full `pnpm run test:unit` on every edit — it is slow and known
+to flake under process-isolation contention. Run affected files standalone;
+run the full suite once at the end if you want a final sweep, and re-check any
+failure standalone before attributing it to your change.
+
+## Scope
+
+**In scope** (the only files you should modify):
+- `src/resources/extensions/gsd/db/engine.ts`
+- `src/resources/extensions/gsd/db-schema-metadata.ts`
+- `src/resources/extensions/gsd/migrate/execution.ts`
+- `src/resources/extensions/gsd/tests/db-engine-migrate-guards.test.ts` (create)
+- `src/resources/extensions/gsd/tests/workflow-migration-gates.test.ts` (create)
+- `plans/README.md` (status row only)
+
+**Out of scope** (do NOT touch, even though they look related):
+- `src/resources/extensions/gsd/flat-phase-migration.ts` and the legacy/flat
+  layout seam — governed by ADR-045 (`docs/dev/ADR-045-flat-phase-layout-completion.md`), maintainer decision pending.
+- `src/resources/extensions/gsd/db-migration-steps.ts` — the individual
+  migration steps are correct; do not restructure them.
+- `db-provider.ts` / provider fallback packaging.
+- Any change to `SCHEMA_VERSION` itself.
+
+## Git workflow
+
+- Branch: `advisor/026-schema-version-and-migration-safety`
+- Conventional commits, one per step, e.g. `fix(gsd-db): refuse to open a newer-schema gsd.db`. Do not credit AI in commit messages.
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Harden `getCurrentSchemaVersion` against the empty-table NULL
+
+In `db-schema-metadata.ts`, make the function return `0` when the table is
+empty or the value is not a number:
+
+```ts
+export function getCurrentSchemaVersion(db: DbAdapter): number {
+  const row = db.prepare("SELECT MAX(version) as v FROM schema_version").get();
+  const v = row?.["v"];
+  return typeof v === "number" ? v : 0;
+}
+```
+
+**Verify**: `pnpm run typecheck:extensions` → exit 0.
+
+### Step 2: Add the newer-DB refusal in `migrateSchema`
+
+In `db/engine.ts`, immediately after `const currentVersion = getCurrentSchemaVersion(db);`,
+add:
+
+```ts
+  if (currentVersion > SCHEMA_VERSION) {
+    throw new Error(
+      `gsd.db schema is v${currentVersion}, newer than the v${SCHEMA_VERSION} this gsd-pi supports. ` +
+      `Update gsd-pi (npm i -g @opengsd/gsd-pi) before opening this project.`,
+    );
+  }
+  if (currentVersion === SCHEMA_VERSION) return;
+```
+
+(replacing the current `>=` early return). Check how `migrateSchema`'s caller
+handles a throw: the open path must fail loudly with this message rather than
+swallowing it — if you find a catch that downgrades it to a warning and
+continues with the connection open, extend that catch to close the connection
+and rethrow for this specific error. Match `engine.ts`'s existing error/log
+style.
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/db-engine-migrate-guards.test.js` — write the test in step 5 first if you prefer test-first; otherwise re-run this verify after step 5.
+
+### Step 3: Guard the fresh-install stamp against non-empty databases
+
+First, investigate reachability: `git log --oneline --follow -- src/resources/extensions/gsd/db/engine.ts | tail -5`
+and `git log -S 'schema_version' --oneline -- src/resources/extensions/gsd | tail -5`
+to see whether `schema_version` has existed since the engine's first commit.
+
+- If it has always existed, the "legacy DB without version rows" path is
+  defensive only — implement the cheap guard below anyway (it also covers an
+  externally truncated version table), but say so in the commit message.
+
+In `initSchema`, before stamping `SCHEMA_VERSION` on `cnt === 0`, probe for
+pre-existing user data:
+
+```ts
+    const existing = db.prepare("SELECT count(*) as cnt FROM schema_version").get();
+    if (existing && (existing["cnt"] as number) === 0) {
+      const hasData = ["milestones", "decisions", "memories"].some((t) => {
+        try {
+          const r = db.prepare(`SELECT count(*) as cnt FROM ${t}`).get();
+          return ((r?.["cnt"] as number) ?? 0) > 0;
+        } catch { /* table absent on a truly fresh DB — treat as no data */ return false; }
+      });
+      if (hasData) {
+        // Legacy DB with data but no version row: record the baseline so
+        // migrateSchema runs the full chain instead of stamping v29.
+        recordSchemaVersion(db, 1);
+      } else {
+        // ... existing fresh-install block unchanged ...
+      }
+    }
+```
+
+The three table names above are literals chosen here, not caller input — no
+interpolation concern. Keep the existing fresh block exactly as is in the
+`else`.
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/gsd-db.test.js` → all pass (fresh-DB creation still works).
+
+### Step 4: Close the workflow DB before (and after) migration restore
+
+In `migrate/execution.ts`, import `closeWorkflowDatabase` from
+`../db-workspace.js` (same import `migrate/safety.ts` uses at line 10), and
+change the catch:
+
+```ts
+  } catch (error) {
+    // The import transaction may have committed and the process may hold an
+    // open handle to the target gsd.db; close before the restore replaces the
+    // file on disk, and leave closed so the next open rebinds to the restored file.
+    try { closeWorkflowDatabase(); } catch { /* best-effort: restore must proceed */ }
+    restoreMigrationTarget(backup);
+    throw error;
+  }
+```
+
+**Verify**: `pnpm run typecheck:extensions` → exit 0, then run the existing
+migrate tests: `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/migrate-writer.test.js dist-test/src/resources/extensions/gsd/tests/migrate-transformer.test.js` (adjust to the actual migrate test filenames present in `dist-test/`) → all pass.
+
+### Step 5: Add a migration rollback/atomicity test (with a `ForTest` fault seam)
+
+In `db/engine.ts`, add a module-level fault seam following the existing
+underscore-`ForTest` convention:
+
+```ts
+let _migrationFaultForTest: boolean = false;
+/** Test-only: force migrateSchema to throw after applying its steps but before COMMIT. */
+export function _setMigrationFaultForTest(v: boolean): void { _migrationFaultForTest = v; }
+```
+
+Inside `migrateSchema`'s `try`, immediately before `db.exec("COMMIT")`, add:
+
+```ts
+    if (_migrationFaultForTest) throw new Error("migration fault injected for test");
+```
+
+Create `tests/db-engine-migrate-guards.test.ts` (model structure after
+`tests/db-migration-steps.integration.test.ts`) covering:
+
+1. **Newer-DB refusal**: open a fresh DB, then manually
+   `recordSchemaVersion(db, SCHEMA_VERSION + 1)` (or raw INSERT), close, reopen
+   → expect the open to throw with a message containing "newer than".
+2. **Rollback atomicity**: build a DB at an older schema version (reuse however
+   `db-migration-steps.integration.test.ts` constructs old-version fixtures),
+   call `_setMigrationFaultForTest(true)`, attempt the open/migration → expect
+   a throw; then verify `SELECT MAX(version) FROM schema_version` still equals
+   the starting version and a table/column introduced by a later migration is
+   absent. Reset the seam in `finally`.
+3. **Legacy-data guard**: create a DB, insert one `milestones` row, delete all
+   `schema_version` rows, reopen → expect the DB to be treated as version 1
+   (migrations run; final version is `SCHEMA_VERSION`) rather than stamped
+   without migrating — assert via a column that only a migration adds
+   (pick one from `db-migration-steps.ts`, e.g. an `ensureColumn` target).
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/db-engine-migrate-guards.test.js` → all new tests pass.
+
+### Step 6: Cover the auto-migration gates
+
+Create `tests/workflow-migration-gates.test.ts` with unit tests for:
+
+- `needsAutoMigration` returns `false` when the `milestones` table has rows;
+  returns `true`/`false` per its documented trigger for a legacy-markdown
+  fixture vs a fresh project (read `workflow-migration.ts:20-60` first and test
+  what the gate actually checks — construct fixtures accordingly).
+- `validateMigration` reports a discrepancy when the DB counts diverge from
+  the markdown fixture, and reports none for a matching pair.
+
+Model the DB/fixture setup after an existing test that already builds a
+temp-project DB (e.g. `tests/gsd-db.test.ts` or the md-importer tests).
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/workflow-migration-gates.test.js` → all pass.
+
+## Test plan
+
+Covered by steps 5–6. Regression sweep: run the existing `db-engine-logs`,
+`db-migration-steps` (unit + integration), `gsd-db`, `worktree-db`,
+`flat-phase-migration` test files standalone → all pass.
+
+## Done criteria
+
+- [ ] `pnpm run typecheck:extensions` exits 0
+- [ ] New tests in `db-engine-migrate-guards.test.ts` and `workflow-migration-gates.test.ts` exist and pass
+- [ ] `grep -n 'currentVersion >= SCHEMA_VERSION' src/resources/extensions/gsd/db/engine.ts` returns no matches (replaced by the two-branch guard)
+- [ ] `grep -n 'closeWorkflowDatabase' src/resources/extensions/gsd/migrate/execution.ts` returns a match in the catch path
+- [ ] Existing migration/db test files listed above pass standalone
+- [ ] No files outside the in-scope list are modified (`git status`)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The `migrateSchema` / `initSchema` code no longer matches the excerpts
+  (drift since `f095797f`).
+- The open path's error handling swallows the newer-DB throw somewhere you
+  cannot cleanly extend (e.g. a broad catch in `db-provider.ts` or callers) —
+  report where, don't weaken the guard to a warning on your own.
+- Building an old-version DB fixture for step 5 requires more than reusing the
+  existing fixture helpers — do not hand-craft multi-version DDL from scratch.
+- `needsAutoMigration`'s actual trigger logic differs materially from "empty
+  milestones table + legacy markdown present" — report what it really checks
+  instead of guessing fixtures.
+
+## Maintenance notes
+
+- Any future `SCHEMA_VERSION` bump now has a hard compatibility edge: older
+  binaries refuse instead of corrupting. Release notes should mention that
+  mixed-version worktrees must update together.
+- The fault seam `_setMigrationFaultForTest` tests the whole-chain rollback
+  only; it does not prove each individual step is transactional under
+  implicit-commit DDL. If a future step uses DDL that implicitly commits in
+  SQLite, the rollback test will NOT catch it — reviewers should check new
+  steps for that class.
+- Deferred (recorded in `plans/README.md` unplanned list): the `.planning`
+  transformer's silent data-loss paths (duplicate phase numbers, phase-less
+  milestones) in `migrate/transformer.ts`.

--- a/plans/README.md
+++ b/plans/README.md
@@ -41,6 +41,7 @@ commit `58dc840f`. Plans 018–024 planned against commit `7cca07ae`.
 | 022 | Test gsd-cloud device-flow polling and SSRF gateway guards | P2 | M | 018 | TODO |
 | 023 | ADR: decide the flat-phase layout migration completion path | P2 | M | — | TODO |
 | 024 | Dependency & dead-code hygiene (hono, daemon SDK, ajv, chart.tsx) | P2 | S | — | TODO |
+| 026 | Refuse newer-schema DBs, harden version detection, close DB before migration restore | P1 | M | — | DONE |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`
 (2026-07-01). Notable deviations recorded in the plan files: 009 skipped the

--- a/src/resources/extensions/gsd/db-schema-metadata.ts
+++ b/src/resources/extensions/gsd/db-schema-metadata.ts
@@ -19,8 +19,11 @@ export function ensureColumn(db: DbAdapter, table: string, column: string, ddl: 
 }
 
 export function getCurrentSchemaVersion(db: DbAdapter): number {
+  // MAX(version) on an empty table returns a row whose value is NULL —
+  // treat that (and any non-numeric value) as version 0, not NULL-as-number.
   const row = db.prepare("SELECT MAX(version) as v FROM schema_version").get();
-  return row ? (row["v"] as number) : 0;
+  const v = row?.["v"];
+  return typeof v === "number" ? v : 0;
 }
 
 export function recordSchemaVersion(db: DbAdapter, version: number): void {

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -114,21 +114,37 @@ function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): 
 
     const existing = db.prepare("SELECT count(*) as cnt FROM schema_version").get();
     if (existing && (existing["cnt"] as number) === 0) {
-      createCoordinationTablesV24(db);
-      createRuntimeKvTableV25(db);
+      // An empty schema_version table usually means a fresh install, but it can
+      // also be a legacy/truncated DB that already holds user data. Stamping
+      // that DB SCHEMA_VERSION without running migrations would mis-mark it as
+      // fully migrated and break at first query. Probe before stamping.
+      const hasData = ["milestones", "decisions", "memories"].some((t) => {
+        try {
+          const r = db.prepare(`SELECT count(*) as cnt FROM ${t}`).get();
+          return ((r?.["cnt"] as number) ?? 0) > 0;
+        } catch { /* table absent on a truly fresh DB — treat as no data */ return false; }
+      });
+      if (hasData) {
+        // Legacy DB with data but no version row: record the baseline so
+        // migrateSchema runs the full chain instead of stamping the current version.
+        recordSchemaVersion(db, 1);
+      } else {
+        createCoordinationTablesV24(db);
+        createRuntimeKvTableV25(db);
 
-      // Fresh install — all tables are created above with the full current schema,
-      // so it is safe to create all migration-specific indexes here.  For existing
-      // databases these indexes are created inside the individual migration guards
-      // in migrateSchema() after the corresponding columns have been added.
-      db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_escalation_pending ON tasks(milestone_id, slice_id, escalation_pending)");
-      db.exec("CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope)");
-      db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_kind ON memory_sources(kind)");
-      db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_scope ON memory_sources(scope)");
-      db.exec("CREATE INDEX IF NOT EXISTS idx_memory_relations_from ON memory_relations(from_id)");
-      db.exec("CREATE INDEX IF NOT EXISTS idx_memory_relations_to ON memory_relations(to_id)");
+        // Fresh install — all tables are created above with the full current schema,
+        // so it is safe to create all migration-specific indexes here.  For existing
+        // databases these indexes are created inside the individual migration guards
+        // in migrateSchema() after the corresponding columns have been added.
+        db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_escalation_pending ON tasks(milestone_id, slice_id, escalation_pending)");
+        db.exec("CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope)");
+        db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_kind ON memory_sources(kind)");
+        db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_scope ON memory_sources(scope)");
+        db.exec("CREATE INDEX IF NOT EXISTS idx_memory_relations_from ON memory_relations(from_id)");
+        db.exec("CREATE INDEX IF NOT EXISTS idx_memory_relations_to ON memory_relations(to_id)");
 
-      recordSchemaVersion(db, SCHEMA_VERSION);
+        recordSchemaVersion(db, SCHEMA_VERSION);
+      }
     }
 
     db.exec("COMMIT");
@@ -183,9 +199,19 @@ function copyQualityGateRowsToRepairedTable(db: DbAdapter): void {
   `);
 }
 
+let _migrationFaultForTest = false;
+/** Test-only: force migrateSchema to throw after applying its steps but before COMMIT. */
+export function _setMigrationFaultForTest(v: boolean): void { _migrationFaultForTest = v; }
+
 function migrateSchema(db: DbAdapter, dbPath: string | null): void {
   const currentVersion = getCurrentSchemaVersion(db);
-  if (currentVersion >= SCHEMA_VERSION) return;
+  if (currentVersion > SCHEMA_VERSION) {
+    throw new Error(
+      `gsd.db schema is v${currentVersion}, newer than the v${SCHEMA_VERSION} this gsd-pi supports. ` +
+      `Update gsd-pi (npm i -g @opengsd/gsd-pi) before opening this project.`,
+    );
+  }
+  if (currentVersion === SCHEMA_VERSION) return;
 
   backupDatabaseBeforeMigration(db, dbPath, currentVersion, {
     existsSync,
@@ -350,6 +376,8 @@ function migrateSchema(db: DbAdapter, dbPath: string | null): void {
       applyMigrationV29RepositoryTargets(db);
       recordSchemaVersion(db, 29);
     }
+
+    if (_migrationFaultForTest) throw new Error("migration fault injected for test");
 
     db.exec("COMMIT");
   } catch (err) {

--- a/src/resources/extensions/gsd/migrate/execution.ts
+++ b/src/resources/extensions/gsd/migrate/execution.ts
@@ -2,6 +2,7 @@
 // File Purpose: Write migrated .gsd files, import them into the DB, verify projection/readiness, and rollback on failure.
 
 import { ensureDbOpen } from "../bootstrap/dynamic-tools.js";
+import { closeWorkflowDatabase } from "../db-workspace.js";
 import { clearArtifacts, clearDecisions, clearEngineHierarchy, clearRequirements, transaction } from "../gsd-db.js";
 import { migrateFromMarkdown } from "../md-importer.js";
 import { deriveState, invalidateStateCache } from "../state.js";
@@ -125,6 +126,10 @@ export async function executeMigrationWrite(
 
     return { backup, written, imported, legacyArchive, verification, audit };
   } catch (error) {
+    // The import transaction may have committed and the process may hold an
+    // open handle to the target gsd.db; close before the restore replaces the
+    // file on disk, and leave closed so the next open rebinds to the restored file.
+    try { closeWorkflowDatabase(); } catch { /* best-effort: restore must proceed */ }
     restoreMigrationTarget(backup);
     throw error;
   }

--- a/src/resources/extensions/gsd/tests/db-engine-migrate-guards.test.ts
+++ b/src/resources/extensions/gsd/tests/db-engine-migrate-guards.test.ts
@@ -1,0 +1,179 @@
+// GSD Extension - Migration guard tests (plan 026).
+// Covers the newer-DB refusal in migrateSchema, whole-chain rollback atomicity
+// via the _setMigrationFaultForTest seam, the legacy-data guard in initSchema,
+// and getCurrentSchemaVersion's empty-table NULL handling.
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { createRequire } from 'node:module';
+
+import {
+  openDatabase,
+  closeDatabase,
+  isDbAvailable,
+  SCHEMA_VERSION,
+  _setMigrationFaultForTest,
+} from '../gsd-db.ts';
+import { createDbAdapter } from '../db-adapter.ts';
+import { getCurrentSchemaVersion } from '../db-schema-metadata.ts';
+
+const _require = createRequire(import.meta.url);
+
+function tempDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-migrate-guards-'));
+  return path.join(dir, 'gsd.db');
+}
+
+function cleanup(dbPath: string): void {
+  closeDatabase();
+  fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+}
+
+interface RawDb {
+  exec(sql: string): void;
+  prepare(sql: string): { get(...args: unknown[]): Record<string, unknown> | undefined; all(...args: unknown[]): Array<Record<string, unknown>> };
+  close(): void;
+}
+
+function openRawSqliteForTest(dbPath: string): RawDb {
+  try {
+    const mod = _require('node:sqlite') as { DatabaseSync: new (path: string) => RawDb };
+    return new mod.DatabaseSync(dbPath);
+  } catch {
+    type SqliteCtor = new (path: string) => RawDb;
+    const mod = _require('better-sqlite3') as SqliteCtor | { default: SqliteCtor };
+    const DatabaseCtor: SqliteCtor = typeof mod === 'function' ? mod : mod.default;
+    return new DatabaseCtor(dbPath);
+  }
+}
+
+function rawColumnNames(raw: RawDb, table: string): string[] {
+  return raw.prepare(`PRAGMA table_info(${table})`).all().map((r) => r['name'] as string);
+}
+
+function rawMaxVersion(raw: RawDb): number | null {
+  const row = raw.prepare('SELECT MAX(version) as v FROM schema_version').get();
+  return (row?.['v'] as number | null) ?? null;
+}
+
+describe('db-engine migrate guards', () => {
+  test('getCurrentSchemaVersion returns 0 on an empty schema_version table', () => {
+    const sqlite = _require('node:sqlite') as { DatabaseSync: new (path: string) => unknown };
+    const adapter = createDbAdapter(new sqlite.DatabaseSync(':memory:'));
+    try {
+      adapter.exec('CREATE TABLE schema_version (version INTEGER NOT NULL, applied_at TEXT NOT NULL)');
+      assert.equal(getCurrentSchemaVersion(adapter), 0);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  test('refuses to open a DB whose schema is newer than this binary', () => {
+    const dbPath = tempDbPath();
+    try {
+      assert.ok(openDatabase(dbPath), 'fresh open should succeed');
+      closeDatabase();
+
+      const raw = openRawSqliteForTest(dbPath);
+      raw.exec(
+        `INSERT INTO schema_version (version, applied_at) VALUES (${SCHEMA_VERSION + 1}, '2026-01-01T00:00:00Z')`,
+      );
+      raw.close();
+
+      assert.throws(() => openDatabase(dbPath), /newer than/);
+      assert.equal(isDbAvailable(), false, 'no connection may stay open on refusal');
+    } finally {
+      cleanup(dbPath);
+    }
+  });
+
+  test('a mid-migration failure rolls back to the starting schema version', () => {
+    const dbPath = tempDbPath();
+    try {
+      assert.ok(openDatabase(dbPath), 'fresh open should succeed');
+      closeDatabase();
+
+      // Rewind the DB to v(SCHEMA_VERSION-1): stamp the prior version and drop
+      // the columns the last migration adds, so the re-run has real work to redo.
+      const startVersion = SCHEMA_VERSION - 1;
+      const raw = openRawSqliteForTest(dbPath);
+      raw.exec('DELETE FROM schema_version');
+      raw.exec(`INSERT INTO schema_version (version, applied_at) VALUES (${startVersion}, '2026-01-01T00:00:00Z')`);
+      raw.exec('ALTER TABLE slices DROP COLUMN target_repositories');
+      raw.exec('ALTER TABLE tasks DROP COLUMN target_repositories');
+      raw.close();
+
+      _setMigrationFaultForTest(true);
+      try {
+        assert.throws(() => openDatabase(dbPath), /migration fault injected/);
+      } finally {
+        _setMigrationFaultForTest(false);
+      }
+      assert.equal(isDbAvailable(), false, 'no connection may stay open on migration failure');
+
+      const inspect = openRawSqliteForTest(dbPath);
+      try {
+        assert.equal(rawMaxVersion(inspect), startVersion, 'version must roll back to the starting version');
+        assert.ok(
+          !rawColumnNames(inspect, 'slices').includes('target_repositories'),
+          'column added by the failed migration must be rolled back',
+        );
+      } finally {
+        inspect.close();
+      }
+
+      // The DB is intact — a clean re-open migrates to the current version.
+      assert.ok(openDatabase(dbPath), 're-open without the fault should succeed');
+      closeDatabase();
+      const after = openRawSqliteForTest(dbPath);
+      try {
+        assert.equal(rawMaxVersion(after), SCHEMA_VERSION);
+        assert.ok(rawColumnNames(after, 'slices').includes('target_repositories'));
+      } finally {
+        after.close();
+      }
+    } finally {
+      cleanup(dbPath);
+    }
+  });
+
+  test('a DB with data but no version rows migrates from v1 instead of being stamped current', () => {
+    const dbPath = tempDbPath();
+    try {
+      assert.ok(openDatabase(dbPath), 'fresh open should succeed');
+      closeDatabase();
+
+      // Simulate a legacy DB: user data present, version table empty, and a
+      // migration-added column missing so we can observe the chain actually run.
+      const raw = openRawSqliteForTest(dbPath);
+      raw.exec("INSERT INTO milestones (id, title) VALUES ('M001', 'Legacy milestone')");
+      raw.exec('DELETE FROM schema_version');
+      raw.exec('ALTER TABLE milestones DROP COLUMN vision');
+      raw.close();
+
+      assert.ok(openDatabase(dbPath), 'legacy DB open should succeed');
+      closeDatabase();
+
+      const inspect = openRawSqliteForTest(dbPath);
+      try {
+        const versions = inspect.prepare('SELECT version FROM schema_version ORDER BY version').all()
+          .map((r) => r['version'] as number);
+        assert.equal(versions[0], 1, 'baseline v1 must be recorded, not a fresh-install stamp');
+        assert.equal(versions[versions.length - 1], SCHEMA_VERSION, 'migration chain must reach the current version');
+        assert.ok(
+          rawColumnNames(inspect, 'milestones').includes('vision'),
+          'migration-added column must be restored by the chain',
+        );
+        const row = inspect.prepare('SELECT count(*) as cnt FROM milestones').get();
+        assert.equal(row?.['cnt'], 1, 'existing data must survive');
+      } finally {
+        inspect.close();
+      }
+    } finally {
+      cleanup(dbPath);
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/workflow-migration-gates.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-migration-gates.test.ts
@@ -1,0 +1,139 @@
+// GSD Extension - Auto-migration gate tests (plan 026).
+// Covers needsAutoMigration's trigger (empty milestones table + .gsd/milestones
+// present) and validateMigration's engine-vs-markdown count comparison.
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { openDatabase, closeDatabase, insertMilestone, insertSlice } from '../gsd-db.ts';
+import { needsAutoMigration, validateMigration } from '../workflow-migration.ts';
+
+function makeProject(): string {
+  return mkdtempSync(join(tmpdir(), 'gsd-migration-gates-'));
+}
+
+function openProjectDb(base: string): string {
+  const gsdDir = join(base, '.gsd');
+  mkdirSync(gsdDir, { recursive: true });
+  const dbPath = join(gsdDir, 'gsd.db');
+  assert.ok(openDatabase(dbPath), 'openDatabase should succeed');
+  return dbPath;
+}
+
+function cleanup(base: string): void {
+  closeDatabase();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function writeRoadmap(base: string, mId: string, sliceLines: string[]): void {
+  const mDir = join(base, '.gsd', 'milestones', mId);
+  mkdirSync(mDir, { recursive: true });
+  writeFileSync(join(mDir, 'ROADMAP.md'), [
+    `# ${mId}: Test`,
+    '',
+    '## Slices',
+    '',
+    ...sliceLines,
+    '',
+  ].join('\n'));
+}
+
+describe('needsAutoMigration', () => {
+  test('false for a fresh project with no legacy markdown', () => {
+    const base = makeProject();
+    try {
+      openProjectDb(base);
+      assert.equal(needsAutoMigration(base), false, 'no .gsd/milestones dir → no migration');
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  test('true when engine tables are empty and .gsd/milestones exists', () => {
+    const base = makeProject();
+    try {
+      openProjectDb(base);
+      mkdirSync(join(base, '.gsd', 'milestones', 'M001'), { recursive: true });
+      assert.equal(needsAutoMigration(base), true, 'legacy markdown + empty engine → migrate');
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  test('false once the milestones table has rows (migration already done)', () => {
+    const base = makeProject();
+    try {
+      openProjectDb(base);
+      mkdirSync(join(base, '.gsd', 'milestones', 'M001'), { recursive: true });
+      insertMilestone({ id: 'M001', title: 'Migrated' });
+      assert.equal(needsAutoMigration(base), false, 'engine rows present → migration already done');
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  test('false when no database connection is open', () => {
+    const base = makeProject();
+    try {
+      mkdirSync(join(base, '.gsd', 'milestones', 'M001'), { recursive: true });
+      closeDatabase();
+      assert.equal(needsAutoMigration(base), false, 'no DB → cannot migrate');
+    } finally {
+      cleanup(base);
+    }
+  });
+});
+
+describe('validateMigration', () => {
+  test('reports no discrepancies when engine counts match markdown', () => {
+    const base = makeProject();
+    try {
+      openProjectDb(base);
+      writeRoadmap(base, 'M001', ['- [ ] **S01: Test Slice** `risk:low` `depends:[]`']);
+      insertMilestone({ id: 'M001', title: 'Test' });
+      insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice' });
+
+      const result = validateMigration(base);
+      assert.deepEqual(result.discrepancies, [], 'matching engine/markdown counts → clean');
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  test('reports discrepancies when engine counts diverge from markdown', () => {
+    const base = makeProject();
+    try {
+      openProjectDb(base);
+      writeRoadmap(base, 'M001', [
+        '- [ ] **S01: Test Slice** `risk:low` `depends:[]`',
+        '- [ ] **S02: Second Slice** `risk:low` `depends:[]`',
+      ]);
+      // Engine has no rows at all → milestone and slice counts both diverge.
+      const result = validateMigration(base);
+      assert.ok(
+        result.discrepancies.some((d) => d.includes('Milestone count mismatch')),
+        `expected milestone mismatch, got: ${result.discrepancies.join('; ')}`,
+      );
+      assert.ok(
+        result.discrepancies.some((d) => d.includes('Slice count mismatch')),
+        `expected slice mismatch, got: ${result.discrepancies.join('; ')}`,
+      );
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  test('reports a validation failure when no database connection is open', () => {
+    const base = makeProject();
+    try {
+      closeDatabase();
+      const result = validateMigration(base);
+      assert.deepEqual(result.discrepancies, ['No database connection for validation']);
+    } finally {
+      cleanup(base);
+    }
+  });
+});


### PR DESCRIPTION
## Linked issue

Closes #1334

- [x] I have linked an issue above.

---

## TL;DR

**What:** Harden the GSD SQLite schema-version and migration machinery against corrupting or split-braining `.gsd/gsd.db` (the single source of truth).
**Why:** Three verified gaps let an older binary silently operate on a newer schema, mis-stamp a legacy DB as fully migrated, or leave a stale/moved DB handle after a migration rollback.
**How:** Refuse newer-schema DBs (fail loud), fix version detection, record baseline v1 for legacy-data DBs, close the DB before migration restore, and add regression tests.

## What

Confined to the gsd extension's DB/migration layer:

- `db-schema-metadata.ts` — `getCurrentSchemaVersion` returns `0` for an empty `schema_version` table instead of a NULL coerced to `number`.
- `db/engine.ts`:
  - `migrateSchema` now **throws** when the DB schema version is newer than this binary's `SCHEMA_VERSION` (29), instead of the old `>=` early return that let the caller read/write a schema it doesn't understand. The open path already closes the adapter and rethrows on `initSchema` failure, so no connection survives the refusal.
  - `initSchema` no longer stamps `SCHEMA_VERSION` on any DB whose `schema_version` table is empty: if user data exists (`milestones`/`decisions`/`memories` rows) it records baseline **v1** so the full migration chain runs.
  - Adds a test-only `_setMigrationFaultForTest` seam (underscore/`ForTest` convention) to drive the `BEGIN/COMMIT/ROLLBACK` wrapper through a mid-migration failure.
- `migrate/execution.ts` — `executeMigrationWrite`'s catch now calls `closeWorkflowDatabase()` before `restoreMigrationTarget` swaps `gsd.db` on disk.
- New tests: `db-engine-migrate-guards.test.ts` (newer-DB refusal, rollback atomicity, legacy-data guard, empty-table version) and `workflow-migration-gates.test.ts` (`needsAutoMigration`/`validateMigration`, previously untested).
- Docs: `plans/026-…md` plan file and a one-row `plans/README.md` status update.

## Why

`.gsd/gsd.db` is authoritative; markdown is projection-only. Sibling git worktrees share the same DB file (`tests/worktree-db-same-file.test.ts`), so mixed-version coexistence is real. See #1334 for the full failure analysis of each gap (silent newer-schema operation, permanent mis-stamp of a legacy DB, and `SQLITE_READONLY_DBMOVED` after a rollback).

## How

- **Newer-DB refusal** replaces the `currentVersion >= SCHEMA_VERSION` early return with an explicit `> SCHEMA_VERSION` throw (remediation message points at `npm i -g @opengsd/gsd-pi`) plus an `=== SCHEMA_VERSION` no-op return.
- **Legacy-data guard** probes three tables before stamping; `schema_version` has existed since the initial commit, so this path is defensive-only (covers an externally truncated version table), noted in the commit message.
- **Close-before-restore** leaves the DB closed so the next open rebinds to the restored file.
- `SCHEMA_VERSION` itself is unchanged; no behavior changes outside the migration/open path.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Verification

- `pnpm run typecheck:extensions` — exit 0
- `pnpm run test:compile` + the two new test files — 11/11 pass
- Regression sweep (standalone): `db-engine-logs`, `db-migration-steps` (unit + integration), `db-migration-backup`, `gsd-db`, `worktree-db`, `worktree-db-same-file`, `flat-phase-migration`, `migrate-safety-audit`, `migrate-writer`, `migrate-transformer`, plus `gsd-db-failed-open-restore`, `gsd-db-workspace-scope`, `worktree-db-integration`, `integration-edge`, `md-importer`, `migrate-hierarchy` — all pass
- Re-verified typecheck + new/key tests after rebasing onto current `main`

> Note: the repo's local no-mistakes gate could not run for this branch because the shared checkout is currently held by a concurrent session on another branch; CI is the validating gate here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect authoritative SQLite open/migration on every project startup and migration rollback; mistakes could block opens or worsen restore behavior, though new tests cover the main failure modes.
> 
> **Overview**
> Hardens `.gsd/gsd.db` open and migration so an older `gsd-pi` cannot silently corrupt a database already migrated by a newer binary.
> 
> **Schema guards:** `getCurrentSchemaVersion` now treats an empty `schema_version` table as version **0**. `migrateSchema` **throws** when the DB version is newer than this binary’s `SCHEMA_VERSION` (replacing the old `>=` early return). `initSchema` probes for existing rows in `milestones` / `decisions` / `memories` before stamping a fresh install—legacy data with no version rows gets baseline **v1** so the full migration chain runs.
> 
> **Migration rollback:** `executeMigrationWrite` calls `closeWorkflowDatabase()` before `restoreMigrationTarget` on failure, avoiding stale handles after the DB file is swapped on disk.
> 
> **Tests & docs:** Adds `_setMigrationFaultForTest` plus `db-engine-migrate-guards.test.ts` and `workflow-migration-gates.test.ts`. GitBook and Mintlify troubleshooting document the newer-schema startup error and upgrade path. Plan 026 and `plans/README.md` are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04582c51b9d82cd98c8d22f070307990f254a152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->