### PR TITLE
fix(issue): Model fallback not triggered for "abort" / "unknown" provider errors

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -66,7 +66,7 @@ const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|web
 // See: https://github.com/open-gsd/gsd-pi/issues/4528
 const SERVER_RE = /internal(?: server)?[ _-]?error|server[ _-]?error|500|502|503|overloaded|server_error|api_error|service.?unavailable|context (?:window|length) exceed|context window exceed/i;
 // ECONNRESET/ECONNREFUSED are in NETWORK_RE (same-model retry first).
-const CONNECTION_RE = /terminated|connection.?(?:refused|error)|other side closed|EPIPE|network.?(?:is\s+)?unavailable|stream_exhausted(?:_without_result)?/i;
+const CONNECTION_RE = /terminated|\babort\b|connection.?(?:refused|error)|other side closed|EPIPE|network.?(?:is\s+)?unavailable|stream_exhausted(?:_without_result)?/i;
 // Catch-all for V8 JSON.parse errors: all modern variants end with "in JSON at position \d+".
 // This eliminates the need to enumerate every error message variant individually.
 const STREAM_RE = /in JSON at position \d+|Unexpected end of JSON|SyntaxError.*JSON/i;
@@ -103,7 +103,7 @@ const UNSUPPORTED_MODEL_SCOPE_RE = /\b(?:account|plan|tier|subscription)\b/i;
  *  3. Network (ECONNRESET, ETIMEDOUT, socket hang up, fetch failed, dns)
  *  4. Stream truncation (malformed JSON from mid-stream cut)
  *  5. Server (500/502/503, overloaded, server_error)
- *  6. Connection (terminated, ECONNREFUSED, EPIPE, other side closed)
+ *  6. Connection (terminated, abort, ECONNREFUSED, EPIPE, other side closed)
  *  7. Model error (400 invalid argument / payload rejected for this model)
  *  8. Unknown
  */

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -65,6 +65,10 @@ const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|web
 // transient errors so auto-mode can retry with reduced budget or fall back to a larger-context model.
 // See: https://github.com/open-gsd/gsd-pi/issues/4528
 const SERVER_RE = /internal(?: server)?[ _-]?error|server[ _-]?error|500|502|503|overloaded|server_error|api_error|service.?unavailable|context (?:window|length) exceed|context window exceed/i;
+// Provider adapters throw this when an upstream stop reason reaches Pi before
+// the adapter knows how to map it. Keep the match scoped so plain "unknown"
+// runtime errors still pause for inspection instead of being retried forever.
+const PROVIDER_STOP_REASON_RE = /unhandled stop reason:\s*(?:abort|unknown)\b/i;
 // ECONNRESET/ECONNREFUSED are in NETWORK_RE (same-model retry first).
 const CONNECTION_RE = /terminated|\babort\b|connection.?(?:refused|error)|other side closed|EPIPE|network.?(?:is\s+)?unavailable|stream_exhausted(?:_without_result)?/i;
 // Catch-all for V8 JSON.parse errors: all modern variants end with "in JSON at position \d+".
@@ -103,7 +107,7 @@ const UNSUPPORTED_MODEL_SCOPE_RE = /\b(?:account|plan|tier|subscription)\b/i;
  *  3. Network (ECONNRESET, ETIMEDOUT, socket hang up, fetch failed, dns)
  *  4. Stream truncation (malformed JSON from mid-stream cut)
  *  5. Server (500/502/503, overloaded, server_error)
- *  6. Connection (terminated, abort, ECONNREFUSED, EPIPE, other side closed)
+ *  6. Connection (terminated, abort/unknown stop reason, ECONNREFUSED, EPIPE, other side closed)
  *  7. Model error (400 invalid argument / payload rejected for this model)
  *  8. Unknown
  */
