### PR TITLE
fix(issue): `language` preference in PREFERENCES.md ignored on guided-flow discuss paths (discuss-milestone, discuss-slice)

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1956,6 +1956,7 @@ function applyLanguageDirectiveToDispatch(
   if (action.action !== "dispatch" || !action.prompt) return action;
   const directive = renderLanguageDirectiveForPrompt(prefs);
   if (!directive) return action;
+  if (action.prompt.startsWith(directive)) return action;
   return { ...action, prompt: `${directive}\n\n${action.prompt}` };
 }
 

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -20,7 +20,7 @@ import {
   relMilestoneFile, relSliceFile, relSlicePath, relMilestonePath,
   relTaskFile, resolveGsdRootFile, relGsdRootFile, resolveRuntimeFile,
 } from "./paths.js";
-import { resolveInlineLevel, loadEffectiveGSDPreferences } from "./preferences.js";
+import { resolveInlineLevel, loadEffectiveGSDPreferences, renderLanguageDirectiveForPrompt } from "./preferences.js";
 import { createRepositoryRegistryFromPreferences } from "./repository-registry.js";
 import { isContextModeEnabled } from "./preferences-types.js";
 import { parseRoadmap } from "./parsers-legacy.js";
@@ -77,6 +77,14 @@ export { buildSkillActivationBlock, buildSkillDiscoveryVars };
  * from their configured executor window.
  */
 const MAX_PREAMBLE_CHARS = 20_000;
