### PR TITLE
fix(issue): Allow projects to configure read-only subagent dispatch for planning units

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -1023,6 +1023,20 @@ pre_dispatch_hooks:
 
 All pre-dispatch hooks support `enabled: true/false` to toggle without removing.
 
+### `planning_subagents`
+
+Project-local allowlists for controlled read-only subagent dispatch during planning:
+
+```yaml
+planning_subagents:
+  plan-milestone:
+    allowed: [scout, planner, security]
+  plan-slice:
+    allowed: [scout, planner, reviewer, security]
+```
+
+Only `plan-milestone` and `plan-slice` are configurable. Agents must be GSD-classified read-only planning specialists (`mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`). The write gate still blocks source writes outside `.gsd/**`, unsafe agents, and agents not listed for the active unit.
+
 ### `always_use_skills` / `prefer_skills` / `avoid_skills`
 
 Skill routing preferences:

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -110,6 +110,20 @@ planning_depth: deep
 
 Enable deep mode with `/gsd new-project --deep`, `/gsd new-milestone --deep`, or by adding the setting to `.gsd/PREFERENCES.md`. The research decision is recorded in `.gsd/runtime/research-decision.json`; choosing research writes `.gsd/research/STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, and `PITFALLS.md`.
 
+### `planning_subagents`
+
+Project-local allowlists for controlled read-only subagent dispatch during planning:
+
+```yaml
+planning_subagents:
+  plan-milestone:
+    allowed: [scout, planner, security]
+  plan-slice:
+    allowed: [scout, planner, reviewer, security]
+```
+
+Only `plan-milestone` and `plan-slice` are configurable. Agents must be GSD-classified read-only planning specialists (`mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`). The write gate still blocks unsafe or unlisted agents.
+
 ### `budget_ceiling`
 
 Maximum USD to spend during auto mode:

--- a/mintlify-docs/guides/configuration.mdx
+++ b/mintlify-docs/guides/configuration.mdx
@@ -242,6 +242,18 @@ pre_dispatch_hooks:
     prepend: "Follow our coding standards."
 ```
 
+### Planning subagents
+
+```yaml
+planning_subagents:
+  plan-milestone:
+    allowed: [scout, planner, security]
+  plan-slice:
+    allowed: [scout, planner, reviewer, security]
+```
+
+Only `plan-milestone` and `plan-slice` are configurable. Agents must be GSD-classified read-only planning specialists (`mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`); the write gate still blocks unsafe or unlisted agents.
+
 ### Skill routing
 
 ```yaml

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -324,7 +324,7 @@ function prependContextModeToBlock(
   block: string,
   renderMode: ContextModeRenderMode = "standalone",
 ): string {
-  const toolSurface = composeToolSurfaceInstructions(unitType, { renderMode });
+  const toolSurface = composeToolSurfaceInstructions(unitType, { renderMode, basePath: base });
   const contextMode = renderContextModeBlockForPrompt(unitType, base, renderMode);
   const guidance = [toolSurface, contextMode].filter(Boolean).join("\n\n");
   if (!guidance) return block;

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -59,6 +59,7 @@ import { installNotifyInterceptor } from "./notify-interceptor.js";
 import { initNotificationStore } from "../notification-store.js";
 import { initNotificationWidget } from "../notification-widget.js";
 import { notifyPreferenceDiagnostics } from "../preferences-diagnostics.js";
+import { resolveEffectivePlanningToolsPolicy } from "../planning-subagent-policy.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { extractSubagentAgentClasses } from "./subagent-input.js";
 import {
@@ -1559,6 +1560,7 @@ export function registerHooks(
     const activeUnitType = dash.currentUnit?.type ?? guidedUnit?.unitType;
     if (activeUnitType) {
       const manifest = resolveManifest(activeUnitType);
+      const planningBasePath = dash.basePath || guidedUnit?.basePath || discussionBasePath;
       let planningInput = "";
       let agentClasses: string[] | undefined;
       if (isToolCallEventType("write", event)) {
@@ -1574,9 +1576,9 @@ export function registerHooks(
       const planningGuard = shouldBlockPlanningUnit(
         event.toolName,
         planningInput,
-        dash.basePath || guidedUnit?.basePath || discussionBasePath,
+        planningBasePath,
         activeUnitType,
-        manifest?.tools,
+        resolveEffectivePlanningToolsPolicy(activeUnitType, manifest?.tools, planningBasePath),
         agentClasses,
         (event as { input?: unknown }).input,
         dash.currentUnit?.id,

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -9,6 +9,10 @@ import { canonicalToolName } from "../engine-hook-contract.js";
 import { loadJsonFileOrNull } from "../json-persistence.js";
 import { getIsolationMode } from "../preferences.js";
 import { compileSubagentPermissionContract, type ToolsPolicy } from "../unit-context-manifest.js";
+import {
+  allowedPlanningDispatchAgentsList,
+  isReadOnlyPlanningDispatchAgent,
+} from "../planning-subagent-registry.js";
 import { logWarning } from "../workflow-logger.js";
 import { acquireSyncLock, releaseSyncLock } from "../sync-lock.js";
 import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "../worktree-root.js";
@@ -1191,35 +1195,9 @@ export function shouldBlockQueueExecutionInSnapshot(
 const PLANNING_WRITE_TOOLS = new Set(["write", "edit", "multi_edit", "notebook_edit"]);
 const PLANNING_SUBAGENT_TOOLS = new Set(["subagent", "task"]);
 
-/**
- * Canonical registry for agents that planning-dispatch may consider. Unit
- * manifests still declare per-unit subsets via ToolsPolicy.allowedSubagents.
- */
-const PLANNING_DISPATCH_AGENT_REGISTRY = {
-  mnemo: { readOnlySpecialist: true },
-  scout: { readOnlySpecialist: true },
-  planner: { readOnlySpecialist: true },
-  reviewer: { readOnlySpecialist: true },
-  security: { readOnlySpecialist: true },
-  tester: { readOnlySpecialist: true },
-} as const satisfies Record<string, { readonly readOnlySpecialist: boolean }>;
-
-export const ALLOWED_PLANNING_DISPATCH_AGENTS = new Set<string>(
-  Object.entries(PLANNING_DISPATCH_AGENT_REGISTRY)
-    .filter(([, metadata]) => metadata.readOnlySpecialist)
-    .map(([agentId]) => agentId),
-);
+export { ALLOWED_PLANNING_DISPATCH_AGENTS } from "../planning-subagent-registry.js";
 
 let warnedMissingControlledDispatchAgentClasses = false;
-
-function isReadOnlySpecialist(agentId: string): boolean {
-  const metadata = PLANNING_DISPATCH_AGENT_REGISTRY[agentId as keyof typeof PLANNING_DISPATCH_AGENT_REGISTRY];
-  return metadata?.readOnlySpecialist === true;
-}
-
-function allowedPlanningDispatchAgentsList(): string {
-  return [...ALLOWED_PLANNING_DISPATCH_AGENTS].join(", ");
-}
 
 function allowsControlledSubagentDispatch(
   policy: ToolsPolicy,
@@ -1393,7 +1371,7 @@ export function shouldBlockPlanningUnit(
       if (requested.length === 0) {
         return { block: false };
       }
-      const globallyDisallowed = requested.find(a => !isReadOnlySpecialist(a));
+      const globallyDisallowed = requested.find(a => !isReadOnlyPlanningDispatchAgent(a));
       if (globallyDisallowed) {
         return planningBlock(
           unitType,
@@ -1406,7 +1384,7 @@ export function shouldBlockPlanningUnit(
         return planningBlock(
           unitType,
           policy.mode,
-          `subagent dispatch of "${disallowedByPolicy}" not permitted by ToolsPolicy.allowedSubagents; permitted agents for this unit: ${allowedSubagents.join(", ")}`,
+          `subagent dispatch of "${disallowedByPolicy}" not permitted by unit allowlist (ToolsPolicy.allowedSubagents/planning_subagents); permitted agents for this unit: ${allowedSubagents.join(", ")}`,
         );
       }
       return { block: false };

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -357,6 +357,28 @@ In `"parent"` mode, slice/task `targetRepositories` default to the declared chil
   - `"replace"` requires `prompt`.
   - `"skip"` is valid with no additional fields.
 
+- `planning_subagents`: object — project-local widening for read-only planning subagent dispatch. Supported unit keys are `plan-milestone` and `plan-slice`; each has:
+  - `allowed`: string[] — additional planning-safe agents for that unit.
+
+  Agents must already be classified by GSD as read-only planning specialists: `mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`. The write gate still blocks source writes outside `.gsd/**`, unrestricted bash, stale subagent calls without agent identities, agents outside the global read-only registry, and agents not listed for the active unit.
+
+  Example:
+
+  ```yaml
+  planning_subagents:
+    plan-milestone:
+      allowed:
+        - scout
+        - planner
+        - security
+    plan-slice:
+      allowed:
+        - scout
+        - planner
+        - reviewer
+        - security
+  ```
+
   **Known unit types for `before`/`after`:** `research-milestone`, `plan-milestone`, `research-slice`, `plan-slice`, `execute-task`, `complete-slice`, `replan-slice`, `reassess-roadmap`, `run-uat`.
 
 - `experimental`: opt-in experimental features. All features here are **off by default** — you must explicitly set each one to `true` to enable it. Features in this block may change or be removed without a deprecation cycle while in experimental status. Keys:

--- a/src/resources/extensions/gsd/planning-subagent-policy.ts
+++ b/src/resources/extensions/gsd/planning-subagent-policy.ts
@@ -1,0 +1,58 @@
+import { CONFIGURABLE_PLANNING_SUBAGENT_UNITS, type GSDPreferences } from "./preferences-types.js";
+import { loadEffectiveGSDPreferences } from "./preferences.js";
+import type { ToolsPolicy } from "./unit-context-manifest.js";
+
+const CONFIGURABLE_UNITS = new Set<string>(CONFIGURABLE_PLANNING_SUBAGENT_UNITS);
+
+function configuredAllowedSubagents(
+  unitType: string,
+  preferences: GSDPreferences | null | undefined,
+): readonly string[] {
+  if (!CONFIGURABLE_UNITS.has(unitType)) return [];
+  return preferences?.planning_subagents?.[
+    unitType as keyof NonNullable<GSDPreferences["planning_subagents"]>
+  ]?.allowed ?? [];
+}
+
+function mergeAllowedSubagents(
+  current: readonly string[],
+  configured: readonly string[],
+): readonly string[] {
+  return Array.from(new Set([...current, ...configured]));
+}
+
+export function applyPlanningSubagentPreferences(
+  unitType: string,
+  policy: ToolsPolicy | null | undefined,
+  preferences: GSDPreferences | null | undefined,
+): ToolsPolicy | null | undefined {
+  if (!policy) return policy;
+  const configured = configuredAllowedSubagents(unitType, preferences);
+  if (configured.length === 0) return policy;
+
+  if (policy.mode === "planning") {
+    return {
+      mode: "planning-dispatch",
+      allowedSubagents: mergeAllowedSubagents([], configured),
+    };
+  }
+
+  if (policy.mode === "planning-dispatch") {
+    return {
+      ...policy,
+      allowedSubagents: mergeAllowedSubagents(policy.allowedSubagents, configured),
+    };
+  }
+
+  return policy;
+}
+
+export function resolveEffectivePlanningToolsPolicy(
+  unitType: string,
+  policy: ToolsPolicy | null | undefined,
+  basePath?: string,
+): ToolsPolicy | null | undefined {
+  if (!basePath) return policy;
+  const preferences = loadEffectiveGSDPreferences(basePath)?.preferences;
+  return applyPlanningSubagentPreferences(unitType, policy, preferences);
+}

--- a/src/resources/extensions/gsd/planning-subagent-registry.ts
+++ b/src/resources/extensions/gsd/planning-subagent-registry.ts
@@ -1,0 +1,31 @@
+/**
+ * Read-only planning specialists that controlled planning dispatch may use.
+ *
+ * Unit manifests and project preferences still declare per-unit subsets. This
+ * registry is the global safety classification checked by the write gate and
+ * preference validation before any configured planning allowlist takes effect.
+ */
+
+const PLANNING_DISPATCH_AGENT_REGISTRY = {
+  mnemo: { readOnlySpecialist: true },
+  scout: { readOnlySpecialist: true },
+  planner: { readOnlySpecialist: true },
+  reviewer: { readOnlySpecialist: true },
+  security: { readOnlySpecialist: true },
+  tester: { readOnlySpecialist: true },
+} as const satisfies Record<string, { readonly readOnlySpecialist: boolean }>;
+
+export const ALLOWED_PLANNING_DISPATCH_AGENTS = new Set<string>(
+  Object.entries(PLANNING_DISPATCH_AGENT_REGISTRY)
+    .filter(([, metadata]) => metadata.readOnlySpecialist)
+    .map(([agentId]) => agentId),
+);
+
+export function isReadOnlyPlanningDispatchAgent(agentId: string): boolean {
+  const metadata = PLANNING_DISPATCH_AGENT_REGISTRY[agentId as keyof typeof PLANNING_DISPATCH_AGENT_REGISTRY];
+  return metadata?.readOnlySpecialist === true;
+}
+
+export function allowedPlanningDispatchAgentsList(): string {
+  return [...ALLOWED_PLANNING_DISPATCH_AGENTS].join(", ");
+}

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -141,6 +141,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "git",
   "post_unit_hooks",
   "pre_dispatch_hooks",
