### PR TITLE
perf(gsd): stop advertising alias tool schemas on model-facing surfaces

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -202,6 +202,7 @@ Recommended verification order:
 - If a server is team-shared and safe to commit, `.mcp.json` is usually the better home.
 - If a server depends on machine-local paths, personal services, or local-only secrets, prefer `.gsd/mcp.json`.
 - For the built-in `gsd-workflow` server, set `GSD_WORKFLOW_PROJECT_ROOT` to the canonical project root when launching from a worktree or wrapper. The packaged server uses it for workflow tool paths and the per-project stale-process registry at `$GSD_HOME/mcp-instances.json`.
+- The packaged `gsd-workflow` MCP server exposes canonical workflow tool names by default. Set `GSD_MCP_ADVERTISE_ALIASES=1` only for clients that still call legacy alias names. Native in-process GSD tools use `GSD_ADVERTISE_TOOL_ALIASES=1` instead.
 - Claude Code sessions that require GSD workflow tools are fail-closed: GSD preflights the same inline `mcpServers.gsd-workflow` entry passed to the Claude SDK, and if `gsd-workflow` is absent, still pending, failed, disabled, missing required tools at startup, or cannot be probed, GSD aborts the unit before the first model turn and retries instead of allowing tool calls against an incomplete surface. Timeout diagnostics include the last MCP probe error when available.
 
 ### Per-Model MCP Filtering
