### PR TITLE
test(gsd): add workflow authority fault coverage

### DIFF
--- a/docs/dev/proposals/rfc-database-authoritative-workflow-refactor.md
+++ b/docs/dev/proposals/rfc-database-authoritative-workflow-refactor.md
@@ -328,7 +328,10 @@ the pre-commit failure rolls back the slice transition, post-commit failures
 preserve it, and a stale projection is surfaced without undoing committed intent.
 Each scenario then closes the original connection and reads authority in a fresh
 process. Contradictory roadmap and state projections cannot fabricate dependency
-unlock or change the next database-derived slice.
+unlock or change the next database-derived slice. For the
+`after-independent-reopen` boundary, production completion first succeeds, a
+fresh child opens the database and faults immediately afterward, and a second
+fresh process retries successfully from the committed database state.
 
 Baseline failure evidence was captured on 2026-07-11 with:
 

--- a/docs/dev/proposals/rfc-database-authoritative-workflow-refactor.md
+++ b/docs/dev/proposals/rfc-database-authoritative-workflow-refactor.md
@@ -311,11 +311,24 @@ The Milestone 0 workflow-authority baseline uses
 real SQLite project through typed write APIs. The fixture persists an active
 milestone, a completed prerequisite slice and task, a pending dependent slice
 and task, an active requirement, and a memory-backed architecture decision.
-Both focused tests independently reopen the database. The fixture test verifies
-the reopened state, while the projection-conflict test proves that contradictory
-`STATE.md`, `PROJECT.md`, `REQUIREMENTS.md`, `DECISIONS.md`, roadmap, and plan
-projections cannot change database-derived lifecycle state, dependencies,
-requirements, or decisions.
+The fixture test verifies reopened state, while the projection-conflict test
+proves that contradictory `STATE.md`, `PROJECT.md`, `REQUIREMENTS.md`,
+`DECISIONS.md`, roadmap, and plan projections cannot change database-derived
+lifecycle state, dependencies, requirements, or decisions.
+
+The test-only fault harness adds five named boundaries without production flags,
+global state, or runtime hooks: `before-transaction-commit`,
+`after-db-commit-before-render`, `during-projection-write`,
+`before-independent-reopen`, and `after-independent-reopen`. Its unit tests prove
+that a harness throws once at only its armed boundary and that harness instances
+do not share state. The authority fault matrix drives the production
+`handleCompleteSlice` path, using temporary SQLite abort triggers for transaction
+boundaries and a filesystem obstruction for projection failure. It verifies that
+the pre-commit failure rolls back the slice transition, post-commit failures
+preserve it, and a stale projection is surfaced without undoing committed intent.
+Each scenario then closes the original connection and reads authority in a fresh
+process. Contradictory roadmap and state projections cannot fabricate dependency
+unlock or change the next database-derived slice.
 
 Baseline failure evidence was captured on 2026-07-11 with:
 
@@ -335,17 +348,21 @@ exited 0 with one passing test. An earlier RED also proved the memory-backed
 decision seam: a provisional legacy-table seed produced `actual []` instead of
 the expected `["D001"]`.
 
-The complete baseline runs both focused tests:
+The complete baseline runs the fixture, projection-conflict, harness, and fault
+matrix tests:
 
 ```sh
 node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
   --experimental-strip-types --test \
   src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts \
-  src/resources/extensions/gsd/tests/workflow-authority-projection-conflict.test.ts
+  src/resources/extensions/gsd/tests/workflow-authority-projection-conflict.test.ts \
+  src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts \
+  src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts
 ```
 
-That command passed with two tests and zero failures after the sabotage was
-removed.
+That command passed with ten tests and zero failures after the sabotage was
+removed: two authority baseline tests, three harness contract tests, and five
+fault-boundary scenarios.
 
 ### Dependency and parallel-work rules
 

