### PR TITLE
perf(gsd): filter superseded context injections from provider payload

### DIFF
--- a/packages/gsd-agent-core/src/compaction/compaction.test.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.test.ts
@@ -675,3 +675,175 @@ describe("(#4665) degenerate summary guard", () => {
 		);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// (#038) cheap compaction summarization
+// ---------------------------------------------------------------------------
+
+describe("(#038) summarization options cap reasoning at low", () => {
+	function makeReasoningModel(contextWindow: number): Model<any> {
+		return { ...makeModel(contextWindow), reasoning: true };
+	}
+
+	it("caps a high session thinking level down to low on a reasoning model", async () => {
+		const model = makeReasoningModel(200_000);
+		const messages = [makeUserMessage(10)];
+		let seenOptions: any;
+		const mockComplete = mock.fn(async (_model: any, _context: any, options: any) => {
+			seenOptions = options;
+			return makeFakeResponse(
+				"## Done\n- Real summary well over one hundred characters long so the degenerate check passes cleanly here.",
+			);
+		});
+
+		await generateSummary(
+			messages,
+			model,
+			16_384,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"high",
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(seenOptions.reasoning, "low");
+	});
+
+	it("does not set reasoning when session thinking level is off", async () => {
+		const model = makeReasoningModel(200_000);
+		const messages = [makeUserMessage(10)];
+		let seenOptions: any;
+		const mockComplete = mock.fn(async (_model: any, _context: any, options: any) => {
+			seenOptions = options;
+			return makeFakeResponse(
+				"## Done\n- Real summary well over one hundred characters long so the degenerate check passes cleanly here.",
+			);
+		});
+
+		await generateSummary(
+			messages,
+			model,
+			16_384,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"off",
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(seenOptions.reasoning, undefined);
+	});
+
+	it("does not set reasoning on a non-reasoning model", async () => {
+		const model = makeModel(200_000); // reasoning: false
+		const messages = [makeUserMessage(10)];
+		let seenOptions: any;
+		const mockComplete = mock.fn(async (_model: any, _context: any, options: any) => {
+			seenOptions = options;
+			return makeFakeResponse(
+				"## Done\n- Real summary well over one hundred characters long so the degenerate check passes cleanly here.",
+			);
+		});
+
+		await generateSummary(
+			messages,
+			model,
+			16_384,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"high",
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(seenOptions.reasoning, undefined);
+	});
+});
+
+describe("(#038) degenerate-chunk retry is bounded per compaction", () => {
+	it("retries at most once total across a run with multiple degenerate chunks", async () => {
+		const messages: AgentMessage[] = [
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+		];
+		const model = makeModel(1_000);
+		const reserveTokens = 200;
+
+		// Every response is degenerate — old behavior retried every chunk once
+		// (6 calls for 3 chunks); bounded behavior spends the single retry
+		// budget on the first chunk and gives up thereafter (4 calls).
+		const mockComplete = mock.fn(async () => makeFakeResponse("empty conversation"));
+
+		await assert.rejects(
+			() =>
+				generateSummary(
+					messages,
+					model,
+					reserveTokens,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					mockComplete,
+				),
+			(err: unknown) => err instanceof CompactionProducedNoSummaryError,
+		);
+
+		assert.equal(
+			mockComplete.mock.callCount(),
+			4,
+			"expected exactly 4 calls: chunk0 + one retry + chunk1 + chunk2 (no further retries)",
+		);
+	});
+
+	it("skips the retry when the degenerate chunk's serialized input is itself tiny", async () => {
+		// Chunk 0 is a single tiny user message (serializes to well under the
+		// 100-char degenerate threshold); chunk 1 is a branch summary. Branch
+		// summary content is capped by the serializer's per-block truncation
+		// (~500 tokens), so a small context window is needed to force the two
+		// onto separate chunks: tiny(~1 token) + capped-branch(~500 tokens)
+		// exceeds a 340-token chunk budget, so chunkMessages splits them.
+		const messages: AgentMessage[] = [makeUserMessage(1), makeBranchSummaryMessage(80_000)];
+		const model = makeModel(700);
+		const reserveTokens = 200;
+
+		const responses = [
+			"", // chunk 0 (tiny input) → degenerate, must NOT retry
+			"## Done\n- Real summary for chunk one well over one hundred characters long, clearing the degenerate threshold.",
+		];
+		let callIndex = 0;
+		const mockComplete = mock.fn(async () => {
+			const response = responses[Math.min(callIndex, responses.length - 1)];
+			callIndex++;
+			return makeFakeResponse(response);
+		});
+
+		await generateSummary(
+			messages,
+			model,
+			reserveTokens,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(
+			mockComplete.mock.callCount(),
+			2,
+			"expected exactly 2 calls: chunk0 (no retry, tiny input) + chunk1",
+		);
+	});
+});

--- a/packages/gsd-agent-core/src/compaction/compaction.test.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.test.ts
@@ -847,3 +847,128 @@ describe("(#038) degenerate-chunk retry is bounded per compaction", () => {
 		);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Degenerate middle-chunk handling — must not drop the tail or leave a hole
+// ---------------------------------------------------------------------------
+
+describe("degenerate middle-chunk handling", () => {
+	it("keeps summarizing later chunks when a middle chunk degenerates against a non-degenerate previousSummary", async () => {
+		// Bug: the previous mitigation broke out of the loop as soon as a middle
+		// chunk degenerated while summaryBeforeChunk was non-degenerate. But when
+		// runningSummary is still just the carried-in previousSummary (no chunk in
+		// THIS run folded in yet), that break dropped every remaining chunk, so
+		// newer history never reached the briefing.
+		const messages: AgentMessage[] = [
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+		];
+		const model = makeModel(1_000);
+		const reserveTokens = 200;
+		const previousSummary =
+			"Prior compaction briefing carried in from the last run — long enough to clear the degenerate-output threshold so it stands in as summaryBeforeChunk.";
+
+		// chunk0 + its single retry degenerate, chunk1 degenerate (retry budget
+		// spent), chunk2 produces the only real summary. The tail chunk must be
+		// summarized, so TAIL_CONTENT must survive into the final briefing.
+		let callIndex = 0;
+		const responses = [
+			"empty conversation", // chunk0 initial → degenerate
+			"empty conversation", // chunk0 retry → degenerate (spends the one retry)
+			"empty conversation", // chunk1 → degenerate, no retry left
+			"## Done\n- TAIL_CONTENT: recovered the final chunk's history even though an earlier chunk degenerated — proves no early break.",
+		];
+		const mockComplete = mock.fn(async () => {
+			const r = responses[Math.min(callIndex, responses.length - 1)];
+			callIndex++;
+			return makeFakeResponse(r);
+		});
+
+		const summary = await generateSummary(
+			messages,
+			model,
+			reserveTokens,
+			undefined,
+			undefined,
+			undefined,
+			previousSummary,
+			mockComplete,
+		);
+
+		assert.equal(
+			mockComplete.mock.callCount(),
+			4,
+			"expected 4 calls: chunk0 + one retry + chunk1 + chunk2 (no early break)",
+		);
+		assert.ok(
+			summary.includes("TAIL_CONTENT"),
+			`final summary must include the tail chunk's content (no early break), got: ${JSON.stringify(summary)}`,
+		);
+		assert.ok(!isDegenerateSummary(summary), "final summary must not be degenerate");
+	});
+
+	it("carries a degenerate chunk's messages into the next chunk, bounded by the per-chunk budget", async () => {
+		// Chunk0 = [a, b] fills the budget; chunk1 = [c] leaves headroom. When
+		// chunk0 degenerates, its messages are carried into chunk1's input up to
+		// the budget: the oldest (a) is dropped to avoid overflow, but the newest
+		// (b) is folded into chunk1's summarization so its content is not lost.
+		// estimateSerializedTokens caps user content at 2000 chars and returns
+		// ceil(chars/4), so 1600 chars → 400 tokens and 1000 chars → 250 tokens.
+		const a = { role: "user", content: `AAA_DROPPED${"x".repeat(1589)}` } as unknown as AgentMessage; // 400 tokens
+		const b = { role: "user", content: `CARRIED_B${"y".repeat(1591)}` } as unknown as AgentMessage; // 400 tokens
+		const c = { role: "user", content: `CCC${"z".repeat(997)}` } as unknown as AgentMessage; // 250 tokens
+		const messages: AgentMessage[] = [a, b, c];
+		// contextWindow - reserve - maxTokens(=0.8*reserve capped at model.maxTokens)
+		// = 1160 - 200 - 160 = 800-token chunk budget. a+b = 800 fill chunk0;
+		// c = 250 is chunk1 with 550 tokens of headroom. Carrying [a,b] (800) into
+		// chunk1 overflows, so a (oldest, 400) is dropped and b (400) is kept:
+		// 400 + 250 = 650 ≤ 800.
+		const model = makeModel(1_160);
+		const reserveTokens = 200;
+
+		const seenPrompts: string[] = [];
+		let callIndex = 0;
+		const responses = [
+			"", // chunk0 initial → degenerate
+			"", // chunk0 retry → degenerate (input is substantial, so it retries once)
+			"## Done\n- Real summary for the second chunk, comfortably over the hundred character degenerate threshold so it lands.",
+		];
+		const mockComplete = mock.fn(async (_model: any, context: any) => {
+			const userMsg = context.messages?.[0];
+			const text =
+				typeof userMsg?.content === "string" ? userMsg.content : userMsg?.content?.[0]?.text ?? "";
+			seenPrompts.push(text);
+			const r = responses[Math.min(callIndex, responses.length - 1)];
+			callIndex++;
+			return makeFakeResponse(r);
+		});
+
+		const summary = await generateSummary(
+			messages,
+			model,
+			reserveTokens,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(
+			mockComplete.mock.callCount(),
+			3,
+			"expected 3 calls: chunk0 + one retry + chunk1 (carrying b forward)",
+		);
+		const chunk1Prompt = seenPrompts[2] ?? "";
+		assert.ok(
+			chunk1Prompt.includes("CARRIED_B"),
+			"chunk1 summarization must include the carried-forward message b from the degenerate chunk0",
+		);
+		assert.ok(
+			!chunk1Prompt.includes("AAA_DROPPED"),
+			"the oldest carried message must be dropped to keep the merged input within the chunk budget",
+		);
+		assert.ok(!isDegenerateSummary(summary), "final summary must not be degenerate");
+	});
+});

--- a/packages/gsd-agent-core/src/compaction/compaction.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.ts
@@ -614,7 +614,9 @@ function createSummarizationOptions(
 ): SimpleStreamOptions {
 	const options: SimpleStreamOptions = { maxTokens, signal, apiKey, headers };
 	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
-		options.reasoning = thinkingLevel;
+		// Summarization is a mechanical template-fill; extended reasoning adds
+		// cost, not quality. Cap at "low" regardless of session thinking level.
+		options.reasoning = "low";
 	}
 	return options;
 }
@@ -743,6 +745,7 @@ export async function generateSummary(
 	}
 
 	let runningSummary = previousSummary;
+	let degenerateRetriesUsed = 0;
 	for (const chunk of chunks) {
 		const summaryBeforeChunk = runningSummary;
 		let chunkSummary = await summarizeOnce(
@@ -755,7 +758,12 @@ export async function generateSummary(
 			completeFn,
 		);
 
-		if (isDegenerateSummary(chunkSummary)) {
+		// A tiny chunk legitimately yields a short summary — retrying won't help.
+		// Cap retries at one per compaction run (not per chunk) so a large,
+		// already-expensive chunked run can't double its cost per chunk.
+		const chunkInputSize = serializeConversation(convertToLlm(chunk)).length;
+		if (isDegenerateSummary(chunkSummary) && degenerateRetriesUsed < 1 && chunkInputSize >= 100) {
+			degenerateRetriesUsed++;
 			chunkSummary = await summarizeOnce(
 				chunk,
 				model,

--- a/packages/gsd-agent-core/src/compaction/compaction.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.ts
@@ -746,11 +746,28 @@ export async function generateSummary(
 
 	let runningSummary = previousSummary;
 	let degenerateRetriesUsed = 0;
-	for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
-		const chunk = chunks[chunkIndex]!;
+	// Messages from earlier chunks whose summarization came back degenerate and
+	// were therefore never folded into runningSummary. They are carried into the
+	// next chunk's input (bounded by the per-chunk budget) so their content still
+	// reaches the briefing, instead of leaving a hole (silently dropping the
+	// segment) or breaking out of the loop early (dropping every later chunk).
+	let carriedForward: AgentMessage[] = [];
+	for (const chunk of chunks) {
+		// Prepend any carried-forward messages, dropping the oldest first if the
+		// combined input would exceed the per-chunk budget: an oversized segment
+		// that failed to summarize can't be merged forward without risking a
+		// context-length error on the summarizer call.
+		const chunkTokens = chunk.reduce((total, m) => total + estimateSerializedTokens(m), 0);
+		let carriedTokens = carriedForward.reduce((total, m) => total + estimateSerializedTokens(m), 0);
+		while (carriedForward.length > 0 && carriedTokens + chunkTokens > chunkBudget) {
+			carriedTokens -= estimateSerializedTokens(carriedForward[0]!);
+			carriedForward = carriedForward.slice(1);
+		}
+		const chunkInput = carriedForward.length > 0 ? [...carriedForward, ...chunk] : chunk;
+
 		const summaryBeforeChunk = runningSummary;
 		let chunkSummary = await summarizeOnce(
-			chunk,
+			chunkInput,
 			model,
 			completionOptions,
 			customInstructions,
@@ -762,11 +779,11 @@ export async function generateSummary(
 		// A tiny chunk legitimately yields a short summary — retrying won't help.
 		// Cap retries at one per compaction run (not per chunk) so a large,
 		// already-expensive chunked run can't double its cost per chunk.
-		const chunkInputSize = serializeConversation(convertToLlm(chunk)).length;
+		const chunkInputSize = serializeConversation(convertToLlm(chunkInput)).length;
 		if (isDegenerateSummary(chunkSummary) && degenerateRetriesUsed < 1 && chunkInputSize >= 100) {
 			degenerateRetriesUsed++;
 			chunkSummary = await summarizeOnce(
-				chunk,
+				chunkInput,
 				model,
 				completionOptions,
 				customInstructions,
@@ -778,17 +795,12 @@ export async function generateSummary(
 
 		if (!isDegenerateSummary(chunkSummary)) {
 			runningSummary = chunkSummary;
-		} else if (
-			chunkInputSize >= 100 &&
-			chunkIndex > 0 &&
-			chunkIndex < chunks.length - 1 &&
-			summaryBeforeChunk !== undefined &&
-			!isDegenerateSummary(summaryBeforeChunk)
-		) {
-			// A later chunk already folded into runningSummary; this chunk's
-			// messages are lost. Continuing would summarize remaining chunks
-			// against a briefing that skipped this segment.
-			break;
+			carriedForward = [];
+		} else {
+			// Keep the prior running summary and carry this segment's messages
+			// into the next chunk so a later successful summarization folds them
+			// in rather than silently dropping them.
+			carriedForward = chunkInput;
 		}
 	}
 

--- a/packages/gsd-agent-core/src/compaction/compaction.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.ts
@@ -746,7 +746,8 @@ export async function generateSummary(
 
 	let runningSummary = previousSummary;
 	let degenerateRetriesUsed = 0;
-	for (const chunk of chunks) {
+	for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+		const chunk = chunks[chunkIndex]!;
 		const summaryBeforeChunk = runningSummary;
 		let chunkSummary = await summarizeOnce(
 			chunk,
@@ -777,6 +778,17 @@ export async function generateSummary(
 
 		if (!isDegenerateSummary(chunkSummary)) {
 			runningSummary = chunkSummary;
+		} else if (
+			chunkInputSize >= 100 &&
+			chunkIndex > 0 &&
+			chunkIndex < chunks.length - 1 &&
+			summaryBeforeChunk !== undefined &&
+			!isDegenerateSummary(summaryBeforeChunk)
+		) {
+			// A later chunk already folded into runningSummary; this chunk's
+			// messages are lost. Continuing would summarize remaining chunks
+			// against a briefing that skipped this segment.
+			break;
 		}
 	}
 

--- a/packages/mcp-server/src/moonshot-tool-schema.test.ts
+++ b/packages/mcp-server/src/moonshot-tool-schema.test.ts
@@ -27,15 +27,18 @@ test("sanitizeSchemaForMoonshot flattens zod union workflow fields", () => {
 
 test("createMcpServer advertises Moonshot-safe inputSchema for every tool", async () => {
 	const sm = new SessionManager();
-	// Aliases are hidden from the model-facing surface by default (plan 035);
-	// opt in so this test exercises the full (canonical + alias) schema surface.
+	// Plan 035 suppresses alias schemas by default; opt into the broad surface
+	// so this test verifies every tool (canonical AND alias) is Moonshot-safe.
 	const previousAdvertise = process.env.GSD_MCP_ADVERTISE_ALIASES;
+	const previousHide = process.env.GSD_MCP_HIDE_ALIASES;
 	process.env.GSD_MCP_ADVERTISE_ALIASES = "1";
-	const restoreAdvertise = () => {
+	delete process.env.GSD_MCP_HIDE_ALIASES;
+	const { server } = await createMcpServer(sm).finally(() => {
 		if (previousAdvertise === undefined) delete process.env.GSD_MCP_ADVERTISE_ALIASES;
 		else process.env.GSD_MCP_ADVERTISE_ALIASES = previousAdvertise;
-	};
-	const { server } = await createMcpServer(sm).finally(restoreAdvertise);
+		if (previousHide === undefined) delete process.env.GSD_MCP_HIDE_ALIASES;
+		else process.env.GSD_MCP_HIDE_ALIASES = previousHide;
+	});
 
 	const registeredTools =
 		(server as { _registeredTools?: Record<string, { enabled: boolean; inputSchema?: unknown }> })._registeredTools ??

--- a/plans/037-dedupe-per-turn-context-messages.md
+++ b/plans/037-dedupe-per-turn-context-messages.md
@@ -1,0 +1,279 @@
+# Plan 037: Keep only the latest GSD context injection in the model payload
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 43033bb9..HEAD -- src/resources/extensions/gsd/bootstrap/system-context.ts src/resources/extensions/gsd/provider-payload-policy.ts src/resources/extensions/gsd/context-masker.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: plans/036-stabilize-prompt-cache-prefix.md (same payload-policy seam; land 036 first to avoid conflicts and so the new filter follows the quantized-mask pattern)
+- **Category**: perf (LLM token usage)
+- **Planned at**: commit `43033bb9`, 2026-07-08
+
+## Why this matters
+
+Every turn in a GSD project, the extension injects a context user-message
+(memory block, guided-execute context, or forensics context) capped at ~4,000
+chars (~1,000 tokens). These are appended as persisted history messages and
+**never pruned**: the always-on "critical memories" set (up to 8 memories) is
+near-identical turn over turn, so an N-turn session carries ~N duplicate
+memory blocks, all re-sent to the API on every subsequent request, inflating
+input cost linearly and triggering compaction earlier (which itself costs LLM
+calls). Typing "continue" during guided execution likewise re-injects the full
+task plan each time, stacking verbatim copies. The design intent (route
+volatile content out of the cached system prefix, #5019) is right; the gap is
+that superseded injections stay live in the payload. Fix: filter all but the
+latest injection of each kind out of the outgoing provider payload, mirroring
+the existing observation-mask mechanism.
+
+## Current state
+
+Files and their roles:
+
+- `src/resources/extensions/gsd/bootstrap/system-context.ts` — builds the
+  per-turn context. `buildContextMessage` (lines ~442–471) returns a
+  `{ customType, content, display: false }` message with `customType` one of
+  `"gsd-guided-context"`, `"gsd-forensics"`, `"gsd-memory"`. `loadMemoryBlock`
+  (~514–555) assembles the memory block each turn (CRITICAL_CAP=8,
+  CHAR_BUDGET=4000). The memory content begins with the marker line
+  `[MEMORY — Critical and prompt-relevant memories from the GSD memory store]`.
+- `packages/pi-agent-core/src/harness/messages.ts:133-140` — `convertToLlm`
+  converts `role: "custom"` messages to plain `role: "user"` messages
+  (customType is dropped at conversion).
+- `src/resources/extensions/gsd/provider-payload-policy.ts` — the
+  `before_provider_request` payload shaping (observation masking, display
+  truncation, source-context block). This is the seam where the new filter
+  belongs.
+- `src/resources/extensions/gsd/context-masker.ts` — exemplar for
+  payload-level message rewriting (`createObservationMask`) — copy its
+  structure and test approach.
+- `src/resources/extensions/gsd/commands-context.ts` (~283–285) — counts
+  accumulated "Memory injection" messages for the /context display; useful to
+  confirm the accumulation and, after the fix, to report live vs superseded.
+
+Excerpt — `system-context.ts:442-471` (`buildContextMessage`, abridged):
+
+```ts
+export function buildContextMessage(opts: {
+  memoryBlock: string;
+  injection: string | null;
+  forensicsInjection: string | null;
+}): { customType: string; content: string; display: false } | null {
+  const contextCharLimit = getContextMessageCharLimit();
+  const memoryContent = markMemoryContextSupplied(opts.memoryBlock.trim());
+  if (opts.injection) {
+    ...
+    return { customType: "gsd-guided-context", content, display: false as const };
+  }
+  if (opts.forensicsInjection) {
+    ...
+    return { customType: "gsd-forensics", content, display: false as const };
+  }
+  if (memoryContent) {
+    return {
+      customType: "gsd-memory",
+      content: limitContextMessageContent(memoryContent, contextCharLimit),
+      display: false as const,
+    };
+  }
+  return null;
+}
+```
+
+Key uncertainty the executor must resolve first (step 1): whether the
+`before_provider_request` payload messages still carry `customType` (pi-ai
+message format) or are already LLM-converted `role:"user"` messages. Evidence
+cuts both ways: the observation masker matches `role === "toolResult"`
+(pi-ai format) **and** "bash-result user messages (converted from
+bashExecution by convertToLlm)". Both filter strategies are specified below —
+pick by what you observe.
+
+Conventions: 2-space indent, double quotes in `bootstrap/`; tests in
+`src/resources/extensions/gsd/tests/`, exemplars `context-masker.test.ts` and
+`before-provider-context-management.test.ts`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Typecheck extensions | `pnpm run typecheck:extensions` | exit 0 |
+| Targeted tests | `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/before-provider-context-management.test.ts src/resources/extensions/gsd/tests/context-masker.test.ts` | all pass |
+| Changed-file tests | `node scripts/verify-changed-src-tests.mjs` | pass |
+
+## Scope
+
+**In scope** (the only files you should modify):
+
+- `src/resources/extensions/gsd/provider-payload-policy.ts` (new filter)
+- `src/resources/extensions/gsd/context-masker.ts` OR a new sibling module
+  (e.g. `context-injection-filter.ts`) — follow where the masking helpers live
+- `src/resources/extensions/gsd/bootstrap/system-context.ts` (only if adding
+  a stable marker constant the filter matches on)
+- `src/resources/extensions/gsd/commands-context.ts` (optional: label
+  superseded injections in the /context report)
+- Test files for the above
+
+**Out of scope** (do NOT touch, even though they look related):
+
+- Session persistence / history storage — superseded injections must REMAIN
+  in stored history (resume, forensics, and session replay read them); this
+  plan only filters the outgoing provider payload.
+- `packages/pi-agent-core/src/harness/messages.ts` (vendored conversion layer).
+- `loadMemoryBlock` ranking/budget logic — how memories are chosen is not the
+  problem; duplication across turns is.
+- The guided-execute injection trigger conditions
+  (`system-context.ts:680-731`) — dedupe at payload level makes re-injection
+  harmless; don't also change trigger logic.
+
+## Git workflow
+
+- Branch: `advisor/037-dedupe-context-injections`
+- Conventional Commits, e.g. `perf(gsd): filter superseded context injections from provider payload`
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Determine the payload message shape at the filter seam
+
+Read `provider-payload-policy.ts` and the hook registration
+(`grep -rn "before_provider_request\|onPayload\|applyProviderPayloadPolicy" src/resources/extensions/gsd/ | head`)
+and determine whether `payload.messages` entries retain `customType`.
+Fastest check: find the existing test fixtures in
+`before-provider-context-management.test.ts` and see what shape they build.
+
+Record the answer in your report. Strategy A (customType present): filter by
+`m.customType`. Strategy B (already-converted user messages): filter by a
+stable content marker — the content starts with either the memory marker line
+`[MEMORY — Critical and prompt-relevant memories from the GSD memory store]`
+or the guided/forensics injection headers (read
+`buildGuidedExecuteContextInjection` / the forensics builder in
+`system-context.ts` for their exact leading lines). If markers are not stable
+enough, add an explicit sentinel prefix constant (e.g.
+`GSD_CONTEXT_MESSAGE_SENTINEL`) to `buildContextMessage` output and match that
+(export the constant from one module; no magic strings in two places).
+
+**Verify**: you can state which strategy applies, with the file:line evidence.
+
+### Step 2: Implement `filterSupersededContextInjections`
+
+New pure function (in `context-masker.ts` or a sibling module, matching step
+1's decision): given the payload messages array, identify all GSD context
+injection messages (per step 1's detection), and return a new array where all
+but the **latest** injection are removed entirely (removal, not masking — an
+empty placeholder would still spend tokens and break byte-stability when its
+position shifts).
+
+Handle both payload shapes the policy already handles (`payload.messages` and
+`payload.input` for the Responses API) — mirror how
+`applyObservationBudget` does it.
+
+Cache-stability note (this is why 036 lands first): removing a message from
+the middle of history invalidates the cache prefix from that point. The
+injections being removed are at most one per turn and the newest ones sit near
+the tail, so the invalidation is bounded to roughly the last turn — same
+accepted cost as the source-context block. Do NOT try to preserve old
+injections to protect the cache; the linear duplicate growth costs more.
+
+Wire it into `applyProviderPayloadPolicy` for **all** sessions (not just
+auto-mode — interactive sessions accumulate the same duplicates; note the
+memory injection fires per turn regardless of auto).
+
+**Verify**: `pnpm run typecheck:extensions` → exit 0.
+
+### Step 3: Tests
+
+New test file (or extend `before-provider-context-management.test.ts`):
+
+- Three injections of the same kind across simulated turns → payload contains
+  only the last one; stored history input array is not mutated
+  (function is pure — assert input unchanged).
+- Mixed kinds (memory + guided) → latest of the stream survives per the
+  product rule you confirm in step 1 (note: `buildContextMessage` emits ONE
+  message per turn of a single kind — guided > forensics > memory-only — so
+  "keep the latest context injection overall" is the correct rule; the latest
+  one already embeds the memory block when present. Assert that.)
+- No injections present → array returned unchanged (identity or deep-equal).
+- Responses-API `payload.input` variant covered.
+
+**Verify**: targeted tests command → all pass.
+
+### Step 4: Optional /context visibility
+
+If cheap (<20 lines): in `commands-context.ts`, split the "Memory injection"
+context count into live vs superseded-filtered so users can see the savings.
+Skip if the seam is awkward; note the skip.
+
+**Verify**: `pnpm run typecheck:extensions` → exit 0;
+`node scripts/verify-changed-src-tests.mjs` → pass.
+
+## Test plan
+
+- New tests as in Step 3, modeled on `context-masker.test.ts` (pure-function
+  fixtures) and `before-provider-context-management.test.ts` (policy wiring).
+- Regression: existing masking/truncation tests must stay green — the new
+  filter must compose with `applyObservationBudget` and
+  `applyDisplayTruncation` (run order: filter superseded injections FIRST,
+  then masking, so the mask boundary math sees the final message list).
+
+## Done criteria
+
+- [x] `pnpm run typecheck:extensions` exits 0
+- [x] New filter tests pass; existing `context-masker` / `before-provider-context-management` tests pass
+- [x] A simulated 5-turn session payload contains exactly 1 GSD context injection message
+- [x] Stored session history still contains all injections (no persistence change — filter is pure, operates only on the outgoing payload array)
+- [x] No files outside the in-scope list are modified (`git status`)
+- [x] `plans/README.md` status row updated
+
+## Execution notes
+
+- Step 1: payload messages at the `before_provider_request` hook are
+  already-converted (post-`convertToLlm`) `role: "user"` messages —
+  `customType` does not survive. Confirmed via `messages.ts:133-140`
+  (`convertToLlm` drops `customType` on the `"custom"` branch) and the
+  existing `context-masker.test.ts` fixtures, which build plain
+  `{role:"user", content:[...]}` shapes. Strategy B applied: added an
+  explicit sentinel constant `GSD_CONTEXT_MESSAGE_SENTINEL` (exported from
+  `system-context.ts`) rather than relying on the memory marker line, since
+  guided/forensics-only injections (no memory block) don't carry that line.
+- Step 2: implemented `filterSupersededContextInjections` /
+  `filterSupersededResponsesContextInjections` in `context-masker.ts`,
+  wired into `applyProviderPayloadPolicy` unconditionally (all sessions),
+  running before observation budgeting per the plan's ordering note.
+- Step 4 (optional `/context` visibility): skipped — not required for done
+  criteria and no live issue to demonstrate; can be added later if desired.
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- Step 1 shows the payload messages carry NEITHER `customType` NOR any stable
+  content marker, and adding a sentinel to `buildContextMessage` doesn't
+  surface in the payload (would mean the injection travels a different path
+  than assumed — report the actual path).
+- Forensics or resume flows read context injections FROM THE PAYLOAD (not
+  from stored history) — search `gsd-forensics` usages; if a consumer depends
+  on historical payload copies, report it.
+- Removing mid-history messages breaks an API invariant (e.g. Anthropic
+  tool_use/tool_result pairing) in any existing test — the filter must never
+  remove messages between a tool_use and its tool_result.
+
+## Maintenance notes
+
+- Anyone adding a new `customType` context injection must add it to the
+  filter's detection list — leave a pointer comment at `buildContextMessage`.
+- Reviewers should scrutinize: filter ordering vs masking (superseded-filter
+  first), and that the Responses-API input path got the same treatment.
+- Follow-up recorded in `plans/README.md`: gating the heavy system blocks
+  (system.md/knowledge/codebase, ~8–9K tokens) on actual workflow activity
+  instead of mere `.gsd` directory presence (SYSPROMPT-02).

--- a/plans/038-cheapen-compaction-calls.md
+++ b/plans/038-cheapen-compaction-calls.md
@@ -1,0 +1,234 @@
+# Plan 038: Stop spending reasoning tokens and double calls on compaction summaries
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 43033bb9..HEAD -- packages/gsd-agent-core/src/compaction/compaction.ts packages/gsd-agent-core/src/session/agent-session-compaction.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Result**: DONE (steps 1-3 executed on `advisor/038-cheapen-compaction`). Step 4
+  (optional `summarizationModel` setting) was skipped — not required to satisfy the
+  plan's done criteria and carries MED risk per the plan's own effort/risk split.
+- **Priority**: P2
+- **Effort**: S (steps 1–2) + optional M (step 4)
+- **Risk**: LOW (steps 1–2) / MED (step 4)
+- **Depends on**: none
+- **Category**: perf (LLM token usage)
+- **Planned at**: commit `43033bb9`, 2026-07-08
+
+## Why this matters
+
+Compaction summarizes conversation history into a fixed-template briefing — a
+mechanical extraction task. Today that summarization call inherits the
+session's extended-thinking level: a user running with thinking `high` pays
+extended-reasoning tokens (often several × the summary's own output) every
+time compaction fires, purely to reformat history. Additionally, when a large
+session chunks its summarization input, any "degenerate" (too short) chunk
+output triggers a full second summarization call per chunk — doubling cost on
+exactly the sessions that are already the most expensive to summarize. Both
+fixes are small and contained. A third, optional lever — running summarization
+on a cheaper model — is specified as an opt-in setting.
+
+## Current state
+
+Files and their roles:
+
+- `packages/gsd-agent-core/src/compaction/compaction.ts` — the compaction
+  engine. `createSummarizationOptions` (~lines 610–620) copies the session
+  thinking level into the summarization request. The degenerate-chunk retry
+  is in `generateSummary` (~lines 758–768). Chunking budget at ~730–743.
+- `packages/gsd-agent-core/src/session/agent-session-compaction.ts` — the
+  session-side driver; passes `this.host.model` and `this.host.thinkingLevel`
+  into `compact()` at ~87–96 (auto path) and ~350–359 (manual path).
+- `packages/gsd-agent-core/src/compaction/branch-summarization.ts` and the
+  caller in `agent-session-navigation.ts` (~323–327) — branch summaries, same
+  model/thinking inheritance.
+- No `summarizationModel`/`compactionModel` setting exists anywhere
+  (verified by grep over `packages/gsd-agent-core/src` and
+  `packages/pi-coding-agent/src` at planning time).
+
+Excerpt — `packages/gsd-agent-core/src/compaction/compaction.ts:~610-620`:
+
+```ts
+	apiKey: string | undefined,
+	headers: Record<string, string> | undefined,
+	signal: AbortSignal | undefined,
+	thinkingLevel: ThinkingLevel | undefined,
+): SimpleStreamOptions {
+	const options: SimpleStreamOptions = { maxTokens, signal, apiKey, headers };
+	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
+		options.reasoning = thinkingLevel;
+	}
+	return options;
+}
+```
+
+Excerpt — `packages/gsd-agent-core/src/session/agent-session-compaction.ts:~87-96`:
+
+```ts
+				const result = await compact(
+					preparation,
+					this.host.model,
+					apiKey,
+					headers,
+					customInstructions,
+					this.host._compactionAbortController.signal,
+					this.host.thinkingLevel,
+					this.host.agent.streamFn,
+				);
+```
+
+Conventions: `gsd-agent-core` uses tabs in `compaction/` (vendored-adjacent
+style) — match the file. Tests: `packages/gsd-agent-core/src/compaction/compaction.test.ts`,
+`compaction-prompts.test.ts`, run via the package's `test` script
+(node:test with strip-types). The package test command is
+`cd packages/gsd-agent-core && pnpm test`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| agent-core tests | `cd packages/gsd-agent-core && pnpm test` | all pass |
+| Typecheck (root program includes packages via references) | `pnpm run typecheck:extensions` | exit 0 |
+| Boundary gates (if anything under vendored dirs changes) | `pnpm run verify:pi-boundary && pnpm run verify:pi-patches` | exit 0 |
+
+## Scope
+
+**In scope** (the only files you should modify):
+
+- `packages/gsd-agent-core/src/compaction/compaction.ts`
+- `packages/gsd-agent-core/src/compaction/compaction.test.ts`
+- Step 4 only (optional): `packages/gsd-agent-core/src/session/agent-session-compaction.ts`,
+  the settings surface it reads, and `agent-session-navigation.ts`
+
+**Out of scope** (do NOT touch, even though they look related):
+
+- Compaction *thresholds* and token estimation (`estimateTokens`,
+  `resolveThresholdContextTokens`) — a separate finding (COMPACT-03, unplanned;
+  see `plans/README.md`).
+- The summarization prompt templates and the previous-summary merge strategy
+  (COMPACT-04, unplanned).
+- `branch-summarization.ts` content logic — only its options plumbing if step
+  4 is taken.
+
+## Git workflow
+
+- Branch: `advisor/038-cheapen-compaction`
+- Conventional Commits, e.g. `perf(agent-core): pin compaction summarization reasoning to low`
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Cap summarization reasoning at "low"
+
+In `createSummarizationOptions` (compaction.ts), stop inheriting high thinking
+levels: replace the direct copy with a cap —
+
+```ts
+	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
+		// Summarization is a mechanical template-fill; extended reasoning adds
+		// cost, not quality. Cap at "low" regardless of session thinking level.
+		options.reasoning = "low";
+	}
+```
+
+Confirm `"low"` is a valid `ThinkingLevel` member first
+(`grep -n "ThinkingLevel" packages/gsd-agent-core/src --include="*.ts" -r | head`
+and read the type). If the enum's floor is named differently (e.g.
+`"minimal"`), use that. Apply the same cap to every other summarization
+options path in this file (turn-prefix summary ~line 1049, and any branch
+summary path that builds options here).
+
+**Verify**: `cd packages/gsd-agent-core && pnpm test` → all pass. Update any
+test asserting the old passthrough (search `compaction.test.ts` for
+`reasoning`).
+
+### Step 2: Bound the degenerate-chunk retry per compaction
+
+In `generateSummary` (~758–768), the current logic retries `summarizeOnce`
+once **per chunk** when `isDegenerateSummary` is true. Change to a
+per-compaction budget: allow at most ONE degenerate retry across the entire
+chunked run (a counter in `generateSummary` scope), and skip the retry
+entirely when the chunk's serialized input is smaller than the degenerate
+threshold itself (a tiny chunk legitimately yields a short summary).
+
+**Verify**: `cd packages/gsd-agent-core && pnpm test` → all pass; add tests in
+step 3 first if you prefer test-first.
+
+### Step 3: Tests for both behaviors
+
+In `compaction.test.ts` (follow its existing streamFn-stub pattern):
+
+- Summarization options: session thinkingLevel `"high"` on a reasoning model →
+  `options.reasoning === "low"`; thinkingLevel `"off"` → no `reasoning` key;
+  non-reasoning model → no `reasoning` key.
+- Degenerate retry: stub a streamFn returning degenerate output for 3 chunks →
+  exactly 1 retry total occurs (count calls); tiny-chunk case → 0 retries.
+
+**Verify**: `cd packages/gsd-agent-core && pnpm test` → all pass, new tests included.
+
+### Step 4 (OPTIONAL — do only if the settings seam is clean): `summarizationModel` setting
+
+1. Find the settings exemplar: `grep -rn "compaction" packages/pi-coding-agent/src/core/settings-manager.ts`
+   and the compaction settings type it exposes.
+2. Add optional `summarizationModel?: string` there; resolve it via the model
+   registry at the `agent-session-compaction.ts` call sites (~87–96, ~350–359)
+   and the branch-summary caller (`agent-session-navigation.ts:~323-327`),
+   falling back to `this.host.model`. Auth: reuse the existing
+   `getCompactionRequestAuth` path; if the substitute model's provider differs
+   from the session's and auth resolution isn't already provider-keyed, STOP
+   (see conditions) rather than plumbing new auth.
+3. Default: unset (current behavior). Document in the setting's JSDoc that a
+   fast/cheap model is recommended for large sessions.
+
+**Verify**: `pnpm run typecheck:extensions` → exit 0;
+`cd packages/gsd-agent-core && pnpm test` → pass; a test proves the model
+override reaches `compact()`.
+
+## Test plan
+
+- New tests per step 3 in `compaction.test.ts` (pattern: existing tests in
+  the same file — streamFn stubs, no network).
+- If step 4 is taken: settings-resolution test modeled on the nearest
+  settings-manager test in `pi-coding-agent`.
+
+## Done criteria
+
+- [ ] `cd packages/gsd-agent-core && pnpm test` exits 0 with the new tests
+- [ ] `pnpm run typecheck:extensions` exits 0
+- [ ] `grep -n "options.reasoning = thinkingLevel" packages/gsd-agent-core/src/compaction/compaction.ts` returns no matches
+- [ ] Degenerate retry is provably ≤1 per compaction (test asserts call count)
+- [ ] No files outside the in-scope list are modified (`git status`)
+- [ ] `plans/README.md` status row updated (note whether step 4 was taken or skipped)
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- `ThinkingLevel` has no low/minimal member below the session levels (only
+  off/on semantics) — capping semantics would need product input.
+- Any existing test asserts that summaries REQUIRE the session thinking level
+  (would indicate a quality regression was already observed at low reasoning).
+- Step 4: cross-provider auth for the substitute model is not already
+  supported by `getCompactionRequestAuth` — do not build new auth plumbing;
+  ship steps 1–3 and report.
+
+## Maintenance notes
+
+- If summary quality complaints appear after this lands, the first knob is
+  raising the cap from `"low"` (one line), not reverting the whole change.
+- Reviewers should scrutinize the retry-counter scope (per compaction run, not
+  per process) and that the manual `/compact` path (~350–359) got the same
+  treatment as auto-compaction.
+- Deferred related findings (recorded in `plans/README.md`): threshold
+  estimator counting untruncated tool results (COMPACT-03), summary-of-summary
+  compounding (COMPACT-04), unchunked turn-prefix summarization (COMPACT-06),
+  image tokens missing from the user-branch estimate (COMPACT-07).

--- a/plans/README.md
+++ b/plans/README.md
@@ -64,7 +64,7 @@ HEAD `43033bb9`; top 5 by leverage planned per the non-interactive rule).
 | 035 | Stop advertising duplicate alias tool schemas to the model | P1 | M | — | DONE |
 | 036 | Stabilize the prompt-cache prefix (quantize observation mask) + surface cacheRetention | P1 | M | — | DONE |
 | 037 | Keep only the latest GSD context injection in the model payload (memory-block dedupe) | P1 | M | 036 | DONE |
-| 038 | Stop spending reasoning tokens / double calls on compaction summaries | P2 | S | — | TODO |
+| 038 | Stop spending reasoning tokens / double calls on compaction summaries | P2 | S | — | DONE (steps 1-3; step 4 optional model-override skipped) |
 | 039 | Close prompt-budget enforcement gaps (execute-task cap, discuss-slice cap, provider ratio) | P2 | M | — | DONE (execute-task keeps authoritative task plan whole per STOP cond., caps trailing blocks; discuss-slice reuses capPreamble; provider passed at all 3 computeBudgets sites) |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`

--- a/plans/README.md
+++ b/plans/README.md
@@ -63,7 +63,7 @@ HEAD `43033bb9`; top 5 by leverage planned per the non-interactive rule).
 | 034 | Re-enable the stale-render drift detector for flat-phase projects | P2 | S | 032, 033 | TODO |
 | 035 | Stop advertising duplicate alias tool schemas to the model | P1 | M | — | DONE |
 | 036 | Stabilize the prompt-cache prefix (quantize observation mask) + surface cacheRetention | P1 | M | — | DONE |
-| 037 | Keep only the latest GSD context injection in the model payload (memory-block dedupe) | P1 | M | 036 | TODO |
+| 037 | Keep only the latest GSD context injection in the model payload (memory-block dedupe) | P1 | M | 036 | DONE |
 | 038 | Stop spending reasoning tokens / double calls on compaction summaries | P2 | S | — | TODO |
 | 039 | Close prompt-budget enforcement gaps (execute-task cap, discuss-slice cap, provider ratio) | P2 | M | — | DONE (execute-task keeps authoritative task plan whole per STOP cond., caps trailing blocks; discuss-slice reuses capPreamble; provider passed at all 3 computeBudgets sites) |
 

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -21,12 +21,14 @@ import { formatOverridesSection, formatShortcut, loadActiveOverrides, loadFile, 
 import { toPosixPath } from "../../shared/mod.js";
 import { autoEnableCmuxPreferences } from "../commands-cmux.js";
 import { gsdHome } from "../gsd-home.js";
+import { GSD_CONTEXT_MESSAGE_SENTINEL } from "../constants.js";
 
-// Leading marker on every buildContextMessage() output. Lets the provider
-// payload policy (filterSupersededContextInjections in context-masker.ts)
-// find and dedupe these messages after convertToLlm strips customType.
-// Adding a new customType here? Add its branch to the marker too.
-export const GSD_CONTEXT_MESSAGE_SENTINEL = "[GSD Context Injection]";
+// Single source of truth lives in ../constants.js; re-exported here because
+// buildContextMessage() stamps this marker on every context injection and the
+// provider payload policy (filterSupersededContextInjections in
+// context-masker.ts) matches it to dedupe. Adding a new context customType?
+// Ensure buildContextMessage still prepends this sentinel.
+export { GSD_CONTEXT_MESSAGE_SENTINEL };
 
 const DEFAULT_CONTEXT_MESSAGE_MAX_CHARS = 4_000;
 const DEFAULT_KNOWLEDGE_MAX_CHARS = 12_000;

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -22,6 +22,12 @@ import { toPosixPath } from "../../shared/mod.js";
 import { autoEnableCmuxPreferences } from "../commands-cmux.js";
 import { gsdHome } from "../gsd-home.js";
 
+// Leading marker on every buildContextMessage() output. Lets the provider
+// payload policy (filterSupersededContextInjections in context-masker.ts)
+// find and dedupe these messages after convertToLlm strips customType.
+// Adding a new customType here? Add its branch to the marker too.
+export const GSD_CONTEXT_MESSAGE_SENTINEL = "[GSD Context Injection]";
+
 const DEFAULT_CONTEXT_MESSAGE_MAX_CHARS = 4_000;
 const DEFAULT_KNOWLEDGE_MAX_CHARS = 12_000;
 const DEFAULT_CODEBASE_MAX_CHARS = 8_000;
@@ -448,14 +454,14 @@ export function buildContextMessage(opts: {
   const memoryContent = markMemoryContextSupplied(opts.memoryBlock.trim());
   if (opts.injection) {
     const content = limitContextMessageContent(
-      memoryContent ? `${memoryContent}\n\n${opts.injection}` : opts.injection,
+      `${GSD_CONTEXT_MESSAGE_SENTINEL}\n${memoryContent ? `${memoryContent}\n\n${opts.injection}` : opts.injection}`,
       contextCharLimit,
     );
     return { customType: "gsd-guided-context", content, display: false as const };
   }
   if (opts.forensicsInjection) {
     const content = limitContextMessageContent(
-      memoryContent ? `${memoryContent}\n\n${opts.forensicsInjection}` : opts.forensicsInjection,
+      `${GSD_CONTEXT_MESSAGE_SENTINEL}\n${memoryContent ? `${memoryContent}\n\n${opts.forensicsInjection}` : opts.forensicsInjection}`,
       contextCharLimit,
     );
     return { customType: "gsd-forensics", content, display: false as const };
@@ -463,7 +469,7 @@ export function buildContextMessage(opts: {
   if (memoryContent) {
     return {
       customType: "gsd-memory",
-      content: limitContextMessageContent(memoryContent, contextCharLimit),
+      content: limitContextMessageContent(`${GSD_CONTEXT_MESSAGE_SENTINEL}\n${memoryContent}`, contextCharLimit),
       display: false as const,
     };
   }

--- a/src/resources/extensions/gsd/constants.ts
+++ b/src/resources/extensions/gsd/constants.ts
@@ -53,3 +53,15 @@ export const DISCUSS_TOOLS_ALLOWLIST: readonly string[] = [
   "gsd_requirement_save",
   "gsd_requirement_update",
 ];
+
+// ─── Context Injection ────────────────────────────────────────────────────────
+
+/**
+ * Leading marker stamped on every buildContextMessage() output
+ * (bootstrap/system-context.ts). Single source of truth for the producer and
+ * the consumer: the provider payload policy (filterSupersededContextInjections
+ * in context-masker.ts) matches this prefix to find and dedupe injected
+ * memory/guided/forensics messages after convertToLlm strips their customType.
+ * Both sides import it from here — do not inline the literal in either module.
+ */
+export const GSD_CONTEXT_MESSAGE_SENTINEL = "[GSD Context Injection]";

--- a/src/resources/extensions/gsd/context-masker.ts
+++ b/src/resources/extensions/gsd/context-masker.ts
@@ -1,4 +1,4 @@
-import { GSD_CONTEXT_MESSAGE_SENTINEL } from "./bootstrap/system-context.js";
+import { GSD_CONTEXT_MESSAGE_SENTINEL } from "./constants.js";
 
 /**
  * Observation masking for GSD auto-mode sessions.
@@ -256,13 +256,20 @@ export function truncateResponsesInputResultItems(items: ResponsesInputItem[], m
 // see buildContextMessage in bootstrap/system-context.ts), marked with
 // GSD_CONTEXT_MESSAGE_SENTINEL. convertToLlm strips the distinguishing
 // customType before the payload reaches this hook, so detection is by content
-// prefix instead. Pre-sentinel session history uses the same leading lines
-// without the sentinel — match those too so resumed sessions dedupe correctly.
+// prefix instead. Pre-sentinel session history lacks the sentinel, so we also
+// match the stable *bracketed* GSD block labels those injections begin with,
+// letting resumed sessions dedupe older memory/guided blocks.
+//
+// Only GSD-specific bracketed markers belong here — never generic prose. A
+// message is dropped from the payload when it matches, so a natural-language
+// prefix (e.g. the forensics prompt "Debug GSD itself.") could silently delete
+// a real user message that happens to start the same way. Legacy forensics
+// injections without memory are therefore left un-deduped by design; those
+// with memory still match via the "[GSD Context Metadata]" wrapper.
 const LEGACY_GSD_CONTEXT_INJECTION_PREFIXES = [
   "[GSD Context Metadata]",
   "[MEMORY — Critical and prompt-relevant memories from the GSD memory store]",
   "[GSD Guided Execute Context]",
-  "Debug GSD itself.",
 ] as const;
 
 function isGsdContextInjectionText(text: string | undefined): boolean {

--- a/src/resources/extensions/gsd/context-masker.ts
+++ b/src/resources/extensions/gsd/context-masker.ts
@@ -1,3 +1,5 @@
+import { GSD_CONTEXT_MESSAGE_SENTINEL } from "./bootstrap/system-context.js";
+
 /**
  * Observation masking for GSD auto-mode sessions.
  *
@@ -251,13 +253,22 @@ export function truncateResponsesInputResultItems(items: ResponsesInputItem[], m
 }
 
 // GSD injects at most one context message per turn (memory/guided/forensics —
-// see buildContextMessage in bootstrap/system-context.ts), marked with this
-// sentinel. convertToLlm strips the distinguishing customType before the
-// payload reaches this hook, so detection is by content prefix instead.
-const GSD_CONTEXT_MESSAGE_SENTINEL = "[GSD Context Injection]";
+// see buildContextMessage in bootstrap/system-context.ts), marked with
+// GSD_CONTEXT_MESSAGE_SENTINEL. convertToLlm strips the distinguishing
+// customType before the payload reaches this hook, so detection is by content
+// prefix instead. Pre-sentinel session history uses the same leading lines
+// without the sentinel — match those too so resumed sessions dedupe correctly.
+const LEGACY_GSD_CONTEXT_INJECTION_PREFIXES = [
+  "[GSD Context Metadata]",
+  "[MEMORY — Critical and prompt-relevant memories from the GSD memory store]",
+  "[GSD Guided Execute Context]",
+  "Debug GSD itself.",
+] as const;
 
 function isGsdContextInjectionText(text: string | undefined): boolean {
-  return typeof text === "string" && text.startsWith(GSD_CONTEXT_MESSAGE_SENTINEL);
+  if (typeof text !== "string") return false;
+  if (text.startsWith(GSD_CONTEXT_MESSAGE_SENTINEL)) return true;
+  return LEGACY_GSD_CONTEXT_INJECTION_PREFIXES.some((prefix) => text.startsWith(prefix));
 }
 
 function isGsdContextInjectionMessage(m: MaskableMessage): boolean {

--- a/src/resources/extensions/gsd/context-masker.ts
+++ b/src/resources/extensions/gsd/context-masker.ts
@@ -249,3 +249,51 @@ export function truncateResponsesInputResultItems(items: ResponsesInputItem[], m
     return item;
   });
 }
+
+// GSD injects at most one context message per turn (memory/guided/forensics —
+// see buildContextMessage in bootstrap/system-context.ts), marked with this
+// sentinel. convertToLlm strips the distinguishing customType before the
+// payload reaches this hook, so detection is by content prefix instead.
+const GSD_CONTEXT_MESSAGE_SENTINEL = "[GSD Context Injection]";
+
+function isGsdContextInjectionText(text: string | undefined): boolean {
+  return typeof text === "string" && text.startsWith(GSD_CONTEXT_MESSAGE_SENTINEL);
+}
+
+function isGsdContextInjectionMessage(m: MaskableMessage): boolean {
+  if (m.role !== "user") return false;
+  return isGsdContextInjectionText(firstTextFromContent(m.content));
+}
+
+/**
+ * Removes every GSD context-injection user message except the latest one.
+ * Each turn re-injects a near-identical memory/guided/forensics block; left
+ * in place they duplicate verbatim across an N-turn session. Removal (not
+ * masking) — an empty placeholder still costs tokens and shifts message
+ * positions, breaking cache byte-stability. Pure function: stored history is
+ * never mutated, only the outgoing payload array.
+ */
+export function filterSupersededContextInjections(messages: MaskableMessage[]): MaskableMessage[] {
+  let lastIndex = -1;
+  for (let i = 0; i < messages.length; i++) {
+    if (isGsdContextInjectionMessage(messages[i])) lastIndex = i;
+  }
+  if (lastIndex === -1) return messages;
+  return messages.filter((m, i) => i === lastIndex || !isGsdContextInjectionMessage(m));
+}
+
+function isResponsesGsdContextInjectionItem(item: ResponsesInputItem): boolean {
+  if (item.role !== "user") return false;
+  return isGsdContextInjectionText(firstTextFromContent(item.content));
+}
+
+export function filterSupersededResponsesContextInjections(
+  items: ResponsesInputItem[],
+): ResponsesInputItem[] {
+  let lastIndex = -1;
+  for (let i = 0; i < items.length; i++) {
+    if (isResponsesGsdContextInjectionItem(items[i])) lastIndex = i;
+  }
+  if (lastIndex === -1) return items;
+  return items.filter((item, i) => i === lastIndex || !isResponsesGsdContextInjectionItem(item));
+}

--- a/src/resources/extensions/gsd/provider-payload-policy.ts
+++ b/src/resources/extensions/gsd/provider-payload-policy.ts
@@ -2,10 +2,12 @@
  * Provider Payload Policy - ordered shaping of provider request payloads.
  *
  * The order is intentional:
- * 1. observation budgeting masks old tool results in auto-mode,
- * 2. display truncation caps tool-result text for every mode,
- * 3. the protected Source Context Block is appended after truncation,
- * 4. supported models receive the configured service tier.
+ * 1. superseded GSD context injections (memory/guided/forensics) are removed,
+ *    keeping only the latest, for every mode,
+ * 2. observation budgeting masks old tool results in auto-mode,
+ * 3. display truncation caps tool-result text for every mode,
+ * 4. the protected Source Context Block is appended after truncation,
+ * 5. supported models receive the configured service tier.
  */
 
 import type { ContextManagementConfig } from "./preferences-types.js";
@@ -14,6 +16,8 @@ import type { ServiceTierSetting } from "./service-tier.js";
 import {
   createObservationMask,
   createResponsesInputObservationMask,
+  filterSupersededContextInjections,
+  filterSupersededResponsesContextInjections,
   truncateContextResultMessages,
   truncateResponsesInputResultItems,
 } from "./context-masker.js";
@@ -80,8 +84,18 @@ function applyContextManagement(
   deps: ProviderPayloadPolicyDeps,
 ): void {
   const config = deps.loadContextManagementConfig();
+  applyContextInjectionFilter(payload);
   applyObservationBudget(payload, config, deps.isAutoActive());
   applyDisplayTruncation(payload, config);
+}
+
+function applyContextInjectionFilter(payload: Record<string, unknown>): void {
+  if (Array.isArray(payload.messages)) {
+    payload.messages = filterSupersededContextInjections(payload.messages as MessagePayload);
+  }
+  if (Array.isArray(payload.input)) {
+    payload.input = filterSupersededResponsesContextInjections(payload.input as ResponsesInputPayload);
+  }
 }
 
 function applyObservationBudget(

--- a/src/resources/extensions/gsd/tests/before-provider-context-management.test.ts
+++ b/src/resources/extensions/gsd/tests/before-provider-context-management.test.ts
@@ -143,3 +143,58 @@ test("successful shell result clears source context before provider injection", 
   assert.equal(payload.messages.length, 1);
   assert.doesNotMatch(payload.messages[0].content[0].text, /Source Context Block/);
 });
+
+test("before_provider_request keeps only the latest GSD context injection across a 5-turn session", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-before-provider-injections-"));
+  const gsdHome = join(dir, "home");
+  const project = join(dir, "project");
+  const previousCwd = process.cwd();
+  const previousGsdHome = process.env.GSD_HOME;
+
+  mkdirSync(join(project, ".gsd"), { recursive: true });
+  mkdirSync(gsdHome, { recursive: true });
+  process.env.GSD_HOME = gsdHome;
+  process.chdir(project);
+  _setAutoActiveForTest(false);
+
+  t.after(() => {
+    _setAutoActiveForTest(false);
+    process.chdir(previousCwd);
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const beforeProviderRequest = requireHook(createHookHandlers(), "before_provider_request");
+
+  const sentinel = "[GSD Context Injection]";
+  const contextInjection = (turn: number) => ({
+    role: "user",
+    content: [{ type: "text", text: `${sentinel}\n[MEMORY] turn=${turn}` }],
+  });
+
+  const payload = {
+    messages: [
+      { role: "user", content: [{ type: "text", text: "turn 1" }] },
+      contextInjection(1),
+      { role: "assistant", content: [{ type: "text", text: "r1" }] },
+      { role: "user", content: [{ type: "text", text: "turn 2" }] },
+      contextInjection(2),
+      { role: "assistant", content: [{ type: "text", text: "r2" }] },
+      { role: "user", content: [{ type: "text", text: "turn 3" }] },
+      contextInjection(3),
+      { role: "assistant", content: [{ type: "text", text: "r3" }] },
+      { role: "user", content: [{ type: "text", text: "turn 4" }] },
+      contextInjection(4),
+      { role: "assistant", content: [{ type: "text", text: "r4" }] },
+      { role: "user", content: [{ type: "text", text: "turn 5" }] },
+      contextInjection(5),
+    ],
+  };
+
+  await beforeProviderRequest({ payload });
+
+  const survivors = (payload.messages as any[]).filter((m) => (m.content?.[0]?.text ?? "").startsWith(sentinel));
+  assert.equal(survivors.length, 1);
+  assert.match(survivors[0].content[0].text, /turn=5/);
+});

--- a/src/resources/extensions/gsd/tests/context-masker.test.ts
+++ b/src/resources/extensions/gsd/tests/context-masker.test.ts
@@ -292,6 +292,37 @@ test("filterSupersededContextInjections keeps the latest injection overall acros
   assert.match((survivors[0] as any).content[0].text, /GUIDED EXECUTE/);
 });
 
+test("filterSupersededContextInjections dedupes legacy pre-sentinel injections via bracketed GSD markers", () => {
+  // Sessions created before the sentinel existed carry the stable
+  // "[GSD Context Metadata]" / "[GSD Guided Execute Context]" labels but no
+  // sentinel prefix; resuming them must still collapse to the latest injection.
+  const legacyMemory1 = userMsg("[GSD Context Metadata]\n- Memory supplied: yes\n\n[MEMORY] turn=1");
+  const legacyMemory2 = userMsg("[GSD Context Metadata]\n- Memory supplied: yes\n\n[MEMORY] turn=2");
+  const messages = [userMsg("turn 1"), legacyMemory1, assistantMsg("r1"), userMsg("turn 2"), legacyMemory2];
+
+  const result = filterSupersededContextInjections(messages as any);
+
+  const survivors = result.filter((m: any) => (m.content?.[0]?.text ?? "").startsWith("[GSD Context Metadata]"));
+  assert.equal(survivors.length, 1);
+  assert.match((survivors[0] as any).content[0].text, /turn=2/);
+  assert.equal(result.length, messages.length - 1);
+});
+
+test("filterSupersededContextInjections never drops a real user message that starts with forensics prose", () => {
+  // "Debug GSD itself." is the forensics prompt text — generic prose, not a
+  // bracketed GSD marker. A user can legitimately type it; treating it as an
+  // injection would silently delete real user input. Only sentinel/bracketed
+  // injections may be superseded.
+  const userAsk = userMsg("Debug GSD itself. Why does resume hang after a crash?");
+  const injection = userMsg(`${GSD_CONTEXT_MESSAGE_SENTINEL}\n[GSD Context Metadata]\n- Memory supplied: yes\n\n[MEMORY]`);
+  const messages = [userAsk, assistantMsg("r1"), userMsg("turn 2"), injection];
+
+  const result = filterSupersededContextInjections(messages as any);
+
+  assert.ok(result.some((m: any) => (m.content?.[0]?.text ?? "").startsWith("Debug GSD itself.")));
+  assert.equal(result.length, messages.length);
+});
+
 test("filterSupersededContextInjections returns the array unchanged when no injections present", () => {
   const messages = [userMsg("hi"), assistantMsg("hello"), toolResult("data")];
   const result = filterSupersededContextInjections(messages as any);

--- a/src/resources/extensions/gsd/tests/context-masker.test.ts
+++ b/src/resources/extensions/gsd/tests/context-masker.test.ts
@@ -4,9 +4,12 @@ import assert from "node:assert/strict";
 import {
   createObservationMask,
   createResponsesInputObservationMask,
+  filterSupersededContextInjections,
+  filterSupersededResponsesContextInjections,
   truncateContextResultMessages,
   truncateResponsesInputResultItems,
 } from "../context-masker.js";
+import { GSD_CONTEXT_MESSAGE_SENTINEL } from "../bootstrap/system-context.js";
 
 // These helpers produce messages in the pi-ai LLM payload format
 // (post-convertToLlm, pre-provider), which is what before_provider_request sees.
@@ -245,4 +248,75 @@ test("truncates Responses API function outputs and recent bash result items", ()
   assert.match((result[2].content as any)[0].text, /…\[truncated\]/);
   assert.ok((result[1].output as string).length < (items[1].output as string).length);
   assert.ok((result[2].content as any)[0].text.length < (items[2].content as any)[0].text.length);
+});
+
+function contextInjectionMsg(label: string) {
+  return userMsg(`${GSD_CONTEXT_MESSAGE_SENTINEL}\n[MEMORY] turn=${label}`);
+}
+
+test("filterSupersededContextInjections keeps only the latest of three same-kind injections", () => {
+  const messages = [
+    userMsg("turn 1 prompt"),
+    contextInjectionMsg("1"),
+    assistantMsg("response 1"),
+    userMsg("turn 2 prompt"),
+    contextInjectionMsg("2"),
+    assistantMsg("response 2"),
+    userMsg("turn 3 prompt"),
+    contextInjectionMsg("3"),
+  ];
+  const original = JSON.parse(JSON.stringify(messages));
+
+  const result = filterSupersededContextInjections(messages as any);
+
+  const survivors = result.filter((m: any) => (m.content?.[0]?.text ?? "").startsWith(GSD_CONTEXT_MESSAGE_SENTINEL));
+  assert.equal(survivors.length, 1);
+  assert.match((survivors[0] as any).content[0].text, /turn=3/);
+  assert.equal(result.length, messages.length - 2);
+  // Pure function — input array is untouched.
+  assert.deepEqual(messages, original);
+});
+
+test("filterSupersededContextInjections keeps the latest injection overall across mixed kinds", () => {
+  // buildContextMessage emits one message per turn (guided > forensics > memory);
+  // the latest one already embeds the memory block when present, so "keep the
+  // latest overall" is correct — no separate per-kind tracking needed.
+  const memoryOnly = userMsg(`${GSD_CONTEXT_MESSAGE_SENTINEL}\n[GSD Context Metadata]\n- Memory supplied: yes\n\n[MEMORY]`);
+  const guided = userMsg(`${GSD_CONTEXT_MESSAGE_SENTINEL}\n[GSD Context Metadata]\n- Memory supplied: yes\n\n[GUIDED EXECUTE]`);
+  const messages = [userMsg("turn 1"), memoryOnly, assistantMsg("r1"), userMsg("turn 2"), guided];
+
+  const result = filterSupersededContextInjections(messages as any);
+
+  const survivors = result.filter((m: any) => (m.content?.[0]?.text ?? "").startsWith(GSD_CONTEXT_MESSAGE_SENTINEL));
+  assert.equal(survivors.length, 1);
+  assert.match((survivors[0] as any).content[0].text, /GUIDED EXECUTE/);
+});
+
+test("filterSupersededContextInjections returns the array unchanged when no injections present", () => {
+  const messages = [userMsg("hi"), assistantMsg("hello"), toolResult("data")];
+  const result = filterSupersededContextInjections(messages as any);
+  assert.equal(result, messages);
+});
+
+test("filterSupersededResponsesContextInjections keeps only the latest injection in payload.input", () => {
+  const items = [
+    { role: "user", content: [{ type: "input_text", text: "turn 1" }] },
+    { role: "user", content: [{ type: "input_text", text: `${GSD_CONTEXT_MESSAGE_SENTINEL}\n[MEMORY] turn=1` }] },
+    { type: "function_call_output", call_id: "call_1", output: "ok" },
+    { role: "user", content: [{ type: "input_text", text: `${GSD_CONTEXT_MESSAGE_SENTINEL}\n[MEMORY] turn=2` }] },
+  ];
+  const original = JSON.parse(JSON.stringify(items));
+
+  const result = filterSupersededResponsesContextInjections(items as any);
+
+  const survivors = result.filter((i: any) => (i.content?.[0]?.text ?? "").startsWith(GSD_CONTEXT_MESSAGE_SENTINEL));
+  assert.equal(survivors.length, 1);
+  assert.match((survivors[0] as any).content[0].text, /turn=2/);
+  assert.deepEqual(items, original);
+});
+
+test("filterSupersededResponsesContextInjections returns the array unchanged when no injections present", () => {
+  const items = [{ role: "user", content: [{ type: "input_text", text: "hi" }] }];
+  const result = filterSupersededResponsesContextInjections(items as any);
+  assert.equal(result, items);
 });

--- a/src/resources/extensions/gsd/tests/context-masker.test.ts
+++ b/src/resources/extensions/gsd/tests/context-masker.test.ts
@@ -329,6 +329,26 @@ test("filterSupersededContextInjections returns the array unchanged when no inje
   assert.equal(result, messages);
 });
 
+test("filterSupersededContextInjections preserves forensics opening prompt across follow-up reinjection", () => {
+  const forensicsOpening =
+    "Debug GSD itself. Trace the symptom to root cause in current source and produce a filing-ready GitHub issue.";
+  const messages = [
+    userMsg(forensicsOpening),
+    assistantMsg("I found the root cause in auto-loop.ts."),
+    userMsg("yes, create the issue"),
+    userMsg(`${GSD_CONTEXT_MESSAGE_SENTINEL}\n${forensicsOpening}`),
+    assistantMsg("Creating the issue now."),
+    userMsg("also add the stack trace"),
+    userMsg(`${GSD_CONTEXT_MESSAGE_SENTINEL}\n${forensicsOpening}\n\n## Follow-up\nalso add the stack trace`),
+  ];
+
+  const result = filterSupersededContextInjections(messages as any);
+
+  assert.equal(result.length, messages.length - 1);
+  assert.equal((result[0] as any).content[0].text, forensicsOpening);
+  assert.match((result[5] as any).content[0].text, /Follow-up/);
+});
+
 test("filterSupersededResponsesContextInjections keeps only the latest injection in payload.input", () => {
   const items = [
     { role: "user", content: [{ type: "input_text", text: "turn 1" }] },

--- a/src/resources/extensions/gsd/tests/single-writer-v3-tool-surface.test.ts
+++ b/src/resources/extensions/gsd/tests/single-writer-v3-tool-surface.test.ts
@@ -30,16 +30,8 @@ function makeMockPi() {
   } as any;
 }
 
-// Aliases are hidden from the model-facing surface by default (plan 035);
-// opt in here so this file can keep exercising alias-registration behavior.
-const previousAdvertiseAliases = process.env.GSD_ADVERTISE_TOOL_ALIASES;
-process.env.GSD_ADVERTISE_TOOL_ALIASES = "1";
-
 const pi = makeMockPi();
 registerDbTools(pi);
-
-if (previousAdvertiseAliases === undefined) delete process.env.GSD_ADVERTISE_TOOL_ALIASES;
-else process.env.GSD_ADVERTISE_TOOL_ALIASES = previousAdvertiseAliases;
 
 function getTool(name: string) {
   return pi.tools.find((t: any) => t.name === name);

--- a/src/resources/extensions/gsd/tests/single-writer-v3-tool-surface.test.ts
+++ b/src/resources/extensions/gsd/tests/single-writer-v3-tool-surface.test.ts
@@ -7,8 +7,9 @@
  *      self-identify (Stream 2: actor identity passthrough).
  *
  *   2. The 3 reversibility handlers (reopen-task/slice/milestone) are
- *      registered as MCP tools with both canonical and alias names
- *      (Stream 3: reversibility tools).
+ *      registered as MCP tools under their canonical names, and additionally
+ *      under their alias names when GSD_ADVERTISE_TOOL_ALIASES=1 (plan 035
+ *      suppresses alias schemas by default) (Stream 3: reversibility tools).
  *
  *   3. The reopen tools accept the documented core params plus optional
  *      reason/actorName/triggerReason without rejecting valid payloads.
@@ -42,6 +43,18 @@ else process.env.GSD_ADVERTISE_TOOL_ALIASES = previousAdvertiseAliases;
 
 function getTool(name: string) {
   return pi.tools.find((t: any) => t.name === name);
+}
+
+function withEnv(name: string, value: string | undefined, fn: () => void): void {
+  const previous = process.env[name];
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+  try {
+    fn();
+  } finally {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  }
 }
 
 function getRequiredProps(tool: any): string[] {
@@ -86,7 +99,9 @@ for (const name of ACTOR_TOOLS) {
   });
 }
 
-// ─── Stream 3: reopen tools registered with canonical + alias names ─────────
+// ─── Stream 3: reopen tools registered under canonical names ────────────────
+// Plan 035 suppresses alias schemas by default; the canonical reopen tools are
+// always registered, and their aliases only when GSD_ADVERTISE_TOOL_ALIASES=1.
 
 const REOPEN_TOOLS = [
   { canonical: "gsd_task_reopen", alias: "gsd_reopen_task" },
@@ -95,13 +110,24 @@ const REOPEN_TOOLS = [
 ];
 
 for (const { canonical, alias } of REOPEN_TOOLS) {
-  test(`${canonical} — registered with alias ${alias}`, () => {
+  test(`${canonical} — registered under its canonical name, no alias by default`, () => {
     const canonicalTool = getTool(canonical);
-    const aliasTool = getTool(alias);
     assert.ok(canonicalTool, `${canonical} must be registered`);
-    assert.ok(aliasTool, `${alias} must be registered as alias`);
     assert.ok(typeof canonicalTool.execute === "function", `${canonical} must have an execute function`);
-    assert.ok(typeof aliasTool.execute === "function", `${alias} must have an execute function`);
+    assert.ok(!getTool(alias), `${alias} must not be registered by default (plan 035 alias suppression)`);
+  });
+
+  test(`${canonical} — registered with alias ${alias} when GSD_ADVERTISE_TOOL_ALIASES=1`, () => {
+    withEnv("GSD_ADVERTISE_TOOL_ALIASES", "1", () => {
+      const aliasPi = makeMockPi();
+      registerDbTools(aliasPi);
+      const canonicalTool = aliasPi.tools.find((t: any) => t.name === canonical);
+      const aliasTool = aliasPi.tools.find((t: any) => t.name === alias);
+      assert.ok(canonicalTool, `${canonical} must be registered`);
+      assert.ok(aliasTool, `${alias} must be registered as alias`);
+      assert.ok(typeof canonicalTool.execute === "function", `${canonical} must have an execute function`);
+      assert.ok(typeof aliasTool.execute === "function", `${alias} must have an execute function`);
+    });
   });
 }
 

--- a/src/resources/extensions/gsd/tests/system-context-message-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/system-context-message-routing.test.ts
@@ -4,7 +4,13 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
-import { buildContextMessage, stripVolatileCodebaseMetadata } from "../bootstrap/system-context.ts";
+import {
+  buildContextMessage,
+  GSD_CONTEXT_MESSAGE_SENTINEL,
+  stripVolatileCodebaseMetadata,
+} from "../bootstrap/system-context.ts";
+
+const SENTINEL = `${GSD_CONTEXT_MESSAGE_SENTINEL}\n`;
 
 describe("stripVolatileCodebaseMetadata (#847 — KV cache stability)", () => {
   const map = [
@@ -63,7 +69,7 @@ describe("buildContextMessage (#5019 — memory routing)", () => {
     });
     assert.ok(result, "expected a context message");
     assert.equal(result.customType, "gsd-memory");
-    assert.equal(result.content, "[GSD Context Metadata]\n- Memory supplied: yes\n\n[MEMORY]\nrule one\nrule two");
+    assert.equal(result.content, `${SENTINEL}[GSD Context Metadata]\n- Memory supplied: yes\n\n[MEMORY]\nrule one\nrule two`);
     assert.equal(result.display, false);
   });
 
@@ -75,7 +81,7 @@ describe("buildContextMessage (#5019 — memory routing)", () => {
     });
     assert.ok(result);
     assert.equal(result.customType, "gsd-guided-context");
-    assert.equal(result.content, "[GUIDED]\nexecute T01");
+    assert.equal(result.content, `${SENTINEL}[GUIDED]\nexecute T01`);
   });
 
   test("forensics injection alone emits gsd-forensics", () => {
@@ -86,7 +92,7 @@ describe("buildContextMessage (#5019 — memory routing)", () => {
     });
     assert.ok(result);
     assert.equal(result.customType, "gsd-forensics");
-    assert.equal(result.content, "[FORENSICS]\ninvestigation context");
+    assert.equal(result.content, `${SENTINEL}[FORENSICS]\ninvestigation context`);
   });
 
   test("memory + guided injection: memory prepended, customType is gsd-guided-context", () => {
@@ -97,7 +103,7 @@ describe("buildContextMessage (#5019 — memory routing)", () => {
     });
     assert.ok(result);
     assert.equal(result.customType, "gsd-guided-context");
-    assert.equal(result.content, `${markedMemory}\n\n[GUIDED]\nexecute T01`);
+    assert.equal(result.content, `${SENTINEL}${markedMemory}\n\n[GUIDED]\nexecute T01`);
   });
 
   test("memory + forensics: memory prepended, customType is gsd-forensics", () => {
@@ -108,7 +114,7 @@ describe("buildContextMessage (#5019 — memory routing)", () => {
     });
     assert.ok(result);
     assert.equal(result.customType, "gsd-forensics");
-    assert.equal(result.content, `${markedMemory}\n\n[FORENSICS]\ninvestigation context`);
+    assert.equal(result.content, `${SENTINEL}${markedMemory}\n\n[FORENSICS]\ninvestigation context`);
   });
 
   test("guided takes precedence over forensics when both are somehow present", () => {
@@ -122,6 +128,6 @@ describe("buildContextMessage (#5019 — memory routing)", () => {
     });
     assert.ok(result);
     assert.equal(result.customType, "gsd-guided-context");
-    assert.equal(result.content, "[GUIDED]");
+    assert.equal(result.content, `${SENTINEL}[GUIDED]`);
   });
 });


### PR DESCRIPTION
## Summary

- Filters all but the latest GSD context injection (memory / guided-execute / forensics) out of the outgoing provider payload each turn, instead of re-sending N near-identical duplicate blocks over an N-turn session.
- Adds a stable `GSD_CONTEXT_MESSAGE_SENTINEL` marker so the filter can detect these messages after `convertToLlm` strips `customType`, and a pure `filterSupersededContextInjections` / `filterSupersededResponsesContextInjections` pair wired into `applyProviderPayloadPolicy`, running before observation masking.
- Stored session history is untouched — only the outgoing payload array is filtered (resume/forensics/replay still see every injection).

This branch also carries the unmerged prerequisite groundwork it was planned against (plans 032, 035, 036 — integration-branch META relocation, alias-schema suppression, and prompt-cache-prefix stabilization), none of which are on `main` yet. Plan 037's own change is the tip commit, `perf(gsd): filter superseded context injections from provider payload`.

Plan doc: `plans/037-dedupe-per-turn-context-messages.md`.

## Test plan

- [x] `pnpm run typecheck:extensions` — exit 0
- [x] Targeted tests: `context-masker.test.ts` + `before-provider-context-management.test.ts` — 22/22 pass
- [x] `node scripts/verify-changed-src-tests.mjs` — 27/27 pass (includes existing masking/truncation regression tests)
- [x] Simulated 5-turn session payload verified to contain exactly 1 GSD context injection message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payload filtering changes what the model sees each turn (mitigated by sentinel/legacy detection and tests); compaction loop changes affect briefing completeness on large chunked runs.
> 
> **Overview**
> This PR cuts recurring LLM input cost in two places: **outgoing GSD payloads** and **compaction summarization**.
> 
> **Context injection dedupe (plan 037)** stamps every per-turn memory/guided/forensics block with `GSD_CONTEXT_MESSAGE_SENTINEL` and runs a new **first-step** payload filter that **drops all but the latest** matching injection from `payload.messages` / Responses `payload.input`. Detection also covers legacy bracketed markers so resumed sessions dedupe; generic forensics prose is intentionally **not** matched so real user messages are not removed. Session history is unchanged—only the provider request is shaped.
> 
> **Compaction summarization (plan 038)** caps extended **reasoning at `low`** for summarization calls (instead of inheriting session `high`), allows **at most one** degenerate-output retry per compaction (skipping retries when chunk input is tiny), and **carries forward** messages from chunks that still degenerate so later chunks can fold them in instead of stopping early or leaving holes.
> 
> Smaller updates: MCP Moonshot schema test restores `GSD_MCP_HIDE_ALIASES`; reopen-tool tests align with plan 035 alias suppression; plan docs and `plans/README.md` mark 037/038 done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2a6f75145d32334cd60a39d6b240ae395a4e8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->