@@ -278,6 +279,9 @@ With this configuration, a Haiku-4-5 subagent sees only `gsd-workflow` and `goog
 | `GSD_WORKFLOW_PROJECT_ROOT` | current working directory | Canonical project root for the packaged `gsd-workflow` MCP server. Used by workflow tools and by the stale-process registry key in `$GSD_HOME/mcp-instances.json`. |
 | `GSD_WORKFLOW_EXECUTORS_MODULE` | auto-discovered when possible | Optional absolute path or `file:` URL for the shared workflow executor module used by `gsd-workflow` mutation tools. |
 | `GSD_WORKFLOW_WRITE_GATE_MODULE` | auto-discovered when possible | Optional absolute path or `file:` URL for the shared write-gate module used by `gsd-workflow` mutation tools. |
+| `GSD_MCP_ADVERTISE_ALIASES` | (unset) | Set to literal `1` to include legacy workflow aliases in the packaged `gsd-workflow` MCP server's `tools/list`. Unset keeps the MCP surface canonical-only to avoid duplicate schemas. |
+| `GSD_MCP_HIDE_ALIASES` | (unset) | Legacy force-hide switch. Set to literal `1` to keep packaged MCP aliases hidden even when `GSD_MCP_ADVERTISE_ALIASES=1`. |
+| `GSD_ADVERTISE_TOOL_ALIASES` | (unset) | Set to literal `1` to register legacy workflow aliases on the native in-process GSD tool surface, including `gsd --mode mcp`. This does not affect `gsd-workflow`; use `GSD_MCP_ADVERTISE_ALIASES` for the packaged MCP server. |
 | `GSD_CURSOR_DISABLE` | (unset) | Set to literal `1` to disable the bundled `cursor-agent` model provider. |
 | `GSD_CURSOR_DEBUG` | (unset) | Set to any value to print Cursor Agent readiness probe diagnostics to stderr. |
 | `CURSOR_AGENT_BIN` | `cursor-agent` | Optional command or absolute path for the Cursor Agent CLI when it is not on `PATH`. |

--- a/docs/zh-CN/user-docs/configuration.md
+++ b/docs/zh-CN/user-docs/configuration.md
@@ -154,6 +154,7 @@ mcp_call(server="my-server", tool="<tool_name>", args={...})
 - 如果某个 server 是团队共享且适合提交到仓库，通常更适合放在 `.mcp.json`
 - 如果某个 server 依赖本机路径、个人服务或本地 secrets，更适合放在 `.gsd/mcp.json`
 - 对内置的 `gsd-workflow` server，如果是从 worktree 或 wrapper 启动，请把 `GSD_WORKFLOW_PROJECT_ROOT` 设为规范项目根目录。打包的 server 会用它定位 workflow 工具路径，并用它作为 `$GSD_HOME/mcp-instances.json` 中的单项目 stale-process registry key。
+- 打包的 `gsd-workflow` MCP server 默认只暴露 canonical workflow tool 名称。只有仍在调用旧 alias 名称的客户端才需要设置 `GSD_MCP_ADVERTISE_ALIASES=1`。原生进程内 GSD 工具使用 `GSD_ADVERTISE_TOOL_ALIASES=1`。
 - 需要 GSD workflow 工具的 Claude Code 会话是 fail-closed 的：如果启动时 `gsd-workflow` 不存在、仍为 pending、failed、disabled，或缺少必需工具，GSD 会在第一个 model turn 前中止该 unit 并重试，而不是允许工具调用落到不完整的 surface 上。
 
 ## 环境变量
@@ -167,6 +168,9 @@ mcp_call(server="my-server", tool="<tool_name>", args={...})
 | `GSD_WORKFLOW_PROJECT_ROOT` | 当前工作目录 | 打包的 `gsd-workflow` MCP server 使用的规范项目根目录。workflow 工具和 `$GSD_HOME/mcp-instances.json` 的 stale-process registry key 都会使用它。 |
 | `GSD_WORKFLOW_EXECUTORS_MODULE` | 尽可能自动发现 | 可选的绝对路径或 `file:` URL，指向 `gsd-workflow` mutation tools 使用的共享 workflow executor module。 |
 | `GSD_WORKFLOW_WRITE_GATE_MODULE` | 尽可能自动发现 | 可选的绝对路径或 `file:` URL，指向 `gsd-workflow` mutation tools 使用的共享 write-gate module。 |
+| `GSD_MCP_ADVERTISE_ALIASES` | （未设置） | 设为字面值 `1` 时，打包的 `gsd-workflow` MCP server 会在 `tools/list` 中包含旧 workflow aliases。默认未设置时只暴露 canonical MCP surface，以避免重复 schemas。 |
+| `GSD_MCP_HIDE_ALIASES` | （未设置） | 旧的强制隐藏开关。设为字面值 `1` 时，即使 `GSD_MCP_ADVERTISE_ALIASES=1`，打包 MCP aliases 也会保持隐藏。 |
+| `GSD_ADVERTISE_TOOL_ALIASES` | （未设置） | 设为字面值 `1` 时，在原生进程内 GSD tool surface 注册旧 workflow aliases，包括 `gsd --mode mcp`。这不会影响 `gsd-workflow`；打包 MCP server 请使用 `GSD_MCP_ADVERTISE_ALIASES`。 |
 | `GSD_ALLOWED_COMMAND_PREFIXES` | （内置列表） | 允许用于 `!command` 值解析的命令前缀，逗号分隔。会覆盖 settings.json 中的 `allowedCommandPrefixes`。见 [自定义模型：命令允许列表](custom-models.md#command-allowlist)。 |
 | `GSD_FETCH_ALLOWED_URLS` | （无） | 对 `fetch_page` URL block 免检的 hostnames，逗号分隔。会覆盖 settings.json 中的 `fetchAllowedUrls`。见 [URL Blocking](#url-blocking-fetch_page)。 |
 | `SCREENSHOT_MAX_WIDTH` | `1568` | `browser_screenshot` 和 `mac_screenshot` 返回的 inline image payload 最大宽度（像素）。超出时会保持宽高比缩小；设为 `0` 可取消宽度限制并返回原始宽度。 |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -110,11 +110,13 @@ The workflow MCP surface includes:
 - `gsd_memory_query`
 - `gsd_memory_graph`
 
-**Aliases (kept for backwards compatibility — prefer the canonical name above):** `gsd_save_decision`, `gsd_update_requirement`, `gsd_save_requirement`, `gsd_save_summary`, `gsd_generate_milestone_id`, `gsd_milestone_plan`, `gsd_slice_plan`, `gsd_task_plan`, `gsd_slice_replan`, `gsd_complete_task`, `gsd_complete_slice`, `gsd_milestone_validate`, `gsd_milestone_complete`, `gsd_roadmap_reassess`, `gsd_reopen_task`, `gsd_reopen_slice`, `gsd_reopen_milestone`.
+By default, the packaged MCP server advertises only the canonical workflow tool names above. Legacy aliases are compatibility names and are not included in `tools/list` unless `GSD_MCP_ADVERTISE_ALIASES=1` is set. Prefer moving clients and prompts to canonical names before enabling aliases, because aliases duplicate schemas in the model-facing tool surface.
 
 These tools use the same GSD workflow handlers as the native in-process tool path wherever a shared handler exists.
 
-`gsd_decision_save` and its `gsd_save_decision` alias persist new decisions to the ADR-013 memory store, not to the legacy `decisions` table. The assigned `D###` ID is recorded in `memories.structured_fields.sourceDecisionId`, and `.gsd/DECISIONS.md` is refreshed as a projection from memory-backed decisions. The legacy table may still be read by compatibility and inspection paths during the cutover window, but it is no longer a write target.
+**Opt-in aliases (kept for backwards compatibility — prefer the canonical name above):** `gsd_save_decision`, `gsd_update_requirement`, `gsd_save_requirement`, `gsd_save_summary`, `gsd_generate_milestone_id`, `gsd_milestone_plan`, `gsd_slice_plan`, `gsd_task_plan`, `gsd_slice_replan`, `gsd_complete_task`, `gsd_complete_slice`, `gsd_milestone_validate`, `gsd_milestone_complete`, `gsd_roadmap_reassess`, `gsd_reopen_task`, `gsd_reopen_slice`, `gsd_reopen_milestone`.
+
+`gsd_decision_save` persists new decisions to the ADR-013 memory store, not to the legacy `decisions` table. If alias advertising is enabled, `gsd_save_decision` delegates to the same behavior. The assigned `D###` ID is recorded in `memories.structured_fields.sourceDecisionId`, and `.gsd/DECISIONS.md` is refreshed as a projection from memory-backed decisions. The legacy table may still be read by compatibility and inspection paths during the cutover window, but it is no longer a write target.
 
 `gsd_summary_save` computes artifact paths from the supplied IDs. `milestone_id` is required for milestone-, slice-, and task-scoped artifact types (`SUMMARY`, `RESEARCH`, `CONTEXT`, `ASSESSMENT`, `CONTEXT-DRAFT`) and should be omitted only for root-level `PROJECT`, `PROJECT-DRAFT`, `REQUIREMENTS`, and `REQUIREMENTS-DRAFT` artifacts. The `content` field has a schema `maxLength` of 50,000 characters per save; callers that produce larger artifacts should save incrementally by writing a substantive draft, then re-save the enriched artifact as more detail is available. For final `REQUIREMENTS` saves, the tool renders content from active database requirement rows; callers must create those rows with `gsd_requirement_save` first.
 
@@ -271,6 +273,9 @@ Resolve a pending blocker in a session by sending a response to the blocked UI r
 | `GSD_WORKFLOW_EXECUTORS_MODULE` | Optional absolute path or `file:` URL for the shared GSD workflow executor module used by workflow mutation tools. |
 | `GSD_WORKFLOW_WRITE_GATE_MODULE` | Optional absolute path or `file:` URL for the shared write-gate module used by workflow mutation tools. |
 | `GSD_WORKFLOW_PROJECT_ROOT` | Canonical project root for workflow tools and the per-project MCP PID registry key. Defaults to the server's current working directory. |
