### PR TITLE
fix(issue): Skill loading instructions cause agents to construct paths instead of using <available_skills> location field

### DIFF
--- a/src/resources/extensions/gsd/skill-activation.ts
+++ b/src/resources/extensions/gsd/skill-activation.ts
@@ -131,10 +131,23 @@ function resolvePreferredSkillNames(
  *  to prevent prompt injection via crafted directory names. */
 const SAFE_SKILL_NAME = /^[a-z0-9][a-z0-9-]*$/;
 
-function formatSkillActivationBlock(skillNames: string[]): string {
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function formatSkillActivationBlock(skillNames: string[], skillPaths: Map<string, string>): string {
   const safe = skillNames.filter(name => SAFE_SKILL_NAME.test(name));
   if (safe.length === 0) return "";
-  const reads = safe.map(name => `Read the installed '${name}' skill file from <available_skills>`).join(". ");
+  const reads = safe.map(name => {
+    const path = skillPaths.get(name);
+    if (path) return `Read the skill file at \`${escapeXml(path)}\``;
+    return `Find '${name}' in <available_skills>, copy its <location> value, and pass that exact path to read`;
+  }).join(". ");
   return `<skill_activation>${reads}.</skill_activation>`;
 }
 
@@ -203,6 +216,7 @@ export function buildSkillActivationBlock(params: {
   const visibleSkills = loaded;
   const manifestScopedSkills = filterSkillsByManifest(visibleSkills, params.unitType);
   const installedNames = new Set(visibleSkills.map(skill => normalizeSkillReference(skill.name)));
+  const installedSkillPaths = new Map(visibleSkills.map(skill => [normalizeSkillReference(skill.name), skill.filePath]));
   warnIfManifestHasMissingSkills(params.unitType, installedNames);
   const avoided = new Set(resolvePreferenceSkillNames(prefs?.avoid_skills ?? [], params.base));
   const matched = new Set<string>();
@@ -252,7 +266,7 @@ export function buildSkillActivationBlock(params: {
   const ordered = [...matched]
     .filter(name => installedNames.has(name) && !avoided.has(name))
     .sort();
-  const activationBlock = formatSkillActivationBlock(ordered);
+  const activationBlock = formatSkillActivationBlock(ordered, installedSkillPaths);
 
   // Omit recommendations when the system catalog is manifest-scoped for this
   // unit — skill names are already listed in <available_skills>.

--- a/src/resources/extensions/gsd/tests/parallel-skill-prompt-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-skill-prompt-integration.test.ts
@@ -29,11 +29,13 @@ import {
 
 const SKILL_NAME = "testskill";
 const COMPLETE_SLICE_SKILL_NAME = "complete-slice-policies";
-const SKILL_ACTIVATION_SUBSTRING = `Read the installed '${SKILL_NAME}' skill file from <available_skills>`;
-const COMPLETE_SLICE_SKILL_ACTIVATION_SUBSTRING = `Read the installed '${COMPLETE_SLICE_SKILL_NAME}' skill file from <available_skills>`;
 
 const tmpDirs: string[] = [];
 let savedCwd: string | undefined;
+
+function expectedSkillRead(base: string, name: string): string {
+  return `Read the skill file at \`${join(base, ".agents", "skills", name, "SKILL.md")}\``;
+}
 
 function setupProjectWithSkill(options: {
   skillName?: string;
@@ -139,7 +141,7 @@ test("worker prompt (buildResearchSlicePrompt) includes <skill_activation> from 
     "research-slice prompt should contain a <skill_activation> block",
   );
   assert.ok(
-    prompt.includes(SKILL_ACTIVATION_SUBSTRING),
+    prompt.includes(expectedSkillRead(base, SKILL_NAME)),
     `research-slice prompt should reference the always-used skill '${SKILL_NAME}'`,
   );
 });
@@ -164,7 +166,7 @@ test("complete-slice prompt includes <skill_activation> from unit-specific skill
     "complete-slice prompt should contain a <skill_activation> block",
   );
   assert.ok(
-    prompt.includes(COMPLETE_SLICE_SKILL_ACTIVATION_SUBSTRING),
+    prompt.includes(expectedSkillRead(base, COMPLETE_SLICE_SKILL_NAME)),
     `complete-slice prompt should reference the skill-rule skill '${COMPLETE_SLICE_SKILL_NAME}'`,
   );
 });
@@ -192,7 +194,7 @@ test("subagent dispatch prompt (buildParallelResearchSlicesPrompt) carries <skil
     `expected at least 2 <skill_activation> blocks (one per slice), got ${blockCount}`,
   );
   assert.ok(
-    prompt.includes(SKILL_ACTIVATION_SUBSTRING),
+    prompt.includes(expectedSkillRead(base, SKILL_NAME)),
     `parallel-research-slices prompt should reference the always-used skill '${SKILL_NAME}'`,
   );
   assert.ok(

--- a/src/resources/extensions/gsd/tests/skill-activation.test.ts
+++ b/src/resources/extensions/gsd/tests/skill-activation.test.ts
@@ -56,6 +56,10 @@ function buildBlock(
   });
 }
 
+function expectedSkillRead(base: string, name: string): string {
+  return `Read the skill file at \`${join(base, "skills", name, "SKILL.md")}\``;
+}
+
 test("buildSkillActivationBlock does not auto-activate skills via broad context heuristic", () => {
   const base = makeTempBase();
   try {
@@ -92,7 +96,7 @@ test("buildSkillActivationBlock activates skills via prefer_skills when context 
       prefer_skills: ["react"],
     });
 
-    assert.match(result, /Read the installed 'react' skill file from <available_skills>/);
+    assert.ok(result.includes(expectedSkillRead(base, "react")));
     assert.doesNotMatch(result, /swiftui/);
   } finally {
     cleanup(base);
@@ -111,7 +115,7 @@ test("buildSkillActivationBlock includes always_use_skills using read-based skil
 
     assert.equal(
       result,
-      "<skill_activation>Read the installed 'swift-testing' skill file from <available_skills>.</skill_activation>",
+      `<skill_activation>Read the skill file at \`${join(base, "skills", "swift-testing", "SKILL.md")}\`.</skill_activation>`,
     );
   } finally {
     cleanup(base);
@@ -140,8 +144,8 @@ test("buildSkillActivationBlock includes skill_rules matches and task-plan skill
       skill_rules: [{ when: "prisma database schema", use: ["prisma"] }],
     });
 
-    assert.match(result, /Read the installed 'accessibility' skill file from <available_skills>/);
-    assert.match(result, /Read the installed 'prisma' skill file from <available_skills>/);
+    assert.ok(result.includes(expectedSkillRead(base, "accessibility")));
+    assert.ok(result.includes(expectedSkillRead(base, "prisma")));
   } finally {
     cleanup(base);
   }
@@ -163,7 +167,7 @@ test("buildSkillActivationBlock matches skill_rules against exact unit type cont
       ],
     });
 
-    assert.match(result, /Read the installed 'complete-slice-policies' skill file from <available_skills>/);
+    assert.ok(result.includes(expectedSkillRead(base, "complete-slice-policies")));
     assert.doesNotMatch(result, /slice-broad/);
   } finally {
     cleanup(base);
@@ -267,8 +271,8 @@ test("buildSkillActivationBlock allows valid skill names and rejects invalid one
     });
 
     assert.match(result, /skill_activation/);
-    assert.match(result, /Read the installed 'react' skill file from <available_skills>/);
-    assert.match(result, /Read the installed 'good-skill-2' skill file from <available_skills>/);
+    assert.ok(result.includes(expectedSkillRead(base, "react")));
+    assert.ok(result.includes(expectedSkillRead(base, "good-skill-2")));
     assert.doesNotMatch(result, /bad'name/);
   } finally {
     cleanup(base);
@@ -292,8 +296,8 @@ test("buildSkillActivationBlock: explicit always_use_skills bypass the unit-type
       always_use_skills: ["write-docs", "swiftui"],
     });
 
-    assert.match(result, /Read the installed 'write-docs' skill file from <available_skills>/);
-    assert.match(result, /Read the installed 'swiftui' skill file from <available_skills>/);
+    assert.ok(result.includes(expectedSkillRead(base, "write-docs")));
+    assert.ok(result.includes(expectedSkillRead(base, "swiftui")));
   } finally {
     cleanup(base);
   }
@@ -310,7 +314,7 @@ test("buildSkillActivationBlock falls through to all skills for unknown unit typ
     });
 
     // Unknown unit type = wildcard fallback (pre-manifest behavior).
