### PR TITLE
fix(issue): [Bug]: claude-code provider re-sends byte-identical duplicate image blocks every turn (no dedup in `extractImageBlocksFromContext`), inflating the request

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -22,6 +22,7 @@ import type {
 import type { ExtensionUIContext } from "@gsd/pi-coding-agent";
 import { EventStream } from "@gsd/pi-ai";
 import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { createRequire } from "node:module";
@@ -583,6 +584,7 @@ function inferMimeTypeFromDataUri(value: string): string | null {
 /** Collect all base64 image blocks from user messages in the context for inclusion in the SDK prompt. */
 export function extractImageBlocksFromContext(context: Context): SDKInputImageBlock[] {
 	const imageBlocks: SDKInputImageBlock[] = [];
+	const seenImageKeys = new Set<string>();
 
 	for (const msg of context.messages) {
 		if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
@@ -597,12 +599,17 @@ export function extractImageBlocksFromContext(context: Context): SDKInputImageBl
 					: inferMimeTypeFromDataUri(block.data);
 			if (!mimeType) continue;
 
+			const data = stripDataUriPrefix(block.data);
+			const imageKey = `${mimeType}\0${createHash("sha1").update(data).digest("hex")}`;
+			if (seenImageKeys.has(imageKey)) continue;
+			seenImageKeys.add(imageKey);
+
 			imageBlocks.push({
 				type: "image",
 				source: {
 					type: "base64",
 					media_type: mimeType,
-					data: stripDataUriPrefix(block.data),
+					data,
 				},
 			});
 		}

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -363,6 +363,53 @@ describe("stream-adapter — image prompt forwarding (#4183)", () => {
 		]);
 	});
 
+	test("extractImageBlocksFromContext deduplicates byte-identical image parts", () => {
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							data: "data:image/png;base64,abc123",
+							mimeType: "image/png",
+						},
+						{
+							type: "image",
+							data: "abc123",
+							mimeType: "image/png",
+						},
+						{
+							type: "image",
+							data: "def456",
+							mimeType: "image/png",
+						},
+					],
+				} as Message,
+			],
+		};
+
+		const imageBlocks = extractImageBlocksFromContext(context);
+		assert.deepEqual(imageBlocks, [
+			{
+				type: "image",
+				source: {
+					type: "base64",
+					media_type: "image/png",
+					data: "abc123",
+				},
+			},
+			{
+				type: "image",
+				source: {
+					type: "base64",
+					media_type: "image/png",
+					data: "def456",
+				},
+			},
+		]);
+	});
+
 	test("buildSdkQueryPrompt returns plain string when no images exist in context", () => {
 		const context: Context = {
 			messages: [{ role: "user", content: "hello" } as Message],


### PR DESCRIPTION
## Summary
- Deduplicated byte-identical claude-code image blocks and added regression coverage; static checks passed, focused tests were blocked by missing dependencies and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1332
- [#1332 [Bug]: claude-code provider re-sends byte-identical duplicate image blocks every turn (no dedup in `extractImageBlocksFromContext`), inflating the request](https://github.com/open-gsd/gsd-pi/issues/1332)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1332-bug-claude-code-provider-re-sends-byte-i-1783459961`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to image block collection for the Claude Code adapter with a focused regression test; no auth or persistence impact.
> 
> **Overview**
> **`extractImageBlocksFromContext`** now skips duplicate user images before they are sent to the Claude Code SDK. After normalizing payload (strip data-URI prefix), each image is keyed by MIME type plus a **SHA-1** of the base64 bytes; repeats across messages or turns are omitted so multi-turn context does not re-attach the same screenshot every request.
> 
> A unit test covers the case where the same PNG appears both as a `data:image/png;base64,...` part and as raw base64—only one SDK image block is emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb0911a804f3ae8ed7983e86d8334b5145e34a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->