### PR TITLE
fix(gsd-cloud): keep project runtime connected in background

### DIFF
--- a/packages/gsd-cloud/README.md
+++ b/packages/gsd-cloud/README.md
@@ -16,14 +16,15 @@ Requires the `gsd` CLI (from `@opengsd/gsd-pi`) to be installed and on your
 ## Usage
 
 ```bash
-# Browser-based pairing against GSD Cloud (recommended). Opens an approval URL,
-# polls for authorization, then auto-connects. No --gateway needed.
+# Browser-based pairing against GSD Cloud (recommended). Run this from the GSD
+# project directory to advertise. After approval, the connection continues in
+# the background and the terminal prompt returns. No --gateway needed.
 npx @opengsd/gsd-cloud login
 
 # Show current cloud runtime configuration and connection status.
 npx @opengsd/gsd-cloud status
 
-# Start the daemon using a previously paired device token.
+# Start or restart the background runtime using saved credentials and projects.
 npx @opengsd/gsd-cloud connect
 
 # Remove cloud runtime configuration from the local config file.
@@ -41,6 +42,11 @@ wins. The `status`, `connect`, and `disconnect` commands do not use a gateway.
 - `GSD_CLI_PATH` — path to the `gsd` binary (default: `gsd` on `PATH`).
 - `GSD_CLOUD_EXECUTOR` — backend adapter: `gsd-pi` (default). `codex` and
   `claude` adapters are stubbed for future use.
+
+The project directory used by `login` is persisted in `~/.gsd/daemon.yaml`.
+Set `GSD_CLOUD_PROJECTS` before `login` to advertise more than one project. Use
+`--foreground` with `login` or `connect` only when debugging the runtime in the
+current terminal.
 
 ## Requirements
 

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-process.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
   },
   "dependencies": {
     "ws": "^8.21.0",

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
   },
   "dependencies": {
     "ws": "^8.21.0",

--- a/packages/gsd-cloud/src/background-cli.test.ts
+++ b/packages/gsd-cloud/src/background-cli.test.ts
@@ -75,7 +75,7 @@ async function createTestGateway(deviceFlow = false): Promise<TestGateway> {
     if (req.url === "/api/device/token") {
       res.end(JSON.stringify({
         status: "approved",
-        token: "fixture-token",
+        token: "test",
         runtimeId: "fixture-runtime",
         gateway_url: baseUrl,
       }));
@@ -125,7 +125,7 @@ test("connect returns while a background runtime advertises the selected project
 
   saveCloudConfig(configPath, {
     gateway_url: gateway.baseUrl,
-    device_token: "fixture-token",
+    device_token: "test",
     runtime_id: "fixture-runtime",
     enabled: true,
   });

--- a/packages/gsd-cloud/src/background-cli.test.ts
+++ b/packages/gsd-cloud/src/background-cli.test.ts
@@ -1,7 +1,7 @@
 // Project/App: Open GSD
 // File Purpose: Acceptance coverage for the detached gsd-cloud runtime lifecycle.
-import { spawn } from "node:child_process";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -26,11 +26,16 @@ interface TestGateway {
   close: () => Promise<void>;
 }
 
-function runCli(args: string[], cwd: string, timeoutMs = 5_000): Promise<CliResult> {
+function runCli(
+  args: string[],
+  cwd: string,
+  timeoutMs = 12_000,
+  extraEnv: Record<string, string | undefined> = {},
+): Promise<CliResult> {
   return new Promise((resolveResult, reject) => {
     const child = spawn(process.execPath, [cliPath, ...args], {
       cwd,
-      env: { ...process.env, GSD_CLOUD_PROJECTS: undefined },
+      env: { ...process.env, GSD_CLOUD_PROJECTS: undefined, ...extraEnv },
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "";
@@ -53,6 +58,25 @@ function runCli(args: string[], cwd: string, timeoutMs = 5_000): Promise<CliResu
       resolveResult({ code, stdout, stderr });
     });
   });
+}
+
+interface ForegroundCli {
+  child: ChildProcess;
+  exited: Promise<number | null>;
+}
+
+// Spawn a long-lived CLI process (e.g. `--foreground`) without waiting for exit,
+// so the test can inspect its state and then stop it.
+function spawnForegroundCli(args: string[], cwd: string): ForegroundCli {
+  const child = spawn(process.execPath, [cliPath, ...args], {
+    cwd,
+    env: { ...process.env, GSD_CLOUD_PROJECTS: undefined },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const exited = new Promise<number | null>((resolveExit) => {
+    child.once("exit", (code) => resolveExit(code));
+  });
+  return { child, exited };
 }
 
 async function createTestGateway(deviceFlow = false): Promise<TestGateway> {
@@ -190,6 +214,92 @@ test("login returns after approval and keeps the selected project connected", as
     assert.equal(statusBody.background?.running, false);
   } finally {
     await runCli(["disconnect", "--config", configPath], projectDir).catch(() => undefined);
+    await gateway.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("advertised project paths are canonicalized through symlinks", async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-cloud-symlink-")));
+  const realProject = join(root, "real-project");
+  mkdirSync(join(realProject, ".gsd"), { recursive: true });
+  const linkProject = join(root, "link-project");
+  symlinkSync(realProject, linkProject);
+  const configPath = join(root, "daemon.yaml");
+  const gateway = await createTestGateway();
+
+  saveCloudConfig(configPath, {
+    gateway_url: gateway.baseUrl,
+    device_token: "test",
+    runtime_id: "fixture-runtime",
+    enabled: true,
+  });
+
+  try {
+    // Point the runtime at the symlink; the advertised path must be the real dir.
+    const connect = await runCli(
+      ["connect", "--config", configPath],
+      realProject,
+      5_000,
+      { GSD_CLOUD_PROJECTS: linkProject },
+    );
+    assert.equal(connect.code, 0, connect.stderr);
+
+    const message = await gateway.hello;
+    const projects = message.projects as Array<{ path: string }>;
+    assert.equal(projects.length, 1);
+    assert.equal(projects[0]?.path, realProject);
+
+    const status = await runCli(["status", "--config", configPath], realProject);
+    const statusBody = JSON.parse(status.stdout) as { projects?: string[] };
+    assert.deepEqual(statusBody.projects, [realProject]);
+  } finally {
+    await runCli(["disconnect", "--config", configPath], realProject).catch(() => undefined);
+    await gateway.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a foreground runtime registers its PID so disconnect can stop it", async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-cloud-foreground-")));
+  const projectDir = join(root, "project");
+  const configPath = join(root, "daemon.yaml");
+  mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+  const gateway = await createTestGateway();
+
+  saveCloudConfig(configPath, {
+    gateway_url: gateway.baseUrl,
+    device_token: "test",
+    runtime_id: "fixture-runtime",
+    enabled: true,
+  });
+
+  const foreground = spawnForegroundCli(["connect", "--foreground", "--config", configPath], projectDir);
+  try {
+    // Once the foreground runtime advertises its project it is fully connected.
+    await gateway.hello;
+
+    // The foreground session must record its own PID in the shared runtime state
+    // so status can see it and a later disconnect can find and stop it.
+    const status = await runCli(["status", "--config", configPath], projectDir);
+    const statusBody = JSON.parse(status.stdout) as {
+      background?: { running?: boolean; pid?: number | null };
+    };
+    assert.equal(statusBody.background?.running, true);
+    assert.equal(statusBody.background?.pid, foreground.child.pid);
+
+    const disconnect = await runCli(["disconnect", "--config", configPath], projectDir);
+    assert.equal(disconnect.code, 0, disconnect.stderr);
+
+    // disconnect must have terminated the foreground process.
+    const exitCode = await foreground.exited;
+    assert.equal(exitCode, 0);
+
+    const afterStatus = await runCli(["status", "--config", configPath], projectDir);
+    const afterBody = JSON.parse(afterStatus.stdout) as { background?: { running?: boolean } };
+    assert.equal(afterBody.background?.running, false);
+  } finally {
+    foreground.child.kill("SIGKILL");
     await gateway.close();
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/gsd-cloud/src/background-cli.test.ts
+++ b/packages/gsd-cloud/src/background-cli.test.ts
@@ -1,0 +1,196 @@
+// Project/App: Open GSD
+// File Purpose: Acceptance coverage for the detached gsd-cloud runtime lifecycle.
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { WebSocketServer } from "ws";
+import { saveCloudConfig } from "./cloud-config.js";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cliPath = join(packageRoot, "bin", "gsd-cloud.js");
+
+interface CliResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface TestGateway {
+  baseUrl: string;
+  hello: Promise<Record<string, unknown>>;
+  close: () => Promise<void>;
+}
+
+function runCli(args: string[], cwd: string, timeoutMs = 5_000): Promise<CliResult> {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      cwd,
+      env: { ...process.env, GSD_CLOUD_PROJECTS: undefined },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+    child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`gsd-cloud did not return within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      resolveResult({ code, stdout, stderr });
+    });
+  });
+}
+
+async function createTestGateway(deviceFlow = false): Promise<TestGateway> {
+  let baseUrl = "";
+  const server = createServer((req, res) => {
+    if (!deviceFlow) {
+      res.writeHead(404).end();
+      return;
+    }
+    res.setHeader("content-type", "application/json");
+    if (req.url === "/api/device/code") {
+      res.end(JSON.stringify({
+        userCode: "TEST-CODE",
+        deviceCode: "test-device",
+        verificationUriComplete: `${baseUrl}/approve-device?code=TEST-CODE`,
+        expiresIn: 30,
+      }));
+      return;
+    }
+    if (req.url === "/api/device/token") {
+      res.end(JSON.stringify({
+        status: "approved",
+        token: "fixture-token",
+        runtimeId: "fixture-runtime",
+        gateway_url: baseUrl,
+      }));
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  const wss = new WebSocketServer({ server });
+  await new Promise<void>((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+
+  let helloTimeout: ReturnType<typeof setTimeout>;
+  const hello = new Promise<Record<string, unknown>>((resolveHello, reject) => {
+    helloTimeout = setTimeout(() => reject(new Error("background runtime did not advertise its project")), 8_000);
+    wss.once("connection", (socket) => {
+      socket.once("message", (data) => {
+        clearTimeout(helloTimeout);
+        resolveHello(JSON.parse(data.toString("utf8")) as Record<string, unknown>);
+      });
+    });
+  });
+
+  return {
+    baseUrl,
+    hello,
+    close: async () => {
+      clearTimeout(helloTimeout);
+      for (const client of wss.clients) client.terminate();
+      await new Promise<void>((resolveClose) => wss.close(() => server.close(() => resolveClose())));
+    },
+  };
+}
+
+test("connect returns while a background runtime advertises the selected project", async () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-background-"));
+  const projectDir = join(root, "project");
+  const expectedProjectDir = join(realpathSync(root), "project");
+  const configPath = join(root, "daemon.yaml");
+  mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+
+  const gateway = await createTestGateway();
+
+  saveCloudConfig(configPath, {
+    gateway_url: gateway.baseUrl,
+    device_token: "fixture-token",
+    runtime_id: "fixture-runtime",
+    enabled: true,
+  });
+
+  try {
+    const connect = await runCli(["connect", "--config", configPath], projectDir);
+    assert.equal(connect.code, 0, connect.stderr);
+    assert.match(connect.stdout, /connected in the background/i);
+
+    const message = await gateway.hello;
+    assert.equal(message.type, "hello");
+    const projects = message.projects as Array<{ path: string }>;
+    assert.equal(projects.length, 1);
+    assert.equal(projects[0]?.path, expectedProjectDir);
+
+    const status = await runCli(["status", "--config", configPath], projectDir);
+    assert.equal(status.code, 0, status.stderr);
+    const statusBody = JSON.parse(status.stdout) as {
+      background?: { running?: boolean; pid?: number | null };
+      projects?: string[];
+    };
+    assert.equal(statusBody.background?.running, true);
+    assert.equal(typeof statusBody.background?.pid, "number");
+    assert.deepEqual(statusBody.projects, [expectedProjectDir]);
+  } finally {
+    await runCli(["disconnect", "--config", configPath], projectDir).catch(() => undefined);
+    await gateway.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("login returns after approval and keeps the selected project connected", async () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-login-background-"));
+  const projectDir = join(root, "project");
+  const expectedProjectDir = join(realpathSync(root), "project");
+  const configPath = join(root, "daemon.yaml");
+  mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+  const gateway = await createTestGateway(true);
+
+  try {
+    const login = await runCli([
+      "login",
+      "--gateway", gateway.baseUrl,
+      "--config", configPath,
+    ], projectDir, 12_000);
+    assert.equal(login.code, 0, login.stderr);
+    assert.match(login.stdout, /Authorization approved!/);
+    assert.match(login.stdout, /connected in the background/i);
+
+    const message = await gateway.hello;
+    const projects = message.projects as Array<{ path: string }>;
+    assert.deepEqual(projects.map((project) => project.path), [expectedProjectDir]);
+
+    const disconnect = await runCli(["disconnect", "--config", configPath], projectDir);
+    assert.equal(disconnect.code, 0, disconnect.stderr);
+    const status = await runCli(["status", "--config", configPath], projectDir);
+    const statusBody = JSON.parse(status.stdout) as {
+      configured?: boolean;
+      background?: { running?: boolean };
+    };
+    assert.equal(statusBody.configured, false);
+    assert.equal(statusBody.background?.running, false);
+  } finally {
+    await runCli(["disconnect", "--config", configPath], projectDir).catch(() => undefined);
+    await gateway.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -102,7 +102,7 @@ export async function handleCloudCommand(argv: string[], opts: {
       });
       return;
     }
-    await startAndReportBackgroundRuntime(configPath, projectDirs, opts.binaryName);
+    await startAndReportBackgroundRuntime(configPath, projectDirs, opts.binaryName, values.verbose);
     return;
   }
 
@@ -141,7 +141,7 @@ export async function handleCloudCommand(argv: string[], opts: {
       });
       return;
     }
-    await startAndReportBackgroundRuntime(configPath, projectDirs, opts.binaryName);
+    await startAndReportBackgroundRuntime(configPath, projectDirs, opts.binaryName, values.verbose);
     return;
   }
 
@@ -218,10 +218,11 @@ async function startAndReportBackgroundRuntime(
   configPath: string,
   projectDirs: string[],
   binaryName: string,
+  verbose = false,
 ): Promise<void> {
   const binaryPath = process.argv[1];
   if (!binaryPath) throw new Error("could not resolve the gsd-cloud executable path");
-  const status = await startBackgroundRuntime({ binaryPath, configPath, projectDirs });
+  const status = await startBackgroundRuntime({ binaryPath, configPath, projectDirs, verbose });
   process.stdout.write(`${binaryName}: connected in the background (PID ${status.pid}).\n`);
   for (const project of projectDirs) process.stdout.write(`${binaryName}: project ${project}\n`);
   process.stdout.write(`${binaryName}: logs ${status.log_file}\n`);

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -66,7 +66,7 @@ export async function handleCloudCommand(argv: string[], opts: {
   }
 
   if (command === "disconnect") {
-    stopBackgroundRuntime(configPath);
+    await stopBackgroundRuntime(configPath);
     clearCloudConfig(configPath);
     process.stdout.write(`${opts.binaryName}: background runtime stopped and cloud credentials removed.\n`);
     return;
@@ -93,7 +93,7 @@ export async function handleCloudCommand(argv: string[], opts: {
     }, projectDirs);
     process.stdout.write(`${opts.binaryName}: cloud runtime ${runtimeId} paired — connecting...\n`);
     if (values.foreground) {
-      stopBackgroundRuntime(configPath);
+      await stopBackgroundRuntime(configPath);
       await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs);
       return;
     }
@@ -130,7 +130,7 @@ export async function handleCloudCommand(argv: string[], opts: {
     const projectDirs = selectedProjectDirs(config.projects.scan_roots);
     config = saveCloudConfig(configPath, config.cloud, projectDirs);
     if (values.foreground) {
-      stopBackgroundRuntime(configPath);
+      await stopBackgroundRuntime(configPath);
       await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs);
       return;
     }

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -6,6 +6,7 @@
 // the WS relay client driving the local GSD runtime through the Executor seam.
 
 import { parseArgs } from "node:util";
+import { realpathSync } from "node:fs";
 import { delimiter, resolve } from "node:path";
 import { resolveConfigPath, loadConfig } from "./config.js";
 import { Logger } from "./logger.js";
@@ -20,8 +21,10 @@ import { CloudRuntime } from "./cloud-runtime.js";
 import { selectExecutor } from "./executors/index.js";
 import {
   backgroundRuntimeStatus,
+  clearRuntimeState,
   startBackgroundRuntime,
   stopBackgroundRuntime,
+  writeRuntimeState,
 } from "./runtime-process.js";
 import type { DaemonConfig } from "./types.js";
 
@@ -94,7 +97,9 @@ export async function handleCloudCommand(argv: string[], opts: {
     process.stdout.write(`${opts.binaryName}: cloud runtime ${runtimeId} paired — connecting...\n`);
     if (values.foreground) {
       await stopBackgroundRuntime(configPath);
-      await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs);
+      await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs, {
+        registerConfigPath: configPath,
+      });
       return;
     }
     await startAndReportBackgroundRuntime(configPath, projectDirs, opts.binaryName);
@@ -131,7 +136,9 @@ export async function handleCloudCommand(argv: string[], opts: {
     config = saveCloudConfig(configPath, config.cloud, projectDirs);
     if (values.foreground) {
       await stopBackgroundRuntime(configPath);
-      await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs);
+      await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs, {
+        registerConfigPath: configPath,
+      });
       return;
     }
     await startAndReportBackgroundRuntime(configPath, projectDirs, opts.binaryName);
@@ -144,8 +151,10 @@ export async function handleCloudCommand(argv: string[], opts: {
       throw new Error("cloud runtime is not paired; run `login` first");
     }
     const projectDirs = selectedProjectDirs(config.projects.scan_roots);
-    await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs, () => {
-      process.send?.({ type: "ready" });
+    await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs, {
+      onConnected: () => {
+        process.send?.({ type: "ready" });
+      },
     });
     return;
   }
@@ -163,7 +172,7 @@ async function runCloudRuntime(
   binaryName: string,
   verbose: boolean,
   projectDirs: string[],
-  onConnected?: () => void,
+  opts: { onConnected?: () => void; registerConfigPath?: string } = {},
 ): Promise<void> {
   if (!config.cloud) throw new Error("cloud runtime is not configured");
   if (config.cloud.enabled === false) {
@@ -176,12 +185,25 @@ async function runCloudRuntime(
   });
   const executor = selectExecutor(logger, { projectDirs });
   const runtime = new CloudRuntime(config.cloud, executor, logger);
-  await runtime.start();
-  onConnected?.();
+  // A foreground session owns the runtime itself, so it records its own PID in
+  // the shared state file. That lets a later `connect`/`disconnect` find and
+  // stop it, just like a detached background runtime. Background `_run` children
+  // do not register here; their launcher records the child PID instead.
+  if (opts.registerConfigPath) {
+    writeRuntimeState(opts.registerConfigPath, process.pid, projectDirs);
+  }
+  try {
+    await runtime.start();
+  } catch (error) {
+    if (opts.registerConfigPath) clearRuntimeState(opts.registerConfigPath);
+    throw error;
+  }
+  opts.onConnected?.();
   process.stdout.write(`${binaryName}: connected to ${config.cloud.gateway_url}. Press Ctrl+C to stop.\n`);
 
   await new Promise<void>((resolve) => {
     const shutdown = () => {
+      if (opts.registerConfigPath) clearRuntimeState(opts.registerConfigPath);
       runtime.stop();
       void Promise.resolve(executor.close?.()).finally(() => {
         void logger.close().finally(() => resolve());
@@ -215,15 +237,32 @@ function selectedProjectDirs(savedProjectDirs: string[]): string[] {
     const savedPaths = uniqueResolvedPaths(savedProjectDirs);
     if (savedPaths.length > 0) return savedPaths;
   }
-  return [process.cwd()];
+  return [canonicalizePath(process.cwd())];
 }
 
 function uniqueResolvedPaths(paths: string[]): string[] {
   const resolved = paths
     .map((path) => path.trim())
     .filter(Boolean)
-    .map((path) => resolve(path));
+    .map((path) => canonicalizePath(path));
   return [...new Set(resolved)];
+}
+
+/**
+ * Resolve a project path to its canonical, symlink-free absolute form. The
+ * executor advertises project paths via `resolve()` alone, so canonicalizing
+ * here keeps the saved `scan_roots` and the advertised hello paths identical to
+ * the real directory (e.g. when the cwd or GSD_CLOUD_PROJECTS points through a
+ * symlink). Falls back to the plain resolved path when the target does not yet
+ * exist on disk.
+ */
+function canonicalizePath(path: string): string {
+  const resolved = resolve(path);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
 }
 
 export function formatUsage(binaryName: string): string {

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -6,6 +6,7 @@
 // the WS relay client driving the local GSD runtime through the Executor seam.
 
 import { parseArgs } from "node:util";
+import { delimiter, resolve } from "node:path";
 import { resolveConfigPath, loadConfig } from "./config.js";
 import { Logger } from "./logger.js";
 import {
@@ -17,6 +18,11 @@ import {
 import { runDeviceFlow } from "./device-flow.js";
 import { CloudRuntime } from "./cloud-runtime.js";
 import { selectExecutor } from "./executors/index.js";
+import {
+  backgroundRuntimeStatus,
+  startBackgroundRuntime,
+  stopBackgroundRuntime,
+} from "./runtime-process.js";
 import type { DaemonConfig } from "./types.js";
 
 export async function handleCloudCommand(argv: string[], opts: {
@@ -36,6 +42,7 @@ export async function handleCloudCommand(argv: string[], opts: {
       code: { type: "string" },
       "runtime-name": { type: "string" },
       verbose: { type: "boolean", short: "v", default: false },
+      foreground: { type: "boolean", default: false },
       help: { type: "boolean", short: "h", default: false },
     },
     strict: true,
@@ -49,13 +56,19 @@ export async function handleCloudCommand(argv: string[], opts: {
   const configPath = resolveConfigPath(values.config);
 
   if (command === "status") {
-    process.stdout.write(`${JSON.stringify(redactedCloudStatus(loadConfig(configPath)), null, 2)}\n`);
+    const config = loadConfig(configPath);
+    process.stdout.write(`${JSON.stringify({
+      ...redactedCloudStatus(config),
+      projects: config.projects.scan_roots,
+      background: backgroundRuntimeStatus(configPath),
+    }, null, 2)}\n`);
     return;
   }
 
   if (command === "disconnect") {
+    stopBackgroundRuntime(configPath);
     clearCloudConfig(configPath);
-    process.stdout.write(`${opts.binaryName}: cloud runtime disconnected locally.\n`);
+    process.stdout.write(`${opts.binaryName}: background runtime stopped and cloud credentials removed.\n`);
     return;
   }
 
@@ -70,15 +83,21 @@ export async function handleCloudCommand(argv: string[], opts: {
       runtimeName,
       binaryName: opts.binaryName,
     });
+    const projectDirs = selectedProjectDirs([]);
     const config = saveCloudConfig(configPath, {
       gateway_url: gatewayUrl,
       device_token: deviceToken,
       runtime_id: runtimeId,
       ...(runtimeName ? { runtime_name: runtimeName } : {}),
       enabled: true,
-    });
+    }, projectDirs);
     process.stdout.write(`${opts.binaryName}: cloud runtime ${runtimeId} paired — connecting...\n`);
-    await runCloudRuntime(config, opts.binaryName, values.verbose);
+    if (values.foreground) {
+      stopBackgroundRuntime(configPath);
+      await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs);
+      return;
+    }
+    await startAndReportBackgroundRuntime(configPath, projectDirs, opts.binaryName);
     return;
   }
 
@@ -104,11 +123,30 @@ export async function handleCloudCommand(argv: string[], opts: {
   }
 
   if (command === "connect") {
+    let config = loadConfig(configPath);
+    if (!config.cloud?.device_token || !config.cloud.runtime_id) {
+      throw new Error("cloud runtime is not paired; run `login` first");
+    }
+    const projectDirs = selectedProjectDirs(config.projects.scan_roots);
+    config = saveCloudConfig(configPath, config.cloud, projectDirs);
+    if (values.foreground) {
+      stopBackgroundRuntime(configPath);
+      await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs);
+      return;
+    }
+    await startAndReportBackgroundRuntime(configPath, projectDirs, opts.binaryName);
+    return;
+  }
+
+  if (command === "_run") {
     const config = loadConfig(configPath);
     if (!config.cloud?.device_token || !config.cloud.runtime_id) {
       throw new Error("cloud runtime is not paired; run `login` first");
     }
-    await runCloudRuntime(config, opts.binaryName, values.verbose);
+    const projectDirs = selectedProjectDirs(config.projects.scan_roots);
+    await runCloudRuntime(config, opts.binaryName, values.verbose, projectDirs, () => {
+      process.send?.({ type: "ready" });
+    });
     return;
   }
 
@@ -120,7 +158,13 @@ export async function handleCloudCommand(argv: string[], opts: {
  * "daemon" for the standalone agent: one CloudRuntime + one Executor, no Discord,
  * no scanner, no session-manager class.
  */
-async function runCloudRuntime(config: DaemonConfig, binaryName: string, verbose: boolean): Promise<void> {
+async function runCloudRuntime(
+  config: DaemonConfig,
+  binaryName: string,
+  verbose: boolean,
+  projectDirs: string[],
+  onConnected?: () => void,
+): Promise<void> {
   if (!config.cloud) throw new Error("cloud runtime is not configured");
   if (config.cloud.enabled === false) {
     throw new Error("cloud runtime is disabled in config; set cloud.enabled to true to connect");
@@ -130,9 +174,10 @@ async function runCloudRuntime(config: DaemonConfig, binaryName: string, verbose
     level: config.log.level,
     verbose,
   });
-  const executor = selectExecutor(logger);
+  const executor = selectExecutor(logger, { projectDirs });
   const runtime = new CloudRuntime(config.cloud, executor, logger);
   await runtime.start();
+  onConnected?.();
   process.stdout.write(`${binaryName}: connected to ${config.cloud.gateway_url}. Press Ctrl+C to stop.\n`);
 
   await new Promise<void>((resolve) => {
@@ -147,21 +192,55 @@ async function runCloudRuntime(config: DaemonConfig, binaryName: string, verbose
   });
 }
 
+async function startAndReportBackgroundRuntime(
+  configPath: string,
+  projectDirs: string[],
+  binaryName: string,
+): Promise<void> {
+  const binaryPath = process.argv[1];
+  if (!binaryPath) throw new Error("could not resolve the gsd-cloud executable path");
+  const status = await startBackgroundRuntime({ binaryPath, configPath, projectDirs });
+  process.stdout.write(`${binaryName}: connected in the background (PID ${status.pid}).\n`);
+  for (const project of projectDirs) process.stdout.write(`${binaryName}: project ${project}\n`);
+  process.stdout.write(`${binaryName}: logs ${status.log_file}\n`);
+}
+
+function selectedProjectDirs(savedProjectDirs: string[]): string[] {
+  const configured = process.env["GSD_CLOUD_PROJECTS"];
+  if (configured?.trim()) {
+    const configuredPaths = uniqueResolvedPaths(configured.split(delimiter));
+    if (configuredPaths.length > 0) return configuredPaths;
+  }
+  if (savedProjectDirs.length > 0) {
+    const savedPaths = uniqueResolvedPaths(savedProjectDirs);
+    if (savedPaths.length > 0) return savedPaths;
+  }
+  return [process.cwd()];
+}
+
+function uniqueResolvedPaths(paths: string[]): string[] {
+  const resolved = paths
+    .map((path) => path.trim())
+    .filter(Boolean)
+    .map((path) => resolve(path));
+  return [...new Set(resolved)];
+}
+
 export function formatUsage(binaryName: string): string {
-  return `Usage: ${binaryName} login [--gateway <url>] [--runtime-name <name>] [--config <path>]
+  return `Usage: ${binaryName} login [--gateway <url>] [--runtime-name <name>] [--config <path>] [--foreground]
        ${binaryName} status [--config <path>]
        ${binaryName} pair --gateway <url> --code <code> [--runtime-name <name>] [--config <path>]
-       ${binaryName} connect [--config <path>] [--verbose]
+       ${binaryName} connect [--config <path>] [--verbose] [--foreground]
        ${binaryName} disconnect [--config <path>]
 
 Commands:
-  login      (Recommended) Browser-based pairing — opens an approval URL in the
-             terminal, polls for authorization, then auto-connects. Defaults to
-             the public GSD Cloud gateway.
+  login      (Recommended) Browser-based pairing — opens an approval URL, then
+             connects the current project in the background. Defaults to the
+             public GSD Cloud gateway.
   status     Show current cloud runtime configuration and connection status.
   pair       Exchange a pairing code for a device token (headless/CI environments).
-  connect    Connect using a previously paired device token.
-  disconnect Remove cloud runtime configuration from the local config file.
+  connect    Start a background connection using saved credentials and projects.
+  disconnect Stop the background runtime and remove local cloud credentials.
 
 Options:
   --config <path>        Path to YAML config file (default: ~/.gsd/daemon.yaml)
@@ -169,6 +248,7 @@ Options:
   --code <code>          Pairing code from the gateway (pair only)
   --runtime-name <name>  Friendly name for this local GSD runtime
   --verbose              Print log entries to stderr in addition to the log file
+  --foreground           Keep login/connect attached to this terminal (debugging)
   --help                 Show this help message and exit
 
 Environment:

--- a/packages/gsd-cloud/src/cloud-config.ts
+++ b/packages/gsd-cloud/src/cloud-config.ts
@@ -61,7 +61,11 @@ export function parseCloudGatewayUrl(value: string): URL {
   return url;
 }
 
-export function saveCloudConfig(configPath: string, nextCloud: NonNullable<DaemonConfig["cloud"]>): DaemonConfig {
+export function saveCloudConfig(
+  configPath: string,
+  nextCloud: NonNullable<DaemonConfig["cloud"]>,
+  projectDirs?: string[],
+): DaemonConfig {
   let raw: Record<string, unknown> = {};
   try {
     raw = parseYaml(readFileSync(configPath, "utf-8")) as Record<string, unknown> ?? {};
@@ -74,6 +78,12 @@ export function saveCloudConfig(configPath: string, nextCloud: NonNullable<Daemo
     gateway_url: parseCloudGatewayUrl(nextCloud.gateway_url).toString(),
     ...(deviceToken ? { device_token_encrypted: protectCloudDeviceToken(deviceToken) } : {}),
   };
+  if (projectDirs) {
+    const projects = raw.projects != null && typeof raw.projects === "object"
+      ? raw.projects as Record<string, unknown>
+      : {};
+    raw.projects = { ...projects, scan_roots: projectDirs };
+  }
   mkdirSync(dirname(configPath), { recursive: true });
   writeConfigFile(configPath, stringifyYaml(raw));
   return loadConfig(configPath);

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -4,6 +4,14 @@ import type { DaemonConfig } from "./types.js";
 import type { Executor } from "./executors/executor.js";
 import { createGatewayLookup, parseCloudGatewayUrl, validateGatewayNetworkTarget } from "./cloud-config.js";
 
+const INITIAL_CONNECT_ATTEMPTS = 5;
+const INITIAL_CONNECT_HANDSHAKE_TIMEOUT_MS = 30_000;
+const RECONNECT_DELAY_MS = 5_000;
+
+export const CLOUD_RUNTIME_INITIAL_CONNECT_WINDOW_MS =
+  INITIAL_CONNECT_ATTEMPTS * INITIAL_CONNECT_HANDSHAKE_TIMEOUT_MS
+  + (INITIAL_CONNECT_ATTEMPTS - 1) * RECONNECT_DELAY_MS;
+
 interface GatewayMessage {
   type: string;
   requestId?: string;
@@ -14,14 +22,11 @@ interface GatewayMessage {
 
 export class CloudRuntime {
   private static readonly MAX_OUTBOX = 200;
-  private static readonly RECONNECT_DELAY_MS = 5_000;
   // How many times to retry the initial connect before rejecting start(). A
   // transient handshake failure (gateway briefly unreachable, DNS hiccup) should
   // retry like the daemon's reconnect loop rather than kill the runtime; a
   // persistent failure (gateway down, session rejected) must eventually reject so
   // the CLI reports an error instead of hanging or exiting silently.
-  private static readonly MAX_INITIAL_CONNECT_ATTEMPTS = 5;
-  private static readonly INITIAL_CONNECT_HANDSHAKE_TIMEOUT_MS = 30_000;
   private socket: WebSocket | undefined;
   private heartbeat: ReturnType<typeof setInterval> | undefined;
   private reconnect: ReturnType<typeof setTimeout> | undefined;
@@ -81,7 +86,7 @@ export class CloudRuntime {
     const socket = new WebSocket(url, {
       headers: { Authorization: `Bearer ${this.cloud.device_token}` },
       lookup: createGatewayLookup(gatewayUrl),
-      handshakeTimeout: CloudRuntime.INITIAL_CONNECT_HANDSHAKE_TIMEOUT_MS,
+      handshakeTimeout: INITIAL_CONNECT_HANDSHAKE_TIMEOUT_MS,
     });
     const previousSocket = this.socket;
     this.socket = socket;
@@ -145,7 +150,7 @@ export class CloudRuntime {
       // start() once the bounded attempts are exhausted, so a brief blip does
       // not kill the runtime while a persistent outage still surfaces an error.
       this.initialConnectAttempts += 1;
-      if (this.initialConnectAttempts >= CloudRuntime.MAX_INITIAL_CONNECT_ATTEMPTS) {
+      if (this.initialConnectAttempts >= INITIAL_CONNECT_ATTEMPTS) {
         this.rejectFirstConnect(
           new Error(
             `cloud runtime connection failed after ${this.initialConnectAttempts} attempt(s)`,
@@ -155,13 +160,13 @@ export class CloudRuntime {
       }
       this.logger.warn("cloud runtime initial connect failed; retrying", {
         attempt: this.initialConnectAttempts,
-        max: CloudRuntime.MAX_INITIAL_CONNECT_ATTEMPTS,
+        max: INITIAL_CONNECT_ATTEMPTS,
       });
     } else {
       this.logger.warn("cloud runtime disconnected; reconnecting");
     }
     if (this.reconnect) clearTimeout(this.reconnect);
-    this.reconnect = setTimeout(() => this.connect(), CloudRuntime.RECONNECT_DELAY_MS);
+    this.reconnect = setTimeout(() => this.connect(), RECONNECT_DELAY_MS);
   }
 
   private handleSocketError(socket: WebSocket, err: Error): void {

--- a/packages/gsd-cloud/src/runtime-process.test.ts
+++ b/packages/gsd-cloud/src/runtime-process.test.ts
@@ -1,7 +1,7 @@
 // Project/App: Open GSD
 // File Purpose: Regression coverage for detached cloud runtime process timing and shutdown.
 import { spawn } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -9,6 +9,8 @@ import assert from "node:assert/strict";
 import { CLOUD_RUNTIME_INITIAL_CONNECT_WINDOW_MS } from "./cloud-runtime.js";
 import {
   BACKGROUND_RUNTIME_READY_TIMEOUT_MS,
+  backgroundRuntimeStatus,
+  startBackgroundRuntime,
   stopBackgroundRuntime,
 } from "./runtime-process.js";
 
@@ -43,3 +45,66 @@ test("stop waits for the detached runtime to exit before removing its state", { 
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("concurrent starts serialize and leave only the newest runtime running", { timeout: 15_000 }, async () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-concurrent-start-"));
+  const configPath = join(root, "daemon.yaml");
+  const binaryPath = writeReadyRuntime(root);
+
+  try {
+    const [first, second] = await Promise.all([
+      startBackgroundRuntime({ binaryPath, configPath, projectDirs: [root] }),
+      startBackgroundRuntime({ binaryPath, configPath, projectDirs: [root] }),
+    ]);
+
+    assert.notEqual(first.pid, second.pid);
+    assert.ok(first.pid);
+    assert.equal(processIsRunning(first.pid), false);
+    assert.equal(backgroundRuntimeStatus(configPath).pid, second.pid);
+  } finally {
+    await stopBackgroundRuntime(configPath).catch(() => undefined);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("verbose background starts forward the flag to the runtime child", { timeout: 10_000 }, async () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-verbose-start-"));
+  const configPath = join(root, "daemon.yaml");
+  const binaryPath = writeReadyRuntime(root);
+
+  try {
+    await startBackgroundRuntime({
+      binaryPath,
+      configPath,
+      projectDirs: [root],
+      verbose: true,
+    });
+
+    const args = JSON.parse(readFileSync(join(root, "runtime-args.json"), "utf8")) as string[];
+    assert.ok(args.includes("--verbose"));
+  } finally {
+    await stopBackgroundRuntime(configPath).catch(() => undefined);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function writeReadyRuntime(root: string): string {
+  const binaryPath = join(root, "runtime.mjs");
+  writeFileSync(binaryPath, [
+    'import { writeFileSync } from "node:fs";',
+    `writeFileSync(${JSON.stringify(join(root, "runtime-args.json"))}, JSON.stringify(process.argv.slice(2)));`,
+    'process.on("SIGTERM", () => process.exit(0));',
+    'process.send?.({ type: "ready" });',
+    'setInterval(() => undefined, 1_000);',
+  ].join("\n"));
+  return binaryPath;
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/gsd-cloud/src/runtime-process.test.ts
+++ b/packages/gsd-cloud/src/runtime-process.test.ts
@@ -1,0 +1,45 @@
+// Project/App: Open GSD
+// File Purpose: Regression coverage for detached cloud runtime process timing and shutdown.
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CLOUD_RUNTIME_INITIAL_CONNECT_WINDOW_MS } from "./cloud-runtime.js";
+import {
+  BACKGROUND_RUNTIME_READY_TIMEOUT_MS,
+  stopBackgroundRuntime,
+} from "./runtime-process.js";
+
+test("background startup allows the cloud runtime's full initial reconnect window", () => {
+  assert.ok(BACKGROUND_RUNTIME_READY_TIMEOUT_MS > CLOUD_RUNTIME_INITIAL_CONNECT_WINDOW_MS);
+});
+
+test("stop waits for the detached runtime to exit before removing its state", { timeout: 5_000 }, async () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-stop-"));
+  const configPath = join(root, "daemon.yaml");
+  const statePath = join(root, "cloud-runtime.json");
+  const child = spawn(process.execPath, [
+    "-e",
+    "process.on('SIGTERM',()=>setTimeout(()=>process.exit(0),200));process.send?.('ready');setInterval(()=>{},1000)",
+  ], { stdio: ["ignore", "ignore", "ignore", "ipc"] });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("message", () => resolve());
+    });
+    assert.ok(child.pid);
+    writeFileSync(statePath, `${JSON.stringify({ pid: child.pid, projects: [root] })}\n`);
+
+    const startedAt = Date.now();
+    assert.equal(await stopBackgroundRuntime(configPath), true);
+
+    assert.ok(Date.now() - startedAt >= 150);
+    assert.equal(existsSync(statePath), false);
+  } finally {
+    child.kill("SIGKILL");
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/gsd-cloud/src/runtime-process.ts
+++ b/packages/gsd-cloud/src/runtime-process.ts
@@ -7,6 +7,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -30,6 +31,7 @@ interface StartRuntimeOptions {
   configPath: string;
   projectDirs: string[];
   readyTimeoutMs?: number;
+  verbose?: boolean;
 }
 
 const PROCESS_STARTUP_GRACE_MS = 5_000;
@@ -41,49 +43,57 @@ export const BACKGROUND_RUNTIME_READY_TIMEOUT_MS =
   CLOUD_RUNTIME_INITIAL_CONNECT_WINDOW_MS + PROCESS_STARTUP_GRACE_MS;
 
 export async function startBackgroundRuntime(opts: StartRuntimeOptions): Promise<RuntimeProcessStatus> {
-  await stopBackgroundRuntime(opts.configPath);
-
-  const statePath = runtimeStatePath(opts.configPath);
-  const logFile = runtimeLogPath(opts.configPath);
-  mkdirSync(dirname(statePath), { recursive: true });
-  const logFd = openSync(logFile, "a", 0o600);
-  chmodSync(logFile, 0o600);
-  let child: ChildProcess;
+  await acquireRuntimeStartLock(opts.configPath);
   try {
-    child = spawn(process.execPath, [opts.binaryPath, "_run", "--config", opts.configPath], {
-      cwd: opts.projectDirs[0] ?? process.cwd(),
-      detached: true,
-      env: process.env,
-      stdio: ["ignore", logFd, logFd, "ipc"],
-    });
-  } finally {
-    closeSync(logFd);
-  }
+    await stopBackgroundRuntime(opts.configPath);
 
-  if (child.pid == null) {
-    child.kill();
-    throw new Error(`could not start the background runtime; see ${logFile}`);
-  }
-  const pid = child.pid;
+    const logFile = runtimeLogPath(opts.configPath);
+    mkdirSync(dirname(runtimeStatePath(opts.configPath)), { recursive: true });
+    const logFd = openSync(logFile, "a", 0o600);
+    chmodSync(logFile, 0o600);
+    const runArgs = [opts.binaryPath, "_run", "--config", opts.configPath];
+    if (opts.verbose) runArgs.push("--verbose");
+    let child: ChildProcess;
+    try {
+      child = spawn(process.execPath, runArgs, {
+        cwd: opts.projectDirs[0] ?? process.cwd(),
+        detached: true,
+        env: process.env,
+        stdio: ["ignore", logFd, logFd, "ipc"],
+      });
+    } finally {
+      closeSync(logFd);
+    }
 
-  try {
-    await waitUntilReady(child, opts.readyTimeoutMs ?? BACKGROUND_RUNTIME_READY_TIMEOUT_MS);
-  } catch (error) {
+    if (child.pid == null) {
+      child.kill();
+      throw new Error(`could not start the background runtime; see ${logFile}`);
+    }
+    const pid = child.pid;
+
+    writeRuntimeState(opts.configPath, pid, opts.projectDirs);
+
+    try {
+      await waitUntilReady(child, opts.readyTimeoutMs ?? BACKGROUND_RUNTIME_READY_TIMEOUT_MS);
+    } catch (error) {
+      if (child.connected) child.disconnect();
+      await terminateProcess(pid);
+      removeRuntimeState(opts.configPath);
+      throw error;
+    }
+
     if (child.connected) child.disconnect();
-    await terminateProcess(pid);
-    throw error;
+    child.unref();
+
+    return {
+      running: true,
+      pid,
+      projects: opts.projectDirs,
+      log_file: logFile,
+    };
+  } finally {
+    releaseRuntimeStartLock(opts.configPath);
   }
-
-  writeRuntimeState(opts.configPath, pid, opts.projectDirs);
-  if (child.connected) child.disconnect();
-  child.unref();
-
-  return {
-    running: true,
-    pid,
-    projects: opts.projectDirs,
-    log_file: logFile,
-  };
 }
 
 /**
@@ -171,6 +181,59 @@ function runtimeStatePath(configPath: string): string {
 
 function runtimeLogPath(configPath: string): string {
   return join(dirname(configPath), "cloud-runtime.log");
+}
+
+function runtimeStartLockPath(configPath: string): string {
+  return join(dirname(configPath), "cloud-runtime.start.lock");
+}
+
+async function acquireRuntimeStartLock(configPath: string): Promise<void> {
+  const lockPath = runtimeStartLockPath(configPath);
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + BACKGROUND_RUNTIME_READY_TIMEOUT_MS + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      const fd = openSync(lockPath, "wx");
+      writeFileSync(fd, `${process.pid}\n`, "utf8");
+      closeSync(fd);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        const ownerPid = readRuntimeStartLockOwner(lockPath);
+        const incompleteLockIsStale = ownerPid === null
+          && Date.now() - statSync(lockPath).mtimeMs > 1_000;
+        if ((ownerPid !== null && !processIsRunning(ownerPid)) || incompleteLockIsStale) {
+          unlinkSync(lockPath);
+          continue;
+        }
+      } catch {
+        // Another process may have released the lock; retry.
+      }
+      await new Promise((resolve) => setTimeout(resolve, STOP_POLL_INTERVAL_MS));
+    }
+  }
+  throw new Error("timed out waiting for the background runtime start lock");
+}
+
+function releaseRuntimeStartLock(configPath: string): void {
+  const lockPath = runtimeStartLockPath(configPath);
+  if (readRuntimeStartLockOwner(lockPath) !== process.pid) return;
+  try {
+    unlinkSync(lockPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+function readRuntimeStartLockOwner(lockPath: string): number | null {
+  try {
+    const pid = Number.parseInt(readFileSync(lockPath, "utf8").trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
 }
 
 function readRuntimeState(configPath: string): RuntimeProcessState | null {

--- a/packages/gsd-cloud/src/runtime-process.ts
+++ b/packages/gsd-cloud/src/runtime-process.ts
@@ -1,0 +1,195 @@
+// Project/App: Open GSD
+// File Purpose: Detached cloud runtime process lifecycle and status persistence.
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  chmodSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+interface RuntimeProcessState {
+  pid: number;
+  projects: string[];
+}
+
+export interface RuntimeProcessStatus {
+  running: boolean;
+  pid: number | null;
+  projects: string[];
+  log_file: string;
+}
+
+interface StartRuntimeOptions {
+  binaryPath: string;
+  configPath: string;
+  projectDirs: string[];
+  readyTimeoutMs?: number;
+}
+
+const DEFAULT_READY_TIMEOUT_MS = 35_000;
+
+export async function startBackgroundRuntime(opts: StartRuntimeOptions): Promise<RuntimeProcessStatus> {
+  stopBackgroundRuntime(opts.configPath);
+
+  const statePath = runtimeStatePath(opts.configPath);
+  const logFile = runtimeLogPath(opts.configPath);
+  mkdirSync(dirname(statePath), { recursive: true });
+  const logFd = openSync(logFile, "a", 0o600);
+  chmodSync(logFile, 0o600);
+  let child: ChildProcess;
+  try {
+    child = spawn(process.execPath, [opts.binaryPath, "_run", "--config", opts.configPath], {
+      cwd: opts.projectDirs[0] ?? process.cwd(),
+      detached: true,
+      env: process.env,
+      stdio: ["ignore", logFd, logFd, "ipc"],
+    });
+  } finally {
+    closeSync(logFd);
+  }
+
+  if (child.pid == null) {
+    child.kill();
+    throw new Error(`could not start the background runtime; see ${logFile}`);
+  }
+
+  try {
+    await waitUntilReady(child, opts.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS);
+  } catch (error) {
+    child.kill("SIGTERM");
+    if (child.connected) child.disconnect();
+    throw error;
+  }
+
+  const state: RuntimeProcessState = {
+    pid: child.pid,
+    projects: opts.projectDirs,
+  };
+  writePrivateJson(statePath, state);
+  if (child.connected) child.disconnect();
+  child.unref();
+
+  return {
+    running: true,
+    pid: state.pid,
+    projects: state.projects,
+    log_file: logFile,
+  };
+}
+
+export function stopBackgroundRuntime(configPath: string): boolean {
+  const state = readRuntimeState(configPath);
+  if (!state) return false;
+  try {
+    process.kill(state.pid, "SIGTERM");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ESRCH") throw error;
+  }
+  removeRuntimeState(configPath);
+  return true;
+}
+
+export function backgroundRuntimeStatus(configPath: string): RuntimeProcessStatus {
+  const state = readRuntimeState(configPath);
+  if (!state) {
+    return { running: false, pid: null, projects: [], log_file: runtimeLogPath(configPath) };
+  }
+  if (!processIsRunning(state.pid)) {
+    removeRuntimeState(configPath);
+    return {
+      running: false,
+      pid: null,
+      projects: state.projects,
+      log_file: runtimeLogPath(configPath),
+    };
+  }
+  return {
+    running: true,
+    pid: state.pid,
+    projects: state.projects,
+    log_file: runtimeLogPath(configPath),
+  };
+}
+
+function waitUntilReady(child: ChildProcess, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let timeout: ReturnType<typeof setTimeout>;
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      child.removeListener("error", onError);
+      child.removeListener("exit", onExit);
+      child.removeListener("message", onMessage);
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null): void => {
+      cleanup();
+      reject(new Error(`background runtime exited before connecting (exit ${code ?? "unknown"})`));
+    };
+    const onMessage = (message: unknown): void => {
+      if (!message || typeof message !== "object" || (message as { type?: unknown }).type !== "ready") return;
+      cleanup();
+      resolve();
+    };
+    timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`background runtime did not connect within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.once("error", onError);
+    child.once("exit", onExit);
+    child.on("message", onMessage);
+  });
+}
+
+function runtimeStatePath(configPath: string): string {
+  return join(dirname(configPath), "cloud-runtime.json");
+}
+
+function runtimeLogPath(configPath: string): string {
+  return join(dirname(configPath), "cloud-runtime.log");
+}
+
+function readRuntimeState(configPath: string): RuntimeProcessState | null {
+  try {
+    const value = JSON.parse(readFileSync(runtimeStatePath(configPath), "utf8")) as Partial<RuntimeProcessState>;
+    const pid = value.pid;
+    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0 || !Array.isArray(value.projects)) return null;
+    return {
+      pid,
+      projects: value.projects.filter((project): project is string => typeof project === "string"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function removeRuntimeState(configPath: string): void {
+  try {
+    unlinkSync(runtimeStatePath(configPath));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+function writePrivateJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  chmodSync(path, 0o600);
+}

--- a/packages/gsd-cloud/src/runtime-process.ts
+++ b/packages/gsd-cloud/src/runtime-process.ts
@@ -11,6 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
+import { CLOUD_RUNTIME_INITIAL_CONNECT_WINDOW_MS } from "./cloud-runtime.js";
 
 interface RuntimeProcessState {
   pid: number;
@@ -31,10 +32,16 @@ interface StartRuntimeOptions {
   readyTimeoutMs?: number;
 }
 
-const DEFAULT_READY_TIMEOUT_MS = 35_000;
+const PROCESS_STARTUP_GRACE_MS = 5_000;
+const FORCED_STOP_TIMEOUT_MS = 5_000;
+const STOP_GRACE_PERIOD_MS = 5_000;
+const STOP_POLL_INTERVAL_MS = 50;
+
+export const BACKGROUND_RUNTIME_READY_TIMEOUT_MS =
+  CLOUD_RUNTIME_INITIAL_CONNECT_WINDOW_MS + PROCESS_STARTUP_GRACE_MS;
 
 export async function startBackgroundRuntime(opts: StartRuntimeOptions): Promise<RuntimeProcessStatus> {
-  stopBackgroundRuntime(opts.configPath);
+  await stopBackgroundRuntime(opts.configPath);
 
   const statePath = runtimeStatePath(opts.configPath);
   const logFile = runtimeLogPath(opts.configPath);
@@ -59,10 +66,10 @@ export async function startBackgroundRuntime(opts: StartRuntimeOptions): Promise
   }
 
   try {
-    await waitUntilReady(child, opts.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS);
+    await waitUntilReady(child, opts.readyTimeoutMs ?? BACKGROUND_RUNTIME_READY_TIMEOUT_MS);
   } catch (error) {
-    child.kill("SIGTERM");
     if (child.connected) child.disconnect();
+    await terminateProcess(child.pid);
     throw error;
   }
 
@@ -82,15 +89,10 @@ export async function startBackgroundRuntime(opts: StartRuntimeOptions): Promise
   };
 }
 
-export function stopBackgroundRuntime(configPath: string): boolean {
+export async function stopBackgroundRuntime(configPath: string): Promise<boolean> {
   const state = readRuntimeState(configPath);
   if (!state) return false;
-  try {
-    process.kill(state.pid, "SIGTERM");
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code !== "ESRCH") throw error;
-  }
+  await terminateProcess(state.pid);
   removeRuntimeState(configPath);
   return true;
 }
@@ -178,6 +180,32 @@ function processIsRunning(pid: number): boolean {
     return true;
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (processIsRunning(pid)) {
+    if (Date.now() >= deadline) return false;
+    await new Promise((resolve) => setTimeout(resolve, STOP_POLL_INTERVAL_MS));
+  }
+  return true;
+}
+
+async function terminateProcess(pid: number): Promise<void> {
+  signalProcess(pid, "SIGTERM");
+  if (await waitForProcessExit(pid, STOP_GRACE_PERIOD_MS)) return;
+  signalProcess(pid, "SIGKILL");
+  if (!await waitForProcessExit(pid, FORCED_STOP_TIMEOUT_MS)) {
+    throw new Error(`background runtime PID ${pid} did not stop`);
+  }
+}
+
+function signalProcess(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
   }
 }
 

--- a/packages/gsd-cloud/src/runtime-process.ts
+++ b/packages/gsd-cloud/src/runtime-process.ts
@@ -190,7 +190,12 @@ function runtimeStartLockPath(configPath: string): string {
 async function acquireRuntimeStartLock(configPath: string): Promise<void> {
   const lockPath = runtimeStartLockPath(configPath);
   mkdirSync(dirname(lockPath), { recursive: true });
-  const deadline = Date.now() + BACKGROUND_RUNTIME_READY_TIMEOUT_MS + 10_000;
+  // Match worst-case `startBackgroundRuntime` hold time: stop prior runtime, wait for
+  // ready, and tear down the child if ready fails, plus one poll interval.
+  const deadline = Date.now()
+    + BACKGROUND_RUNTIME_READY_TIMEOUT_MS
+    + 2 * (STOP_GRACE_PERIOD_MS + FORCED_STOP_TIMEOUT_MS)
+    + STOP_POLL_INTERVAL_MS;
   while (Date.now() < deadline) {
     try {
       const fd = openSync(lockPath, "wx");

--- a/packages/gsd-cloud/src/runtime-process.ts
+++ b/packages/gsd-cloud/src/runtime-process.ts
@@ -64,29 +64,42 @@ export async function startBackgroundRuntime(opts: StartRuntimeOptions): Promise
     child.kill();
     throw new Error(`could not start the background runtime; see ${logFile}`);
   }
+  const pid = child.pid;
 
   try {
     await waitUntilReady(child, opts.readyTimeoutMs ?? BACKGROUND_RUNTIME_READY_TIMEOUT_MS);
   } catch (error) {
     if (child.connected) child.disconnect();
-    await terminateProcess(child.pid);
+    await terminateProcess(pid);
     throw error;
   }
 
-  const state: RuntimeProcessState = {
-    pid: child.pid,
-    projects: opts.projectDirs,
-  };
-  writePrivateJson(statePath, state);
+  writeRuntimeState(opts.configPath, pid, opts.projectDirs);
   if (child.connected) child.disconnect();
   child.unref();
 
   return {
     running: true,
-    pid: state.pid,
-    projects: state.projects,
+    pid,
+    projects: opts.projectDirs,
     log_file: logFile,
   };
+}
+
+/**
+ * Record a running runtime so a later launch can find and stop it. Used both by
+ * the detached launcher (child PID) and by a `--foreground` session (its own
+ * PID), so the two modes share one source of truth and never coexist on the
+ * same device token.
+ */
+export function writeRuntimeState(configPath: string, pid: number, projects: string[]): void {
+  const statePath = runtimeStatePath(configPath);
+  mkdirSync(dirname(statePath), { recursive: true });
+  writePrivateJson(statePath, { pid, projects } satisfies RuntimeProcessState);
+}
+
+export function clearRuntimeState(configPath: string): void {
+  removeRuntimeState(configPath);
 }
 
 export async function stopBackgroundRuntime(configPath: string): Promise<boolean> {


### PR DESCRIPTION
## TL;DR

**What:** Make gsd-cloud login and connect start a detached project runtime by default.
**Why:** Login currently occupies the terminal, and ending it disconnects the project from GSD Cloud.
**How:** Add a supervised background runtime process, persist its PID and project roots, and expose status/stop lifecycle commands.

## What

- Starts the cloud runtime in the background after login or connect.
- Captures the current GSD project and advertises it to the cloud relay.
- Persists runtime PID and project metadata in the cloud config directory.
- Adds foreground mode for debugging.
- Stops the detached runtime during disconnect.
- Reports background runtime and project state from status.
- Serializes concurrent starts, tracks foreground runtimes, and canonicalizes project paths.
- Documents the single-terminal login workflow.

## Why

Users should be able to run gsd-cloud login from a project directory, regain their prompt, and continue using that project while the machine remains connected to GSD Cloud. The previous foreground-only behavior required a second terminal and made Ctrl+C disconnect the machine.

## How

The CLI launches a hidden runtime subcommand as a detached child and waits for an IPC ready message only after the relay WebSocket is connected. It then disconnects and unreferences the child so the invoking shell returns while the runtime remains alive. Runtime state and logs are written to the existing cloud config directory.

## Verification

- Added acceptance coverage for detached connect and full device-flow login lifecycle.
- Package test suite: 50 passed.
- Fast verification gates passed.
- Package tarball validation passed, including isolated and global install checks.
- Sabotage checks confirmed both acceptance tests fail if login or connect returns to foreground mode.
- Full repository merge verification reached 12,024 passing tests; six unrelated existing tests failed on macOS private-path normalization and unrelated environment state.

- [ ] feat — New feature or capability
- [x] fix — Bug fix
- [ ] refactor — Code restructuring (no behavior change)
- [x] test — Adding or updating tests
- [x] docs — Documentation only
- [ ] chore — Build, CI, or tooling changes