+
+function prependLanguageDirectiveForBase(base: string, prompt: string): string {
+  const directive = renderLanguageDirectiveForPrompt(
+    loadEffectiveGSDPreferences(base)?.preferences,
+  );
+  if (!directive || prompt.startsWith(directive)) return prompt;
+  return `${directive}\n\n${prompt}`;
+}
 
 /**
  * Resolve prompt budgets from the configured executor context window.
@@ -1730,7 +1738,7 @@ export async function buildDiscussMilestonePrompt(
   if (headless) {
     const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
     const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
-    return loadPrompt("discuss-headless", {
+    const prompt = loadPrompt("discuss-headless", {
       seedContext: roadmapContent ?? "",
       inlinedTemplates: contextTemplate,
       workingDirectory: base,
@@ -1739,6 +1747,7 @@ export async function buildDiscussMilestonePrompt(
       commitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
       multiMilestoneCommitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
     });
+    return prependLanguageDirectiveForBase(base, prompt);
   }
 
   const rawInlinedContext = await buildDiscussMilestoneInlinedContext(mid, base);
@@ -1769,10 +1778,11 @@ export async function buildDiscussMilestonePrompt(
     const truncationNote = cappedDraftSeed !== draftSeed
       ? `\n\n_(Draft seed truncated; read the full draft at \`${draftRelPath}\` if needed.)_`
       : "";
-    return `${promptWithContextMode}\n\n## Prior Discussion (Draft Seed)\n\nThe following draft was captured from a prior multi-milestone discussion. Use it as seed material — the user has already provided this context. Start with a brief reflection on what the draft covers, then probe for any gaps or open questions before writing the full CONTEXT.md.\n\n${cappedDraftSeed}${truncationNote}`;
+    const promptWithDraftSeed = `${promptWithContextMode}\n\n## Prior Discussion (Draft Seed)\n\nThe following draft was captured from a prior multi-milestone discussion. Use it as seed material — the user has already provided this context. Start with a brief reflection on what the draft covers, then probe for any gaps or open questions before writing the full CONTEXT.md.\n\n${cappedDraftSeed}${truncationNote}`;
+    return prependLanguageDirectiveForBase(base, promptWithDraftSeed);
   }
 
-  return promptWithContextMode;
+  return prependLanguageDirectiveForBase(base, promptWithContextMode);
 }
 
 /**

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1282,7 +1282,7 @@ export async function buildDiscussSlicePrompt(
     : "";
 
   const inlinedTemplates = inlineTemplate("slice-context", "Slice Context");
-  return loadPrompt("guided-discuss-slice", {
+  return prependLanguageDirective(base, loadPrompt("guided-discuss-slice", {
     milestoneId: mid,
     sliceId: sid,
     sliceTitle: sTitle,
@@ -1293,7 +1293,7 @@ export async function buildDiscussSlicePrompt(
     inlinedTemplates,
     structuredQuestionsAvailable: options?.structuredQuestionsAvailable ?? "false",
     commitInstruction: buildDocsCommitInstruction(`docs(${mid}/${sid}): slice context from discuss`),
-  });
+  }));
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-discuss-milestone-prompt-rendering.test.ts
@@ -87,6 +87,28 @@ test("guided milestone prompt builder preloads milestone planning context", asyn
   }
 });
 
+test("guided milestone prompt builder prepends configured response language", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-guided-milestone-language-"));
+  const gsdHome = mkdtempSync(join(tmpdir(), "gsd-guided-milestone-language-home-"));
+  const previousGsdHome = process.env.GSD_HOME;
+  process.env.GSD_HOME = gsdHome;
+
+  try {
+    writeFileSync(join(gsdHome, "PREFERENCES.md"), "---\nversion: 1\nlanguage: 中文\n---\n", "utf-8");
+
+    const prompt = await buildDiscussMilestonePrompt("M001", "Language Preference", base, "true", {
+      includeContextMode: false,
+    });
+
+    assert.match(prompt, /^## Response Language\n\nAlways respond in 中文/);
+  } finally {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(base, { recursive: true, force: true });
+    rmSync(gsdHome, { recursive: true, force: true });
+  }
+});
+
 test("guided milestone prompt builder caps prior draft seed before interpolation", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-guided-milestone-draft-cap-"));
   const previousGsdHome = process.env.GSD_HOME;

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -775,6 +775,27 @@ describe("prompt-budget: execute-task inline cap (039)", () => {
 });
 
 describe("prompt-budget: discuss-slice inline cap (039)", () => {
+  it("prepends the configured response language", async () => {
+    const base = createFixtureBase();
+    const gsdHome = mkdtempSync(join(tmpdir(), "gsd-discuss-slice-language-home-"));
+    const previousGsdHome = process.env.GSD_HOME;
+    process.env.GSD_HOME = gsdHome;
+
+    try {
+      writeFileSync(join(gsdHome, "PREFERENCES.md"), "---\nversion: 1\nlanguage: 中文\n---\n", "utf-8");
+      mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+      const prompt = await buildDiscussSlicePrompt("M001", "S01", "Current", base);
+
+      assert.match(prompt, /^## Response Language\n\nAlways respond in 中文/);
+    } finally {
+      if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = previousGsdHome;
+      cleanup(base);
+      cleanup(gsdHome);
+    }
+  });
+
   it("caps the inlined block — roadmap survives first, the trailing decisions register truncates", async () => {
     const base = createFixtureBase();
     try {


### PR DESCRIPTION
## Summary
- Fixed guided discuss milestone and slice prompts to honor language preferences, with syntax checks passing and focused tests blocked by missing dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1369
- [#1369 `language` preference in PREFERENCES.md ignored on guided-flow discuss paths (discuss-milestone, discuss-slice)](https://github.com/open-gsd/gsd-pi/issues/1369)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1369-language-preference-in-preferences-md-ig-1783637718`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only behavior for optional language preferences, with idempotent prepending and focused tests; no auth, data, or execution-path changes.
> 
> **Overview**
> Guided **discuss-milestone** and **discuss-slice** prompts now prepend the `## Response Language` block from `PREFERENCES.md`, matching auto-dispatch and other discuss paths (#1369).
> 
> `buildDiscussMilestonePrompt` applies a shared `prependLanguageDirectiveForBase` helper on every return path (headless, draft-seed, and default). `buildDiscussSlicePrompt` wraps its template with the existing `prependLanguageDirective` helper in `guided-flow.ts`. **Auto-dispatch** skips re-prepending when the prompt already starts with that directive, so builders and `applyLanguageDirectiveToDispatch` do not duplicate the block.
> 
> Tests assert configured language (e.g. 中文) appears at the start of milestone and slice discuss prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acbb9e8fd06333e4e9c7bfc3e490dd2dcdf80379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->