### PR TITLE
fix(issue): [npm package bug] integrations/hermes/plugin.yaml is missing from npm package, breaking `gsd hermes install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "packages/*/README.md",
     "pkg",
     "src/resources",
+    "integrations/hermes/plugin.yaml",
     "integrations/hermes",
     "scripts/postinstall.js",
     "scripts/install.js",

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -326,6 +326,7 @@ try {
     'packages/cloud-mcp-gateway/bin/gsd-cloud-mcp-gateway.js',
     'packages/cloud-mcp-gateway/dist/cli.js',
     'scripts/link-workspace-packages.cjs',
+    'integrations/hermes/plugin.yaml',
     'dist/web/standalone/server.js',
   ];
 


### PR DESCRIPTION
## Summary
- Added a validate-pack guard for integrations/hermes/plugin.yaml and verified npm pack metadata includes it.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1367
- [#1367 [npm package bug] integrations/hermes/plugin.yaml is missing from npm package, breaking `gsd hermes install`](https://github.com/open-gsd/gsd-pi/issues/1367)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1367-npm-package-bug-integrations-hermes-plug-1783608501`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and release-validation only; no runtime logic, auth, or data-path changes.
> 
> **Overview**
> Fixes npm installs where **`gsd hermes install`** failed because **`integrations/hermes/plugin.yaml`** was not in the published package.
> 
> The root **`package.json`** `files` list now explicitly includes **`integrations/hermes/plugin.yaml`** (in addition to the Hermes integration folder), and **`scripts/validate-pack.js`** treats that path as a required tarball entry so a future publish cannot ship without it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c4a72f59ec181a269be70c9f1b781128e9d7801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->