-    assert.match(result, /Read the installed 'swiftui' skill file from <available_skills>/);
+    assert.ok(result.includes(expectedSkillRead(base, "swiftui")));
   } finally {
     cleanup(base);
   }
@@ -327,7 +331,7 @@ test("buildSkillActivationBlock without unitType preserves pre-manifest behavior
       always_use_skills: ["swiftui"],
     });
 
-    assert.match(result, /Read the installed 'swiftui' skill file from <available_skills>/);
+    assert.ok(result.includes(expectedSkillRead(base, "swiftui")));
   } finally {
     cleanup(base);
   }
@@ -344,12 +348,12 @@ test("milestone prompt builders propagate always_use_skills through buildSkillAc
     loadOnlyTestSkills(base);
 
     const researchPrompt = await buildResearchMilestonePrompt("M001", "Test", base);
-    assert.match(researchPrompt, /Read the installed 'write-docs' skill file from <available_skills>/);
-    assert.match(researchPrompt, /Read the installed 'swiftui' skill file from <available_skills>/);
+    assert.ok(researchPrompt.includes(expectedSkillRead(base, "write-docs")));
+    assert.ok(researchPrompt.includes(expectedSkillRead(base, "swiftui")));
 
     const planPrompt = await buildPlanMilestonePrompt("M001", "Test", base);
-    assert.match(planPrompt, /Read the installed 'write-docs' skill file from <available_skills>/);
-    assert.match(planPrompt, /Read the installed 'swiftui' skill file from <available_skills>/);
+    assert.ok(planPrompt.includes(expectedSkillRead(base, "write-docs")));
+    assert.ok(planPrompt.includes(expectedSkillRead(base, "swiftui")));
   } finally {
     cleanup(base);
   }
