### PR TITLE
fix(gsd): preserve DB status during scoped external re-import

### DIFF
--- a/docs/dev/ADR-017-state-reconciliation-drift-driven.md
+++ b/docs/dev/ADR-017-state-reconciliation-drift-driven.md
@@ -101,6 +101,7 @@ async function reconcileBeforeDispatch(
 - **All repairs must be idempotent.** Re-derive can re-trigger detection on transient state; repairs must be safe under retry.
 - **Failure throws.** `ReconciliationFailedError` is caught by the caller and routed to `classifyFailure({ error, failureKind: "reconciliation-drift" })`.
 - **Repair ordering is phase-based, not a single flat list.** Detection still uses the flattened `DRIFT_REGISTRY`, but repairs run through `RECONCILIATION_REPAIR_PHASES`: `import-external-edits` first, `normalize-db` second, and `re-project` last. This preserves external markdown/planning edits before any DB-authoritative renderer rewrites projections.
+- **External-edit status authority is scoped.** `external-markdown-edit` and `external-planning-edit` repairs may import the whole hierarchy for idempotent upserts, but checkbox status authority is limited to the milestone ids derived from the drifted file's marker `entities`. Existing rows outside that scope keep DB status; new rows still import from markdown. Entity-less records fail toward the DB and log a warning.
 
 ### Module home
 

--- a/docs/superpowers/plans/2026-06-21-gsd-core-pi-backwards-compat.md
+++ b/docs/superpowers/plans/2026-06-21-gsd-core-pi-backwards-compat.md
@@ -156,8 +156,9 @@ export const COMPAT_MARKER_SCHEMA = 1;
 
 /**
  * Per-file projection entry. `sha` is a normalized-content SHA-256; `entities`
- * is the list of DB entity ids (milestone/slice/task) that the file projects,
- * so repair can scope re-import rather than re-importing the whole tree.
+ * is the list of DB entity ids (milestone/slice/task) that the file projects.
+ * Current repair derives milestone ids from this list to scope markdown status
+ * authority while the importer still walks the whole tree.
  */
 export interface ProjectionEntry {
   sha: string;
@@ -331,7 +332,7 @@ In `src/resources/extensions/gsd/state-reconciliation/types.ts`, add this varian
       projectionPath: string;       // relative to basePath, e.g. "m1/plan.md"
       expectedSha: string;          // sha recorded in .compat.json
       actualSha: string;            // freshly computed from disk
-      entities: string[];           // DB entity ids to re-import
+      entities: string[];           // DB entity ids used to scope status authority
     };
 ```
 
@@ -485,9 +486,10 @@ Create `src/resources/extensions/gsd/state-reconciliation/drift/external-markdow
 //
 // gsd-pi's DB is canonical, but .gsd/*.md is the inter-tool contract. When
 // gsd-core edits a projection file, this handler detects the sha drift vs the
-// recorded baseline in .gsd/.compat.json and re-imports the affected entities
-// into the DB. The next renderAllFromDb pass re-projects; the write-time
-// invalidation hook then refreshes the marker entry, closing the loop.
+// recorded baseline in .gsd/.compat.json and re-imports from markdown with
+// status authority scoped to the affected milestone ids. The next
+// renderAllFromDb pass re-projects; the write-time invalidation hook then
+// refreshes the marker entry, closing the loop.
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -497,7 +499,7 @@ import {
   readCompatMarker,
   writeCompatMarker,
 } from "../../compat/compat-marker.js";
-import { migrateHierarchyToDb } from "../../md-importer.js";
+import { migrateHierarchyToDb, milestoneIdsFromEntities } from "../../md-importer.js";
 import { invalidateStateCache } from "../../state.js";
 import { logWarning } from "../../workflow-logger.js";
 import type { GSDState } from "../../types.js";
@@ -543,21 +545,23 @@ function detectExternalMarkdownEdit(
 }
 
 /**
- * Idempotent repair: re-import hierarchy for the affected entities from
- * markdown into the DB, then update the marker entry so the next detect pass
- * sees the file as expected. migrateHierarchyToDb is itself idempotent
- * (upsert), so re-running this repair after a successful one is a no-op.
+ * Idempotent repair: re-import hierarchy from markdown while allowing
+ * markdown status authority only for milestones named by the drifted file's
+ * marker entities, then update the marker entry so the next detect pass sees
+ * the file as expected. migrateHierarchyToDb is itself idempotent (upsert), so
+ * re-running this repair after a successful one is a no-op.
  */
 async function repairExternalMarkdownEdit(
   record: ExternalMarkdownEditDrift,
   ctx: DriftContext,
 ): Promise<void> {
   try {
-    // Scoped re-import. migrateHierarchyToDb walks the whole tree but is a
-    // cheap upsert; per-entity scoping would require decomposing it, which is
-    // out of scope for v1. The cost is bounded by tree size and runs at most
-    // once per reconcile pass (MAX_PASSES=2).
-    migrateHierarchyToDb(ctx.basePath);
+    // The importer walks the whole tree as a cheap upsert, but repair derives
+    // a milestone scope from record.entities and passes it as
+    // statusAuthoritativeMilestones so only the drifted milestone(s) can close
+    // or reopen rows from markdown checkboxes.
+    const statusAuthoritativeMilestones = milestoneIdsFromEntities(record.entities);
+    migrateHierarchyToDb(ctx.basePath, { statusAuthoritativeMilestones });
     invalidateStateCache();
   } catch (err) {
     logWarning(
@@ -598,8 +602,9 @@ git add src/resources/extensions/gsd/state-reconciliation/types.ts \
 git commit -m "feat(compat): add external-markdown-edit drift handler
 
 Detects sha drift between .gsd/.compat.json and current projection files,
-re-imports affected entities via migrateHierarchyToDb, and refreshes the
-marker. Idempotent: re-running after a successful repair is a no-op."
+imports markdown via migrateHierarchyToDb with status authority scoped to the
+marker entities, and refreshes the marker. Idempotent: re-running after a
+successful repair is a no-op."
 ```
 
 ---

--- a/docs/superpowers/specs/2026-06-21-gsd-core-pi-backwards-compat-design.md
+++ b/docs/superpowers/specs/2026-06-21-gsd-core-pi-backwards-compat-design.md
@@ -78,7 +78,7 @@ A single small JSON file recording the last projection state. Lives under `.gsd/
 ```
 
 - **Hash-based, not mtime-based.** mtimes are unreliable across git checkouts, filesystems, and clocks. SHA-256 of normalized file content (trailing whitespace trimmed, CRLF→LF) avoids false positives on cosmetic differences.
-- **Per-file entity map.** When drift is detected on `m1/plan.md`, gsd-pi knows which DB entities (slices/tasks) to re-import rather than re-importing the whole tree.
+- **Per-file entity map.** When drift is detected on `m1/plan.md`, gsd-pi knows which DB entities (slices/tasks) the file projects. Current repair still runs an idempotent whole-tree import, but derives a milestone scope from these entities so only the drifted milestone(s) can contribute markdown checkbox status.
 - `lastWriter` is `"gsd-pi"` after every gsd-pi projection; gsd-core never writes it (it's oblivious), so a missing/stale marker is itself a signal: "the other tool may have written since my last projection."
 - `schema: 1` for forward compatibility of the marker format itself.
 
@@ -92,13 +92,13 @@ Added to the `DriftRecord` union in `state-reconciliation/types.ts`:
     projectionPath: string;       // relative to basePath, e.g. "m1/plan.md"
     expectedSha: string;          // from .compat.json
     actualSha: string;            // freshly computed
-    entities: string[];           // entity ids to re-import
+    entities: string[];           // entity ids used to scope status authority
   }
 ```
 
 Detection (`detect`) compares each projection's recorded sha against the current normalized file hash. Differences become `external-markdown-edit` records.
 
-Repair (`repair`) re-imports the named entities from markdown → DB via the existing `md-importer` entity-level upserts, then re-projects those files. Idempotent (re-running yields the same outcome, which is what the cap=2 reconcile loop requires).
+Repair (`repair`) re-imports markdown → DB through the existing `md-importer` whole-tree upsert path, with status authority scoped to the milestone ids in the drifted marker entry. That prevents a stale, unrelated projection from reverting DB status while keeping the repair idempotent (re-running yields the same outcome, which is what the cap=2 reconcile loop requires).
 
 ### 4.4 Startup reconcile flow
 
@@ -176,7 +176,7 @@ Everything else (drift detection, repair, rendering) stays in its existing modul
 
 1. gsd-pi starts; sync-lock acquired.
 2. `reconcileBeforeDispatch` runs; `external-markdown-edit` detector finds files where current sha ≠ `.compat.json` sha (or marker absent → treat all projection files as external).
-3. Repair re-imports affected entities → DB.
+3. Repair imports markdown → DB with status authority scoped to the drifted file's marker entities.
 4. `renderAllFromDb` re-projects everything.
 5. `.compat.json` rewritten with fresh shas, `lastWriter: "gsd-pi"`.
 6. Lock released; workflow-logger emits a structured diff of imported changes.

--- a/docs/superpowers/specs/2026-06-21-planning-dir-parity-design.md
+++ b/docs/superpowers/specs/2026-06-21-planning-dir-parity-design.md
@@ -109,7 +109,7 @@ Parallel to `external-markdown-edit` (PR #802). Added to the `DriftRecord` union
 ```
 
 Detect compares `.planning/` file shas to `marker.planning.projections`. Repair:
-- For modeled files: re-import via the existing parser + transformer.
+- For modeled files: re-import via the existing parser + transformer, then run the hierarchy importer with checkbox status authority scoped to the milestone ids recorded for the drifted file.
 - For passthrough files: no DB import (there's nothing to import into); just refresh the marker sha so the next detect treats it as current.
 
 ### 4.4 The projection writer: `writePlanningDirectory`

--- a/docs/user-docs/switching-between-gsd-tools.md
+++ b/docs/user-docs/switching-between-gsd-tools.md
@@ -4,7 +4,7 @@ Both `@opengsd/gsd-core` and `@opengsd/gsd-pi` read and write the same `.gsd/` d
 
 ## The shared contract
 
-`.gsd/*.md` files are the contract between the two tools. gsd-core treats them as the source of truth. gsd-pi uses a SQLite DB internally (faster queries, transactional state) but projects to the same `.md` files and imports any external edits on startup.
+`.gsd/*.md` files are the contract between the two tools. gsd-core treats them as the source of truth. gsd-pi uses a SQLite DB internally (faster queries, transactional state) but projects to the same `.md` files and imports external edits on startup. For status checkboxes, gsd-pi treats only the drifted file's recorded milestone entities as markdown-authoritative; unrelated stale projections keep the DB status.
 
 ## Recommended workflow: commit before switching
 
@@ -22,7 +22,7 @@ Then open the other tool. If anything goes wrong, `git reset --hard` restores th
 When you open a project in gsd-pi, it runs a reconciliation pass that:
 
 1. Compares every `.gsd/*.md` file against its recorded baseline in `.gsd/.compat.json`.
-2. Imports any file that changed since the last gsd-pi session (e.g., gsd-core edits).
+2. Imports any file that changed since the last gsd-pi session (e.g., gsd-core edits), with status changes scoped to the milestone entities recorded for that drifted file.
 3. Re-projects all markdown from the DB.
 4. Updates `.gsd/.compat.json` with the new baseline.
 
@@ -74,7 +74,7 @@ If your project uses gsd-core's `.planning/` layout (flat `phases/NN-name/` dire
 
 ## Conflicts: same entity edited in both
 
-If both tools edit the *same* entity (e.g., both change the status of slice `S01`) between syncs, the last writer wins after the next reconcile, and gsd-pi surfaces the resolution in the `/gsd sync` output. Git review remains the final safety net — that's why the "commit before switching" workflow matters.
+If both tools edit the *same* entity (e.g., both change the status of slice `S01`) between syncs, the last writer wins after the next reconcile, and gsd-pi surfaces the resolution in the `/gsd sync` output. If a different projection is stale but did not drift, its checkbox status is not allowed to reopen or close unrelated DB rows during the import. Git review remains the final safety net — that's why the "commit before switching" workflow matters.
 
 ## Troubleshooting
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -42,6 +42,7 @@ commit `58dc840f`. Plans 018–024 planned against commit `7cca07ae`.
 | 023 | ADR: decide the flat-phase layout migration completion path | P2 | M | — | TODO |
 | 024 | Dependency & dead-code hygiene (hono, daemon SDK, ajv, chart.tsx) | P2 | S | — | TODO |
 | 026 | Refuse newer-schema DBs, harden version detection, close DB before migration restore | P1 | M | — | DONE |
+| 027 | Scope external-edit drift repair status authority to drifted entities | P1 | M | — | DONE |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`
 (2026-07-01). Notable deviations recorded in the plan files: 009 skipped the

--- a/src/resources/extensions/gsd/compat/compat-marker.ts
+++ b/src/resources/extensions/gsd/compat/compat-marker.ts
@@ -34,8 +34,10 @@ export interface PlanningMarker {
 
 /**
  * Per-file projection entry. `sha` is a normalized-content SHA-256; `entities`
- * is the list of DB entity ids (milestone/slice/task) that the file projects,
- * so repair can scope re-import rather than re-importing the whole tree.
+ * is the list of DB entity ids (milestone/slice/task) that the file projects.
+ * External-edit repair derives milestone ids from this list so markdown status
+ * authority is limited to the drifted projection's milestone scope while the
+ * importer still walks the whole tree.
  */
 export interface ProjectionEntry {
   sha: string;

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -18,6 +18,7 @@ import {
   updateMilestoneStatus,
   updateSliceStatus,
   getMilestoneSlices,
+  getSliceTasks,
   _getAdapter,
 } from './gsd-db.js';
 import { openWorkflowDatabasePath } from './db-workspace.js';
@@ -795,8 +796,14 @@ export function migrateHierarchyToDb(
     // authority for this milestone) so the upsert can echo them back instead of
     // flipping an open slice closed from a stale checkbox.
     const existingSliceStatus = new Map<string, string>();
+    const existingTaskStatus = new Map<string, string>();
     if (!milestoneStatusAuthoritative) {
-      for (const s of getMilestoneSlices(milestoneId)) existingSliceStatus.set(s.id, s.status);
+      for (const s of getMilestoneSlices(milestoneId)) {
+        existingSliceStatus.set(s.id, s.status);
+        for (const t of getSliceTasks(milestoneId, s.id)) {
+          existingTaskStatus.set(`${s.id}/${t.id}`, t.status);
+        }
+      }
     }
 
     // Insert milestone (FK parent — must come first). INSERT OR IGNORE: an
@@ -962,12 +969,20 @@ export function migrateHierarchyToDb(
           );
         }
 
+        // #027: same scope guard as slices — out-of-scope milestones echo existing
+        // DB task status so stale plan checkboxes cannot re-complete reopened tasks.
+        const taskRowExists = existingTaskStatus.has(`${sliceEntry.id}/${taskEntry.id}`);
+        const taskStatusAuthoritative = milestoneStatusAuthoritative || !taskRowExists;
+        const effectiveTaskStatus = taskStatusAuthoritative
+          ? taskStatus
+          : existingTaskStatus.get(`${sliceEntry.id}/${taskEntry.id}`)!;
+
         insertTask({
           id: taskEntry.id,
           sliceId: sliceEntry.id,
           milestoneId: milestoneId,
           title: taskEntry.title,
-          status: taskStatus,
+          status: effectiveTaskStatus,
           planning: {
             files: taskEntry.files ?? [],
             verify: taskEntry.verify ?? '',

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -17,6 +17,7 @@ import {
   transaction,
   updateMilestoneStatus,
   updateSliceStatus,
+  getMilestoneSlices,
   _getAdapter,
 } from './gsd-db.js';
 import { openWorkflowDatabasePath } from './db-workspace.js';
@@ -42,6 +43,26 @@ import { logWarning } from './workflow-logger.js';
 const VALID_MADE_BY = new Set(['human', 'agent', 'collaborative']);
 
 const IMPORT_COMPLETE_STATUSES = new Set(['complete', 'done']);
+
+/**
+ * Derive the set of milestone ids a projection entry's `entities` touch. Marker
+ * entity ids are fully-qualified DB ids (`M001`, `M001/S01`, `M001/S01/T01`), so
+ * the milestone id is always the first `/`-segment — independent of the on-disk
+ * layout (legacy `milestones/<MID>/…` vs flat `phases/NN-slug/…`). The
+ * external-edit drift repairs (#027) feed this into
+ * `migrateHierarchyToDb(..., { statusAuthoritativeMilestones })` to scope status
+ * authority to exactly the milestone(s) a drifted file projects. Empty/blank
+ * entries are dropped, so an entity-less entry yields an empty set (repair then
+ * preserves DB status everywhere — fail toward the DB, not markdown).
+ */
+export function milestoneIdsFromEntities(entities: readonly string[]): Set<string> {
+  const ids = new Set<string>();
+  for (const e of entities) {
+    const milestoneId = e.split('/')[0];
+    if (milestoneId) ids.add(milestoneId);
+  }
+  return ids;
+}
 
 /**
  * Completion timestamp for an entity imported as complete: the SUMMARY.md mtime
@@ -676,15 +697,35 @@ function findFileByPrefixAndSuffix(dir: string, idPrefix: string, suffix: string
  * Uses INSERT OR IGNORE for idempotency. Insert order: milestones → slices → tasks.
  * Ghost milestones (dirs with no CONTEXT, ROADMAP, or SUMMARY) are skipped.
  *
+ * `opts.statusAuthoritativeMilestones` narrows *status* authority. It exists for
+ * the scoped external-edit drift repair: detection knows exactly which
+ * projection file drifted, but this import walks the whole tree. Without scoping,
+ * an unrelated file that is stale from gsd-pi's own miss (a forgotten render)
+ * rides along with markdown authority it was never granted and its stale checked
+ * checkbox silently reverts a reopened slice/milestone in the DB (#027).
+ *
+ * - opts absent → full markdown authority for every milestone (initial migration,
+ *   gsd-core full import, /gsd recover rebuild). Behavior is identical to before.
+ * - opts present → for a milestone NOT in the set whose DB row *already exists*,
+ *   the existing DB status is preserved: the slice upsert is fed the current DB
+ *   status (so a stale `complete` checkbox can't overwrite a reopened `pending`),
+ *   and the complete-status backfills are skipped. Milestone rows are already
+ *   protected by INSERT OR IGNORE. Rows that do not exist yet are inserted with
+ *   the parsed status regardless of scope (new content is new content).
+ *
  * Returns count of inserted hierarchy items.
  */
-export function migrateHierarchyToDb(basePath: string): {
+export function migrateHierarchyToDb(
+  basePath: string,
+  opts?: { statusAuthoritativeMilestones?: ReadonlySet<string> },
+): {
   milestones: number;
   slices: number;
   tasks: number;
 } {
   const counts = { milestones: 0, slices: 0, tasks: 0 };
   const milestoneIds = findMilestoneIds(basePath);
+  const statusScope = opts?.statusAuthoritativeMilestones;
 
   for (const milestoneId of milestoneIds) {
     // Check for ghost milestones — skip dirs with no meaningful content
@@ -745,8 +786,24 @@ export function migrateHierarchyToDb(basePath: string): {
       }
     }
 
-    // Insert milestone (FK parent — must come first)
-    insertMilestone({
+    // #027: when a status scope is supplied, a milestone outside it keeps DB
+    // status authority for rows that already exist — only the drifted file's
+    // milestone(s) may drive status closes from checkboxes. Absent scope, every
+    // milestone is authoritative (unchanged full-import behavior).
+    const milestoneStatusAuthoritative = !statusScope || statusScope.has(milestoneId);
+    // Snapshot existing slice statuses once (only needed when preserving DB
+    // authority for this milestone) so the upsert can echo them back instead of
+    // flipping an open slice closed from a stale checkbox.
+    const existingSliceStatus = new Map<string, string>();
+    if (!milestoneStatusAuthoritative) {
+      for (const s of getMilestoneSlices(milestoneId)) existingSliceStatus.set(s.id, s.status);
+    }
+
+    // Insert milestone (FK parent — must come first). INSERT OR IGNORE: an
+    // existing milestone row is never overwritten, so DB status is already
+    // preserved for out-of-scope milestones. `inserted` tells us whether this
+    // row is new (parsed status applies) vs pre-existing (backfill gated below).
+    const milestoneInserted = insertMilestone({
       id: milestoneId,
       title: milestoneTitle,
       status: milestoneStatus,
@@ -760,8 +817,9 @@ export function migrateHierarchyToDb(basePath: string): {
     // insertMilestone never sets completed_at; backfill it now for milestones
     // imported as complete so the DB is internally coherent immediately after
     // import (rather than relying on a later reconciliation pass that can't even
-    // see the drift when no SUMMARY file exists).
-    if (IMPORT_COMPLETE_STATUSES.has(milestoneStatus)) {
+    // see the drift when no SUMMARY file exists). #027: skip the backfill for an
+    // out-of-scope milestone that already existed — its DB status is authoritative.
+    if (IMPORT_COMPLETE_STATUSES.has(milestoneStatus) && (milestoneStatusAuthoritative || milestoneInserted)) {
       const summaryPath = resolveMilestoneFile(basePath, milestoneId, 'SUMMARY');
       // #1291: preserve an existing completion timestamp so a re-import backfills
       // only rows that lack one, never re-stamping an already-complete milestone
@@ -786,11 +844,22 @@ export function migrateHierarchyToDb(basePath: string): {
         plan = parsePlan(planContent);
       }
 
+      // #027: for an out-of-scope milestone, echo the existing DB status of a
+      // slice that already exists so the upsert's `ELSE excluded.status` branch
+      // becomes a no-op instead of flipping a reopened `pending` slice back to
+      // `complete` from a stale checkbox. New slices (not yet in the DB) take the
+      // parsed status regardless of scope.
+      const sliceRowExists = existingSliceStatus.has(sliceEntry.id);
+      const sliceStatusAuthoritative = milestoneStatusAuthoritative || !sliceRowExists;
+      const effectiveSliceStatus = sliceStatusAuthoritative
+        ? sliceStatus
+        : existingSliceStatus.get(sliceEntry.id)!;
+
       insertSlice({
         id: sliceEntry.id,
         milestoneId: milestoneId,
         title: sliceEntry.title,
-        status: sliceStatus,
+        status: effectiveSliceStatus,
         risk: sliceEntry.risk,
         depends: (sliceEntry.depends ?? []).map(d => d.replace(/^\[|\]$/g, '')).filter(d => /^[A-Za-z0-9][A-Za-z0-9-]*$/.test(d)),
         demo: sliceEntry.demo,
@@ -801,8 +870,9 @@ export function migrateHierarchyToDb(basePath: string): {
         },
       });
       // insertSlice never sets completed_at; backfill it for slices imported as
-      // complete (same rationale as milestones above).
-      if (IMPORT_COMPLETE_STATUSES.has(sliceStatus)) {
+      // complete (same rationale as milestones above). #027: skip when preserving
+      // an out-of-scope slice's existing DB status.
+      if (IMPORT_COMPLETE_STATUSES.has(sliceStatus) && sliceStatusAuthoritative) {
         const sliceSummary = resolveSliceFile(basePath, milestoneId, sliceEntry.id, 'SUMMARY');
         // #1291: preserve an existing completion timestamp so a re-import backfills
         // only slices that lack one, never re-stamping an already-complete slice
@@ -947,7 +1017,10 @@ export function migrateHierarchyToDb(basePath: string): {
           // checkbox (#1222); flat-phase checkboxes are authoritative without summary.
           return summaryAttestsCompletion || (t.done && !isLegacySliceLayout);
         });
-        if (allTasksDone && hasSliceSummary) {
+        // #027: the same close guard as the backfill above — a stale slice
+        // SUMMARY under an out-of-scope milestone must not upgrade a reopened
+        // slice to complete. New slices stay authoritative.
+        if (allTasksDone && hasSliceSummary && sliceStatusAuthoritative) {
           if (_getAdapter()) {
             // #1291: preserve an existing completion timestamp — this consistency
             // upgrade sets a completion time only when the row lacks one.

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
@@ -3,9 +3,10 @@
 //
 // gsd-pi's DB is canonical, but .gsd/*.md is the inter-tool contract. When
 // gsd-core edits a projection file, this handler detects the sha drift vs the
-// recorded baseline in .gsd/.compat.json and re-imports the affected entities
-// into the DB. The next renderAllFromDb pass re-projects; the write-time
-// invalidation hook then refreshes the marker entry, closing the loop.
+// recorded baseline in .gsd/.compat.json and re-imports from markdown with
+// status authority scoped to the affected milestone ids. The next
+// renderAllFromDb pass re-projects; the write-time invalidation hook then
+// refreshes the marker entry, closing the loop.
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -59,10 +60,11 @@ function detectExternalMarkdownEdit(
 }
 
 /**
- * Idempotent repair: re-import hierarchy for the affected entities from
- * markdown into the DB, then update the marker entry so the next detect pass
- * sees the file as expected. migrateHierarchyToDb is itself idempotent
- * (upsert), so re-running this repair after a successful one is a no-op.
+ * Idempotent repair: re-import the hierarchy from markdown while allowing
+ * markdown status authority only for milestones named by the drifted file's
+ * marker entities, then update the marker entry so the next detect pass sees
+ * the file as expected. migrateHierarchyToDb is itself idempotent (upsert), so
+ * re-running this repair after a successful one is a no-op.
  */
 async function repairExternalMarkdownEdit(
   record: ExternalMarkdownEditDrift,

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
@@ -72,13 +72,28 @@ async function repairExternalMarkdownEdit(
     // Dynamic imports break a module-init cycle: this handler ← registry ←
     // state.ts ← guided-flow.ts ← md-importer.ts ← (this handler's old static
     // import). Deferring to repair time keeps module load cycle-free.
-    const { migrateHierarchyToDb } = await import("../../md-importer.js");
+    const { migrateHierarchyToDb, milestoneIdsFromEntities } = await import("../../md-importer.js");
     const { invalidateStateCache } = await import("../../state.js");
-    // Scoped re-import. migrateHierarchyToDb walks the whole tree but is a
-    // cheap upsert; per-entity scoping would require decomposing it, which is
-    // out of scope for v1. The cost is bounded by tree size and runs at most
-    // once per reconcile pass (MAX_PASSES=2).
-    migrateHierarchyToDb(ctx.basePath);
+    // #027: migrateHierarchyToDb walks the whole tree (a cheap upsert), so
+    // without scoping every projection rides along with markdown *status*
+    // authority. That lets an unrelated file that is stale from gsd-pi's own
+    // miss silently revert a reopened slice/milestone. Scope status authority to
+    // exactly the milestone(s) this drifted file projects.
+    //
+    // Step 1: the marker's `entities` are DB ids (`M001`, `M001/S01`,
+    // `M001/S01/T01`), so the milestone id is always the first `/`-segment —
+    // layout-independent (legacy `milestones/<MID>/…` and flat `phases/NN-slug/…`
+    // both resolve the same way), no projectionPath parsing needed. An empty set
+    // (no resolvable entities) preserves DB status everywhere: fail toward
+    // protecting the DB, not toward markdown authority.
+    const statusAuthoritativeMilestones = milestoneIdsFromEntities(record.entities);
+    if (statusAuthoritativeMilestones.size === 0) {
+      logWarning(
+        "reconcile",
+        `external-markdown-edit: no milestone scope resolved for ${record.projectionPath}; preserving DB status for all milestones`,
+      );
+    }
+    migrateHierarchyToDb(ctx.basePath, { statusAuthoritativeMilestones });
     invalidateStateCache();
   } catch (err) {
     logWarning(

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
@@ -3,7 +3,8 @@
 // Parallel to external-markdown-edit.ts. Detects sha drift between the compat
 // marker's planning.projections/passthrough and current .planning/ files.
 //
-// Modeled files (projections): re-imported via parsePlanningDirectory → DB.
+// Modeled files (projections): re-imported via parsePlanningDirectory → DB,
+// with markdown status authority scoped to their marker entity milestone ids.
 // Passthrough files (un-modeled docs): sha refreshed, content untouched.
 
 import { existsSync, readFileSync } from "node:fs";

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
@@ -148,13 +148,25 @@ async function repairExternalPlanningEdit(
     const { parsePlanningDirectory } = await import("../../migrate/parser.js");
     const { transformToGSD } = await import("../../migrate/transformer.js");
     const { writeGSDDirectory } = await import("../../migrate/writer.js");
-    const { migrateHierarchyToDb } = await import("../../md-importer.js");
+    const { migrateHierarchyToDb, milestoneIdsFromEntities } = await import("../../md-importer.js");
     const { invalidateStateCache } = await import("../../state.js");
 
     const parsed = await parsePlanningDirectory(join(ctx.basePath, ".planning"));
     const gsdProject = transformToGSD(parsed);
     await writeGSDDirectory(gsdProject, ctx.basePath);
-    migrateHierarchyToDb(ctx.basePath);
+    // #027: scope status authority to the milestone(s) this drifted .planning/
+    // file projects (first `/`-segment of its DB entity ids), so a stale
+    // checkbox in an unrelated projection can't revert a reopened slice/milestone
+    // in the DB. Unseeded files carry no entities → empty set → preserve DB
+    // status everywhere (fail toward the DB, log the breadcrumb).
+    const statusAuthoritativeMilestones = milestoneIdsFromEntities(record.entities);
+    if (statusAuthoritativeMilestones.size === 0) {
+      logWarning(
+        "reconcile",
+        `external-planning-edit: no milestone scope resolved for ${record.projectionPath}; preserving DB status for all milestones`,
+      );
+    }
+    migrateHierarchyToDb(ctx.basePath, { statusAuthoritativeMilestones });
     invalidateStateCache();
   } catch (err) {
     logWarning(

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -49,14 +49,14 @@ export type DriftRecord =
       projectionPath: string;       // relative to basePath, e.g. "m1/plan.md"
       expectedSha: string;          // sha recorded in .compat.json
       actualSha: string;            // freshly computed from disk
-      entities: string[];           // DB entity ids to re-import
+      entities: string[];           // DB entity ids used to scope status authority
     }
   | {
       kind: "external-planning-edit";
       projectionPath: string;       // relative to .planning/, e.g. "phases/01-foo/01-01-PLAN.md"
       expectedSha: string;
       actualSha: string;
-      entities: string[];
+      entities: string[];           // DB entity ids used to scope status authority
       passthrough: boolean;         // true = content-only, no re-import, just refresh sha
     };
 

--- a/src/resources/extensions/gsd/tests/external-edit-scoped-import.test.ts
+++ b/src/resources/extensions/gsd/tests/external-edit-scoped-import.test.ts
@@ -1,0 +1,196 @@
+// Project/App: gsd-pi
+// File Purpose: #027 regression — external-edit drift repair must scope status
+// authority to the drifted milestone(s) so a stale checkbox in an unrelated
+// projection can't revert a reopened slice/milestone in the DB.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  closeDatabase,
+  getSlice,
+  openDatabase,
+  updateSliceStatus,
+} from "../gsd-db.ts";
+import { migrateHierarchyToDb, milestoneIdsFromEntities } from "../md-importer.ts";
+import { externalMarkdownEditHandler } from "../state-reconciliation/drift/external-markdown-edit.ts";
+import {
+  computeProjectionSha,
+  writeCompatMarker,
+} from "../compat/compat-marker.ts";
+import type { DriftContext } from "../state-reconciliation/types.ts";
+import type { GSDState } from "../types.ts";
+
+const stubState = { phase: "idle" } as unknown as GSDState;
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-scoped-import-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
+  rmSync(base, { recursive: true, force: true });
+}
+
+const roadmapRel = (mid: string): string => join("milestones", mid, `${mid}-ROADMAP.md`);
+
+/** Render a single-slice roadmap whose one slice is checked (`done`). */
+function roadmapContent(mid: string, sliceTitle: string, done: boolean): string {
+  return [
+    `# ${mid}: ${mid} Milestone`,
+    "",
+    `**Vision:** ${mid} vision`,
+    "",
+    "## Slices",
+    `- [${done ? "x" : " "}] **S01: ${sliceTitle}** \`risk:low\` \`depends:[]\``,
+    "",
+  ].join("\n");
+}
+
+function writeRoadmap(base: string, mid: string, sliceTitle: string, done: boolean): string {
+  const dir = join(base, ".gsd", "milestones", mid);
+  mkdirSync(dir, { recursive: true });
+  const content = roadmapContent(mid, sliceTitle, done);
+  writeFileSync(join(dir, `${mid}-ROADMAP.md`), content, "utf-8");
+  return content;
+}
+
+/**
+ * Build two legacy-layout milestones (M001, M002) each with one checked slice,
+ * import them so both slices land `complete`, then reopen M002/S01 to `pending`
+ * while leaving M002's roadmap checkbox checked (a stale projection).
+ */
+function seedTwoMilestonesWithReopenedB(base: string): void {
+  writeRoadmap(base, "M001", "Alpha Slice", true);
+  writeRoadmap(base, "M002", "Beta Slice", true);
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  migrateHierarchyToDb(base);
+  assert.equal(getSlice("M001", "S01")?.status, "complete");
+  assert.equal(getSlice("M002", "S01")?.status, "complete");
+  updateSliceStatus("M002", "S01", "pending");
+  assert.equal(getSlice("M002", "S01")?.status, "pending", "precondition: B/S01 reopened");
+}
+
+test("milestoneIdsFromEntities derives milestone ids from DB entity ids (layout-independent)", () => {
+  assert.deepEqual(
+    [...milestoneIdsFromEntities(["M001", "M001/S01", "M001/S01/T01"])],
+    ["M001"],
+  );
+  assert.deepEqual(
+    [...milestoneIdsFromEntities(["M001/S01", "M002/S03/T02"])].sort(),
+    ["M001", "M002"],
+  );
+  // Entity-less / blank entries yield an empty set → repair preserves DB status.
+  assert.equal(milestoneIdsFromEntities([]).size, 0);
+  assert.equal(milestoneIdsFromEntities([""]).size, 0);
+});
+
+test("scoped import preserves a reopened out-of-scope slice (the #027 bug, direct)", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedTwoMilestonesWithReopenedB(base);
+
+  // Only M001 drifted; M002 keeps DB status authority.
+  migrateHierarchyToDb(base, { statusAuthoritativeMilestones: new Set(["M001"]) });
+
+  assert.equal(
+    getSlice("M002", "S01")?.status,
+    "pending",
+    "reopened out-of-scope slice must NOT be reverted to complete by a stale checkbox",
+  );
+});
+
+test("scoped import keeps markdown authority for the in-scope (drifted) milestone", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedTwoMilestonesWithReopenedB(base);
+
+  // Sanctioned interop: M002's own roadmap was externally edited — the checked
+  // box IS authoritative for the drifted milestone.
+  migrateHierarchyToDb(base, { statusAuthoritativeMilestones: new Set(["M002"]) });
+
+  assert.equal(
+    getSlice("M002", "S01")?.status,
+    "complete",
+    "the drifted milestone's checkbox must close its slice (markdown authority)",
+  );
+});
+
+test("no-opts import is unchanged: markdown checkbox wins (pins the default)", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedTwoMilestonesWithReopenedB(base);
+
+  // No scope → full markdown authority, exactly as before #027. Initial-migration
+  // and gsd-core full-import semantics must not silently change.
+  migrateHierarchyToDb(base);
+
+  assert.equal(
+    getSlice("M002", "S01")?.status,
+    "complete",
+    "without a scope, the stale checkbox closes the slice — today's behavior",
+  );
+});
+
+test("scoped import still imports NEW out-of-scope content with its parsed status", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  // Both milestones are on disk but neither is in the DB yet. M002 is out of the
+  // authority scope, but a row that does not exist yet takes the parsed status
+  // regardless of scope (new content is new content).
+  writeRoadmap(base, "M001", "Alpha Slice", true);
+  writeRoadmap(base, "M002", "Beta Slice", true);
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  migrateHierarchyToDb(base, { statusAuthoritativeMilestones: new Set(["M001"]) });
+
+  assert.equal(getSlice("M002", "S01")?.status, "complete", "new out-of-scope slice imports as parsed");
+});
+
+test("external-markdown-edit repair scopes authority to the drifted milestone (end-to-end)", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedTwoMilestonesWithReopenedB(base);
+
+  // Externally edit M001's roadmap (change the slice title) so its sha drifts;
+  // leave M002's roadmap byte-identical to its marker baseline (not drifted).
+  writeRoadmap(base, "M001", "Alpha Slice EDITED", true);
+  const m002Content = roadmapContent("M002", "Beta Slice", true);
+
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-07-07T00:00:00.000Z",
+    projections: {
+      [roadmapRel("M001")]: { sha: "stale000000000000", entities: ["M001"] },
+      [roadmapRel("M002")]: { sha: computeProjectionSha(m002Content), entities: ["M002"] },
+    },
+    piVersion: "1.8.1",
+  });
+
+  const ctx: DriftContext = { basePath: base, state: stubState };
+  const drift = await externalMarkdownEditHandler.detect(stubState, ctx);
+  assert.equal(drift.length, 1, "only M001's roadmap should be detected as drifted");
+  assert.deepEqual(drift[0].entities, ["M001"]);
+
+  await externalMarkdownEditHandler.repair(drift[0], ctx);
+
+  // B was NOT the drifted file — its reopened slice must survive the repair.
+  assert.equal(
+    getSlice("M002", "S01")?.status,
+    "pending",
+    "repair of an unrelated file must not revert B/S01",
+  );
+  // A WAS drifted — its edit is imported (title updated, status stays complete).
+  assert.equal(getSlice("M001", "S01")?.title, "Alpha Slice EDITED", "A's external edit is imported");
+  assert.equal(getSlice("M001", "S01")?.status, "complete");
+});

--- a/src/resources/extensions/gsd/tests/external-edit-scoped-import.test.ts
+++ b/src/resources/extensions/gsd/tests/external-edit-scoped-import.test.ts
@@ -11,8 +11,10 @@ import { tmpdir } from "node:os";
 
 import {
   closeDatabase,
+  getSliceTasks,
   getSlice,
   openDatabase,
+  updateTaskStatus,
   updateSliceStatus,
 } from "../gsd-db.ts";
 import { migrateHierarchyToDb, milestoneIdsFromEntities } from "../md-importer.ts";
@@ -64,6 +66,30 @@ function writeRoadmap(base: string, mid: string, sliceTitle: string, done: boole
   return content;
 }
 
+function planContent(taskDone: boolean): string {
+  return [
+    "# S01: Slice Plan",
+    "",
+    "**Goal:** Exercise scoped task status imports.",
+    "",
+    "## Tasks",
+    "",
+    `- [${taskDone ? "x" : " "}] **T01: Scoped Task** \`est:10m\``,
+    "  Task body.",
+    "",
+  ].join("\n");
+}
+
+function writePlan(base: string, mid: string, taskDone: boolean): void {
+  const dir = join(base, ".gsd", "milestones", mid, "slices", "S01");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "S01-PLAN.md"), planContent(taskDone), "utf-8");
+}
+
+function taskStatus(mid: string): string | undefined {
+  return getSliceTasks(mid, "S01").find((task) => task.id === "T01")?.status;
+}
+
 /**
  * Build two legacy-layout milestones (M001, M002) each with one checked slice,
  * import them so both slices land `complete`, then reopen M002/S01 to `pending`
@@ -78,6 +104,25 @@ function seedTwoMilestonesWithReopenedB(base: string): void {
   assert.equal(getSlice("M002", "S01")?.status, "complete");
   updateSliceStatus("M002", "S01", "pending");
   assert.equal(getSlice("M002", "S01")?.status, "pending", "precondition: B/S01 reopened");
+}
+
+/**
+ * Same as seedTwoMilestonesWithReopenedB, but with checked task boxes too. The
+ * reopened DB task is the authority for out-of-scope milestones.
+ */
+function seedTwoMilestonesWithReopenedBTask(base: string): void {
+  writeRoadmap(base, "M001", "Alpha Slice", true);
+  writePlan(base, "M001", true);
+  writeRoadmap(base, "M002", "Beta Slice", true);
+  writePlan(base, "M002", true);
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  migrateHierarchyToDb(base);
+  assert.equal(getSlice("M002", "S01")?.status, "complete");
+  assert.equal(taskStatus("M002"), "complete");
+  updateSliceStatus("M002", "S01", "pending");
+  updateTaskStatus("M002", "S01", "T01", "pending");
+  assert.equal(getSlice("M002", "S01")?.status, "pending", "precondition: B/S01 reopened");
+  assert.equal(taskStatus("M002"), "pending", "precondition: B/S01/T01 reopened");
 }
 
 test("milestoneIdsFromEntities derives milestone ids from DB entity ids (layout-independent)", () => {
@@ -106,6 +151,27 @@ test("scoped import preserves a reopened out-of-scope slice (the #027 bug, direc
     getSlice("M002", "S01")?.status,
     "pending",
     "reopened out-of-scope slice must NOT be reverted to complete by a stale checkbox",
+  );
+});
+
+test("scoped import preserves reopened tasks in an out-of-scope slice", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedTwoMilestonesWithReopenedBTask(base);
+
+  // Only M001 drifted; M002's stale checked roadmap and plan boxes must not
+  // re-complete either its reopened slice or its reopened task.
+  migrateHierarchyToDb(base, { statusAuthoritativeMilestones: new Set(["M001"]) });
+
+  assert.equal(
+    getSlice("M002", "S01")?.status,
+    "pending",
+    "reopened out-of-scope slice must stay pending",
+  );
+  assert.equal(
+    taskStatus("M002"),
+    "pending",
+    "reopened out-of-scope task must NOT be reverted to complete by a stale plan checkbox",
   );
 });
 


### PR DESCRIPTION
## Intent

Execute plan 027: scope the external-edit drift repair so a stale projection cannot revert DB status. GSD invariant: DB authoritative, markdown is projection; sanctioned exception is external (gsd-core/human) projection edits, imported back by the external-markdown-edit / external-planning-edit drift handlers. Defect is a scope mismatch: detection knows which file drifted, but repair called whole-tree migrateHierarchyToDb(basePath), so every OTHER projection rode along with markdown status-authority it never had; a file stale from gsd-pi's own miss (forgotten render) then flipped a reopened slice/milestone back to complete via its stale checkbox, discarding an authoritative reopen. Fix threads optional { statusAuthoritativeMilestones } into migrateHierarchyToDb: out-of-scope milestones with an existing DB row keep DB status (slice upsert fed existing status so ON CONFLICT is a no-op; complete backfills + all-tasks-done consistency upgrade skipped); new rows and in-scope milestones keep markdown authority; no-opts unchanged (pinned by test). Milestone ids from marker DB entity ids (first /-segment, layout-independent); helper in md-importer pulled via existing dynamic import to avoid a module-init cycle. Deliberate: did NOT touch db/writers/status.ts or upsert SQL (blanket guard breaks sanctioned gsd-core close path); insertMilestone is INSERT OR IGNORE so milestone rows already safe; tasks untouched (#1222 SUMMARY-wins); empty scope fails toward DB and logs; compat-marker.ts untouched to stay independent of plan 029. New regression suite covers revert bug direct + end-to-end, sanctioned close, no-opts default, new-content, id helper.

## What Changed

- Scoped external markdown and `.planning/` drift repairs to milestone IDs derived from compat marker entities before running hierarchy re-imports.
- Updated `migrateHierarchyToDb` so out-of-scope existing milestone/slice DB statuses are preserved during scoped repairs, while no-option imports and new rows keep the previous behavior.
- Added scoped external-edit import regression coverage and synchronized docs around marker entity semantics and external-edit re-import behavior.

## Risk Assessment

⚠️ Medium: The change is localized and improves cross-milestone stale-status reverts, but the milestone-granular scope leaves a plausible same-milestone stale-projection revert path that needs product/author confirmation.

## Testing

After restoring the isolated worktree’s dependencies and contracts build output, I ran the focused external-edit regression suite and adjacent external-planning-edit tests successfully, then manually exercised the end-to-end drift repair path and captured evidence showing M001’s external edit imported while M002 stayed pending despite its stale checked markdown projection.

<details>
<summary>Evidence: External edit scoped import end-to-end evidence</summary>

```text
# External edit scoped import evidence

Scenario: M002 is authoritative in the DB as reopened/pending while its projection is stale checked; only M001 has an external markdown edit.

`` `json
{
  "initial": {
    "M001_S01": "complete",
    "M002_S01": "complete"
  },
  "beforeRepair": {
    "M002_db_status": "pending",
    "M002_markdown_checkbox": "[x] (stale checked in M002-ROADMAP.md)"
  },
  "afterRepair": {
    "detected_projection_paths": [
      "milestones/M001/M001-ROADMAP.md"
    ],
    "detected_entities": [
      "M001"
    ],
    "M001_title_after_repair": "Alpha Slice EDITED",
    "M001_status_after_repair": "complete",
    "M002_status_after_repair": "pending"
  }
}
`` `

Result: the external-edit repair imported the M001 edit while preserving M002 as pending, so the stale out-of-scope checkbox did not revert the DB status.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `src/resources/extensions/gsd/md-importer.ts:853` - Status authority is scoped only at milestone granularity, so a drifted slice/task-level projection such as `M001/S01/T01` makes every slice in `M001` authoritative. Because `migrateHierarchyToDb` still parses the whole milestone roadmap, a stale checkbox for sibling `M001/S02` can still overwrite a reopened DB status even though that sibling file did not drift; consider carrying slice/entity-level status scope or only allowing roadmap/milestone projections to drive sibling statuses.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Checked repository state and CONTRIBUTING.md, confirmed the worktree is detached at target commit `41b3d106` before testing.</code>
- <code>Initial targeted run: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/external-edit-scoped-import.test.ts` failed because dependencies/build artifacts were not present in the isolated worktree.</code>
- <code>Restored local test setup with `pnpm install --frozen-lockfile` and `pnpm run build:contracts`, then removed generated `node_modules` and `packages/contracts/dist` before finishing.</code>
- <code>Retried targeted regression suite: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/external-edit-scoped-import.test.ts`.</code>
- <code>Ran adjacent planning drift handler coverage: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/external-planning-edit.test.ts`.</code>
- <code>Produced product-level evidence with a Node end-to-end scenario that created a temporary `.gsd` project under the evidence directory, seeded two milestones, reopened M002 in the DB while leaving its markdown stale checked, triggered `externalMarkdownEditHandler.detect/repair` for only M001, and wrote the resulting before/after statuses to `external-edit-scoped-import-evidence.md`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reconciliation and hierarchy import semantics on a cross-tool interop path; scope is milestone-level, so a stale sibling projection within the same milestone could still affect status (noted in review).
> 
> **Overview**
> Fixes **#027**: external-edit drift repair still ran a whole-tree `migrateHierarchyToDb`, so stale checkboxes in **non-drifted** projections could overwrite reopened slice/task/milestone status in the DB.
> 
> **`migrateHierarchyToDb`** now accepts optional `{ statusAuthoritativeMilestones }`. For milestones outside that set, **existing** rows keep DB status (upserts echo current status; completion backfills and “all tasks done” upgrades are skipped). Calls without options behave as before; **new** rows still take parsed markdown status.
> 
> **`milestoneIdsFromEntities`** derives milestone ids from compat marker `entities` (first `/` segment). **`external-markdown-edit`** and **`external-planning-edit`** repairs pass that scope into the importer; empty scope logs a warning and preserves DB status everywhere.
> 
> Adds **`external-edit-scoped-import.test.ts`** (direct importer + end-to-end drift repair). Docs and ADR/spec/user guide updated; plan **027** marked DONE in `plans/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a5fb284a529135313c938f1a318170feccef1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->