### PR TITLE
fix(issue): Packaged standalone web host: CJS chunk uses import.meta.url, fails to load on every /api request

### DIFF
--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -10,7 +10,7 @@
 // writer layer.
 import { createRequire } from "node:module";
 import { existsSync, copyFileSync, mkdirSync, realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { GSDError, GSD_STALE_STATE } from "../errors.js";
 import type { GsdWorkspace, MilestoneScope } from "../workspace.js";
 import { logError, logWarning } from "../workflow-logger.js";
@@ -71,7 +71,10 @@ let _gsdRequire: ReturnType<typeof createRequire> | null | undefined;
 function getGsdRequire(): ReturnType<typeof createRequire> | null {
   if (_gsdRequire !== undefined) return _gsdRequire;
   try {
-    _gsdRequire = createRequire(import.meta.url);
+    // Next.js may emit this module into a CommonJS chunk. Avoid ESM-only module
+    // metadata syntax here; it is a hard parse error there.
+    const packageRoot = process.env.GSD_WEB_PACKAGE_ROOT || process.env.GSD_PKG_ROOT || process.cwd();
+    _gsdRequire = createRequire(resolve(packageRoot, "package.json"));
   } catch {
     _gsdRequire = null;
   }

--- a/src/resources/extensions/gsd/tests/db-engine-cjs-compat.test.ts
+++ b/src/resources/extensions/gsd/tests/db-engine-cjs-compat.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+test("db engine stays free of import.meta syntax for CommonJS chunks", () => {
+  const enginePath = join(dirname(fileURLToPath(import.meta.url)), "..", "db", "engine.ts");
+  const source = readFileSync(enginePath, "utf-8");
+
+  assert.doesNotMatch(source, /\bimport\.meta\b/);
+});


### PR DESCRIPTION
## Summary
- Fixed the CJS chunk import.meta failure by changing DB provider require seeding and verified it with focused regression/provider tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1381
- [#1381 Packaged standalone web host: CJS chunk uses import.meta.url, fails to load on every /api request](https://github.com/open-gsd/gsd-pi/issues/1381)

## User
- @athompson-hoho

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1381-packaged-standalone-web-host-cjs-chunk-u-1783658423`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the DB engine resolves `createRequire` for SQLite providers—a startup-critical path—but the scope is small, env vars align with existing packaged-host conventions, and a source-level guard reduces recurrence risk.
> 
> **Overview**
> Fixes packaged standalone web host failures where **every `/api` request** died because Next emitted the DB engine into a **CommonJS chunk** that still contained ESM-only `import.meta` syntax.
> 
> In `getGsdRequire()` (`db/engine.ts`), **`createRequire(import.meta.url)`** is replaced with **`createRequire(resolve(packageRoot, "package.json"))`**, where `packageRoot` is `GSD_WEB_PACKAGE_ROOT`, then `GSD_PKG_ROOT`, then `process.cwd()`. SQLite provider loading (`node:sqlite` / `better-sqlite3`) no longer depends on module metadata that CJS cannot parse.
> 
> Adds **`db-engine-cjs-compat.test.ts`**, which asserts `engine.ts` source does not match `\bimport\.meta\b`, so this regression is caught in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50687d9d603b95656a0f091dba8339ab899572c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->