+  "planning_subagents",
   "dynamic_routing",
   "disabled_model_providers",
   "uok",
@@ -216,6 +217,20 @@ export const KNOWN_UNIT_LABELS = [
   "research-decision", "research-project",
 ] as const;
 export type UnitLabel = (typeof KNOWN_UNIT_LABELS)[number];
+
+export const CONFIGURABLE_PLANNING_SUBAGENT_UNITS = [
+  "plan-milestone",
+  "plan-slice",
+] as const;
+export type ConfigurablePlanningSubagentUnit = (typeof CONFIGURABLE_PLANNING_SUBAGENT_UNITS)[number];
+
+export interface PlanningSubagentUnitConfig {
+  allowed?: string[];
+}
+
+export type PlanningSubagentsConfig = Partial<
+  Record<ConfigurablePlanningSubagentUnit, PlanningSubagentUnitConfig>
+>;
 
 
 export const SKILL_ACTIONS = new Set(["use", "prefer", "avoid"]);
@@ -476,6 +491,7 @@ export interface GSDPreferences {
   git?: GitPreferences;
   post_unit_hooks?: PostUnitHookConfig[];
   pre_dispatch_hooks?: PreDispatchHookConfig[];
+  planning_subagents?: PlanningSubagentsConfig;
   dynamic_routing?: DynamicRoutingConfig;
   /** Provider IDs to exclude from /model and automatic model routing while leaving tool auth intact. */
   disabled_model_providers?: string[];

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -17,6 +17,7 @@ import { getGateIdsForTurn } from "./gate-registry.js";
 import {
   KNOWN_PREFERENCE_KEYS,
   KNOWN_UNIT_LABELS,
+  CONFIGURABLE_PLANNING_SUBAGENT_UNITS,
   GSD_MODEL_PHASE_KEYS,
 
   SKILL_ACTIONS,
@@ -26,6 +27,10 @@ import {
   type GSDSkillRule,
   type GSDThinkingLevel,
 } from "./preferences-types.js";
+import {
+  ALLOWED_PLANNING_DISPATCH_AGENTS,
+  allowedPlanningDispatchAgentsList,
+} from "./planning-subagent-registry.js";
 
 const VALID_TOKEN_PROFILES = new Set<TokenProfile>(["budget", "balanced", "quality", "burn-max"]);
 const VALID_THINKING_LEVELS = new Set<GSDThinkingLevel>([
@@ -744,6 +749,63 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
     if (validPreHooks.length > 0) {
       validated.pre_dispatch_hooks = validPreHooks;
+    }
+  }
+
+  // ─── Planning Subagents ─────────────────────────────────────────────────
+  if (preferences.planning_subagents !== undefined) {
+    if (
+      !preferences.planning_subagents ||
+      typeof preferences.planning_subagents !== "object" ||
+      Array.isArray(preferences.planning_subagents)
+    ) {
+      errors.push("planning_subagents must be an object keyed by planning unit type");
+    } else {
+      const validUnits = new Set<string>(CONFIGURABLE_PLANNING_SUBAGENT_UNITS);
+      const validPlanningSubagents: NonNullable<GSDPreferences["planning_subagents"]> = {};
+
+      for (const [unitType, rawConfig] of Object.entries(preferences.planning_subagents as Record<string, unknown>)) {
+        if (!validUnits.has(unitType)) {
+          errors.push(
+            `planning_subagents unknown or unsupported unit "${unitType}" — supported units: ` +
+            `${CONFIGURABLE_PLANNING_SUBAGENT_UNITS.join(", ")}`,
+          );
+          continue;
+        }
+        if (!rawConfig || typeof rawConfig !== "object" || Array.isArray(rawConfig)) {
+          errors.push(`planning_subagents.${unitType} must be an object with an allowed array`);
+          continue;
+        }
+
+        const allowed = normalizeStringArray((rawConfig as Record<string, unknown>).allowed);
+        if (allowed.length === 0) {
+          errors.push(`planning_subagents.${unitType}.allowed must include at least one read-only planning specialist`);
+          continue;
+        }
+
+        const sanitizedAllowed: string[] = [];
+        for (const agentId of allowed) {
+          if (!ALLOWED_PLANNING_DISPATCH_AGENTS.has(agentId)) {
+            errors.push(
+              `planning_subagents.${unitType}.allowed includes "${agentId}", which is not classified as a ` +
+              `read-only planning specialist. Allowed agents: ${allowedPlanningDispatchAgentsList()}`,
+            );
+            continue;
+          }
+          sanitizedAllowed.push(agentId);
+        }
+
+        const dedupedAllowed = Array.from(new Set(sanitizedAllowed));
+        if (dedupedAllowed.length > 0) {
+          validPlanningSubagents[unitType as keyof NonNullable<GSDPreferences["planning_subagents"]>] = {
+            allowed: dedupedAllowed,
+          };
+        }
+      }
+
+      if (Object.keys(validPlanningSubagents).length > 0) {
+        validated.planning_subagents = validPlanningSubagents;
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -817,6 +817,7 @@ function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPr
       : undefined,
     post_unit_hooks: mergePostUnitHooks(base.post_unit_hooks, override.post_unit_hooks),
     pre_dispatch_hooks: mergePreDispatchHooks(base.pre_dispatch_hooks, override.pre_dispatch_hooks),
+    planning_subagents: mergePlanningSubagents(base.planning_subagents, override.planning_subagents),
     dynamic_routing: (base.dynamic_routing || override.dynamic_routing)
       ? { ...(base.dynamic_routing ?? {}), ...(override.dynamic_routing ?? {}) } as DynamicRoutingConfig
       : undefined,
@@ -941,6 +942,30 @@ function mergePreDispatchHooks(
     }
   }
   return merged.length > 0 ? merged : undefined;
+}
+
+function mergePlanningSubagents(
+  base?: GSDPreferences["planning_subagents"],
+  override?: GSDPreferences["planning_subagents"],
+): GSDPreferences["planning_subagents"] | undefined {
+  if (!base && !override) return undefined;
+  const merged: NonNullable<GSDPreferences["planning_subagents"]> = {};
+  const unitTypes = new Set([
+    ...Object.keys(base ?? {}),
+    ...Object.keys(override ?? {}),
+  ]);
+
+  for (const unitType of unitTypes) {
+    const allowed = mergeStringLists(
+      base?.[unitType as keyof NonNullable<GSDPreferences["planning_subagents"]>]?.allowed,
+      override?.[unitType as keyof NonNullable<GSDPreferences["planning_subagents"]>]?.allowed,
+    );
+    if (allowed?.length) {
+      merged[unitType as keyof NonNullable<GSDPreferences["planning_subagents"]>] = { allowed };
+    }
+  }
+
+  return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
 // ─── System Prompt Rendering ──────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/templates/PREFERENCES.md
+++ b/src/resources/extensions/gsd/templates/PREFERENCES.md
@@ -92,6 +92,11 @@ remote_questions:
 uat_dispatch:
 post_unit_hooks: []
 pre_dispatch_hooks: []
+# planning_subagents:
+#   plan-milestone:
+#     allowed: [scout, planner, security]
+#   plan-slice:
+#     allowed: [scout, planner, reviewer, security]
 # language:
 # experimental:
 #   rtk: false

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -823,6 +823,90 @@ test("pre-dispatch hook action validation via validatePreferences", () => {
   assert.ok(e3.some(e => e.includes("invalid action")));
 });
 
+test("planning_subagents validation accepts configured read-only planning specialists", () => {
+  const { preferences, errors } = validatePreferences({
+    planning_subagents: {
+      "plan-milestone": { allowed: ["security", "reviewer"] },
+      "plan-slice": { allowed: ["scout", "security", "security"] },
+    },
+  } as any);
+
+  assert.equal(errors.length, 0);
+  assert.deepEqual(preferences.planning_subagents?.["plan-milestone"]?.allowed, ["security", "reviewer"]);
+  assert.deepEqual(preferences.planning_subagents?.["plan-slice"]?.allowed, ["scout", "security"]);
+});
+
+test("planning_subagents validation rejects unsupported units and unsafe agents", () => {
+  const { preferences, errors } = validatePreferences({
+    planning_subagents: {
+      "execute-task": { allowed: ["security"] },
+      "plan-slice": { allowed: ["worker"] },
+    },
+  } as any);
+
+  assert.equal(preferences.planning_subagents, undefined);
+  assert.ok(errors.some(e => e.includes("unsupported unit \"execute-task\"")));
+  assert.ok(errors.some(e => e.includes("\"worker\"") && e.includes("read-only planning specialist")));
+});
+
+test("loadEffectiveGSDPreferences merges planning_subagents allowlists", (t) => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-planning-subagents-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-planning-subagents-home-"));
+
+  t.after(() => {
+    clearGSDPreferencesCache();
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(tempProject);
+  clearGSDPreferencesCache();
+
+  writeFileSync(
+    getGlobalGSDPreferencesPath(),
+    [
+      "---",
+      "version: 1",
+      "planning_subagents:",
+      "  plan-slice:",
+      "    allowed: [scout, reviewer]",
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  writeFileSync(
+    getProjectGSDPreferencesPath(tempProject),
+    [
+      "---",
+      "version: 1",
+      "planning_subagents:",
+      "  plan-slice:",
+      "    allowed: [security]",
+      "  plan-milestone:",
+      "    allowed: [planner]",
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const loaded = loadEffectiveGSDPreferences(tempProject);
+  assert.deepEqual(loaded?.preferences.planning_subagents?.["plan-slice"]?.allowed, [
+    "scout",
+    "reviewer",
+    "security",
+  ]);
+  assert.deepEqual(loaded?.preferences.planning_subagents?.["plan-milestone"]?.allowed, ["planner"]);
+});
+
 // ── Model config parsing ─────────────────────────────────────────────────────
 
 test("parses OpenRouter model config with org/model IDs and fallbacks", () => {

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -54,6 +54,10 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   },
   post_unit_hooks: [{ command: "npm test" }],
   pre_dispatch_hooks: [{ command: "npm run lint" }],
+  planning_subagents: {
+    "plan-milestone": { allowed: ["scout", "planner"] },
+    "plan-slice": { allowed: ["scout"] },
+  },
   dynamic_routing: { enabled: true },
   disabled_model_providers: ["slow-provider"],
   uok: { enabled: true },

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -46,6 +46,7 @@ import {
   insertTask,
   saveReworkBrief,
 } from "../gsd-db.ts";
+import { clearGSDPreferencesCache, getProjectGSDPreferencesPath } from "../preferences.ts";
 
 // ─── Pure composer tests ──────────────────────────────────────────────────
 
@@ -416,6 +417,44 @@ test("Tool Surface composer: planning-dispatch lists allowed subagents", () => {
   const out = composeToolSurfaceInstructions("plan-slice", { renderMode: "standalone" });
   assert.match(out, /\*\*scout\*\*/);
   assert.match(out, /\*\*planner\*\*/);
+});
+
+test("Tool Surface composer: planning_subagents updates plan-milestone dispatch guidance", (t) => {
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-tool-surface-planning-subagents-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-tool-surface-planning-subagents-home-"));
+
+  t.after(() => {
+    clearGSDPreferencesCache();
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  });
+
+  process.env.GSD_HOME = tempGsdHome;
+  mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+  clearGSDPreferencesCache();
+  writeFileSync(
+    getProjectGSDPreferencesPath(tempProject),
+    [
+      "---",
+      "version: 1",
+      "planning_subagents:",
+      "  plan-milestone:",
+      "    allowed: [security]",
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const out = composeToolSurfaceInstructions("plan-milestone", {
+    renderMode: "standalone",
+    basePath: tempProject,
+  });
+  assert.match(out, /Dispatch subagents only to \*\*security\*\*/);
+  assert.doesNotMatch(out, /Do not dispatch subagents/);
 });
 
 test("Tool Surface composer: execute-task warns against slice/milestone closeout tools", () => {

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -13,6 +13,7 @@ import { GSD_PHASE_SCOPE_DISPLAY_REASON, GSD_SECTION_CLOSE_GATE_DISPLAY_REASON }
 import { ALLOWED_PLANNING_DISPATCH_AGENTS, shouldBlockPlanningUnit } from '../bootstrap/write-gate.ts';
 import { extractSubagentAgentClasses } from '../bootstrap/subagent-input.ts';
 import { isDeterministicPolicyError } from '../auto-tool-tracking.ts';
+import { applyPlanningSubagentPreferences } from '../planning-subagent-policy.ts';
 import type { ToolsPolicy } from '../unit-context-manifest.ts';
 
 const BASE = join('/tmp', 'fake-project');
@@ -333,6 +334,39 @@ test('planning-dispatch: still allows writes inside .gsd/', () => {
     PLANNING_DISPATCH,
   );
   assert.strictEqual(r.block, false);
+});
+
+test('planning_subagents: upgrades plan-milestone to controlled read-only dispatch', () => {
+  const policy = applyPlanningSubagentPreferences('plan-milestone', PLANNING, {
+    planning_subagents: {
+      'plan-milestone': { allowed: ['security'] },
+    },
+  });
+  const allowed = shouldBlockPlanningUnit('subagent', '', BASE, 'plan-milestone', policy, ['security']);
+  assert.strictEqual(allowed.block, false);
+
+  const blocked = shouldBlockPlanningUnit('subagent', '', BASE, 'plan-milestone', policy, ['reviewer']);
+  assert.strictEqual(blocked.block, true);
+  assert.match(blocked.reason!, /planning_subagents/);
+  assert.match(blocked.reason!, /permitted agents for this unit: security/);
+});
+
+test('planning_subagents: widens plan-slice manifest allowlist without allowing unsafe agents', () => {
+  const policy = applyPlanningSubagentPreferences('plan-slice', {
+    mode: 'planning-dispatch',
+    allowedSubagents: ['scout', 'planner'],
+  }, {
+    planning_subagents: {
+      'plan-slice': { allowed: ['security'] },
+    },
+  });
+
+  const added = shouldBlockPlanningUnit('subagent', '', BASE, 'plan-slice', policy, ['security']);
+  assert.strictEqual(added.block, false);
+
+  const unsafe = shouldBlockPlanningUnit('subagent', '', BASE, 'plan-slice', policy, ['worker']);
+  assert.strictEqual(unsafe.block, true);
+  assert.match(unsafe.reason!, /read-only specialists/);
 });
 
 // ─── planning mode: pass-through tools ────────────────────────────────────

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -46,6 +46,7 @@ import {
   type ToolsPolicy,
   type UnitContextManifest,
 } from "./unit-context-manifest.js";
+import { resolveEffectivePlanningToolsPolicy } from "./planning-subagent-policy.js";
 import { getUnitToolSurfaceContract } from "./unit-tool-contracts.js";
 import type { UnitPromptContextContract } from "./tool-contract.js";
 
@@ -207,6 +208,7 @@ export function composeContextModeInstructions(
 
 export interface ComposeToolSurfaceInstructionOptions {
   readonly renderMode: ContextModeRenderMode;
+  readonly basePath?: string;
 }
 
 const TOOL_SURFACE_GUIDANCE_BY_UNIT: Record<string, string> = {
@@ -226,15 +228,38 @@ const TOOL_SURFACE_GUIDANCE_BY_UNIT: Record<string, string> = {
     "Persist completion only through `gsd_complete_milestone` after verification passes. Do not query `.gsd/gsd.db` directly. Do not write `.gsd/PROJECT.md` or `.gsd/REQUIREMENTS.md` by hand — use `gsd_summary_save` and `gsd_requirement_update`.",
   "replan-slice":
     "Persist replans through `gsd_replan_slice` only. Do not edit `PLAN.md` or task plans directly.",
-  "plan-slice":
-    "Persist planning through `gsd_plan_slice` only. Dispatch subagents only to **scout** or **planner** for reconnaissance — not implementation agents. Do not edit user source files outside `.gsd/**`.",
-  "refine-slice":
-    "Persist refinements through `gsd_plan_slice` only. Dispatch subagents only to **scout** or **planner**. Do not edit user source files outside `.gsd/**`.",
-  "plan-milestone":
-    "Persist milestone planning through `gsd_plan_milestone` / `gsd_plan_slice`. Do not edit user source files outside `.gsd/**`.",
   "research-slice":
     "Dispatch subagents only to **scout** or **planner** for reconnaissance. Do not edit user source files outside `.gsd/**`.",
 };
+
+function formatAllowedAgents(agents: readonly string[]): string {
+  return agents.map((agent) => `**${agent}**`).join(", ");
+}
+
+function guidanceForUnitToolsPolicy(unitType: string, policy: ToolsPolicy): string | undefined {
+  if (unitType === "plan-slice") {
+    const dispatch = policy.mode === "planning-dispatch"
+      ? ` Dispatch subagents only to ${formatAllowedAgents(policy.allowedSubagents)} for reconnaissance — not implementation agents.`
+      : " Do not dispatch subagents.";
+    return `Persist planning through \`gsd_plan_slice\` only.${dispatch} Do not edit user source files outside \`.gsd/**\`.`;
+  }
+
+  if (unitType === "refine-slice") {
+    const dispatch = policy.mode === "planning-dispatch"
+      ? ` Dispatch subagents only to ${formatAllowedAgents(policy.allowedSubagents)}.`
+      : " Do not dispatch subagents.";
+    return `Persist refinements through \`gsd_plan_slice\` only.${dispatch} Do not edit user source files outside \`.gsd/**\`.`;
+  }
+
+  if (unitType === "plan-milestone") {
+    const dispatch = policy.mode === "planning-dispatch"
+      ? ` Dispatch subagents only to ${formatAllowedAgents(policy.allowedSubagents)}.`
+      : "";
+    return `Persist milestone planning through \`gsd_plan_milestone\` / \`gsd_plan_slice\`.${dispatch} Do not edit user source files outside \`.gsd/**\`.`;
+  }
+
+  return undefined;
+}
 
 function guidanceForToolsPolicy(policy: ToolsPolicy): string | null {
   switch (policy.mode) {
@@ -280,8 +305,9 @@ export function composeToolSurfaceInstructions(
   const manifest = resolveManifest(unitType);
   if (!manifest) return "";
 
-  const unitGuidance = TOOL_SURFACE_GUIDANCE_BY_UNIT[unitType];
-  const policyGuidance = unitGuidance ? null : guidanceForToolsPolicy(manifest.tools);
+  const effectiveTools = resolveEffectivePlanningToolsPolicy(unitType, manifest.tools, opts.basePath) ?? manifest.tools;
+  const unitGuidance = guidanceForUnitToolsPolicy(unitType, effectiveTools) ?? TOOL_SURFACE_GUIDANCE_BY_UNIT[unitType];
+  const policyGuidance = unitGuidance ? null : guidanceForToolsPolicy(effectiveTools);
   const forbiddenLine = formatForbiddenWorkflowToolsLine(unitType, unitGuidance);
   const parts = [unitGuidance, policyGuidance, forbiddenLine].filter(
     (part): part is string => typeof part === "string" && part.length > 0,


### PR DESCRIPTION
## Summary
- Added validated planning_subagents allowlists for plan-milestone and plan-slice, wired them into dispatch gating and prompt guidance, and verified whitespace while tests were blocked by missing dependencies/network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1346
- [#1346 Allow projects to configure read-only subagent dispatch for planning units](https://github.com/open-gsd/gsd-pi/issues/1346)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1346-allow-projects-to-configure-read-only-su-1783550807`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes planning-unit subagent gating and can widen dispatch for configured units, but remains bounded by the global read-only registry and existing `.gsd/**` write restrictions.
> 
> **Overview**
> Adds **`planning_subagents`** in `.gsd/PREFERENCES.md` so projects can allowlist read-only planning specialists (`scout`, `planner`, `security`, etc.) for **`plan-milestone`** and **`plan-slice`** only. Preferences are validated, merged across global/project files, and applied by merging into the unit **`ToolsPolicy`**—including upgrading plain **`planning`** mode to **`planning-dispatch`** when an allowlist is set.
> 
> **Runtime wiring:** the planning write gate and auto-mode hook use **`resolveEffectivePlanningToolsPolicy`** instead of the raw manifest; block messages reference **`planning_subagents`**. The read-only agent registry moves to **`planning-subagent-registry.ts`**. Tool-surface / prompt guidance for planning units is built from the effective policy (with **`basePath`** passed through **`auto-prompts`**), so allowed agents shown to the model match what the gate permits.
> 
> User docs, GitBook, Mintlify, and the preferences template/reference are updated with examples and constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf21f89d0f852888f5fb0f867d9cffd2b98e517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->