### PR TITLE
fix(issue): [Bug]: glm-5.2 (OpenRouter/Z.ai) intermittently emits text-serialized tool calls; pi-ai parses them as plain text and gsd auto-mode mislabels the failure "context exhaustion", stuck-looping the unit

### DIFF
--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -79,6 +79,85 @@ function isImageContentBlock(block: { type: string }): block is ImageContent {
 	return block.type === "image";
 }
 
+const ZAI_TEXT_TOOL_CALL_ARG_RE =
+	/<arg_key>([\s\S]*?)<\/arg_key>\s*<arg_value>([\s\S]*?)<\/arg_value>/gi;
+const ZAI_TEXT_TOOL_CALL_CLOSE_RE = /<\/tool_call>/i;
+
+function decodeXmlEntities(value: string): string {
+	return value.replace(/&(?:amp|lt|gt|quot|apos);|&#(?:x[0-9a-f]+|\d+);/gi, (entity) => {
+		switch (entity.toLowerCase()) {
+			case "&amp;":
+				return "&";
+			case "&lt;":
+				return "<";
+			case "&gt;":
+				return ">";
+			case "&quot;":
+				return '"';
+			case "&apos;":
+				return "'";
+			default: {
+				const numeric = entity.match(/^&#(x[0-9a-f]+|\d+);$/i);
+				if (!numeric) return entity;
+				const raw = numeric[1];
+				const codePoint = raw.toLowerCase().startsWith("x")
+					? Number.parseInt(raw.slice(1), 16)
+					: Number.parseInt(raw, 10);
+				return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+					? String.fromCodePoint(codePoint)
+					: entity;
+			}
+		}
+	});
+}
+
+function parseTextSerializedZaiToolCall(text: string): ToolCall | null {
+	const closeMatch = ZAI_TEXT_TOOL_CALL_CLOSE_RE.exec(text);
+	if (!closeMatch) {
+		return null;
+	}
+
+	const closedEnd = closeMatch.index + closeMatch[0].length;
+	if (text.slice(closedEnd).trim().length > 0) {
+		return null;
+	}
+
+	const candidate = text.slice(0, closedEnd).trim();
+	const firstArgIndex = candidate.search(/<arg_key>/i);
+	if (firstArgIndex <= 0 || !/<arg_value>/i.test(candidate)) {
+		return null;
+	}
+
+	const toolName = candidate
+		.slice(0, firstArgIndex)
+		.replace(/^<tool_call[^>]*>/i, "")
+		.trim();
+	if (!/^[A-Za-z0-9_.:-]+$/.test(toolName)) {
+		return null;
+	}
+
+	const args: Record<string, string> = {};
+	ZAI_TEXT_TOOL_CALL_ARG_RE.lastIndex = 0;
+	for (const match of candidate.matchAll(ZAI_TEXT_TOOL_CALL_ARG_RE)) {
+		const key = decodeXmlEntities(match[1]).trim();
+		if (!key) {
+			return null;
+		}
+		args[key] = decodeXmlEntities(match[2]);
+	}
+
+	if (Object.keys(args).length === 0) {
+		return null;
+	}
+
+	return {
+		type: "toolCall",
+		id: "call_zai_text_0",
+		name: toolName,
+		arguments: args,
+	};
+}
+
 export interface OpenAICompletionsOptions extends StreamOptions {
 	toolChoice?: "auto" | "none" | "required" | { type: "function"; function: { name: string } };
 	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
@@ -265,6 +344,40 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				}
 				return block;
 			};
+			const convertTextSerializedToolCall = () => {
+				if (!textBlock || output.stopReason !== "stop" || blocks.some((block) => block.type === "toolCall")) {
+					return;
+				}
+				const toolCall = parseTextSerializedZaiToolCall(textBlock.text);
+				if (!toolCall) {
+					return;
+				}
+
+				const contentIndex = getContentIndex(textBlock);
+				if (contentIndex === -1) {
+					return;
+				}
+
+				const partialArgs = JSON.stringify(toolCall.arguments);
+				const block: StreamingToolCallBlock = {
+					...toolCall,
+					partialArgs,
+				};
+				blocks.splice(contentIndex, 1, block);
+				textBlock = null;
+				output.stopReason = "toolUse";
+				stream.push({
+					type: "toolcall_start",
+					contentIndex,
+					partial: output,
+				});
+				stream.push({
+					type: "toolcall_delta",
+					contentIndex,
+					delta: partialArgs,
+					partial: output,
+				});
+			};
 
 			for await (const chunk of openaiStream) {
 				if (!chunk || typeof chunk !== "object") continue;
@@ -388,6 +501,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				}
 			}
 
