### PR TITLE
fix(gsd): harden DB write-layer state updates

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -58,7 +58,7 @@ After commit: regenerate markdown artifacts → write to disk → invalidate cac
 2. `better-sqlite3` (npm) — fallback if node:sqlite unavailable
 3. null → DB unavailable. Runtime `deriveState()` fails closed with an explicit blocker; markdown-only recovery is available only through explicit migration/recovery commands.
 
-**Runtime state derivation:** `deriveState()` opens the existing workflow DB through `state/derive/db-open.ts`, projects rows in `state/derive/from-db.ts`, and returns a DB-unavailable blocker instead of implicitly deriving runtime state from markdown projections. Markdown hierarchy import is explicit recovery/migration behavior, not the normal read path.
+**Runtime state derivation:** `deriveState()` opens the existing workflow DB through `state/derive/db-open.ts`, projects rows in `state/derive/from-db.ts`, and returns a DB-unavailable blocker instead of implicitly deriving runtime state from markdown projections. Markdown hierarchy import is explicit recovery/migration behavior, not the normal read path. When `GSD_MILESTONE_LOCK` changes, auto-mode invalidates the short-lived derive cache because the cache key is only the base path while the DB projection is lock-filtered.
 
 ---
 
@@ -220,7 +220,7 @@ PRIMARY KEY (milestone_id, id)
 FOREIGN KEY milestone_id → milestones(id)
 ```
 - Index: `idx_slices_active` (milestone_id, status)
-- Status values: `pending`, `in_progress`, `complete`, `skipped`
+- Status values: `pending`, `in_progress`, `complete`, `skipped` (legacy/imported `done` and `closed` are treated as closed aliases by `status-guards.ts`)
 
 ---
 
@@ -261,7 +261,7 @@ PRIMARY KEY (milestone_id, slice_id, id)
 FOREIGN KEY (milestone_id, slice_id) → slices(milestone_id, id)
 ```
 - Indexes: `idx_tasks_active` (milestone_id, slice_id, status), `idx_tasks_escalation_pending`
-- Status values: `pending`, `in_progress`, `complete`, `skipped`, `blocked`
+- Status values: `pending`, `in_progress`, `complete`, `skipped`, `blocked` (legacy/imported `done` and `closed` are treated as complete aliases; `insertTask` stamps `completed_at` for `complete`/`done`/`closed`, but not `skipped`)
 
 ---
 