+| `GSD_MCP_ADVERTISE_ALIASES` | Set to literal `1` to include legacy workflow aliases in the packaged MCP server's `tools/list`. Unset by default, so the server advertises canonical tool names only. |
+| `GSD_MCP_HIDE_ALIASES` | Legacy force-hide switch. Set to literal `1` to keep packaged MCP aliases hidden even when `GSD_MCP_ADVERTISE_ALIASES=1`. |
+| `GSD_ADVERTISE_TOOL_ALIASES` | Set to literal `1` to register legacy workflow aliases on the native in-process GSD tool surface. This does not affect the packaged MCP server; use `GSD_MCP_ADVERTISE_ALIASES` for `gsd-mcp-server`. |
 | `GSD_HOME` | Global GSD directory. Also controls where `mcp-instances.json` is stored. |
 
 The server also hydrates supported model-provider and tool credentials from `~/.gsd/agent/auth.json` on startup. Keys saved through `/gsd config` or `/gsd keys` become available to the MCP server process automatically, and any explicitly-set environment variable still wins.

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -30,6 +30,7 @@ import {
 } from './server.js';
 import { MAX_EVENTS } from './types.js';
 import type { ManagedSession, CostAccumulator, PendingBlocker } from './types.js';
+import { WORKFLOW_TOOL_ALIAS_NAMES } from '@opengsd/contracts';
 
 describe('installGlobalErrorHandlers', () => {
   it('logs uncaught exceptions and unhandled rejections to stderr, then terminates (#783)', () => {
@@ -811,23 +812,51 @@ describe('createMcpServer tool registration', () => {
     assert.deepEqual(receivedOptions, { timeout: 600000, signal });
   });
 
-  it('advertises workflow aliases by default for external MCP clients', async () => {
-    const previous = process.env.GSD_MCP_HIDE_ALIASES;
+  it('hides workflow aliases by default for the model-facing surface', async () => {
+    const previousAdvertise = process.env.GSD_MCP_ADVERTISE_ALIASES;
+    const previousHide = process.env.GSD_MCP_HIDE_ALIASES;
+    delete process.env.GSD_MCP_ADVERTISE_ALIASES;
     delete process.env.GSD_MCP_HIDE_ALIASES;
     try {
       const { server } = await createMcpServer(sm);
       const registeredTools = (server as any)._registeredTools ?? {};
-      for (const alias of ['gsd_save_summary', 'gsd_milestone_plan', 'gsd_slice_plan']) {
-        assert.ok(registeredTools[alias], `${alias} should be advertised by default`);
+      for (const canonical of ['gsd_summary_save', 'gsd_plan_milestone', 'gsd_plan_slice']) {
+        assert.ok(registeredTools[canonical], `${canonical} should be advertised by default`);
       }
+      const registeredNames = new Set(Object.keys(registeredTools));
+      const hiddenAliases = WORKFLOW_TOOL_ALIAS_NAMES.filter((name) => !registeredNames.has(name));
+      assert.equal(
+        hiddenAliases.length,
+        WORKFLOW_TOOL_ALIAS_NAMES.length,
+        'all alias tools should be hidden by default',
+      );
     } finally {
-      if (previous === undefined) delete process.env.GSD_MCP_HIDE_ALIASES;
-      else process.env.GSD_MCP_HIDE_ALIASES = previous;
+      if (previousAdvertise === undefined) delete process.env.GSD_MCP_ADVERTISE_ALIASES;
+      else process.env.GSD_MCP_ADVERTISE_ALIASES = previousAdvertise;
+      if (previousHide === undefined) delete process.env.GSD_MCP_HIDE_ALIASES;
+      else process.env.GSD_MCP_HIDE_ALIASES = previousHide;
     }
   });
 
-  it('can hide workflow aliases when explicitly requested', async () => {
-    const previous = process.env.GSD_MCP_HIDE_ALIASES;
+  it('can restore workflow aliases when explicitly requested', async () => {
+    const previous = process.env.GSD_MCP_ADVERTISE_ALIASES;
+    process.env.GSD_MCP_ADVERTISE_ALIASES = '1';
+    try {
+      const { server } = await createMcpServer(sm);
+      const registeredTools = (server as any)._registeredTools ?? {};
+      for (const alias of ['gsd_save_summary', 'gsd_milestone_plan', 'gsd_slice_plan']) {
+        assert.ok(registeredTools[alias], `${alias} should be advertised when restored`);
+      }
+    } finally {
+      if (previous === undefined) delete process.env.GSD_MCP_ADVERTISE_ALIASES;
+      else process.env.GSD_MCP_ADVERTISE_ALIASES = previous;
+    }
+  });
+
+  it('GSD_MCP_HIDE_ALIASES=1 force-hides aliases even if advertise is set', async () => {
+    const previousAdvertise = process.env.GSD_MCP_ADVERTISE_ALIASES;
+    const previousHide = process.env.GSD_MCP_HIDE_ALIASES;
+    process.env.GSD_MCP_ADVERTISE_ALIASES = '1';
     process.env.GSD_MCP_HIDE_ALIASES = '1';
     try {
       const { server } = await createMcpServer(sm);
@@ -835,8 +864,10 @@ describe('createMcpServer tool registration', () => {
       assert.ok(registeredTools.gsd_summary_save, 'canonical tool should remain advertised');
       assert.equal(registeredTools.gsd_save_summary, undefined);
     } finally {
-      if (previous === undefined) delete process.env.GSD_MCP_HIDE_ALIASES;
-      else process.env.GSD_MCP_HIDE_ALIASES = previous;
+      if (previousAdvertise === undefined) delete process.env.GSD_MCP_ADVERTISE_ALIASES;
+      else process.env.GSD_MCP_ADVERTISE_ALIASES = previousAdvertise;
+      if (previousHide === undefined) delete process.env.GSD_MCP_HIDE_ALIASES;
+      else process.env.GSD_MCP_HIDE_ALIASES = previousHide;
     }
   });
 

--- a/packages/mcp-server/src/moonshot-tool-schema.test.ts
+++ b/packages/mcp-server/src/moonshot-tool-schema.test.ts
@@ -27,7 +27,15 @@ test("sanitizeSchemaForMoonshot flattens zod union workflow fields", () => {
 
 test("createMcpServer advertises Moonshot-safe inputSchema for every tool", async () => {
 	const sm = new SessionManager();
-	const { server } = await createMcpServer(sm);
+	// Aliases are hidden from the model-facing surface by default (plan 035);
+	// opt in so this test exercises the full (canonical + alias) schema surface.
+	const previousAdvertise = process.env.GSD_MCP_ADVERTISE_ALIASES;
+	process.env.GSD_MCP_ADVERTISE_ALIASES = "1";
+	const restoreAdvertise = () => {
+		if (previousAdvertise === undefined) delete process.env.GSD_MCP_ADVERTISE_ALIASES;
+		else process.env.GSD_MCP_ADVERTISE_ALIASES = previousAdvertise;
+	};
+	const { server } = await createMcpServer(sm).finally(restoreAdvertise);
 
 	const registeredTools =
 		(server as { _registeredTools?: Record<string, { enabled: boolean; inputSchema?: unknown }> })._registeredTools ??

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1541,12 +1541,13 @@ export async function createMcpServer(
     },
   );
 
-  // Advertise backwards-compatibility aliases by default so external clients
-  // (especially Claude Code CLI) can call every gsd_* tool name the native LLM
-  // path recognizes. Set GSD_MCP_HIDE_ALIASES=1 to trim duplicate schemas when
-  // a client is known to use only canonical names.
+  // Canonical-only model-facing surface: the 17 alias tools would add ~6.8K
+  // tokens/turn of duplicate schemas. Set GSD_MCP_ADVERTISE_ALIASES=1 to
+  // restore alias advertising for clients that still call legacy names.
+  // GSD_MCP_HIDE_ALIASES=1 (legacy var) is honored as a no-op force-hide.
   registerWorkflowTools(server, {
-    advertiseAliases: process.env.GSD_MCP_HIDE_ALIASES !== '1',
+    advertiseAliases:
+      process.env.GSD_MCP_ADVERTISE_ALIASES === '1' && process.env.GSD_MCP_HIDE_ALIASES !== '1',
   });
 
   installMoonshotCompatibleToolSchemas(server as unknown as Parameters<typeof installMoonshotCompatibleToolSchemas>[0]);

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2126,11 +2126,12 @@ function wrapServerWithErrorHandler(realServer: McpToolServer): McpToolServer {
 
 export interface RegisterWorkflowToolsOptions {
   /**
-   * Whether to advertise the 14 backwards-compatibility alias tools in the
+   * Whether to advertise the 17 backwards-compatibility alias tools in the
    * server's tool list. Defaults to `true` so in-process callers (e.g. the
    * daemon's handler map) keep resolving alias names. The MCP subprocess
-   * passes `false` to drop ~5.6K tokens/turn of duplicate alias schemas from
-   * the model-facing surface; canonical names are always registered.
+   * passes `false` by default to drop ~6.8K tokens/turn of duplicate alias
+   * schemas from the model-facing surface; canonical names are always
+   * registered.
    */
   advertiseAliases?: boolean;
 }

--- a/plans/README.md
+++ b/plans/README.md
@@ -46,6 +46,9 @@ commit `58dc840f`. Plans 018–024 planned against commit `7cca07ae`.
 | 028 | Six small state/DB correctness fixes (status aliases, gate atomicity, claim locking, derive-cache lock, lease test) | P1 | S | — | DONE |
 | 029 | Reject path-traversal keys in the compat marker before drift detectors read them | P1 | S | — | DONE |
 | 030 | Stop the write-gate's cross-process read-merge-write from losing an armed gate | P2 | M | — | DONE |
+| 032 | Relocate integration-branch META out of `milestones/<MID>/` so it can't poison layout detection | P1 | M | — | DONE |
+| 033 | Fixtures: zero false-positive stale-render drift for flat-phase (multi-slice + remediation, two cycles) | P2 | M | 032 | TODO |
+| 034 | Re-enable the stale-render drift detector for flat-phase projects | P2 | S | 032, 033 | TODO |
 | 039 | Close prompt-budget enforcement gaps (execute-task cap, discuss-slice cap, provider ratio) | P2 | M | — | DONE (execute-task keeps authoritative task plan whole per STOP cond., caps trailing blocks; discuss-slice reuses capPreamble; provider passed at all 3 computeBudgets sites) |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`
@@ -61,6 +64,7 @@ previously-orphaned `message-batcher.test.js` into the daemon test script.
 - **022 depends on 018**: its new tests only run in CI once 018 wires the cloud packages' test scripts in. If 020 lands first, `postJsonToValidatedGateway` gains an optional `timeoutMs` param — harmless to 022.
 - **018 is P0** because every published `@opengsd/gsd-cloud` (1.7.0–1.8.1) is broken on npm today (`dist.fileCount = 3`, no build output); the next release republishes broken without it. 020 and 024 both touch `packages/daemon` (different files: `cloud-config.ts` vs `package.json`) — no conflict, but land 020's daemon test additions before 024's SDK bump to get the extra regression signal.
 - **023 is document-only** (ADR). The migration code work it proposes is NOT planned yet — it needs maintainer approval of the ADR first (CONTRIBUTING requires an RFC/ADR for this territory).
+- **032 → 033 → 034 are the ADR-045 Option B stage-1 code plans** (added 2026-07-08, planned against `897b3c90`, after the maintainer greenlit the "lean 3" path). Strict order: **032** removes the git-service META poisoning root cause (the precondition the detector TODO names); **033** adds fixtures proving zero false-positive stale-render drift across two reconcile cycles for the exact multi-slice/remediation scenarios that got the detector disabled (033 also exports `detectStaleRendersImpl`); **034** flips `detectStaleRenders` from its `return []` stub to the real impl, gated on 033's fixtures being green. 034 must not start before 033, and 033 not before 032. The ADR's Option B step 1 (route all 13 layout-detection sites through one authority) was **deliberately deferred** — see "considered and rejected" below.
 
 ## Findings surviving verification but NOT planned this round
 
@@ -100,7 +104,7 @@ larger/looser scope, or already partly mitigated. Recorded so they aren't lost.
 Grounded in repo evidence; each selected one becomes a design/spike plan, not a
 build-everything plan. Effort estimates are coarse.
 
-1. **Finish the flat-phase migration** — planned as the ADR in plan 023 (the drift alarm `detectStaleRenders` is still hard-disabled at 1.8.1 while the seam keeps shipping projection bugs: #1303/#1305/#1313/#1316 in six days).
+1. **Finish the flat-phase migration** — ADR-045 written (plan 023, DONE); Option B stage-1 now broken into code plans **032 → 033 → 034** (added 2026-07-08). Stage 2 / Option A (forced migration + legacy-branch deletion) remains release-gated and needs maintainer sign-off on ADR-045's open questions. The drift alarm `detectStaleRenders` is still hard-disabled at HEAD; 034 turns it back on once 032/033 land.
 2. **Team sharing + RBAC for GSD Cloud — build or formally defer**: promised twice in the product brief; zero backing code (`auth-store.ts`/`runtime-registry.ts` model single-user only; grep for team/org/rbac/tenant across gateway+gsd-cloud → 0 non-test hits). Multi-machine is delivered; multi-user is absent. Retrofitting authz late is the expensive path — a record-schema + gateway-ownership-seam ADR is the cheap first step. L (coarse).
 3. **Linux systemd service packaging for the daemon**: the brief requires macOS AND Linux service install; only `launchd.ts` exists (`packages/daemon/src/cli.ts` wires install/uninstall/status exclusively to launchd). A `systemd.ts` mirroring the launchd trio (user unit in `~/.config/systemd/user/`) + a platform switch is a bounded M. The cloud story leans on always-on daemons, which mostly run on Linux.
 4. **Bidirectional GitHub sync**: `github-sync` is export-only by design (all ops are `ghCreate*/ghClose*/ghAddComment`; zero inbound reads). Maintainers whose backlog lives in GitHub Issues must re-enter everything. Spike a read-only `github-sync import` preview (issues → milestone/task mapping) to surface the DB-single-writer conflict questions before committing to two-way. M–L (coarse).
@@ -109,6 +113,7 @@ build-everything plan. Effort estimates are coarse.
 
 ## Findings considered and rejected
 
+- **ADR-045 Option B step 1 — route all 13 layout-detection sites through one "single detection authority" module** (2026-07-08): deferred, not rejected. Plan 032 removes the *poisoning input* (git-service META), which is the concrete cause of the shipped bugs and the detector false positives; with poisoning gone, Plan 033's fixtures become the real safety gate for re-enabling the detector (034), so the 13-file refactor is not required to close this cluster. It is a large, churny change VISION discourages doing for its own sake. Revisit only if 033's fixtures surface actual cross-site disagreement (i.e. the detector and a resolved render target disagree even with reliable layout detection). Inventory is in ADR-045's appendix.
 - **Task/slice closed→open guard missing from Status Transition Core**: explicitly deferred by ADR-030 until sanctioned `reopenTaskStatus`/`reopenSliceStatus` faces exist; not planned independently.
 - **Log redaction regex misses lowercase secret key names**: the regex already carries the `i` flag, so lowercase keys are matched; no change needed.
 - **Static tool-contract gate sites not folded into one helper**: the four sites already share `getUnitWorkflowDispatchReadinessError` in `tool-contract.ts`; further unification is not a clean, bounded change.

--- a/plans/README.md
+++ b/plans/README.md
@@ -49,6 +49,7 @@ commit `58dc840f`. Plans 018–024 planned against commit `7cca07ae`.
 | 032 | Relocate integration-branch META out of `milestones/<MID>/` so it can't poison layout detection | P1 | M | — | DONE |
 | 033 | Fixtures: zero false-positive stale-render drift for flat-phase (multi-slice + remediation, two cycles) | P2 | M | 032 | TODO |
 | 034 | Re-enable the stale-render drift detector for flat-phase projects | P2 | S | 032, 033 | TODO |
+| 035 | Stop advertising duplicate alias tool schemas to the model | P1 | M | — | DONE |
 | 039 | Close prompt-budget enforcement gaps (execute-task cap, discuss-slice cap, provider ratio) | P2 | M | — | DONE (execute-task keeps authoritative task plan whole per STOP cond., caps trailing blocks; discuss-slice reuses capPreamble; provider passed at all 3 computeBudgets sites) |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`

--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -104,12 +104,15 @@ function resolveProjectMilestonePath(base: string, mid: string): string | null {
   const milestonesDir = join(gsdRoot(base), "milestones");
   const dir = resolveDir(milestonesDir, mid);
   if (!dir) return null;
-  // git-service.ts creates milestones/<MID>/ for integration-branch metadata
-  // (<MID>-META.json) even in flat-phase projects. A dir that holds ONLY
-  // *-META.json files must not be treated as a real legacy milestone dir —
-  // otherwise this early-return resolves CONTEXT/ROADMAP/SUMMARY to the legacy
-  // path (milestones/<MID>/<MID>-<SUFFIX>.md) before the flat-phase fallback
-  // can run, trapping the unit in a finalize-retry loop (#852 follow-up).
+  // Historically git-service.ts wrote integration-branch metadata into
+  // milestones/<MID>/<MID>-META.json, which could create that dir in flat-phase
+  // projects and poison layout detection. As of ADR-045 that META lives flat at
+  // .gsd/<MID>-META.json and no longer poisons detection. A dir that holds ONLY
+  // *-META.json files (a pre-migration on-disk tree) must still not be treated
+  // as a real legacy milestone dir — otherwise this early-return resolves
+  // CONTEXT/ROADMAP/SUMMARY to the legacy path (milestones/<MID>/<MID>-<SUFFIX>.md)
+  // before the flat-phase fallback can run, trapping the unit in a
+  // finalize-retry loop (#852 follow-up).
   //
   // We use dirIsMetaOnlyLegacyMilestone rather than !dirIsContentBearingLegacyMilestone
   // so that an EMPTY dir (a new milestone before any content is written) is NOT

--- a/src/resources/extensions/gsd/auto-worktree-cleanup.ts
+++ b/src/resources/extensions/gsd/auto-worktree-cleanup.ts
@@ -10,6 +10,7 @@ import { existsSync, realpathSync, unlinkSync } from "node:fs";
 import { isAbsolute, join, relative } from "node:path";
 
 import { gsdRoot } from "./paths.js";
+import { milestoneMetaPath } from "./git-service.js";
 import { logWarning } from "./workflow-logger.js";
 
 function isSamePath(a: string, b: string): boolean {
@@ -93,6 +94,9 @@ export function clearProjectRootStateFiles(
   // worth removing on teardown.
   const transientFiles = [
     join(gsdDir, "STATE.md"),
+    // Integration-branch META now lives flat at .gsd/<MID>-META.json (ADR-045).
+    milestoneMetaPath(basePath, milestoneId),
+    // Legacy location — still cleaned for pre-migration trees.
     join(gsdDir, "milestones", milestoneId, `${milestoneId}-META.json`),
   ];
 

--- a/src/resources/extensions/gsd/auto-worktree-teardown.ts
+++ b/src/resources/extensions/gsd/auto-worktree-teardown.ts
@@ -65,7 +65,7 @@ export function teardownAutoWorktree(
 
     // Mirror cleanup steps from mergeMilestoneToMain abort path:
 
-    // 1. Remove transient state files (STATE.md, auto.lock, {MID}-META.json).
+    // 1. Remove transient state files (STATE.md, auto.lock, .gsd/{MID}-META.json).
     //    Non-fatal — must not block teardown.
     try {
       clearProjectRootStateFiles(originalBasePath, milestoneId);

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -58,6 +58,7 @@ function registerAlias(pi: ExtensionAPI, toolDef: any, aliasName: string, canoni
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- toolDef shape matches ToolDefinition but varies by schema
 function registerWorkflowTool(pi: ExtensionAPI, toolDef: any): void {
   pi.registerTool(toolDef);
+  if (process.env.GSD_ADVERTISE_TOOL_ALIASES !== "1") return; // canonical-only model surface (see plan 035)
   for (const alias of aliasesForWorkflowTool(toolDef.name)) {
     registerAlias(pi, toolDef, alias, toolDef.name);
   }

--- a/src/resources/extensions/gsd/constants.ts
+++ b/src/resources/extensions/gsd/constants.ts
@@ -31,36 +31,25 @@ export const CACHE_MAX = 50;
  * By scoping tools to this allowlist during discuss dispatches, the grammar
  * sent to the provider stays well under provider limits.
  *
- * Included tools and why:
+ * Included tools and why (canonical names only — aliases are no longer
+ * advertised to models by default, see plan 035):
  *   - gsd_summary_save: writes CONTEXT.md artifacts (all discuss prompts)
- *   - gsd_save_summary: alias for above
  *   - gsd_decision_save: records decisions (discuss.md output phase)
- *   - gsd_save_decision: alias for above
  *   - gsd_plan_milestone: writes roadmap (discuss.md single/multi milestone)
- *   - gsd_milestone_plan: alias for above
  *   - gsd_milestone_generate_id: generates milestone IDs (discuss.md multi-milestone)
- *   - gsd_generate_milestone_id: alias for above
  *   - gsd_requirement_save: creates requirements during discuss
- *   - gsd_save_requirement: alias for above
  *   - gsd_requirement_update: updates requirements during discuss
- *   - gsd_update_requirement: alias for above
  */
 export const DISCUSS_TOOLS_ALLOWLIST: readonly string[] = [
   // Context / summary writing
   "gsd_summary_save",
-  "gsd_save_summary",
   // Decision recording
   "gsd_decision_save",
-  "gsd_save_decision",
   // Milestone planning (needed for discuss.md output phase)
   "gsd_plan_milestone",
-  "gsd_milestone_plan",
   // Milestone ID generation (multi-milestone flow)
   "gsd_milestone_generate_id",
-  "gsd_generate_milestone_id",
   // Requirement updates
   "gsd_requirement_save",
-  "gsd_save_requirement",
   "gsd_requirement_update",
-  "gsd_update_requirement",
 ];

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -385,10 +385,16 @@ const runtimeFilesCleanedUpRepos = new Set<string>();
 // ─── Integration Branch Metadata ───────────────────────────────────────────
 
 /**
- * Path to the milestone metadata file that stores the integration branch.
- * Format: .gsd/milestones/<MID>/<MID>-META.json
+ * Path to the milestone integration-branch metadata file.
+ * Format: .gsd/<MID>-META.json  (deliberately OUTSIDE milestones/<MID>/ so it
+ * cannot poison isLegacyMilestonesLayout — see ADR-045).
  */
-function milestoneMetaPath(basePath: string, milestoneId: string): string {
+export function milestoneMetaPath(basePath: string, milestoneId: string): string {
+  return join(gsdRoot(basePath), `${milestoneId}-META.json`);
+}
+
+/** Legacy location (pre-ADR-045). Read-only fallback for existing on-disk trees. */
+function legacyMilestoneMetaPath(basePath: string, milestoneId: string): string {
   return join(gsdRoot(basePath), "milestones", milestoneId, `${milestoneId}-META.json`);
 }
 
@@ -398,8 +404,12 @@ function milestoneMetaPath(basePath: string, milestoneId: string): string {
  */
 export function readIntegrationBranch(basePath: string, milestoneId: string): string | null {
   try {
-    const metaFile = milestoneMetaPath(basePath, milestoneId);
-    if (!existsSync(metaFile)) return null;
+    let metaFile = milestoneMetaPath(basePath, milestoneId);
+    if (!existsSync(metaFile)) {
+      const legacy = legacyMilestoneMetaPath(basePath, milestoneId);
+      if (!existsSync(legacy)) return null;
+      metaFile = legacy;
+    }
     const data = JSON.parse(readFileSync(metaFile, "utf-8"));
     const branch = data?.integrationBranch;
     if (typeof branch === "string" && branch.trim() !== "" && VALID_BRANCH_NAME.test(branch)) {
@@ -451,7 +461,10 @@ export function writeIntegrationBranch(
   if (existingBranch === branch) return;
 
   const metaFile = milestoneMetaPath(basePath, milestoneId);
-  mkdirSync(join(gsdRoot(basePath), "milestones", milestoneId), { recursive: true });
+  // Ensure the flat .gsd/ root exists (never milestones/<MID>/ — that would
+  // poison layout detection, ADR-045). In production .gsd/ already exists; this
+  // guards fresh trees so the write below can't ENOENT.
+  mkdirSync(gsdRoot(basePath), { recursive: true });
 
   // Merge with existing metadata if present
   let existing: Record<string, unknown> = {};

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -1218,6 +1218,10 @@ test("hasImplementationArtifacts finds integration implementation-only commits w
 
     execFileSync("git", ["checkout", "-b", "milestone/M001"], { cwd: base, stdio: "ignore" });
     writeIntegrationBranch(base, "M001", "main");
+    // ADR-045: writeIntegrationBranch no longer creates milestones/<MID>/ as a
+    // side effect (META is now flat at .gsd/<MID>-META.json), so scaffold the
+    // legacy summary dir explicitly.
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
     writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"), "# Milestone Summary\nDone.");
     execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
     execFileSync("git", ["commit", "-m", "chore: auto-commit after complete-milestone\n\nGSD-Unit: M001"], { cwd: base, stdio: "ignore" });

--- a/src/resources/extensions/gsd/tests/db-tools-alias-suppression.test.ts
+++ b/src/resources/extensions/gsd/tests/db-tools-alias-suppression.test.ts
@@ -1,0 +1,62 @@
+// Project/App: gsd-pi
+// File Purpose: Verifies GSD_ADVERTISE_TOOL_ALIASES gates alias registration on the native tool path (plan 035).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { registerDbTools } from '../bootstrap/db-tools.ts';
+import { WORKFLOW_TOOL_ALIAS_NAMES, WORKFLOW_TOOL_CONTRACTS } from '../workflow-tool-surface.ts';
+
+function makeMockPi() {
+  const tools: any[] = [];
+  return {
+    registerTool: (tool: any) => tools.push(tool),
+    tools,
+  } as any;
+}
+
+function withEnv(name: string, value: string | undefined, fn: () => void): void {
+  const previous = process.env[name];
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+  try {
+    fn();
+  } finally {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  }
+}
+
+test('default: only canonical names are registered, no aliases', () => {
+  withEnv('GSD_ADVERTISE_TOOL_ALIASES', undefined, () => {
+    const pi = makeMockPi();
+    registerDbTools(pi);
+    const names = new Set(pi.tools.map((tool: any) => tool.name));
+
+    for (const alias of WORKFLOW_TOOL_ALIAS_NAMES) {
+      assert.ok(!names.has(alias), `alias "${alias}" should not be registered by default`);
+    }
+    const registeredCanonical = WORKFLOW_TOOL_CONTRACTS
+      .map((tool) => tool.canonicalName)
+      .filter((name) => names.has(name));
+    assert.ok(registeredCanonical.length > 0, 'canonical tools should still be registered');
+  });
+});
+
+test('GSD_ADVERTISE_TOOL_ALIASES=1: aliases are registered with the "(alias for ...)" description suffix', () => {
+  withEnv('GSD_ADVERTISE_TOOL_ALIASES', '1', () => {
+    const pi = makeMockPi();
+    registerDbTools(pi);
+    const toolByName = new Map<string, any>(pi.tools.map((tool: any) => [tool.name, tool]));
+
+    const registeredAliases = WORKFLOW_TOOL_ALIAS_NAMES.filter((alias) => toolByName.has(alias));
+    assert.ok(registeredAliases.length > 0, 'at least one alias should be registered when opted in');
+
+    for (const alias of registeredAliases) {
+      const aliasTool = toolByName.get(alias);
+      assert.ok(
+        aliasTool.description.includes('(alias for '),
+        `alias "${alias}" description should include "(alias for ...)"`,
+      );
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/integration-branch-meta-location.test.ts
+++ b/src/resources/extensions/gsd/tests/integration-branch-meta-location.test.ts
@@ -1,0 +1,62 @@
+// gsd-pi — Integration-branch META lives OUTSIDE milestones/<MID>/ (ADR-045).
+// Verifies the relocation from milestones/<MID>/<MID>-META.json to the flat
+// .gsd/<MID>-META.json so it can never poison isLegacyMilestonesLayout.
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { readIntegrationBranch, writeIntegrationBranch } from "../git-service.js";
+import { gsdRoot, isLegacyMilestonesLayout } from "../paths.js";
+
+let repo: string;
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "gsd-meta-loc-"));
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("write goes to the new flat .gsd/<MID>-META.json, not milestones/<MID>/", () => {
+  writeIntegrationBranch(repo, "M001", "main");
+
+  assert.ok(
+    existsSync(join(gsdRoot(repo), "M001-META.json")),
+    "META written to flat .gsd/<MID>-META.json",
+  );
+  assert.ok(
+    !existsSync(join(gsdRoot(repo), "milestones", "M001", "M001-META.json")),
+    "no META in legacy milestones/<MID>/ location",
+  );
+});
+
+test("round-trip: read returns what write recorded", () => {
+  writeIntegrationBranch(repo, "M001", "main");
+  assert.equal(readIntegrationBranch(repo, "M001"), "main");
+});
+
+test("read falls back to the legacy milestones/<MID>/ location", () => {
+  const legacyDir = join(gsdRoot(repo), "milestones", "M001");
+  mkdirSync(legacyDir, { recursive: true });
+  writeFileSync(
+    join(legacyDir, "M001-META.json"),
+    JSON.stringify({ integrationBranch: "develop" }) + "\n",
+    "utf-8",
+  );
+
+  assert.equal(readIntegrationBranch(repo, "M001"), "develop");
+});
+
+test("writing META does not create milestones/<MID>/ or flip layout detection", () => {
+  assert.equal(isLegacyMilestonesLayout(repo), false, "clean tree is not legacy layout");
+  writeIntegrationBranch(repo, "M001", "main");
+  assert.equal(
+    isLegacyMilestonesLayout(repo),
+    false,
+    "writing integration-branch META must not poison layout detection",
+  );
+});

--- a/src/resources/extensions/gsd/tests/single-writer-v3-tool-surface.test.ts
+++ b/src/resources/extensions/gsd/tests/single-writer-v3-tool-surface.test.ts
@@ -29,8 +29,16 @@ function makeMockPi() {
   } as any;
 }
 
+// Aliases are hidden from the model-facing surface by default (plan 035);
+// opt in here so this file can keep exercising alias-registration behavior.
+const previousAdvertiseAliases = process.env.GSD_ADVERTISE_TOOL_ALIASES;
+process.env.GSD_ADVERTISE_TOOL_ALIASES = "1";
+
 const pi = makeMockPi();
 registerDbTools(pi);
+
+if (previousAdvertiseAliases === undefined) delete process.env.GSD_ADVERTISE_TOOL_ALIASES;
+else process.env.GSD_ADVERTISE_TOOL_ALIASES = previousAdvertiseAliases;
 
 function getTool(name: string) {
   return pi.tools.find((t: any) => t.name === name);

--- a/src/resources/extensions/gsd/tests/tool-naming.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-naming.test.ts
@@ -25,8 +25,16 @@ function makeMockPi() {
 
 console.log('\n── Tool naming: registration count ──');
 
+// Aliases are hidden from the model-facing surface by default (plan 035);
+// opt in here so this file can keep exercising alias-registration behavior.
+const previousAdvertiseAliases = process.env.GSD_ADVERTISE_TOOL_ALIASES;
+process.env.GSD_ADVERTISE_TOOL_ALIASES = "1";
+
 const pi = makeMockPi();
 registerDbTools(pi);
+
+if (previousAdvertiseAliases === undefined) delete process.env.GSD_ADVERTISE_TOOL_ALIASES;
+else process.env.GSD_ADVERTISE_TOOL_ALIASES = previousAdvertiseAliases;
 const toolByName = new Map<string, any>(pi.tools.map((tool: any) => [tool.name, tool]));
 const registeredCanonicalNames = new Set<string>(
   WORKFLOW_TOOL_CONTRACTS

--- a/src/resources/extensions/gsd/workspace.ts
+++ b/src/resources/extensions/gsd/workspace.ts
@@ -10,6 +10,7 @@ import {
   normalizeRealPath,
 } from "./paths.js";
 import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
+import { milestoneMetaPath } from "./git-service.js";
 
 export type GsdWorkspaceMode = "project" | "worktree";
 
@@ -107,7 +108,7 @@ export function scopeMilestone(workspace: GsdWorkspace, milestoneId: string): Mi
     stateFile: () => join(gsd, "STATE.md"),
     dbPath: () => contract.projectDb,
     milestoneDir: () => scopeMilestoneDir(basePath, milestoneId),
-    metaJson: () => join(gsd, `${milestoneId}-META.json`),
+    metaJson: () => milestoneMetaPath(basePath, milestoneId),
   });
 
   return scope;


### PR DESCRIPTION
## Summary
- MCP subprocess (`server.ts`) and the native tool path (`db-tools.ts`) both defaulted to advertising 17 backwards-compatibility alias tools alongside their canonicals — a full duplicate schema per alias sent to the model every turn (~6.8K tokens/turn). Both now default to canonical-only.
- `GSD_MCP_ADVERTISE_ALIASES=1` (MCP subprocess) and `GSD_ADVERTISE_TOOL_ALIASES=1` (native path) restore alias advertising for clients that still call legacy names; `GSD_MCP_HIDE_ALIASES=1` still force-hides on the MCP side.
- The daemon's own `registerWorkflowTools` call is untouched (still defaults to advertising aliases), so daemon alias-name resolution keeps working.
- Deduped `DISCUSS_TOOLS_ALLOWLIST` down to its 6 canonical entries — the alias twins defeated the point of the allowlist (shrinking grammar size for constrained-decoding providers).
- Grepped model-facing prompt/workflow markdown for alias names — zero hits, so no prompt content needed changes.

Implements plans/035-hide-alias-tool-schemas.md.

## Test plan
- [x] `pnpm run typecheck:extensions` — exit 0
- [x] `packages/mcp-server`: `mcp-server.test.js`, `workflow-tools.test.js`, `workflow-tools-parity.test.js` — 76/76 pass
- [x] New `db-tools-alias-suppression.test.ts` — default hides all aliases, `GSD_ADVERTISE_TOOL_ALIASES=1` restores them with the "(alias for ...)" description suffix
- [x] Updated `tool-naming.test.ts` to opt into aliases so it keeps covering the opt-in registration path
- [x] Discuss-tool-scoping / allowlist / token-gating test suites (53 tests) — all pass with the deduped allowlist
- [x] Spot-check grep for `gsd_save_decision`/`gsd_milestone_plan` in prompt/workflow markdown — no hits

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-off legacy tool aliases can break clients still calling old names until env vars are set; META path changes affect integration-branch persistence and layout detection across worktree/git paths.
> 
> **Overview**
> **Model-facing workflow tools** now default to **canonical names only**, dropping ~17 duplicate alias schemas (~6.8K tokens/turn) from packaged `gsd-workflow` MCP `tools/list` and from native in-process registration in `db-tools.ts`. Opt back in with `GSD_MCP_ADVERTISE_ALIASES=1` (MCP) or `GSD_ADVERTISE_TOOL_ALIASES=1` (native); `GSD_MCP_HIDE_ALIASES=1` still force-hides MCP aliases. `DISCUSS_TOOLS_ALLOWLIST` is trimmed to canonical entries only.
> 
> **Integration-branch metadata (ADR-045 / plan 032):** writes and reads move from `milestones/<MID>/<MID>-META.json` to flat `.gsd/<MID>-META.json`, with legacy-path read fallback and teardown cleanup for both locations, so META no longer creates a meta-only milestone dir that poisons flat-phase layout detection.
> 
> Docs (`configuration.md`, `mcp-server` README) and tests cover alias gating and the new META paths; `plans/README.md` marks plans 032 and 035 done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a78f7e53bce2c48b7b93d69213431878b6112a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->