### PR TITLE
fix(issue): planning_subagents should support user-defined planning agents

### DIFF
--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -115,14 +115,18 @@ Enable deep mode with `/gsd new-project --deep`, `/gsd new-milestone --deep`, or
 Project-local allowlists for controlled read-only subagent dispatch during planning:
 
 ```yaml
+planning_subagent_registry:
+  my-custom-planner:
+    read_only_specialist: true
+
 planning_subagents:
   plan-milestone:
-    allowed: [scout, planner, security]
+    allowed: [scout, planner, my-custom-planner, security]
   plan-slice:
-    allowed: [scout, planner, reviewer, security]
+    allowed: [scout, planner, my-custom-planner, reviewer, security]
 ```
 
-Only `plan-milestone` and `plan-slice` are configurable. Agents must be GSD-classified read-only planning specialists (`mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`). The write gate still blocks unsafe or unlisted agents.
+Only `plan-milestone` and `plan-slice` are configurable. Agents must be built-in read-only planning specialists (`mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`) or registered in `planning_subagent_registry` with `read_only_specialist: true`. The write gate still blocks unsafe or unlisted agents.
 
 ### `budget_ceiling`
 

--- a/mintlify-docs/guides/configuration.mdx
+++ b/mintlify-docs/guides/configuration.mdx
@@ -245,14 +245,18 @@ pre_dispatch_hooks:
 ### Planning subagents
 
 ```yaml
+planning_subagent_registry:
+  my-custom-planner:
+    read_only_specialist: true
+
 planning_subagents:
   plan-milestone:
-    allowed: [scout, planner, security]
+    allowed: [scout, planner, my-custom-planner, security]
   plan-slice:
-    allowed: [scout, planner, reviewer, security]
+    allowed: [scout, planner, my-custom-planner, reviewer, security]
 ```
 
