### PR TITLE
fix(issue): [Feature]: Support using pi-llama-cpp for local models

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1085,7 +1085,7 @@ export async function bootstrapAutoSession(
   // provider the user is not logged into and surface as "Not logged in · Please
   // run /login" before pausing and resetting to claude-code/claude-sonnet-4-6.
   const manualSessionOverride = getSessionModelOverride(ctx.sessionManager.getSessionId());
-  const sessionProviderIsCustom = isCustomProvider(ctx.model?.provider);
+  const sessionProviderIsCustom = isCustomProvider(ctx.model?.provider, ctx.modelRegistry);
   const profileModelIds = modelIdsForProfileResolution(
     ctx.modelRegistry,
     resolveProfileAnchorProvider(ctx.model?.provider),

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -9,6 +9,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { getProviders } from "@gsd/pi-ai";
 import { gsdHome } from "./gsd-home.js";
 import type { DynamicRoutingConfig } from "./model-router.js";
 import { canonicalModelForTier, defaultRoutingConfig, resolveModelForTier } from "./model-router.js";
@@ -30,6 +31,12 @@ import { getUnitPhaseChain } from "./unit-registry.js";
 
 // Re-export types so existing consumers of ./preferences-models.js keep working
 export type { GSDPhaseModelConfig, GSDModelConfig, GSDModelConfigV2, ResolvedModelConfig } from "./preferences-types.js";
+
+type ProviderModelRegistry = {
+  getAll?: () => ReadonlyArray<{ provider: string }>;
+  getAvailable?: () => ReadonlyArray<{ provider: string }>;
+  getAllWithDiscovered?: () => ReadonlyArray<{ provider: string }>;
+};
 
 /**
  * Resolve which model ID to use for a given auto-mode unit type.
@@ -321,9 +328,8 @@ export function resolveDefaultSessionModel(
 }
 
 /**
- * Returns true if `provider` is defined as a custom provider in the user's
- * `~/.gsd/agent/models.json` (Ollama, vLLM, LM Studio, OpenAI-compatible
- * proxies, etc.).
+ * Returns true if `provider` is a custom provider. Custom providers may be
+ * declared in `models.json` or registered dynamically by a Pi extension.
  *
  * Used by auto-mode bootstrap to decide whether the session model
  * (set via `/gsd model`) should override `PREFERENCES.md`.  Custom providers
@@ -332,13 +338,13 @@ export function resolveDefaultSessionModel(
  * priority — otherwise auto-mode tries to start the built-in provider from
  * PREFERENCES.md and fails with "Not logged in · Please run /login" (#4122).
  *
- * Reads models.json directly with a lightweight JSON parse to avoid
- * pulling in the full model-registry at this call site.  Falls back to
- * `~/.pi/agent/models.json` for parity with `resolveModelsJsonPath()`.
- * Any read or parse error yields `false` (treat as not-custom) so a
- * malformed models.json never breaks the session bootstrap.
+ * Reads models.json directly with a lightweight JSON parse, then checks the
+ * live model registry for extension-registered providers that are not in the
+ * generated built-in provider catalog.  Falls back to `~/.pi/agent/models.json`
+ * for parity with `resolveModelsJsonPath()`. Any read, parse, or registry error
+ * yields `false` (treat as not-custom) so bootstrap stays non-fatal.
  */
-export function isCustomProvider(provider: string | undefined): boolean {
+export function isCustomProvider(provider: string | undefined, registry?: ProviderModelRegistry): boolean {
   if (!provider) return false;
   const candidates = [
     join(gsdHome(), "agent", "models.json"),
@@ -356,7 +362,20 @@ export function isCustomProvider(provider: string | undefined): boolean {
       // Ignore — malformed models.json must not break bootstrap.
     }
   }
-  return false;
+  try {
+    const normalizedProvider = provider.trim().toLowerCase();
+    if (!normalizedProvider) return false;
+    const builtInProviders = new Set(getProviders().map((p) => p.toLowerCase()));
+    if (builtInProviders.has(normalizedProvider)) return false;
+    const registryModels =
+      registry?.getAllWithDiscovered?.()
+      ?? registry?.getAll?.()
+      ?? registry?.getAvailable?.()
+      ?? [];
+    return registryModels.some((m) => m.provider.toLowerCase() === normalizedProvider);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -39,6 +39,27 @@ type ProviderModelRegistry = {
 };
 
 /**
+ * First-party providers shipped as bundled extensions that delegate to a
+ * vendor CLI (`authMode: "externalCli"`). They are registered into the live
+ * model registry at runtime, so they are absent from the generated `@gsd/pi-ai`
+ * catalog (`getProviders()`), but they are NOT custom: `PREFERENCES.md` can
+ * route to them, so they must defer to `PREFERENCES.md` like any other built-in
+ * provider. Without this exclusion the registry check below would classify the
+ * default `claude-code` provider (and the other CLI providers) as custom and
+ * silently skip `PREFERENCES.md` in auto-mode (#801, extends #4122).
+ *
+ * Kept in sync with the `registerProvider(...)` calls in the bundled CLI
+ * extensions (claude-code-cli, cursor-cli, google-cli). Names are lowercase for
+ * direct comparison against normalized provider ids.
+ */
+const BUILTIN_EXTENSION_PROVIDERS: ReadonlySet<string> = new Set([
+  "claude-code",
+  "cursor-agent",
+  "google-gemini-cli",
+  "google-antigravity",
+]);
+
+/**
  * Resolve which model ID to use for a given auto-mode unit type.
  * Returns undefined if no model preference is set for this unit type.
  */
@@ -340,9 +361,12 @@ export function resolveDefaultSessionModel(
  *
  * Reads models.json directly with a lightweight JSON parse, then checks the
  * live model registry for extension-registered providers that are not in the
- * generated built-in provider catalog.  Falls back to `~/.pi/agent/models.json`
- * for parity with `resolveModelsJsonPath()`. Any read, parse, or registry error
- * yields `false` (treat as not-custom) so bootstrap stays non-fatal.
+ * generated built-in provider catalog (`getProviders()`) and not one of the
+ * bundled external-CLI providers (`BUILTIN_EXTENSION_PROVIDERS`, e.g.
+ * `claude-code`), which register at runtime but are still built-in.  Falls back
+ * to `~/.pi/agent/models.json` for parity with `resolveModelsJsonPath()`. Any
+ * read, parse, or registry error yields `false` (treat as not-custom) so
+ * bootstrap stays non-fatal.
  */
 export function isCustomProvider(provider: string | undefined, registry?: ProviderModelRegistry): boolean {
   if (!provider) return false;
@@ -365,6 +389,7 @@ export function isCustomProvider(provider: string | undefined, registry?: Provid
   try {
     const normalizedProvider = provider.trim().toLowerCase();
     if (!normalizedProvider) return false;
+    if (BUILTIN_EXTENSION_PROVIDERS.has(normalizedProvider)) return false;
     const builtInProviders = new Set(getProviders().map((p) => p.toLowerCase()));
     if (builtInProviders.has(normalizedProvider)) return false;
     const registryModels =

--- a/src/resources/extensions/gsd/tests/model-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/model-isolation.test.ts
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { isCustomProvider } from "../preferences-models.ts";
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -303,3 +304,44 @@ describe("custom provider session model overrides PREFERENCES.md (#4122)", () =>
   });
 });
 
+describe("custom provider detection (#801)", () => {
+  let originalGsdHome: string | undefined;
+  let tmpGsdHome: string;
+
+  beforeEach(() => {
+    originalGsdHome = process.env.GSD_HOME;
+    tmpGsdHome = makeTmpDir("gsd-home");
+    process.env.GSD_HOME = tmpGsdHome;
+  });
+
+  afterEach(() => {
+    if (originalGsdHome === undefined) {
+      delete process.env.GSD_HOME;
+    } else {
+      process.env.GSD_HOME = originalGsdHome;
+    }
+    try { rmSync(tmpGsdHome, { recursive: true, force: true }); } catch {}
+  });
+
+  it("detects extension-registered providers that are not declared in models.json", () => {
+    const registry = {
+      getAllWithDiscovered: () => [
+        { provider: "pi-llama-cpp" },
+      ],
+    };
+
+    assert.equal(isCustomProvider("pi-llama-cpp", registry), true,
+      "runtime providers outside the built-in catalog should count as custom");
+  });
+
+  it("does not treat built-in providers as custom just because they are in the registry", () => {
+    const registry = {
+      getAll: () => [
+        { provider: "claude-code" },
+      ],
+    };
+
+    assert.equal(isCustomProvider("claude-code", registry), false,
+      "built-in providers must still defer to PREFERENCES.md");
+  });
+});

--- a/src/resources/extensions/gsd/tests/model-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/model-isolation.test.ts
@@ -344,4 +344,17 @@ describe("custom provider detection (#801)", () => {
     assert.equal(isCustomProvider("claude-code", registry), false,
       "built-in providers must still defer to PREFERENCES.md");
   });
+
+  it("does not treat bundled external-CLI providers as custom", () => {
+    // claude-code/cursor-agent/google-gemini-cli/google-antigravity register at
+    // runtime (so they are absent from the generated @gsd/pi-ai catalog), but
+    // they are first-party built-ins that PREFERENCES.md can route to. They must
+    // never be classified as custom, otherwise auto-mode silently ignores
+    // PREFERENCES.md for the default provider.
+    for (const provider of ["cursor-agent", "google-gemini-cli", "google-antigravity"]) {
+      const registry = { getAll: () => [{ provider }] };
+      assert.equal(isCustomProvider(provider, registry), false,
+        `${provider} is a built-in CLI provider and must defer to PREFERENCES.md`);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Fixed auto-start custom provider detection for runtime-registered local providers and verified the diff while dependency-based tests were blocked by missing install artifacts.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #801
- [#801 [Feature]: Support using pi-llama-cpp for local models](https://github.com/open-gsd/gsd-pi/issues/801)

## User
- @grumd

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/801-feature-support-using-pi-llama-cpp-for-l-1783824508`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode bootstrap model precedence logic; misclassification could still skip or honor PREFERENCES.md incorrectly, though errors degrade to non-custom and new tests cover the main cases.
> 
> **Overview**
> **Auto-mode** now treats extension-registered providers (e.g. `pi-llama-cpp`) as **custom** when deciding whether the session model overrides `PREFERENCES.md`, so `/gsd auto` keeps the locally selected model instead of rerouting to a built-in provider from preferences (#4122 behavior for `models.json` providers).
> 
> `isCustomProvider` gains an optional **live model registry** argument: after the existing `models.json` check, it treats providers present in the registry but absent from `@gsd/pi-ai`’s `getProviders()` catalog as custom. **Bundled external-CLI providers** (`claude-code`, `cursor-agent`, `google-gemini-cli`, `google-antigravity`) are explicitly excluded so runtime registration does not incorrectly skip `PREFERENCES.md` (#801).
> 
> `auto-start` passes `ctx.modelRegistry` into that helper; tests cover `pi-llama-cpp`, `claude-code`, and the other CLI builtins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d24e2f30abf1ff1f16f7a4a2d06e7963dc47a6c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->