### PR TITLE
fix(gsd): serialize write-gate snapshot read-merge-write across processes

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -45,6 +45,7 @@ commit `58dc840f`. Plans 018–024 planned against commit `7cca07ae`.
 | 027 | Scope external-edit drift repair status authority to drifted entities | P1 | M | — | DONE |
 | 028 | Six small state/DB correctness fixes (status aliases, gate atomicity, claim locking, derive-cache lock, lease test) | P1 | S | — | DONE |
 | 029 | Reject path-traversal keys in the compat marker before drift detectors read them | P1 | S | — | DONE |
+| 030 | Stop the write-gate's cross-process read-merge-write from losing an armed gate | P2 | M | — | DONE |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`
 (2026-07-01). Notable deviations recorded in the plan files: 009 skipped the

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -10,6 +10,7 @@ import { loadJsonFileOrNull } from "../json-persistence.js";
 import { getIsolationMode } from "../preferences.js";
 import { compileSubagentPermissionContract, type ToolsPolicy } from "../unit-context-manifest.js";
 import { logWarning } from "../workflow-logger.js";
+import { acquireSyncLock, releaseSyncLock } from "../sync-lock.js";
 import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { worktreesDirs } from "../worktree-placement.js";
 import { bashReferencesProjectRootOutsideWorktree } from "../worktree-shell-guard.js";
@@ -364,12 +365,63 @@ export function refreshWriteGateStateFromDisk(basePath: string): WriteGateSnapsh
   return currentWriteGateSnapshot(basePath);
 }
 
