### PR TITLE
feat: add workflow authority baseline gate

### DIFF
--- a/docs/dev/proposals/rfc-database-authoritative-workflow-refactor.md
+++ b/docs/dev/proposals/rfc-database-authoritative-workflow-refactor.md
@@ -293,10 +293,10 @@ The detailed task contract is recorded in [Decompose the approved contracts into
 
 | Milestone | Duration | Outcome | Primary gate |
 | --- | --- | --- | --- |
-| 0. Architecture and deletion safety | 1–2 weeks | Approved RFC/ADR, database-seeded fixture, fault harness, workflow-authority baseline | `pnpm run verify:fast`; targeted baseline |
+| 0. Architecture and deletion safety | 1–2 weeks | Approved RFC/ADR, database-seeded fixture, fault harness, workflow-authority baseline | `pnpm run verify:fast`; `pnpm run baseline:workflow-authority` |
 | 1. Additive canonical database foundation | 2–4 weeks | Authority, lifecycle, conversation, recovery, projection, import, kernel, and closeout schema plus Domain Operations | Migration, invariant, single-writer tests; typecheck |
 | 2. Explicit import, backfill, and rollback | 2–3 weeks | Corpus, preview, verified backup, transactional application, Authority Epoch, rollback/Forward Repair | Import, backup, restore, fault, restart corpus |
-| 3. Canonical queries and durable projection | 2–4 weeks | Canonical Query Module and durable Projection Worker exercised in shadow replacement paths without changing runtime authority | Workflow-authority baseline; projection benchmark |
+| 3. Canonical queries and durable projection | 2–4 weeks | Canonical Query Module and durable Projection Worker exercised in shadow replacement paths without changing runtime authority | `pnpm run baseline:workflow-authority`; projection benchmark |
 | 4. Resumable discovery and natural conversation | 3–4 weeks | Multi-week discovery Milestones, revision-linked interactions, restart-identical correction/resume | Conversation and checkpoint contract tests |
 | 5. Autonomous recovery, verification, and UAT | 3–4 weeks | Persisted classifier/budgets, evidence verdicts, remediation, automated UAT, narrow escalation | Fault, evidence freshness, sabotage, UAT tests |
 | 6. Lifecycle Kernel vertical slice | 3–5 weeks | Persisted five-stage kernel and two-part closeout running one low-risk unit | Restart-at-stage and semantic shadow tests |
@@ -351,21 +351,18 @@ exited 0 with one passing test. An earlier RED also proved the memory-backed
 decision seam: a provisional legacy-table seed produced `actual []` instead of
 the expected `["D001"]`.
 
-The complete baseline runs the fixture, projection-conflict, harness, and fault
-matrix tests:
+The canonical complete baseline runs the fixture, projection-conflict, harness,
+and fault matrix as four separate child invariants:
 
 ```sh
-node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
-  --experimental-strip-types --test \
-  src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts \
-  src/resources/extensions/gsd/tests/workflow-authority-projection-conflict.test.ts \
-  src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts \
-  src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts
+pnpm run baseline:workflow-authority
 ```
 
 That command passed with ten tests and zero failures after the sabotage was
 removed: two authority baseline tests, three harness contract tests, and five
-fault-boundary scenarios.
+fault-boundary scenarios. See the
+[refactor baseline runbook](../refactor-baseline-runbook.md#workflow-authority-gate)
+for JSON capture, stable comparison, and remediation instructions.
 
 ### Dependency and parallel-work rules
 

--- a/docs/dev/refactor-baseline-runbook.md
+++ b/docs/dev/refactor-baseline-runbook.md
@@ -102,6 +102,53 @@ For Phase 2 token/context work, the prompt metrics are the primary gate. For Pha
 
 ## Verification
 
+### Workflow authority gate
+
+Run the database-authority and fault-safety corpus in human-readable mode:
+
+```bash
+pnpm run baseline:workflow-authority
+```
+
+The four fixed invariants cover the real SQLite fixture, contradictory
+projections, the one-shot fault controller, and the production fault-boundary
+matrix. Each row reports its verdict, duration, and exact rerunnable command.
+
+Capture the machine-readable report outside the repository:
+
+```bash
+pnpm --silent run baseline:workflow-authority -- --json \
+  > /tmp/gsd-workflow-authority-before.json
+```
+
+Durations are diagnostic and vary by machine. Compare the stable schema,
+verdict, invariant order, commands, exit codes, signals, and errors after
+removing duration fields:
+
+```bash
+jq 'del(.durationMs) | .invariants |= map(del(.durationMs))' \
+  /tmp/gsd-workflow-authority-before.json \
+  > /tmp/gsd-workflow-authority-before.stable.json
+
+pnpm --silent run baseline:workflow-authority -- --json \
+  | jq 'del(.durationMs) | .invariants |= map(del(.durationMs))' \
+  > /tmp/gsd-workflow-authority-after.stable.json
+
+diff -u \
+  /tmp/gsd-workflow-authority-before.stable.json \
+  /tmp/gsd-workflow-authority-after.stable.json
+```
+
+The runner executes every invariant and exits with the first failing child's
+nonzero status. Its contract test also creates a temporary failing test to
+prove that controlled sabotage cannot produce a passing baseline. Do not
+weaken or edit an authority assertion to clear this gate; rerun the exact
+command printed for the failed invariant and repair the underlying behavior.
+
+A baseline regression is ordinary agent-remediated work. Escalate only when
+repair requires missing authority or access, irreversible/public consent, or a
+materially ambiguous product decision. Do not commit captured JSON reports.
+
 Run the focused baseline fixture gate:
 
 ```bash

--- a/docs/dev/refactor-baseline-runbook.md
+++ b/docs/dev/refactor-baseline-runbook.md
@@ -110,9 +110,11 @@ Run the database-authority and fault-safety corpus in human-readable mode:
 pnpm run baseline:workflow-authority
 ```
 
-The four fixed invariants cover the real SQLite fixture, contradictory
-projections, the one-shot fault controller, and the production fault-boundary
-matrix. Each row reports its verdict, duration, and exact rerunnable command.
+The four fixed invariants run in this stable order: `db-authority-fixture`,
+`projection-conflict`, `fault-harness-contract`, and `fault-boundary-matrix`.
+Together they cover the real SQLite fixture, contradictory projections, the
+one-shot fault controller, and the production fault-boundary matrix. Each row
+reports its verdict, duration, and exact rerunnable command.
 
 Capture the machine-readable report outside the repository:
 
@@ -138,6 +140,10 @@ diff -u \
   /tmp/gsd-workflow-authority-before.stable.json \
   /tmp/gsd-workflow-authority-after.stable.json
 ```
+
+The v1 JSON object contains `schemaVersion`, `verdict`, `durationMs`, and
+`invariants`. Each invariant contains `id`, `name`, `command`, `verdict`,
+`exitCode`, `durationMs`, `signal`, and `error`, in that order.
 
 The runner executes every invariant and exits with the first failing child's
 nonzero status. Its contract test also creates a temporary failing test to

--- a/docs/dev/refactor-baseline-runbook.md
+++ b/docs/dev/refactor-baseline-runbook.md
@@ -146,10 +146,11 @@ The v1 JSON object contains `schemaVersion`, `verdict`, `durationMs`, and
 `exitCode`, `durationMs`, `signal`, and `error`, in that order.
 
 The runner executes every invariant and exits with the first failing child's
-nonzero status. Its contract test also creates a temporary failing test to
-prove that controlled sabotage cannot produce a passing baseline. Do not
-weaken or edit an authority assertion to clear this gate; rerun the exact
-command printed for the failed invariant and repair the underlying behavior.
+nonzero status. Its contract test also sabotages one fixed child through the
+package-script path to prove that controlled sabotage cannot produce a passing
+baseline. Do not weaken or edit an authority assertion to clear this gate;
+rerun the exact command printed for the failed invariant and repair the
+underlying behavior.
 
 A baseline regression is ordinary agent-remediated work. Escalate only when
 repair requires missing authority or access, irreversible/public consent, or a

--- a/docs/dev/refactor-baseline-runbook.md
+++ b/docs/dev/refactor-baseline-runbook.md
@@ -146,11 +146,13 @@ The v1 JSON object contains `schemaVersion`, `verdict`, `durationMs`, and
 `exitCode`, `durationMs`, `signal`, and `error`, in that order.
 
 The runner executes every invariant and exits with the first failing child's
-nonzero status. Its contract test also sabotages one fixed child through the
-package-script path to prove that controlled sabotage cannot produce a passing
-baseline. Do not weaken or edit an authority assertion to clear this gate;
-rerun the exact command printed for the failed invariant and repair the
-underlying behavior.
+nonzero status. Each child has a fixed 60-second timeout; a timeout, signal, or
+spawn error produces a failing row and exits 1 when no nonzero child status is
+available. `--json` is the only CLI option. The contract test also sabotages one
+fixed child through the package-script path to prove that controlled sabotage
+cannot produce a passing baseline. Do not weaken or edit an authority assertion
+to clear this gate; rerun the exact command printed for the failed invariant and
+repair the underlying behavior.
 
 A baseline regression is ordinary agent-remediated work. Escalate only when
 repair requires missing authority or access, irreversible/public consent, or a

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "baseline:refactor": "node scripts/refactor-baseline.mjs",
     "baseline:auto-dispatch": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types scripts/auto-dispatch-baseline.mjs",
     "baseline:auto-dispatch:compare": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types scripts/auto-dispatch-baseline.mjs --no-write",
+    "baseline:workflow-authority": "node scripts/workflow-authority-baseline.mjs",
     "baseline:refactor:gate": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/refactor-baseline.test.ts src/tests/rpc-golden-fixtures.test.ts src/tests/prompt-golden-fixtures.test.ts src/tests/contracts-rpc-fixtures.test.ts",
     "baseline:refactor:phase0": "pnpm run baseline:refactor:gate && node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/derive-state-db.test.ts src/resources/extensions/gsd/tests/single-writer-invariant.test.ts src/resources/extensions/gsd/tests/auto-recovery.test.ts src/resources/extensions/gsd/tests/auto-worktree-registry.test.ts",
     "legacy:cleanup:gate": "node scripts/legacy-cleanup-gate.mjs",

--- a/scripts/workflow-authority-baseline.mjs
+++ b/scripts/workflow-authority-baseline.mjs
@@ -42,7 +42,8 @@ function commandText(executable, args) {
 }
 
 function commandForInvariant(invariant) {
-  const resolver = join(REPO_ROOT, "src/resources/extensions/gsd/tests/resolve-ts.mjs");
+  const resolverFile = "src/resources/extensions/gsd/tests/resolve-ts.mjs";
+  const resolver = join(REPO_ROOT, resolverFile);
   const testFile = isAbsolute(invariant.file)
     ? invariant.file
     : join(REPO_ROOT, invariant.file);
@@ -56,7 +57,13 @@ function commandForInvariant(invariant) {
   return {
     executable: process.execPath,
     args,
-    text: commandText(process.execPath, args),
+    text: commandText("node", [
+      "--import",
+      `./${resolverFile}`,
+      "--experimental-strip-types",
+      "--test",
+      invariant.file,
+    ]),
   };
 }
 

--- a/scripts/workflow-authority-baseline.mjs
+++ b/scripts/workflow-authority-baseline.mjs
@@ -97,11 +97,12 @@ export function runInvariant(
 }
 
 export function runWorkflowAuthorityBaseline({
-  invariants = WORKFLOW_AUTHORITY_INVARIANTS,
   now = () => performance.now(),
   spawnSyncImpl = spawnSync,
 } = {}) {
-  const results = invariants.map((invariant) => runInvariant(invariant, { now, spawnSyncImpl }));
+  const results = WORKFLOW_AUTHORITY_INVARIANTS.map(
+    (invariant) => runInvariant(invariant, { now, spawnSyncImpl }),
+  );
   return {
     schemaVersion: 1,
     verdict: results.every((result) => result.verdict === "pass") ? "pass" : "fail",

--- a/scripts/workflow-authority-baseline.mjs
+++ b/scripts/workflow-authority-baseline.mjs
@@ -43,27 +43,22 @@ function commandText(executable, args) {
 
 function commandForInvariant(invariant) {
   const resolverFile = "src/resources/extensions/gsd/tests/resolve-ts.mjs";
-  const resolver = join(REPO_ROOT, resolverFile);
-  const testFile = isAbsolute(invariant.file)
-    ? invariant.file
-    : join(REPO_ROOT, invariant.file);
-  const args = [
+  const reportedArgs = [
     "--import",
-    resolver,
+    `./${resolverFile}`,
     "--experimental-strip-types",
     "--test",
-    testFile,
+    invariant.file,
   ];
+  const args = reportedArgs.map((arg, index) => {
+    if (index === 1) return join(REPO_ROOT, resolverFile);
+    if (index === 4 && !isAbsolute(arg)) return join(REPO_ROOT, arg);
+    return arg;
+  });
   return {
     executable: process.execPath,
     args,
-    text: commandText("node", [
-      "--import",
-      `./${resolverFile}`,
-      "--experimental-strip-types",
-      "--test",
-      invariant.file,
-    ]),
+    text: commandText("node", reportedArgs),
   };
 }
 

--- a/scripts/workflow-authority-baseline.mjs
+++ b/scripts/workflow-authority-baseline.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { isAbsolute, dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+
+export const WORKFLOW_AUTHORITY_INVARIANTS = Object.freeze([
+  {
+    id: "db-authority-fixture",
+    name: "DB authority fixture",
+    file: "src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts",
+  },
+  {
+    id: "projection-conflict",
+    name: "Projection conflict",
+    file: "src/resources/extensions/gsd/tests/workflow-authority-projection-conflict.test.ts",
+  },
+  {
+    id: "fault-harness-contract",
+    name: "Fault harness contract",
+    file: "src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts",
+  },
+  {
+    id: "fault-boundary-matrix",
+    name: "Fault boundary matrix",
+    file: "src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts",
+  },
+]);
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  for (const arg of argv) {
+    if (arg !== "--" && arg !== "--json") throw new Error(`Unknown argument: ${arg}`);
+  }
+  return { json: argv.includes("--json") };
+}
+
+function commandText(executable, args) {
+  return [executable, ...args].map((part) => JSON.stringify(part)).join(" ");
+}
+
+function commandForInvariant(invariant) {
+  const resolver = join(REPO_ROOT, "src/resources/extensions/gsd/tests/resolve-ts.mjs");
+  const testFile = isAbsolute(invariant.file)
+    ? invariant.file
+    : join(REPO_ROOT, invariant.file);
+  const args = [
+    "--import",
+    resolver,
+    "--experimental-strip-types",
+    "--test",
+    testFile,
+  ];
+  return {
+    executable: process.execPath,
+    args,
+    text: commandText(process.execPath, args),
+  };
+}
+
+export function runInvariant(
+  invariant,
+  {
+    now = () => performance.now(),
+    spawnSyncImpl = spawnSync,
+  } = {},
+) {
+  const command = commandForInvariant(invariant);
+  const childEnv = { ...process.env };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const startedAt = now();
+  const child = spawnSyncImpl(command.executable, command.args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: childEnv,
+    maxBuffer: 50 * 1024 * 1024,
+    timeout: 60_000,
+  });
+  const durationMs = Math.max(0, Math.round(now() - startedAt));
+  const exitCode = Number.isInteger(child.status) ? child.status : null;
+  const error = child.error?.message ?? null;
+
+  return {
+    id: invariant.id,
+    name: invariant.name,
+    command: command.text,
+    verdict: exitCode === 0 && error === null ? "pass" : "fail",
+    exitCode,
+    durationMs,
+    signal: child.signal ?? null,
+    error,
+  };
+}
+
+export function runWorkflowAuthorityBaseline({
+  invariants = WORKFLOW_AUTHORITY_INVARIANTS,
+  now = () => performance.now(),
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  const results = invariants.map((invariant) => runInvariant(invariant, { now, spawnSyncImpl }));
+  return {
+    schemaVersion: 1,
+    verdict: results.every((result) => result.verdict === "pass") ? "pass" : "fail",
+    durationMs: results.reduce((total, result) => total + result.durationMs, 0),
+    invariants: results,
+  };
+}
+
+export function exitCodeForReport(report) {
+  const failure = report.invariants.find((invariant) => invariant.verdict === "fail");
+  if (!failure) return 0;
+  return typeof failure.exitCode === "number" && failure.exitCode !== 0
+    ? failure.exitCode
+    : 1;
+}
+
+export function renderWorkflowAuthoritySummary(report) {
+  const passed = report.invariants.filter((invariant) => invariant.verdict === "pass").length;
+  const lines = [
+    "Workflow authority baseline",
+    `Status: ${report.verdict.toUpperCase()} (${passed}/${report.invariants.length})`,
+    "",
+  ];
+  for (const invariant of report.invariants) {
+    const mark = invariant.verdict === "pass" ? "PASS" : "FAIL";
+    lines.push(`${invariant.id}: ${mark} (${invariant.durationMs}ms)`);
+    lines.push(`  ${invariant.name}`);
+    lines.push(`  ${invariant.command}`);
+    if (invariant.error) lines.push(`  ${invariant.error}`);
+  }
+  lines.push("", `Total: ${report.durationMs}ms`, "");
+  return lines.join("\n");
+}
+
+function main() {
+  try {
+    const options = parseArgs();
+    const report = runWorkflowAuthorityBaseline();
+    process.stdout.write(options.json
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : renderWorkflowAuthoritySummary(report));
+    process.exitCode = exitCodeForReport(report);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main();
+}

--- a/src/tests/workflow-authority-baseline.test.ts
+++ b/src/tests/workflow-authority-baseline.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+
+const baselinePath = join(process.cwd(), "scripts/workflow-authority-baseline.mjs");
+const baseline = await import(pathToFileURL(baselinePath).href);
+
+test("workflow authority baseline reports four fixed invariants in stable order", () => {
+  const calls: string[][] = [];
+  let now = 0;
+  const report = baseline.runWorkflowAuthorityBaseline({
+    now: () => now += 5,
+    spawnSyncImpl: (_executable: string, args: string[]) => {
+      calls.push(args);
+      return { status: 0, signal: null, stdout: "", stderr: "" };
+    },
+  });
+
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.verdict, "pass");
+  assert.deepEqual(
+    report.invariants.map((entry: { id: string }) => entry.id),
+    ["db-authority-fixture", "projection-conflict", "fault-harness-contract", "fault-boundary-matrix"],
+  );
+  assert.equal(calls.length, 4, "each accepted invariant must execute in its own process");
+  assert.equal(baseline.exitCodeForReport(report), 0);
+});
+
+test("workflow authority baseline preserves the first failing child status", () => {
+  let call = 0;
+  const report = baseline.runWorkflowAuthorityBaseline({
+    now: () => 0,
+    spawnSyncImpl: () => {
+      call += 1;
+      return { status: call === 2 ? 7 : 0, signal: null, stdout: "", stderr: "failed" };
+    },
+  });
+
+  assert.equal(report.verdict, "fail");
+  assert.equal(report.invariants[1].exitCode, 7);
+  assert.equal(report.invariants[1].verdict, "fail");
+  assert.equal(baseline.exitCodeForReport(report), 7);
+  assert.match(baseline.renderWorkflowAuthoritySummary(report), /projection-conflict.*FAIL.*node/s);
+});
+
+test("workflow authority baseline controlled sabotage exits nonzero", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "workflow-authority-baseline-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const failingTest = join(root, "controlled-sabotage.test.mjs");
+  writeFileSync(
+    failingTest,
+    'import test from "node:test"; import assert from "node:assert/strict"; test("controlled sabotage", () => assert.fail("invariant sabotage"));\n',
+  );
+
+  const report = baseline.runWorkflowAuthorityBaseline({
+    invariants: [{ id: "controlled-sabotage", name: "Controlled sabotage", file: failingTest }],
+  });
+
+  assert.equal(report.verdict, "fail");
+  assert.equal(report.invariants[0].exitCode, 1);
+  assert.equal(baseline.exitCodeForReport(report), 1);
+});
+
+test("workflow authority baseline CLI emits the v1 JSON report", { timeout: 60_000 }, () => {
+  const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+  const child = spawnSync(pnpm, ["--silent", "run", "baseline:workflow-authority", "--", "--json"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    timeout: 55_000,
+  });
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  const report = JSON.parse(child.stdout);
+  assert.deepEqual(Object.keys(report), ["schemaVersion", "verdict", "durationMs", "invariants"]);
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.verdict, "pass");
+  assert.equal(report.invariants.length, 4);
+  for (const invariant of report.invariants) {
+    assert.deepEqual(
+      Object.keys(invariant),
+      ["id", "name", "command", "verdict", "exitCode", "durationMs", "signal", "error"],
+    );
+  }
+});

--- a/src/tests/workflow-authority-baseline.test.ts
+++ b/src/tests/workflow-authority-baseline.test.ts
@@ -8,11 +8,14 @@ import test from "node:test";
 
 const baselinePath = join(process.cwd(), "scripts/workflow-authority-baseline.mjs");
 const baseline = await import(pathToFileURL(baselinePath).href);
+const BASELINE_SPAWN_TIMEOUT_MS = 255_000;
+const BASELINE_TEST_TIMEOUT_MS = 270_000;
 
 test("workflow authority baseline reports four fixed invariants in stable order", () => {
   const calls: Array<{ executable: string; args: string[] }> = [];
   let now = 0;
   const report = baseline.runWorkflowAuthorityBaseline({
+    invariants: [{ id: "override", name: "Override", file: "override.test.ts" }],
     now: () => now += 5,
     spawnSyncImpl: (executable: string, args: string[]) => {
       calls.push({ executable, args });
@@ -80,30 +83,67 @@ test("workflow authority baseline preserves the first failing child status", () 
   assert.match(baseline.renderWorkflowAuthoritySummary(report), /projection-conflict.*FAIL.*node/s);
 });
 
-test("workflow authority baseline controlled sabotage exits nonzero", (t) => {
-  const root = mkdtempSync(join(tmpdir(), "workflow-authority-baseline-"));
-  t.after(() => rmSync(root, { recursive: true, force: true }));
-  const failingTest = join(root, "controlled-sabotage.test.mjs");
-  writeFileSync(
-    failingTest,
-    'import test from "node:test"; import assert from "node:assert/strict"; test("controlled sabotage", () => assert.fail("invariant sabotage"));\n',
-  );
+test(
+  "workflow authority baseline controlled sabotage exits nonzero",
+  { timeout: BASELINE_TEST_TIMEOUT_MS },
+  (t) => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-authority-baseline-"));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    const sabotageModule = join(root, "controlled-sabotage.mjs");
+    writeFileSync(
+      sabotageModule,
+      `if (process.argv.some((arg) => arg.endsWith("workflow-authority-projection-conflict.test.ts"))) {
+  process.exit(7);
+}
+`,
+    );
 
-  const report = baseline.runWorkflowAuthorityBaseline({
-    invariants: [{ id: "controlled-sabotage", name: "Controlled sabotage", file: failingTest }],
-  });
+    const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+    const nodeOptions = [
+      process.env.NODE_OPTIONS,
+      `--import=${pathToFileURL(sabotageModule).href}`,
+    ]
+      .filter(Boolean)
+      .join(" ");
+    const child = spawnSync(
+      pnpm,
+      ["--silent", "run", "baseline:workflow-authority", "--", "--json"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, NODE_OPTIONS: nodeOptions },
+        timeout: BASELINE_SPAWN_TIMEOUT_MS,
+      },
+    );
 
-  assert.equal(report.verdict, "fail");
-  assert.equal(report.invariants[0].exitCode, 1);
-  assert.equal(baseline.exitCodeForReport(report), 1);
-});
+    assert.equal(child.status, 1, child.stderr || child.stdout);
+    const report = JSON.parse(child.stdout);
+    assert.equal(report.verdict, "fail");
+    assert.deepEqual(
+      report.invariants.map((invariant: { id: string }) => invariant.id),
+      baseline.WORKFLOW_AUTHORITY_INVARIANTS.map(
+        (invariant: { id: string }) => invariant.id,
+      ),
+    );
+    assert.equal(report.invariants[1].exitCode, 1);
+    assert.equal(report.invariants[1].verdict, "fail");
+    assert.equal(
+      report.invariants.filter(
+        (invariant: { verdict: string }) => invariant.verdict === "pass",
+      ).length,
+      3,
+    );
+  },
+);
 
-test("workflow authority baseline CLI emits the v1 JSON report", { timeout: 60_000 }, () => {
+test("workflow authority baseline CLI emits the v1 JSON report", {
+  timeout: BASELINE_TEST_TIMEOUT_MS,
+}, () => {
   const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
   const child = spawnSync(pnpm, ["--silent", "run", "baseline:workflow-authority", "--", "--json"], {
     cwd: process.cwd(),
     encoding: "utf8",
-    timeout: 55_000,
+    timeout: BASELINE_SPAWN_TIMEOUT_MS,
   });
 
   assert.equal(child.status, 0, child.stderr || child.stdout);

--- a/src/tests/workflow-authority-baseline.test.ts
+++ b/src/tests/workflow-authority-baseline.test.ts
@@ -22,25 +22,43 @@ test("workflow authority baseline reports four fixed invariants in stable order"
 
   assert.equal(report.schemaVersion, 1);
   assert.equal(report.verdict, "pass");
+  const expected = [
+    ["db-authority-fixture", "workflow-authority-fixture.test.ts"],
+    ["projection-conflict", "workflow-authority-projection-conflict.test.ts"],
+    ["fault-harness-contract", "workflow-fault-harness.test.ts"],
+    ["fault-boundary-matrix", "workflow-authority-faults.test.ts"],
+  ].map(([id, filename]) => {
+    const file = `src/resources/extensions/gsd/tests/${filename}`;
+    const reportedArgs = [
+      "--import",
+      "./src/resources/extensions/gsd/tests/resolve-ts.mjs",
+      "--experimental-strip-types",
+      "--test",
+      file,
+    ];
+    return {
+      id,
+      executable: process.execPath,
+      args: [
+        "--import",
+        join(baseline.REPO_ROOT, "src/resources/extensions/gsd/tests/resolve-ts.mjs"),
+        "--experimental-strip-types",
+        "--test",
+        join(baseline.REPO_ROOT, file),
+      ],
+      command: ["node", ...reportedArgs].map((part) => JSON.stringify(part)).join(" "),
+    };
+  });
+
   assert.deepEqual(
-    report.invariants.map((entry: { id: string }) => entry.id),
-    ["db-authority-fixture", "projection-conflict", "fault-harness-contract", "fault-boundary-matrix"],
-  );
-  assert.equal(calls.length, 4, "each accepted invariant must execute in its own process");
-  assert.equal(calls[0].executable, process.execPath);
-  assert.deepEqual(calls[0].args, [
-    "--import",
-    join(baseline.REPO_ROOT, "src/resources/extensions/gsd/tests/resolve-ts.mjs"),
-    "--experimental-strip-types",
-    "--test",
-    join(
-      baseline.REPO_ROOT,
-      "src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts",
-    ),
-  ]);
-  assert.equal(
-    report.invariants[0].command,
-    '"node" "--import" "./src/resources/extensions/gsd/tests/resolve-ts.mjs" "--experimental-strip-types" "--test" "src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts"',
+    report.invariants.map((entry: { id: string; command: string }, index: number) => ({
+      id: entry.id,
+      executable: calls[index].executable,
+      args: calls[index].args,
+      command: entry.command,
+    })),
+    expected,
+    "each accepted invariant must retain its exact ID, execution path, and reported command",
   );
   assert.equal(baseline.exitCodeForReport(report), 0);
 });

--- a/src/tests/workflow-authority-baseline.test.ts
+++ b/src/tests/workflow-authority-baseline.test.ts
@@ -10,12 +10,12 @@ const baselinePath = join(process.cwd(), "scripts/workflow-authority-baseline.mj
 const baseline = await import(pathToFileURL(baselinePath).href);
 
 test("workflow authority baseline reports four fixed invariants in stable order", () => {
-  const calls: string[][] = [];
+  const calls: Array<{ executable: string; args: string[] }> = [];
   let now = 0;
   const report = baseline.runWorkflowAuthorityBaseline({
     now: () => now += 5,
-    spawnSyncImpl: (_executable: string, args: string[]) => {
-      calls.push(args);
+    spawnSyncImpl: (executable: string, args: string[]) => {
+      calls.push({ executable, args });
       return { status: 0, signal: null, stdout: "", stderr: "" };
     },
   });
@@ -27,6 +27,21 @@ test("workflow authority baseline reports four fixed invariants in stable order"
     ["db-authority-fixture", "projection-conflict", "fault-harness-contract", "fault-boundary-matrix"],
   );
   assert.equal(calls.length, 4, "each accepted invariant must execute in its own process");
+  assert.equal(calls[0].executable, process.execPath);
+  assert.deepEqual(calls[0].args, [
+    "--import",
+    join(baseline.REPO_ROOT, "src/resources/extensions/gsd/tests/resolve-ts.mjs"),
+    "--experimental-strip-types",
+    "--test",
+    join(
+      baseline.REPO_ROOT,
+      "src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts",
+    ),
+  ]);
+  assert.equal(
+    report.invariants[0].command,
+    '"node" "--import" "./src/resources/extensions/gsd/tests/resolve-ts.mjs" "--experimental-strip-types" "--test" "src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts"',
+  );
   assert.equal(baseline.exitCodeForReport(report), 0);
 });
 


### PR DESCRIPTION
## Intent

Complete M001/S05 of the database-authoritative gsd-pi refactor with one small, deterministic workflow authority baseline. Add pnpm run baseline:workflow-authority and --json output that execute only the accepted S03/S04 corpus as four fixed child invariants, report stable ordered verdicts/durations/exact repo-relative commands, run every invariant, and preserve the first failing child status. Prove the complete four-row ID/path/command mapping, clean pass, schema shape, package-script execution, and controlled sabotage without weakening authority assertions or adding production flags, arbitrary command overrides, telemetry, generated state, schema/runtime changes, or legacy deletion. Document JSON capture/comparison with durations excluded from stable comparison and agent-first remediation. Local verify:merge produced 12,056 passes and only four known macOS path-alias failures plus the existing summary-save baseline failure; hosted CI remains required. Direct developer approval governs this run; GitHub tags and labels are metadata only.

## What Changed

- Add `pnpm run baseline:workflow-authority` to run four fixed workflow authority invariants with human-readable or versioned JSON output, executing every invariant and preserving the first failing status.
- Add coverage for invariant ordering and commands, JSON schema, package-script execution, controlled sabotage, and safe cumulative timeouts.
- Update the refactor RFC and runbook with the canonical gate, stable duration-free comparison workflow, and remediation guidance.

## Risk Assessment

✅ Low: The fixed four-invariant runner, package-script path, JSON contract, failure propagation, timeout budgeting, and documentation are coherent and well-bounded, with no material introduced risks found.

## Testing

Using the author-reported prior `verify:merge` result as context rather than rerunning that broad suite, I exercised the focused four-invariant contract, clean package-script human/JSON paths, exact schema and mapping, controlled sabotage, first-failure propagation, duration-excluded repeatability, and override rejection; everything passed after one setup-only retry caused by zsh’s reserved `status` variable. This is CLI-only, so no screenshot or rendered UI artifact applies.

<details>
<summary>Evidence: Clean human-readable baseline</summary>

```text

> @opengsd/gsd-pi@1.10.0 baseline:workflow-authority /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KX9ZD9RK7RHYZF9AYZJFBJCY
> node scripts/workflow-authority-baseline.mjs

Workflow authority baseline
Status: PASS (4/4)

db-authority-fixture: PASS (6863ms)
  DB authority fixture
  "node" "--import" "./src/resources/extensions/gsd/tests/resolve-ts.mjs" "--experimental-strip-types" "--test" "src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts"
projection-conflict: PASS (5047ms)
  Projection conflict
  "node" "--import" "./src/resources/extensions/gsd/tests/resolve-ts.mjs" "--experimental-strip-types" "--test" "src/resources/extensions/gsd/tests/workflow-authority-projection-conflict.test.ts"
fault-harness-contract: PASS (587ms)
  Fault harness contract
  "node" "--import" "./src/resources/extensions/gsd/tests/resolve-ts.mjs" "--experimental-strip-types" "--test" "src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts"
fault-boundary-matrix: PASS (36029ms)
  Fault boundary matrix
  "node" "--import" "./src/resources/extensions/gsd/tests/resolve-ts.mjs" "--experimental-strip-types" "--test" "src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts"

Total: 48526ms
```
</details>
<details>
<summary>Evidence: Clean v1 JSON report</summary>

```text
{
  "schemaVersion": 1,
  "verdict": "pass",
  "durationMs": 46286,
  "invariants": [
    {
      "id": "db-authority-fixture",
      "name": "DB authority fixture",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts\"",
      "verdict": "pass",
      "exitCode": 0,
      "durationMs": 5238,
      "signal": null,
      "error": null
    },
    {
      "id": "projection-conflict",
      "name": "Projection conflict",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-authority-projection-conflict.test.ts\"",
      "verdict": "pass",
      "exitCode": 0,
      "durationMs": 5059,
      "signal": null,
      "error": null
    },
    {
      "id": "fault-harness-contract",
      "name": "Fault harness contract",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts\"",
      "verdict": "pass",
      "exitCode": 0,
      "durationMs": 661,
      "signal": null,
      "error": null
    },
    {
      "id": "fault-boundary-matrix",
      "name": "Fault boundary matrix",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts\"",
      "verdict": "pass",
      "exitCode": 0,
      "durationMs": 35328,
      "signal": null,
      "error": null
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Validated schema and fixed command mapping</summary>

```text
{
  "schemaVersion": 1,
  "verdict": "pass",
  "invariantCount": 4,
  "mapping": [
    {
      "id": "db-authority-fixture",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts\"",
      "verdict": "pass",
      "exitCode": 0
    },
    {
      "id": "projection-conflict",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-authority-projection-conflict.test.ts\"",
      "verdict": "pass",
      "exitCode": 0
    },
    {
      "id": "fault-harness-contract",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts\"",
      "verdict": "pass",
      "exitCode": 0
    },
    {
      "id": "fault-boundary-matrix",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts\"",
      "verdict": "pass",
      "exitCode": 0
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Controlled sabotage report</summary>

```text
{
  "schemaVersion": 1,
  "verdict": "fail",
  "durationMs": 41648,
  "invariants": [
    {
      "id": "db-authority-fixture",
      "name": "DB authority fixture",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-authority-fixture.test.ts\"",
      "verdict": "pass",
      "exitCode": 0,
      "durationMs": 5036,
      "signal": null,
      "error": null
    },
    {
      "id": "projection-conflict",
      "name": "Projection conflict",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-authority-projection-conflict.test.ts\"",
      "verdict": "fail",
      "exitCode": 1,
      "durationMs": 313,
      "signal": null,
      "error": null
    },
    {
      "id": "fault-harness-contract",
      "name": "Fault harness contract",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-fault-harness.test.ts\"",
      "verdict": "pass",
      "exitCode": 0,
      "durationMs": 585,
      "signal": null,
      "error": null
    },
    {
      "id": "fault-boundary-matrix",
      "name": "Fault boundary matrix",
      "command": "\"node\" \"--import\" \"./src/resources/extensions/gsd/tests/resolve-ts.mjs\" \"--experimental-strip-types\" \"--test\" \"src/resources/extensions/gsd/tests/workflow-authority-faults.test.ts\"",
      "verdict": "pass",
      "exitCode": 0,
      "durationMs": 35714,
      "signal": null,
      "error": null
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Controlled sabotage verification</summary>

```text
{
  "packageExitCode": 1,
  "reportVerdict": "fail",
  "allFourRan": true,
  "rows": [
    {
      "id": "db-authority-fixture",
      "verdict": "pass",
      "exitCode": 0
    },
    {
      "id": "projection-conflict",
      "verdict": "fail",
      "exitCode": 1
    },
    {
      "id": "fault-harness-contract",
      "verdict": "pass",
      "exitCode": 0
    },
    {
      "id": "fault-boundary-matrix",
      "verdict": "pass",
      "exitCode": 0
    }
  ],
  "firstFailingChild": {
    "id": "projection-conflict",
    "exitCode": 1
  }
}
```
</details>
<details>
<summary>Evidence: Focused contract test</summary>

```text
✔ workflow authority baseline reports four fixed invariants in stable order (5.222ms)
✔ workflow authority baseline preserves the first failing child status (1.427208ms)
✔ workflow authority baseline controlled sabotage exits nonzero (42450.507083ms)
✔ workflow authority baseline CLI emits the v1 JSON report (67749.622ms)
ℹ tests 4
ℹ suites 0
ℹ pass 4
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 110598.118833
```
</details>
<details>
<summary>Evidence: Duration-excluded stable comparison</summary>

`Stable comparison: MATCH after excluding top-level and per-invariant durationMs fields.`

```text
Stable comparison: MATCH after excluding top-level and per-invariant durationMs fields.
```
</details>
<details>
<summary>Evidence: Arbitrary override rejection</summary>

`Unknown argument: --command`

```text
Unknown argument: --command
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `src/tests/workflow-authority-baseline.test.ts:92` - The controlled-sabotage test replaces the fixed four-invariant corpus with an arbitrary temporary test through the `invariants` override. This proves that Node detects an intentionally failing dummy test, not that the canonical authority gate catches sabotage through the package-script failure path, conflicting with the stated fixed-corpus/no-arbitrary-overrides contract. Confirm whether this test-only exception is intentional; otherwise sabotage an accepted child seam while keeping the corpus fixed.
- ⚠️ `src/tests/workflow-authority-baseline.test.ts:106` - The CLI contract test permits the complete four-child run only 55 seconds, although the runner permits each sequential child 60 seconds. A valid baseline can therefore satisfy the runner contract but be killed by this test on a slow host; raise the outer test and spawn timeouts above the cumulative child budget plus headroom.

🔧 Fix: Enforce fixed workflow corpus and safe CLI timeouts
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git branch -a --contains HEAD` and diff inspection from `00e00d0e...5bb6a2fb`</code>
- `pnpm run baseline:workflow-authority`
- <code>`pnpm --silent run baseline:workflow-authority -- --json` with explicit v1 schema, key-order, row-count, ID, command, verdict, and exit-code assertions</code>
- <code>Controlled sabotage via `NODE_OPTIONS=--import=.../controlled-sabotage.mjs pnpm --silent run baseline:workflow-authority -- --json`, asserting package exit 1, all four rows executed, and the first failing child status was retained</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/workflow-authority-baseline.test.ts`
- <code>Two clean JSON captures normalized with `jq &#39;del(.durationMs) | .invariants |= map(del(.durationMs))&#39;` and compared with `diff -u`</code>
- <code>`pnpm --silent run baseline:workflow-authority -- --command &#34;echo unsafe&#34;`, asserting exit 1 and `Unknown argument: --command`</code>
- <code>Final `git status --short` and evidence-directory inventory</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
