### PR TITLE
fix(pi-coding-agent): exclude legacy gsd-core skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 - **gsd**: add task rework briefs
 
 ### Fixed
+- **skills**: omit legacy gsd-core v1 skills without hiding unrelated installed skills
 - **gsd**: only persist rework resolutions that satisfy the evidence gate
 - **gsd**: keep rework blocking gate intact on save and rollback
 - **gsd**: serialize write-gate snapshot read-merge-write across processes

--- a/docs/dev/what-is-pi/09-the-customization-stack.md
+++ b/docs/dev/what-is-pi/09-the-customization-stack.md
@@ -53,6 +53,11 @@ On-demand capability packages following the [Agent Skills standard](https://agen
 - `~/.agents/skills/` (global ecosystem)
 - `~/.claude/skills/` and `.claude/skills/` (Claude Code compatibility, lower precedence)
 
+The loader omits legacy `gsd-*` skills owned by the separate
+`@opengsd/gsd-core` runtime, whether discovered in a package checkout, a copied
+installer layout, or through a symlink. Other skills colocated with that runtime
+and independently authored `gsd-*` skills remain in the catalog.
+
 **Preference reference resolution** (bare skill names in `PREFERENCES.md`) scans
 `~/.gsd/agent/skills/` before ecosystem directories so bundled GSD skills win
 when resolving preference refs — even though a project-local skill with the same

--- a/docs/user-docs/skills.md
+++ b/docs/user-docs/skills.md
@@ -20,6 +20,12 @@ Earlier entries take precedence when names collide. Bundled GSD skills win over 
 
 > **Bundled vs user skills:** GSD bundled skills are managed in `~/.gsd/agent/skills/`. Install your own shared skills into `~/.agents/skills/`, or commit project-specific skills under `.agents/skills/`.
 
+GSD omits legacy `gsd-*` skills supplied by the separate
+`@opengsd/gsd-core` v1 runtime. This applies to package checkouts and copied
+installer layouts, including skills reached through symlinks. Unrelated skills
+in the same location and independently authored `gsd-*` skills remain
+available.
+
 The managed `gsd-browser` skill is package-owned: on startup GSD installs it
 from the installed `@opengsd/gsd-browser` package, including referenced support
 files under `docs/`, `scripts/`, and `gsd-browser-skill/`. GSD refreshes stale

--- a/docs/zh-CN/user-docs/skills.md
+++ b/docs/zh-CN/user-docs/skills.md
@@ -20,6 +20,10 @@ GSD 会按优先级顺序从这些位置读取技能：
 
 > **内置技能与用户技能：** GSD 内置技能由 `~/.gsd/agent/skills/` 管理。你自己的共享技能应安装到 `~/.agents/skills/`，项目专用技能应提交到 `.agents/skills/`。
 
+GSD 会忽略由独立的 `@opengsd/gsd-core` v1 运行时提供的旧版 `gsd-*`
+技能。无论技能来自包检出目录、安装程序复制的布局，还是通过符号链接访问，
+此规则都适用。同一位置中的无关技能以及独立创作的 `gsd-*` 技能仍然可用。
+
 托管的 `gsd-browser` 技能由包提供：GSD 启动时会从已安装的
 `@opengsd/gsd-browser` 包安装它，并带上 `docs/`、`scripts/` 和
 `gsd-browser-skill/` 下被引用的辅助文件。GSD 会刷新

--- a/packages/pi-coding-agent/docs/skills.md
+++ b/packages/pi-coding-agent/docs/skills.md
@@ -37,6 +37,7 @@ Discovery rules:
 - In `~/.pi/agent/skills/` and `.pi/skills/`, direct root `.md` files are discovered as individual skills
 - In all skill locations, directories containing `SKILL.md` are discovered recursively
 - In `~/.agents/skills/` and project `.agents/skills/`, root `.md` files are ignored
+- Legacy `gsd-*` skills from the separate `@opengsd/gsd-core` runtime are omitted. Pi recognizes both package checkouts and copied installer layouts, follows symlinks, and retains unrelated skills from the same location. Independently authored `gsd-*` skills still load.
 
 Disable discovery with `--no-skills` (explicit `--skill` paths still load).
 

--- a/packages/pi-coding-agent/src/core/skills.ts
+++ b/packages/pi-coding-agent/src/core/skills.ts
@@ -452,6 +452,11 @@ export interface LoadSkillsOptions {
  * (`resourcePrecedenceRank`): settings-entry before auto-discovered, project
  * before user, and bundled GSD before foreign (Claude / `~/.agents`) skills, so
  * bundled auto-mode skills win over same-named foreign skills.
+ *
+ * Legacy `gsd-*` skills owned by an `@opengsd/gsd-core` package checkout or
+ * listed in a gsd-core installer manifest are omitted, including through
+ * symlinks. Other skills in those roots and independently authored `gsd-*`
+ * skills remain eligible for loading.
  */
 export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 	const { agentDir, skillPaths, includeDefaults } = options;

--- a/packages/pi-coding-agent/src/core/skills.ts
+++ b/packages/pi-coding-agent/src/core/skills.ts
@@ -14,11 +14,64 @@ const MAX_NAME_LENGTH = 64;
 const MAX_DESCRIPTION_LENGTH = 1024;
 
 const IGNORE_FILE_NAMES = [".gitignore", ".ignore", ".fdignore"];
+const GSD_CORE_PACKAGE_NAME = "@opengsd/gsd-core";
+const GSD_CORE_MANIFEST_NAME = "gsd-file-manifest.json";
 
 type IgnoreMatcher = ReturnType<typeof ignore>;
+type GsdCoreRoot = "package" | Set<string> | null;
 
 function toPosixPath(p: string): string {
 	return p.split(sep).join("/");
+}
+
+function getGsdCoreRoot(root: string, cache: Map<string, GsdCoreRoot>): GsdCoreRoot {
+	if (cache.has(root)) {
+		return cache.get(root) ?? null;
+	}
+
+	try {
+		const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf-8")) as { name?: string };
+		if (packageJson.name === GSD_CORE_PACKAGE_NAME) {
+			cache.set(root, "package");
+			return "package";
+		}
+	} catch {}
+
+	try {
+		const manifest = JSON.parse(readFileSync(join(root, GSD_CORE_MANIFEST_NAME), "utf-8")) as {
+			files?: Record<string, unknown>;
+		};
+		const files = new Set(Object.keys(manifest.files ?? {}).map(toPosixPath));
+		cache.set(root, files);
+		return files;
+	} catch {
+		cache.set(root, null);
+		return null;
+	}
+}
+
+function isGsdCoreSkill(skill: Skill, rootCache: Map<string, GsdCoreRoot>): boolean {
+	if (!skill.name.startsWith("gsd-")) {
+		return false;
+	}
+
+	for (const filePath of new Set([skill.filePath, canonicalizePath(skill.filePath)])) {
+		const skillsDir = dirname(dirname(filePath));
+		if (basename(skillsDir) !== "skills") {
+			continue;
+		}
+
+		const root = dirname(skillsDir);
+		const gsdCoreRoot = getGsdCoreRoot(root, rootCache);
+		if (gsdCoreRoot === "package") {
+			return true;
+		}
+		if (gsdCoreRoot?.has(toPosixPath(relative(root, filePath)))) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 function prefixIgnorePattern(line: string, prefix: string): string | null {
@@ -411,10 +464,15 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 	const realPathSet = new Set<string>();
 	const allDiagnostics: ResourceDiagnostic[] = [];
 	const collisionDiagnostics: ResourceDiagnostic[] = [];
+	const gsdCoreRootCache = new Map<string, GsdCoreRoot>();
 
 	function addSkills(result: LoadSkillsResult) {
 		allDiagnostics.push(...result.diagnostics);
 		for (const skill of result.skills) {
+			if (isGsdCoreSkill(skill, gsdCoreRootCache)) {
+				continue;
+			}
+
 			// Resolve symlinks to detect duplicate files
 			const realPath = canonicalizePath(skill.filePath);
 

--- a/packages/pi-coding-agent/test/skills.test.ts
+++ b/packages/pi-coding-agent/test/skills.test.ts
@@ -1,4 +1,5 @@
-import { homedir } from "os";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
 import { join, resolve } from "path";
 import { describe, expect, it } from "vitest";
 import type { ResourceDiagnostic } from "../src/core/diagnostics.ts";
@@ -387,6 +388,59 @@ describe("skills", () => {
 				includeDefaults: true,
 			});
 			expect(withTilde.length).toBe(withoutTilde.length);
+		});
+
+		it("should omit gsd-core skills while retaining other installed skills", () => {
+			const tempRoot = mkdtempSync(join(tmpdir(), "gsd-core-skills-"));
+			const gsdCorePackageRoot = join(tempRoot, "gsd-core-package");
+			const gsdCoreInstallRoot = join(tempRoot, "gsd-core-install");
+			const otherInstallRoot = join(tempRoot, "other-install");
+
+			try {
+				mkdirSync(join(gsdCorePackageRoot, "skills", "gsd-plan-phase"), { recursive: true });
+				mkdirSync(join(gsdCorePackageRoot, "skills", "unrelated-skill"), { recursive: true });
+				writeFileSync(
+					join(gsdCorePackageRoot, "package.json"),
+					JSON.stringify({ name: "@opengsd/gsd-core" }),
+				);
+				mkdirSync(join(gsdCoreInstallRoot, "skills", "gsd-review"), { recursive: true });
+				writeFileSync(
+					join(gsdCoreInstallRoot, "gsd-file-manifest.json"),
+					JSON.stringify({ files: { "skills/gsd-review/SKILL.md": "checksum" } }),
+				);
+				mkdirSync(join(otherInstallRoot, "skills", "gsd-custom"), { recursive: true });
+				writeFileSync(
+					join(gsdCorePackageRoot, "skills", "gsd-plan-phase", "SKILL.md"),
+					"---\nname: gsd-plan-phase\ndescription: GSD Core plan skill.\n---\n",
+				);
+				writeFileSync(
+					join(gsdCorePackageRoot, "skills", "unrelated-skill", "SKILL.md"),
+					"---\nname: unrelated-skill\ndescription: Unrelated installed skill.\n---\n",
+				);
+				writeFileSync(
+					join(gsdCoreInstallRoot, "skills", "gsd-review", "SKILL.md"),
+					"---\nname: gsd-review\ndescription: Installed GSD Core review skill.\n---\n",
+				);
+				writeFileSync(
+					join(otherInstallRoot, "skills", "gsd-custom", "SKILL.md"),
+					"---\nname: gsd-custom\ndescription: Non-gsd-core skill.\n---\n",
+				);
+
+				const { skills } = loadSkills({
+					agentDir: emptyAgentDir,
+					cwd: emptyCwd,
+					skillPaths: [
+						join(gsdCorePackageRoot, "skills"),
+						join(gsdCoreInstallRoot, "skills"),
+						join(otherInstallRoot, "skills"),
+					],
+					includeDefaults: false,
+				});
+
+				expect(skills.map((skill) => skill.name).sort()).toEqual(["gsd-custom", "unrelated-skill"]);
+			} finally {
+				rmSync(tempRoot, { recursive: true, force: true });
+			}
 		});
 	});
 

--- a/packages/pi-coding-agent/test/skills.test.ts
+++ b/packages/pi-coding-agent/test/skills.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join, resolve } from "path";
 import { describe, expect, it } from "vitest";
@@ -438,6 +438,44 @@ describe("skills", () => {
 				});
 
 				expect(skills.map((skill) => skill.name).sort()).toEqual(["gsd-custom", "unrelated-skill"]);
+			} finally {
+				rmSync(tempRoot, { recursive: true, force: true });
+			}
+		});
+
+		it("should omit symlinked gsd-core skills while retaining unrelated symlinked skills", () => {
+			const tempRoot = mkdtempSync(join(tmpdir(), "gsd-core-symlinked-skills-"));
+			const gsdCoreRoot = join(tempRoot, "gsd-core");
+			const otherRoot = join(tempRoot, "other");
+			const linkedSkillsRoot = join(tempRoot, "linked-skills");
+			const directoryLinkType = process.platform === "win32" ? "junction" : "dir";
+
+			try {
+				const gsdCoreSkill = join(gsdCoreRoot, "skills", "gsd-plan-phase");
+				const otherSkill = join(otherRoot, "skills", "gsd-custom");
+				mkdirSync(gsdCoreSkill, { recursive: true });
+				mkdirSync(otherSkill, { recursive: true });
+				mkdirSync(linkedSkillsRoot);
+				writeFileSync(join(gsdCoreRoot, "package.json"), JSON.stringify({ name: "@opengsd/gsd-core" }));
+				writeFileSync(
+					join(gsdCoreSkill, "SKILL.md"),
+					"---\nname: gsd-plan-phase\ndescription: Symlinked GSD Core skill.\n---\n",
+				);
+				writeFileSync(
+					join(otherSkill, "SKILL.md"),
+					"---\nname: gsd-custom\ndescription: Unrelated symlinked skill.\n---\n",
+				);
+				symlinkSync(gsdCoreSkill, join(linkedSkillsRoot, "gsd-plan-phase"), directoryLinkType);
+				symlinkSync(otherSkill, join(linkedSkillsRoot, "gsd-custom"), directoryLinkType);
+
+				const { skills } = loadSkills({
+					agentDir: emptyAgentDir,
+					cwd: emptyCwd,
+					skillPaths: [linkedSkillsRoot],
+					includeDefaults: false,
+				});
+
+				expect(skills.map((skill) => skill.name)).toEqual(["gsd-custom"]);
 			} finally {
 				rmSync(tempRoot, { recursive: true, force: true });
 			}

--- a/scripts/verify-pi-boundary.cjs
+++ b/scripts/verify-pi-boundary.cjs
@@ -40,6 +40,7 @@ const ALLOWLIST = new Set([
   join(ROOT, 'packages/pi-coding-agent/src/core/model-resolver.ts'),
   join(ROOT, 'packages/pi-coding-agent/src/core/package-commands.ts'),
   join(ROOT, 'packages/pi-coding-agent/src/core/skill-tool.test.ts'),
+  join(ROOT, 'packages/pi-coding-agent/src/core/skills.ts'),
   join(ROOT, 'packages/pi-coding-agent/src/tests/system-prompt-skill-filter.test.ts'),
   join(ROOT, 'packages/pi-coding-agent/src/tests/system-prompt-file-safety.test.ts'),
   join(ROOT, 'packages/pi-coding-agent/src/tests/system-prompt-cache-stability.test.ts'),


### PR DESCRIPTION
## Intent

Prevent gsd-pi from loading installed gsd-* skills that originate from the separate gsd-core v1 runtime at ~/github/open-gsd/gsd-core or from a gsd-core installer manifest. Preserve unrelated skills, including independently authored gsd-* skills and non-gsd skills colocated with gsd-core. Recognize both package checkouts and copied installer layouts, and follow symlinks without hardcoding the user's home path. Add focused executable regression coverage and publish the focused fix as a PR.

## What Changed

- Exclude legacy `gsd-*` skills discovered from `@opengsd/gsd-core` package checkouts or installer manifests, including symlinked paths.
- Preserve unrelated colocated skills and independently authored `gsd-*` skills.
- Add regression coverage and document the updated discovery behavior across user and developer guides.

## Risk Assessment

✅ Low: The change is narrowly scoped, matches the gsd-core package and installer-manifest layouts, preserves unrelated skills, and includes focused direct and symlink regression coverage.

## Testing

Preflight confirmed the clean target was not merged; focused regressions and the complete skill-loader test file passed, and a corrected mixed-layout end-to-end harness demonstrated the exact visible slash-command and prompt inventory. Transcript evidence was captured; no screenshot was appropriate because this is non-visual skill-discovery behavior.

<details>
<summary>Evidence: End-to-end skill discovery transcript</summary>

```text
GSD Pi skill discovery end-to-end evidence
==========================================
Fixture: gsd-core package checkout + copied manifest install + symlink discovery
Visible slash commands: skill:gsd-custom, skill:gsd-local-addon, skill:release-notes, skill:team-notes
Excluded core skills: gsd-plan-phase, gsd-review
Preserved skills: gsd-custom, gsd-local-addon, release-notes, team-notes
Checks:
{
  "loadedExactlyExpected": true,
  "excludedCoreSkillsAbsent": true,
  "preservedSkillsPresent": true,
  "promptExcludesCoreSkills": true,
  "promptPreservesExpectedSkills": true,
  "diagnostics": 0
}
Rendered <available_skills> inventory:
The following skills provide specialized instructions for specific tasks.
Use the read tool to load a skill's file when the task matches its description.
When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.

<available_skills>
  <skill>
    <name>team-notes</name>
    <description>non-gsd skill colocated with core</description>
    <location>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-skill-discovery-e2e-VnWtVy/package-checkout/skills/team-notes/SKILL.md</location>
  </skill>
  <skill>
    <name>gsd-local-addon</name>
    <description>independent gsd skill colocated with copied core</description>
    <location>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-skill-discovery-e2e-VnWtVy/copied-install/skills/gsd-local-addon/SKILL.md</location>
  </skill>
  <skill>
    <name>release-notes</name>
    <description>non-gsd copied skill</description>
    <location>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-skill-discovery-e2e-VnWtVy/copied-install/skills/release-notes/SKILL.md</location>
  </skill>
  <skill>
    <name>gsd-custom</name>
    <description>independently authored gsd skill</description>
    <location>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-skill-discovery-e2e-VnWtVy/discovered-links/gsd-custom/SKILL.md</location>
  </skill>
</available_skills>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `packages/pi-coding-agent/test/skills.test.ts:393` - The regression test covers package and manifest layouts only through direct paths, so it does not verify the required symlink behavior implemented via canonical path comparison. Add a focused case loading a symlinked gsd-core skill while retaining an unrelated symlinked `gsd-*` skill.

🔧 Fix: Cover symlinked gsd-core skill exclusion
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git merge-base --is-ancestor c6e492e553f97226f880be0f47d57fb200b1f0a8 origin/main`
- `git diff --find-renames --find-copies 97ef11e37fa413aa4a71e94f4426cfa3b9d9efa8..c6e492e553f97226f880be0f47d57fb200b1f0a8 --`
- `pnpm exec vitest run packages/pi-coding-agent/test/skills.test.ts -t "should omit gsd-core skills while retaining other installed skills|should omit symlinked gsd-core skills while retaining unrelated symlinked skills"`
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --input-type=module --eval &lt;mixed-layout loadSkills and formatSkillsForPrompt evidence harness&gt;`; retried after correcting a fixture-only `ENOENT` setup error</code>
- `pnpm exec vitest run packages/pi-coding-agent/test/skills.test.ts`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow discovery filter with manifest/package heuristics, preserved unrelated skills, and focused unit tests; no auth or data-path changes.
> 
> **Overview**
> **Skill loading** now drops legacy `gsd-*` skills that come from the separate `@opengsd/gsd-core` v1 runtime. Detection uses an `@opengsd/gsd-core` package checkout (`package.json`) or a copied installer tree (`gsd-file-manifest.json`), resolves paths through symlinks, and only filters `gsd-*` names under a `skills/` parent—unrelated colocated skills and independently authored `gsd-*` skills still load.
> 
> User, developer, and Pi skill docs describe this behavior. **Regression tests** cover direct package/manifest layouts and symlinked discovery. **CHANGELOG** records the fix; `skills.ts` is on the Pi boundary allowlist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32a5eedb2a8ed1bfb3ce6f08404ac17973aa0127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->