@@ -615,6 +615,7 @@ completed_at TEXT
 result_json  TEXT
 ```
 - Index: `idx_command_queue_pending` (target_worker, claimed_at)
+- Claiming is a read-then-write path and uses `immediateTransaction()` so WAL workers serialize before selecting the pending row instead of failing a deferred write upgrade with `SQLITE_BUSY_SNAPSHOT`.
 
 ---
 
@@ -719,7 +720,7 @@ remain outside manifest restore.
 | `gsd_task_reopen` | tasks, slices, milestones | tasks | deletes T##-SUMMARY.md |
 | `gsd_slice_reopen` | slices, tasks, milestones | slices, tasks | deletes S##-SUMMARY.md, UAT, all T##-SUMMARY.md |
 | `gsd_milestone_reopen` | milestones, slices, tasks | milestones, slices, tasks | deletes all summaries |
-| `gsd_save_gate_result` | quality_gates | quality_gates, gate_runs | — |
+| `gsd_save_gate_result` | quality_gates | quality_gates, gate_runs (same transaction) | — |
 | `capture_thought` | memories | memories | KNOWLEDGE.md projection for Patterns/Lessons (both backfilled and newly captured) |
 | `memory_query` | memories, memories_fts, memory_embeddings | memories (hit_count++) | — |
 
@@ -760,15 +761,15 @@ remain outside manifest restore.
 
 1. **Single-writer rule**: all write SQL lives in the explicit single-writer *layer* — `db/engine.ts` for schema, migrations, lifecycle, and transaction primitives; `db/writers/**` for domain write subsystems; `gsd-db.ts` as the compatibility barrel and remaining mid-migration wrappers; the typed coordination/runtime writer modules `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, and `db/command-queue.ts`; the schema/migration helpers `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, and `db-verification-evidence-schema.ts`; and the ADR migration/backfill helper `memory-backfill.ts`. This is an allowlist, not permission for arbitrary raw writes under `db/`. `unit-ownership.ts` remains excluded because it owns a separate `.gsd/unit-claims.db`. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks this allowlist.
 
-2. **Transaction wrapping**: every multi-table write uses `transaction()` or `immediateTransaction()` when it needs SQLite's reserved writer lock up front. Rollback on any error. Re-entrant: nested calls increment the shared depth counter; no nested `BEGIN`.
+2. **Transaction wrapping**: every multi-table write uses `transaction()` or `immediateTransaction()` when it needs SQLite's reserved writer lock up front. Rollback on any error. Re-entrant: nested calls increment the shared depth counter; no nested `BEGIN`. `gsd_save_gate_result` commits the `quality_gates` verdict update and matching `gate_runs` ledger insert together, so recovery never sees a completed gate without its audit row.
 
 3. **Cascade semantics**: hierarchy status cascades are named **Domain Write Operations** in `db/writers/cascades.ts`, each owning its own `transaction()` so the milestone/slice/task subtree transitions atomically (callers keep only projection/file-cleanup/event logic):
    - `gsd_slice_complete` (`completeSliceCascade`) cascades `pending` tasks → `skipped`
-   - `gsd_skip_slice` (`skipSliceCascade`) cascades `pending`/`active` tasks → `skipped`, preserves `complete`
+   - `gsd_skip_slice` (`skipSliceCascade`) rejects closed slices (`complete`/`done`/`closed`) without clearing `completed_at`, re-skips `skipped` slices as a no-op, cascades `pending`/`active` tasks → `skipped`, and preserves closed tasks
    - `gsd_milestone_reopen` (`reopenMilestoneCascade`) cascades all slices → `in_progress`, all tasks → `pending`
    - `gsd_slice_reopen` (`reopenSliceCascade`) and `undo`'s reset (`resetSliceCascade`) reopen a slice's subtree atomically
 
-4. **Conflict guards**: `insertSlice`, `insertTask` use `ON CONFLICT` to preserve existing completed status and non-empty fields. Fresh INSERT of an already-complete row is a no-op.
+4. **Conflict guards**: `insertSlice`, `insertTask` use `ON CONFLICT` to preserve existing completed status and non-empty fields. `insertTask` treats `complete`/`done`/`closed` as complete for `completed_at` stamping and preserves existing completion metadata when `preserveCompletionMetadata` is set; `skipped` stays terminal but does not get a completion timestamp.
 
 5. **FTS fallback**: if FTS5 unavailable, `memory_query` falls back to LIKE scan on `memories.content`.
 

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -107,7 +107,7 @@ Each row = one prompt file. Columns show which DB tables it touches and how.
 
 | Prompt | DB Reads | DB Writes | Disk Artifact Written |
 |--------|----------|-----------|----------------------|
-| `gate-evaluate` | quality_gates | quality_gates (UPDATE), gate_runs (INSERT) | gate result per subagent |
+| `gate-evaluate` | quality_gates | quality_gates (UPDATE), gate_runs (INSERT, same transaction) | gate result per subagent |
 | `validate-milestone` | milestones, slices, tasks, quality_gates | assessments (INSERT VALIDATION) | VALIDATION.md |
 | `run-uat` | slices, assessments | assessments (INSERT ASSESSMENT) | S##-ASSESSMENT.md |
 
@@ -246,7 +246,7 @@ execute-task prompt fires
               completed_at, blocker_discovered
         └─► INSERT INTO verification_evidence (command, exit_code, verdict, duration_ms)
         └─► UPDATE quality_gates SET status='evaluated', verdict (if gate was open)
-        └─► INSERT INTO gate_runs (audit)
+        └─► INSERT INTO gate_runs (audit; same transaction as the gate verdict)
         └─► Write T##-SUMMARY.md to disk
         └─► Toggle checkbox in NN-MM-PLAN.md
         └─► If summary or plan projection write fails:
@@ -332,6 +332,7 @@ user cancels
 command broadcast
   └─► INSERT INTO command_queue (target_worker=NULL, command, args_json)  ← NULL = all workers
   └─► INSERT INTO command_queue (target_worker='w-123', command, args_json) ← targeted
+  └─► worker claims with BEGIN IMMEDIATE so read-then-write claim races serialize under WAL
 
 unit completes
   └─► UPDATE unit_dispatches SET status='done'|'failed', ended_at, exit_reason, error_summary
@@ -373,7 +374,7 @@ unit completes
 | Single-writer: all write SQL in the explicit single-writer allowlist (`db/engine.ts`, `db/writers/**`, `gsd-db.ts`, typed coordination/runtime writers `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, `db/command-queue.ts`, schema/migration helpers `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, `db-verification-evidence-schema.ts`, and ADR migration/backfill helper `memory-backfill.ts`); this is not permission for arbitrary writes under `db/`; `unit-ownership.ts` owns separate `.gsd/unit-claims.db`; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (explicit allowlist) |
 | Cascade on slice complete: pending tasks → skipped | `gsd_slice_complete` transaction |
 | Cascade on milestone reopen: all slices → in_progress, tasks → pending | `gsd_milestone_reopen` transaction |
-| No nested write transactions: `transaction()` and `immediateTransaction()` share one depth counter | `db-transaction.test.ts` |
+| No nested write transactions: `transaction()` and `immediateTransaction()` share one depth counter; read-then-write claims use `immediateTransaction()` and gate verdict + ledger writes commit atomically | `db-transaction.test.ts`, `command-queue.test.ts`, `gate-storage.test.ts` |
 | Workspace isolation: one DB per project root, shared across worktrees via WAL | `db-connection-cache.ts` identityKey |
 | Coordination: one active dispatch per unit_id at a time | `idx_unit_dispatches_active_per_unit` unique partial index |
 | Memory FTS fallback: LIKE scan if FTS5 unavailable | `tryCreateMemoriesFtsSchema` onUnavailable callback |

--- a/plans/028-db-write-layer-small-fixes.md
+++ b/plans/028-db-write-layer-small-fixes.md
@@ -1,0 +1,322 @@
+# Plan 028: Six small state/DB correctness fixes (status aliases, gate atomicity, claim locking, derive-cache locks, lease test)
+
+> **Executor instructions**: Follow this plan step by step. Each step is an
+> independent fix — commit each one separately. Run every verification command
+> and confirm the expected result before moving on. If anything in the "STOP
+> conditions" section occurs, stop and report — do not improvise. When done,
+> update the status row for this plan in `plans/README.md` — unless a reviewer
+> dispatched you and told you they maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat f095797f..HEAD -- src/resources/extensions/gsd/db/writers/cascades.ts src/resources/extensions/gsd/gsd-db.ts src/resources/extensions/gsd/db/command-queue.ts src/resources/extensions/gsd/auto.ts src/resources/extensions/gsd/db/milestone-leases.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S (per step; S–M total)
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: bug + tests
+- **Planned at**: commit `f095797f`, 2026-07-07
+
+## Why this matters
+
+Six independently-verified, small-blast-radius defects in the state/DB layer.
+Background you need: the DB stores free-form status strings with legacy
+aliases — `RAW_CLOSED_STATUSES = ["complete", "done", "skipped", "closed"]`
+in `status-guards.ts:37` is the single closed-set source of truth, and
+`isClosedStatus()` / `toStatus()` are the sanctioned predicates. Inline
+re-derivations that hand-pick two of the four aliases are how completed data
+gets silently corrupted.
+
+1. `skipSliceCascade` guards "already complete" with two inline literals,
+   missing the `closed` alias — a completed slice stored as `closed` gets
+   downgraded to `skipped` with its `completed_at` nulled. (Found
+   independently by two auditors.)
+2. `insertTask` stamps `completed_at` only for `done`/`complete` — a task
+   imported as `closed` is terminal but has no completion timestamp, so
+   `completed_at`-dependent reads (recent-completions, timelines) miss it.
+3. `saveGateResult` writes the gate verdict UPDATE and the `gate_runs` audit
+   INSERT as two separate autocommits — a crash between them records a
+   completed gate with no ledger row (the ledger Recovery Classification
+   reads).
+4. `claimNextCommand` does SELECT-then-UPDATE inside a **deferred**
+   transaction — under WAL, two workers racing produces
+   `SQLITE_BUSY_SNAPSHOT` (which `busy_timeout` does not retry), so the loser
+   **throws** instead of gracefully returning `null`. `immediateTransaction`
+   exists for exactly this.
+5. The 100 ms derive-state cache is keyed on `basePath` only, but
+   `deriveStateFromDb` filters by `GSD_MILESTONE_LOCK`, which auto-mode
+   mutates at runtime — a derive cached before a lock flip serves the
+   wrong-lock phase for up to 100 ms after it.
+6. `forceReleaseLeasesForWorker` — the crash-recovery path that frees a dead
+   worker's milestone leases — has zero test references. Over-matching frees
+   a *live* peer's lease (two workers drive one milestone); under-matching
+   leaves a milestone leased forever.
+
+## Current state
+
+Files and roles:
+
+- `src/resources/extensions/gsd/db/writers/cascades.ts` — hierarchy cascade
+  writers; `skipSliceCascade` at ~line 208.
+- `src/resources/extensions/gsd/gsd-db.ts` — DB barrel + write primitives;
+  `insertTask` completed_at at ~line 518; `saveGateResult` at ~line 1075;
+  `insertGateRun` at ~line 1197.
+- `src/resources/extensions/gsd/status-guards.ts` — `RAW_CLOSED_STATUSES`,
+  `isClosedStatus`, `toStatus`.
+- `src/resources/extensions/gsd/db/command-queue.ts` — worker IPC queue;
+  `claimNextCommand` at ~line 73.
+- `src/resources/extensions/gsd/db-transaction.ts` + `db/engine.ts` —
+  `transaction()` (BEGIN deferred) and `immediateTransaction()` (BEGIN
+  IMMEDIATE), both re-entrant via a depth counter.
+- `src/resources/extensions/gsd/state/derive/cache.ts` — single-slot 100 ms
+  cache keyed on `basePath`; `invalidateStateCache()` at line ~28.
+- `src/resources/extensions/gsd/auto.ts` — `captureMilestoneLockEnv` (line
+  ~434) / `restoreMilestoneLockEnv` (line ~448) set/delete
+  `process.env.GSD_MILESTONE_LOCK`.
+- `src/resources/extensions/gsd/db/milestone-leases.ts` —
+  `forceReleaseLeasesForWorker` at ~line 279.
+
+Key excerpts (verify you see these before editing):
+
+`cascades.ts` ~line 214 — the alias-blind guard (note the same function uses
+`isClosedStatus` for tasks a few lines below):
+
+```ts
+    if (slice.status === "complete" || slice.status === "done") {
+      outcome = { ok: false, reason: "slice-already-complete" };
+      return;
+    }
+    const wasAlreadySkipped = slice.status === "skipped";
+```
+
+`gsd-db.ts` ~lines 518 and 534 — the two-literal completion stamp:
+
+```ts
+    ":completed_at": t.status === "done" || t.status === "complete" ? new Date().toISOString() : null,
+    ...
+    ":preserve_completion": t.preserveCompletionMetadata && (t.status === "complete" || t.status === "done") ? 1 : 0,
+```
+
+`gsd-db.ts` `saveGateResult` — UPDATE `quality_gates` ... then, after a
+changes check and verdict→outcome mapping, a separate `insertGateRun(...)`
+call. No `transaction(` wrapper appears inside the function.
+
+`db/command-queue.ts:78` — `return transaction((): CommandQueueRow | null => {`
+wrapping a SELECT (line ~81) then a conditional UPDATE (line ~96) with a
+`changes !== 1 → return null` race guard that never runs if the write upgrade
+throws first.
+
+`state/derive/cache.ts:33-46` — cache hit requires only
+`_stateCache.basePath === cacheKey` + TTL.
+
+`db/milestone-leases.ts:279` — `forceReleaseLeasesForWorker(workerId)` runs
+`UPDATE milestone_leases SET status = 'released' WHERE worker_id = :worker_id AND status = 'held'`.
+
+Conventions: single quotes in gsd extension files, 2-space indent, WHY
+comments, `_*ForTest` seams, `node:test` tests in
+`src/resources/extensions/gsd/tests/`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Typecheck | `pnpm run typecheck:extensions` | exit 0 |
+| Compile tests | `pnpm run test:compile` | exit 0 |
+| Run one test file | `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/<name>.test.js` | all pass |
+
+## Scope
+
+**In scope**:
+- `src/resources/extensions/gsd/db/writers/cascades.ts`
+- `src/resources/extensions/gsd/gsd-db.ts` (only `insertTask` and `saveGateResult`)
+- `src/resources/extensions/gsd/db/command-queue.ts`
+- `src/resources/extensions/gsd/auto.ts` (only the two lock-env functions)
+- Test files: `tests/skip-slice-cascades-tasks.test.ts` (extend),
+  `tests/gsd-db.test.ts` or `tests/gate-storage.test.ts` (extend),
+  `tests/command-queue.test.ts` (extend), `tests/milestone-leases.test.ts`
+  (extend), plus a small derive-cache test (extend `tests/derive-state-db.test.ts`
+  or the file that tests `state/derive/cache.ts`)
+- `plans/README.md` (status row only)
+
+**Out of scope**:
+- Routing the cascades through `applyStatusTransition` — ADR-030 explicitly
+  sequences that behind sanctioned reopen faces; do not attempt it here.
+- Any other inline status comparison elsewhere in the codebase (~50 sites) —
+  this plan fixes only the two with verified data-loss consequences.
+- `db/writers/status.ts`, `state-transition-matrix.ts`.
+- Changing `transaction()`/`immediateTransaction()` themselves.
+
+## Git workflow
+
+- Branch: `advisor/028-db-write-layer-small-fixes`
+- One conventional commit per step, e.g. `fix(gsd-db): recognize closed alias in skipSliceCascade guard`. No AI credit.
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Fix the `skipSliceCascade` already-closed guard
+
+In `cascades.ts`, replace the two-literal check with the shared predicate,
+keeping the intentional re-skip path (`skipped` must NOT be rejected — it
+falls through to the `wasAlreadySkipped` no-op):
+
+```ts
+    if (isClosedStatus(slice.status) && slice.status !== 'skipped') {
+      outcome = { ok: false, reason: 'slice-already-complete' };
+      return;
+    }
+```
+
+(`isClosedStatus` is already imported in this file for the task loop.) Add a
+test case to `tests/skip-slice-cascades-tasks.test.ts`: insert a slice with
+raw status `closed`, call `skipSliceCascade`, assert
+`{ ok: false, reason: 'slice-already-complete' }` and that the row's status
+and `completed_at` are unchanged. Also assert the existing `skipped` re-skip
+case still returns `ok: true, wasAlreadySkipped: true`.
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/skip-slice-cascades-tasks.test.js` → all pass.
+
+### Step 2: Stamp `completed_at` for all complete-aliases in `insertTask`
+
+In `gsd-db.ts`, compute once above the `.run({...})`:
+
+```ts
+  const isCompleteAlias = t.status != null && toStatus(t.status) === 'complete';
+```
+
+and use it for both params: `":completed_at": isCompleteAlias ? new Date().toISOString() : null`
+and `":preserve_completion": t.preserveCompletionMetadata && isCompleteAlias ? 1 : 0`.
+Import `toStatus` from `./status-guards.js` if not already imported (check the
+existing import line). Deliberately do NOT stamp for `skipped` — the cascade
+writers set `completed_at = NULL` for skipped rows; a skipped task was not
+completed. Say this in a one-line comment.
+
+Add a test (in `tests/gsd-db.test.ts`, near existing `insertTask` coverage):
+inserting a task with status `closed` yields a non-null `completed_at`;
+inserting with `skipped` yields null.
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/gsd-db.test.js` → all pass.
+
+### Step 3: Make `saveGateResult` atomic
+
+Wrap the body of `saveGateResult` (the `quality_gates` UPDATE, the
+changes-check throw, and the `insertGateRun` call) in the module's existing
+`transaction(() => { ... })` helper (check how other functions in `gsd-db.ts`
+import/call it — e.g. `deleteTask`). The runner is re-entrant (depth counter),
+so callers already inside a transaction are safe. Keep the throw-on-zero-changes
+inside the transaction so a missing gate row rolls back nothing.
+
+Add a test (extend `tests/gate-storage.test.ts` if it covers `saveGateResult`,
+else `tests/gsd-db.test.ts`): stub/point `insertGateRun` at a failure — if no
+seam exists, instead assert transactional behavior structurally: begin →
+UPDATE + INSERT commit together by checking that after a successful
+`saveGateResult` both the gate row shows `complete` AND exactly one matching
+`gate_runs` row exists (`SELECT count(*) FROM gate_runs WHERE gate_id = ...`).
+If you can trigger the failure path cheaply (e.g. drop the `gate_runs` table
+in the test DB before the call), assert the gate row's status/verdict are
+UNCHANGED after the throw — that is the regression this fixes.
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/gate-storage.test.js` (or gsd-db) → all pass.
+
+### Step 4: Claim commands with `BEGIN IMMEDIATE`
+
+In `db/command-queue.ts`, switch `claimNextCommand` from `transaction(` to
+`immediateTransaction(` (check the import at the top of the file — both come
+from the same module; add `immediateTransaction` to the import list). Add a
+WHY comment:
+
+```ts
+  // BEGIN IMMEDIATE: this is a read-then-write claim. Under WAL, a deferred
+  // transaction that reads first and then upgrades to a writer can fail with
+  // SQLITE_BUSY_SNAPSHOT (not retried by busy_timeout) when two workers race;
+  // taking the write lock up front serializes claimants so the loser waits
+  // and then sees the row already claimed (changes !== 1 → null).
+```
+
+Leave `markCommandComplete`/enqueue paths alone (they are write-first).
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/command-queue.test.js` → all pass.
+
+### Step 5: Invalidate the derive cache when the milestone lock flips
+
+In `auto.ts`, at the end of `captureMilestoneLockEnv` and
+`restoreMilestoneLockEnv`, call `invalidateStateCache()` (check `auto.ts`'s
+existing imports — it very likely already imports from `./state.js`; if not,
+import `invalidateStateCache` the same way sibling modules do). One WHY
+comment at the first call site:
+
+```ts
+  // The derive cache is keyed on basePath only; GSD_MILESTONE_LOCK changes
+  // what deriveState computes, so a lock flip must not serve a cached result.
+```
+
+Test: in the derive-cache test file, assert that after a cached
+`deriveState`, changing `process.env.GSD_MILESTONE_LOCK` and calling
+`invalidateStateCache()` yields a fresh derivation — if wiring a full
+auto-mode fixture is disproportionate, a direct unit test that
+`captureMilestoneLockEnv`/`restoreMilestoneLockEnv` clear the cache
+(observable via the exported cache read/write helpers in
+`state/derive/cache.ts`) is sufficient. If `auto.ts`'s lock functions are not
+exported and have no test seam, cover via the cache helpers only and note it.
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/derive-state-db.test.js` → all pass.
+
+### Step 6: Test `forceReleaseLeasesForWorker`
+
+Extend `tests/milestone-leases.test.ts` (the harness — in-memory DB +
+`registerAutoWorker` + `claimMilestoneLease` — already exists there):
+
+1. Register workers A and B; A claims milestone M1, B claims M2.
+   `forceReleaseLeasesForWorker(A)` → returns 1; M1's lease row is
+   `released`; **B's M2 lease is still `held`** (the over-release guard).
+2. After the force release, a new claim on M1 succeeds and the fencing token
+   is greater than the released lease's token.
+3. `forceReleaseLeasesForWorker` on a worker with no held leases returns 0.
+
+**Verify**: `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/milestone-leases.test.js` → all pass, including 3 new cases.
+
+## Test plan
+
+Per-step above. Final sweep: run the five touched test files standalone; then
+`pnpm run typecheck:extensions`.
+
+## Done criteria
+
+- [ ] `pnpm run typecheck:extensions` exits 0
+- [ ] `grep -n '"complete" || slice.status === "done"' src/resources/extensions/gsd/db/writers/cascades.ts` → no matches
+- [ ] `grep -n 'immediateTransaction' src/resources/extensions/gsd/db/command-queue.ts` → match in `claimNextCommand`
+- [ ] `saveGateResult` body is inside a `transaction(` callback
+- [ ] Both lock-env functions call `invalidateStateCache()`
+- [ ] New/extended tests pass in all five test files; each fix has at least one assertion that fails on the pre-change code
+- [ ] No files outside the in-scope list modified (`git status`)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- Any excerpt in "Current state" doesn't match the live code.
+- `gsd-db.ts` does not already have a usable `transaction` import for step 3
+  and adding one creates an import cycle — report the cycle.
+- `immediateTransaction` is not exported along the path `command-queue.ts`
+  currently gets `transaction` from.
+- Step 5: `auto.ts` cannot import `invalidateStateCache` without a cycle —
+  report; do not inline a copy of the cache.
+- Any existing test in the five suites fails for a reason you can't trace to
+  your specific change within two attempts.
+
+## Maintenance notes
+
+- Steps 1–2 are instances of a repo-wide pattern (inline status literals vs
+  `status-guards.ts`); ADR-030's deferred write-normalization is the real fix.
+  Reviewers: reject any NEW inline `status === "complete" || ...` in review.
+- Step 4 sets the precedent: any read-then-write claim helper on this DB
+  should use `immediateTransaction`. `milestone-leases.ts` and
+  `auto-workers.ts` are write-first and correct as-is — do not "fix" them.
+- Step 3 makes the gate verdict + ledger row atomic; if `saveGateResult` ever
+  grows more side effects (notifications, cache pokes), keep DB writes inside
+  and side effects outside the transaction.

--- a/plans/README.md
+++ b/plans/README.md
@@ -43,6 +43,7 @@ commit `58dc840f`. Plans 018–024 planned against commit `7cca07ae`.
 | 024 | Dependency & dead-code hygiene (hono, daemon SDK, ajv, chart.tsx) | P2 | S | — | DONE |
 | 026 | Refuse newer-schema DBs, harden version detection, close DB before migration restore | P1 | M | — | DONE |
 | 027 | Scope external-edit drift repair status authority to drifted entities | P1 | M | — | DONE |
+| 028 | Six small state/DB correctness fixes (status aliases, gate atomicity, claim locking, derive-cache lock, lease test) | P1 | S | — | DONE |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`
 (2026-07-01). Notable deviations recorded in the plan files: 009 skipped the

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -19,7 +19,7 @@ import type {
   SessionMessageEntry,
 } from "@gsd/pi-coding-agent";
 
-import { deriveState } from "./state.js";
+import { deriveState, invalidateStateCache } from "./state.js";
 import {
   buildRequirementsBacklogSummaryLines,
   countUnmappedActiveRequirements,
@@ -443,6 +443,9 @@ function captureMilestoneLockEnv(milestoneId: string | null): void {
   } else {
     delete process.env.GSD_MILESTONE_LOCK;
   }
+  // The derive cache is keyed on basePath only; GSD_MILESTONE_LOCK changes
+  // what deriveState computes, so a lock flip must not serve a cached result.
+  invalidateStateCache();
 }
 
 function restoreMilestoneLockEnv(): void {
@@ -457,6 +460,7 @@ function restoreMilestoneLockEnv(): void {
   s.previousMilestoneLockEnv = null;
   s.hadMilestoneLockEnv = false;
   s.milestoneLockEnvCaptured = false;
+  invalidateStateCache();
 }
 
 /**

--- a/src/resources/extensions/gsd/db/command-queue.ts
+++ b/src/resources/extensions/gsd/db/command-queue.ts
@@ -15,6 +15,7 @@
 
 import {
   _getAdapter,
+  immediateTransaction,
   isDbAvailable,
   transaction,
 } from "../gsd-db.js";
@@ -75,7 +76,12 @@ export function claimNextCommand(workerId: string): CommandQueueRow | null {
   const now = new Date().toISOString();
   const db = _getAdapter()!;
 
-  return transaction((): CommandQueueRow | null => {
+  // BEGIN IMMEDIATE: this is a read-then-write claim. Under WAL, a deferred
+  // transaction that reads first and then upgrades to a writer can fail with
+  // SQLITE_BUSY_SNAPSHOT (not retried by busy_timeout) when two workers race;
+  // taking the write lock up front serializes claimants so the loser waits
+  // and then sees the row already claimed (changes !== 1 → null).
+  return immediateTransaction((): CommandQueueRow | null => {
     // Find the oldest unclaimed command targeted at this worker OR
     // broadcast. The partial index covers both via NULL-in-B-tree.
     const row = db.prepare(

--- a/src/resources/extensions/gsd/db/writers/cascades.ts
+++ b/src/resources/extensions/gsd/db/writers/cascades.ts
@@ -211,7 +211,11 @@ export function skipSliceCascade(milestoneId: string, sliceId: string): SkipSlic
   transaction(() => {
     const slice = getSlice(milestoneId, sliceId);
     if (!slice) { outcome = { ok: false, reason: "slice-not-found" }; return; }
-    if (slice.status === "complete" || slice.status === "done") {
+    // Reject any closed slice except "skipped" (which falls through to the
+    // wasAlreadySkipped no-op). isClosedStatus covers the "closed"/"done"
+    // aliases too — hand-picking literals here nulls a completed slice's
+    // completed_at on re-skip.
+    if (isClosedStatus(slice.status) && slice.status !== "skipped") {
       outcome = { ok: false, reason: "slice-already-complete" };
       return;
     }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1089,52 +1089,59 @@ export function saveGateResult(g: {
 }): void {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   const evaluatedAt = new Date().toISOString();
-  const result = getDbOrNull()!.prepare(
-    `UPDATE quality_gates
-     SET status = 'complete', verdict = :verdict, rationale = :rationale,
-         findings = :findings, evaluated_at = :evaluated_at
-     WHERE milestone_id = :mid AND slice_id = :sid AND gate_id = :gid
-       AND (task_id = :tid OR (:tid = '' AND task_id IS NULL))`,
-  ).run({
-    ":mid": g.milestoneId,
-    ":sid": g.sliceId,
-    ":gid": g.gateId,
-    ":tid": g.taskId ?? "",
-    ":verdict": g.verdict,
-    ":rationale": g.rationale,
-    ":findings": g.findings,
-    ":evaluated_at": evaluatedAt,
-  }) as { changes?: number };
+  // Atomic: the gate verdict UPDATE and the gate_runs ledger INSERT must commit
+  // together. As two autocommits, a crash between them records a completed gate
+  // with no ledger row (the row Recovery Classification reads). transaction()
+  // is re-entrant, so callers already inside a transaction are safe. The
+  // throw-on-zero-changes stays inside so a missing gate row rolls back cleanly.
+  transaction(() => {
+    const result = getDbOrNull()!.prepare(
+      `UPDATE quality_gates
+       SET status = 'complete', verdict = :verdict, rationale = :rationale,
+           findings = :findings, evaluated_at = :evaluated_at
+       WHERE milestone_id = :mid AND slice_id = :sid AND gate_id = :gid
+         AND (task_id = :tid OR (:tid = '' AND task_id IS NULL))`,
+    ).run({
+      ":mid": g.milestoneId,
+      ":sid": g.sliceId,
+      ":gid": g.gateId,
+      ":tid": g.taskId ?? "",
+      ":verdict": g.verdict,
+      ":rationale": g.rationale,
+      ":findings": g.findings,
+      ":evaluated_at": evaluatedAt,
+    }) as { changes?: number };
 
-  if ((result.changes ?? 0) === 0) {
-    throw new GSDError(
-      GSD_STALE_STATE,
-      `quality gate row not found for ${g.milestoneId}/${g.sliceId}/${g.gateId}${g.taskId ? `/${g.taskId}` : ""}`,
-    );
-  }
+    if ((result.changes ?? 0) === 0) {
+      throw new GSDError(
+        GSD_STALE_STATE,
+        `quality gate row not found for ${g.milestoneId}/${g.sliceId}/${g.gateId}${g.taskId ? `/${g.taskId}` : ""}`,
+      );
+    }
 
-  const outcome =
-    g.verdict === "pass"
-      ? "pass"
-      : g.verdict === "omitted"
-        ? "manual-attention"
-        : "fail";
-  insertGateRun({
-    traceId: `quality-gate:${g.milestoneId}:${g.sliceId}`,
-    turnId: `gate:${g.gateId}:${g.taskId ?? "slice"}`,
-    gateId: g.gateId,
-    gateType: "quality-gate",
-    milestoneId: g.milestoneId,
-    sliceId: g.sliceId,
-    taskId: g.taskId ?? undefined,
-    outcome,
-    failureClass: outcome === "fail" ? "verification" : outcome === "manual-attention" ? "manual-attention" : "none",
-    rationale: g.rationale,
-    findings: g.findings,
-    attempt: 1,
-    maxAttempts: 1,
-    retryable: false,
-    evaluatedAt,
+    const outcome =
+      g.verdict === "pass"
+        ? "pass"
+        : g.verdict === "omitted"
+          ? "manual-attention"
+          : "fail";
+    insertGateRun({
+      traceId: `quality-gate:${g.milestoneId}:${g.sliceId}`,
+      turnId: `gate:${g.gateId}:${g.taskId ?? "slice"}`,
+      gateId: g.gateId,
+      gateType: "quality-gate",
+      milestoneId: g.milestoneId,
+      sliceId: g.sliceId,
+      taskId: g.taskId ?? undefined,
+      outcome,
+      failureClass: outcome === "fail" ? "verification" : outcome === "manual-attention" ? "manual-attention" : "none",
+      rationale: g.rationale,
+      findings: g.findings,
+      attempt: 1,
+      maxAttempts: 1,
+      retryable: false,
+      evaluatedAt,
+    });
   });
 }
 

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -41,7 +41,7 @@ import {
 } from "./db-decision-requirement-rows.js";
 import { rowToGate } from "./db-gate-rows.js";
 import { rowToArtifact, rowToMilestone, type ArtifactRow, type MilestoneRow } from "./db-milestone-artifact-rows.js";
-import { isClosedStatus } from "./status-guards.js";
+import { isClosedStatus, toStatus } from "./status-guards.js";
 import { rowToSlice, rowToTask, type SliceRow, type TaskRow } from "./db-task-slice-rows.js";
 
 // Connection ownership, lifecycle, schema/migrations and transaction
@@ -464,6 +464,11 @@ export function insertTask(t: {
   preserveCompletionMetadata?: boolean;
 }): void {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  // Stamp completed_at for every terminal-complete alias (complete/done/closed),
+  // not just two literals — a task imported as "closed" is completed and must
+  // carry a timestamp. NOT for "skipped": a skipped task was never completed
+  // (cascade writers set its completed_at = NULL).
+  const isCompleteAlias = t.status != null && toStatus(t.status) === "complete";
   getDbOrNull()!.prepare(
     `INSERT INTO tasks (
       milestone_id, slice_id, id, title, status, one_liner, narrative,
@@ -515,7 +520,7 @@ export function insertTask(t: {
     ":narrative": t.narrative ?? "",
     ":verification_result": t.verificationResult ?? "",
     ":duration": t.duration ?? "",
-    ":completed_at": t.status === "done" || t.status === "complete" ? new Date().toISOString() : null,
+    ":completed_at": isCompleteAlias ? new Date().toISOString() : null,
     ":blocker_discovered": t.blockerDiscovered ? 1 : 0,
     ":deviations": t.deviations ?? "",
     ":known_issues": t.knownIssues ?? "",
@@ -531,7 +536,7 @@ export function insertTask(t: {
     ":observability_impact": t.planning?.observabilityImpact ?? "",
     ":full_plan_md": t.planning?.fullPlanMd ?? "",
     ":sequence": t.sequence ?? 0,
-    ":preserve_completion": t.preserveCompletionMetadata && (t.status === "complete" || t.status === "done") ? 1 : 0,
+    ":preserve_completion": t.preserveCompletionMetadata && isCompleteAlias ? 1 : 0,
     ":target_repositories": JSON.stringify(t.planning?.targetRepositories ?? []),
     ":raw_target_repositories":
       t.planning && "targetRepositories" in t.planning

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -7,6 +7,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { deriveState, invalidateStateCache, _deriveStateImpl, deriveStateFromDb, isGhostMilestone } from '../state.ts';
+import { readCachedDeriveState, writeCachedDeriveState } from '../state/derive/cache.ts';
+import type { GSDState } from '../types.ts';
 import {
   openDatabase,
   closeDatabase,
@@ -579,6 +581,33 @@ describe('derive-state-db', async () => {
     } finally {
       closeDatabase();
       cleanup(base);
+    }
+  });
+
+  // ─── Test 7b: lock flip must not serve a basePath-keyed cache hit ─────
+  // The derive cache is keyed on basePath only, but deriveStateFromDb filters
+  // by GSD_MILESTONE_LOCK. auto.ts's capture/restoreMilestoneLockEnv call
+  // invalidateStateCache() on every flip; this guards that the cache is
+  // genuinely lock-blind (so that invalidate call is load-bearing, not
+  // redundant) and that invalidation defeats the stale read.
+  test('derive-state-db: a milestone-lock flip needs explicit cache invalidation', () => {
+    const prevLock = process.env.GSD_MILESTONE_LOCK;
+    try {
+      const base = '/tmp/gsd-lock-flip-fixture';
+      const stateA = { phase: 'planning' } as unknown as GSDState;
+      process.env.GSD_MILESTONE_LOCK = 'M001';
+      writeCachedDeriveState(base, stateA);
+
+      // Lock flips but basePath is unchanged → the cache still hits.
+      process.env.GSD_MILESTONE_LOCK = 'M002';
+      assert.strictEqual(readCachedDeriveState(base), stateA, 'basePath-only cache ignores the lock flip');
+
+      // What the lock-env functions do on flip:
+      invalidateStateCache();
+      assert.strictEqual(readCachedDeriveState(base), null, 'invalidation defeats the stale-lock read');
+    } finally {
+      if (prevLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
+      else process.env.GSD_MILESTONE_LOCK = prevLock;
     }
   });
 

--- a/src/resources/extensions/gsd/tests/gate-storage.test.ts
+++ b/src/resources/extensions/gsd/tests/gate-storage.test.ts
@@ -19,6 +19,11 @@ import {
   insertMilestone,
   insertSlice,
 } from "../gsd-db.ts";
+import { getDb } from "../db/engine.ts";
+
+function gateRunCount(gateId: string): number {
+  return (getDb().prepare("SELECT count(*) AS cnt FROM gate_runs WHERE gate_id = :gid").get({ ":gid": gateId }) as { cnt: number }).cnt;
+}
 
 describe("quality_gates CRUD", () => {
   let tmpDir: string;
@@ -81,6 +86,30 @@ describe("quality_gates CRUD", () => {
     assert.equal(results[0].verdict, "pass");
     assert.equal(results[0].rationale, "No auth surface");
     assert.ok(results[0].evaluated_at);
+  });
+
+  test("saveGateResult commits the verdict and the gate_runs ledger row together", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    saveGateResult({
+      milestoneId: "M001", sliceId: "S01", gateId: "Q3",
+      verdict: "pass", rationale: "OK", findings: "",
+    });
+    assert.equal(getGateResults("M001", "S01")[0].status, "complete");
+    assert.equal(gateRunCount("Q3"), 1, "exactly one ledger row must accompany the verdict");
+  });
+
+  test("saveGateResult rolls back the verdict UPDATE if the ledger INSERT fails", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    // Force the insertGateRun step to throw after the UPDATE by removing the
+    // ledger table. Atomicity means the gate row must stay pending.
+    getDb().exec("DROP TABLE gate_runs");
+    assert.throws(() => saveGateResult({
+      milestoneId: "M001", sliceId: "S01", gateId: "Q3",
+      verdict: "pass", rationale: "OK", findings: "",
+    }));
+    const gate = getGateResults("M001", "S01")[0];
+    assert.equal(gate.status, "pending", "gate verdict UPDATE must roll back when the ledger INSERT fails");
+    assert.equal(gate.verdict ?? "", "", "verdict must not persist after rollback");
   });
 
   test("saveGateResult throws when the gate row does not exist", () => {

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -280,6 +280,31 @@ describe('gsd-db', () => {
     }
   });
 
+  test("gsd-db: insertTask stamps completed_at for every complete-alias but not for skipped", () => {
+    openDatabase(":memory:");
+
+    try {
+      insertMilestone({ id: "M001", title: "Completion stamp", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active", sequence: 1 });
+      insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Closed", status: "closed", sequence: 1 });
+      insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", title: "Done", status: "done", sequence: 2 });
+      insertTask({ id: "T03", sliceId: "S01", milestoneId: "M001", title: "Skipped", status: "skipped", sequence: 3 });
+
+      assert.ok(
+        getTask("M001", "S01", "T01")?.completed_at,
+        "a task imported as 'closed' is terminal and must carry a completed_at",
+      );
+      assert.ok(getTask("M001", "S01", "T02")?.completed_at, "'done' alias must stamp completed_at");
+      assert.equal(
+        getTask("M001", "S01", "T03")?.completed_at,
+        null,
+        "a skipped task was never completed and must have null completed_at",
+      );
+    } finally {
+      closeDatabase();
+    }
+  });
+
   test('gsd-db: active_decisions view excludes superseded', () => {
     openDatabase(':memory:');
 

--- a/src/resources/extensions/gsd/tests/milestone-leases.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-leases.test.ts
@@ -18,6 +18,7 @@ import {
   releaseMilestoneLease,
   refreshMilestoneLease,
   getMilestoneLease,
+  forceReleaseLeasesForWorker,
 } from "../db/milestone-leases.ts";
 
 function makeBase(): string {
@@ -161,6 +162,60 @@ test("refreshMilestoneLease only succeeds with the matching fencing token", (t) 
 
   // Stale token (e.g. claim.token - 1) refuses
   assert.equal(refreshMilestoneLease(w1, "M001", claim.token - 1), false);
+});
+
+test("forceReleaseLeasesForWorker frees only the dead worker's leases, not a live peer's", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "One", status: "active" });
+  insertMilestone({ id: "M002", title: "Two", status: "active" });
+
+  // Distinct project roots → distinct processes (not re-entrant peers).
+  const wA = registerAutoWorker({ projectRootRealpath: base });
+  const wB = registerAutoWorker({ projectRootRealpath: join(base, "peer") });
+  assert.equal(claimMilestoneLease(wA, "M001").ok, true);
+  assert.equal(claimMilestoneLease(wB, "M002").ok, true);
+
+  const freed = forceReleaseLeasesForWorker(wA);
+  assert.equal(freed, 1, "exactly A's one held lease is released");
+
+  assert.equal(getMilestoneLease("M001")!.status, "released", "A's M001 lease is released");
+  const m2 = getMilestoneLease("M002")!;
+  assert.equal(m2.status, "held", "B's M002 lease must stay held (no over-release)");
+  assert.equal(m2.worker_id, wB);
+});
+
+test("after force release a fresh claim on the freed milestone gets a larger fencing token", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "One", status: "active" });
+
+  const wA = registerAutoWorker({ projectRootRealpath: base });
+  const wB = registerAutoWorker({ projectRootRealpath: join(base, "peer") });
+  const first = claimMilestoneLease(wA, "M001");
+  assert.equal(first.ok, true);
+  const releasedToken = first.ok ? first.token : 0;
+
+  assert.equal(forceReleaseLeasesForWorker(wA), 1);
+
+  const takeover = claimMilestoneLease(wB, "M001");
+  assert.equal(takeover.ok, true);
+  if (takeover.ok) {
+    assert.ok(takeover.token > releasedToken, "takeover token must exceed the released lease's token");
+  }
+  assert.equal(getMilestoneLease("M001")!.worker_id, wB);
+});
+
+test("forceReleaseLeasesForWorker returns 0 for a worker holding no leases", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "One", status: "active" });
+
+  const wA = registerAutoWorker({ projectRootRealpath: base });
+  assert.equal(forceReleaseLeasesForWorker(wA), 0);
 });
 
 test("claimMilestoneLease rethrows foreign-key failures instead of treating them as lease contention", (t) => {

--- a/src/resources/extensions/gsd/tests/skip-slice-cascades-tasks.test.ts
+++ b/src/resources/extensions/gsd/tests/skip-slice-cascades-tasks.test.ts
@@ -25,6 +25,7 @@ import {
   updateTaskStatus,
 } from "../gsd-db.ts";
 import { handleSkipSlice } from "../tools/skip-slice.ts";
+import { skipSliceCascade } from "../db/writers/cascades.ts";
 
 describe("handleSkipSlice cascades skip to tasks (#4375)", () => {
   let dir: string;
@@ -121,5 +122,25 @@ describe("handleSkipSlice cascades skip to tasks (#4375)", () => {
     assert.ok(result.error);
     assert.match(result.error!, /not found/i);
     assert.equal(result.errorCode, "slice_not_found");
+  });
+
+  test("skipSliceCascade rejects a slice in the legacy 'closed' status without nulling completed_at", () => {
+    const completedAt = "2026-01-01T00:00:00.000Z";
+    updateSliceStatus("M001", "S03", "closed", completedAt);
+
+    const outcome = skipSliceCascade("M001", "S03");
+    assert.deepEqual(outcome, { ok: false, reason: "slice-already-complete" });
+
+    const slice = getSlice("M001", "S03");
+    assert.equal(slice?.status, "closed", "closed slice must not be downgraded to skipped");
+    assert.equal(slice?.completed_at, completedAt, "completed_at must be preserved");
+  });
+
+  test("skipSliceCascade still re-skips an already-skipped slice (ok, wasAlreadySkipped)", () => {
+    updateSliceStatus("M001", "S03", "skipped");
+
+    const outcome = skipSliceCascade("M001", "S03");
+    assert.equal(outcome.ok, true);
+    if (outcome.ok) assert.equal(outcome.wasAlreadySkipped, true);
   });
 });


### PR DESCRIPTION
## Intent

The developer wanted to turn the completed plan 028 database/write-layer fixes into a pull request. They required the PR branch to contain only the 028 work, so the agent needed to rebase off origin/main and drop unrelated 027 changes while preserving concurrent untracked plan files. They also wanted the no-mistakes pipeline run before/while creating the PR, with CI/conflict monitoring and fixes as needed. The transcript shows an additional constraint to diagnose the no-mistakes gate when the push hook failed, including using the documented manual notify-push workaround for the gate path issue.

## What Changed

- Hardened GSD DB write-layer behavior by making quality gate result updates and gate-run ledger writes atomic, stamping completion timestamps for all complete-status aliases, and preserving completed slices during skip cascades.
- Reduced state/queue race cases by invalidating derived-state cache when the milestone lock environment changes and claiming queued commands with an immediate transaction under WAL.
- Added targeted regression coverage for gate storage, task completion aliases, skip cascades, milestone lease release guards, and milestone-lock-derived state; synced DB write-layer docs and marked plan 028 complete.

## Risk Assessment

⚠️ Medium: The changes are small and well-covered, but they touch database transaction/concurrency behavior and state-cache invalidation paths where regressions can have broad workflow impact.

## Testing

After temporary dependency setup, I ran the smallest relevant DB/write-layer regression tests plus a persisted DB/API evidence script covering closed-status handling, skip-slice guards, atomic gate-result ledger writes, and command-queue single-claim behavior; all targeted tests passed, evidence artifacts were written, and transient `node_modules` outputs were removed.

<details>
<summary>Evidence: GSD write-layer persisted behavior evidence</summary>

<code>Persisted DB/API evidence showing: a legacy `closed` task is completed and skipped by active-task selection; a `closed` slice cannot be re-skipped and keeps its completion timestamp; `saveGateResult` writes both the completed gate and `gate_runs` ledger row; command queue broadcast claim is single-delivery.</code>

```text
{
  "dbPath": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KWZ5TN0PHTB36MAGQXFF8PEH/gsd-write-layer-demo.db",
  "checks": {
    "closedTaskImport": {
      "taskId": "T-closed",
      "status": "closed",
      "completedAtIsPersisted": true,
      "activeTaskSelectedInstead": "T-pending"
    },
    "closedSliceSkipGuard": {
      "outcome": {
        "ok": false,
        "reason": "slice-already-complete"
      },
      "persistedStatus": "closed",
      "persistedCompletedAt": "2026-07-07T12:00:00.000Z"
    },
    "qualityGateLedger": {
      "gateStatus": "complete",
      "gateVerdict": "pass",
      "gateLedgerRows": [
        {
          "gate_id": "Q3",
          "outcome": "pass",
          "failure_class": "none",
          "rationale": "No auth surface in this slice."
        }
      ]
    },
    "commandQueueClaim": {
      "enqueuedCommandId": 1,
      "firstClaim": {
        "id": 1,
        "claimedBy": "worker-a",
        "command": "pause"
      },
      "secondClaim": null,
      "persistedClaim": {
        "id": 1,
        "claimedBy": "worker-a",
        "completedAt": null
      }
    }
  }
}
```
</details>
<details>
<summary>Evidence: GSD write-layer demo SQLite DB</summary>

Source: GSD write-layer demo SQLite DB (local file: <code>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KWZ5TN0PHTB36MAGQXFF8PEH/gsd-write-layer-demo.db</code>)

```text
SQLite database backing the JSON evidence artifact, left intact for reviewer inspection.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - medium risk</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Read `CONTRIBUTING.md` and checked the worktree was on the target commit/branch before testing with `git status --short --branch`, `git branch --contains HEAD --all --no-color`, and `git diff --name-status a56c2ac31932ad08a30285f10dfb87c73bd1ff2e..420b1bf66ba1fa812d9875126626a7612ebc5a8b`.</code>
- <code>Installed local workspace dependencies for testing with `pnpm install --frozen-lockfile --ignore-scripts`; removed generated `node_modules` directories before finishing.</code>
- <code>Ran targeted DB/write-layer regressions: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/gate-storage.test.ts src/resources/extensions/gsd/tests/gsd-db.test.ts src/resources/extensions/gsd/tests/skip-slice-cascades-tasks.test.ts src/resources/extensions/gsd/tests/milestone-leases.test.ts src/resources/extensions/gsd/tests/derive-state-db.test.ts`.</code>
- <code>Ran changed command-queue coverage: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/command-queue.test.ts`.</code>
- <code>Performed an end-to-end DB behavior check with a Node script using the public GSD DB/write-layer APIs, persisting evidence to `/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KWZ5TN0PHTB36MAGQXFF8PEH/gsd-write-layer-demo.json` and `/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KWZ5TN0PHTB36MAGQXFF8PEH/gsd-write-layer-demo.db`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch core workflow persistence (cascades, gate ledger, command claims) and auto-mode derive caching; blast radius is limited but regressions could affect multi-worker coordination and dispatch phase selection.
> 
> **Overview**
> Implements **plan 028**: six targeted fixes in the GSD SQLite write layer, with docs and regression tests.
> 
> **Status aliases:** `skipSliceCascade` now uses `isClosedStatus` so legacy `closed`/`done` slices are not re-skipped (preserving `completed_at`). `insertTask` stamps `completed_at` for all complete aliases via `toStatus`, not only `complete`/`done`, and still leaves `skipped` without a completion timestamp.
> 
> **Atomicity and WAL:** `saveGateResult` wraps the `quality_gates` update and `gate_runs` insert in one `transaction()`. `claimNextCommand` uses `immediateTransaction()` so concurrent workers serialize claims instead of hitting `SQLITE_BUSY_SNAPSHOT`.
> 
> **Auto-mode state:** `captureMilestoneLockEnv` / `restoreMilestoneLockEnv` call `invalidateStateCache()` when `GSD_MILESTONE_LOCK` changes, since the derive cache is keyed only by `basePath`.
> 
> **Tests and docs:** New/extended coverage for skip cascades, task import timestamps, gate ledger rollback, derive-cache invalidation, and `forceReleaseLeasesForWorker` peer isolation; `db-map.md` and `prompt-db-combined-map.md` updated; plan 028 marked DONE in `plans/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb94c1fe43ec4d857dd20e3d383f1a32e3a1045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->