+			convertTextSerializedToolCall();
 			for (const block of blocks) {
 				finishBlock(block);
 			}

--- a/packages/pi-ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/pi-ai/test/openai-completions-tool-choice.test.ts
@@ -365,6 +365,74 @@ describe("openai-completions tool_choice", () => {
 		expect(params.tool_stream).toBeUndefined();
 	});
 
+	it("parses z.ai text-serialized tool calls emitted as assistant text", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-zai-text-tool",
+				choices: [
+					{
+						delta: {
+							content:
+								'bash<arg_key>command</arg_key><arg_value>ls -la /tmp && echo "---SRC---"</arg_value></tool_call>',
+						},
+						finish_reason: null,
+					},
+				],
+			},
+			{
+				id: "chatcmpl-zai-text-tool",
+				choices: [{ delta: {}, finish_reason: "stop" }],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 6,
+					prompt_tokens_details: { cached_tokens: 0 },
+					completion_tokens_details: { reasoning_tokens: 0 },
+				},
+			},
+		];
+
+		const model = getModel("openrouter", "z-ai/glm-5")!;
+		const tool: Tool = {
+			name: "bash",
+			description: "Run a shell command",
+			parameters: Type.Object({
+				command: Type.String(),
+			}),
+		};
+		const s = streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "List the project files",
+						timestamp: Date.now(),
+					},
+				],
+				tools: [tool],
+			},
+			{ apiKey: "test" },
+		);
+
+		const eventTypes: string[] = [];
+		for await (const event of s) {
+			eventTypes.push(event.type);
+		}
+
+		const response = await s.result();
+		expect(response.stopReason).toBe("toolUse");
+		expect(response.content).toEqual([
+			{
+				type: "toolCall",
+				id: "call_zai_text_0",
+				name: "bash",
+				arguments: { command: 'ls -la /tmp && echo "---SRC---"' },
+			},
+		]);
+		expect(eventTypes).toContain("toolcall_start");
+		expect(eventTypes).toContain("toolcall_end");
+	});
+
 	it("maps non-standard provider finish_reason values to stopReason error", async () => {
 		mockState.chunks = [
 			{

--- a/src/resources/extensions/gsd/auto/unit-phase.ts
+++ b/src/resources/extensions/gsd/auto/unit-phase.ts
@@ -801,11 +801,7 @@ export async function runUnitPhase(
           await deps.pauseAuto(ctx, pi);
           return { action: "break", reason: "zero-tool-serialization-drift" };
         }
-        if (
-          providerMessageClass &&
-          providerMessageClass.kind !== "pseudo-tool-call" &&
-          isTransient(providerMessageClass)
-        ) {
+        if (providerMessageClass && isTransient(providerMessageClass)) {
           const retryAfterMs = "retryAfterMs" in providerMessageClass ? providerMessageClass.retryAfterMs : 15_000;
           await pauseAutoForProviderError(
             ctx.ui,

--- a/src/resources/extensions/gsd/auto/unit-phase.ts
+++ b/src/resources/extensions/gsd/auto/unit-phase.ts
@@ -60,23 +60,24 @@ const ZERO_TOOL_PSEUDO_TOOL_CALL_RE =
   /<arg_key>[\s\S]*?<\/arg_key>\s*<arg_value>[\s\S]*?<\/arg_value>[\s\S]*?<\/tool_call>/i;
 const ZERO_TOOL_PSEUDO_TOOL_CALL_SNIPPET_CHARS = 200;
 
-type ZeroToolProviderMessageClass =
-  | ReturnType<typeof classifyError>
-  | { kind: "pseudo-tool-call"; snippet: string };
-
 function zeroToolMessageSnippet(message: string): string {
   const compact = message.trim().replace(/\s+/g, " ");
   if (compact.length <= ZERO_TOOL_PSEUDO_TOOL_CALL_SNIPPET_CHARS) return compact;
   return `${compact.slice(0, ZERO_TOOL_PSEUDO_TOOL_CALL_SNIPPET_CHARS - 3)}...`;
 }
 
-function classifyZeroToolProviderMessage(message: string): ZeroToolProviderMessageClass | null {
-  if (ZERO_TOOL_PSEUDO_TOOL_CALL_RE.test(message)) {
-    return {
-      kind: "pseudo-tool-call",
-      snippet: zeroToolMessageSnippet(message),
-    };
-  }
+// Provider serialization drift: the model emitted a tool call as plain assistant
+// text (`toolName<arg_key>…</arg_key><arg_value>…</arg_value></tool_call>`)
+// instead of a structured tool call. Returns an operator-visible snippet when
+// detected. Kept separate from error classification so a drift snippet is never
+// conflated with an ErrorClass (which would force a fragile union whose
+// narrowing the root and extensions tsconfigs disagree on).
+function zeroToolPseudoToolCallSnippet(message: string): string | null {
+  if (!ZERO_TOOL_PSEUDO_TOOL_CALL_RE.test(message)) return null;
+  return zeroToolMessageSnippet(message);
+}
+
+function classifyZeroToolProviderMessage(message: string): ReturnType<typeof classifyError> | null {
   const firstLine = message.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
   if (
     !firstLine ||
@@ -87,6 +88,7 @@ function classifyZeroToolProviderMessage(message: string): ZeroToolProviderMessa
 }
 
 export const _classifyZeroToolProviderMessageForTest = classifyZeroToolProviderMessage;
+export const _zeroToolPseudoToolCallSnippetForTest = zeroToolPseudoToolCallSnippet;
 
 export function resolveDispatchRecoveryAttempts(
   unitRecoveryCount: Map<string, number>,
@@ -786,29 +788,30 @@ export async function runUnitPhase(
       );
       if (lastUnit && lastUnit.toolCalls === 0) {
         const lastAssistantMessage = lastAssistantText(s.lastUnitAgentEndMessages);
-        const providerMessageClass = classifyZeroToolProviderMessage(lastAssistantMessage);
-        if (providerMessageClass?.kind === "pseudo-tool-call") {
+        const pseudoToolCallSnippet = zeroToolPseudoToolCallSnippet(lastAssistantMessage);
+        if (pseudoToolCallSnippet) {
           debugLog("runUnitPhase", {
             phase: "zero-tool-serialization-drift",
             unitType,
             unitId,
-            snippet: providerMessageClass.snippet,
+            snippet: pseudoToolCallSnippet,
           });
           ctx.ui.notify(
-            `${unitType} ${unitId} completed with 0 tool calls - provider serialization drift: model emitted pseudo-tool-call text. Snippet: ${providerMessageClass.snippet}`,
+            `${unitType} ${unitId} completed with 0 tool calls - provider serialization drift: model emitted pseudo-tool-call text. Snippet: ${pseudoToolCallSnippet}`,
             "error",
           );
           await deps.pauseAuto(ctx, pi);
           return { action: "break", reason: "zero-tool-serialization-drift" };
         }
-        if (providerMessageClass && isTransient(providerMessageClass)) {
-          const retryAfterMs = "retryAfterMs" in providerMessageClass ? providerMessageClass.retryAfterMs : 15_000;
+        const providerErrorClass = classifyZeroToolProviderMessage(lastAssistantMessage);
+        if (providerErrorClass && isTransient(providerErrorClass)) {
+          const retryAfterMs = "retryAfterMs" in providerErrorClass ? providerErrorClass.retryAfterMs : 15_000;
           await pauseAutoForProviderError(
             ctx.ui,
             ` for ${unitType} ${unitId}`,
             () => deps.pauseAuto(ctx, pi),
             {
-              isRateLimit: providerMessageClass.kind === "rate-limit",
+              isRateLimit: providerErrorClass.kind === "rate-limit",
               isTransient: true,
               retryAfterMs,
               resume: () => {
@@ -826,7 +829,7 @@ export async function runUnitPhase(
           });
           return {
             action: "break",
-            reason: providerMessageClass.kind === "rate-limit" ? "rate-limit" : "api-timeout",
+            reason: providerErrorClass.kind === "rate-limit" ? "rate-limit" : "api-timeout",
           };
         }
         if (USER_DRIVEN_DEEP_UNITS.has(unitType) && isAwaitingUserInput(s.lastUnitAgentEndMessages ?? undefined)) {

--- a/src/resources/extensions/gsd/auto/unit-phase.ts
+++ b/src/resources/extensions/gsd/auto/unit-phase.ts
@@ -56,8 +56,27 @@ const ZERO_TOOL_PROVIDER_ERROR_PREFIX_RE =
   /^(?:api error(?::|$|\s*\()|provider error(?::|$|\s*\()|request failed\b|(?:http\s*)?(?:429|500|502|503)\b|\b(?:econnreset|etimedout|econnrefused|epipe)\b|socket hang up\b|fetch failed\b|(?:network|connection|server) error(?::|$)|connection (?:reset|refused)(?::|$|\s+by\b)|dns\b.*(?:fail|error|timeout)|unexpected eof\b|stream idle timeout\b|partial response received\b|stream_exhausted\b|terminated(?::|$)|(?:connection|stream|request)\b.{0,40}\bterminated\b|other side closed\b|rate.?limit(?:ed| exceeded| reached| error)|too many requests\b|you(?:'ve| have) (?:hit|reached) your (?:\w+ )?limit\b|.*\b(?:usage|session|weekly|daily|monthly|quota) limit\b|limit\b.{0,40}\bresets?\b|out of extra usage\b|service.?unavailable\b|internal(?: server)? error(?::|$)|internal(?:[_-]server)?[_-]error\b|server[_-]error\b|(?:provider|server|api|model|codex|claude|openai|anthropic|gemini)\b.{0,80}\boverloaded\b|overloaded\b.{0,80}\b(?:provider|server|api|model)\b|context (?:window|length) exceed|context window exceed)/i;
 const ZERO_TOOL_PROVIDER_ERROR_SIGNAL_RE =
   /(?:\b(?:http|status(?: code)?|code|error:)\s*(?:429|500|502|503)\b|\b(?:api|provider) error\s*[:(]?\s*(?:429|500|502|503)\b|\b(?:typeerror|error):\s*(?:fetch failed\b|socket hang up\b|terminated(?::|$)|connection (?:reset|refused)(?::|$|\s+by\b)|(?:network|connection|server) error(?::|$)|stream idle timeout\b|partial response received\b|unexpected eof\b)|\b(?:server_error|api_error|stream_exhausted(?:_without_result)?)\b|\b(?:econnreset|etimedout|econnrefused|epipe)\b|context (?:window|length) exceed|context window exceed)/i;
+const ZERO_TOOL_PSEUDO_TOOL_CALL_RE =
+  /<arg_key>[\s\S]*?<\/arg_key>\s*<arg_value>[\s\S]*?<\/arg_value>[\s\S]*?<\/tool_call>/i;
+const ZERO_TOOL_PSEUDO_TOOL_CALL_SNIPPET_CHARS = 200;
 
-function classifyZeroToolProviderMessage(message: string): ReturnType<typeof classifyError> | null {
+type ZeroToolProviderMessageClass =
+  | ReturnType<typeof classifyError>
+  | { kind: "pseudo-tool-call"; snippet: string };
+
+function zeroToolMessageSnippet(message: string): string {
+  const compact = message.trim().replace(/\s+/g, " ");
+  if (compact.length <= ZERO_TOOL_PSEUDO_TOOL_CALL_SNIPPET_CHARS) return compact;
+  return `${compact.slice(0, ZERO_TOOL_PSEUDO_TOOL_CALL_SNIPPET_CHARS - 3)}...`;
+}
+
+function classifyZeroToolProviderMessage(message: string): ZeroToolProviderMessageClass | null {
+  if (ZERO_TOOL_PSEUDO_TOOL_CALL_RE.test(message)) {
+    return {
+      kind: "pseudo-tool-call",
+      snippet: zeroToolMessageSnippet(message),
+    };
+  }
   const firstLine = message.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
   if (
     !firstLine ||
@@ -768,7 +787,25 @@ export async function runUnitPhase(
       if (lastUnit && lastUnit.toolCalls === 0) {
         const lastAssistantMessage = lastAssistantText(s.lastUnitAgentEndMessages);
         const providerMessageClass = classifyZeroToolProviderMessage(lastAssistantMessage);
-        if (providerMessageClass && isTransient(providerMessageClass)) {
+        if (providerMessageClass?.kind === "pseudo-tool-call") {
+          debugLog("runUnitPhase", {
+            phase: "zero-tool-serialization-drift",
+            unitType,
+            unitId,
+            snippet: providerMessageClass.snippet,
+          });
+          ctx.ui.notify(
+            `${unitType} ${unitId} completed with 0 tool calls - provider serialization drift: model emitted pseudo-tool-call text. Snippet: ${providerMessageClass.snippet}`,
+            "error",
+          );
+          await deps.pauseAuto(ctx, pi);
+          return { action: "break", reason: "zero-tool-serialization-drift" };
+        }
+        if (
+          providerMessageClass &&
+          providerMessageClass.kind !== "pseudo-tool-call" &&
+          isTransient(providerMessageClass)
+        ) {
           const retryAfterMs = "retryAfterMs" in providerMessageClass ? providerMessageClass.retryAfterMs : 15_000;
           await pauseAutoForProviderError(
             ctx.ui,

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -5421,6 +5421,114 @@ test("runUnitPhase retries 0-tool units with ordinary network-related assistant 
   assert.equal(deps.callLog.includes("pauseAuto"), false);
 });
 
+test("runUnitPhase pauses 0-tool units with pseudo tool-call text as serialization drift", async (t) => {
+  _resetPendingResolve();
+
+  const basePath = makeLoopTestBase("gsd-zero-tool-pseudo-tool-");
+  t.after(() => {
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  const notifications: string[] = [];
+  const ctx = {
+    ...makeMockCtx(),
+    ui: {
+      notify: (msg: string) => { notifications.push(msg); },
+      setStatus: () => {},
+      setWorkingMessage: () => {},
+    },
+    sessionManager: {
+      getEntries: () => [],
+    },
+    modelRegistry: {
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => true,
+    },
+  } as any;
+  const pi = {
+    ...makeMockPi(),
+    sendMessage: () => {
+      queueMicrotask(() => resolveAgentEnd(makeEvent([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: 'bash<arg_key>command</arg_key><arg_value>ls -la /tmp && echo "---SRC---"</arg_value></tool_call>',
+            },
+          ],
+        },
+      ])));
+    },
+  } as any;
+  const s = makeLoopSession({
+    basePath,
+    canonicalProjectRoot: basePath,
+    originalBasePath: basePath,
+  });
+  const mockLedger = {
+    version: 1,
+    projectStartedAt: Date.now(),
+    units: [] as any[],
+  };
+  const deps = makeMockDeps({
+    closeoutUnit: async () => {
+      mockLedger.units.push({
+        type: "execute-task",
+        id: "M001/S01/T01",
+        startedAt: s.currentUnit?.startedAt ?? Date.now(),
+        toolCalls: 0,
+        assistantMessages: 1,
+        tokens: { input: 100, output: 20, total: 120, cacheRead: 0, cacheWrite: 0 },
+        cost: 0.01,
+      });
+    },
+    getLedger: () => mockLedger,
+  });
+  let seq = 0;
+
+  const result = await runUnitPhase(
+    { ctx, pi, s, deps, prefs: undefined, iteration: 1, flowId: "flow-zero-tool-pseudo-tool", nextSeq: () => ++seq },
+    {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "do work",
+      finalPrompt: "do work",
+      pauseAfterUatDispatch: false,
+      state: {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Milestone" },
+        activeSlice: { id: "S01", title: "Slice" },
+        activeTask: { id: "T01", title: "Task" },
+        registry: [{ id: "M001", title: "Milestone", status: "active" }],
+        recentDecisions: [],
+        blockers: [],
+        nextAction: "",
+        progress: { milestones: { done: 0, total: 1 } },
+        requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      } as any,
+      mid: "M001",
+      midTitle: "Milestone",
+      isRetry: false,
+      previousTier: undefined,
+    },
+    { recentUnits: [{ key: "execute-task/M001/S01/T01" }], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 },
+  );
+
+  assert.equal(result.action, "break");
+  assert.equal((result as any).reason, "zero-tool-serialization-drift");
+  assert.equal(deps.callLog.includes("pauseAuto"), true);
+  assert.equal(s.zeroToolRetryCount.has("execute-task/M001/S01/T01"), false);
+  assert.ok(
+    notifications.some((msg) => msg.includes("serialization drift") && msg.includes("bash<arg_key>command")),
+    "serialization drift notification should include a snippet of the pseudo tool-call text",
+  );
+  assert.ok(
+    !notifications.some((msg) => msg.includes("context exhaustion")),
+    "pseudo tool-call text should not be labeled as context exhaustion",
+  );
+});
+
 test("runUnitPhase pauses auto-mode when zero-tool-call retry is exhausted", async (t) => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -23,7 +23,10 @@ import {
 } from "../bootstrap/agent-end-recovery.ts";
 import { blockModelUntil, clearTemporaryModelBlocksForTest } from "../blocked-models.ts";
 import { _buildCancelledUnitStopReason } from "../auto/phase-helpers.ts";
-import { _classifyZeroToolProviderMessageForTest } from "../auto/unit-phase.ts";
+import {
+  _classifyZeroToolProviderMessageForTest,
+  _zeroToolPseudoToolCallSnippetForTest,
+} from "../auto/unit-phase.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 import { getNextFallbackModel } from "../preferences.ts";
 import { clearGuidedUnitContext, getGuidedUnitContext, setGuidedUnitContext } from "../guided-unit-context.ts";
@@ -77,13 +80,19 @@ test("zero-tool provider classifier treats weekly limit wording as transient rat
   assert.equal(result.kind, "rate-limit");
 });
 
-test("zero-tool provider classifier identifies pseudo tool-call serialization drift", () => {
+test("zero-tool pseudo tool-call detector identifies serialization drift", () => {
+  const snippet = _zeroToolPseudoToolCallSnippetForTest(
+    'bash<arg_key>command</arg_key><arg_value>ls -la /tmp && echo "---SRC---"</arg_value></tool_call>',
+  );
+  assert.ok(snippet, "pseudo tool-call text should be recognized");
+  assert.match(snippet, /bash<arg_key>command<\/arg_key>/);
+});
+
+test("zero-tool provider classifier does not treat pseudo tool-call text as an error class", () => {
   const result = _classifyZeroToolProviderMessageForTest(
     'bash<arg_key>command</arg_key><arg_value>ls -la /tmp && echo "---SRC---"</arg_value></tool_call>',
-  ) as any;
-  assert.ok(result, "pseudo tool-call text should be recognized");
-  assert.equal(result.kind, "pseudo-tool-call");
-  assert.match(result.snippet, /bash<arg_key>command<\/arg_key>/);
+  );
+  assert.equal(result, null, "pseudo tool-call text is drift, not a provider error");
 });
 
 test("classifyError treats extra-usage phrasing as transient rate-limit (#4397)", () => {

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -77,6 +77,15 @@ test("zero-tool provider classifier treats weekly limit wording as transient rat
   assert.equal(result.kind, "rate-limit");
 });
 
+test("zero-tool provider classifier identifies pseudo tool-call serialization drift", () => {
+  const result = _classifyZeroToolProviderMessageForTest(
+    'bash<arg_key>command</arg_key><arg_value>ls -la /tmp && echo "---SRC---"</arg_value></tool_call>',
+  ) as any;
+  assert.ok(result, "pseudo tool-call text should be recognized");
+  assert.equal(result.kind, "pseudo-tool-call");
+  assert.match(result.snippet, /bash<arg_key>command<\/arg_key>/);
+});
+
 test("classifyError treats extra-usage phrasing as transient rate-limit (#4397)", () => {
   const result = classifyError("You are out of extra usage. Please wait before retrying.");
   assert.ok(isTransient(result));


### PR DESCRIPTION
## Summary
- Fixed GLM/Z.ai serialized tool-call parsing and GSD serialization-drift reporting; lightweight checks passed while full tests were blocked by unavailable dependencies.

## Bugs Addressed
- [x] **pi-ai does not handle GLM/Z.ai text-serialized tool calls**
- [x] **gsd zero-tool guard misdiagnoses pseudo-tool-call text**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1362
- [#1362 [Bug]: glm-5.2 (OpenRouter/Z.ai) intermittently emits text-serialized tool calls; pi-ai parses them as plain text and gsd auto-mode mislabels the failure "context exhaustion", stuck-looping the unit](https://github.com/open-gsd/gsd-pi/issues/1362)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1362-bug-glm-5-2-openrouter-z-ai-intermittent-1783596629`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how assistant completions are interpreted (text vs tool use) and auto-mode failure handling for zero-tool units; mis-parsing could wrongly promote text to tool calls or miss drift, but behavior is gated on strict patterns and covered by new tests.
> 
> **Overview**
> Fixes GLM/Z.ai models (e.g. via OpenRouter) that sometimes emit **tool calls as assistant text** (`toolName<arg_key>…</arg_key><arg_value>…</arg_value></tool_call>`) instead of structured `tool_calls` deltas.
> 
> **pi-ai:** After the OpenAI-completions stream finishes, matching assistant text is parsed (XML entities, arg pairs) and **replaced with a normal `toolCall` block**, with `stopReason` set to `toolUse` and the usual `toolcall_*` stream events.
> 
> **gsd auto-mode:** The zero-tool-call guard **recognizes the same pseudo-tool-call pattern** in the last assistant message. That case **pauses auto** with an explicit “provider serialization drift” message and snippet, instead of treating it as context exhaustion and retry-looping the unit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0fe6d87e174dff597fd1ce9693be3af5ed41b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->