### PR TITLE
fix(issue): fix(artifacts): stale phases/ artifact rows after gsd_plan_milestone - empty .gsd/milestones/ and migrate- backup leak

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -88,6 +88,7 @@ import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.
 import { extractVerdict } from "./verdict-parser.js";
 import { auditOrphanedPreflightStashes } from "./orphan-stash-audit.js";
 import { parseProject } from "./schemas/parsers.js";
+import { LAYOUT_SEGMENTS } from "./layout-policy.js";
 
 import {
   debugLog,
@@ -150,6 +151,33 @@ const MAX_CONSECUTIVE_COMPLETE_BOOTSTRAPS = 2;
 
 export function hasGitIndexLockForTest(basePath: string): boolean {
   return existsSync(join(basePath, ".git", "index.lock"));
+}
+
+function isEmptyDirectory(dirPath: string): boolean {
+  try {
+    return existsSync(dirPath) && readdirSync(dirPath).length === 0;
+  } catch {
+    return false;
+  }
+}
+
+export function reconcileFlatPhaseBootstrapLayout(basePath: string): boolean {
+  const gsdDir = join(basePath, ".gsd");
+  const phasesPath = join(gsdDir, LAYOUT_SEGMENTS.level1);
+  const milestonesPath = join(gsdDir, "milestones");
+
+  if (isEmptyDirectory(milestonesPath)) {
+    if (!existsSync(phasesPath)) mkdirSync(phasesPath, { recursive: true });
+    rmSync(milestonesPath, { recursive: true, force: true });
+    return true;
+  }
+
+  if (!existsSync(phasesPath) && !existsSync(milestonesPath)) {
+    mkdirSync(phasesPath, { recursive: true });
+    return true;
+  }
+
+  return false;
 }
 
 export function _shouldAbortBootstrapForUnavailableDbForTest(
@@ -1152,19 +1180,14 @@ export async function bootstrapAutoSession(
     ensureGitignore(base, { manageGitignore });
     if (manageGitignore !== false) untrackRuntimeFiles(base);
 
-    // Bootstrap milestones/ if it doesn't exist.
-    // Check milestones/ directly — ensureGsdSymlink above already created .gsd/,
-    // so checking .gsd/ existence would be dead code (#2942).
-    const gsdDir = join(base, ".gsd");
-    const milestonesPath = join(gsdDir, "milestones");
-    if (!existsSync(milestonesPath)) {
-      mkdirSync(milestonesPath, { recursive: true });
+    // Bootstrap the flat-phase projection root and clean empty legacy scaffolds.
+    if (reconcileFlatPhaseBootstrapLayout(base)) {
       try {
         nativeAddAll(base);
         nativeCommit(base, "chore: init gsd");
       } catch (err) {
         /* nothing to commit */
-        logWarning("engine", `mkdir failed: ${err instanceof Error ? err.message : String(err)}`);
+        logWarning("engine", `layout bootstrap commit failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 

--- a/src/resources/extensions/gsd/auto-worktree-sync.ts
+++ b/src/resources/extensions/gsd/auto-worktree-sync.ts
@@ -16,7 +16,7 @@ import {
   _isSamePath as isSamePath,
   _shouldReconcileWorktreeDb,
 } from "./auto-worktree-cleanup.js";
-import { resolveGsdPathContract } from "./paths.js";
+import { dirIsContentBearingLegacyMilestone, resolveGsdPathContract } from "./paths.js";
 import type { MilestoneScope } from "./workspace.js";
 import { WorktreeStateProjection } from "./worktree-state-projection.js";
 import { logWarning } from "./workflow-logger.js";
@@ -211,10 +211,17 @@ function syncMilestoneLayout(
   if (!existsSync(mainMilestonesDir)) return;
 
   try {
-    mkdirSync(wtMilestonesDir, { recursive: true });
     const mainMilestones = readdirSync(mainMilestonesDir, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
+      .map((entry) => entry.name)
+      .filter((name) =>
+        layoutSegment !== "milestones" ||
+        dirIsContentBearingLegacyMilestone(join(mainMilestonesDir, name)),
+      );
+
+    if (mainMilestones.length === 0) return;
+
+    mkdirSync(wtMilestonesDir, { recursive: true });
 
     for (const milestoneId of mainMilestones) {
       syncMilestoneDirectory(

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -434,7 +434,9 @@ function staleMilestonesArtifactRowFixable(basePath: string, row: ArtifactRow, a
 
 function stalePhasesArtifactRowFixable(basePath: string, row: ArtifactRow, artifactRows: ArtifactRow[]): boolean {
   const issuePath = artifactPathRelativeToGsd(row.path);
-  return issuePath.startsWith(`${LAYOUT_SEGMENTS.level1}/`) && hasPresentMilestonesReplacement(basePath, row, artifactRows);
+  return issuePath.startsWith(`${LAYOUT_SEGMENTS.level1}/`) &&
+    (hasPresentFlatPhaseReplacement(basePath, row, artifactRows) ||
+      hasPresentMilestonesReplacement(basePath, row, artifactRows));
 }
 
 function staleArtifactRowFixable(basePath: string, row: ArtifactRow, artifactRows: ArtifactRow[]): boolean {

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -155,6 +155,19 @@ function isInsideFlatProjectionBackup(backupDir: string, src: string): boolean {
   return src === phaseBackupDir || src.startsWith(`${phaseBackupDir}/`) || src.startsWith(`${phaseBackupDir}\\`);
 }
 
+function removeFlatProjectionBackup(backupDir: string): void {
+  const phaseBackupDir = join(backupDir, "__phases");
+  if (!existsSync(phaseBackupDir)) return;
+  try {
+    removePathWithRetries(phaseBackupDir);
+  } catch (err) {
+    logWarning(
+      "migration",
+      `flat-phase migration succeeded but could not remove temporary ${LAYOUT_SEGMENTS.level1}/ backup: ${(err as Error).message}`,
+    );
+  }
+}
+
 function restoreFlatProjectionFromBackup(basePath: string, backupDir: string): void {
   const phaseBackupDir = join(backupDir, "__phases");
   if (!existsSync(phaseBackupDir)) return;
@@ -494,4 +507,5 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
       `flat-phase migration succeeded but could not remove ${LEGACY_MIGRATING_SEGMENT}: ${(err as Error).message}`,
     );
   }
+  removeFlatProjectionBackup(backupDir);
 }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -67,6 +67,13 @@ export type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 
 import { TERMINAL_STATUS_SQL } from "./db/sql-constants.js";
 import { applyStatusTransition } from "./db/writers/status.js";
+import {
+  LAYOUT_SEGMENTS,
+  derivePhaseSlug,
+  milestoneIdToPhaseNum,
+  milestoneIdUniqueSuffix,
+  phaseDirName,
+} from "./layout-policy.js";
 
 export function insertDecision(d: Omit<Decision, "seq">): void {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
@@ -206,6 +213,47 @@ export function insertArtifact(a: {
   });
 }
 
+function canonicalPhaseDirNameForDb(milestoneId: string, title: string): string {
+  const phaseNum = milestoneIdToPhaseNum(milestoneId);
+  const slug = derivePhaseSlug(title || milestoneId);
+  const suffix = milestoneIdUniqueSuffix(milestoneId);
+  return phaseDirName(phaseNum, suffix ? `${suffix}-${slug}` : slug);
+}
+
+function reconcileMilestonePhaseArtifactPaths(milestoneId: string, title: string): void {
+  const db = getDbOrNull()!;
+  const phaseNumPrefix = String(milestoneIdToPhaseNum(milestoneId)).padStart(2, "0");
+  const canonicalDir = canonicalPhaseDirNameForDb(milestoneId, title);
+  const staleRows = db.prepare(
+    `SELECT path
+       FROM artifacts
+      WHERE milestone_id = :milestone_id
+        AND path LIKE :phase_prefix`,
+  ).all({
+    ":milestone_id": milestoneId,
+    ":phase_prefix": `${LAYOUT_SEGMENTS.level1}/${phaseNumPrefix}-%/%`,
+  }) as Array<{ path: string }>;
+
+  const updatePath = db.prepare("UPDATE artifacts SET path = :new_path WHERE path = :old_path");
+  const deletePath = db.prepare("DELETE FROM artifacts WHERE path = :path");
+  const existingPath = db.prepare("SELECT 1 AS present FROM artifacts WHERE path = :path");
+
+  for (const row of staleRows) {
+    const parts = row.path.split("/");
+    if (parts.length < 3) continue;
+    if (parts[0] !== LAYOUT_SEGMENTS.level1) continue;
+    if (parts[1] === canonicalDir) continue;
+    if (!parts[1]?.startsWith(`${phaseNumPrefix}-`)) continue;
+
+    const newPath = [LAYOUT_SEGMENTS.level1, canonicalDir, ...parts.slice(2)].join("/");
+    if (existingPath.get({ ":path": newPath })) {
+      deletePath.run({ ":path": row.path });
+      continue;
+    }
+    updatePath.run({ ":new_path": newPath, ":old_path": row.path });
+  }
+}
+
 export interface MilestonePlanningRecord {
   vision: string;
   successCriteria: string[];
@@ -287,39 +335,43 @@ export function insertMilestone(m: {
 
 export function upsertMilestonePlanning(milestoneId: string, planning: Partial<MilestonePlanningRecord> & { title?: string; status?: string; depends_on?: string[] }): void {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  getDbOrNull()!.prepare(
-    `UPDATE milestones SET
-      title = COALESCE(NULLIF(:title, ''), title),
-      status = COALESCE(NULLIF(:status, ''), status),
-      depends_on = COALESCE(:depends_on, depends_on),
-      vision = COALESCE(:vision, vision),
-      success_criteria = COALESCE(:success_criteria, success_criteria),
-      key_risks = COALESCE(:key_risks, key_risks),
-      proof_strategy = COALESCE(:proof_strategy, proof_strategy),
-      verification_contract = COALESCE(:verification_contract, verification_contract),
-      verification_integration = COALESCE(:verification_integration, verification_integration),
-      verification_operational = COALESCE(:verification_operational, verification_operational),
-      verification_uat = COALESCE(:verification_uat, verification_uat),
-      definition_of_done = COALESCE(:definition_of_done, definition_of_done),
-      requirement_coverage = COALESCE(:requirement_coverage, requirement_coverage),
-      boundary_map_markdown = COALESCE(:boundary_map_markdown, boundary_map_markdown)
-     WHERE id = :id`,
-  ).run({
-    ":id": milestoneId,
-    ":title": planning.title ?? "",
-    ":status": planning.status ?? "",
-    ":depends_on": planning.depends_on ? JSON.stringify(planning.depends_on) : null,
-    ":vision": planning.vision ?? null,
-    ":success_criteria": planning.successCriteria ? JSON.stringify(planning.successCriteria) : null,
-    ":key_risks": planning.keyRisks ? JSON.stringify(planning.keyRisks) : null,
-    ":proof_strategy": planning.proofStrategy ? JSON.stringify(planning.proofStrategy) : null,
-    ":verification_contract": planning.verificationContract ?? null,
-    ":verification_integration": planning.verificationIntegration ?? null,
-    ":verification_operational": planning.verificationOperational ?? null,
-    ":verification_uat": planning.verificationUat ?? null,
-    ":definition_of_done": planning.definitionOfDone ? JSON.stringify(planning.definitionOfDone) : null,
-    ":requirement_coverage": planning.requirementCoverage ?? null,
-    ":boundary_map_markdown": planning.boundaryMapMarkdown ?? null,
+  transaction(() => {
+    getDbOrNull()!.prepare(
+      `UPDATE milestones SET
+        title = COALESCE(NULLIF(:title, ''), title),
+        status = COALESCE(NULLIF(:status, ''), status),
+        depends_on = COALESCE(:depends_on, depends_on),
+        vision = COALESCE(:vision, vision),
+        success_criteria = COALESCE(:success_criteria, success_criteria),
+        key_risks = COALESCE(:key_risks, key_risks),
+        proof_strategy = COALESCE(:proof_strategy, proof_strategy),
+        verification_contract = COALESCE(:verification_contract, verification_contract),
+        verification_integration = COALESCE(:verification_integration, verification_integration),
+        verification_operational = COALESCE(:verification_operational, verification_operational),
+        verification_uat = COALESCE(:verification_uat, verification_uat),
+        definition_of_done = COALESCE(:definition_of_done, definition_of_done),
+        requirement_coverage = COALESCE(:requirement_coverage, requirement_coverage),
+        boundary_map_markdown = COALESCE(:boundary_map_markdown, boundary_map_markdown)
+       WHERE id = :id`,
+    ).run({
+      ":id": milestoneId,
+      ":title": planning.title ?? "",
+      ":status": planning.status ?? "",
+      ":depends_on": planning.depends_on ? JSON.stringify(planning.depends_on) : null,
+      ":vision": planning.vision ?? null,
+      ":success_criteria": planning.successCriteria ? JSON.stringify(planning.successCriteria) : null,
+      ":key_risks": planning.keyRisks ? JSON.stringify(planning.keyRisks) : null,
+      ":proof_strategy": planning.proofStrategy ? JSON.stringify(planning.proofStrategy) : null,
+      ":verification_contract": planning.verificationContract ?? null,
+      ":verification_integration": planning.verificationIntegration ?? null,
+      ":verification_operational": planning.verificationOperational ?? null,
+      ":verification_uat": planning.verificationUat ?? null,
+      ":definition_of_done": planning.definitionOfDone ? JSON.stringify(planning.definitionOfDone) : null,
+      ":requirement_coverage": planning.requirementCoverage ?? null,
+      ":boundary_map_markdown": planning.boundaryMapMarkdown ?? null,
+    });
+    const finalTitle = planning.title?.trim();
+    if (finalTitle) reconcileMilestonePhaseArtifactPaths(milestoneId, finalTitle);
   });
 }
 

--- a/src/resources/extensions/gsd/tests/auto-start-index-lock.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-index-lock.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { hasGitIndexLockForTest } from "../auto-start.ts";
+import { hasGitIndexLockForTest, reconcileFlatPhaseBootstrapLayout } from "../auto-start.ts";
 
 test("bootstrapAutoSession detects .git/index.lock without deleting it", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-index-lock-"));
@@ -23,4 +23,24 @@ test("bootstrapAutoSession reports no index lock when the lock file is absent", 
   mkdirSync(join(base, ".git"), { recursive: true });
 
   assert.equal(hasGitIndexLockForTest(base), false);
+});
+
+test("bootstrapAutoSession removes empty legacy milestones dir in flat-phase projects", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-flat-bootstrap-clean-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  mkdirSync(join(base, ".gsd", "phases"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+
+  assert.equal(reconcileFlatPhaseBootstrapLayout(base), true);
+  assert.equal(existsSync(join(base, ".gsd", "phases")), true);
+  assert.equal(existsSync(join(base, ".gsd", "milestones")), false);
+});
+
+test("bootstrapAutoSession creates phases instead of milestones for empty GSD state", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-flat-bootstrap-init-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  assert.equal(reconcileFlatPhaseBootstrapLayout(base), true);
+  assert.equal(existsSync(join(base, ".gsd", "phases")), true);
+  assert.equal(existsSync(join(base, ".gsd", "milestones")), false);
 });

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -428,6 +428,50 @@ test("checkEngineHealth repair prunes stale phases artifact rows with present mi
   assert.deepEqual(rows.map((row) => row.path), []);
 });
 
+test("checkEngineHealth repair prunes stale phases artifact rows with renamed flat-phase files", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-prune-renamed-flat-phase-artifact-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const stalePath = "phases/01-new-milestone-m001/01-01-PLAN.md";
+  const replacementPath = "phases/01-lokably-brand-foundation-and-welcome-pag/01-01-PLAN.md";
+  mkdirSync(join(gsdDir, "phases", "01-lokably-brand-foundation-and-welcome-pag"), { recursive: true });
+  writeFileSync(join(gsdDir, replacementPath), "# Plan\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: stalePath,
+    artifact_type: "PLAN",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# stale plan\n",
+  });
+
+  const beforeIssues: any[] = [];
+  await checkEngineHealth(base, beforeIssues, []);
+
+  const beforeIssue = beforeIssues.find((issue) => issue.code === "artifact_file_missing" && issue.file === stalePath);
+  assert.ok(beforeIssue, "stale renamed phases row should be reported when repair is off");
+  assert.equal(beforeIssue.fixable, true, "renamed phases rows with a flat replacement should be fixable");
+
+  const repairIssues: any[] = [];
+  const fixes: string[] = [];
+  await checkEngineHealth(base, repairIssues, fixes, { repair: true });
+
+  assert.equal(
+    repairIssues.some((issue) => issue.code === "artifact_file_missing" && issue.file === stalePath),
+    false,
+    "repair should not report stale rows it pruned",
+  );
+  assert.ok(fixes.includes(`pruned stale flat-phase artifact row ${stalePath}`));
+
+  const rows = _getAdapter()!
+    .prepare("SELECT path FROM artifacts ORDER BY path")
+    .all() as Array<{ path: string }>;
+  assert.deepEqual(rows.map((row) => row.path), []);
+});
+
 test("checkEngineHealth repair keeps phases rows whose own file is still present", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-keep-present-phase-artifact-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -122,7 +122,7 @@ test("migrateToFlatPhase creates a backup", async () => {
   assert.ok(backups.length >= 1, "at least one migrate-* backup dir should exist");
 });
 
-test("migrateToFlatPhase backs up existing phases projection before clearing it", async () => {
+test("migrateToFlatPhase removes disposable phases snapshot after successful migration", async () => {
   const base = makeTmp();
   const reviewPath = join(base, ".gsd", "phases", "01-foundation", "PLAN-REVIEW.md");
   mkdirSync(join(base, ".gsd", "phases", "01-foundation"), { recursive: true });
@@ -133,11 +133,10 @@ test("migrateToFlatPhase backs up existing phases projection before clearing it"
   const backupRoot = join(base, ".gsd-backups");
   const backups = readdirSync(backupRoot).filter(d => d.startsWith("migrate-"));
   assert.equal(backups.length, 1, "one migrate backup should exist");
-  const backedUpReview = join(backupRoot, backups[0]!, "__phases", "01-foundation", "PLAN-REVIEW.md");
   assert.equal(
-    readFileSync(backedUpReview, "utf-8"),
-    "# Plan Review\n\nHand-authored review.",
-    "pre-existing phases/ files should have a recovery copy",
+    existsSync(join(backupRoot, backups[0]!, "__phases")),
+    false,
+    "temporary phases/ recovery snapshot should be removed after success",
   );
 });
 
@@ -202,7 +201,7 @@ test("failed migration rolls back without leaking a .gsd-backups/migrate-* dir",
   assert.equal(leaked.length, 0, "rollback must delete the migrate-* backup it created");
 });
 
-test("resumed migration stores phases backup in retained migrate snapshot", async () => {
+test("resumed migration removes disposable phases snapshot after success", async () => {
   const base = makeTmp();
   const milestonesPath = join(base, ".gsd", "milestones");
   const migratingPath = join(base, ".gsd", "milestones.migrating");
@@ -218,9 +217,9 @@ test("resumed migration stores phases backup in retained migrate snapshot", asyn
   const backups = readdirSync(backupRoot).filter((d) => d.startsWith("migrate-"));
   assert.equal(backups.length, 1, "resumed migration should create one retained migrate backup");
   assert.equal(
-    readFileSync(join(backupRoot, backups[0]!, "__phases", "01-foundation", "PLAN-REVIEW.md"), "utf-8"),
-    "# Plan Review\n\nResume recovery copy.",
-    "resume should retain the phases snapshot under .gsd-backups",
+    existsSync(join(backupRoot, backups[0]!, "__phases")),
+    false,
+    "temporary phases/ recovery snapshot should be removed after resumed success",
   );
   assert.equal(
     existsSync(join(migratingPath, "__phases")),

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -46,6 +46,9 @@ import {
   tryCreateMemoriesFts,
   _isLikelyWslDrvFsPathForTest,
   _shouldAttemptVacuumRecoveryForTest,
+  insertArtifact,
+  getArtifact,
+  upsertMilestonePlanning,
 } from '../gsd-db.ts';
 import { MigrationBackupError } from '../db-migration-backup.ts';
 import { _resetLogs, peekLogs, setStderrLoggingEnabled } from '../workflow-logger.ts';
@@ -353,6 +356,35 @@ describe('gsd-db', () => {
     const d1 = getDecisionById('D001');
     assert.ok(d1 !== null, 'superseded decision still exists in raw table');
     assert.deepStrictEqual(d1?.superseded_by, 'D002', 'superseded_by is set');
+
+    closeDatabase();
+  });
+
+  test("gsd-db: upsertMilestonePlanning rewrites placeholder phase artifact paths to final title slug", () => {
+    openDatabase(":memory:");
+
+    const stalePath = "phases/01-new-milestone-m001/01-ROADMAP.md";
+    const finalPath = "phases/01-lokably-brand-foundation-and-welcome-pag/01-ROADMAP.md";
+    insertMilestone({ id: "M001", title: "New milestone M001", status: "active" });
+    insertArtifact({
+      path: stalePath,
+      artifact_type: "ROADMAP",
+      milestone_id: "M001",
+      slice_id: null,
+      task_id: null,
+      full_content: "# Placeholder roadmap\n",
+    });
+
+    upsertMilestonePlanning("M001", {
+      title: "Lokably brand foundation and welcome page rebuild",
+    });
+
+    assert.equal(getArtifact(stalePath), null, "placeholder-derived artifact row should be removed");
+    assert.equal(
+      getArtifact(finalPath)?.full_content,
+      "# Placeholder roadmap\n",
+      "artifact row should move to the final title-derived phase path",
+    );
 
     closeDatabase();
   });

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -1428,6 +1428,19 @@ process.exit(result.status ?? 0);
     rmSync(repo, { recursive: true, force: true });
   });
 
+  test('Integration branch: write does not create legacy milestones scaffold', () => {
+    const repo = initBranchTestRepo();
+    mkdirSync(join(repo, ".gsd", "phases"), { recursive: true });
+
+    writeIntegrationBranch(repo, "M001", "f-123-new-thing");
+
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), "f-123-new-thing");
+    assert.ok(existsSync(join(repo, ".gsd", "M001-META.json")), "metadata is written at the flat .gsd root");
+    assert.ok(!existsSync(join(repo, ".gsd", "milestones")), "legacy milestones/ root is not created");
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
   // ─── writeIntegrationBranch: updates when branch changes (#300) ──────
 
   test('Integration branch: updates on branch change', () => {

--- a/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
@@ -117,8 +117,8 @@ test("projectRootToWorktree projects flat-phase discuss artifacts before dispatc
     new WorktreeStateProjection().projectRootToWorktree(scope);
 
     assert.ok(
-      existsSync(join(worktree, ".gsd", "milestones", "M001", "M001-META.json")),
-      "milestone metadata is projected into the worktree",
+      !existsSync(join(worktree, ".gsd", "milestones")),
+      "stale metadata-only legacy milestones/ scaffold is not projected into the worktree",
     );
     assert.ok(
       existsSync(join(worktree, ".gsd", "phases", "01-foundation", "01-CONTEXT.md")),

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -246,6 +246,66 @@ describe('worktree-sync-milestones', async () => {
     }
   }
 
+  // ─── 7b. flat-phase sync skips empty legacy milestones root ───────────
+  console.log('\n=== 7b. flat-phase sync skips empty legacy milestones root ===');
+  {
+    const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-sync-flat-main-'));
+    const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-sync-flat-wt-'));
+
+    try {
+      const phaseDir = join(mainBase, '.gsd', 'phases', '01-foundation');
+      mkdirSync(phaseDir, { recursive: true });
+      mkdirSync(join(mainBase, '.gsd', 'milestones'), { recursive: true });
+      mkdirSync(join(wtBase, '.gsd'), { recursive: true });
+      writeFileSync(join(phaseDir, '01-CONTEXT.md'), '# Foundation\n');
+
+      syncGsdStateToWorktree(mainBase, wtBase);
+
+      assert.ok(
+        existsSync(join(wtBase, '.gsd', 'phases', '01-foundation', '01-CONTEXT.md')),
+        'flat-phase artifact is synced to worktree',
+      );
+      assert.ok(
+        !existsSync(join(wtBase, '.gsd', 'milestones')),
+        'empty legacy milestones/ root is not recreated in worktree',
+      );
+    } finally {
+      rmSync(mainBase, { recursive: true, force: true });
+      rmSync(wtBase, { recursive: true, force: true });
+    }
+  }
+
+  // ─── 7c. flat-phase sync skips metadata-only legacy milestone dirs ────
+  console.log('\n=== 7c. flat-phase sync skips metadata-only legacy milestone dirs ===');
+  {
+    const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-sync-flat-meta-main-'));
+    const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-sync-flat-meta-wt-'));
+
+    try {
+      const phaseDir = join(mainBase, '.gsd', 'phases', '01-foundation');
+      const metaDir = join(mainBase, '.gsd', 'milestones', 'M001');
+      mkdirSync(phaseDir, { recursive: true });
+      mkdirSync(metaDir, { recursive: true });
+      mkdirSync(join(wtBase, '.gsd'), { recursive: true });
+      writeFileSync(join(phaseDir, '01-CONTEXT.md'), '# Foundation\n');
+      writeFileSync(join(metaDir, 'M001-META.json'), '{"integrationBranch":"main"}\n');
+
+      syncGsdStateToWorktree(mainBase, wtBase);
+
+      assert.ok(
+        existsSync(join(wtBase, '.gsd', 'phases', '01-foundation', '01-CONTEXT.md')),
+        'flat-phase artifact is synced to worktree',
+      );
+      assert.ok(
+        !existsSync(join(wtBase, '.gsd', 'milestones')),
+        'metadata-only legacy milestones/ scaffold is not recreated in worktree',
+      );
+    } finally {
+      rmSync(mainBase, { recursive: true, force: true });
+      rmSync(wtBase, { recursive: true, force: true });
+    }
+  }
+
   // ─── 8. syncWorktreeStateBack does not copy task projections ───────────
   console.log('\n=== 8. syncWorktreeStateBack leaves task projections in worktree ===');
   {

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -32,7 +32,7 @@ import {
 import { join } from "node:path";
 
 import { reconcileWorktreeDb } from "./gsd-db.js";
-import { resolveGsdPathContract } from "./paths.js";
+import { dirIsContentBearingLegacyMilestone, resolveGsdPathContract } from "./paths.js";
 import { safeCopy, safeCopyRecursive } from "./safe-fs.js";
 import type { MilestoneScope } from "./workspace.js";
 import { logError, logWarning } from "./workflow-logger.js";
@@ -161,6 +161,7 @@ function syncOtherMilestoneArtifacts(
       // additive safeCopyRecursive; skip it here to avoid redundant work.
       if (milestoneEntry.name === currentMilestoneId) continue;
       const srcMilestoneDir = join(srcMilestonesDir, milestoneEntry.name);
+      if (!dirIsContentBearingLegacyMilestone(srcMilestoneDir)) continue;
       const dstMilestoneDir = join(dstMilestonesDir, milestoneEntry.name);
 
       // Additively project the entire milestone subtree (force:false), not just
@@ -271,35 +272,31 @@ export function _projectRootToWorktreeImpl(
   // Without this, worktree-local files (e.g. VALIDATION.md written
   // by validate-milestone) get clobbered by stale project root copies,
   // causing an infinite re-validation loop (#1886).
-  safeCopyRecursive(
-    join(prGsd, "milestones", milestoneId),
-    join(wtGsd, "milestones", milestoneId),
-    { force: false },
-  );
+  const prMilestoneDir = join(prGsd, "milestones", milestoneId);
+  const wtMilestoneDir = join(wtGsd, "milestones", milestoneId);
+  if (dirIsContentBearingLegacyMilestone(prMilestoneDir)) {
+    safeCopyRecursive(prMilestoneDir, wtMilestoneDir, { force: false });
 
-  // Additively project the full subtree of every OTHER milestone so
-  // worktree-bound units can read prior-milestone context artifacts and so
-  // completed milestones retain their per-slice/per-task SUMMARY.md and
-  // UAT.md on the worktree filesystem (otherwise the stale-render detector
-  // flags them as "complete in DB but missing on disk").
+    // Force-sync ASSESSMENT files that have a verdict from project root (#2821).
+    // The additive-only copy above preserves worktree-local files, but
+    // ASSESSMENT files are special: after run-uat writes a verdict and post-unit
+    // syncs it to the project root, the worktree may retain a stale copy (e.g.
+    // verdict:fail while the project root has verdict:pass from a retry). On
+    // session resume the DB is rebuilt from disk, and if the stale ASSESSMENT
+    // persists, checkNeedsRunUat finds no passing verdict → re-dispatches
+    // run-uat indefinitely (stuck-loop ×9).
+    forceOverwriteValidationWithVerdict(prMilestoneDir, wtMilestoneDir, milestoneId);
+    forceOverwriteAssessmentsWithVerdict(prMilestoneDir, wtMilestoneDir);
+  }
+
+  // Additively project the full subtree of every OTHER content-bearing legacy
+  // milestone so worktree-bound units can read prior-milestone context artifacts
+  // without recreating empty/meta-only milestones/ scaffolds in flat-phase projects.
   syncOtherMilestoneArtifacts(
     join(prGsd, "milestones"),
     join(wtGsd, "milestones"),
     milestoneId,
   );
-
-  // Force-sync ASSESSMENT files that have a verdict from project root (#2821).
-  // The additive-only copy above preserves worktree-local files, but
-  // ASSESSMENT files are special: after run-uat writes a verdict and post-unit
-  // syncs it to the project root, the worktree may retain a stale copy (e.g.
-  // verdict:fail while the project root has verdict:pass from a retry). On
-  // session resume the DB is rebuilt from disk, and if the stale ASSESSMENT
-  // persists, checkNeedsRunUat finds no passing verdict → re-dispatches
-  // run-uat indefinitely (stuck-loop ×9).
-  const prMilestoneDir = join(prGsd, "milestones", milestoneId);
-  const wtMilestoneDir = join(wtGsd, "milestones", milestoneId);
-  forceOverwriteValidationWithVerdict(prMilestoneDir, wtMilestoneDir, milestoneId);
-  forceOverwriteAssessmentsWithVerdict(prMilestoneDir, wtMilestoneDir);
 
   // Forward-sync completed-units.json from project root to worktree.
   // Project root is authoritative for completion state after crash recovery;


### PR DESCRIPTION
## Summary
- Fixed stale flat-phase artifact paths, doctor repair detection, empty legacy layout scaffolding, and migration snapshot cleanup with focused regression tests.

## Bugs Addressed
- [x] **Artifact paths keep placeholder milestone slug**
- [x] **Doctor cannot fix stale renamed phases artifact rows**
- [x] **Flat-phase projects recreate empty milestones folders**
- [x] **Flat-phase migration keeps disposable __phases backups**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1383
- [#1383 fix(artifacts): stale phases/ artifact rows after gsd_plan_milestone - empty .gsd/milestones/ and migrate- backup leak](https://github.com/open-gsd/gsd-pi/issues/1383)

## User
- @klajdo-f

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1383-fix-artifacts-stale-phases-artifact-rows-1783716575`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect on-disk layout bootstrap, SQLite artifact paths, doctor repair, migration backups, and worktree projection—areas that can desync DB rows from files if edge cases are missed, but no auth or external data handling.
> 
> **Overview**
> Aligns flat-phase projects with **`phases/`** as the bootstrap projection root: auto-start now runs **`reconcileFlatPhaseBootstrapLayout`** to create `phases/`, drop an empty legacy **`milestones/`** folder, and init-commit when layout changes—instead of always scaffolding **`milestones/`**.
> 
> When milestone planning updates a real title, **`upsertMilestonePlanning`** rewrites stale **`phases/01-new-milestone-*`** artifact rows in the DB to the canonical title-derived phase directory (merge or delete on collision).
> 
> **Doctor** repair treats stale **`phases/`** DB paths as fixable when a matching flat-phase file exists on disk (not only legacy **`milestones/`** replacements). **Flat-phase migration** deletes the temporary **`__phases`** snapshot under migrate backups after success so **`migrate-*`** dirs do not keep leaking recovery copies.
> 
> **Worktree sync/projection** only copies legacy **`milestones/<id>`** trees that **`dirIsContentBearingLegacyMilestone`** considers real content—skipping empty roots and metadata-only scaffolds so worktrees are not repopulated with stale **`milestones/`** in flat-phase layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9fb1cf6c6d59b5ed7780650a3f271f9c1060ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->