+const WRITE_GATE_LOCK_NAME = "write-gate.lock";
+
+/**
+ * Test-only seam: fires once inside the held cross-process lock (after acquire,
+ * before the read-merge-write body) with the resolved lock root. Lets a
+ * regression test observe that a concurrent process is genuinely locked out of
+ * the critical section. Production leaves it null. Follows the repo's
+ * `_setGhAvailableForTest` naming convention.
+ */
+let interleaveHookForTest: ((lockRoot: string) => void) | null = null;
+export function _setWriteGateInterleaveHookForTest(fn: ((lockRoot: string) => void) | null): void {
+  interleaveHookForTest = fn;
+}
+
+/**
+ * Serialize the read-merge-write critical section across the two processes
+ * that share the snapshot file (extension host + workflow MCP child). Atomic
+ * rename prevents torn files but not lost updates: without this lock the host
+ * can read the snapshot, the child can arm a gate and persist, then the host's
+ * later persist overwrites `pendingGateId`/`activeQueuePhase` (last-writer-wins
+ * fields) and silently drops the armed HARD-BLOCK gate.
+ *
+ * Fail-OPEN by contract: if a live peer holds the lock we proceed WITHOUT it —
+ * exactly the racy-but-functional behavior that shipped before this lock — and
+ * log once. The lock shrinks the race window to ~zero; it must never block,
+ * throw, or refuse a gate mutation. The lock is skipped entirely when snapshot
+ * persistence is off (no disk file, no cross-process seam).
+ */
+function withWriteGateLock<T>(basePath: string, fn: () => T): T {
+  if (!shouldPersistWriteGateSnapshot()) return fn();
+  const lockRoot = resolveWriteGateSnapshotRoot(basePath);
+  // Materialize `.gsd/` (including a dangling external-state symlink target)
+  // before locking. acquireSyncLock's own mkdir does NOT follow a symlink to
+  // create its target, so without this the O_EXCL open lands on a missing
+  // parent and the lock silently fails open — leaving the seam unserialized
+  // for exactly the external-state projects that need it. This is the same
+  // directory the persist path ensures anyway.
+  try { ensureWriteGateSnapshotDirectory(basePath); } catch { /* best-effort; acquire fails-open below */ }
+  const { acquired } = acquireSyncLock(lockRoot, 0, WRITE_GATE_LOCK_NAME);
+  if (!acquired) {
+    logWarning("intercept", "write-gate: proceeding without cross-process lock (held by live peer)", { lockRoot });
+    return fn();
+  }
+  try {
+    interleaveHookForTest?.(lockRoot);
+    return fn();
+  } finally {
+    releaseSyncLock(lockRoot, WRITE_GATE_LOCK_NAME);
+  }
+}
+
 /**
  * Read-modify-write primitive for gate mutations. Reconciles the disk
  * snapshot into memory (union merge), applies the mutation on top, then
- * persists. The whole sequence is synchronous, so the reconcile read
- * doubles as the pre-persist merge of concurrent writes — there is no
- * version field; the read-merge-write is simply unconditional.
+ * persists — all under the cross-process lock (withWriteGateLock). The whole
+ * sequence is synchronous, so the reconcile read doubles as the pre-persist
+ * merge of concurrent writes; there is no version field.
  *
  * The mutate callback sees the already-reconciled state, so policy checks
  * (e.g. host setPending's verified-on-disk-wins guard) can live inside it
@@ -385,21 +437,23 @@ function mutateWriteGateState(
   opts?: { writer?: WriteGateWriter; reconcile?: boolean },
 ): boolean {
   const state = getWriteGateState(basePath);
-  if (shouldPersistWriteGateSnapshot() && (opts?.reconcile ?? true)) {
-    const disk = readDiskSnapshot(basePath);
-    if (disk) {
-      mergeSnapshotIntoState(state, disk);
-    } else {
-      // Missing OR unparseable on disk: treat as a full reset. Keeping
-      // stale in-memory state across a corrupt snapshot would persist it
-      // back on this very mutation and defeat the documented
-      // "delete the file to clear the HARD BLOCK gate" escape hatch.
-      replaceStateFromSnapshot(state, EMPTY_SNAPSHOT);
+  return withWriteGateLock(basePath, () => {
+    if (shouldPersistWriteGateSnapshot() && (opts?.reconcile ?? true)) {
+      const disk = readDiskSnapshot(basePath);
+      if (disk) {
+        mergeSnapshotIntoState(state, disk);
+      } else {
+        // Missing OR unparseable on disk: treat as a full reset. Keeping
+        // stale in-memory state across a corrupt snapshot would persist it
+        // back on this very mutation and defeat the documented
+        // "delete the file to clear the HARD BLOCK gate" escape hatch.
+        replaceStateFromSnapshot(state, EMPTY_SNAPSHOT);
+      }
     }
-  }
-  if (mutate(state) === false) return false;
-  persistWriteGateSnapshot(basePath, opts?.writer ?? defaultWriteGateWriter());
-  return true;
+    if (mutate(state) === false) return false;
+    persistWriteGateSnapshot(basePath, opts?.writer ?? defaultWriteGateWriter());
+    return true;
+  });
 }
 
 export function isDepthVerified(basePath: string = process.cwd()): boolean {
@@ -643,13 +697,15 @@ export const childWriteGateAdapter: WriteGateStateAdapter = {
 
 function childMutate(basePath: string, mutate: (state: InMemoryWriteGateState) => void): void {
   const state = getWriteGateState(basePath);
-  if (shouldPersistWriteGateSnapshot()) {
-    // Always-fresh: disk is the only truth for the child; discard any
-    // cross-turn in-memory residue before mutating.
-    replaceStateFromSnapshot(state, readDiskSnapshot(basePath) ?? EMPTY_SNAPSHOT);
-  }
-  mutate(state);
-  persistWriteGateSnapshot(basePath, "child");
+  withWriteGateLock(basePath, () => {
+    if (shouldPersistWriteGateSnapshot()) {
+      // Always-fresh: disk is the only truth for the child; discard any
+      // cross-turn in-memory residue before mutating.
+      replaceStateFromSnapshot(state, readDiskSnapshot(basePath) ?? EMPTY_SNAPSHOT);
+    }
+    mutate(state);
+    persistWriteGateSnapshot(basePath, "child");
+  });
 }
 
 /**

--- a/src/resources/extensions/gsd/sync-lock.ts
+++ b/src/resources/extensions/gsd/sync-lock.ts
@@ -9,8 +9,10 @@ import { dirname, join } from "node:path";
 const STALE_THRESHOLD_MS = 60_000; // 60 seconds
 const DEFAULT_TIMEOUT_MS = 0;      // fail fast; sync waits block the JS event loop
 
-function lockFilePath(basePath: string): string {
-  return join(basePath, ".gsd", "sync.lock");
+const DEFAULT_LOCK_NAME = "sync.lock";
+
+function lockFilePath(basePath: string, lockName: string = DEFAULT_LOCK_NAME): string {
+  return join(basePath, ".gsd", lockName);
 }
 
 /** True if the given PID is alive in the current process namespace. */
