### PR TITLE
fix(issue): [Bug]: compat marker-key mismatch still fires whole-tree re-import walks at every dispatch; writer/checker key derivation unshared, poisoned markers never healed (follow-up to #1292)

### DIFF
--- a/src/resources/extensions/gsd/compat/compat-marker.ts
+++ b/src/resources/extensions/gsd/compat/compat-marker.ts
@@ -6,8 +6,8 @@
 // (drift to import). gsd-core is oblivious to this file and ignores it.
 
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync, mkdirSync } from "node:fs";
-import { dirname, join, isAbsolute, normalize } from "node:path";
+import { existsSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join, isAbsolute, normalize, relative, resolve } from "node:path";
 
 /** Current marker schema version. Bump on breaking format changes + migrate. */
 export const COMPAT_MARKER_SCHEMA = 2;
@@ -54,6 +54,13 @@ export interface CompatMarker {
   piVersion: string;
 }
 
+export interface ReadCompatMarkerOptions {
+  /** Rewrite invalid-but-derivable marker keys back to safe root-relative keys. */
+  healInvalidKeys?: boolean;
+  /** Quarantine malformed/unsafe markers. Disable only for read-only previews. */
+  quarantineInvalid?: boolean;
+}
+
 /** Marker returned when no marker exists yet (fresh project, first gsd-pi run). */
 export const EMPTY_MARKER: CompatMarker = {
   schema: COMPAT_MARKER_SCHEMA,
@@ -81,6 +88,37 @@ export function computeProjectionSha(content: string): string {
   return createHash("sha256").update(normalizeForHash(content)).digest("hex").slice(0, 16);
 }
 
+function normalizeRealPath(p: string): string {
+  try {
+    return realpathSync.native(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+function rootRelativeKey(rootPath: string, absPath: string): string | null {
+  const root = normalizeRealPath(rootPath);
+  const abs = normalizeRealPath(absPath);
+  const rel = relative(root, abs);
+  if (!rel || rel === ".." || rel.startsWith(`..${sepForRelative(rel)}`) || isAbsolute(rel)) {
+    return null;
+  }
+  return rel.replace(/\\/g, "/");
+}
+
+function sepForRelative(rel: string): string {
+  return rel.includes("\\") ? "\\" : "/";
+}
+
+export function deriveCompatProjectionKey(absPath: string, roots: readonly string[]): string {
+  for (const root of roots) {
+    const key = rootRelativeKey(root, absPath);
+    if (key) return key;
+  }
+  const fallbackRoot = roots[roots.length - 1] ?? dirname(absPath);
+  return relative(fallbackRoot, absPath).replace(/\\/g, "/");
+}
+
 /**
  * Read & validate the marker. A missing marker → EMPTY_MARKER (treat every
  * projection as external on next reconcile). A malformed marker is quarantined
@@ -88,7 +126,12 @@ export function computeProjectionSha(content: string): string {
  * EMPTY_MARKER. A schema-mismatch returns EMPTY_MARKER (forward-compat: refuse
  * to act on a future format we don't understand).
  */
-export function readCompatMarker(basePath: string): CompatMarker {
+export function readCompatMarker(
+  basePath: string,
+  options: ReadCompatMarkerOptions = {},
+): CompatMarker {
+  const healInvalidKeys = options.healInvalidKeys ?? true;
+  const quarantineInvalid = options.quarantineInvalid ?? true;
   const path = compatMarkerPath(basePath);
   if (!existsSync(path)) return emptyMarker();
 
@@ -103,12 +146,16 @@ export function readCompatMarker(basePath: string): CompatMarker {
   try {
     parsed = JSON.parse(raw);
   } catch {
-    quarantine(basePath, raw);
+    if (quarantineInvalid) quarantine(basePath, raw);
     return emptyMarker();
   }
 
+  if (healInvalidKeys && healMarkerProjectionKeys(basePath, parsed) && isValidMarker(parsed)) {
+    writeCompatMarker(basePath, parsed);
+  }
+
   if (!isValidMarker(parsed)) {
-    quarantine(basePath, raw);
+    if (quarantineInvalid) quarantine(basePath, raw);
     return emptyMarker();
   }
   // Promote older markers by defaulting absent fields. Schema 1 → 2 only adds
@@ -243,6 +290,53 @@ function isValidProjectionMap(x: unknown): boolean {
     if (!isValidProjectionEntry(v)) return false;
   }
   return true;
+}
+
+function healMarkerProjectionKeys(basePath: string, marker: unknown): marker is CompatMarker {
+  if (typeof marker !== "object" || marker === null) return false;
+  const m = marker as Record<string, unknown>;
+  let changed = false;
+
+  if (typeof m.projections === "object" && m.projections !== null) {
+    changed = healProjectionMapKeys(basePath, ".gsd", m.projections as Record<string, ProjectionEntry>) || changed;
+  }
+
+  const planning = m.planning;
+  if (typeof planning === "object" && planning !== null) {
+    const p = planning as Record<string, unknown>;
+    if (typeof p.projections === "object" && p.projections !== null) {
+      changed = healProjectionMapKeys(basePath, ".planning", p.projections as Record<string, ProjectionEntry>) || changed;
+    }
+    if (typeof p.passthrough === "object" && p.passthrough !== null) {
+      changed = healProjectionMapKeys(basePath, ".planning", p.passthrough as Record<string, ProjectionEntry>) || changed;
+    }
+  }
+
+  return changed;
+}
+
+function healProjectionMapKeys(
+  basePath: string,
+  rootName: ".gsd" | ".planning",
+  map: Record<string, ProjectionEntry>,
+): boolean {
+  let changed = false;
+  const root = join(basePath, rootName);
+
+  for (const key of Object.keys(map)) {
+    if (isSafeProjectionKey(key)) continue;
+    if (key.includes("\0") || isAbsolute(key) || /^[A-Za-z]:/.test(key)) continue;
+    const healedKey = rootRelativeKey(root, resolve(root, key));
+    if (!healedKey || !isSafeProjectionKey(healedKey)) continue;
+
+    if (!map[healedKey]) {
+      map[healedKey] = map[key]!;
+    }
+    delete map[key];
+    changed = true;
+  }
+
+  return changed;
 }
 
 function isValidPlanningMarker(x: unknown): x is PlanningMarker {

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -12,7 +12,7 @@
 import { readFileSync, existsSync, mkdirSync, statSync, unlinkSync } from "node:fs";
 import { logWarning } from "./workflow-logger.js";
 import { isClosedStatus } from "./status-guards.js";
-import { dirname, join, relative } from "node:path";
+import { dirname, join } from "node:path";
 import {
   getAllMilestones,
   getMilestone,
@@ -50,7 +50,7 @@ import { saveFile, clearParseCache, registerCacheClearCallback } from "./files.j
 import { parseRoadmap, parsePlan } from "./parsers-legacy.js";
 import { invalidateStateCache } from "./state.js";
 import { clearPathCache, milestonesDir, legacyMilestonesDir, isLegacyMilestonesLayout, resolveMilestonePath, relSliceFile, canonicalPhaseDirName } from "./paths.js";
-import { readCompatMarker, writeCompatMarker, computeProjectionSha } from "./compat/compat-marker.js";
+import { readCompatMarker, writeCompatMarker, computeProjectionSha, deriveCompatProjectionKey } from "./compat/compat-marker.js";
 import type { RiskLevel } from "./types.js";
 import {
   phaseDirName,
@@ -109,13 +109,7 @@ function flushProjectionWritesToMarker(): void {
  */
 function toArtifactPath(absPath: string, basePath: string): string {
   const projectionRoot = gsdProjectionRoot(basePath);
-  const projectionRel = relative(projectionRoot, absPath);
-  const root = projectionRel && !projectionRel.startsWith("..") && !projectionRel.startsWith("/")
-    ? projectionRoot
-    : gsdRoot(basePath);
-  const rel = relative(root, absPath);
-  // Normalize to forward slashes for consistent DB keys
-  return rel.replace(/\\/g, "/");
+  return deriveCompatProjectionKey(absPath, [projectionRoot, gsdRoot(basePath)]);
 }
 
 /**

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-markdown-edit.ts
@@ -9,13 +9,15 @@
 // refreshes the marker entry, closing the loop.
 
 import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import {
   computeProjectionSha,
   readCompatMarker,
   writeCompatMarker,
+  type ProjectionEntry,
 } from "../../compat/compat-marker.js";
+import { _getAdapter } from "../../gsd-db.js";
 import { logWarning } from "../../workflow-logger.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
@@ -24,6 +26,102 @@ type ExternalMarkdownEditDrift = Extract<
   DriftRecord,
   { kind: "external-markdown-edit" }
 >;
+
+type ArtifactContentRow = {
+  full_content: string;
+};
+
+type ProjectionScope = {
+  milestoneId: string;
+  sliceId: string | null;
+  taskId: string | null;
+};
+
+function deepestProjectionScope(entities: readonly string[]): ProjectionScope | null {
+  let best: string[] | null = null;
+  for (const entity of entities) {
+    const parts = entity.split("/").filter(Boolean);
+    if (parts.length === 0) continue;
+    if (!best || parts.length > best.length) best = parts;
+  }
+  if (!best) return null;
+  return {
+    milestoneId: best[0]!,
+    sliceId: best[1] ?? null,
+    taskId: best[2] ?? null,
+  };
+}
+
+function artifactTypeFromProjectionPath(projectionPath: string): string | null {
+  const name = basename(projectionPath);
+  const match = name.match(/^(?:[A-Za-z]\d+|\d+(?:-\d+)?)-(.+)\.md$/);
+  return match?.[1]?.toUpperCase() ?? null;
+}
+
+function dbProjectionMatches(
+  projectionPath: string,
+  entry: ProjectionEntry,
+  actualSha: string,
+): boolean {
+  const adapter = _getAdapter();
+  if (!adapter) return false;
+
+  try {
+    const rows: ArtifactContentRow[] = adapter
+      .prepare("SELECT full_content FROM artifacts WHERE path = :path")
+      .all({ ":path": projectionPath }) as ArtifactContentRow[];
+
+    const scope = deepestProjectionScope(entry.entities);
+    const artifactType = artifactTypeFromProjectionPath(projectionPath);
+    if (scope?.taskId) {
+      rows.push(
+        ...(adapter
+          .prepare(
+            `SELECT full_content
+             FROM artifacts
+             WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid
+               AND (:type IS NULL OR artifact_type = :type)`,
+          )
+          .all({
+            ":mid": scope.milestoneId,
+            ":sid": scope.sliceId,
+            ":tid": scope.taskId,
+            ":type": artifactType,
+          }) as ArtifactContentRow[]),
+      );
+    } else if (scope?.sliceId) {
+      rows.push(
+        ...(adapter
+          .prepare(
+            `SELECT full_content
+             FROM artifacts
+             WHERE milestone_id = :mid AND slice_id = :sid AND task_id IS NULL
+               AND (:type IS NULL OR artifact_type = :type)`,
+          )
+          .all({
+            ":mid": scope.milestoneId,
+            ":sid": scope.sliceId,
+            ":type": artifactType,
+          }) as ArtifactContentRow[]),
+      );
+    } else if (scope) {
+      rows.push(
+        ...(adapter
+          .prepare(
+            `SELECT full_content
+             FROM artifacts
+             WHERE milestone_id = :mid AND slice_id IS NULL AND task_id IS NULL
+               AND (:type IS NULL OR artifact_type = :type)`,
+          )
+          .all({ ":mid": scope.milestoneId, ":type": artifactType }) as ArtifactContentRow[]),
+      );
+    }
+
+    return rows.some((row) => computeProjectionSha(row.full_content) === actualSha);
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Detect sha drift between the marker baseline and current file contents.
@@ -38,16 +136,43 @@ function detectExternalMarkdownEdit(
   _state: GSDState,
   ctx: DriftContext,
 ): ExternalMarkdownEditDrift[] {
-  const marker = readCompatMarker(ctx.basePath);
+  const marker = readCompatMarker(ctx.basePath, {
+    healInvalidKeys: !ctx.dryRun,
+    quarantineInvalid: !ctx.dryRun,
+  });
   const entries = Object.entries(marker.projections);
   if (entries.length === 0) return [];
 
   const records: ExternalMarkdownEditDrift[] = [];
+  let markerChanged = false;
   for (const [projectionPath, entry] of entries) {
     const abs = join(ctx.basePath, ".gsd", projectionPath);
     if (!existsSync(abs)) continue;
     const actual = computeProjectionSha(readFileSync(abs, "utf-8"));
     if (actual === entry.sha) continue;
+    if (dbProjectionMatches(projectionPath, entry, actual)) {
+      if (!ctx.dryRun) {
+        marker.projections[projectionPath] = {
+          sha: actual,
+          entities: entry.entities,
+        };
+        markerChanged = true;
+        logWarning(
+          "reconcile",
+          `external-markdown-edit: refreshed stale compat marker for ${projectionPath} (expectedSha=${entry.sha}, actualSha=${actual})`,
+        );
+      } else {
+        logWarning(
+          "reconcile",
+          `external-markdown-edit: stale compat marker for ${projectionPath} (expectedSha=${entry.sha}, actualSha=${actual})`,
+        );
+      }
+      continue;
+    }
+    logWarning(
+      "reconcile",
+      `external-markdown-edit drift for ${projectionPath} (expectedSha=${entry.sha}, actualSha=${actual})`,
+    );
     records.push({
       kind: "external-markdown-edit",
       projectionPath,
@@ -55,6 +180,11 @@ function detectExternalMarkdownEdit(
       actualSha: actual,
       entities: entry.entities,
     });
+  }
+  if (markerChanged) {
+    marker.lastWriter = "gsd-pi";
+    marker.lastProjectedAt = new Date().toISOString();
+    writeCompatMarker(ctx.basePath, marker);
   }
   return records;
 }

--- a/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/external-planning-edit.ts
@@ -82,7 +82,10 @@ async function detectExternalPlanningEdit(
   _state: GSDState,
   ctx: DriftContext,
 ): Promise<ExternalPlanningEditDrift[]> {
-  const marker = readCompatMarker(ctx.basePath);
+  const marker = readCompatMarker(ctx.basePath, {
+    healInvalidKeys: !ctx.dryRun,
+    quarantineInvalid: !ctx.dryRun,
+  });
   if (!marker.planning?.active) {
     // Not yet activated. Activation (layout parse + DB import) is owned by
     // capturePlanningCompatIfNeeded, called from reconcileBeforeDispatch when

--- a/src/resources/extensions/gsd/tests/compat-marker.test.ts
+++ b/src/resources/extensions/gsd/tests/compat-marker.test.ts
@@ -242,6 +242,31 @@ test("readCompatMarker preserves legitimate nested projection keys", () => {
   assert.equal(Object.keys(marker.projections).length, 2);
 });
 
+test("readCompatMarker heals invalid keys that canonicalize back under .gsd", () => {
+  const base = makeTmpBase();
+  const safeKey = "m1/roadmap.md";
+  mkdirSync(join(base, ".gsd", "m1"), { recursive: true });
+  writeFileSync(join(base, ".gsd", safeKey), "# Roadmap\n", "utf-8");
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-07-07T00:00:00.000Z",
+    projections: {
+      [`../.gsd/${safeKey}`]: { sha: "aaaaaaaaaaaaaaaa", entities: ["M001"] },
+    },
+    planning: { active: false, layout: null, projections: {}, passthrough: {} },
+    piVersion: "1.8.1",
+  });
+
+  const marker = readCompatMarker(base);
+  assert.ok(marker.projections[safeKey], "derivable traversal-form key must be rewritten");
+  assert.equal(marker.projections[`../.gsd/${safeKey}`], undefined);
+  assert.ok(
+    !readdirSync(join(base, ".gsd")).some((f: string) => f.startsWith(".compat.json.bad-")),
+    "healed marker must not be quarantined",
+  );
+});
+
 test("an escaping key in planning.passthrough also invalidates the whole marker", () => {
   const base = makeTmpBase();
   writeCompatMarker(base, {

--- a/src/resources/extensions/gsd/tests/external-markdown-edit.test.ts
+++ b/src/resources/extensions/gsd/tests/external-markdown-edit.test.ts
@@ -8,7 +8,8 @@ import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
 import { externalMarkdownEditHandler } from "../state-reconciliation/drift/external-markdown-edit.ts";
-import { writeCompatMarker, computeProjectionSha } from "../compat/compat-marker.ts";
+import { readCompatMarker, writeCompatMarker, computeProjectionSha } from "../compat/compat-marker.ts";
+import { closeDatabase, insertArtifact, openDatabase } from "../gsd-db.ts";
 import type { DriftContext } from "../state-reconciliation/types.ts";
 import type { GSDState } from "../types.ts";
 
@@ -28,6 +29,11 @@ function ctx(base: string): DriftContext {
 }
 
 afterEach(() => {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
   for (const dir of tmpDirs) {
     try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
   }
@@ -69,6 +75,37 @@ test("detect returns drift when file content differs from marker", async () => {
   assert.equal(drift[0].kind, "external-markdown-edit");
   assert.equal(drift[0].projectionPath, rel);
   assert.deepEqual(drift[0].entities, ["m1"]);
+});
+
+test("detect refreshes stale marker when current file already matches DB artifact", async () => {
+  const base = makeTmpBase();
+  const rel = "milestones/M001/M001-ROADMAP.md";
+  const dbRel = "phases/01-alpha/01-ROADMAP.md";
+  const content = "# M001: Alpha\n\n## Slices\n\n- [ ] **S01: Work** `risk:low` `depends:[]`\n";
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(join(base, ".gsd", rel), content, "utf-8");
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertArtifact({
+    path: dbRel,
+    artifact_type: "ROADMAP",
+    milestone_id: "M001",
+    slice_id: null,
+    task_id: null,
+    full_content: content,
+  });
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-06-21T00:00:00.000Z",
+    projections: { [rel]: { sha: "stale000000000000", entities: ["M001"] } },
+    planning: { active: false, layout: null, projections: {}, passthrough: {} },
+    piVersion: "1.9.0",
+  });
+
+  const drift = await externalMarkdownEditHandler.detect(stubState, ctx(base));
+  assert.equal(drift.length, 0);
+  const marker = readCompatMarker(base);
+  assert.equal(marker.projections[rel]?.sha, computeProjectionSha(content));
 });
 
 test("detect treats missing marker as drift on every tracked projection file", async () => {


### PR DESCRIPTION
## Summary
- Fixed compat marker key healing and stale-marker refresh logic, with dependency-free checks passing and focused tests blocked by missing dependencies/network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1359
- [#1359 [Bug]: compat marker-key mismatch still fires whole-tree re-import walks at every dispatch; writer/checker key derivation unshared, poisoned markers never healed (follow-up to #1292)](https://github.com/open-gsd/gsd-pi/issues/1359)

## User
- @evolv3ai

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1359-bug-compat-marker-key-mismatch-still-fir-1783637731`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ADR-017 reconcile and marker persistence; incorrect DB-vs-disk matching could skip a real external edit, though scope is limited to artifact lookups and dry-run disables writes.
> 
> **Overview**
> Stops **repeated whole-tree re-imports** caused by `.gsd/.compat.json` projection keys that don’t match what the renderer writes, and by marker SHAs that lag disk even when content already matches the DB.
> 
> **Shared key derivation:** `deriveCompatProjectionKey` (realpath-aware, root-relative) replaces ad hoc `relative()` logic in the markdown renderer so writer and drift checker use the same keys.
> 
> **Marker healing:** `readCompatMarker` can rewrite derivable unsafe keys (e.g. traversal forms) to safe `.gsd`/`.planning` paths and persist the fix; quarantine/healing honor `dryRun` via `healInvalidKeys` / `quarantineInvalid`.
> 
> **Stale SHA without real drift:** `external-markdown-edit` compares mismatched files to DB artifact content (by path and scoped entity queries); when the on-disk file already matches canonical DB content, it **refreshes the marker SHA** instead of emitting external-edit drift. Planning drift detection uses the same read options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d770ac3cda988568232f5d4842c2fb8814b618d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->