### PR TITLE
fix(issue): auto-verification.js writes VERIFY.json to legacy tasks/ subdir in flat-phase projects

### DIFF
--- a/docs/dev/ADR-003-pipeline-simplification.md
+++ b/docs/dev/ADR-003-pipeline-simplification.md
@@ -221,14 +221,14 @@ For the same 4-slice, 3-task milestone:
 
 **New:** The system mechanically aggregates verification results from all tasks and slices. The canonical verification data sources are:
 
-1. **`T##-VERIFY.json`** files (written by `writeVerificationJSON()` in `verification-evidence.ts`) — machine-readable per-task verification results with command, exit code, verdict, duration, and blocking status.
+1. **Task verification JSON** files (written by `writeVerificationJSON()` in `verification-evidence.ts`) — machine-readable per-task verification results with command, exit code, verdict, duration, and blocking status. Flat-phase projects write `S##-T##-VERIFY.json` at the phase root; legacy milestone/slice layouts keep `T##-VERIFY.json` under `slices/S##/tasks/`.
 2. **`S##-UAT-RESULT.md`** files (when `uat_dispatch` is enabled) — human or artifact-driven UAT outcomes.
 3. **Task summary frontmatter** `verification_result` field — a human-readable pass/fail string (not structured, used as a secondary signal).
 
-The aggregator reads `T##-VERIFY.json` as the primary source of truth, supplements with UAT-RESULT artifacts, and produces a deterministic VALIDATION.md.
+The aggregator reads task verification JSON as the primary source of truth, supplements with UAT-RESULT artifacts, and produces a deterministic VALIDATION.md.
 
 **What changes:**
-- A new `aggregateMilestoneVerification()` function collects `T##-VERIFY.json` files and `S##-UAT-RESULT.md` files across all slices.
+- A new `aggregateMilestoneVerification()` function collects flat-phase `S##-T##-VERIFY.json` files, legacy `T##-VERIFY.json` files, and `S##-UAT-RESULT.md` files across all slices.
 - The function produces a VALIDATION.md with per-task and per-slice pass/fail status, UAT evidence, and an overall verdict.
 - The LLM-driven validate-milestone session is removed from the default pipeline.
 - The validate-milestone template is retained for explicit dispatch (users who want LLM-driven validation can run `/gsd dispatch validate`).
