### PR TITLE
fix(issue): GSD 1.9.0: persistent checkbox_db_status_divergence with duplicate bare/suffixed flat-phase projections

### DIFF
--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -95,6 +95,25 @@ function reportCheckboxDbStatusDivergence(
   });
 }
 
+function bareDuplicateMilestoneId(milestoneId: string): string | null {
+  const match = milestoneId.match(/^(M\d{3})-[a-z0-9]{6}$/i);
+  return match?.[1]?.toUpperCase() ?? null;
+}
+
+function checkboxDbStatusMilestoneIds(basePath: string, milestoneIds: string[]): string[] {
+  if (!hasFlatPhaseLayout(basePath)) return milestoneIds;
+
+  // Flat-phase directories are keyed by phase number. A restored
+  // M003-xxxxxx row alongside M003 is a stale duplicate for the same
+  // phases/03-* projection, so checking both can compare DB status against two
+  // competing PLAN files and report a persistent false divergence.
+  const allIds = new Set(milestoneIds.map((id) => id.toUpperCase()));
+  return milestoneIds.filter((milestoneId) => {
+    const bareId = bareDuplicateMilestoneId(milestoneId);
+    return !bareId || !allIds.has(bareId);
+  });
+}
+
 function checkProjectionCheckboxDbStatus(basePath: string, milestoneIds: string[], issues: DoctorIssue[]): void {
   for (const milestoneId of milestoneIds) {
     const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
@@ -807,7 +826,11 @@ export async function checkEngineHealth(
   // block doctor.
   try {
     if (isDbAvailable()) {
-      checkProjectionCheckboxDbStatus(basePath, getAllMilestones().map((milestone) => milestone.id), issues);
+      checkProjectionCheckboxDbStatus(
+        basePath,
+        checkboxDbStatusMilestoneIds(basePath, getAllMilestones().map((milestone) => milestone.id)),
+        issues,
+      );
     }
   } catch {
     // Non-fatal: checkbox-vs-DB divergence check must never block doctor

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -167,6 +167,45 @@ test("checkEngineHealth keeps PLAN checkbox divergence after stale projection fl
   assert.match(readFileSync(plan.planPath, "utf-8"), /- \[ \] \*\*T01\*\*:/);
 });
 
+test("checkEngineHealth ignores stale suffixed flat-phase duplicate when bare milestone exists", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-checkbox-flat-duplicate-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M003", title: "M003-vaz73w: New milestone M003-vaz73w", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M003", title: "Slice", status: "pending", risk: "low", depends: [], sequence: 1 });
+  for (const taskId of ["T01", "T02", "T03"]) {
+    insertTask({ id: taskId, milestoneId: "M003", sliceId: "S01", title: taskId, status: "complete", sequence: Number(taskId.slice(1)) });
+  }
+
+  insertMilestone({ id: "M003-vaz73w", title: "New milestone M003-vaz73w", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M003-vaz73w", title: "Slice", status: "pending", risk: "low", depends: [], sequence: 1 });
+  for (const taskId of ["T01", "T02", "T03"]) {
+    insertTask({ id: taskId, milestoneId: "M003-vaz73w", sliceId: "S01", title: taskId, status: "complete", sequence: Number(taskId.slice(1)) });
+  }
+
+  const canonicalPlan = await renderPlanFromDb(base, "M003", "S01");
+  const staleDir = join(gsdDir, "phases", "03-vaz73w-new-milestone-m003-vaz73w");
+  mkdirSync(staleDir, { recursive: true });
+  writeFileSync(
+    join(staleDir, "03-01-PLAN.md"),
+    canonicalPlan.content.replace("- [x] **T03**:", "- [ ] **T03**:"),
+    "utf-8",
+  );
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  assert.deepEqual(
+    issues.filter((issue) => issue.code === "checkbox_db_status_divergence").map((issue) => issue.unitId),
+    [],
+    "stale suffixed duplicate phase projection must not compete with the bare milestone projection",
+  );
+});
+
 test("checkEngineHealth reads task checkboxes from the <tasks> block, not a stray line above it", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-task-section-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary
- Filtered stale suffixed flat-phase duplicate milestones from doctor checkbox divergence checks and added a regression; syntax and diff checks passed, full test execution was blocked by missing dependencies and registry DNS.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1385
- [#1385 GSD 1.9.0: persistent checkbox_db_status_divergence with duplicate bare/suffixed flat-phase projections](https://github.com/open-gsd/gsd-pi/issues/1385)

## User
- @mik888em

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1385-gsd-1-9-0-persistent-checkbox-db-status--1783716566`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted doctor diagnostic filtering with a regression test; no auth, persistence, or projection write-path changes beyond which milestones are checked.
> 
> **Overview**
> **Doctor** no longer reports persistent false `checkbox_db_status_divergence` when the DB has both a bare milestone (e.g. `M003`) and a suffixed duplicate (`M003-xxxxxx`) that map to the same flat-phase `phases/03-*` projection.
> 
> On flat-phase layouts, `checkEngineHealth` now passes milestone IDs through `checkboxDbStatusMilestoneIds`, which drops suffixed IDs when the matching bare `M###` row is still present, so checkbox-vs-DB checks use one canonical PLAN/ROADMAP instead of two competing files. A regression test covers a stale suffixed phase directory with a wrong checkbox alongside the bare milestone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821673e8124d6523395bd99f406f589af5f3f2c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->