@@ -161,6 +165,13 @@ export function classifyError(errorMsg: string, retryAfterMs?: number): ErrorCla
     const resetMatch = errorMsg.match(RESET_DELAY_RE);
     const delayMs = resetMatch ? Number(resetMatch[1]) * 1000 : 60_000;
     return { kind: "rate-limit", retryAfterMs: delayMs };
+  }
+
+  // Provider stop-reason adapter gaps are usually request/stream failures from
+  // the current model. Treat the scoped adapter message as fallback-eligible,
+  // but keep generic unknown errors on the indefinite pause path.
+  if (PROVIDER_STOP_REASON_RE.test(errorMsg)) {
+    return { kind: "connection", retryAfterMs: retryAfterMs ?? 15_000 };
   }
 
   // 3. Network errors — same-model retry candidate

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -651,6 +651,108 @@ test("rate-limit agent_end walks past unavailable fallback models before pausing
   }
 });
 
+test("retry-exhausted abort/unknown provider stop reasons trigger model fallback (#1364)", async () => {
+  const originalCwd = process.cwd();
+  const originalSetTimeout = globalThis.setTimeout;
+
+  globalThis.setTimeout = ((fn: (...args: unknown[]) => void, delay?: number) => {
+    if ((delay ?? 0) === 0) {
+      fn();
+    }
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  try {
+    for (const reason of ["abort", "unknown"]) {
+      const base = mkdtempSync(join(tmpdir(), `gsd-stop-reason-${reason}-`));
+      const notifications: Array<{ message: string; level?: string }> = [];
+      const setModelCalls: string[] = [];
+      const sendMessageCalls: unknown[][] = [];
+
+      try {
+        resetTransientRetryState();
+        clearTemporaryModelBlocksForTest();
+        autoSession.reset();
+        mkdirSync(join(base, ".gsd"), { recursive: true });
+        writeFileSync(
+          join(base, ".gsd", "PREFERENCES.md"),
+          [
+            "---",
+            "models:",
+            "  execution:",
+            "    model: gpt-5.5",
+            "    provider: openai-codex",
+            "    fallbacks:",
+            "      - anthropic/claude-sonnet-4-6",
+            "---",
+          ].join("\n"),
+          "utf-8",
+        );
+        process.chdir(base);
+
+        autoSession.active = true;
+        autoSession.basePath = base;
+        autoSession.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+        autoSession.autoModeStartModel = { provider: "openai-codex", id: "gpt-5.5" };
+
+        const availableModels = [
+          { id: "gpt-5.5", provider: "openai-codex", api: "responses" },
+          { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+        ];
+        const ctx = {
+          model: availableModels[0],
+          modelRegistry: { getAvailable: () => availableModels },
+          ui: {
+            notify(message: string, level?: "info" | "warning" | "error" | "success") {
+              notifications.push({ message, level });
+            },
+            setStatus: () => {},
+            setWidget: () => {},
+            setWorkingMessage: () => {},
+          },
+        } as any;
+        const pi = {
+          setModel: async (model: { provider: string; id: string }) => {
+            setModelCalls.push(`${model.provider}/${model.id}`);
+            return true;
+          },
+          sendMessage: (...args: unknown[]) => {
+            sendMessageCalls.push(args);
+          },
+        } as any;
+
+        await handleAgentEnd(pi, {
+          messages: [{
+            role: "assistant",
+            stopReason: "error",
+            errorMessage: `Retry failed after 3 attempts: Unhandled stop reason: ${reason}`,
+          }],
+        } as any, ctx);
+
+        assert.deepEqual(setModelCalls, ["anthropic/claude-sonnet-4-6"], `${reason} should switch to configured fallback`);
+        assert.equal(sendMessageCalls.length, 1, `${reason} fallback recovery must trigger a continuation turn`);
+        assert.deepEqual(sendMessageCalls[0][1], { triggerTurn: true });
+        assert.ok(
+          notifications.some((n) => n.message.includes("anthropic/claude-sonnet-4-6")),
+          `${reason} notification should name the selected fallback`,
+        );
+      } finally {
+        process.chdir(originalCwd);
+        clearTemporaryModelBlocksForTest();
+        resetTransientRetryState();
+        autoSession.reset();
+        rmSync(base, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    process.chdir(originalCwd);
+    clearTemporaryModelBlocksForTest();
+    resetTransientRetryState();
+    autoSession.reset();
+  }
+});
+
 test("isTerminalDeletedWorktreeProviderError matches removed auto-worktree paths only", () => {
   assert.equal(
     isTerminalDeletedWorktreeProviderError('Path "/Users/dev/.gsd/projects/abc123/worktrees/M005" does not exist'),

--- a/src/resources/extensions/gsd/tests/terminated-transient.test.ts
+++ b/src/resources/extensions/gsd/tests/terminated-transient.test.ts
@@ -17,6 +17,13 @@ test("#2309: 'terminated' errors should be classified as transient", () => {
   assert.equal("retryAfterMs" in result && result.retryAfterMs, 15_000, "'terminated' should use 15s backoff");
 });
 
+test("#1364: provider abort stop reasons should be classified as transient", () => {
+  const result = classifyError("Unhandled stop reason: abort");
+  assert.equal(isTransient(result), true, "'abort' provider errors should be transient");
+  assert.equal(result.kind, "connection", "'abort' matches connection");
+  assert.equal("retryAfterMs" in result && result.retryAfterMs, 15_000, "'abort' should use 15s backoff");
+});
+
 test("#2309: 'connection reset by peer' errors should be classified as transient (network)", () => {
   const result = classifyError("connection reset by peer");
   assert.equal(isTransient(result), true, "'connection reset by peer' should be transient");

--- a/src/resources/extensions/gsd/tests/terminated-transient.test.ts
+++ b/src/resources/extensions/gsd/tests/terminated-transient.test.ts
@@ -24,6 +24,13 @@ test("#1364: provider abort stop reasons should be classified as transient", () 
   assert.equal("retryAfterMs" in result && result.retryAfterMs, 15_000, "'abort' should use 15s backoff");
 });
 
+test("#1364: provider unknown stop reasons should be classified as transient", () => {
+  const result = classifyError("Unhandled stop reason: unknown");
+  assert.equal(isTransient(result), true, "'unknown' provider stop reasons should be transient");
+  assert.equal(result.kind, "connection", "'unknown' stop reasons match connection");
+  assert.equal("retryAfterMs" in result && result.retryAfterMs, 15_000, "'unknown' should use 15s backoff");
+});
+
 test("#2309: 'connection reset by peer' errors should be classified as transient (network)", () => {
   const result = classifyError("connection reset by peer");
   assert.equal(isTransient(result), true, "'connection reset by peer' should be transient");


### PR DESCRIPTION
## Summary
- Classified provider abort stop-reason errors as transient connection failures and added focused regression coverage; verification passed source/diff checks but dependency install was DNS-blocked.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1364
- [#1364 Model fallback not triggered for "abort" / "unknown" provider errors](https://github.com/open-gsd/gsd-pi/issues/1364)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1364-model-fallback-not-triggered-for-abort-u-1783600098`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to error-string classification and test coverage in the GSD extension; behavior for unrelated errors is explicitly preserved via a narrow regex match.
> 
> **Overview**
> Auto-mode now treats provider adapter errors **`Unhandled stop reason: abort`** and **`Unhandled stop reason: unknown`** as transient **connection** failures (15s backoff), so after retries are exhausted **`handleAgentEnd`** can switch to configured fallback models instead of pausing indefinitely.
> 
> Classification uses a **scoped** regex so generic “unknown” runtime errors still land on **`unknown`** and pause for inspection. **`CONNECTION_RE`** also gains a word-boundary **`abort`** match as a secondary path.
> 
> Regression tests cover **`classifyError`** for both stop reasons and an integration case where retry-exhausted messages trigger **`setModel`** to the fallback and a **`triggerTurn`** continuation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d9eae9931fa1c326120ee08d49676f3d14e439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->