### PR TITLE
fix(gsd): latch rejected ScheduleWakeup continuations

### DIFF
--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -3,11 +3,10 @@ import { AutoSession } from "./auto/session.js";
 import type { CurrentUnit } from "./auto/session.js";
 import type { SourceObservationStore } from "./source-observations.js";
 import {
-  isDeterministicPolicyError,
-  isQueuedUserMessageSkip,
-  isToolInvocationError,
   markToolEnd as markTrackedToolEnd,
   markToolStart as markTrackedToolStart,
+  shouldClearToolInvocationErrorAfterSuccess,
+  updateToolInvocationError,
 } from "./auto-tool-tracking.js";
 // Re-exported as a pure pass-through. Must stay UNGATED (no autoSession.active
 // argument, unlike markToolStart at the bottom of this file) so it is true in
@@ -99,13 +98,19 @@ export function markToolEnd(toolCallId: string): void {
 
 export function recordToolInvocationError(toolName: string, errorMsg: string): void {
   if (!autoSession.active) return;
-  if (isToolInvocationError(errorMsg) || isQueuedUserMessageSkip(errorMsg) || isDeterministicPolicyError(errorMsg)) {
-    autoSession.lastToolInvocationError = `${toolName}: ${errorMsg}`;
-  }
+  autoSession.lastToolInvocationError = updateToolInvocationError(
+    autoSession.lastToolInvocationError,
+    toolName,
+    errorMsg,
+  );
 }
 
-export function clearToolInvocationError(): void {
+export function clearToolInvocationError(successfulToolName?: string): void {
   if (!autoSession.active) return;
+  if (!shouldClearToolInvocationErrorAfterSuccess(
+    autoSession.lastToolInvocationError,
+    successfulToolName,
+  )) return;
   autoSession.lastToolInvocationError = null;
 }
 

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -130,7 +130,7 @@ export function clearInFlightTools(): void {
  * from the tool handler. When these errors occur, retrying the same unit will
  * produce the same failure, so the retry loop must be broken.
  */
-const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Input validation error|Invalid arguments for tool|MCP error -32602|No such tool available|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON|does not provide an export named|Named export .* not found|Cannot find module|ERR_MODULE_NOT_FOUND|ERR_MODULE_NOT_EXPORTED|ERR_PACKAGE_PATH_NOT_EXPORTED/i;
+const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Input validation error|Invalid arguments for tool|MCP error -32602|No such tool available|`[^`]+` is required when `[^`]+`|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON|does not provide an export named|Named export .* not found|Cannot find module|ERR_MODULE_NOT_FOUND|ERR_MODULE_NOT_EXPORTED|ERR_PACKAGE_PATH_NOT_EXPORTED/i;
 const DETERMINISTIC_POLICY_ERROR_RE = /(?:^|\b)(?:HARD BLOCK:|Blocked: \/gsd queue is a planning tool|Direct writes to \.gsd\/STATE\.md and \.gsd\/gsd\.db are blocked|This is a mechanical gate)/i;
 
 /**

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -130,8 +130,10 @@ export function clearInFlightTools(): void {
  * from the tool handler. When these errors occur, retrying the same unit will
  * produce the same failure, so the retry loop must be broken.
  */
-const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Input validation error|Invalid arguments for tool|MCP error -32602|No such tool available|`[^`]+` is required when `[^`]+`|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON|does not provide an export named|Named export .* not found|Cannot find module|ERR_MODULE_NOT_FOUND|ERR_MODULE_NOT_EXPORTED|ERR_PACKAGE_PATH_NOT_EXPORTED/i;
+const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Input validation error|Invalid arguments for tool|MCP error -32602|No such tool available|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON|does not provide an export named|Named export .* not found|Cannot find module|ERR_MODULE_NOT_FOUND|ERR_MODULE_NOT_EXPORTED|ERR_PACKAGE_PATH_NOT_EXPORTED/i;
 const DETERMINISTIC_POLICY_ERROR_RE = /(?:^|\b)(?:HARD BLOCK:|Blocked: \/gsd queue is a planning tool|Direct writes to \.gsd\/STATE\.md and \.gsd\/gsd\.db are blocked|This is a mechanical gate)/i;
+const SCHEDULE_WAKEUP_TOOL_NAME = "ScheduleWakeup";
+const SCHEDULE_WAKEUP_CONTINUATION_ERROR = "`prompt` is required when `stop` is not true";
 
 /**
  * Matches the runtime's "tool not registered" error. Unlike the deterministic
@@ -149,6 +151,60 @@ const TOOL_UNAVAILABLE_ERROR_RE = new RegExp(`No such tool available|${TOOL_SURF
 export function isToolInvocationError(errorMsg: string): boolean {
   if (!errorMsg) return false;
   return TOOL_INVOCATION_ERROR_RE.test(errorMsg) || isDeterministicPolicyError(errorMsg);
+}
+
+/**
+ * Claude Code validates its native ScheduleWakeup tool outside GSD's schema.
+ * Keep this exact and tool-scoped so similarly worded business validation from
+ * unrelated tools does not pause auto-mode.
+ */
+export function isScheduleWakeupContinuationError(toolName: string, errorMsg: string): boolean {
+  return stripMcpToolPrefix(toolName) === SCHEDULE_WAKEUP_TOOL_NAME
+    && errorMsg.trim() === SCHEDULE_WAKEUP_CONTINUATION_ERROR;
+}
+
+function shouldRecordToolInvocationError(toolName: string, errorMsg: string): boolean {
+  return isScheduleWakeupContinuationError(toolName, errorMsg)
+    || isToolInvocationError(errorMsg)
+    || isQueuedUserMessageSkip(errorMsg);
+}
+
+function isRecordedScheduleWakeupContinuationError(recordedError: string | null): boolean {
+  if (!recordedError) return false;
+
+  const separator = recordedError.indexOf(": ");
+  return separator >= 0 && isScheduleWakeupContinuationError(
+    recordedError.slice(0, separator),
+    recordedError.slice(separator + 2),
+  );
+}
+
+export function updateToolInvocationError(
+  recordedError: string | null,
+  toolName: string,
+  errorMsg: string,
+): string | null {
+  if (!shouldRecordToolInvocationError(toolName, errorMsg)) return recordedError;
+  if (
+    isRecordedScheduleWakeupContinuationError(recordedError)
+    && !isScheduleWakeupContinuationError(toolName, errorMsg)
+  ) return recordedError;
+
+  return `${toolName}: ${errorMsg}`;
+}
+
+/**
+ * A failed continuation must survive successful diagnostic/read calls in the
+ * same turn. Only a later successful ScheduleWakeup proves the continuation
+ * was armed; all other invocation errors retain their existing clear-on-success
+ * behavior.
+ */
+export function shouldClearToolInvocationErrorAfterSuccess(
+  recordedError: string | null,
+  successfulToolName?: string,
+): boolean {
+  return !isRecordedScheduleWakeupContinuationError(recordedError)
+    || stripMcpToolPrefix(successfulToolName ?? "") === SCHEDULE_WAKEUP_TOOL_NAME;
 }
 
 /**

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -110,9 +110,7 @@ import {
   getOldestInFlightToolStart,
   hasInteractiveToolInFlight,
   clearInFlightTools,
-  isToolInvocationError,
-  isQueuedUserMessageSkip,
-  isDeterministicPolicyError,
+  updateToolInvocationError,
 } from "./auto-tool-tracking.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
@@ -1001,14 +999,17 @@ export function markToolEnd(toolCallId: string): void {
  * Called from tool_execution_end when a GSD tool fails with isError.
  * Stores the error if it matches:
  *   - tool-invocation-error pattern (malformed/truncated JSON)
+ *   - failed ScheduleWakeup continuation validation (#1379)
  *   - queued-user-message skip pattern
  *   - deterministic policy rejection (#4973, e.g. context_write_blocked)
  */
 export function recordToolInvocationError(toolName: string, errorMsg: string): void {
   if (!s.active) return;
-  if (isToolInvocationError(errorMsg) || isQueuedUserMessageSkip(errorMsg) || isDeterministicPolicyError(errorMsg)) {
-    s.lastToolInvocationError = `${toolName}: ${errorMsg}`;
-  }
+  s.lastToolInvocationError = updateToolInvocationError(
+    s.lastToolInvocationError,
+    toolName,
+    errorMsg,
+  );
 }
 
 export function getOldestInFlightToolAgeMs(): number {

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1769,7 +1769,7 @@ export function registerHooks(
       recordToolInvocationError(event.toolName, errorText);
       recordRetryableHarnessToolError(toolName, resultPayload, errorText);
     } else if (isAutoActive()) {
-      clearToolInvocationError();
+      clearToolInvocationError(event.toolName);
     }
     // Interactive Closeout adapter (ADR-032): auto-mode owns closeout for its
     // own units; interactive completions get the durable git subset (commit +
@@ -1980,7 +1980,7 @@ export function registerHooks(
       recordToolInvocationError(event.toolName, errorText);
       recordRetryableHarnessToolError(toolName, event.result, errorText);
     } else if (isAutoActive()) {
-      clearToolInvocationError();
+      clearToolInvocationError(event.toolName);
     }
     // Safety harness: record tool execution results for evidence cross-referencing
     if (isAutoActive()) {

--- a/src/resources/extensions/gsd/tests/register-hooks-loop-guard-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-loop-guard-auto.test.ts
@@ -6,8 +6,10 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
 import { autoSession } from "../auto-runtime-state.ts";
+import { postUnitPreVerification } from "../auto-post-unit.ts";
 import { registerHooks } from "../bootstrap/register-hooks.ts";
 import { resetToolCallLoopGuard } from "../bootstrap/tool-call-loop-guard.ts";
+import { closeDatabase, openDatabase } from "../gsd-db.ts";
 import { readUnitHarnessAbort } from "../unit-runtime.ts";
 
 type Handler = (event: any, ctx?: any) => Promise<any> | any;
@@ -164,6 +166,109 @@ test("register-hooks does not record normal product tool failures as harness abo
 
   const abort = readUnitHarnessAbort(base, "gate-evaluate", "M001/S01/gates+Q3", startedAt);
   assert.equal(abort, null);
+});
+
+test("tool_execution_end latches a failed ScheduleWakeup across unrelated tool success", async (t) => {
+  const base = makeRuntimeBase();
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.basePath = base;
+  autoSession.currentUnit = { type: "discuss-milestone", id: "M001", startedAt: Date.now() };
+  t.after(() => {
+    closeDatabase();
+    autoSession.reset();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const { emitToolExecutionEnd } = makeHookHarness();
+  const error = "`prompt` is required when `stop` is not true";
+
+  await emitToolExecutionEnd({
+    toolName: "ScheduleWakeup",
+    isError: true,
+    result: error,
+  });
+  assert.equal(autoSession.lastToolInvocationError, `ScheduleWakeup: ${error}`);
+
+  await emitToolExecutionEnd({
+    toolName: "read",
+    isError: false,
+    result: "file contents",
+  });
+  assert.equal(
+    autoSession.lastToolInvocationError,
+    `ScheduleWakeup: ${error}`,
+    "an unrelated success must not erase a failed continuation before the unit boundary",
+  );
+
+  await emitToolExecutionEnd({
+    toolName: "parse_payload",
+    isError: true,
+    result: "Unexpected end of JSON input",
+  });
+  assert.equal(
+    autoSession.lastToolInvocationError,
+    `ScheduleWakeup: ${error}`,
+    "a later invocation error must not replace the failed continuation",
+  );
+
+  let pauseCalled = false;
+  const notifications: Array<{ message: string; severity?: string }> = [];
+  const result = await postUnitPreVerification(
+    {
+      s: autoSession,
+      ctx: {
+        ui: {
+          notify: (message: string, severity?: string) => notifications.push({ message, severity }),
+        },
+      } as any,
+      pi: {} as any,
+      buildSnapshotOpts: () => ({}) as any,
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto: async () => { pauseCalled = true; },
+      updateProgressWidget: () => {},
+    },
+    { skipSettleDelay: true, skipWorktreeSync: true },
+  );
+
+  assert.equal(result, "dispatched");
+  assert.equal(pauseCalled, true);
+  assert.equal(autoSession.pendingVerificationRetry, null);
+  assert.ok(
+    notifications.some(({ message, severity }) => severity === "error" && message.includes(error)),
+    "the unit boundary must surface the rejected continuation",
+  );
+  assert.equal(autoSession.lastToolInvocationError, null);
+
+  await emitToolExecutionEnd({
+    toolName: "ScheduleWakeup",
+    isError: true,
+    result: error,
+  });
+  await emitToolExecutionEnd({
+    toolName: "ScheduleWakeup",
+    isError: false,
+    result: "Wakeup scheduled",
+  });
+  assert.equal(autoSession.lastToolInvocationError, null);
+});
+
+test("tool_execution_end ignores ScheduleWakeup-shaped business validation from other tools", async (t) => {
+  autoSession.reset();
+  autoSession.active = true;
+  t.after(() => autoSession.reset());
+
+  const { emitToolExecutionEnd } = makeHookHarness();
+  await emitToolExecutionEnd({
+    toolName: "submit_review",
+    isError: true,
+    result: "`prompt` is required when `stop` is not true",
+  });
+
+  assert.equal(autoSession.lastToolInvocationError, null);
 });
 
 test("register-hooks does not classify normal gsd_uat_exec nonzero exits as harness aborts", async (t) => {

--- a/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
@@ -118,6 +118,13 @@ describe("#2883: isToolInvocationError classification", () => {
     assert.equal(isToolInvocationError("Invalid arguments for tool gsd_slice_complete"), true);
   });
 
+  test("detects conditional required-field validation from external tools", () => {
+    assert.equal(
+      isToolInvocationError("`prompt` is required when `stop` is not true"),
+      true,
+    );
+  });
+
   test("detects 'No such tool available' error", () => {
     assert.equal(isToolInvocationError("No such tool available: mcp__gsd-workflow__memory_query"), true);
   });

--- a/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
@@ -47,6 +47,7 @@ describe("#2883: tool invocation error tracking on AutoSession", () => {
 import {
   isDeterministicPolicyError,
   isPendingUserApprovalGateError,
+  isScheduleWakeupContinuationError,
   isToolInvocationError,
   isToolUnavailableError,
   isQueuedUserMessageSkip,
@@ -118,10 +119,21 @@ describe("#2883: isToolInvocationError classification", () => {
     assert.equal(isToolInvocationError("Invalid arguments for tool gsd_slice_complete"), true);
   });
 
-  test("detects conditional required-field validation from external tools", () => {
+  test("scopes conditional required-field validation to ScheduleWakeup", () => {
+    const error = "`prompt` is required when `stop` is not true";
+
+    assert.equal(isToolInvocationError(error), false);
     assert.equal(
-      isToolInvocationError("`prompt` is required when `stop` is not true"),
+      isScheduleWakeupContinuationError("ScheduleWakeup", error),
       true,
+    );
+    assert.equal(isScheduleWakeupContinuationError("read", error), false);
+    assert.equal(
+      isScheduleWakeupContinuationError(
+        "ScheduleWakeup",
+        "`evidence` is required when `status` is blocking",
+      ),
+      false,
     );
   });
 


### PR DESCRIPTION
## TL;DR

**What:** Treat the exact rejected Claude Code `ScheduleWakeup` continuation as a latched auto-mode failure.
**Why:** A later successful read or diagnostic tool could otherwise erase the rejection before the unit boundary, leaving an unattended run silent with no armed wakeup.
**How:** Scope classification to the exact tool and validation text, retain that failure until `ScheduleWakeup` succeeds or post-unit handling pauses, and cover the universal external hook end to end.

## What

This change handles the exact Claude Code rejection:

```
`prompt` is required when `stop` is not true
```

Only `ScheduleWakeup` receives this special treatment. The failure survives unrelated successful and failed tool calls in the same turn. A successful `ScheduleWakeup` clears it; otherwise the existing post-unit path emits an error, pauses auto-mode, and does not schedule a verification retry.

The regression drives the real universal `tool_execution_end` hook used by external engines and verifies the downstream pause/notification behavior.

## Why

The initial classifier-only fix had two gaps:

- its conditional-required-field regex could classify similarly worded business validation from unrelated tools;
- any later successful tool result cleared `lastToolInvocationError`, so the failed continuation could still disappear before post-unit handling.

This revision closes both gaps without adding a general heartbeat policy.

Closes #1379

## How

- Match the exact missing-prompt error only when the tool is `ScheduleWakeup`.
- Centralize tool-error state updates so a latched continuation cannot be overwritten by another tool error.
- Pass successful tool identity into error clearing, allowing only successful `ScheduleWakeup` to clear the latch mid-unit.
- Preserve existing behavior for all other invocation, policy, user-skip, business, and network errors.

## Verification

- [x] RED: hook regression proved unrelated success erased the wakeup failure before the fix
- [x] RED: negative regression proved the broad regex classified identical text from another tool
- [x] GREEN: focused classifier, hook, runtime-state suites pass (48/48)
- [x] Mutation checks: disabling clear protection and overwrite protection each fails the hook regression
- [x] `pnpm run typecheck:extensions`
- [x] `pnpm run verify:fast` from a clean detached worktree
- [x] GitHub full CI

## Impact analysis

- **Blast radius:** Auto-mode tool-error retention and the two native/universal success hook paths.
- **Affected workflow:** Claude Code external-engine continuation scheduling during an active unit.
- **Compatibility:** Generic conditional business validation is not classified. Existing deterministic failures retain their prior clear-on-success behavior.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes