### PR TITLE
fix(issue): [Bug]: headless slash-command assembly loses argv quoting — multi-word flag values split into bare words, so `verdict pass --rationale "..."` still fails after #1301

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -97,7 +97,8 @@ export function buildHeadlessSlashCommand(options: Pick<HeadlessOptions, 'comman
   if (options.command === 'new-milestone' && options.auto && !commandArgs.includes(HEADLESS_CHAIN_AUTO_FLAG)) {
     commandArgs.push(HEADLESS_CHAIN_AUTO_FLAG)
   }
-  return `/gsd ${options.command}${commandArgs.length > 0 ? ' ' + commandArgs.join(' ') : ''}`
+  const serializedArgs = commandArgs.map(arg => /\s/.test(arg) ? JSON.stringify(arg) : arg)
+  return `/gsd ${options.command}${serializedArgs.length > 0 ? ' ' + serializedArgs.join(' ') : ''}`
 }
 
 /**

--- a/src/tests/headless-multi-turn.test.ts
+++ b/src/tests/headless-multi-turn.test.ts
@@ -60,3 +60,14 @@ test('new-milestone without --auto keeps the normal guided-flow auto handoff', (
     '/gsd new-milestone',
   )
 })
+
+test('headless slash command assembly preserves multi-word argv tokens (#1372)', () => {
+  assert.equal(
+    buildHeadlessSlashCommand({
+      command: 'verdict',
+      commandArgs: ['pass', '--rationale', '1297 regression check: flag must reach the slash command'],
+      auto: false,
+    }),
+    '/gsd verdict pass --rationale "1297 regression check: flag must reach the slash command"',
+  )
+})


### PR DESCRIPTION
## Summary
- Quoted whitespace-containing headless argv tokens, added a regression test, and verified the focused path with temporary dependency stubs while normal execution was blocked by missing dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1372
- [#1372 [Bug]: headless slash-command assembly loses argv quoting — multi-word flag values split into bare words, so `verdict pass --rationale "..."` still fails after #1301](https://github.com/open-gsd/gsd-pi/issues/1372)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1372-bug-headless-slash-command-assembly-lose-1783629389`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to headless prompt string assembly with a dedicated regression test; no auth, data, or broad orchestration changes.
> 
> **Overview**
> **Headless slash commands now keep multi-word flag values intact** when `buildHeadlessSlashCommand` turns CLI `commandArgs` into the `/gsd …` prompt string.
> 
> Arguments that contain whitespace are wrapped with `JSON.stringify` before joining; single-token args are unchanged. That fixes cases like `verdict pass --rationale "…"` where the rationale was previously emitted as bare words and the subcommand saw the wrong argv.
> 
> A regression test in `headless-multi-turn.test.ts` locks in the expected assembled string for a multi-word `--rationale` value (#1372).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a3c28418517fa96a107f85c979157714e57b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->