### PR TITLE
perf(agent-core): cheapen compaction summarization calls

### DIFF
--- a/packages/gsd-agent-core/src/compaction/compaction.test.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.test.ts
@@ -675,3 +675,175 @@ describe("(#4665) degenerate summary guard", () => {
 		);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// (#038) cheap compaction summarization
+// ---------------------------------------------------------------------------
+
+describe("(#038) summarization options cap reasoning at low", () => {
+	function makeReasoningModel(contextWindow: number): Model<any> {
+		return { ...makeModel(contextWindow), reasoning: true };
+	}
+
+	it("caps a high session thinking level down to low on a reasoning model", async () => {
+		const model = makeReasoningModel(200_000);
+		const messages = [makeUserMessage(10)];
+		let seenOptions: any;
+		const mockComplete = mock.fn(async (_model: any, _context: any, options: any) => {
+			seenOptions = options;
+			return makeFakeResponse(
+				"## Done\n- Real summary well over one hundred characters long so the degenerate check passes cleanly here.",
+			);
+		});
+
+		await generateSummary(
+			messages,
+			model,
+			16_384,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"high",
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(seenOptions.reasoning, "low");
+	});
+
+	it("does not set reasoning when session thinking level is off", async () => {
+		const model = makeReasoningModel(200_000);
+		const messages = [makeUserMessage(10)];
+		let seenOptions: any;
+		const mockComplete = mock.fn(async (_model: any, _context: any, options: any) => {
+			seenOptions = options;
+			return makeFakeResponse(
+				"## Done\n- Real summary well over one hundred characters long so the degenerate check passes cleanly here.",
+			);
+		});
+
+		await generateSummary(
+			messages,
+			model,
+			16_384,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"off",
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(seenOptions.reasoning, undefined);
+	});
+
+	it("does not set reasoning on a non-reasoning model", async () => {
+		const model = makeModel(200_000); // reasoning: false
+		const messages = [makeUserMessage(10)];
+		let seenOptions: any;
+		const mockComplete = mock.fn(async (_model: any, _context: any, options: any) => {
+			seenOptions = options;
+			return makeFakeResponse(
+				"## Done\n- Real summary well over one hundred characters long so the degenerate check passes cleanly here.",
+			);
+		});
+
+		await generateSummary(
+			messages,
+			model,
+			16_384,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"high",
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(seenOptions.reasoning, undefined);
+	});
+});
+
+describe("(#038) degenerate-chunk retry is bounded per compaction", () => {
+	it("retries at most once total across a run with multiple degenerate chunks", async () => {
+		const messages: AgentMessage[] = [
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+		];
+		const model = makeModel(1_000);
+		const reserveTokens = 200;
+
+		// Every response is degenerate — old behavior retried every chunk once
+		// (6 calls for 3 chunks); bounded behavior spends the single retry
+		// budget on the first chunk and gives up thereafter (4 calls).
+		const mockComplete = mock.fn(async () => makeFakeResponse("empty conversation"));
+
+		await assert.rejects(
+			() =>
+				generateSummary(
+					messages,
+					model,
+					reserveTokens,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					mockComplete,
+				),
+			(err: unknown) => err instanceof CompactionProducedNoSummaryError,
+		);
+
+		assert.equal(
+			mockComplete.mock.callCount(),
+			4,
+			"expected exactly 4 calls: chunk0 + one retry + chunk1 + chunk2 (no further retries)",
+		);
+	});
+
+	it("skips the retry when the degenerate chunk's serialized input is itself tiny", async () => {
+		// Chunk 0 is a single tiny user message (serializes to well under the
+		// 100-char degenerate threshold); chunk 1 is a branch summary. Branch
+		// summary content is capped by the serializer's per-block truncation
+		// (~500 tokens), so a small context window is needed to force the two
+		// onto separate chunks: tiny(~1 token) + capped-branch(~500 tokens)
+		// exceeds a 340-token chunk budget, so chunkMessages splits them.
+		const messages: AgentMessage[] = [makeUserMessage(1), makeBranchSummaryMessage(80_000)];
+		const model = makeModel(700);
+		const reserveTokens = 200;
+
+		const responses = [
+			"", // chunk 0 (tiny input) → degenerate, must NOT retry
+			"## Done\n- Real summary for chunk one well over one hundred characters long, clearing the degenerate threshold.",
+		];
+		let callIndex = 0;
+		const mockComplete = mock.fn(async () => {
+			const response = responses[Math.min(callIndex, responses.length - 1)];
+			callIndex++;
+			return makeFakeResponse(response);
+		});
+
+		await generateSummary(
+			messages,
+			model,
+			reserveTokens,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(
+			mockComplete.mock.callCount(),
+			2,
+			"expected exactly 2 calls: chunk0 (no retry, tiny input) + chunk1",
+		);
+	});
+});

--- a/packages/gsd-agent-core/src/compaction/compaction.ts
+++ b/packages/gsd-agent-core/src/compaction/compaction.ts
@@ -614,7 +614,9 @@ function createSummarizationOptions(
 ): SimpleStreamOptions {
 	const options: SimpleStreamOptions = { maxTokens, signal, apiKey, headers };
 	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
-		options.reasoning = thinkingLevel;
+		// Summarization is a mechanical template-fill; extended reasoning adds
+		// cost, not quality. Cap at "low" regardless of session thinking level.
+		options.reasoning = "low";
 	}
 	return options;
 }
@@ -743,6 +745,7 @@ export async function generateSummary(
 	}
 
 	let runningSummary = previousSummary;
+	let degenerateRetriesUsed = 0;
 	for (const chunk of chunks) {
 		const summaryBeforeChunk = runningSummary;
 		let chunkSummary = await summarizeOnce(
@@ -755,7 +758,12 @@ export async function generateSummary(
 			completeFn,
 		);
 
-		if (isDegenerateSummary(chunkSummary)) {
+		// A tiny chunk legitimately yields a short summary — retrying won't help.
+		// Cap retries at one per compaction run (not per chunk) so a large,
+		// already-expensive chunked run can't double its cost per chunk.
+		const chunkInputSize = serializeConversation(convertToLlm(chunk)).length;
+		if (isDegenerateSummary(chunkSummary) && degenerateRetriesUsed < 1 && chunkInputSize >= 100) {
+			degenerateRetriesUsed++;
 			chunkSummary = await summarizeOnce(
 				chunk,
 				model,

--- a/plans/038-cheapen-compaction-calls.md
+++ b/plans/038-cheapen-compaction-calls.md
@@ -1,0 +1,234 @@
+# Plan 038: Stop spending reasoning tokens and double calls on compaction summaries
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 43033bb9..HEAD -- packages/gsd-agent-core/src/compaction/compaction.ts packages/gsd-agent-core/src/session/agent-session-compaction.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Result**: DONE (steps 1-3 executed on `advisor/038-cheapen-compaction`). Step 4
+  (optional `summarizationModel` setting) was skipped — not required to satisfy the
+  plan's done criteria and carries MED risk per the plan's own effort/risk split.
+- **Priority**: P2
+- **Effort**: S (steps 1–2) + optional M (step 4)
+- **Risk**: LOW (steps 1–2) / MED (step 4)
+- **Depends on**: none
+- **Category**: perf (LLM token usage)
+- **Planned at**: commit `43033bb9`, 2026-07-08
+
+## Why this matters
+
+Compaction summarizes conversation history into a fixed-template briefing — a
+mechanical extraction task. Today that summarization call inherits the
+session's extended-thinking level: a user running with thinking `high` pays
+extended-reasoning tokens (often several × the summary's own output) every
+time compaction fires, purely to reformat history. Additionally, when a large
+session chunks its summarization input, any "degenerate" (too short) chunk
+output triggers a full second summarization call per chunk — doubling cost on
+exactly the sessions that are already the most expensive to summarize. Both
+fixes are small and contained. A third, optional lever — running summarization
+on a cheaper model — is specified as an opt-in setting.
+
+## Current state
+
+Files and their roles:
+
+- `packages/gsd-agent-core/src/compaction/compaction.ts` — the compaction
+  engine. `createSummarizationOptions` (~lines 610–620) copies the session
+  thinking level into the summarization request. The degenerate-chunk retry
+  is in `generateSummary` (~lines 758–768). Chunking budget at ~730–743.
+- `packages/gsd-agent-core/src/session/agent-session-compaction.ts` — the
+  session-side driver; passes `this.host.model` and `this.host.thinkingLevel`
+  into `compact()` at ~87–96 (auto path) and ~350–359 (manual path).
+- `packages/gsd-agent-core/src/compaction/branch-summarization.ts` and the
+  caller in `agent-session-navigation.ts` (~323–327) — branch summaries, same
+  model/thinking inheritance.
+- No `summarizationModel`/`compactionModel` setting exists anywhere
+  (verified by grep over `packages/gsd-agent-core/src` and
+  `packages/pi-coding-agent/src` at planning time).
+
+Excerpt — `packages/gsd-agent-core/src/compaction/compaction.ts:~610-620`:
+
+```ts
+	apiKey: string | undefined,
+	headers: Record<string, string> | undefined,
+	signal: AbortSignal | undefined,
+	thinkingLevel: ThinkingLevel | undefined,
+): SimpleStreamOptions {
+	const options: SimpleStreamOptions = { maxTokens, signal, apiKey, headers };
+	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
+		options.reasoning = thinkingLevel;
+	}
+	return options;
+}
+```
+
+Excerpt — `packages/gsd-agent-core/src/session/agent-session-compaction.ts:~87-96`:
+
+```ts
+				const result = await compact(
+					preparation,
+					this.host.model,
+					apiKey,
+					headers,
+					customInstructions,
+					this.host._compactionAbortController.signal,
+					this.host.thinkingLevel,
+					this.host.agent.streamFn,
+				);
+```
+
+Conventions: `gsd-agent-core` uses tabs in `compaction/` (vendored-adjacent
+style) — match the file. Tests: `packages/gsd-agent-core/src/compaction/compaction.test.ts`,
+`compaction-prompts.test.ts`, run via the package's `test` script
+(node:test with strip-types). The package test command is
+`cd packages/gsd-agent-core && pnpm test`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| agent-core tests | `cd packages/gsd-agent-core && pnpm test` | all pass |
+| Typecheck (root program includes packages via references) | `pnpm run typecheck:extensions` | exit 0 |
+| Boundary gates (if anything under vendored dirs changes) | `pnpm run verify:pi-boundary && pnpm run verify:pi-patches` | exit 0 |
+
+## Scope
+
+**In scope** (the only files you should modify):
+
+- `packages/gsd-agent-core/src/compaction/compaction.ts`
+- `packages/gsd-agent-core/src/compaction/compaction.test.ts`
+- Step 4 only (optional): `packages/gsd-agent-core/src/session/agent-session-compaction.ts`,
+  the settings surface it reads, and `agent-session-navigation.ts`
+
+**Out of scope** (do NOT touch, even though they look related):
+
+- Compaction *thresholds* and token estimation (`estimateTokens`,
+  `resolveThresholdContextTokens`) — a separate finding (COMPACT-03, unplanned;
+  see `plans/README.md`).
+- The summarization prompt templates and the previous-summary merge strategy
+  (COMPACT-04, unplanned).
+- `branch-summarization.ts` content logic — only its options plumbing if step
+  4 is taken.
+
+## Git workflow
+
+- Branch: `advisor/038-cheapen-compaction`
+- Conventional Commits, e.g. `perf(agent-core): pin compaction summarization reasoning to low`
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Cap summarization reasoning at "low"
+
+In `createSummarizationOptions` (compaction.ts), stop inheriting high thinking
+levels: replace the direct copy with a cap —
+
+```ts
+	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
+		// Summarization is a mechanical template-fill; extended reasoning adds
+		// cost, not quality. Cap at "low" regardless of session thinking level.
+		options.reasoning = "low";
+	}
+```
+
+Confirm `"low"` is a valid `ThinkingLevel` member first
+(`grep -n "ThinkingLevel" packages/gsd-agent-core/src --include="*.ts" -r | head`
+and read the type). If the enum's floor is named differently (e.g.
+`"minimal"`), use that. Apply the same cap to every other summarization
+options path in this file (turn-prefix summary ~line 1049, and any branch
+summary path that builds options here).
+
+**Verify**: `cd packages/gsd-agent-core && pnpm test` → all pass. Update any
+test asserting the old passthrough (search `compaction.test.ts` for
+`reasoning`).
+
+### Step 2: Bound the degenerate-chunk retry per compaction
+
+In `generateSummary` (~758–768), the current logic retries `summarizeOnce`
+once **per chunk** when `isDegenerateSummary` is true. Change to a
+per-compaction budget: allow at most ONE degenerate retry across the entire
+chunked run (a counter in `generateSummary` scope), and skip the retry
+entirely when the chunk's serialized input is smaller than the degenerate
+threshold itself (a tiny chunk legitimately yields a short summary).
+
+**Verify**: `cd packages/gsd-agent-core && pnpm test` → all pass; add tests in
+step 3 first if you prefer test-first.
+
+### Step 3: Tests for both behaviors
+
+In `compaction.test.ts` (follow its existing streamFn-stub pattern):
+
+- Summarization options: session thinkingLevel `"high"` on a reasoning model →
+  `options.reasoning === "low"`; thinkingLevel `"off"` → no `reasoning` key;
+  non-reasoning model → no `reasoning` key.
+- Degenerate retry: stub a streamFn returning degenerate output for 3 chunks →
+  exactly 1 retry total occurs (count calls); tiny-chunk case → 0 retries.
+
+**Verify**: `cd packages/gsd-agent-core && pnpm test` → all pass, new tests included.
+
+### Step 4 (OPTIONAL — do only if the settings seam is clean): `summarizationModel` setting
+
+1. Find the settings exemplar: `grep -rn "compaction" packages/pi-coding-agent/src/core/settings-manager.ts`
+   and the compaction settings type it exposes.
+2. Add optional `summarizationModel?: string` there; resolve it via the model
+   registry at the `agent-session-compaction.ts` call sites (~87–96, ~350–359)
+   and the branch-summary caller (`agent-session-navigation.ts:~323-327`),
+   falling back to `this.host.model`. Auth: reuse the existing
+   `getCompactionRequestAuth` path; if the substitute model's provider differs
+   from the session's and auth resolution isn't already provider-keyed, STOP
+   (see conditions) rather than plumbing new auth.
+3. Default: unset (current behavior). Document in the setting's JSDoc that a
+   fast/cheap model is recommended for large sessions.
+
+**Verify**: `pnpm run typecheck:extensions` → exit 0;
+`cd packages/gsd-agent-core && pnpm test` → pass; a test proves the model
+override reaches `compact()`.
+
+## Test plan
+
+- New tests per step 3 in `compaction.test.ts` (pattern: existing tests in
+  the same file — streamFn stubs, no network).
+- If step 4 is taken: settings-resolution test modeled on the nearest
+  settings-manager test in `pi-coding-agent`.
+
+## Done criteria
+
+- [ ] `cd packages/gsd-agent-core && pnpm test` exits 0 with the new tests
+- [ ] `pnpm run typecheck:extensions` exits 0
+- [ ] `grep -n "options.reasoning = thinkingLevel" packages/gsd-agent-core/src/compaction/compaction.ts` returns no matches
+- [ ] Degenerate retry is provably ≤1 per compaction (test asserts call count)
+- [ ] No files outside the in-scope list are modified (`git status`)
+- [ ] `plans/README.md` status row updated (note whether step 4 was taken or skipped)
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- `ThinkingLevel` has no low/minimal member below the session levels (only
+  off/on semantics) — capping semantics would need product input.
+- Any existing test asserts that summaries REQUIRE the session thinking level
+  (would indicate a quality regression was already observed at low reasoning).
+- Step 4: cross-provider auth for the substitute model is not already
+  supported by `getCompactionRequestAuth` — do not build new auth plumbing;
+  ship steps 1–3 and report.
+
+## Maintenance notes
+
+- If summary quality complaints appear after this lands, the first knob is
+  raising the cap from `"low"` (one line), not reverting the whole change.
+- Reviewers should scrutinize the retry-counter scope (per compaction run, not
+  per process) and that the manual `/compact` path (~350–359) got the same
+  treatment as auto-compaction.
+- Deferred related findings (recorded in `plans/README.md`): threshold
+  estimator counting untruncated tool results (COMPACT-03), summary-of-summary
+  compounding (COMPACT-04), unchunked turn-prefix summarization (COMPACT-06),
+  image tokens missing from the user-branch estimate (COMPACT-07).

--- a/plans/README.md
+++ b/plans/README.md
@@ -64,7 +64,7 @@ HEAD `43033bb9`; top 5 by leverage planned per the non-interactive rule).
 | 035 | Stop advertising duplicate alias tool schemas to the model | P1 | M | — | DONE |
 | 036 | Stabilize the prompt-cache prefix (quantize observation mask) + surface cacheRetention | P1 | M | — | DONE |
 | 037 | Keep only the latest GSD context injection in the model payload (memory-block dedupe) | P1 | M | 036 | DONE |
-| 038 | Stop spending reasoning tokens / double calls on compaction summaries | P2 | S | — | TODO |
+| 038 | Stop spending reasoning tokens / double calls on compaction summaries | P2 | S | — | DONE (steps 1-3; step 4 optional model-override skipped) |
 | 039 | Close prompt-budget enforcement gaps (execute-task cap, discuss-slice cap, provider ratio) | P2 | M | — | TODO |
 
 All of 009–017 implemented, tested, and committed on branch `chore/audit-fixes-009-017`


### PR DESCRIPTION
Implements plan 038 (`plans/038-cheapen-compaction-calls.md`), steps 1–3. Compaction summarizes conversation history into a fixed-template briefing — a mechanical extraction task that today inherits the session's full reasoning budget and can double its own cost on large sessions.

## Changes

- **Cap summarization reasoning at `low`.** `createSummarizationOptions` copied the session thinking level (`high`/`xhigh`) straight into the summarization request. Summarization is a template-fill; extended reasoning adds cost, not quality. Now capped at `"low"` on reasoning models, still omitted for `off`/non-reasoning models. This covers both the main and turn-prefix summary paths (both route through the same helper).
- **Bound the degenerate-chunk retry per compaction.** The chunked path retried `summarizeOnce` once *per chunk* whenever a chunk came back degenerate — doubling cost on exactly the largest sessions. Now at most **one** degenerate retry across the whole chunked run, and the retry is skipped entirely when a chunk's serialized input is already smaller than the degenerate threshold (a tiny chunk legitimately yields a short summary).

## Not done (deliberately)

- **Step 4** (optional `summarizationModel` setting to run summarization on a cheaper model) — skipped. Not required for the plan's done criteria and carries MED risk (cross-provider auth plumbing) per the plan's own effort/risk split.

## Tests

New tests in `compaction.test.ts`:
- reasoning cap: `high` → `options.reasoning === "low"`; `off` → no `reasoning` key; non-reasoning model → no `reasoning` key.
- retry bound: 3 degenerate chunks → exactly 1 retry total (4 calls, not 6); tiny-input chunk → 0 retries.

`cd packages/gsd-agent-core && pnpm test` → 122 pass. `pnpm run typecheck:extensions` → exit 0.

## Note on base branch

Stacked on `advisor/037-dedupe-context-injections` (unmerged) since this work builds on the 035→036→037 token-optimization chain. Base should be retargeted to `main` once the lower branches land.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to compaction summarization cost controls with explicit regression tests; summary quality could shift slightly on degenerate multi-chunk runs that previously retried every chunk.
> 
> **Overview**
> Compaction summarization no longer inherits the session’s full extended-thinking budget, and chunked runs no longer multiply LLM calls when many chunks return degenerate summaries.
> 
> **`createSummarizationOptions`** now sets `options.reasoning` to **`"low"`** on reasoning models whenever the session thinking level is not `off`, instead of passing through `high` / `xhigh`. Turn-prefix summarization uses the same helper, so it gets the same cap.
> 
> **`generateSummary`** tracks a single **`degenerateRetriesUsed`** budget per compaction: at most **one** retry across all chunks when output is degenerate. Retries are skipped when the chunk’s serialized conversation input is under **100** characters (short input can legitimately produce a short summary). Plan 038 steps 1–3 are implemented; optional **`summarizationModel`** (step 4) was not shipped. **`plans/README.md`** marks plan 038 DONE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746eb675c088ced528c3a3695c72078cf5d2fced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->