@@ -380,7 +384,7 @@ test("complete-slice prompt propagates always_use_skills through buildSkillActiv
 
     const prompt = await buildCompleteSlicePrompt("M001", "Test", "S01", "Slice", base);
 
-    assert.match(prompt, /Read the installed 'write-docs' skill file from <available_skills>/);
+    assert.ok(prompt.includes(expectedSkillRead(base, "write-docs")));
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## Summary
- Rendered skill activation now uses absolute skill file paths; diff check passed and focused tests were blocked by missing TypeScript dependency/network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1348
- [#1348 Skill loading instructions cause agents to construct paths instead of using <available_skills> location field](https://github.com/open-gsd/gsd-pi/issues/1348)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1348-skill-loading-instructions-cause-agents--1783550817`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-text and test-only changes in skill activation; no auth, data, or runtime API surface beyond clearer paths in generated prompts.
> 
> **Overview**
> **Skill activation** no longer tells agents to infer paths from `<available_skills>`; it now emits **concrete read instructions** using each installed skill’s `filePath`.
> 
> `formatSkillActivationBlock` takes a name→path map built from `getInstalledSkills`, and for each safe skill name outputs `Read the skill file at \`<escaped path>\``. Paths are passed through a new **`escapeXml`** helper so unusual characters in paths cannot break or inject into the prompt XML. If a path is missing, the fallback still points at `<available_skills>` but asks the model to **copy the `<location>` value** instead of guessing a path.
> 
> Unit and integration tests were updated to assert the new wording (including full expected paths under `.agents/skills` or test `skills/` dirs) across `buildSkillActivationBlock`, research/complete-slice prompts, and parallel subagent dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632b0aba299a5d1c3a3d51bbc14650847aff2e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->