--- a/src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { promises as fs, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { atomicWriteAsyncWithOps, type AtomicWriteAsyncOps } from "../atomic-write.js";
+import {
+  getActiveSliceFromDb,
+  getSlice,
+  getTask,
+  insertSlice,
+  insertTask,
+  transaction,
+  updateSliceStatus,
+  updateTaskStatus,
+} from "../gsd-db.js";
+import { createWorkflowAuthorityFixture } from "./workflow-authority-fixture.js";
+import {
+  createWorkflowFaultHarness,
+  type WorkflowFaultHarness,
+  type WorkflowFaultPoint,
+} from "./workflow-fault-harness.js";
+
+interface FaultScenario {
+  point: WorkflowFaultPoint;
+  committed: boolean;
+}
+
+const SCENARIOS: FaultScenario[] = [
+  { point: "before-transaction-commit", committed: false },
+  { point: "after-db-commit-before-render", committed: true },
+  { point: "during-projection-write", committed: true },
+  { point: "before-independent-reopen", committed: true },
+  { point: "after-independent-reopen", committed: true },
+];
+
+function seedBlockedDependentSlice(): void {
+  insertSlice({
+    id: "S03",
+    milestoneId: "M001",
+    title: "Blocked dependent slice",
+    status: "pending",
+    depends: ["S02"],
+    sequence: 3,
+  });
+  insertTask({
+    id: "T01",
+    milestoneId: "M001",
+    sliceId: "S03",
+    title: "Blocked task",
+    status: "pending",
+    sequence: 1,
+  });
+}
+
+function projectionForCurrentAuthority(): string {
+  return `S02=${getSlice("M001", "S02")?.status ?? "missing"}\n`;
+}
+
+function projectionOps(harness: WorkflowFaultHarness): AtomicWriteAsyncOps {
+  return {
+    async mkdir(path, options) {
+      await fs.mkdir(path, options);
+    },
+    writeFile: fs.writeFile,
+    async rename(from, to) {
+      harness.hit("during-projection-write", "render-authority-projection");
+      await fs.rename(from, to);
+    },
+    unlink: fs.unlink,
+    sleep: async () => {},
+    createTempPath: (filePath) => `${filePath}.tmp.fault-test`,
+  };
+}
+
+async function renderProjection(
+  path: string,
+  harness: WorkflowFaultHarness,
+): Promise<void> {
+  await atomicWriteAsyncWithOps(
+    path,
+    projectionForCurrentAuthority(),
+    "utf-8",
+    projectionOps(harness),
+  );
+}
+
+async function runFaultedCompletion(
+  scenario: FaultScenario,
+  harness: WorkflowFaultHarness,
+  projectionPath: string,
+  reopen: () => void,
+): Promise<void> {
+  transaction(() => {
+    updateTaskStatus("M001", "S02", "T01", "complete", "2026-07-11T00:00:00.000Z");
+    updateSliceStatus("M001", "S02", "complete", "2026-07-11T00:00:00.000Z");
+    harness.hit("before-transaction-commit", "complete-dependent-slice");
+  });
+
+  harness.hit("after-db-commit-before-render", "complete-dependent-slice");
+  await renderProjection(projectionPath, harness);
+  harness.hit("before-independent-reopen", "complete-dependent-slice");
+  reopen();
+  harness.hit("after-independent-reopen", "complete-dependent-slice");
+}
+
+for (const scenario of SCENARIOS) {
+  test(`database authority remains coherent at ${scenario.point}`, async (t) => {
+    const fixture = await createWorkflowAuthorityFixture();
+    t.after(() => fixture.cleanup());
+    seedBlockedDependentSlice();
+
+    const projectionPath = join(fixture.root, "WORKFLOW-STATUS.md");
+    const initialProjection = scenario.committed ? "S02=pending\n" : "S02=complete\n";
+    writeFileSync(projectionPath, initialProjection);
+    const harness = createWorkflowFaultHarness(scenario.point);
+
+    await assert.rejects(
+      runFaultedCompletion(scenario, harness, projectionPath, fixture.reopen),
+      new RegExp(scenario.point),
+    );
+    assert.equal(harness.count(scenario.point), 1);
+
+    fixture.reopen();
+    const expectedStatus = scenario.committed ? "complete" : "pending";
+    const expectedActiveSlice = scenario.committed ? "S03" : "S02";
+    assert.equal(getTask("M001", "S02", "T01")?.status, expectedStatus);
+    assert.equal(getSlice("M001", "S02")?.status, expectedStatus);
+    assert.equal(
+      getActiveSliceFromDb("M001")?.id,
+      expectedActiveSlice,
+      "dependency selection must follow reopened database state, not the projection",
+    );
+    const renderCompletedBeforeFault =
+      scenario.point === "before-independent-reopen"
+      || scenario.point === "after-independent-reopen";
+    const expectedProjection = renderCompletedBeforeFault
+      ? "S02=complete\n"
+      : initialProjection;
+    assert.equal(readFileSync(projectionPath, "utf-8"), expectedProjection);
+
+    if (scenario.committed) {
+      await renderProjection(projectionPath, harness);
+      assert.equal(readFileSync(projectionPath, "utf-8"), "S02=complete\n");
+      assert.equal(getActiveSliceFromDb("M001")?.id, "S03");
+    }
+  });
+}

--- a/src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts
@@ -1,19 +1,21 @@
 import assert from "node:assert/strict";
-import { promises as fs, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import test from "node:test";
 
-import { atomicWriteAsyncWithOps, type AtomicWriteAsyncOps } from "../atomic-write.js";
+import type { CompleteSliceParams } from "../types.js";
 import {
-  getActiveSliceFromDb,
+  closeDatabase,
   getSlice,
   getTask,
   insertSlice,
   insertTask,
-  transaction,
-  updateSliceStatus,
   updateTaskStatus,
 } from "../gsd-db.js";
+import { relSliceFile } from "../paths.js";
+import { handleCompleteSlice } from "../tools/complete-slice.js";
 import { createWorkflowAuthorityFixture } from "./workflow-authority-fixture.js";
 import {
   createWorkflowFaultHarness,
@@ -26,6 +28,13 @@ interface FaultScenario {
   committed: boolean;
 }
 
+interface AuthoritySnapshot {
+  pid: number;
+  taskStatus: string | null;
+  sliceStatus: string | null;
+  activeSlice: string | null;
+}
+
 const SCENARIOS: FaultScenario[] = [
   { point: "before-transaction-commit", committed: false },
   { point: "after-db-commit-before-render", committed: true },
@@ -34,7 +43,18 @@ const SCENARIOS: FaultScenario[] = [
   { point: "after-independent-reopen", committed: true },
 ];
 
-function seedBlockedDependentSlice(): void {
+const COMPLETE_SLICE_PARAMS: CompleteSliceParams = {
+  milestoneId: "M001",
+  sliceId: "S02",
+  sliceTitle: "Ready dependent slice",
+  oneLiner: "Complete the dependent slice",
+  narrative: "The database records the completed slice before projections are refreshed.",
+  verification: "The focused authority matrix passed.",
+  uatContent: "## UAT Type\n\n- UAT mode: runtime-executable\n\n## Result\n\nPassed.",
+};
+
+function seedCompletionBoundary(): void {
+  updateTaskStatus("M001", "S02", "T01", "complete", "2026-07-11T00:00:00.000Z");
   insertSlice({
     id: "S03",
     milestoneId: "M001",
@@ -53,96 +73,147 @@ function seedBlockedDependentSlice(): void {
   });
 }
 
-function projectionForCurrentAuthority(): string {
-  return `S02=${getSlice("M001", "S02")?.status ?? "missing"}\n`;
+function writeProjection(root: string, relativePath: string, content: string): void {
+  const path = join(root, ".gsd", relativePath);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf8");
 }
 
-function projectionOps(harness: WorkflowFaultHarness): AtomicWriteAsyncOps {
-  return {
-    async mkdir(path, options) {
-      await fs.mkdir(path, options);
-    },
-    writeFile: fs.writeFile,
-    async rename(from, to) {
-      harness.hit("during-projection-write", "render-authority-projection");
-      await fs.rename(from, to);
-    },
-    unlink: fs.unlink,
-    sleep: async () => {},
-    createTempPath: (filePath) => `${filePath}.tmp.fault-test`,
-  };
-}
-
-async function renderProjection(
-  path: string,
-  harness: WorkflowFaultHarness,
-): Promise<void> {
-  await atomicWriteAsyncWithOps(
-    path,
-    projectionForCurrentAuthority(),
-    "utf-8",
-    projectionOps(harness),
+function writeContradictoryProjection(root: string, committed: boolean): void {
+  const s02Checked = committed ? " " : "x";
+  const s03Checked = committed ? "x" : " ";
+  writeProjection(
+    root,
+    "milestones/M001/M001-ROADMAP.md",
+    [
+      "# M001: Contradictory projection",
+      "",
+      "## Slices",
+      "- [x] **S01: Completed prerequisite** `risk:low` `depends:[]`",
+      `- [${s02Checked}] **S02: Ready dependent slice** \`risk:medium\` \`depends:[S01]\``,
+      `- [${s03Checked}] **S03: Blocked dependent slice** \`risk:low\` \`depends:[S02]\``,
+    ].join("\n"),
+  );
+  writeProjection(
+    root,
+    "STATE.md",
+    [
+      "# GSD State",
+      "",
+      `**Active Slice:** ${committed ? "S02" : "S03"}`,
+      "**Phase:** executing",
+    ].join("\n"),
   );
 }
 
-async function runFaultedCompletion(
-  scenario: FaultScenario,
+function armProductionFault(
+  point: WorkflowFaultPoint,
   harness: WorkflowFaultHarness,
-  projectionPath: string,
-  reopen: () => void,
-): Promise<void> {
-  transaction(() => {
-    updateTaskStatus("M001", "S02", "T01", "complete", "2026-07-11T00:00:00.000Z");
-    updateSliceStatus("M001", "S02", "complete", "2026-07-11T00:00:00.000Z");
-    harness.hit("before-transaction-commit", "complete-dependent-slice");
-  });
+  root: string,
+): void {
+  if (point === "before-transaction-commit") {
+    harness.armDatabaseAbort("status", "NEW.status = 'complete' AND OLD.status <> 'complete'");
+  } else if (point === "after-db-commit-before-render") {
+    harness.armDatabaseAbort("full_summary_md", "NEW.full_summary_md IS NOT OLD.full_summary_md");
+  } else if (point === "during-projection-write") {
+    const summaryPath = join(root, relSliceFile(root, "M001", "S02", "SUMMARY"));
+    harness.obstructProjection(summaryPath);
+  }
+}
 
-  harness.hit("after-db-commit-before-render", "complete-dependent-slice");
-  await renderProjection(projectionPath, harness);
-  harness.hit("before-independent-reopen", "complete-dependent-slice");
-  reopen();
-  harness.hit("after-independent-reopen", "complete-dependent-slice");
+function readAuthorityInFreshProcess(root: string, dbPath: string): AuthoritySnapshot {
+  const resolver = join(process.cwd(), "src/resources/extensions/gsd/tests/resolve-ts.mjs");
+  const databaseModule = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/gsd-db.ts")).href;
+  const stateModule = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/state.ts")).href;
+  const script = `
+    const [{ openDatabase, closeDatabase, getSlice, getTask }, { deriveStateFromDb }] = await Promise.all([
+      import(${JSON.stringify(databaseModule)}),
+      import(${JSON.stringify(stateModule)}),
+    ]);
+    const [root, dbPath] = process.argv.slice(-2);
+    if (!openDatabase(dbPath)) throw new Error("fresh process could not open workflow database");
+    const state = await deriveStateFromDb(root);
+    const snapshot = {
+      pid: process.pid,
+      taskStatus: getTask("M001", "S02", "T01")?.status ?? null,
+      sliceStatus: getSlice("M001", "S02")?.status ?? null,
+      activeSlice: state.activeSlice?.id ?? null,
+    };
+    closeDatabase();
+    process.stdout.write("AUTHORITY_SNAPSHOT=" + JSON.stringify(snapshot) + "\\n");
+  `;
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      resolver,
+      "--experimental-strip-types",
+      "--input-type=module",
+      "--eval",
+      script,
+      root,
+      dbPath,
+    ],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  const line = child.stdout.split("\n").find((entry) => entry.startsWith("AUTHORITY_SNAPSHOT="));
+  assert.ok(line, `fresh process did not return an authority snapshot: ${child.stdout}`);
+  return JSON.parse(line.slice("AUTHORITY_SNAPSHOT=".length)) as AuthoritySnapshot;
 }
 
 for (const scenario of SCENARIOS) {
   test(`database authority remains coherent at ${scenario.point}`, async (t) => {
     const fixture = await createWorkflowAuthorityFixture();
     t.after(() => fixture.cleanup());
-    seedBlockedDependentSlice();
-
-    const projectionPath = join(fixture.root, "WORKFLOW-STATUS.md");
-    const initialProjection = scenario.committed ? "S02=pending\n" : "S02=complete\n";
-    writeFileSync(projectionPath, initialProjection);
+    seedCompletionBoundary();
     const harness = createWorkflowFaultHarness(scenario.point);
+    armProductionFault(scenario.point, harness, fixture.root);
 
-    await assert.rejects(
-      runFaultedCompletion(scenario, harness, projectionPath, fixture.reopen),
-      new RegExp(scenario.point),
-    );
-    assert.equal(harness.count(scenario.point), 1);
-
-    fixture.reopen();
-    const expectedStatus = scenario.committed ? "complete" : "pending";
-    const expectedActiveSlice = scenario.committed ? "S03" : "S02";
-    assert.equal(getTask("M001", "S02", "T01")?.status, expectedStatus);
-    assert.equal(getSlice("M001", "S02")?.status, expectedStatus);
-    assert.equal(
-      getActiveSliceFromDb("M001")?.id,
-      expectedActiveSlice,
-      "dependency selection must follow reopened database state, not the projection",
-    );
-    const renderCompletedBeforeFault =
-      scenario.point === "before-independent-reopen"
-      || scenario.point === "after-independent-reopen";
-    const expectedProjection = renderCompletedBeforeFault
-      ? "S02=complete\n"
-      : initialProjection;
-    assert.equal(readFileSync(projectionPath, "utf-8"), expectedProjection);
-
-    if (scenario.committed) {
-      await renderProjection(projectionPath, harness);
-      assert.equal(readFileSync(projectionPath, "utf-8"), "S02=complete\n");
-      assert.equal(getActiveSliceFromDb("M001")?.id, "S03");
+    let completionError: unknown;
+    let completionStale = false;
+    try {
+      const result = await handleCompleteSlice(COMPLETE_SLICE_PARAMS, fixture.root);
+      assert.ok(!("error" in result), "production completion must reach its mutation boundary");
+      completionStale = result.stale === true;
+      harness.hit("before-independent-reopen", "complete-dependent-slice");
+    } catch (error) {
+      completionError = error;
     }
+
+    if (scenario.point === "during-projection-write") {
+      assert.equal(completionStale, true, "the production renderer must surface a stale projection");
+    } else if (scenario.point !== "after-independent-reopen") {
+      assert.match(String(completionError), new RegExp(scenario.point));
+    }
+
+    writeContradictoryProjection(fixture.root, scenario.committed);
+    closeDatabase();
+    let snapshot: AuthoritySnapshot;
+    try {
+      snapshot = readAuthorityInFreshProcess(fixture.root, fixture.dbPath);
+      harness.hit("after-independent-reopen", "complete-dependent-slice");
+    } catch (error) {
+      if (scenario.point === "after-independent-reopen") {
+        assert.match(String(error), /after-independent-reopen/);
+        snapshot = readAuthorityInFreshProcess(fixture.root, fixture.dbPath);
+      } else {
+        throw error;
+      }
+    } finally {
+      fixture.reopen();
+    }
+
+    const expectedStatus = scenario.committed ? "complete" : "pending";
+    const { pid, ...authority } = snapshot;
+    assert.notEqual(pid, process.pid, "authority must be verified by another process");
+    assert.deepEqual(authority, {
+      taskStatus: "complete",
+      sliceStatus: expectedStatus,
+      activeSlice: scenario.committed ? "S03" : "S02",
+    });
+    assert.equal(getTask("M001", "S02", "T01")?.status, "complete");
+    assert.equal(getSlice("M001", "S02")?.status, expectedStatus);
   });
 }

--- a/src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -121,17 +121,34 @@ function armProductionFault(
   }
 }
 
-function readAuthorityInFreshProcess(root: string, dbPath: string): AuthoritySnapshot {
+function runAuthorityProcess(
+  root: string,
+  dbPath: string,
+  faultPoint?: WorkflowFaultPoint,
+): SpawnSyncReturns<string> {
   const resolver = join(process.cwd(), "src/resources/extensions/gsd/tests/resolve-ts.mjs");
   const databaseModule = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/gsd-db.ts")).href;
   const stateModule = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/state.ts")).href;
+  const faultHarnessModule = pathToFileURL(join(
+    process.cwd(),
+    "src/resources/extensions/gsd/tests/workflow-fault-harness.ts",
+  )).href;
   const script = `
-    const [{ openDatabase, closeDatabase, getSlice, getTask }, { deriveStateFromDb }] = await Promise.all([
+    const [
+      { openDatabase, closeDatabase, getSlice, getTask },
+      { deriveStateFromDb },
+      { createWorkflowFaultHarness },
+    ] = await Promise.all([
       import(${JSON.stringify(databaseModule)}),
       import(${JSON.stringify(stateModule)}),
+      import(${JSON.stringify(faultHarnessModule)}),
     ]);
-    const [root, dbPath] = process.argv.slice(-2);
+    const [root, dbPath, faultPoint] = process.argv.slice(-3);
     if (!openDatabase(dbPath)) throw new Error("fresh process could not open workflow database");
+    if (faultPoint) {
+      process.stderr.write("DATABASE_OPENED_BEFORE_FAULT=" + process.pid + "\\n");
+      createWorkflowFaultHarness(faultPoint).hit(faultPoint, "fresh-process-reopen");
+    }
     const state = await deriveStateFromDb(root);
     const snapshot = {
       pid: process.pid,
@@ -142,7 +159,7 @@ function readAuthorityInFreshProcess(root: string, dbPath: string): AuthoritySna
     closeDatabase();
     process.stdout.write("AUTHORITY_SNAPSHOT=" + JSON.stringify(snapshot) + "\\n");
   `;
-  const child = spawnSync(
+  return spawnSync(
     process.execPath,
     [
       "--import",
@@ -153,9 +170,14 @@ function readAuthorityInFreshProcess(root: string, dbPath: string): AuthoritySna
       script,
       root,
       dbPath,
+      faultPoint ?? "",
     ],
     { cwd: process.cwd(), encoding: "utf8" },
   );
+}
+
+function readAuthorityInFreshProcess(root: string, dbPath: string): AuthoritySnapshot {
+  const child = runAuthorityProcess(root, dbPath);
 
   assert.equal(child.status, 0, child.stderr || child.stdout);
   const line = child.stdout.split("\n").find((entry) => entry.startsWith("AUTHORITY_SNAPSHOT="));
@@ -184,26 +206,23 @@ for (const scenario of SCENARIOS) {
 
     if (scenario.point === "during-projection-write") {
       assert.equal(completionStale, true, "the production renderer must surface a stale projection");
-    } else if (scenario.point !== "after-independent-reopen") {
+    } else if (scenario.point === "after-independent-reopen") {
+      assert.equal(completionError, undefined, "completion must succeed before the reopen fault");
+      assert.equal(completionStale, false, "completion must not be stale before the reopen fault");
+    } else {
       assert.match(String(completionError), new RegExp(scenario.point));
     }
 
     writeContradictoryProjection(fixture.root, scenario.committed);
     closeDatabase();
-    let snapshot: AuthoritySnapshot;
-    try {
-      snapshot = readAuthorityInFreshProcess(fixture.root, fixture.dbPath);
-      harness.hit("after-independent-reopen", "complete-dependent-slice");
-    } catch (error) {
-      if (scenario.point === "after-independent-reopen") {
-        assert.match(String(error), /after-independent-reopen/);
-        snapshot = readAuthorityInFreshProcess(fixture.root, fixture.dbPath);
-      } else {
-        throw error;
-      }
-    } finally {
-      fixture.reopen();
+    if (scenario.point === "after-independent-reopen") {
+      const faultedChild = runAuthorityProcess(fixture.root, fixture.dbPath, scenario.point);
+      assert.notEqual(faultedChild.status, 0, "fresh process must fault after opening the database");
+      assert.match(faultedChild.stderr, /DATABASE_OPENED_BEFORE_FAULT=/);
+      assert.match(faultedChild.stderr, /after-independent-reopen/);
     }
+    const snapshot = readAuthorityInFreshProcess(fixture.root, fixture.dbPath);
+    fixture.reopen();
 
     const expectedStatus = scenario.committed ? "complete" : "pending";
     const { pid, ...authority } = snapshot;

--- a/src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createWorkflowFaultHarness,
+  type WorkflowFaultPoint,
+} from "./workflow-fault-harness.js";
+
+test("fault harness throws once at the armed named boundary", () => {
+  const harness = createWorkflowFaultHarness("after-db-commit-before-render");
+
+  harness.hit("before-transaction-commit", "complete-task");
+  assert.throws(
+    () => harness.hit("after-db-commit-before-render", "complete-task"),
+    /complete-task.*after-db-commit-before-render.*hit 1/,
+  );
+
+  assert.equal(harness.count("before-transaction-commit"), 1);
+  assert.equal(harness.count("after-db-commit-before-render"), 1);
+});
+
+test("fault harness automatically disarms after its first matching hit", () => {
+  const point: WorkflowFaultPoint = "during-projection-write";
+  const harness = createWorkflowFaultHarness(point);
+
+  assert.throws(() => harness.hit(point, "complete-slice"));
+  assert.doesNotThrow(() => harness.hit(point, "complete-slice"));
+  assert.equal(harness.count(point), 2);
+});
+
+test("fault harness instances never share armed state or counts", () => {
+  const first = createWorkflowFaultHarness("before-independent-reopen");
+  const second = createWorkflowFaultHarness("before-independent-reopen");
+
+  assert.throws(() => first.hit("before-independent-reopen", "resume"));
+  assert.equal(first.count("before-independent-reopen"), 1);
+  assert.equal(second.count("before-independent-reopen"), 0);
+  assert.throws(() => second.hit("before-independent-reopen", "resume"));
+});

--- a/src/resources/extensions/gsd/tests/workflow-fault-harness.ts
+++ b/src/resources/extensions/gsd/tests/workflow-fault-harness.ts
@@ -1,0 +1,46 @@
+export type WorkflowFaultPoint =
+  | "before-transaction-commit"
+  | "after-db-commit-before-render"
+  | "during-projection-write"
+  | "before-independent-reopen"
+  | "after-independent-reopen";
+
+export interface WorkflowFaultHarness {
+  hit(point: WorkflowFaultPoint, operation?: string): void;
+  count(point: WorkflowFaultPoint): number;
+}
+
+export class WorkflowFaultError extends Error {
+  readonly point: WorkflowFaultPoint;
+  readonly operation: string;
+  readonly hitCount: number;
+
+  constructor(point: WorkflowFaultPoint, operation: string, hitCount: number) {
+    super(`${operation} fault at ${point} (hit ${hitCount})`);
+    this.name = "WorkflowFaultError";
+    this.point = point;
+    this.operation = operation;
+    this.hitCount = hitCount;
+  }
+}
+
+export function createWorkflowFaultHarness(
+  armedPoint: WorkflowFaultPoint,
+): WorkflowFaultHarness {
+  const counts = new Map<WorkflowFaultPoint, number>();
+  let armed = true;
+
+  return {
+    hit(point, operation = "workflow-operation") {
+      const hitCount = (counts.get(point) ?? 0) + 1;
+      counts.set(point, hitCount);
+      if (armed && point === armedPoint) {
+        armed = false;
+        throw new WorkflowFaultError(point, operation, hitCount);
+      }
+    },
+    count(point) {
+      return counts.get(point) ?? 0;
+    },
+  };
+}

--- a/src/resources/extensions/gsd/tests/workflow-fault-harness.ts
+++ b/src/resources/extensions/gsd/tests/workflow-fault-harness.ts
@@ -1,3 +1,7 @@
+import { mkdirSync } from "node:fs";
+
+import { getDb } from "../gsd-db.js";
+
 export type WorkflowFaultPoint =
   | "before-transaction-commit"
   | "after-db-commit-before-render"
@@ -8,6 +12,13 @@ export type WorkflowFaultPoint =
 export interface WorkflowFaultHarness {
   hit(point: WorkflowFaultPoint, operation?: string): void;
   count(point: WorkflowFaultPoint): number;
+  armDatabaseAbort(
+    column: "status" | "full_summary_md",
+    predicate:
+      | "NEW.status = 'complete' AND OLD.status <> 'complete'"
+      | "NEW.full_summary_md IS NOT OLD.full_summary_md",
+  ): void;
+  obstructProjection(path: string): void;
 }
 
 export class WorkflowFaultError extends Error {
@@ -41,6 +52,21 @@ export function createWorkflowFaultHarness(
     },
     count(point) {
       return counts.get(point) ?? 0;
+    },
+    armDatabaseAbort(column, predicate) {
+      const triggerName = `workflow_fault_${armedPoint.replaceAll("-", "_")}`;
+      const message = `complete-dependent-slice fault at ${armedPoint}`;
+      getDb().exec(`
+        CREATE TEMP TRIGGER ${triggerName}
+        BEFORE UPDATE OF ${column} ON slices
+        WHEN ${predicate}
+        BEGIN
+          SELECT RAISE(ABORT, '${message}');
+        END
+      `);
+    },
+    obstructProjection(path) {
+      mkdirSync(path, { recursive: true });
     },
   };
 }


### PR DESCRIPTION
## Intent

Refactor gsd-pi toward one database-authoritative workflow. For M001/S04, add the smallest test-only deterministic fault harness and real SQLite authority matrix needed before architecture changes: pre-commit rollback, committed intent survival after post-commit projection/reopen faults, explicit named failures, independent restart proof, and no dependency unlock fabricated by Markdown. Keep production runtime, schema, recovery policy, legacy readers, and durable projection scheduling unchanged; avoid globals, production flags, plugin frameworks, or speculative abstractions. The follow-up must close the prior review gap by proving production completion succeeds before the after-reopen fault and firing that fault inside a fresh child immediately after database open, then succeeding on a second fresh-process retry. Direct developer approval governs this run; GitHub labels/tags are metadata only.

## What Changed

- Add a test-only, instance-isolated fault harness with five named workflow boundaries.
- Exercise SQLite authority across rollback, post-commit projection failures, contradictory Markdown, and independent fresh-process recovery scenarios.
- Document the expanded workflow-authority fault matrix and its focused ten-test baseline in the database-authority RFC.

## Risk Assessment

✅ Low: The change is confined to a focused test harness and RFC evidence, exercises the real production completion path across all specified fault boundaries, and introduces no production runtime or schema changes.

## Testing

The baseline run initially lacked dependencies; after frozen restoration, all focused rollback, post-commit, projection, contradiction, and restart scenarios passed. A separate runtime transcript demonstrates production completion succeeding, a named fault firing immediately after SQLite opens in a fresh child, and a second fresh process recovering database-authoritative S02 completion and S03 dependency unlock despite Markdown claiming the opposite. No visual artifact was captured because this change only adds a non-UI test harness and SQLite workflow verification.

<details>
<summary>Evidence: Focused authority test transcript</summary>

```text
✔ database authority remains coherent at before-transaction-commit (8248.322708ms)
✔ database authority remains coherent at after-db-commit-before-render (10320.219084ms)
✔ database authority remains coherent at during-projection-write (9949.966875ms)
✔ database authority remains coherent at before-independent-reopen (9497.332083ms)
✔ database authority remains coherent at after-independent-reopen (12413.672125ms)
✔ workflow authority fixture seeds a reopenable DB-backed workflow (368.814792ms)
✔ direct DB authority queries ignore contradictory Markdown projections (352.107541ms)
✔ fault harness throws once at the armed named boundary (0.695209ms)
✔ fault harness automatically disarms after its first matching hit (0.084584ms)
✔ fault harness instances never share armed state or counts (0.058042ms)
ℹ tests 10
ℹ suites 0
ℹ pass 10
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 75391.493875
```
</details>
<details>
<summary>Evidence: After-reopen production/restart transcript</summary>

<code>1 PRODUCTION_COMPLETION {&#34;error&#34;:null,&#34;stale&#34;:false}&#10;2 MARKDOWN_PROJECTION {&#34;S02&#34;:&#34;incomplete&#34;,&#34;S03&#34;:&#34;complete&#34;,&#34;activeSlice&#34;:&#34;S02&#34;}&#10;3 FIRST_FRESH_CHILD {&#34;exit&#34;:1,&#34;databaseOpened&#34;:true,&#34;namedFault&#34;:true}&#10;4 SECOND_FRESH_CHILD {&#34;exit&#34;:0,&#34;authority&#34;:{&#34;pid&#34;:1987,&#34;S02&#34;:&#34;complete&#34;,&#34;S03&#34;:&#34;pending&#34;,&#34;task&#34;:&#34;complete&#34;,&#34;activeSlice&#34;:&#34;S03&#34;}}</code>

```text
1 PRODUCTION_COMPLETION {"error":null,"stale":false}
2 MARKDOWN_PROJECTION {"S02":"incomplete","S03":"complete","activeSlice":"S02"}
3 FIRST_FRESH_CHILD {"exit":1,"databaseOpened":true,"namedFault":true}
4 SECOND_FRESH_CHILD {"exit":0,"authority":{"pid":1987,"S02":"complete","S03":"pending","task":"complete","activeSlice":"S03"}}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff f13b2f6d5ed304d13c3312d398a4ab09aa977c41..0d010ec5bcbb57cd5e01d15d7211442ef97c9a6e` plus `CONTRIBUTING.md`.</code>
- <code>Ran `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts src/resources/extensions/gsd/tests/workflow-authority-projection-conflict.test.ts src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts`; the baseline attempt exposed missing checkout dependencies.</code>
- <code>Ran `pnpm install --frozen-lockfile` to restore the test environment, then reran the same focused command successfully.</code>
- <code>Executed a standalone production-path demonstration through `handleCompleteSlice`: completion succeeded before the after-reopen fault, the first fresh child opened SQLite and hit the named fault, and a second fresh child recovered the committed state despite contradictory Markdown.</code>
- <code>Confirmed `git status --short` remained empty after removing temporary scripts and installed dependency directories.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