-Only `plan-milestone` and `plan-slice` are configurable. Agents must be GSD-classified read-only planning specialists (`mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`); the write gate still blocks unsafe or unlisted agents.
+Only `plan-milestone` and `plan-slice` are configurable. Agents must be built-in read-only planning specialists (`mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`) or registered in `planning_subagent_registry` with `read_only_specialist: true`; the write gate still blocks unsafe or unlisted agents.
 
 ### Skill routing
 

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -7,7 +7,7 @@ import { minimatch } from "minimatch";
 import { GSD_PHASE_SCOPE_DISPLAY_REASON, shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.js";
 import { canonicalToolName } from "../engine-hook-contract.js";
 import { loadJsonFileOrNull } from "../json-persistence.js";
-import { getIsolationMode } from "../preferences.js";
+import { getIsolationMode, loadEffectiveGSDPreferences } from "../preferences.js";
 import { compileSubagentPermissionContract, type ToolsPolicy } from "../unit-context-manifest.js";
 import {
   allowedPlanningDispatchAgentsList,
@@ -1354,6 +1354,7 @@ export function shouldBlockPlanningUnit(
       const dispatchContract = compileSubagentPermissionContract(policy);
       const allowedSubagents = dispatchContract.allowedSubagents;
       const allowed = new Set(allowedSubagents);
+      const planningSubagentRegistry = loadEffectiveGSDPreferences(basePath)?.preferences.planning_subagent_registry;
       // When agentClasses is undefined, the caller has not been updated to extract
       // agent identities yet. Block and warn so stale callers surface in telemetry
       // instead of silently bypassing the gate.
@@ -1371,12 +1372,12 @@ export function shouldBlockPlanningUnit(
       if (requested.length === 0) {
         return { block: false };
       }
-      const globallyDisallowed = requested.find(a => !isReadOnlyPlanningDispatchAgent(a));
+      const globallyDisallowed = requested.find(a => !isReadOnlyPlanningDispatchAgent(a, planningSubagentRegistry));
       if (globallyDisallowed) {
         return planningBlock(
           unitType,
           policy.mode,
-          `subagent dispatch of "${globallyDisallowed}" not permitted; only read-only specialists (${allowedPlanningDispatchAgentsList()}) may be dispatched from ${policy.mode} units`,
+          `subagent dispatch of "${globallyDisallowed}" not permitted; only read-only specialists (${allowedPlanningDispatchAgentsList(planningSubagentRegistry)}) may be dispatched from ${policy.mode} units`,
         );
       }
       const disallowedByPolicy = requested.find(a => !allowed.has(a));

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -357,24 +357,33 @@ In `"parent"` mode, slice/task `targetRepositories` default to the declared chil
   - `"replace"` requires `prompt`.
   - `"skip"` is valid with no additional fields.
 
+- `planning_subagent_registry`: object — optional classification for custom planning agents. Each key is an agent id and must set:
+  - `read_only_specialist`: boolean — set to `true` to classify the custom agent as safe for planning dispatch.
+
 - `planning_subagents`: object — project-local widening for read-only planning subagent dispatch. Supported unit keys are `plan-milestone` and `plan-slice`; each has:
   - `allowed`: string[] — additional planning-safe agents for that unit.
 
-  Agents must already be classified by GSD as read-only planning specialists: `mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`. The write gate still blocks source writes outside `.gsd/**`, unrestricted bash, stale subagent calls without agent identities, agents outside the global read-only registry, and agents not listed for the active unit.
+  Agents must be built-in read-only planning specialists (`mnemo`, `scout`, `planner`, `reviewer`, `security`, or `tester`) or registered in `planning_subagent_registry` with `read_only_specialist: true`. The write gate still blocks source writes outside `.gsd/**`, unrestricted bash, stale subagent calls without agent identities, agents outside the read-only registry, and agents not listed for the active unit.
 
   Example:
 
   ```yaml
+  planning_subagent_registry:
+    my-custom-planner:
+      read_only_specialist: true
+
   planning_subagents:
     plan-milestone:
       allowed:
         - scout
         - planner
+        - my-custom-planner
         - security
     plan-slice:
       allowed:
         - scout
         - planner
+        - my-custom-planner
         - reviewer
         - security
   ```

--- a/src/resources/extensions/gsd/planning-subagent-registry.ts
+++ b/src/resources/extensions/gsd/planning-subagent-registry.ts
@@ -6,6 +6,8 @@
  * preference validation before any configured planning allowlist takes effect.
  */
 
+import type { PlanningSubagentRegistryConfig } from "./preferences-types.js";
+
 const PLANNING_DISPATCH_AGENT_REGISTRY = {
   mnemo: { readOnlySpecialist: true },
   scout: { readOnlySpecialist: true },
@@ -21,11 +23,23 @@ export const ALLOWED_PLANNING_DISPATCH_AGENTS = new Set<string>(
     .map(([agentId]) => agentId),
 );
 
-export function isReadOnlyPlanningDispatchAgent(agentId: string): boolean {
-  const metadata = PLANNING_DISPATCH_AGENT_REGISTRY[agentId as keyof typeof PLANNING_DISPATCH_AGENT_REGISTRY];
-  return metadata?.readOnlySpecialist === true;
+function configuredPlanningDispatchAgents(registry?: PlanningSubagentRegistryConfig): string[] {
+  return Object.entries(registry ?? {})
+    .filter(([, metadata]) => metadata.read_only_specialist === true)
+    .map(([agentId]) => agentId);
 }
 
-export function allowedPlanningDispatchAgentsList(): string {
-  return [...ALLOWED_PLANNING_DISPATCH_AGENTS].join(", ");
+export function isReadOnlyPlanningDispatchAgent(
+  agentId: string,
+  registry?: PlanningSubagentRegistryConfig,
+): boolean {
+  const metadata = PLANNING_DISPATCH_AGENT_REGISTRY[agentId as keyof typeof PLANNING_DISPATCH_AGENT_REGISTRY];
+  return metadata?.readOnlySpecialist === true || registry?.[agentId]?.read_only_specialist === true;
+}
+
+export function allowedPlanningDispatchAgentsList(registry?: PlanningSubagentRegistryConfig): string {
+  return Array.from(new Set([
+    ...ALLOWED_PLANNING_DISPATCH_AGENTS,
+    ...configuredPlanningDispatchAgents(registry),
+  ])).join(", ");
 }

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -141,6 +141,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "git",
   "post_unit_hooks",
   "pre_dispatch_hooks",
+  "planning_subagent_registry",
   "planning_subagents",
   "dynamic_routing",
   "disabled_model_providers",
@@ -231,6 +232,12 @@ export interface PlanningSubagentUnitConfig {
 export type PlanningSubagentsConfig = Partial<
   Record<ConfigurablePlanningSubagentUnit, PlanningSubagentUnitConfig>
 >;
+
+export interface PlanningSubagentRegistryEntry {
+  read_only_specialist?: boolean;
+}
+
+export type PlanningSubagentRegistryConfig = Record<string, PlanningSubagentRegistryEntry>;
 
 
 export const SKILL_ACTIONS = new Set(["use", "prefer", "avoid"]);
@@ -491,6 +498,7 @@ export interface GSDPreferences {
   git?: GitPreferences;
   post_unit_hooks?: PostUnitHookConfig[];
   pre_dispatch_hooks?: PreDispatchHookConfig[];
+  planning_subagent_registry?: PlanningSubagentRegistryConfig;
   planning_subagents?: PlanningSubagentsConfig;
   dynamic_routing?: DynamicRoutingConfig;
   /** Provider IDs to exclude from /model and automatic model routing while leaving tool auth intact. */

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -28,8 +28,8 @@ import {
   type GSDThinkingLevel,
 } from "./preferences-types.js";
 import {
-  ALLOWED_PLANNING_DISPATCH_AGENTS,
   allowedPlanningDispatchAgentsList,
+  isReadOnlyPlanningDispatchAgent,
 } from "./planning-subagent-registry.js";
 
 const VALID_TOKEN_PROFILES = new Set<TokenProfile>(["budget", "balanced", "quality", "burn-max"]);
@@ -752,6 +752,46 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  // ─── Planning Subagent Registry ──────────────────────────────────────────
+  if (preferences.planning_subagent_registry !== undefined) {
+    if (
+      !preferences.planning_subagent_registry ||
+      typeof preferences.planning_subagent_registry !== "object" ||
+      Array.isArray(preferences.planning_subagent_registry)
+    ) {
+      errors.push("planning_subagent_registry must be an object keyed by agent id");
+    } else {
+      const validRegistry: NonNullable<GSDPreferences["planning_subagent_registry"]> = {};
+
+      for (const [rawAgentId, rawConfig] of Object.entries(preferences.planning_subagent_registry as Record<string, unknown>)) {
+        const agentId = rawAgentId.trim();
+        if (!agentId) {
+          errors.push("planning_subagent_registry includes an empty agent id");
+          continue;
+        }
+        if (!rawConfig || typeof rawConfig !== "object" || Array.isArray(rawConfig)) {
+          errors.push(`planning_subagent_registry.${agentId} must be an object with read_only_specialist: true`);
+          continue;
+        }
+
+        const readOnlySpecialist = (rawConfig as Record<string, unknown>).read_only_specialist;
+        if (readOnlySpecialist !== true) {
+          errors.push(
+            `planning_subagent_registry.${agentId}.read_only_specialist must be true to classify ` +
+            `"${agentId}" as a read-only planning specialist`,
+          );
+          continue;
+        }
+
+        validRegistry[agentId] = { read_only_specialist: true };
+      }
+
+      if (Object.keys(validRegistry).length > 0) {
+        validated.planning_subagent_registry = validRegistry;
+      }
+    }
+  }
+
   // ─── Planning Subagents ─────────────────────────────────────────────────
   if (preferences.planning_subagents !== undefined) {
     if (
@@ -785,10 +825,12 @@ export function validatePreferences(preferences: GSDPreferences): {
 
         const sanitizedAllowed: string[] = [];
         for (const agentId of allowed) {
-          if (!ALLOWED_PLANNING_DISPATCH_AGENTS.has(agentId)) {
+          if (!isReadOnlyPlanningDispatchAgent(agentId, validated.planning_subagent_registry)) {
             errors.push(
               `planning_subagents.${unitType}.allowed includes "${agentId}", which is not classified as a ` +
-              `read-only planning specialist. Allowed agents: ${allowedPlanningDispatchAgentsList()}`,
+              `read-only planning specialist. Allowed agents: ` +
+              `${allowedPlanningDispatchAgentsList(validated.planning_subagent_registry)}. ` +
+              `For custom planning agents, add planning_subagent_registry.${agentId}.read_only_specialist: true`,
             );
             continue;
           }

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -817,6 +817,10 @@ function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPr
       : undefined,
     post_unit_hooks: mergePostUnitHooks(base.post_unit_hooks, override.post_unit_hooks),
     pre_dispatch_hooks: mergePreDispatchHooks(base.pre_dispatch_hooks, override.pre_dispatch_hooks),
+    planning_subagent_registry: mergePlanningSubagentRegistry(
+      base.planning_subagent_registry,
+      override.planning_subagent_registry,
+    ),
     planning_subagents: mergePlanningSubagents(base.planning_subagents, override.planning_subagents),
     dynamic_routing: (base.dynamic_routing || override.dynamic_routing)
       ? { ...(base.dynamic_routing ?? {}), ...(override.dynamic_routing ?? {}) } as DynamicRoutingConfig
@@ -965,6 +969,15 @@ function mergePlanningSubagents(
     }
   }
 
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function mergePlanningSubagentRegistry(
+  base?: GSDPreferences["planning_subagent_registry"],
+  override?: GSDPreferences["planning_subagent_registry"],
+): GSDPreferences["planning_subagent_registry"] | undefined {
+  if (!base && !override) return undefined;
+  const merged = { ...(base ?? {}), ...(override ?? {}) };
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 

--- a/src/resources/extensions/gsd/templates/PREFERENCES.md
+++ b/src/resources/extensions/gsd/templates/PREFERENCES.md
@@ -92,6 +92,9 @@ remote_questions:
 uat_dispatch:
 post_unit_hooks: []
 pre_dispatch_hooks: []
+# planning_subagent_registry:
+#   my-custom-planner:
+#     read_only_specialist: true
 # planning_subagents:
 #   plan-milestone:
 #     allowed: [scout, planner, security]

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -836,6 +836,31 @@ test("planning_subagents validation accepts configured read-only planning specia
   assert.deepEqual(preferences.planning_subagents?.["plan-slice"]?.allowed, ["scout", "security"]);
 });
 
+test("planning_subagents validation accepts custom agents registered as read-only planning specialists", () => {
+  const { preferences, errors } = validatePreferences({
+    planning_subagent_registry: {
+      "my-custom-planner": { read_only_specialist: true },
+    },
+    planning_subagents: {
+      "plan-milestone": { allowed: ["planner", "my-custom-planner"] },
+      "plan-slice": { allowed: ["scout", "my-custom-planner"] },
+    },
+  } as any);
+
+  assert.equal(errors.length, 0);
+  assert.deepEqual(preferences.planning_subagent_registry?.["my-custom-planner"], {
+    read_only_specialist: true,
+  });
+  assert.deepEqual(preferences.planning_subagents?.["plan-milestone"]?.allowed, [
+    "planner",
+    "my-custom-planner",
+  ]);
+  assert.deepEqual(preferences.planning_subagents?.["plan-slice"]?.allowed, [
+    "scout",
+    "my-custom-planner",
+  ]);
+});
+
 test("planning_subagents validation rejects unsupported units and unsafe agents", () => {
   const { preferences, errors } = validatePreferences({
     planning_subagents: {
@@ -847,6 +872,33 @@ test("planning_subagents validation rejects unsupported units and unsafe agents"
   assert.equal(preferences.planning_subagents, undefined);
   assert.ok(errors.some(e => e.includes("unsupported unit \"execute-task\"")));
   assert.ok(errors.some(e => e.includes("\"worker\"") && e.includes("read-only planning specialist")));
+});
+
+test("planning_subagents validation explains how to register custom planning agents", () => {
+  const { preferences, errors } = validatePreferences({
+    planning_subagents: {
+      "plan-slice": { allowed: ["my-custom-planner"] },
+    },
+  } as any);
+
+  assert.equal(preferences.planning_subagents, undefined);
+  assert.ok(errors.some(e =>
+    e.includes("my-custom-planner") &&
+    e.includes("planning_subagent_registry.my-custom-planner.read_only_specialist: true")
+  ));
+});
+
+test("planning_subagent_registry validation requires explicit read_only_specialist true", () => {
+  const { preferences, errors } = validatePreferences({
+    planning_subagent_registry: {
+      "write-capable-agent": { read_only_specialist: false },
+    },
+  } as any);
+
+  assert.equal(preferences.planning_subagent_registry, undefined);
+  assert.ok(errors.some(e =>
+    e.includes("planning_subagent_registry.write-capable-agent.read_only_specialist must be true")
+  ));
 });
 
 test("loadEffectiveGSDPreferences merges planning_subagents allowlists", (t) => {
@@ -874,9 +926,12 @@ test("loadEffectiveGSDPreferences merges planning_subagents allowlists", (t) => 
     [
       "---",
       "version: 1",
+      "planning_subagent_registry:",
+      "  global-custom-planner:",
+      "    read_only_specialist: true",
       "planning_subagents:",
       "  plan-slice:",
-      "    allowed: [scout, reviewer]",
+      "    allowed: [scout, reviewer, global-custom-planner]",
       "---",
       "",
     ].join("\n"),
@@ -887,11 +942,14 @@ test("loadEffectiveGSDPreferences merges planning_subagents allowlists", (t) => 
     [
       "---",
       "version: 1",
+      "planning_subagent_registry:",
+      "  project-custom-planner:",
+      "    read_only_specialist: true",
       "planning_subagents:",
       "  plan-slice:",
-      "    allowed: [security]",
+      "    allowed: [security, project-custom-planner]",
       "  plan-milestone:",
-      "    allowed: [planner]",
+      "    allowed: [planner, project-custom-planner]",
       "---",
       "",
     ].join("\n"),
@@ -899,12 +957,21 @@ test("loadEffectiveGSDPreferences merges planning_subagents allowlists", (t) => 
   );
 
   const loaded = loadEffectiveGSDPreferences(tempProject);
+  assert.deepEqual(loaded?.preferences.planning_subagent_registry, {
+    "global-custom-planner": { read_only_specialist: true },
+    "project-custom-planner": { read_only_specialist: true },
+  });
   assert.deepEqual(loaded?.preferences.planning_subagents?.["plan-slice"]?.allowed, [
     "scout",
     "reviewer",
+    "global-custom-planner",
     "security",
+    "project-custom-planner",
   ]);
-  assert.deepEqual(loaded?.preferences.planning_subagents?.["plan-milestone"]?.allowed, ["planner"]);
+  assert.deepEqual(loaded?.preferences.planning_subagents?.["plan-milestone"]?.allowed, [
+    "planner",
+    "project-custom-planner",
+  ]);
 });
 
 // ── Model config parsing ─────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -54,6 +54,9 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   },
   post_unit_hooks: [{ command: "npm test" }],
   pre_dispatch_hooks: [{ command: "npm run lint" }],
+  planning_subagent_registry: {
+    "custom-planner": { read_only_specialist: true },
+  },
   planning_subagents: {
     "plan-milestone": { allowed: ["scout", "planner"] },
     "plan-slice": { allowed: ["scout"] },

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -7,12 +7,15 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 
 import { GSD_PHASE_SCOPE_DISPLAY_REASON, GSD_SECTION_CLOSE_GATE_DISPLAY_REASON } from '../auto-unit-tool-scope.ts';
 import { ALLOWED_PLANNING_DISPATCH_AGENTS, shouldBlockPlanningUnit } from '../bootstrap/write-gate.ts';
 import { extractSubagentAgentClasses } from '../bootstrap/subagent-input.ts';
 import { isDeterministicPolicyError } from '../auto-tool-tracking.ts';
+import { clearGSDPreferencesCache, getProjectGSDPreferencesPath, loadEffectiveGSDPreferences } from '../preferences.ts';
 import { applyPlanningSubagentPreferences } from '../planning-subagent-policy.ts';
 import type { ToolsPolicy } from '../unit-context-manifest.ts';
 
@@ -367,6 +370,43 @@ test('planning_subagents: widens plan-slice manifest allowlist without allowing 
   const unsafe = shouldBlockPlanningUnit('subagent', '', BASE, 'plan-slice', policy, ['worker']);
   assert.strictEqual(unsafe.block, true);
   assert.match(unsafe.reason!, /read-only specialists/);
+});
+
+test('planning_subagents: registered custom planning agents pass runtime read-only registry', (t) => {
+  const tempProject = mkdtempSync(join(tmpdir(), 'gsd-custom-planning-agent-'));
+
+  t.after(() => {
+    clearGSDPreferencesCache();
+    rmSync(tempProject, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(tempProject, '.gsd'), { recursive: true });
+  writeFileSync(
+    getProjectGSDPreferencesPath(tempProject),
+    [
+      '---',
+      'version: 1',
+      'planning_subagent_registry:',
+      '  my-custom-planner:',
+      '    read_only_specialist: true',
+      'planning_subagents:',
+      '  plan-slice:',
+      '    allowed: [my-custom-planner]',
+      '---',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+  clearGSDPreferencesCache();
+
+  const preferences = loadEffectiveGSDPreferences(tempProject)?.preferences;
+  const policy = applyPlanningSubagentPreferences('plan-slice', PLANNING_DISPATCH, preferences);
+  const custom = shouldBlockPlanningUnit('subagent', '', tempProject, 'plan-slice', policy, ['my-custom-planner']);
+  assert.strictEqual(custom.block, false, custom.reason);
+
+  const unregistered = shouldBlockPlanningUnit('subagent', '', tempProject, 'plan-slice', policy, ['other-planner']);
+  assert.strictEqual(unregistered.block, true);
+  assert.match(unregistered.reason!, /read-only specialists/);
 });
 
 // ─── planning mode: pass-through tools ────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added custom planning subagent registry support with validation/runtime enforcement and verified syntax plus patch hygiene; full tests were blocked by offline dependency install.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1401
- [#1401 planning_subagents should support user-defined planning agents](https://github.com/open-gsd/gsd-pi/issues/1401)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1401-planning-subagents-should-support-user-d-1783780407`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes planning subagent dispatch policy in the write gate—security-sensitive—but only allows explicitly registered read-only specialists; built-in allowlist behavior is unchanged.
> 
> **Overview**
> Adds **`planning_subagent_registry`** so projects can declare user-defined planning agents as read-only specialists (`read_only_specialist: true`), then list them in **`planning_subagents`** for `plan-milestone` / `plan-slice` alongside built-ins (`scout`, `planner`, etc.).
> 
> Preference **types**, **validation**, and **global/project merge** understand the new block; validation errors now point at registering custom agents when an id is missing from the registry. **`planning-subagent-registry`** and the planning **write gate** load effective preferences and treat registered custom ids like built-in read-only agents for dispatch checks and error messages.
> 
> Docs and **`PREFERENCES.md`** templates are updated; tests cover validation, merge, and runtime write-gate behavior for registered custom planners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9debc8145f9f10760fd8d8745ba5a8cf1ca5abc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->