@@ -74,8 +76,9 @@ function tryCreateLockFile(lp: string, payload: string): boolean {
 export function acquireSyncLock(
   basePath: string,
   _timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  lockName: string = DEFAULT_LOCK_NAME,
 ): { acquired: boolean } {
-  const lp = lockFilePath(basePath);
+  const lp = lockFilePath(basePath, lockName);
   const lockData = JSON.stringify(
     { pid: process.pid, acquired_at: new Date().toISOString() },
     null,
@@ -89,7 +92,12 @@ export function acquireSyncLock(
         return { acquired: true };
       }
     } catch {
-      /* unexpected — fall through to retry */
+      // tryCreateLockFile only throws for non-EEXIST errors — a persistently
+      // uncreatable lock path (dangling-symlink parent, ENOTDIR, read-only FS).
+      // Retrying would spin the loop forever with no progress condition,
+      // blocking the JS event loop. Fail open like a contended lock so callers
+      // proceed (racy but functional) instead of hanging.
+      return { acquired: false };
     }
 
     // File exists. Decide whether to steal (stale + owner dead) or skip.
@@ -131,8 +139,8 @@ export function acquireSyncLock(
 /**
  * Release the advisory sync lock. No-op if lock file does not exist.
  */
-export function releaseSyncLock(basePath: string): void {
-  const lp = lockFilePath(basePath);
+export function releaseSyncLock(basePath: string, lockName: string = DEFAULT_LOCK_NAME): void {
+  const lp = lockFilePath(basePath, lockName);
   try {
     if (existsSync(lp)) {
       unlinkSync(lp);

--- a/src/resources/extensions/gsd/tests/sync-lock.test.ts
+++ b/src/resources/extensions/gsd/tests/sync-lock.test.ts
@@ -174,3 +174,22 @@ test('sync-lock: contended fresh lock fails fast without honoring long sync time
     cleanupDir(base);
   }
 });
+
+test('sync-lock: uncreatable lock path fails open instead of spinning forever', () => {
+  const base = tempDir();
+  try {
+    // `.gsd` is a dangling symlink to a missing target: the O_EXCL open lands
+    // on a missing parent and throws non-EEXIST on every attempt. Without the
+    // fail-open guard the retry loop spins forever, blocking the event loop.
+    fs.symlinkSync(path.join(base, 'missing-external-state'), path.join(base, '.gsd'), 'junction');
+
+    const startedAt = performance.now();
+    const result = acquireSyncLock(base, 0, 'write-gate.lock');
+    const elapsedMs = performance.now() - startedAt;
+
+    assert.strictEqual(result.acquired, false, 'uncreatable lock path must fail open, not acquire');
+    assert.ok(elapsedMs < 250, `must return promptly, not spin; elapsed=${elapsedMs.toFixed(1)}ms`);
+  } finally {
+    cleanupDir(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/write-gate-seam.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-seam.test.ts
@@ -26,6 +26,7 @@ import { tmpdir } from "node:os";
 
 import { registerHooks } from "../bootstrap/register-hooks.ts";
 import {
+  _setWriteGateInterleaveHookForTest,
   childWriteGateAdapter,
   clearDiscussionFlowState,
   getPendingGate,
@@ -36,6 +37,9 @@ import {
   setPendingGate,
   type WriteGateSnapshot,
 } from "../bootstrap/write-gate.ts";
+import { acquireSyncLock, releaseSyncLock } from "../sync-lock.ts";
+
+const WRITE_GATE_LOCK_NAME = "write-gate.lock";
 
 function makeTempDir(prefix: string): string {
   const dir = join(
@@ -355,4 +359,52 @@ test("seam: mutateWriteGateState reset path drops stale pendingGateId on a corru
   const persisted = readDiskRaw(dir);
   assert.equal(persisted.pendingGateId, null, "stale pending id must not be persisted after a corrupt-snapshot reconcile");
   assert.deepEqual(persisted.verifiedDepthMilestones, ["M099"]);
+});
+
+// ── (f) cross-process lock closes the read-merge-write lost-update window ────
+
+test("seam: read-merge-write holds the write-gate lock across the whole critical section", (t) => {
+  const dir = makeTempDir("lock-held");
+  t.after(() => {
+    _setWriteGateInterleaveHookForTest(null);
+    cleanup(dir);
+  });
+
+  // Fire inside the host's critical section, standing in for the OTHER process
+  // attempting to enter its own read-merge-write. The lock must lock it out.
+  let peerAcquiredMidSection: boolean | null = null;
+  _setWriteGateInterleaveHookForTest((lockRoot) => {
+    const res = acquireSyncLock(lockRoot, 0, WRITE_GATE_LOCK_NAME);
+    peerAcquiredMidSection = res.acquired;
+    if (res.acquired) releaseSyncLock(lockRoot, WRITE_GATE_LOCK_NAME);
+  });
+
+  markDepthVerified("M001", dir);
+
+  assert.equal(
+    peerAcquiredMidSection,
+    false,
+    "a concurrent process must be locked out of the read-merge-write section — this is what prevents the lost-update",
+  );
+  // The lock is released after the mutation, and the mutation still took effect.
+  assert.ok(loadWriteGateSnapshot(dir).verifiedDepthMilestones.includes("M001"));
+  assert.equal(acquireSyncLock(dir, 0, WRITE_GATE_LOCK_NAME).acquired, true, "lock released after mutation");
+  releaseSyncLock(dir, WRITE_GATE_LOCK_NAME);
+});
+
+test("seam: gate mutation fails OPEN when a live peer holds the lock (never blocks/refuses)", (t) => {
+  const dir = makeTempDir("lock-fail-open");
+  t.after(() => cleanup(dir));
+
+  // A live peer holds the lock (its own PID → never stolen as stale).
+  assert.equal(acquireSyncLock(dir, 0, WRITE_GATE_LOCK_NAME).acquired, true);
+  try {
+    // Host arms a gate while contended: fail-open means it proceeds anyway.
+    const armed = setPendingGate(GATE, dir);
+    assert.equal(armed, true, "arm must succeed (fail-open) even though the lock is held");
+    assert.equal(getPendingGate(dir), GATE);
+    assert.equal(readDiskRaw(dir).pendingGateId, GATE, "fail-open still persists the mutation");
+  } finally {
+    releaseSyncLock(dir, WRITE_GATE_LOCK_NAME);
+  }
 });


### PR DESCRIPTION
## TL;DR

**What:** Serialize the write-gate snapshot's cross-process read-merge-write behind a fail-open advisory lock so an armed HARD-BLOCK gate can't be silently dropped.
**Why:** The host and MCP child share `write-gate-state.json` via a whole-file snapshot; atomic rename prevents torn files but not lost updates, so an unprotected interleave could overwrite `pendingGateId`/`activeQueuePhase` and let an agent proceed past an unconfirmed gate.
**How:** Wrap both read-merge-write seams in a `write-gate.lock` built on the existing `sync-lock` primitive, fail-open on contention.

## What

- `sync-lock.ts` — generalized `acquireSyncLock`/`releaseSyncLock` to take an optional lock name (default `sync.lock`, unchanged for the existing worktree-sync caller). Also hardened `acquireSyncLock` so a persistently-uncreatable lock path (dangling-symlink parent, `ENOTDIR`, read-only FS) **fails open instead of spinning its retry loop forever** and blocking the event loop.
- `bootstrap/write-gate.ts` — new `withWriteGateLock` wraps `mutateWriteGateState` and `childMutate` (the two read-merge-write seams). It materializes `.gsd/` first (so the lock engages under an external-state symlink instead of silently failing open), acquires the lock, and releases it in a `finally`. Added a test-only `_setWriteGateInterleaveHookForTest` seam.
- Tests — `write-gate-seam.test.ts` and `sync-lock.test.ts` extended.

## Why

The write-gate HARD-BLOCKs an agent from proceeding past unconfirmed depth/approval gates. Its state is shared between two OS processes with no cross-process lock; the merge assigns `pendingGateId`/`activeQueuePhase` last-writer-wins. The unprotected interleave: the child arms a gate and persists while the host is mid-mutation having read the snapshot *before* the child's write — the host's persist lands last and writes `pendingGateId = null`, dropping the armed gate. (Distinct from the already-fixed "host re-arm clobbered child verification" incident, which the `verified-wins-over-pending` rule covers.)

## How

The lock is **fail-OPEN by contract**: on contention it logs once and proceeds exactly as before (racy but functional) — it never blocks, throws, or refuses a gate mutation. It shrinks the lost-update window to lock-contention-fail-open, a deliberate residual (the next step, if audits ever show the warning firing, is a monotonic sequence number with refuse-stale-overwrite on the two fields).

The `acquireSyncLock` hardening was surfaced during verification: the added caller exposed a latent infinite-loop (spin at ~96% CPU) when the lock path's parent can't be created — it also reached the existing `workflow-reconcile` caller, so fixing it in the primitive protects both.

Verified-wins-over-pending (`dropVerifiedPendingGate`) and the "delete the snapshot file to clear the HARD BLOCK" escape hatch are unchanged.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] New/updated tests included — interleave hook pins that the lock brackets the critical section (fails if the wrapping is ever removed); fail-open-under-held-lock and uncreatable-path-fails-open regressions; existing delete-file escape hatch and verified-wins rules still pass.
- [x] 256 tests green across sync-lock, write-gate, write-gate-seam, predicates, planning-unit, worktree-write-gate, register-hooks-depth-verification, workflow-reconcile, and the MCP-server bridge suites; `typecheck:extensions` clean.
- [x] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency around persisted HARD-BLOCK gate state shared by two processes; fail-open on lock contention leaves a small residual race, but behavior on contention matches the pre-fix path.
> 
> **Overview**
> Fixes a cross-process race where the extension host and workflow MCP child both update `write-gate-state.json`: atomic rename avoids torn files but **last-writer-wins** on `pendingGateId` / `activeQueuePhase` could let the host persist over a child-armed gate and drop a **HARD BLOCK**.
> 
> **Write gate:** `mutateWriteGateState` and `childMutate` now run inside `withWriteGateLock`, using `write-gate.lock` via the existing advisory lock. `.gsd/` is ensured first (including external-state symlink targets) so locking actually engages. On contention the path **fails open**—logs once and proceeds like before—so mutations are never refused or blocked.
> 
> **Sync lock:** `acquireSyncLock` / `releaseSyncLock` accept an optional lock name (default `sync.lock` unchanged). Non-`EEXIST` create failures **fail open** instead of spinning forever on uncreatable paths (e.g. dangling `.gsd` symlink).
> 
> **Tests:** Interleave hook proves the lock brackets the critical section; fail-open under held lock; uncreatable-path regression. Plan **030** marked DONE in `plans/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c0482228b917342d079cac804ccdf8182f9823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->