### PR TITLE
fix(gsd): read doctor checkboxes from canonical worktree

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       '@opengsd/engine-linux-x64-gnu':
         specifier: 1.10.0
         version: 1.10.0
+      '@opengsd/engine-win32-x64-msvc':
+        specifier: 1.10.0
+        version: 1.10.0
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -1970,6 +1973,11 @@ packages:
     resolution: {integrity: sha512-r9va2E6nMGPpMap7ImY5fiDd30I3CowGowz4FHVwu2AoYw5qTEqrMUUhh5aZNkMxPUq0l/e80JCkJLup7bJCmQ==}
     cpu: [x64]
     os: [linux]
+
+  '@opengsd/engine-win32-x64-msvc@1.10.0':
+    resolution: {integrity: sha512-Fs/ZijN6ezFlcZRwJhZ1Y/NbcSnxxhNsyi3G7N/oRx67GoKtSVfQJsPl09wKOCa31G8IiLXUoiEBcl0Q05vAEQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@opengsd/gsd-browser@0.2.2':
     resolution: {integrity: sha512-ld4TOZKcXJF3v0KVlUqrOfHC+rYG8l00Dw0GkEuHtQTIYq7+blYO2acnGHN+P2Owod0xlq/2k1UQDaYgrRSKgw==}
@@ -7636,6 +7644,9 @@ snapshots:
     optional: true
 
   '@opengsd/engine-linux-x64-gnu@1.10.0':
+    optional: true
+
+  '@opengsd/engine-win32-x64-msvc@1.10.0':
     optional: true
 
   '@opengsd/gsd-browser@0.2.2': {}

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -32,6 +32,7 @@ import { parseRoadmapSlices } from "./roadmap-slices.js";
 import { parsePlan } from "./parsers-legacy.js";
 import { parseSummary } from "./files.js";
 import { LAYOUT_SEGMENTS } from "./layout-policy.js";
+import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 
 const USER_AUTHORED_ARTIFACT_TYPES = new Set(["CONTEXT", "RESEARCH"]);
 
@@ -116,7 +117,8 @@ function checkboxDbStatusMilestoneIds(basePath: string, milestoneIds: string[]):
 
 function checkProjectionCheckboxDbStatus(basePath: string, milestoneIds: string[], issues: DoctorIssue[]): void {
   for (const milestoneId of milestoneIds) {
-    const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+    const artifactBasePath = resolveCanonicalMilestoneRoot(basePath, milestoneId);
+    const roadmapPath = resolveMilestoneFile(artifactBasePath, milestoneId, "ROADMAP");
     const slices = getMilestoneSlices(milestoneId);
 
     if (roadmapPath && existsSync(roadmapPath)) {
@@ -142,7 +144,7 @@ function checkProjectionCheckboxDbStatus(basePath: string, milestoneIds: string[
     }
 
     for (const slice of slices) {
-      const planPath = resolveSliceFile(basePath, milestoneId, slice.id, "PLAN");
+      const planPath = resolveSliceFile(artifactBasePath, milestoneId, slice.id, "PLAN");
       if (!planPath || !existsSync(planPath)) continue;
       try {
         const plan = readFileSync(planPath, "utf-8");

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -206,6 +206,38 @@ test("checkEngineHealth ignores stale suffixed flat-phase duplicate when bare mi
   );
 });
 
+test("checkEngineHealth reads task checkboxes from the canonical milestone worktree", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-checkbox-worktree-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M003", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M003", title: "Slice", status: "pending", risk: "low", depends: [], sequence: 1 });
+  insertTask({ id: "T03", milestoneId: "M003", sliceId: "S01", title: "Task", status: "complete", sequence: 1 });
+
+  const plan = await renderPlanFromDb(base, "M003", "S01");
+  const checkedPlan = readFileSync(plan.planPath, "utf-8");
+  writeFileSync(plan.planPath, checkedPlan.replace("- [x] **T03**:", "- [ ] **T03**:"), "utf-8");
+
+  const worktree = join(base, ".gsd-worktrees", "M003");
+  const worktreePlan = join(worktree, ".gsd", "phases", "03-milestone", "03-01-PLAN.md");
+  mkdirSync(join(worktree, ".gsd", "phases", "03-milestone"), { recursive: true });
+  writeFileSync(join(worktree, ".git"), `gitdir: ${join(base, ".git", "worktrees", "M003")}\n`);
+  writeFileSync(worktreePlan, checkedPlan, "utf-8");
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  assert.deepEqual(
+    issues.filter((issue) => issue.code === "checkbox_db_status_divergence").map((issue) => issue.unitId),
+    [],
+    "the stale project-root PLAN must not compete with the live milestone worktree projection",
+  );
+});
+
 test("checkEngineHealth reads task checkboxes from the <tasks> block, not a stray line above it", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-task-section-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## TL;DR

**What:** Make doctor checkbox-vs-DB diagnostics read each milestone's canonical live worktree projection.
**Why:** A stale project-root PLAN can otherwise produce a false `checkbox_db_status_divergence` after work completes in a registered milestone worktree.
**How:** Resolve the canonical milestone root before reading ROADMAP and PLAN projections, with a regression covering stale root vs checked worktree files.

## What

- Route checkbox diagnostic ROADMAP and PLAN reads through `resolveCanonicalMilestoneRoot`.
- Preserve the shared project DB, all other doctor checks and repair behavior, and PR #1392's duplicate-ID filtering.
- Add an executable regression for an unchecked project-root PLAN and checked registered-worktree PLAN.

## Why

Doctor previously resolved checkbox projections from the launch root even when the active milestone's authoritative projection lived in a registered worktree. That compared complete DB state with stale markdown and reported a blocking false positive.

Closes #1397

## How

The checkbox-vs-DB diagnostic resolves one `artifactBasePath` per milestone using the existing canonical-root contract, then uses it for both milestone ROADMAP and slice PLAN lookup. Reporting remains rooted at the project path, and no persistence or projection-write paths change.

## Verification

- RED: the new regression reported `M003/S01/T03` on the pre-fix behavior.
- GREEN: focused regression passed after the fix.
- Sabotage: temporarily restoring project-root resolution made the regression fail again.
- `pnpm run test:changed:src` — 28/28 passed.
- Full doctor sweep in the no-mistakes gate — 98 tests, 96 passed and 2 Windows-only tests skipped.
- `pnpm run typecheck:extensions` — passed.
- no-mistakes review, documentation, and lint gates — passed.

## Impact analysis

- Blast radius: moderate but tightly bounded to checkbox diagnostic artifact reads across the project/worktree boundary.
- Affected workflow: `/gsd doctor` checkbox-vs-DB validation for milestones with live registered worktrees.
- Compatibility: no DB schema, public API, CLI syntax, repair, or write-path changes.

## Change type

- [ ] feat — New feature or capability
- [x] fix — Bug fix
- [ ] refactor — Code restructuring (no behavior change)
- [x] test — Adding or updating tests
- [ ] docs — Documentation only
- [ ] chore — Build, CI, or tooling changes

## Notes

AI-assisted contribution; implementation and verification were reviewed against the issue, repository contracts, and executable tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to doctor checkbox-vs-DB read paths only; no schema, repair, or projection-write behavior changes. Risk is limited to milestones with registered worktrees where diagnostics may now read different files.
> 
> **Overview**
> Fixes false **`checkbox_db_status_divergence`** errors when `/gsd doctor` compared DB state to **stale ROADMAP/PLAN markdown at the project launch root** while the live milestone projection lived in a **registered worktree**.
> 
> **`checkProjectionCheckboxDbStatus`** now resolves **`artifactBasePath`** per milestone via **`resolveCanonicalMilestoneRoot`** (same contract as closeout/artifact verification) and uses it for milestone ROADMAP and slice PLAN reads; issue reporting still uses the project **`basePath`**.
> 
> Adds a regression test: unchecked PLAN at the project root and a checked PLAN in **`.gsd-worktrees/M003`** must not report drift when the DB marks the task complete.
> 
> **`pnpm-lock.yaml`** also records optional **`@opengsd/engine-win32-x64-msvc@1.10.0`** (tooling dependency, not doctor logic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f5ced5a31c3b435867d9d48dfe1111d04d9ec14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->