### PR TITLE
fix(issue): fix(doctor): artifact_file_missing false positive for active-worktree artifacts; checkbox_db_status_divergence regression on plan-slice re-dispatch

### DIFF
--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -194,7 +194,7 @@ function artifactExistsOnDisk(basePath: string, artifactPath: string, row?: Arti
   return resolveArtifactDiskPath(basePath, artifactPath, row) !== null;
 }
 
-function resolveLiteralArtifactDiskPath(basePath: string, artifactPath: string): string | null {
+function resolveLiteralArtifactDiskPath(basePath: string, artifactPath: string, row?: ArtifactRow): string | null {
   const relativeArtifactPath = artifactPathRelativeToGsd(artifactPath);
   if (isAbsolute(relativeArtifactPath)) {
     return existsSync(relativeArtifactPath) ? relativeArtifactPath : null;
@@ -202,6 +202,15 @@ function resolveLiteralArtifactDiskPath(basePath: string, artifactPath: string):
   for (const root of [gsdProjectionRoot(basePath), gsdRoot(basePath)]) {
     const candidate = join(root, relativeArtifactPath);
     if (isPathInside(root, candidate) && existsSync(candidate)) return candidate;
+  }
+  if (row?.milestone_id) {
+    const artifactBasePath = resolveCanonicalMilestoneRoot(basePath, row.milestone_id);
+    if (artifactBasePath !== basePath) {
+      for (const root of [gsdProjectionRoot(artifactBasePath), gsdRoot(artifactBasePath)]) {
+        const candidate = join(root, relativeArtifactPath);
+        if (isPathInside(root, candidate) && existsSync(candidate)) return candidate;
+      }
+    }
   }
   return null;
 }
@@ -245,7 +254,7 @@ function resolveArtifactDiskPath(basePath: string, artifactPath: string, row?: A
     const flatPath = resolveFlatPhaseArtifactDiskPath(basePath, row);
     if (flatPath) return flatPath;
   }
-  return resolveLiteralArtifactDiskPath(basePath, artifactPath);
+  return resolveLiteralArtifactDiskPath(basePath, artifactPath, row);
 }
 
 function taskExistsInPlan(basePath: string, milestoneId: string, sliceId: string, taskId: string): boolean {

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -407,6 +407,38 @@ test("checkEngineHealth reports artifact rows whose files are missing on disk", 
   assert.equal(missing.fixable, false);
 });
 
+test("checkEngineHealth resolves artifact rows through the canonical milestone worktree", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-artifact-worktree-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  const artifactPath = "phases/03-milestone/03-01-PLAN.md";
+  const worktree = join(base, ".gsd-worktrees", "M003");
+  mkdirSync(gsdDir, { recursive: true });
+  mkdirSync(join(worktree, ".gsd", "phases", "03-milestone"), { recursive: true });
+  writeFileSync(join(worktree, ".git"), `gitdir: ${join(base, ".git", "worktrees", "M003")}\n`);
+  writeFileSync(join(worktree, ".gsd", artifactPath), "# Plan\n", "utf-8");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertArtifact({
+    path: artifactPath,
+    artifact_type: "PLAN",
+    milestone_id: "M003",
+    slice_id: "S01",
+    task_id: null,
+    full_content: "# Plan\n",
+  });
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  assert.equal(
+    issues.some((issue) => issue.code === "artifact_file_missing" && issue.file === artifactPath),
+    false,
+    "worktree-local artifact rows must not be reported missing from the project root",
+  );
+});
+
 test("checkEngineHealth resolves escaped .gsd artifact rows against the project .gsd directory", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-doctor-escaped-artifact-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -104,6 +104,30 @@ test('handlePlanSlice writes slice/task planning state and renders plan artifact
   }
 });
 
+test('handlePlanSlice re-dispatch preserves completed task checkboxes', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+
+    const first = await handlePlanSlice(validParams(), base);
+    assert.ok(!('error' in first), `unexpected error: ${'error' in first ? first.error : ''}`);
+
+    updateTaskStatus('M001', 'S02', 'T01', 'complete', '2026-07-11T00:00:00.000Z');
+
+    const second = await handlePlanSlice(validParams(), base);
+    assert.ok(!('error' in second), `unexpected error: ${'error' in second ? second.error : ''}`);
+
+    const planPath = join(base, '.gsd', 'phases', '01-test', '01-02-PLAN.md');
+    const parsedPlan = parsePlan(readFileSync(planPath, 'utf-8'));
+    assert.equal(parsedPlan.tasks.find((task) => task.id === 'T01')?.done, true);
+    assert.equal(parsedPlan.tasks.find((task) => task.id === 'T02')?.done, false);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanSlice persists explicit slice/task target repositories', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -20,7 +20,7 @@ import {
 } from "../gsd-db.js";
 import type { GateEvaluationConfig, GateId } from "../types.js";
 import { invalidateStateCache } from "../state.js";
-import { renderPlanFromDb } from "../markdown-renderer.js";
+import { renderPlanCheckboxes, renderPlanFromDb } from "../markdown-renderer.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
@@ -469,9 +469,13 @@ export async function handlePlanSlice(
     }
 
     const sliceTasks = getSliceTasks(params.milestoneId, params.sliceId);
+    const hasClosedTasks = sliceTasks.some((task) => isClosedStatus(task.status));
     const renderResult = sliceTasks.length === 0
       ? { planPath: "", taskPlanPaths: [] as string[] }
       : await renderPlanFromDb(basePath, params.milestoneId, params.sliceId);
+    if (sliceTasks.length > 0 && hasClosedTasks) {
+      await renderPlanCheckboxes(basePath, params.milestoneId, params.sliceId);
+    }
     if (sliceTasks.length > 0) {
       setSliceSketchFlag(params.milestoneId, params.sliceId, false);
     }


### PR DESCRIPTION
## Summary
- Fixed worktree-aware doctor artifact lookup and plan-slice checkbox preservation, with focused tests added and verification limited by missing dependencies plus blocked registry access.

## Bugs Addressed
- [x] **Doctor checks active worktree artifacts in the wrong root**
- [x] **Plan-slice re-render resets completed task checkboxes**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1419
- [#1419 fix(doctor): artifact_file_missing false positive for active-worktree artifacts; checkbox_db_status_divergence regression on plan-slice re-dispatch](https://github.com/open-gsd/gsd-pi/issues/1419)

## User
- @birdypme

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1419-fix-doctor-artifact-file-missing-false-p-1783806864`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized changes to doctor artifact resolution and plan-slice render sequencing, with focused tests and no auth or data-migration impact.
> 
> **Overview**
> Fixes two GSD health/planning regressions: doctor no longer flags on-disk artifacts as missing when they live under a milestone worktree, and **plan-slice** re-dispatch keeps task checkboxes aligned with closed DB task status.
> 
> **Doctor (`checkEngineHealth`)** extends literal artifact path resolution with the artifact row’s `milestone_id`, searching projection and `.gsd` roots under `resolveCanonicalMilestoneRoot` when that root differs from the project base. Artifact existence checks therefore find files in active worktrees instead of emitting false `artifact_file_missing` from the project root.
> 
> **Plan-slice** still runs `renderPlanFromDb` after planning writes, but when the slice has any closed tasks it follows with `renderPlanCheckboxes` so completed tasks stay checked and doctor does not report `checkbox_db_status_divergence` on replan.
> 
> Tests cover worktree-local artifact rows from the project root and checkbox preservation across a second `handlePlanSlice` after marking a task complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3995170411086bbe191ff78ab3d25c3027b3975b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->