### PR TITLE
feat(pi-ai): add Meta Muse Spark 1.1 to the model catalog

### DIFF
--- a/packages/pi-ai/src/models.generated.ts
+++ b/packages/pi-ai/src/models.generated.ts
@@ -14706,6 +14706,23 @@ export const MODELS = {
 			contextWindow: 128000,
 			maxTokens: 8192,
 		} satisfies Model<"anthropic-messages">,
+		"meta/muse-spark-1.1": {
+			id: "meta/muse-spark-1.1",
+			name: "Muse Spark 1.1",
+			api: "anthropic-messages",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://ai-gateway.vercel.sh",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 1.25,
+				output: 4.25,
+				cacheRead: 0.15,
+				cacheWrite: 0,
+			},
+			contextWindow: 1048576,
+			maxTokens: 1048576,
+		} satisfies Model<"anthropic-messages">,
 		"minimax/minimax-m2": {
 			id: "minimax/minimax-m2",
 			name: "MiniMax M2",

--- a/packages/pi-ai/test/generated-models.test.ts
+++ b/packages/pi-ai/test/generated-models.test.ts
@@ -150,6 +150,30 @@ describe("models.generated.ts", () => {
 		});
 	});
 
+	test("includes Muse Spark 1.1 as a first-class Vercel AI Gateway model", () => {
+		const model = MODELS["vercel-ai-gateway"]["meta/muse-spark-1.1"];
+
+		expect(model).toMatchObject({
+			id: "meta/muse-spark-1.1",
+			name: "Muse Spark 1.1",
+			// The generator tags every Vercel AI Gateway model as anthropic-messages;
+			// the gateway serves an Anthropic-compatible endpoint across its catalog.
+			api: "anthropic-messages",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://ai-gateway.vercel.sh",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 1.25,
+				output: 4.25,
+				cacheRead: 0.15,
+				cacheWrite: 0,
+			},
+			contextWindow: 1048576,
+			maxTokens: 1048576,
+		});
+	});
+
 	test("keeps GitHub Copilot Claude 4.6 context at Copilot's 200K limit", () => {
 		for (const id of ["claude-opus-4.6", "claude-sonnet-4.6"] as const) {
 			const model = MODELS["github-copilot"][id];


### PR DESCRIPTION
## Linked issue

Closes #1386

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds `meta/muse-spark-1.1` to the generated model catalog.
**Why:** Meta shipped it on 2026-07-09 and the Vercel AI Gateway already serves it, but it was unreachable without a hand-written `models.json` override.
**How:** One 17-line entry, byte-identical to what `pnpm generate` emits — no new provider, no new code.

## What

A single model entry in `packages/pi-ai/src/models.generated.ts`:

- `id: meta/muse-spark-1.1`, provider `vercel-ai-gateway`
- 1,048,576 token context window
- `reasoning: true`, input `["text", "image"]`
- $1.25/M input, $4.25/M output, $0.15/M cache read

No other files change.

## Why

Muse Spark 1.1 is Meta Superintelligence Labs' current flagship agentic model (tool use, computer use, long-running multi-step tasks). It is already carried by the Vercel AI Gateway, a provider this repo supports, so exposing it costs one catalog row.

## How

The entry was produced by running `pnpm generate` in `packages/pi-ai` and lifting out only the Muse Spark block, then reverting the rest. It is byte-identical to generator output, so a future regeneration will not conflict with it.

### Why not just commit the full regeneration

Running `pnpm generate` against today's upstream catalogs produces a 3,896-line diff that **removes 53 models**, including:

- `claude-opus-4-0`, `claude-sonnet-4-0`
- `claude-3-5-sonnet-20241022`, `claude-3-7-sonnet-20250219`
- `claude-3-opus-20240229`, and 48 others

Anyone pinning those IDs would break. That refresh is real and probably wanted, but it is a breaking change and deserves its own PR and its own review — not a free ride on a one-model addition.

### Reviewer notes

- `api: "anthropic-messages"` looks surprising for a Meta model, but the generator hardcodes that for **all 192** Vercel AI Gateway models (the gateway exposes an Anthropic-compatible endpoint across its catalog). This entry follows the existing convention rather than forking from it.
- Requires `AI_GATEWAY_API_KEY`. Meta's own Model API (`developer.meta.com`) is a different endpoint and is **not** wired up here — that would need a new module in `packages/pi-ai/src/providers/` plus a `register-builtins.ts` entry.
- `maxTokens` equals the context window (1,048,576) because that is what the gateway reports. Almost certainly not the true output cap, but it is the generator's data verbatim; "fixing" it by hand would cause churn on the next regeneration.

## Change type

- [x] `feat` — New feature or capability

## Scope

- [x] `pi-ai` — AI/LLM layer

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included

`tsc -p tsconfig.json --noEmit --incremental false` in `packages/pi-ai` exits 0 (clean build, not the incremental cache).

Adds one test to `packages/pi-ai/test/generated-models.test.ts`, following the existing `Grok 4.5` / `MiniMax M3` precedent in that file:

```
✓ includes Muse Spark 1.1 as a first-class Vercel AI Gateway model
Test Files  1 passed (1)
      Tests  9 passed (9)
```

The test is not a tautology — it pins the exact regression this PR is designed around. Deleting the catalog entry and re-running turns it red:

```
× includes Muse Spark 1.1 as a first-class Vercel AI Gateway model
AssertionError: expected undefined to match object { id: 'meta/muse-spark-1.1', …(9) }
```

So if a future `pnpm generate` silently drops the model — the same class of removal that would have taken out 53 models here — CI catches it.

Also verified at runtime against the built `dist/models.js`:

```
resolved: {"id":"meta/muse-spark-1.1","api":"anthropic-messages",
           "ctx":1048576,"maxTokens":1048576,"reasoning":true,"input":["text","image"]}
thinking levels: off,minimal,low,medium,high
cost 1M in + 1M out: $5.50          # matches Meta's published $1.25/$4.25
listed in getModels(vercel-ai-gateway): true
```
