### PR TITLE
fix(issue): [Bug]: Orphaned MCP servers busy-loop at ~100% CPU for hours (SIGTERM-proof) — orphan cleanup from #758/#783 can't fire because the event loop is blocked

### DIFF
--- a/packages/mcp-server/src/cli-runner.test.ts
+++ b/packages/mcp-server/src/cli-runner.test.ts
@@ -55,6 +55,68 @@ function spawnMcpServer(projectDir: string, gsdHome: string): ChildProcessWithou
   });
 }
 
+function spawnBusyLoopingMcpServerParent(projectDir: string, gsdHome: string): ChildProcessWithoutNullStreams {
+  const runnerUrl = new URL('./cli-runner.js', import.meta.url).href;
+  const childCode = `
+    import { runMcpServerCli } from ${JSON.stringify(runnerUrl)};
+    await runMcpServerCli({
+      sweepProjectOrphanMcpServers() {},
+      stdinIdleTimeoutMs: 100,
+      orphanParentLossCheckIntervalMs: 25,
+      createMcpServer: async () => ({
+        server: {
+          connect: async () => {
+            process.stderr.write('BUSY_READY\\n');
+            while (true) {}
+          },
+          close: async () => {},
+        },
+      }),
+      importStdioServerTransport: async () => ({ StdioServerTransport: class {} }),
+      warmWorkflowToolBridges() {},
+    });
+  `;
+  const parentCode = `
+    import { spawn } from 'node:child_process';
+    const child = spawn(process.execPath, ['--input-type=module', '--eval', ${JSON.stringify(childCode)}], {
+      cwd: ${JSON.stringify(projectDir)},
+      env: { ...process.env, GSD_HOME: ${JSON.stringify(gsdHome)} },
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+    if (!child.pid) throw new Error('missing child pid');
+    process.stdout.write(String(child.pid) + '\\n');
+    let done = false;
+    child.stderr.on('data', (chunk) => {
+      const text = String(chunk);
+      process.stderr.write(text);
+      if (!done && text.includes('BUSY_READY')) {
+        done = true;
+        process.exit(0);
+      }
+    });
+    child.once('exit', (code, signal) => {
+      if (done) return;
+      done = true;
+      process.stderr.write('busy child exited before parent loss: code=' + code + ' signal=' + signal + '\\n');
+      process.exit(1);
+    });
+    setTimeout(() => {
+      if (done) return;
+      done = true;
+      process.stderr.write('timed out waiting for busy child readiness\\n');
+      process.exit(2);
+    }, 5000);
+  `;
+  return spawn(process.execPath, ['--input-type=module', '--eval', parentCode], {
+    cwd: projectDir,
+    env: {
+      ...process.env,
+      GSD_HOME: gsdHome,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
 async function waitForRegistryPid(gsdHome: string, pid: number | undefined, timeoutMs = 5_000): Promise<void> {
   assert.ok(pid, 'spawned child must have a pid');
   const registryPath = join(gsdHome, 'mcp-instances.json');
@@ -67,6 +129,51 @@ async function waitForRegistryPid(gsdHome: string, pid: number | undefined, time
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error(`timed out waiting for registry pid=${pid}`);
+}
+
+function readSpawnedPid(child: ChildProcessWithoutNullStreams): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    let settled = false;
+    child.stdout.on('data', (chunk) => {
+      if (settled) return;
+      buffer += String(chunk);
+      const newline = buffer.indexOf('\n');
+      if (newline < 0) return;
+      settled = true;
+      const pid = Number(buffer.slice(0, newline));
+      if (Number.isSafeInteger(pid) && pid > 1) {
+        resolve(pid);
+      } else {
+        reject(new Error(`invalid pid line: ${JSON.stringify(buffer.slice(0, newline))}`));
+      }
+    });
+    child.once('exit', (code, signal) => {
+      if (!settled) reject(new Error(`process exited before pid line: code=${code} signal=${signal}`));
+    });
+  });
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return !(
+      err instanceof Error &&
+      'code' in err &&
+      (err as NodeJS.ErrnoException).code === 'ESRCH'
+    );
+  }
+}
+
+async function waitForPidExit(pid: number, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pidIsAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for pid=${pid} to exit`);
 }
 
 describe('runMcpServerCli', () => {
@@ -590,6 +697,40 @@ describe('runMcpServerCli', () => {
     assert.ok(calls.includes('cleanup-session-manager'));
     assert.ok(calls.includes('close-server'));
     assert.ok(calls.includes('exit:0'));
+  });
+
+  test('worker monitor hard-kills a busy-looped orphaned server (#1384)', {
+    skip: process.platform === 'win32'
+      ? 'real orphan/reparent timing is covered on POSIX; Windows orphan detection is unit-tested in pid-registry'
+      : false,
+  }, async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'mcp-busy-orphan-project-'));
+    const gsdHome = mkdtempSync(join(tmpdir(), 'mcp-busy-orphan-home-'));
+    let parent: ChildProcessWithoutNullStreams | undefined;
+    let childPid: number | undefined;
+    const stderrChunks: string[] = [];
+
+    try {
+      parent = spawnBusyLoopingMcpServerParent(projectDir, gsdHome);
+      parent.stderr.on('data', (chunk) => stderrChunks.push(String(chunk)));
+      childPid = await readSpawnedPid(parent);
+
+      const parentExit = await waitForChildExit(parent);
+      assert.equal(
+        parentExit.code,
+        0,
+        `parent should exit after child enters busy loop; stderr=${stderrChunks.join('')}`,
+      );
+
+      await waitForPidExit(childPid, 5_000);
+    } finally {
+      if (childPid && pidIsAlive(childPid)) {
+        try { process.kill(childPid, 'SIGKILL'); } catch {}
+      }
+      if (parent && !parent.killed && parent.exitCode === null) parent.kill('SIGKILL');
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(gsdHome, { recursive: true, force: true });
+    }
   });
 
   test('exits shutdown when server close hangs', async () => {

--- a/packages/mcp-server/src/cli-runner.test.ts
+++ b/packages/mcp-server/src/cli-runner.test.ts
@@ -1,10 +1,10 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn, type ChildProcess, type ChildProcessByStdio, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { PassThrough, Writable } from 'node:stream';
+import { PassThrough, type Readable, Writable } from 'node:stream';
 
 import { runMcpServerCli } from './cli-runner.js';
 
@@ -14,6 +14,8 @@ class ExitError extends Error {
   }
 }
 
+type ChildProcessWithReadableOutput = ChildProcessByStdio<null, Readable, Readable>;
+
 function waitFor<T>(promise: Promise<T>, timeoutMs = 100): Promise<T> {
   return Promise.race([
     promise,
@@ -22,7 +24,7 @@ function waitFor<T>(promise: Promise<T>, timeoutMs = 100): Promise<T> {
 }
 
 function waitForChildExit(
-  child: ChildProcessWithoutNullStreams,
+  child: ChildProcess,
   timeoutMs = 5_000,
 ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
   return new Promise((resolve, reject) => {
@@ -55,7 +57,7 @@ function spawnMcpServer(projectDir: string, gsdHome: string): ChildProcessWithou
   });
 }
 
-function spawnBusyLoopingMcpServerParent(projectDir: string, gsdHome: string): ChildProcessWithoutNullStreams {
+function spawnBusyLoopingMcpServerParent(projectDir: string, gsdHome: string): ChildProcessWithReadableOutput {
   const runnerUrl = new URL('./cli-runner.js', import.meta.url).href;
   const childCode = `
     import { runMcpServerCli } from ${JSON.stringify(runnerUrl)};
@@ -131,7 +133,7 @@ async function waitForRegistryPid(gsdHome: string, pid: number | undefined, time
   throw new Error(`timed out waiting for registry pid=${pid}`);
 }
 
-function readSpawnedPid(child: ChildProcessWithoutNullStreams): Promise<number> {
+function readSpawnedPid(child: ChildProcessWithReadableOutput): Promise<number> {
   return new Promise((resolve, reject) => {
     let buffer = '';
     let settled = false;
@@ -706,7 +708,7 @@ describe('runMcpServerCli', () => {
   }, async () => {
     const projectDir = mkdtempSync(join(tmpdir(), 'mcp-busy-orphan-project-'));
     const gsdHome = mkdtempSync(join(tmpdir(), 'mcp-busy-orphan-home-'));
-    let parent: ChildProcessWithoutNullStreams | undefined;
+    let parent: ChildProcessWithReadableOutput | undefined;
     let childPid: number | undefined;
     const stderrChunks: string[] = [];
 

--- a/packages/mcp-server/src/cli-runner.ts
+++ b/packages/mcp-server/src/cli-runner.ts
@@ -1,4 +1,5 @@
 import type { Readable, Writable } from 'node:stream';
+import { Worker } from 'node:worker_threads';
 
 import { SessionManager } from './session-manager.js';
 import { createMcpServer } from './server.js';
@@ -19,17 +20,57 @@ const STDIN_IDLE_CHECK_INTERVAL_MS = 60 * 1000;
 const CLEANUP_STEP_TIMEOUT_MS = 2 * 1000;
 
 /**
- * Cadence for the ref-held parent-liveness monitor.
+ * Cadence for the worker-thread parent-liveness monitor.
  *
- * Separate from the `.unref()`'d idle watchdog: a process already pegged at
- * ~100% CPU starves its event loop, so the watchdog timer may never fire and a
- * spinning orphan lingers until the next spawn sweeps it. This monitor is
- * ref-held (NOT `.unref()`'d) so the libuv loop keeps scheduling it under load,
- * and it exits the process itself the moment the parent is gone — independent
- * of the external PID-registry sweep that only runs on the next launch. See
- * #783.
+ * Separate from the main-thread idle watchdog: a process pegged at ~100% CPU
+ * can starve the JS event loop, preventing timers and signal handlers from
+ * dispatching. The worker has its own event loop and hard-kills this process
+ * when the parent is gone and stdin has been idle long enough. See #1384.
  */
 const ORPHAN_PARENT_LOSS_CHECK_INTERVAL_MS = 10 * 1000;
+
+const ORPHAN_MONITOR_WORKER_SOURCE = `
+const { parentPort, workerData } = require('node:worker_threads');
+const { writeSync } = require('node:fs');
+
+const lastActivityMs = new BigInt64Array(workerData.lastActivityMsBuffer);
+let stopped = false;
+
+function parentGone() {
+  if (process.ppid !== workerData.initialParentPid) return true;
+  try {
+    process.kill(workerData.initialParentPid, 0);
+    return false;
+  } catch (err) {
+    return err && err.code === 'ESRCH';
+  }
+}
+
+function check() {
+  if (stopped) return;
+  const last = Number(Atomics.load(lastActivityMs, 0));
+  if (Date.now() - last <= workerData.idleTimeoutMs) return;
+  if (!parentGone()) return;
+  try {
+    writeSync(2, '[gsd-mcp-server] Parent process is gone and stdin is idle; hard-killing orphaned server\\n');
+  } catch {}
+  try {
+    process.kill(workerData.targetPid, 'SIGKILL');
+  } catch {
+    process.exit(0);
+  }
+}
+
+const timer = setInterval(check, workerData.checkIntervalMs);
+parentPort?.on('message', (message) => {
+  if (message && message.type === 'stop') {
+    stopped = true;
+    clearInterval(timer);
+    process.exit(0);
+  }
+});
+check();
+`;
 
 interface SessionManagerLike {
   cleanup(): Promise<void>;
@@ -42,6 +83,10 @@ interface McpServerLike {
 
 interface StdioTransportConstructor {
   new(input?: Readable, output?: Writable): unknown;
+}
+
+interface OrphanMonitorHandle {
+  stop(): void;
 }
 
 export interface RunMcpServerCliOptions {
@@ -65,6 +110,9 @@ export interface RunMcpServerCliOptions {
   clearInterval?: typeof clearInterval;
   isOrphaned?: () => boolean;
   cleanupStepTimeoutMs?: number;
+  stdinIdleTimeoutMs?: number;
+  stdinIdleCheckIntervalMs?: number;
+  orphanParentLossCheckIntervalMs?: number;
 }
 
 function createDefaultIsOrphaned(initialParentPid: number): () => boolean {
@@ -76,6 +124,64 @@ function createDefaultIsOrphaned(initialParentPid: number): () => boolean {
     } catch (err) {
       return (err as NodeJS.ErrnoException).code === 'ESRCH';
     }
+  };
+}
+
+function startWorkerOrphanMonitor(options: {
+  initialParentPid: number;
+  targetPid: number;
+  lastActivityMsBuffer: SharedArrayBuffer;
+  idleTimeoutMs: number;
+  checkIntervalMs: number;
+  stderr: Writable;
+}): OrphanMonitorHandle {
+  const worker = new Worker(ORPHAN_MONITOR_WORKER_SOURCE, {
+    eval: true,
+    workerData: {
+      initialParentPid: options.initialParentPid,
+      targetPid: options.targetPid,
+      lastActivityMsBuffer: options.lastActivityMsBuffer,
+      idleTimeoutMs: options.idleTimeoutMs,
+      checkIntervalMs: options.checkIntervalMs,
+    },
+  });
+  worker.unref();
+  worker.on('error', (err) => {
+    options.stderr.write(
+      `[gsd-mcp-server] Orphan monitor failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  });
+  return {
+    stop() {
+      worker.postMessage({ type: 'stop' });
+      void worker.terminate();
+    },
+  };
+}
+
+function startMainThreadOrphanMonitor(options: {
+  startInterval: typeof setInterval;
+  stopInterval: typeof clearInterval;
+  isOrphaned: () => boolean;
+  idleMs: () => number;
+  idleTimeoutMs: number;
+  checkIntervalMs: number;
+  stderr: Writable;
+  cleanup: () => void;
+}): OrphanMonitorHandle {
+  const interval = options.startInterval(() => {
+    if (!options.isOrphaned()) return;
+    if (options.idleMs() <= options.idleTimeoutMs) return;
+    options.stderr.write(
+      `[gsd-mcp-server] Parent process is gone; shutting down to avoid orphan spin\n`,
+    );
+    options.cleanup();
+  }, options.checkIntervalMs);
+
+  return {
+    stop() {
+      options.stopInterval(interval);
+    },
   };
 }
 
@@ -94,8 +200,12 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
   const now = options.now ?? (() => Date.now());
   const startInterval = options.setInterval ?? setInterval;
   const stopInterval = options.clearInterval ?? clearInterval;
-  const isOrphaned = options.isOrphaned ?? createDefaultIsOrphaned(process.ppid);
+  const initialParentPid = process.ppid;
+  const isOrphaned = options.isOrphaned ?? createDefaultIsOrphaned(initialParentPid);
   const cleanupStepTimeoutMs = options.cleanupStepTimeoutMs ?? CLEANUP_STEP_TIMEOUT_MS;
+  const stdinIdleTimeoutMs = options.stdinIdleTimeoutMs ?? STDIN_IDLE_TIMEOUT_MS;
+  const stdinIdleCheckIntervalMs = options.stdinIdleCheckIntervalMs ?? STDIN_IDLE_CHECK_INTERVAL_MS;
+  const orphanParentLossCheckIntervalMs = options.orphanParentLossCheckIntervalMs ?? ORPHAN_PARENT_LOSS_CHECK_INTERVAL_MS;
   const loadEnv = options.loadStoredCredentialEnvKeys ?? loadStoredCredentialEnvKeys;
   const registerInstance = options.registerMcpInstance ?? registerMcpInstance;
   const sweepOrphans = options.sweepProjectOrphanMcpServers ?? sweepProjectOrphanMcpServers;
@@ -114,7 +224,8 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
   let registered = false;
   let cleaningUp = false;
   let idleWatchdog: ReturnType<typeof setInterval> | undefined;
-  let orphanMonitor: ReturnType<typeof setInterval> | undefined;
+  let orphanMonitor: OrphanMonitorHandle | undefined;
+  const lastActivityMs = new BigInt64Array(new SharedArrayBuffer(8));
   let trackedStdin: ActivityTrackingInput | undefined;
   let sessionManager: SessionManagerLike | undefined;
   let server: McpServerLike | undefined;
@@ -140,7 +251,7 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
 
   async function stopRuntime(): Promise<void> {
     if (idleWatchdog) stopInterval(idleWatchdog);
-    if (orphanMonitor) stopInterval(orphanMonitor);
+    orphanMonitor?.stop();
     trackedStdin?.close();
     if (registered) unregisterInstance(projectDir);
     await runCleanupStep('session manager cleanup', () => sessionManager?.cleanup());
@@ -174,37 +285,42 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
     ({ server } = await createServer(sessionManager));
 
     const { StdioServerTransport } = await importTransport();
-    trackedStdin = createActivityTrackingInput(stdin, now);
+    trackedStdin = createActivityTrackingInput(stdin, () => {
+      const current = now();
+      Atomics.store(lastActivityMs, 0, BigInt(Math.trunc(current)));
+      return current;
+    });
     const transport = new StdioServerTransport(trackedStdin.input, stdout);
 
     idleWatchdog = startInterval(() => {
-      if (trackedStdin && now() - trackedStdin.lastActivityAt() > STDIN_IDLE_TIMEOUT_MS && isOrphaned()) {
+      if (trackedStdin && now() - trackedStdin.lastActivityAt() > stdinIdleTimeoutMs && isOrphaned()) {
         stderr.write(
-          `[gsd-mcp-server] Idle stdin watchdog: no activity for ${STDIN_IDLE_TIMEOUT_MS / 1000}s and parent process is gone, shutting down\n`,
+          `[gsd-mcp-server] Idle stdin watchdog: no activity for ${stdinIdleTimeoutMs / 1000}s and parent process is gone, shutting down\n`,
         );
         void cleanup();
       }
-    }, STDIN_IDLE_CHECK_INTERVAL_MS);
+    }, stdinIdleCheckIntervalMs);
     idleWatchdog.unref();
 
-    // Ref-held parent-liveness monitor (#783). The idle watchdog above is
-    // `.unref()`'d, so a process pegged at ~100% CPU (e.g. a repeating throw
-    // against a dead stdio pipe) starves its event loop and the watchdog never
-    // fires — the orphan spins until the next launch sweeps it. This monitor is
-    // NOT unref'd: the loop keeps scheduling it under load, so parent loss is
-    // detected in seconds regardless of CPU state. It still requires the same
-    // idle gate as the watchdog so an active session whose parent briefly
-    // appears gone is not killed (#783 "stays alive when parent is gone but
-    // stdin is still active").
-    orphanMonitor = startInterval(() => {
-      if (!isOrphaned()) return;
-      const idleMs = trackedStdin ? now() - trackedStdin.lastActivityAt() : 0;
-      if (idleMs <= STDIN_IDLE_TIMEOUT_MS) return;
-      stderr.write(
-        `[gsd-mcp-server] Parent process is gone; shutting down to avoid orphan spin\n`,
-      );
-      void cleanup();
-    }, ORPHAN_PARENT_LOSS_CHECK_INTERVAL_MS);
+    orphanMonitor = options.isOrphaned === undefined
+      ? startWorkerOrphanMonitor({
+        initialParentPid,
+        targetPid: process.pid,
+        lastActivityMsBuffer: lastActivityMs.buffer as SharedArrayBuffer,
+        idleTimeoutMs: stdinIdleTimeoutMs,
+        checkIntervalMs: orphanParentLossCheckIntervalMs,
+        stderr,
+      })
+      : startMainThreadOrphanMonitor({
+        startInterval,
+        stopInterval,
+        isOrphaned,
+        idleMs: () => trackedStdin ? now() - trackedStdin.lastActivityAt() : 0,
+        idleTimeoutMs: stdinIdleTimeoutMs,
+        checkIntervalMs: orphanParentLossCheckIntervalMs,
+        stderr,
+        cleanup: () => void cleanup(),
+      });
 
     // Fail closed (ADR-036): warm the executor / write-gate bridges BEFORE
     // connecting the transport. If a bridge is broken we must not advertise the

--- a/packages/mcp-server/src/cli-runner.ts
+++ b/packages/mcp-server/src/cli-runner.ts
@@ -30,8 +30,8 @@ const CLEANUP_STEP_TIMEOUT_MS = 2 * 1000;
 const ORPHAN_PARENT_LOSS_CHECK_INTERVAL_MS = 10 * 1000;
 
 const ORPHAN_MONITOR_WORKER_SOURCE = `
-const { parentPort, workerData } = require('node:worker_threads');
-const { writeSync } = require('node:fs');
+import { writeSync } from 'node:fs';
+import { parentPort, workerData } from 'node:worker_threads';
 
 const lastActivityMs = new BigInt64Array(workerData.lastActivityMsBuffer);
 let stopped = false;


### PR DESCRIPTION
## Summary
- Added a worker-thread MCP orphan monitor with a busy-loop orphan regression and verified it with diff checks plus a dependency-free reaping harness.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1384
- [#1384 [Bug]: Orphaned MCP servers busy-loop at ~100% CPU for hours (SIGTERM-proof) — orphan cleanup from #758/#783 can't fire because the event loop is blocked](https://github.com/open-gsd/gsd-pi/issues/1384)

## User
- @SashaMarchuk

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1384-bug-orphaned-mcp-servers-busy-loop-at-10-1783716564`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process lifecycle and uses SIGKILL from a worker; behavior is gated on parent loss plus stdin idle, with test-only main-thread fallback when `isOrphaned` is mocked.
> 
> **Overview**
> Fixes orphaned MCP servers that **busy-loop at ~100% CPU** and ignore prior main-thread orphan/idle shutdown because the **event loop never runs**.
> 
> **Production path** replaces the ref-held main-thread orphan interval with a **`worker_threads` monitor** that shares stdin last-activity time via **`SharedArrayBuffer` / `Atomics`**. On a separate event loop it periodically checks **parent loss + stdin idle past the timeout**, then **`SIGKILL`s the server PID** instead of calling graceful `cleanup()`.
> 
> Tests keep the **main-thread orphan monitor** when `isOrphaned` is injected. Timeout/check intervals are **configurable** on `runMcpServerCli` for faster tests.
> 
> Adds a **POSIX integration test** that spawns a real child MCP server that enters an infinite loop after connect, drops the parent, and asserts the child process is reaped within a few seconds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 599ac621ca14354337204d494f2ae4a32d2ac397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->