@@ -241,16 +241,13 @@ async function aggregateMilestoneVerification(base: string, mid: string): Promis
   const uatResults: { sliceId: string; content: string }[] = [];
 
   for (const slice of roadmap.slices) {
-    // Primary source: T##-VERIFY.json files (machine-readable, written by verification-gate.ts)
-    const tDir = resolveTasksDir(base, mid, slice.id);
-    if (tDir) {
-      const verifyFiles = resolveTaskFiles(tDir, "VERIFY");
-      for (const file of verifyFiles) {
-        const content = await loadFile(join(tDir, file));
-        if (content) {
-          const evidence: EvidenceJSON = JSON.parse(content);
-          checks.push(...evidence.checks);
-        }
+    // Primary source: task verification JSON (machine-readable, written by verification-gate.ts)
+    const verifyFiles = resolveVerificationEvidenceFiles(base, mid, slice.id);
+    for (const file of verifyFiles) {
+      const content = await loadFile(file);
+      if (content) {
+        const evidence: EvidenceJSON = JSON.parse(content);
+        checks.push(...evidence.checks);
       }
     }
 
@@ -272,7 +269,7 @@ async function aggregateMilestoneVerification(base: string, mid: string): Promis
 
 **Token savings:** 1 session × 12–37K tokens. This session is one of the most context-heavy — it inlines the ROADMAP + all slice summaries + all UAT results.
 
-**Quality impact:** Positive. Mechanical verification is deterministic and complete. LLM validation is subjective and can miss things. The verification gate and UAT system already do the hard work — the validate session was a redundant re-check. The `T##-VERIFY.json` artifacts are the canonical machine-readable source, not task summary frontmatter.
+**Quality impact:** Positive. Mechanical verification is deterministic and complete. LLM validation is subjective and can miss things. The verification gate and UAT system already do the hard work — the validate session was a redundant re-check. The task verification JSON artifacts are the canonical machine-readable source, not task summary frontmatter.
 
 #### 6. Replace complete-milestone with mechanical completion
 
@@ -476,7 +473,7 @@ async function mechanicalSliceCompletion(base: string, mid: string, sid: string)
 
 #### Mechanical milestone validation
 
-See `aggregateMilestoneVerification()` above (Section 5). Reads `T##-VERIFY.json` and `S##-UAT-RESULT.md` as canonical sources.
+See `aggregateMilestoneVerification()` above (Section 5). Reads task verification JSON (`S##-T##-VERIFY.json` at flat phase roots, `T##-VERIFY.json` under legacy `tasks/`) and `S##-UAT-RESULT.md` as canonical sources.
 
 #### Mechanical milestone summary
 
@@ -547,7 +544,7 @@ At current Opus pricing ($15/MTok input, $75/MTok output — as of March 2026), 
 | `auto-prompts.ts` — plan-milestone exploration | ~30 | Research instructions merged in |
 | `auto-prompts.ts` — plan-slice reassessment + exploration | ~25 | Reassessment + exploration preamble |
 | `auto-post-unit.ts` — `mechanicalSliceCompletion()` | ~80 | Structured frontmatter aggregation, UAT generation, artifact writes |
-| `auto-verification.ts` — `aggregateMilestoneVerification()` | ~60 | T##-VERIFY.json + UAT-RESULT aggregation |
+| `auto-verification.ts` — `aggregateMilestoneVerification()` | ~60 | Task verification JSON + UAT-RESULT aggregation |
 | `auto-unit-closeout.ts` — `generateMilestoneSummary()` | ~60 | Mechanical summary generation |
 | **Total added** | **~255** | |
 
@@ -694,7 +691,7 @@ The mechanical summary quality might be insufficient for complex slices.
 13. Implement `mechanicalRequirementsUpdate()` and `appendNewDecisions()`
 
 ### Phase 3: Mechanical milestone validation + completion
-14. Implement `aggregateMilestoneVerification()` reading `T##-VERIFY.json` and `S##-UAT-RESULT.md`
+14. Implement `aggregateMilestoneVerification()` reading task verification JSON and `S##-UAT-RESULT.md`
 15. Implement `generateMilestoneSummary()` from slice summary aggregation
 16. Wire into post-unit processing: after last slice completion, run mechanical validation + summary
 17. Make reassess-roadmap opt-in via `reassess_after_slice` preference (default: false)
@@ -723,14 +720,14 @@ The mechanical summary quality might be insufficient for complex slices.
 3. ✅ Token savings double-counting (eliminated sessions + re-ingestion) — **fixed**: removed overlap, noted savings are not additive
 4. ✅ Context inlining change (file paths vs inline) underanalyzed — **fixed**: expanded to dedicated risk section with enforcement strategy, phased rollout, and interaction with budget engine
 5. ✅ Budget engine interaction not discussed — **fixed**: addressed in context inlining section
-6. ✅ `aggregateMilestoneVerification()` reads wrong data source — **fixed**: now reads `T##-VERIFY.json` as primary source, supplemented by `S##-UAT-RESULT.md`
+6. ✅ `aggregateMilestoneVerification()` reads wrong data source — **fixed**: now reads task verification JSON as primary source, supplemented by `S##-UAT-RESULT.md`
 7. ✅ Phase ordering creates heavy intermediate state (Phase 1 without Phase 4) — **fixed**: Phase 1 now includes targeted inlining reduction for planning sessions
 8. ✅ ADR number conflict — **fixed**: confirmed no ADR-003 exists in `docs/` (the referenced file doesn't exist in current git)
 
 **OpenAI Codex** identified 6 issues:
 1. ✅ HIGH: Folding completion into execute-task breaks verification-retry model — **fixed**: moved completion to post-gate mechanical processing instead of executor prompt. Added Alternative D explaining why.
-2. ✅ HIGH: Mechanical validation reads nonexistent `verification_evidence` frontmatter — **fixed**: now reads `T##-VERIFY.json` (canonical machine-readable source from `verification-evidence.ts`)
-3. ✅ HIGH: Replacement validation drops UAT evidence — **fixed**: aggregator now reads both `T##-VERIFY.json` and `S##-UAT-RESULT.md`
+2. ✅ HIGH: Mechanical validation reads nonexistent `verification_evidence` frontmatter — **fixed**: now reads task verification JSON (canonical machine-readable source from `verification-evidence.ts`)
+3. ✅ HIGH: Replacement validation drops UAT evidence — **fixed**: aggregator now reads both task verification JSON and `S##-UAT-RESULT.md`
 4. ✅ HIGH: "State derivation stays unchanged" is false — **fixed**: explicitly documented that `deriveState()` phases are preserved, mechanical processing resolves them synchronously, fallback dispatch rules handle failures
 5. ✅ MEDIUM: Folded completion omits REQUIREMENTS.md and KNOWLEDGE.md updates — **fixed**: mechanical completion handles REQUIREMENTS.md and DECISIONS.md; KNOWLEDGE.md addressed in Risk 5
 6. ✅ MEDIUM: Session and token math inconsistent — **fixed**: complete rederivation with per-slice breakdown, corrected to 30 baseline sessions, noted profile variations

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -15,7 +15,7 @@
 
 import type { ExtensionContext, ExtensionAPI } from "@gsd/pi-coding-agent";
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { gsdProjectionRoot, relMilestoneFile, resolveSliceFile, resolveSlicePath } from "./paths.js";
+import { gsdProjectionRoot, legacyMilestonesDir, relMilestoneFile, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "./paths.js";
 import { resolveMilestoneValidationVerdict } from "./milestone-validation-verdict.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { parseUnitId } from "./unit-id.js";
@@ -61,6 +61,30 @@ export interface VerificationContext {
 
 export type VerificationResult = "continue" | "retry" | "pause";
 type PauseAutoFn = (ctx?: ExtensionContext, pi?: ExtensionAPI, errorContext?: ErrorContext) => Promise<void>;
+
+interface VerificationEvidenceLocation {
+  dir: string;
+  fileSliceId?: string;
+}
+
+function resolveVerificationEvidenceLocation(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+): VerificationEvidenceLocation | null {
+  const mDir = resolveMilestonePath(basePath, milestoneId);
+  if (!mDir) return null;
+
+  const legacyBase = legacyMilestonesDir(basePath);
+  const isLegacy = mDir.startsWith(legacyBase + "/") || mDir.startsWith(legacyBase + "\\");
+  if (!isLegacy) {
+    return { dir: mDir, fileSliceId: sliceId };
+  }
+
+  const sDir = resolveSlicePath(basePath, milestoneId, sliceId);
+  if (!sDir) return null;
+  return { dir: join(sDir, "tasks") };
+}
 
 function getCurrentUnitCostStats(unitId: string): { unitCostUsd: number; rollingAvgUsd: number } {
   const ledger = getLedger();
@@ -551,11 +575,18 @@ export async function runPostUnitVerification(
     const taskAlreadyComplete = taskRow?.status === "complete" || taskRow?.status === "done";
     if (mid && sid && tid) {
       try {
-        const sDir = resolveSlicePath(s.basePath, mid, sid);
-        if (sDir) {
-          const tasksDir = join(sDir, "tasks");
+        const evidenceLocation = resolveVerificationEvidenceLocation(s.basePath, mid, sid);
+        if (evidenceLocation) {
           if (result.passed) {
-            writeVerificationJSON(result, tasksDir, tid, s.currentUnit.id);
+            writeVerificationJSON(
+              result,
+              evidenceLocation.dir,
+              tid,
+              s.currentUnit.id,
+              undefined,
+              undefined,
+              evidenceLocation.fileSliceId,
+            );
           } else {
             const nextAttempt = attempt + 1;
             const includeRetryMetadata =
@@ -566,11 +597,12 @@ export async function runPostUnitVerification(
               nextAttempt <= maxRetries;
             writeVerificationJSON(
               result,
-              tasksDir,
+              evidenceLocation.dir,
               tid,
               s.currentUnit.id,
               includeRetryMetadata ? nextAttempt : undefined,
               includeRetryMetadata ? maxRetries : undefined,
+              evidenceLocation.fileSliceId,
             );
           }
         }
@@ -718,9 +750,8 @@ export async function runPostUnitVerification(
     // Re-write verification evidence JSON with post-execution checks
     if (postExecChecks && postExecChecks.length > 0 && mid && sid && tid) {
       try {
-        const sDir = resolveSlicePath(s.basePath, mid, sid);
-        if (sDir) {
-          const tasksDir = join(sDir, "tasks");
+        const evidenceLocation = resolveVerificationEvidenceLocation(s.basePath, mid, sid);
+        if (evidenceLocation) {
           // Add postExecutionChecks to the result for the JSON write
           const resultWithPostExec = {
             ...result,
@@ -730,12 +761,13 @@ export async function runPostUnitVerification(
           // Manually write with postExecutionChecks field
           writeVerificationJSONWithPostExec(
             resultWithPostExec,
-            tasksDir,
+            evidenceLocation.dir,
             tid,
             s.currentUnit.id,
             postExecChecks,
             postExecBlockingFailure ? attempt + 1 : undefined,
-            postExecBlockingFailure ? maxRetries : undefined
+            postExecBlockingFailure ? maxRetries : undefined,
+            evidenceLocation.fileSliceId,
           );
         }
       } catch (evidenceErr) {
@@ -940,6 +972,7 @@ function writeVerificationJSONWithPostExec(
   postExecutionChecks: PostExecutionCheckJSON[],
   retryAttempt?: number,
   maxRetries?: number,
+  sliceId?: string,
 ): void {
   mkdirSync(tasksDir, { recursive: true });
 
@@ -980,6 +1013,7 @@ function writeVerificationJSONWithPostExec(
     }));
   }
 
-  const filePath = join(tasksDir, `${taskId}-VERIFY.json`);
+  const fileName = sliceId ? `${sliceId}-${taskId}-VERIFY.json` : `${taskId}-VERIFY.json`;
+  const filePath = join(tasksDir, fileName);
   writeFileSync(filePath, JSON.stringify(evidence, null, 2) + "\n", "utf-8");
 }

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -11,7 +11,7 @@
 import { describe, test, mock, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
-import { mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import { runPostUnitVerification, type VerificationContext } from "../auto-verification.ts";
@@ -111,6 +111,15 @@ ${yamlLines.join("\n")}
   writeFileSync(join(tempDir, ".gsd", "PREFERENCES.md"), prefsContent);
   invalidateAllCaches();
   _clearGsdRootCache();
+}
+
+function useFlatPhaseLayout(): string {
+  rmSync(join(tempDir, ".gsd", "milestones"), { recursive: true, force: true });
+  const phaseDir = join(tempDir, ".gsd", "phases", "01-m001");
+  mkdirSync(phaseDir, { recursive: true });
+  invalidateAllCaches();
+  _clearGsdRootCache();
+  return phaseDir;
 }
 
 /**
@@ -459,6 +468,34 @@ describe("Post-execution blocking failure retry bypass", () => {
         "Post-execution checks failed: [import] src/broken.ts:1"
       )
     );
+  });
+
+  test("flat-phase post-unit evidence writes slice-task VERIFY.json at phase level", async () => {
+    const phaseDir = useFlatPhaseLayout();
+    createPostExecFailureTask();
+    writePreferences({
+      enhanced_verification: true,
+      enhanced_verification_post: true,
+      verification_auto_fix: true,
+      verification_max_retries: 3,
+    });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+
+    const result = await runPostUnitVerification({ s, ctx, pi }, pauseAutoMock);
+
+    assert.equal(result, "pause");
+    const evidencePath = join(phaseDir, "S01-T01-VERIFY.json");
+    const legacyEvidencePath = join(phaseDir, "tasks", "T01-VERIFY.json");
+    assert.ok(existsSync(evidencePath), "flat-phase evidence should be written at phase level");
+    assert.equal(existsSync(legacyEvidencePath), false, "flat-phase evidence should not create legacy tasks/ path");
+
+    const evidence = JSON.parse(readFileSync(evidencePath, "utf-8"));
+    assert.equal(evidence.passed, false);
+    assert.ok(Array.isArray(evidence.postExecutionChecks), "post-execution checks should be included in rewritten evidence");
   });
 
   test("strict post-exec warning pause includes warning details", async () => {

--- a/src/resources/extensions/gsd/tests/verification-evidence.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-evidence.test.ts
@@ -99,6 +99,18 @@ test("verification-evidence: writeVerificationJSON creates directory if it doesn
   }
 });
 
+test("verification-evidence: writeVerificationJSON can write flat-phase slice-task filename", () => {
+  const tmp = makeTempDir("ve-flat-name");
+  try {
+    writeVerificationJSON(makeResult(), tmp, "T02", "M001/S03/T02", undefined, undefined, "S03");
+
+    assert.ok(existsSync(join(tmp, "S03-T02-VERIFY.json")), "flat-phase JSON file should exist");
+    assert.equal(existsSync(join(tmp, "T02-VERIFY.json")), false, "legacy JSON file should not be written");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("verification-evidence: writeVerificationJSON maps exitCode to verdict correctly", () => {
   const tmp = makeTempDir("ve-verdict");
   try {

--- a/src/resources/extensions/gsd/verification-evidence.ts
+++ b/src/resources/extensions/gsd/verification-evidence.ts
@@ -98,8 +98,9 @@ export interface EvidenceJSON {
 }
 
 /**
- * Write a T##-VERIFY.json artifact to the tasks directory.
+ * Write a T##-VERIFY.json artifact to the evidence directory.
  * Creates the directory with mkdirSync({ recursive: true }) if it doesn't exist.
+ * Flat-phase callers can pass sliceId to write S##-T##-VERIFY.json.
  *
  * stdout/stderr are excluded from the JSON — the full output lives in VerificationResult
  * in memory and is logged to stderr during the gate run.
@@ -111,6 +112,7 @@ export function writeVerificationJSON(
   unitId?: string,
   retryAttempt?: number,
   maxRetries?: number,
+  sliceId?: string,
 ): void {
   mkdirSync(tasksDir, { recursive: true });
 
@@ -150,7 +152,8 @@ export function writeVerificationJSON(
     }));
   }
 
-  const filePath = join(tasksDir, `${taskId}-VERIFY.json`);
+  const fileName = sliceId ? `${sliceId}-${taskId}-VERIFY.json` : `${taskId}-VERIFY.json`;
+  const filePath = join(tasksDir, fileName);
   writeFileSync(filePath, JSON.stringify(evidence, null, 2) + "\n", "utf-8");
 }
 


### PR DESCRIPTION
## Summary
- Fixed flat-phase VERIFY.json path and filename handling, with focused evidence tests passing and broader post-unit verification blocked by missing workspace dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1402
- [#1402 auto-verification.js writes VERIFY.json to legacy tasks/ subdir in flat-phase projects](https://github.com/open-gsd/gsd-pi/issues/1402)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1402-auto-verification-js-writes-verify-json--1783778896`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized path/filename logic in verification evidence writes with tests; legacy milestone layout behavior is unchanged.
> 
> **Overview**
> Post-unit verification evidence was always written under legacy `slices/.../tasks/T##-VERIFY.json`, which broke **flat-phase** layouts that expect `S##-T##-VERIFY.json` at the phase root.
> 
> **`resolveVerificationEvidenceLocation`** in `auto-verification.ts` picks the evidence directory from milestone layout (flat phase dir vs legacy `tasks/`) and passes **`sliceId`** into the writers so flat phases get the correct filename.
> 
> **`writeVerificationJSON`** (and the post-exec variant) accept optional **`sliceId`** and emit `S##-T##-VERIFY.json` when set; legacy callers still get `T##-VERIFY.json`.
> 
> Tests cover flat-phase naming and an integration path through `runPostUnitVerification`; **ADR-003** docs are updated so mechanical milestone validation references both flat and legacy verification JSON paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb1c455f25d5d3dae470ac33efadfa876d614d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->