### PR TITLE
fix(issue): ask_user_questions: options column is truncated with +N lines hidden and not scrollable (side-by-side preview path)

### DIFF
--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -252,6 +252,11 @@ export async function showInterviewRound(
 		let previewTotal = 0;
 		function resetPreviewScroll() { previewScroll = 0; }
 
+		let optionsScroll = 0;
+		let optionsViewport = 0;
+		let optionsTotal = 0;
+		function resetOptionsScroll() { optionsScroll = 0; }
+
 		function finish(result: RoundResult) {
 			if (completed) return;
 			completed = true;
@@ -318,6 +323,7 @@ export async function showInterviewRound(
 			saveEditorToState();
 			currentIdx = newIdx;
 			resetPreviewScroll();
+			resetOptionsScroll();
 			loadStateToEditor();
 			focusNotes = states[currentIdx].notesVisible && states[currentIdx].notes.length > 0;
 			refresh();
@@ -464,20 +470,39 @@ export async function showInterviewRound(
 				if (matchesKey(data, Key.right)) { switchQuestion((currentIdx + 1) % questions.length); return; }
 			}
 
-			// ── Preview scrolling ────────────────────────────────────────
+			// ── Side-by-side panel scrolling ─────────────────────────────
 			if (matchesKey(data, Key.pageUp)) {
-				if (previewScroll > 0) { previewScroll = Math.max(0, previewScroll - previewViewport); refresh(); }
+				let didScroll = false;
+				if (optionsScroll > 0) {
+					optionsScroll = Math.max(0, optionsScroll - optionsViewport);
+					didScroll = true;
+				}
+				if (previewScroll > 0) {
+					previewScroll = Math.max(0, previewScroll - previewViewport);
+					didScroll = true;
+				}
+				if (didScroll) refresh();
 				return;
 			}
 			if (matchesKey(data, Key.pageDown)) {
+				let didScroll = false;
+				const maxOptionsScroll = Math.max(0, optionsTotal - optionsViewport);
+				if (optionsScroll < maxOptionsScroll) {
+					optionsScroll = Math.min(maxOptionsScroll, optionsScroll + optionsViewport);
+					didScroll = true;
+				}
 				const maxScroll = Math.max(0, previewTotal - previewViewport);
-				if (previewScroll < maxScroll) { previewScroll = Math.min(maxScroll, previewScroll + previewViewport); refresh(); }
+				if (previewScroll < maxScroll) {
+					previewScroll = Math.min(maxScroll, previewScroll + previewViewport);
+					didScroll = true;
+				}
+				if (didScroll) refresh();
 				return;
 			}
 
 			// ── Cursor navigation ────────────────────────────────────────
-			if (matchesKey(data, Key.up)) { st.cursorIndex = (st.cursorIndex - 1 + optCount) % optCount; resetPreviewScroll(); refresh(); return; }
-			if (matchesKey(data, Key.down)) { st.cursorIndex = (st.cursorIndex + 1) % optCount; resetPreviewScroll(); refresh(); return; }
+			if (matchesKey(data, Key.up)) { st.cursorIndex = (st.cursorIndex - 1 + optCount) % optCount; resetPreviewScroll(); resetOptionsScroll(); refresh(); return; }
+			if (matchesKey(data, Key.down)) { st.cursorIndex = (st.cursorIndex + 1) % optCount; resetPreviewScroll(); resetOptionsScroll(); refresh(); return; }
 
 			if (multiSel) {
 				const doneI = noneOrDoneIdx(currentIdx);
@@ -695,6 +720,8 @@ export async function showInterviewRound(
 			// No scrollable preview unless the side-by-side path sets these below.
 			previewTotal = 0;
 			previewViewport = 0;
+			optionsTotal = 0;
+			optionsViewport = 0;
 
 			if (useSideBySide) {
 				// ── Preview path ──────────────────────────────────────
@@ -734,10 +761,21 @@ export async function showInterviewRound(
 				const leftWidth = Math.max(MIN_OPTIONS_WIDTH, contentWidth - previewWidth - DIVIDER_WIDTH);
 
 				const fullLeft = renderOptionsColumn(leftWidth);
-				const leftLines = fullLeft.slice(0, maxBody);
+				optionsTotal = fullLeft.length;
+				optionsViewport = maxBody;
+				const maxOptionsScroll = Math.max(0, fullLeft.length - maxBody);
+				if (optionsScroll > maxOptionsScroll) optionsScroll = maxOptionsScroll;
+
+				const leftLines = fullLeft.slice(optionsScroll, optionsScroll + maxBody);
 				if (fullLeft.length > maxBody) {
-					const n = fullLeft.length - maxBody + 1;
-					leftLines[maxBody - 1] = scrollIndicator(`+${n} lines hidden`, leftWidth);
+					const hiddenAbove = optionsScroll;
+					const hiddenBelow = fullLeft.length - (optionsScroll + maxBody);
+					if (hiddenAbove > 0) {
+						leftLines[0] = scrollIndicator(`▲ ${hiddenAbove} more`, leftWidth);
+					}
+					if (hiddenBelow > 0) {
+						leftLines[leftLines.length - 1] = scrollIndicator(`▼ ${hiddenBelow} more · PgUp/PgDn`, leftWidth);
+					}
 				}
 
 				const preview = getCurrentPreview();
@@ -791,6 +829,7 @@ export async function showInterviewRound(
 					hints.push(isLast && allAnswered() ? "enter to review" : "enter to next");
 				}
 				if (previewTotal > previewViewport) hints.push("pgup/pgdn scroll preview");
+				if (optionsTotal > optionsViewport) hints.push("pgup/pgdn scroll options");
 				hints.push("esc to exit");
 				const footer = ui.hints(hints)[0] ?? "";
 

--- a/src/resources/extensions/shared/tests/interview-ui-border.test.ts
+++ b/src/resources/extensions/shared/tests/interview-ui-border.test.ts
@@ -192,4 +192,33 @@ describe("interview-ui dialog borders", () => {
 		const back = stripAnsi(widget.render(100).join("\n"));
 		assert.doesNotMatch(back, /▲ \d+ more/, "top indicator should disappear after scrolling back to top");
 	});
+
+	it("makes overflowing side-by-side options scrollable with PgUp/PgDn", async () => {
+		const overflowOptions = Array.from({ length: 8 }, (_, i) => ({
+			label: `Overflow Option ${i + 1}`,
+			description: `Detailed explanation for option ${i + 1} that is intentionally long enough to wrap in the options column and force vertical overflow.`,
+			...(i === 0 ? { preview: "Short preview" } : {}),
+		}));
+		const widget = await captureInterviewWidget([{
+			...questions[0],
+			options: overflowOptions,
+		}]);
+
+		const initial = stripAnsi(widget.render(100).join("\n"));
+		assertFullOuterBorder(widget.render(100), 100);
+		assert.match(initial, /▼ \d+ more/, "bottom scroll indicator should appear when options overflow");
+		assert.match(initial, /pgup\/pgdn scroll options/, "footer should hint at options scrolling");
+		assert.doesNotMatch(initial, /\+\d+ lines hidden/, "options overflow should not be a dead-end hidden-lines marker");
+		assert.doesNotMatch(initial, /▲ \d+ more/, "top indicator should be absent before scrolling");
+
+		widget.handleInput(PAGE_DOWN);
+		const scrolled = stripAnsi(widget.render(100).join("\n"));
+		assertFullOuterBorder(widget.render(100), 100);
+		assert.match(scrolled, /▲ \d+ more/, "top scroll indicator should appear after scrolling down");
+		assert.ok(scrolled !== initial, "scrolling should change the rendered options");
+
+		widget.handleInput(PAGE_UP);
+		const back = stripAnsi(widget.render(100).join("\n"));
+		assert.doesNotMatch(back, /▲ \d+ more/, "top indicator should disappear after scrolling back to top");
+	});
 });


### PR DESCRIPTION
## Summary
- Added side-by-side options scrolling with regression coverage and completed syntax/diff checks; full test execution was blocked by unavailable npm dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1361
- [#1361 ask_user_questions: options column is truncated with +N lines hidden and not scrollable (side-by-side preview path)](https://github.com/open-gsd/gsd-pi/issues/1361)

## User
- @klajdo-f

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1361-ask-user-questions-options-column-is-tru-1783637720`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only behavior in the side-by-side preview path; non-preview layout unchanged and covered by new regression test.
> 
> **Overview**
> Fixes **ask_user_questions** / interview UI when the **options column** overflows in the **side-by-side preview** layout: options were clipped with a dead-end `+N lines hidden` marker instead of being reachable.
> 
> The side-by-side path now tracks **options scroll state** (`optionsScroll`, viewport, total) like the preview column. **PgUp/PgDn** scroll both panels when either overflows; **↑/↓** and question switches **reset** options scroll. Overflow UI uses **▲/▼ more** indicators and a footer hint (`pgup/pgdn scroll options`) instead of the old hidden-lines footer row.
> 
> Adds a regression test in `interview-ui-border.test.ts` for overflowing options scrolling and border integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c51203839a4780391381190af0f6f88c7d157019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->