### PR TITLE
feat(models): add Grok 4.5 as a first-class xAI model

### DIFF
--- a/packages/pi-ai/scripts/generate-models.ts
+++ b/packages/pi-ai/scripts/generate-models.ts
@@ -1824,6 +1824,21 @@ async function generateModels() {
 
 	// Add missing Grok models
 	const missingGrokModels: Model<"openai-completions">[] = [
+		// Grok 4.5 — xAI's frontier model (launched 2026-07-09); hand-added
+		// until models.dev includes it. Specs from the xAI launch announcement:
+		// $2/M input, $0.50/M cached input, $6/M output, 500K context window.
+		{
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			api: "openai-completions",
+			baseUrl: "https://api.x.ai/v1",
+			provider: "xai",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+			contextWindow: 500000,
+			maxTokens: 30000,
+		},
 		{
 			id: "grok-3",
 			name: "Grok 3",

--- a/packages/pi-ai/src/models.generated.ts
+++ b/packages/pi-ai/src/models.generated.ts
@@ -16452,6 +16452,23 @@ export const MODELS = {
 			contextWindow: 1000000,
 			maxTokens: 30000,
 		} satisfies Model<"openai-completions">,
+		"grok-4.5": {
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			api: "openai-completions",
+			provider: "xai",
+			baseUrl: "https://api.x.ai/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 2,
+				output: 6,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 500000,
+			maxTokens: 30000,
+		} satisfies Model<"openai-completions">,
 		"grok-build-0.1": {
 			id: "grok-build-0.1",
 			name: "Grok Build 0.1",

--- a/packages/pi-ai/test/generated-models.test.ts
+++ b/packages/pi-ai/test/generated-models.test.ts
@@ -109,6 +109,28 @@ describe("models.generated.ts", () => {
 		}
 	});
 
+	test("includes Grok 4.5 as a first-class xAI model", () => {
+		const model = MODELS.xai["grok-4.5"];
+
+		expect(model).toMatchObject({
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			api: "openai-completions",
+			provider: "xai",
+			baseUrl: "https://api.x.ai/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 2,
+				output: 6,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 500000,
+			maxTokens: 30000,
+		});
+	});
+
 	test("keeps GitHub Copilot Claude 4.6 context at Copilot's 200K limit", () => {
 		for (const id of ["claude-opus-4.6", "claude-sonnet-4.6"] as const) {
 			const model = MODELS["github-copilot"][id];

--- a/packages/pi-coding-agent/src/core/model-resolver.ts
+++ b/packages/pi-coding-agent/src/core/model-resolver.ts
@@ -30,7 +30,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"github-copilot": "gpt-5.4",
 	openrouter: "moonshotai/kimi-k2.6",
 	"vercel-ai-gateway": "zai/glm-5.1",
-	xai: "grok-4.20-0309-reasoning",
+	xai: "grok-4.5",
 	groq: "openai/gpt-oss-120b",
 	cerebras: "zai-glm-4.7",
 	zai: "glm-5.1",

--- a/packages/pi-coding-agent/test/model-resolver.test.ts
+++ b/packages/pi-coding-agent/test/model-resolver.test.ts
@@ -393,6 +393,10 @@ describe("default model selection", () => {
 		expect(defaultModelPerProvider["vercel-ai-gateway"]).toBe("zai/glm-5.1");
 	});
 
+	test("xai default tracks current model", () => {
+		expect(defaultModelPerProvider.xai).toBe("grok-4.5");
+	});
+
 	test("findInitialModel accepts explicit provider custom model ids", async () => {
 		const registry = {
 			getAll: () => allModels,

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -115,6 +115,7 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "o3": "heavy",
   "o4-mini": "heavy",
   "o4-mini-deep-research": "heavy",
+  "grok-4.5": "heavy",
 };
 
 // ─── Cost Table (per 1K input tokens, approximate USD) ───────────────────────
@@ -154,6 +155,7 @@ const MODEL_COST_PER_1K_INPUT: Record<string, number> = {
   "gemini-2.0-flash": 0.0001,
   "gemini-2.5-pro": 0.00125,
   "deepseek-chat": 0.00014,
+  "grok-4.5": 0.002,
 };
 
 // ─── Capability Profiles Data Table ──────────────────────────────────────────
@@ -212,6 +214,11 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
 
   // ── DeepSeek ───────────────────────────────────────────────────────────────
   "deepseek-chat":                { coding: 75, debugging: 65, research: 55, reasoning: 70, speed: 70, longContext: 55, instruction: 65 },
+
+  // ── xAI ────────────────────────────────────────────────────────────────────
+  // Grok 4.5 (2026-07): Opus-class frontier model tuned for coding and agentic
+  // work; notably faster and more token-efficient than peer heavy models.
+  "grok-4.5":                     { coding: 95, debugging: 90, research: 82, reasoning: 93, speed: 55, longContext: 80, instruction: 90 },
 };
 
 // ─── Base Task Requirements Data Table ───────────────────────────────────────


### PR DESCRIPTION
- Add grok-4.5 to the xai catalog (generate-models.ts hand-add block +
  models.generated.ts, matching the Sonnet 5 precedent): $2/M input,
  $0.50/M cached input, $6/M output, 500K context, reasoning,
  text+image input.
- Make grok-4.5 the default xAI model (was grok-4.20-0309-reasoning).
- Register grok-4.5 in dynamic routing: heavy capability tier, cost
  table, and capability profile in model-router.ts.
- Regression tests: catalog entry shape (pi-ai) and xai default pin
  (pi-coding-agent).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016zyGT9giTg5MG31hPM7gUC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog metadata and default-provider pins only; no auth or API client logic changes. Users on xAI without an explicit model will get grok-4.5 instead of the previous default.
> 
> **Overview**
> Adds **Grok 4.5** to the xAI model catalog (hand-maintained in `generate-models.ts` and mirrored in `models.generated.ts`) with reasoning, text+image input, 500K context, and launch pricing until models.dev lists it.
> 
> **Default xAI** selection switches from `grok-4.20-0309-reasoning` to **`grok-4.5`** in `model-resolver.ts`, so new xAI sessions pick the frontier model without an explicit model id.
> 
> **GSD dynamic routing** (`model-router.ts`) registers `grok-4.5` as a **heavy** tier model with input cost and a capability profile aligned with other frontier models.
> 
> Regression coverage: catalog shape in `pi-ai` and the pinned xAI default in `pi-coding-agent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a17b254ba8b86cdc26ad9084bed67462217e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->