### PR TITLE
fix(issue): [Bug]: `gsd headless verdict` never detects its own completion — terminal notifies match no classifier prefix, so every invocation pays the full idle timeout (or hangs under `--timeout 0`)

### DIFF
--- a/src/resources/extensions/gsd/commands-verdict.ts
+++ b/src/resources/extensions/gsd/commands-verdict.ts
@@ -11,6 +11,7 @@ import { executeValidateMilestone } from "./tools/workflow-tool-executors.js";
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 import { getLatestAssessmentByScope } from "./gsd-db.js";
 import { checkpointWorkflowDatabase } from "./db-workspace.js";
+import { formatVerdictRecordedNotice, formatVerdictRejectedNotice } from "./stop-notice.js";
 import {
   VALIDATION_VERDICTS,
   extractVerdict,
@@ -165,17 +166,17 @@ export async function handleVerdict(
   basePath: string,
 ): Promise<void> {
   if (!rawArgs.trim()) {
-    ctx.ui.notify(USAGE, "warning");
+    ctx.ui.notify(formatVerdictRejectedNotice(USAGE), "warning");
     return;
   }
 
   const parsed = parseArgs(rawArgs);
   if ("error" in parsed) {
-    ctx.ui.notify(`${parsed.error}\n${USAGE}`, "warning");
+    ctx.ui.notify(formatVerdictRejectedNotice(`${parsed.error}\n${USAGE}`), "warning");
     return;
   }
   if (!parsed.verdict) {
-    ctx.ui.notify(USAGE, "warning");
+    ctx.ui.notify(formatVerdictRejectedNotice(USAGE), "warning");
     return;
   }
 
@@ -184,7 +185,7 @@ export async function handleVerdict(
     const state = await deriveState(basePath);
     if (!state.activeMilestone) {
       ctx.ui.notify(
-        "No active milestone — pass --milestone Mxxx to target a specific milestone.",
+        formatVerdictRejectedNotice("No active milestone — pass --milestone Mxxx to target a specific milestone."),
         "warning",
       );
       return;
@@ -195,7 +196,9 @@ export async function handleVerdict(
   const existingValidation = await loadExistingValidation(basePath, milestoneId);
   if (!existingValidation) {
     ctx.ui.notify(
-      `No milestone validation found for ${milestoneId}. Run /gsd auto to validate first, then retry /gsd verdict.`,
+      formatVerdictRejectedNotice(
+        `No milestone validation found for ${milestoneId}. Run /gsd auto to validate first, then retry /gsd verdict.`,
+      ),
       "warning",
     );
     return;
@@ -205,7 +208,7 @@ export async function handleVerdict(
 
   if (parsed.verdict !== "pass" && !parsed.rationale) {
     ctx.ui.notify(
-      `--rationale is required when overriding to ${parsed.verdict}.`,
+      formatVerdictRejectedNotice(`--rationale is required when overriding to ${parsed.verdict}.`),
       "warning",
     );
     return;
@@ -234,7 +237,7 @@ export async function handleVerdict(
   if (result.isError) {
     const msg =
       result.content[0]?.type === "text" ? result.content[0].text : "Unknown error";
-    ctx.ui.notify(msg, "error");
+    ctx.ui.notify(formatVerdictRejectedNotice(msg), "error");
     return;
   }
 
@@ -244,12 +247,16 @@ export async function handleVerdict(
   const effectiveVerdict = extractEffectiveVerdict(result.details, parsed.verdict);
   if (effectiveVerdict !== parsed.verdict) {
     ctx.ui.notify(
-      `Milestone ${milestoneId} verdict requested: ${parsed.verdict}, effective: ${effectiveVerdict} (${existingValidation.source})`,
+      formatVerdictRecordedNotice(
+        `Milestone ${milestoneId} verdict requested: ${parsed.verdict}, effective: ${effectiveVerdict} (${existingValidation.source})`,
+      ),
       "warning",
     );
   } else {
     ctx.ui.notify(
-      `Milestone ${milestoneId} verdict: ${prevVerdict} -> ${effectiveVerdict} (${existingValidation.source})`,
+      formatVerdictRecordedNotice(
+        `Milestone ${milestoneId} verdict: ${prevVerdict} -> ${effectiveVerdict} (${existingValidation.source})`,
+      ),
       "success",
     );
   }

--- a/src/resources/extensions/gsd/stop-notice.ts
+++ b/src/resources/extensions/gsd/stop-notice.ts
@@ -29,6 +29,14 @@ export function formatStopNoticePrefix(reason?: string | null): string {
   return displayReason ? `${prefix} — ${displayReason}` : prefix;
 }
 
+export function formatVerdictRecordedNotice(message: string): string {
+  return `Verdict recorded: ${message}`;
+}
+
+export function formatVerdictRejectedNotice(message: string): string {
+  return `Verdict rejected: ${message}`;
+}
+
 // ─── Classification (headless host side) ────────────────────────────────
 // The canonical lowercase prefixes the headless event loop recognizes in
 // notify messages. Emitters above and ad-hoc emitters elsewhere must start
@@ -42,6 +50,8 @@ export const TERMINAL_NOTICE_PREFIXES = [
   "auto-mode complete",
   "no active milestone",
   "auto-mode idle",
+  "verdict recorded",
+  "verdict rejected",
 ] as const;
 
 /** Manual-resolution notices emitted before auto-mode can formally pause/stop. */
@@ -85,6 +95,7 @@ export function isInteractiveMenuUnavailableNotice(message: string): boolean {
 export function isBlockedNoticeMessage(message: string): boolean {
   return (
     message.includes("blocked:") ||
+    message.startsWith("verdict rejected") ||
     (isPauseNotice(message) && !isNonBlockingPauseNotice(message)) ||
     isManualResolutionNotice(message) ||
     isInteractiveMenuUnavailableNotice(message)

--- a/src/resources/extensions/gsd/tests/commands-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-verdict.test.ts
@@ -201,6 +201,7 @@ test("handleVerdict rejects missing verdict", async () => {
   const { ctx, calls } = makeMockCtx();
   await handleVerdict("", ctx, "/tmp/unused");
   assert.equal(calls.length, 1);
+  assert.match(calls[0].message, /^Verdict rejected:/);
   assert.match(calls[0].message, /Usage: \/gsd verdict/);
   assert.equal(calls[0].kind, "warning");
 });
@@ -209,6 +210,7 @@ test("handleVerdict rejects invalid verdict", async () => {
   const { ctx, calls } = makeMockCtx();
   await handleVerdict("yolo", ctx, "/tmp/unused");
   assert.equal(calls.length, 1);
+  assert.match(calls[0].message, /^Verdict rejected:/);
   assert.match(calls[0].message, /Invalid verdict "yolo"/);
   assert.equal(calls[0].kind, "warning");
 });
@@ -250,6 +252,10 @@ test("handleVerdict rejects when milestone validation is missing", async () => {
       calls.some((c) => /No milestone validation found/.test(c.message)),
       `expected missing-validation warning, got: ${JSON.stringify(calls)}`,
     );
+    assert.ok(
+      calls.some((c) => /^Verdict rejected:/.test(c.message)),
+      `expected terminal rejection prefix, got: ${JSON.stringify(calls)}`,
+    );
   } finally {
     closeDatabase();
     invalidateStateCache();
@@ -279,6 +285,10 @@ test("handleVerdict pass override flips verdict and preserves sections", async (
     assert.ok(
       calls.some((c) => c.kind === "success" && /needs-attention.*->.*pass/.test(c.message)),
       `expected success notification, got: ${JSON.stringify(calls)}`,
+    );
+    assert.ok(
+      calls.some((c) => c.kind === "success" && /^Verdict recorded:/.test(c.message)),
+      `expected terminal recorded prefix, got: ${JSON.stringify(calls)}`,
     );
   } finally {
     closeDatabase();

--- a/src/resources/extensions/gsd/tests/stop-notice.test.ts
+++ b/src/resources/extensions/gsd/tests/stop-notice.test.ts
@@ -7,6 +7,8 @@ import assert from "node:assert/strict";
 
 import {
   formatStopNoticePrefix,
+  formatVerdictRecordedNotice,
+  formatVerdictRejectedNotice,
   isBlockedStopReason,
   stopNoticeDisplayReason,
   stopNoticeKind,
@@ -63,6 +65,17 @@ describe("emitter↔detector round-trip", () => {
     assert.ok(isBlockedNoticeMessage(message));
   });
 
+  test("verdict notices classify as terminal with rejected notices blocked", () => {
+    const recorded = formatVerdictRecordedNotice("Milestone M001 verdict: needs-attention -> pass").toLowerCase();
+    const rejected = formatVerdictRejectedNotice("No milestone validation found for M001.").toLowerCase();
+
+    assert.ok(isTerminalNotice(recorded));
+    assert.equal(isBlockedNoticeMessage(recorded), false);
+
+    assert.ok(isTerminalNotice(rejected));
+    assert.ok(isBlockedNoticeMessage(rejected));
+  });
+
   test("un-showable menu notices classify as blocked (#1294)", () => {
     // Emitted verbatim by notifyCommandMenuUnavailable (next-action-ui.ts / command-feedback.ts).
     const menuUnavailable =
@@ -80,7 +93,14 @@ describe("emitter↔detector round-trip", () => {
   });
 
   test("terminal prefixes cover the known stop vocabulary", () => {
-    for (const message of ["auto-mode stopped.", "auto-mode complete", "auto-mode idle", "no active milestone"]) {
+    for (const message of [
+      "auto-mode stopped.",
+      "auto-mode complete",
+      "auto-mode idle",
+      "no active milestone",
+      "verdict recorded: milestone m001 verdict: needs-attention -> pass",
+      "verdict rejected: unexpected argument: x",
+    ]) {
       assert.ok(TERMINAL_NOTICE_PREFIXES.some((prefix) => message.startsWith(prefix)), message);
     }
   });

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -290,6 +290,16 @@ test('un-showable menu notifications are terminal and blocked (#1294)', () => {
   assert.equal(isBlockedNotification(picker), true)
 })
 
+test('verdict notifications are terminal and rejected verdicts are blocked (#1373)', () => {
+  const recorded = makeNotify('Verdict recorded: Milestone M001 verdict: needs-attention -> pass')
+  assert.equal(isTerminalNotification(recorded), true)
+  assert.equal(isBlockedNotification(recorded), false)
+
+  const rejected = makeNotify('Verdict rejected: No milestone validation found for M001. Run /gsd auto to validate first, then retry /gsd verdict.')
+  assert.equal(isTerminalNotification(rejected), true)
+  assert.equal(isBlockedNotification(rejected), true)
+})
+
 test('isInteractiveHeadlessTool: ask_user_questions is interactive', () => {
   assert.equal(isInteractiveHeadlessTool('ask_user_questions'), true)
 })


### PR DESCRIPTION
## Summary
- Added canonical verdict terminal notices and verified classifier coverage where dependencies allowed.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1373
- [#1373 [Bug]: `gsd headless verdict` never detects its own completion — terminal notifies match no classifier prefix, so every invocation pays the full idle timeout (or hangs under `--timeout 0`)](https://github.com/open-gsd/gsd-pi/issues/1373)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1373-bug-gsd-headless-verdict-never-detects-i-1783629741`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to verdict UI messaging and headless notice classification; no auth or data-path changes.
> 
> **Overview**
> **Fixes headless `/gsd verdict` never finishing** because completion `notify` messages did not use prefixes the headless host recognizes, so runs idled until timeout (or hung with `--timeout 0`).
> 
> `/gsd verdict` now emits **`Verdict recorded:`** on success and **`Verdict rejected:`** on validation or execution failures via helpers in `stop-notice.ts`. Those strings are added to **`TERMINAL_NOTICE_PREFIXES`**, and **`verdict rejected`** is treated as **blocked** in `isBlockedNoticeMessage` so failed overrides exit with the blocked code instead of success. Tests lock the emitter↔classifier round-trip in the extension and in `headless-events`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e47f043df231cc9d2f528179b5912a093371af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->