### PR TITLE
fix(issue): Data loss: session-creation failure (newSession is not a function) cancels the unit without committing executor work

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -3163,7 +3163,15 @@ export async function dispatchHookUnit(
     workspaceRoot: s.basePath,
   });
 
-  const result = await s.cmdCtx!.newSession({ workspaceRoot: s.basePath });
+  const cmdCtx = s.cmdCtx;
+  if (typeof cmdCtx?.newSession !== "function") {
+    const message = "Auto-mode has no command context for dispatch.";
+    ctx.ui.notify(message, "error");
+    await stopAuto(ctx, pi, message, { preserveWorktree: true });
+    return false;
+  }
+
+  const result = await cmdCtx.newSession({ workspaceRoot: s.basePath });
   if (result.cancelled) {
     await stopAuto(ctx, pi);
     return false;

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -3167,6 +3167,10 @@ export async function dispatchHookUnit(
   if (typeof cmdCtx?.newSession !== "function") {
     const message = "Auto-mode has no command context for dispatch.";
     ctx.ui.notify(message, "error");
+    const unitToCommit = previousCurrentUnit ?? s.currentUnit;
+    if (unitToCommit) {
+      await autoCommitUnit(s.basePath, unitToCommit.type, unitToCommit.id, ctx);
+    }
     await stopAuto(ctx, pi, message, { preserveWorktree: true });
     return false;
   }

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -355,7 +355,41 @@ async function enforceMinRequestInterval(s: AutoSession, prefs: IterationContext
   }
 }
 
-function closeOutCrashedUnit(s: AutoSession, iterData: IterationData, err: unknown): void {
+async function snapshotCrashedUnitWork(
+  ctx: ExtensionContext,
+  s: AutoSession,
+  deps: LoopDeps,
+  iterData: IterationData,
+): Promise<void> {
+  try {
+    const commitMsg = await deps.autoCommitUnit?.(
+      s.basePath,
+      iterData.unitType,
+      iterData.unitId,
+      ctx,
+    );
+    if (commitMsg) {
+      debugLog("autoLoop", {
+        phase: "crash-snapshot-commit",
+        unitType: iterData.unitType,
+        unitId: iterData.unitId,
+      });
+    }
+  } catch (snapshotErr) {
+    logWarning(
+      "dispatch",
+      `unit crash snapshot failed: ${snapshotErr instanceof Error ? snapshotErr.message : String(snapshotErr)}`,
+    );
+  }
+}
+
+async function closeOutCrashedUnit(
+  ctx: ExtensionContext,
+  s: AutoSession,
+  deps: LoopDeps,
+  iterData: IterationData,
+  err: unknown,
+): Promise<void> {
   const summary = formatDispatchExceptionSummary({ error: err });
   try {
     emitOpenUnitEndForUnit(
@@ -383,6 +417,7 @@ function closeOutCrashedUnit(s: AutoSession, iterData: IterationData, err: unkno
   } catch (closeoutErr) {
     logWarning("dispatch", `unit crash closeout failed: ${closeoutErr instanceof Error ? closeoutErr.message : String(closeoutErr)}`);
   }
+  await snapshotCrashedUnitWork(ctx, s, deps, iterData);
 }
 
 /**
@@ -526,11 +561,12 @@ export async function autoLoop(
       active: s.active,
       iteration,
       maxIterations: MAX_LOOP_ITERATIONS,
-      hasCommandContext: Boolean(s.cmdCtx),
+      hasCommandContext: typeof s.cmdCtx?.newSession === "function",
       sessionLockValid: true,
     });
     if (commandContextDecision.action === "stop" && commandContextDecision.reason === "missing-command-context") {
       debugLog("autoLoop", { phase: "exit", reason: "no-cmdCtx" });
+      await deps.stopAuto(ctx, pi, commandContextDecision.message, { preserveWorktree: true });
       finishTurn("stopped", "manual-attention", commandContextDecision.reason);
       break;
     }
@@ -730,7 +766,7 @@ export async function autoLoop(
           if (err instanceof ModelPolicyDispatchBlockedError) {
             throw err;
           }
-          closeOutCrashedUnit(s, iterData, err);
+          await closeOutCrashedUnit(ctx, s, deps, iterData, err);
           throw err;
         }
         if (unitPhaseResult.action === "next") {
@@ -1285,7 +1321,7 @@ export async function autoLoop(
         if (err instanceof ModelPolicyDispatchBlockedError) {
           throw err;
         }
-        closeOutCrashedUnit(s, iterData, err);
+        await closeOutCrashedUnit(ctx, s, deps, iterData, err);
         dispatchSettled = settleDispatchFailed(
           dispatchId,
           formatDispatchExceptionSummary({ error: err }),

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -566,6 +566,14 @@ export async function autoLoop(
     });
     if (commandContextDecision.action === "stop" && commandContextDecision.reason === "missing-command-context") {
       debugLog("autoLoop", { phase: "exit", reason: "no-cmdCtx" });
+      if (s.currentUnit) {
+        await deps.autoCommitUnit?.(
+          s.basePath,
+          s.currentUnit.type,
+          s.currentUnit.id,
+          ctx,
+        );
+      }
       await deps.stopAuto(ctx, pi, commandContextDecision.message, { preserveWorktree: true });
       finishTurn("stopped", "manual-attention", commandContextDecision.reason);
       break;

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -91,6 +91,25 @@ export async function runUnit(
   // ── Session creation with timeout ──
   debugLog("runUnit", { phase: "session-create", unitType, unitId });
 
+  const cmdCtx = s.cmdCtx;
+  if (typeof cmdCtx?.newSession !== "function") {
+    const msg = "command context is missing newSession";
+    debugLog("runUnit", {
+      phase: "session-error",
+      unitType,
+      unitId,
+      error: msg,
+    });
+    return {
+      status: "cancelled",
+      errorContext: {
+        message: `Session creation failed: ${msg}`,
+        category: "session-failed",
+        isTransient: false,
+      },
+    };
+  }
+
   let sessionResult: { cancelled: boolean };
   let sessionTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const mySessionSwitchGeneration = ++sessionSwitchGeneration;
@@ -100,7 +119,7 @@ export async function runUnit(
   const sessionAbortController = new AbortController();
   _setSessionSwitchInFlight(true);
   try {
-    const sessionPromise = s.cmdCtx!.newSession({
+    const sessionPromise = cmdCtx.newSession({
       abortSignal: sessionAbortController.signal,
       workspaceRoot: s.basePath,
     }).finally(() => {

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -41,6 +41,7 @@ import { claimMilestoneLease } from "../db/milestone-leases.js";
 import { recordDispatchClaim, markCanceled } from "../db/unit-dispatches.js";
 import { setRuntimeKv, getRuntimeKv } from "../db/runtime-kv.js";
 import { SourceObservationStore } from "../source-observations.js";
+import { autoCommitCurrentBranch } from "../worktree.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -832,6 +833,37 @@ test("runUnit returns cancelled when session creation fails", async () => {
   assert.equal(pi.calls.length, 0);
 });
 
+test("runUnit returns cancelled when command context lacks newSession", async () => {
+  _resetPendingResolve();
+
+  const ctx = {
+    ...makeMockCtx(),
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWorkingMessage: () => {},
+    },
+    sessionManager: {
+      getEntries: () => [],
+    },
+    modelRegistry: {
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => true,
+    },
+  } as any;
+  const pi = makeMockPi();
+  const s = makeMockSession();
+  s.cmdCtx = {} as any;
+
+  const result = await runUnit(ctx, pi, s, "task", "T01", "prompt");
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "session-failed");
+  assert.equal(result.errorContext?.isTransient, false);
+  assert.match(result.errorContext?.message ?? "", /missing newSession/);
+  assert.equal(pi.calls.length, 0);
+});
+
 test("runUnit: TypeError from newSession is classified as structural (isTransient: false)", async () => {
   // Regression for #572: a TypeError thrown from newSession (e.g. "something is
   // not a function") indicates a programming error, not a transient provider
@@ -1580,6 +1612,82 @@ test("autoLoop exits when s.active is set to false", async (t) => {
     !deps.callLog.includes("deriveState"),
     "loop should not have iterated",
   );
+});
+
+test("autoLoop stops before dispatch when command context lacks newSession", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  const s = makeLoopSession({
+    cmdCtx: {
+      getContextUsage: () => ({ percent: 10, tokens: 1000, limit: 10000 }),
+    },
+  });
+  let stopReason: string | undefined;
+  let preserveWorktree: boolean | undefined;
+  let deriveCalled = false;
+
+  try {
+    const deps = makeMockDeps({
+      stopAuto: async (_ctx, _pi, reason, options) => {
+        stopReason = reason;
+        preserveWorktree = options?.preserveWorktree;
+        s.active = false;
+      },
+      deriveState: async () => {
+        deriveCalled = true;
+        throw new Error("deriveState should not run without command session support");
+      },
+    });
+
+    await autoLoop(ctx, pi, s, deps);
+
+    assert.equal(stopReason, "Auto-mode has no command context for dispatch.");
+    assert.equal(preserveWorktree, true);
+    assert.equal(deriveCalled, false);
+    assert.equal(pi.calls.length, 0);
+  } finally {
+    rmSync(s.basePath, { recursive: true, force: true });
+  }
+});
+
+test("autoLoop snapshots dirty work when unit dispatch crashes", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+  const outputPath = join(s.basePath, "executor-output.txt");
+  let autoCommitCalls = 0;
+
+  try {
+    const deps = makeMockDeps({
+      ensurePreconditions: () => {
+        writeFileSync(outputPath, "saved before crash\n", "utf-8");
+        throw new Error("dispatch crash after file write");
+      },
+      autoCommitUnit: async (basePath, unitType, unitId) => {
+        autoCommitCalls++;
+        const commitMsg = autoCommitCurrentBranch(basePath, unitType, unitId);
+        s.active = false;
+        return commitMsg;
+      },
+    });
+
+    await autoLoop(ctx, pi, s, deps);
+
+    assert.equal(autoCommitCalls, 1);
+    const committed = execSync("git show HEAD:executor-output.txt", {
+      cwd: s.basePath,
+      encoding: "utf-8",
+    });
+    assert.equal(committed, "saved before crash\n");
+  } finally {
+    rmSync(s.basePath, { recursive: true, force: true });
+  }
 });
 
 test("autoLoop pauses visibly when Auto Orchestration Module is not wired", async () => {

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1653,6 +1653,54 @@ test("autoLoop stops before dispatch when command context lacks newSession", asy
   }
 });
 
+test("autoLoop commits open unit work when command context lacks newSession", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  const s = makeLoopSession({
+    cmdCtx: {
+      getContextUsage: () => ({ percent: 10, tokens: 1000, limit: 10000 }),
+    },
+    currentUnit: { type: "execute-task", id: "T01", startedAt: Date.now() },
+  });
+  const outputPath = join(s.basePath, "executor-output.txt");
+  let autoCommitArgs: { unitType: string; unitId: string } | undefined;
+  let preserveWorktree: boolean | undefined;
+
+  try {
+    const deps = makeMockDeps({
+      autoCommitUnit: async (basePath, unitType, unitId) => {
+        autoCommitArgs = { unitType, unitId };
+        return autoCommitCurrentBranch(basePath, unitType, unitId);
+      },
+      stopAuto: async (_ctx, _pi, _reason, options) => {
+        preserveWorktree = options?.preserveWorktree;
+        s.active = false;
+      },
+      deriveState: async () => {
+        throw new Error("deriveState should not run without command session support");
+      },
+    });
+
+    writeFileSync(outputPath, "open unit work before stop\n", "utf-8");
+
+    await autoLoop(ctx, pi, s, deps);
+
+    assert.deepEqual(autoCommitArgs, { unitType: "execute-task", unitId: "T01" });
+    assert.equal(preserveWorktree, true);
+    const committed = execSync("git show HEAD:executor-output.txt", {
+      cwd: s.basePath,
+      encoding: "utf-8",
+    });
+    assert.equal(committed, "open unit work before stop\n");
+    assert.equal(pi.calls.length, 0);
+  } finally {
+    rmSync(s.basePath, { recursive: true, force: true });
+  }
+});
+
 test("autoLoop snapshots dirty work when unit dispatch crashes", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
@@ -3,7 +3,8 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -95,6 +96,78 @@ describe("hook dispatch session workspace root", () => {
 
     assert.equal(dispatched, true);
     assert.deepEqual(newSessionOptions, { workspaceRoot: basePath });
+  });
+
+  test("dispatchHookUnit commits in-flight work when command context lacks newSession", async (t) => {
+    const originalCwd = process.cwd();
+    const basePath = realpathSync(mkdtempSync(join(tmpdir(), "gsd-hook-nosnap-")));
+    mkdirSync(join(basePath, ".gsd"), { recursive: true });
+    execSync("git init --initial-branch=main", { cwd: basePath, stdio: "ignore" });
+    execSync("git config user.email test@test.com", { cwd: basePath, stdio: "ignore" });
+    execSync("git config user.name Test", { cwd: basePath, stdio: "ignore" });
+    execSync("git commit --allow-empty -m init", { cwd: basePath, stdio: "ignore" });
+
+    autoSession.reset();
+    autoSession.active = true;
+    autoSession.basePath = basePath;
+    autoSession.originalBasePath = basePath;
+    // Simulate an in-flight unit whose executor already wrote files, then a hook
+    // fires with a command context missing newSession.
+    autoSession.currentUnit = {
+      type: "execute-task",
+      id: "M001/S01/T01",
+      startedAt: Date.now(),
+    };
+    t.after(() => {
+      try {
+        process.chdir(originalCwd);
+      } catch {
+        // best effort cleanup after cwd-sensitive dispatch tests
+      }
+      autoSession.reset();
+      rmSync(basePath, { recursive: true, force: true });
+    });
+
+    const outputPath = join(basePath, "executor-output.txt");
+    writeFileSync(outputPath, "in-flight executor work\n", "utf-8");
+
+    // Command context intentionally lacks newSession — the guard must snapshot
+    // the dirty work before stopping instead of discarding it.
+    const ctx = {
+      ui: {
+        notify: () => {},
+        setStatus: () => {},
+        setWidget: () => {},
+      },
+      modelRegistry: {
+        getAvailable: () => [],
+      },
+      sessionManager: {
+        getSessionFile: () => join(basePath, "session.jsonl"),
+      },
+    };
+    const pi = {
+      sendMessage: () => {},
+      setModel: async () => true,
+    };
+
+    const dispatched = await dispatchHookUnit(
+      ctx as any,
+      pi as any,
+      "review",
+      "execute-task",
+      "M001/S01/T01",
+      "review the completed unit",
+      undefined,
+      basePath,
+    );
+
+    assert.equal(dispatched, false);
+    const committed = execSync("git show HEAD:executor-output.txt", {
+      cwd: basePath,
+      encoding: "utf-8",
+    });
+    assert.equal(committed, "in-flight executor work\n");
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixed partial command-context handling and crash closeout snapshots, with static verification passing and test execution blocked by unavailable npm dependencies.

## Bugs Addressed
- [x] **Re-entry command context can lack newSession**
- [x] **Command-context guard accepts partial contexts**
- [x] **Crashed or cancelled units skip worktree snapshot commits**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1389
- [#1389 Data loss: session-creation failure (newSession is not a function) cancels the unit without committing executor work](https://github.com/open-gsd/gsd-pi/issues/1389)

## User
- @DragonSigh

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1389-data-loss-session-creation-failure-newse-1783700681`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes failure paths in auto-mode dispatch and git commit-on-stop behavior; incorrect guards could stop early or commit unexpectedly, but scope is limited to missing-session and unit-crash handling.
> 
> **Overview**
> Fixes **data loss** when auto-mode cannot create a session because the command context is missing or incomplete (`newSession` is not a function). Executor-written files were previously abandoned when the unit was cancelled.
> 
> **Session guards** now require `typeof cmdCtx?.newSession === "function"` in `runUnit`, `dispatchHookUnit`, and the auto loop (replacing truthy `cmdCtx` checks). On failure, paths **snapshot dirty work** via `autoCommitUnit` before stopping with **`preserveWorktree: true`**.
> 
> **Crash closeout** in the auto loop is async: after journaling a crashed unit, **`snapshotCrashedUnitWork`** attempts the same commit so dispatch exceptions after file writes are not lost.
> 
> Regression tests cover missing `newSession` in `runUnit`, loop stop/commit, hook dispatch, and crash snapshot behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141431d7f9725c96b5ce59cdf146ec5acf98b020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->