### PR TITLE
fix(issue): auto blocked by roadmap-divergence oscillation: completed + active milestones sharing same phase dir both enter reconciler

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
@@ -16,7 +16,7 @@ import { renderRoadmapFromDb } from "../../markdown-renderer.js";
 import { findMilestoneIds } from "../../milestone-ids.js";
 import { parseRoadmap } from "../../parsers-legacy.js";
 import { resolveMilestoneFile } from "../../paths.js";
-import { isClosedStatus } from "../../status-guards.js";
+import { isClosedStatus, isSkippedForDispatch } from "../../status-guards.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
@@ -94,7 +94,9 @@ export function detectRoadmapDivergenceDrift(
   for (const milestoneId of findMilestoneIds(ctx.basePath)) {
     // Skip milestones that don't yet have a DB row — that's the
     // unregistered-milestone drift handler's responsibility.
-    if (!getMilestone(milestoneId)) continue;
+    const milestone = getMilestone(milestoneId);
+    if (!milestone) continue;
+    if (isSkippedForDispatch(milestone.status)) continue;
     if (milestoneHasDivergence(ctx.basePath, milestoneId)) {
       drifts.push({ kind: "roadmap-divergence", milestoneId });
     }

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1618,6 +1618,58 @@ test("ADR-017 (#5705): in-sync ROADMAP and DB → no roadmap-divergence drift", 
   );
 });
 
+test("ADR-017 (#1370): roadmap-divergence skips completed milestone sharing active worktree phase", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-shared-phase-"));
+  const milestoneDir = join(base, ".gsd", "phases", "06-rlrbot-m006-rlrbot-tool-registry-and-command-sa");
+  const roadmapPath = join(milestoneDir, "06-ROADMAP.md");
+  mkdirSync(milestoneDir, { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M006"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M006-rlrbot"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "milestones", "M006", "M006-META.json"), "{}\n");
+  writeFileSync(join(base, ".gsd", "milestones", "M006-rlrbot", "M006-rlrbot-META.json"), "{}\n");
+  const activeRoadmap = [
+    "# M006-rlrbot: Active worktree",
+    "",
+    "**Vision:** Keep the active worktree projection authoritative.",
+    "",
+    "## Slices",
+    "",
+    "- [ ] **S01: Shared slice** `risk:medium` `depends:[]`",
+    "  > After this: Active work remains pending.",
+    "",
+  ].join("\n");
+  writeFileSync(roadmapPath, activeRoadmap);
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M006", title: "Completed source", status: "complete" });
+  insertSlice({ id: "S01", milestoneId: "M006", title: "Shared slice", status: "complete", risk: "medium", depends: [], demo: "Completed.", sequence: 1 });
+  insertMilestone({
+    id: "M006-rlrbot",
+    title: "Active worktree",
+    status: "active",
+    planning: { vision: "Keep the active worktree projection authoritative." },
+  });
+  insertSlice({ id: "S01", milestoneId: "M006-rlrbot", title: "Shared slice", status: "pending", risk: "medium", depends: [], demo: "Active work remains pending.", sequence: 1 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M006-rlrbot", title: "Plan active work", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: "M006-rlrbot", title: "Active worktree" } }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.repaired.some((d) => d.kind === "roadmap-divergence"),
+    false,
+    "completed milestone sharing the phase dir must not trigger roadmap-divergence repair",
+  );
+  assert.equal(readFileSync(roadmapPath, "utf-8"), activeRoadmap);
+});
+
 // ─── #5706: missing-completion-timestamp drift ──────────────────────────────
 
 test("ADR-017 (#5706): task with SUMMARY but null completed_at → backfilled", async (t) => {


### PR DESCRIPTION
## Summary
- Fixed roadmap-divergence detection to skip non-dispatchable milestones and added a focused regression; syntax and whitespace checks passed, while test execution was blocked by unavailable npm dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1370
- [#1370 auto blocked by roadmap-divergence oscillation: completed + active milestones sharing same phase dir both enter reconciler](https://github.com/open-gsd/gsd-pi/issues/1370)

## User
- @birdypme

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1370-auto-blocked-by-roadmap-divergence-oscil-1783626743`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard in pre-dispatch reconciliation with a targeted regression test; behavior aligns with existing `isSkippedForDispatch` usage elsewhere.
> 
> **Overview**
> Fixes **roadmap-divergence oscillation** when a **completed** milestone and an **active** worktree milestone share the same phase directory and both were entering reconciliation.
> 
> **`detectRoadmapDivergenceDrift`** now skips milestones whose status is non-dispatchable via **`isSkippedForDispatch`** (e.g. `complete`), matching dispatch-guard behavior, so only the active milestone’s ROADMAP projection is compared and repaired.
> 
> Adds an ADR-017 regression test for **#1370** covering the shared-phase-dir scenario and asserting no `roadmap-divergence` repair overwrites the active worktree roadmap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c7bf1ad5f8250b74a896e8699dcc15fcef30f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->