### PR TITLE
feat(gsd): add canonical database foundation

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -24,7 +24,8 @@ gsd-db.ts  ← compatibility barrel over the explicit single-writer allowlist
        ├── db/writers/*.ts  ← the Single Writer Layer (one write subsystem per file)
        ├── db/{milestone-leases,unit-dispatches,auto-workers,runtime-kv,command-queue}.ts
        │                    ← typed coordination/runtime writers
-       ├── db-memory-fts-schema.ts, db-schema-metadata.ts, db-verification-evidence-schema.ts
+       ├── db-canonical-foundation-schema.ts, db-memory-fts-schema.ts,
+       │   db-schema-metadata.ts, db-verification-evidence-schema.ts
        │                    ← allowlisted schema/migration helpers
        ├── memory-backfill.ts
        │                    ← allowlisted ADR migration/backfill helper
@@ -64,7 +65,7 @@ After commit: regenerate markdown artifacts → write to disk → invalidate cac
 
 ## 2. Schema Version History
 
-Current version: **V30**
+Current version: **V31**
 
 | Version | What Changed |
 |---------|-------------|
@@ -98,6 +99,7 @@ Current version: **V30**
 | V28 | memories.last_hit_at; incrementMemoryHitCount sets it; queryMemoriesRanked applies time-decay (1.0 → 0.7 floor over 90 days) |
 | V29 | slices.target_repositories and tasks.target_repositories for multi-repository planning |
 | V30 | rework_briefs and rework_brief_findings for structured task rework gates |
+| V31 | **Additive canonical foundation**: singleton project authority with revision and Authority Epoch, workflow operation provenance/idempotency receipts, immutable revision-linked domain events, and a durable event outbox |
 
 ---
 
@@ -669,6 +671,101 @@ Non-correctness-critical state: UI cursors, dashboard caches, resume pointers. S
 
 ---
 
+### 3e. Additive Canonical Foundation (V31)
+
+V31 creates these tables on fresh databases and transactionally upgrades V30
+databases. It is schema-only in this release: existing runtime read/write paths
+are not routed through these tables yet, and no import, projection worker,
+lifecycle API, or legacy deletion ships with this migration.
+
+#### `project_authority`
+```
+singleton            INTEGER PRIMARY KEY CHECK (singleton = 1)
+project_id           TEXT NOT NULL UNIQUE
+project_root_realpath TEXT NOT NULL DEFAULT ''
+revision             INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0)
+authority_epoch      INTEGER NOT NULL DEFAULT 0 CHECK (authority_epoch >= 0)
+created_at           TEXT NOT NULL DEFAULT ''
+updated_at           TEXT NOT NULL DEFAULT ''
+```
+- Exactly one row is seeded with a generated 32-character lowercase hex
+  `project_id`; fresh and upgraded databases begin at revision/epoch `0`.
+- `schema_version` remains the DDL compatibility version and is not this domain
+  revision.
+
+#### `workflow_operations`
+```
+operation_id             TEXT PRIMARY KEY
+project_id               TEXT NOT NULL
+operation_type           TEXT NOT NULL
+idempotency_key          TEXT NOT NULL
+expected_revision        INTEGER NOT NULL CHECK (expected_revision >= 0)
+resulting_revision       INTEGER NOT NULL CHECK (resulting_revision = expected_revision + 1)
+expected_authority_epoch INTEGER NOT NULL CHECK (expected_authority_epoch >= 0)
+resulting_authority_epoch INTEGER NOT NULL
+actor_type               TEXT NOT NULL
+actor_id                 TEXT DEFAULT NULL
+source_transport         TEXT NOT NULL
+trace_id                 TEXT DEFAULT NULL
+turn_id                  TEXT DEFAULT NULL
+request_hash             TEXT NOT NULL
+created_at               TEXT NOT NULL
+FOREIGN KEY project_id → project_authority(project_id)
+```
+- `resulting_authority_epoch` must equal the expected epoch or advance it by
+  exactly one.
+- `(project_id, idempotency_key)` and `(project_id, resulting_revision)` are
+  unique. The composite operation/project/result revision/result epoch key binds
+  emitted events to the exact recorded operation result.
+- Index: `idx_workflow_operations_created` (project_id, created_at, operation_id)
+
+#### `workflow_domain_events`
+```
+event_id          TEXT PRIMARY KEY
+operation_id      TEXT NOT NULL
+event_index       INTEGER NOT NULL DEFAULT 0 CHECK (event_index >= 0)
+project_id        TEXT NOT NULL
+project_revision  INTEGER NOT NULL CHECK (project_revision > 0)
+authority_epoch   INTEGER NOT NULL CHECK (authority_epoch >= 0)
+event_type        TEXT NOT NULL
+entity_type       TEXT NOT NULL
+entity_id         TEXT NOT NULL
+caused_by_event_id TEXT DEFAULT NULL
+payload_json      TEXT NOT NULL DEFAULT '{}'
+created_at        TEXT NOT NULL
+```
+- `(operation_id, event_index)` is unique.
+- The composite foreign key to `workflow_operations` requires every event's
+  project revision and Authority Epoch to match its operation result exactly;
+  `caused_by_event_id` may link to another domain event.
+- Update and delete triggers abort with `workflow domain events are immutable`.
+- Index: `idx_workflow_domain_events_entity`
+  (project_id, entity_type, entity_id, project_revision, event_index)
+
+#### `workflow_outbox`
+```
+outbox_id        INTEGER PRIMARY KEY AUTOINCREMENT
+event_id         TEXT NOT NULL
+destination      TEXT NOT NULL
+available_at     TEXT NOT NULL DEFAULT ''
+attempt_count    INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0)
+claimed_by       TEXT DEFAULT NULL
+claim_expires_at TEXT DEFAULT NULL
+delivered_at     TEXT DEFAULT NULL
+last_error       TEXT DEFAULT NULL
+FOREIGN KEY event_id → workflow_domain_events(event_id)
+```
+- `(event_id, destination)` is unique.
+- Index: `idx_workflow_outbox_pending` (delivered_at, available_at, outbox_id)
+
+These four tables are deliberately distinct from existing narrower concepts:
+`audit_events` remains optional operational telemetry,
+`milestone_commit_attributions` remains Git-specific attribution, and
+`command_queue`/`runtime_kv` remain coordination/cache surfaces rather than
+operation provenance, domain history, or an outbox.
+
+---
+
 ## 4. Entity Relationship Diagram
 
 ```
@@ -711,6 +808,12 @@ turn_git_transactions  (audit, keyed by trace_id + turn_id + stage)
 audit_events  (append-only audit log)
 audit_turn_index  (turn-level index into audit_events)
 runtime_kv  (soft state KV)
+
+project_authority ──► workflow_operations (project_id)
+workflow_operations ──► workflow_domain_events
+  (operation_id + project_id + resulting revision + resulting Authority Epoch)
+workflow_domain_events ──► workflow_domain_events (caused_by_event_id)
+workflow_domain_events ──► workflow_outbox (event_id)
 ```
 
 ---
@@ -722,13 +825,16 @@ artifacts, milestones, slices, tasks, decisions, replan history, assessments,
 quality gates, verification evidence, and milestone commit attributions. Restore
 rebuilds decision mirror memories from the restored decisions and preserves
 optional rows when reading older manifests that predate the extended arrays.
+The additive V31 canonical-foundation tables are not yet part of this legacy
+manifest surface because runtime reads/writes have not cut over to them.
 
 `reconcileWorktreeDb` merges hidden-worktree correctness rows back into the main
 DB, including hierarchy, requirements, artifacts, memories, replan history,
 assessments, quality gates, slice dependencies, verification evidence, gate
 runs, and milestone commit attributions. Runtime-only/audit substrates such as
 `runtime_kv`, `turn_git_transactions`, `audit_events`, and `audit_turn_index`
-remain outside manifest restore.
+remain outside manifest restore. The V31 canonical-foundation tables likewise
+remain outside worktree reconciliation until a later runtime-routing slice.
 
 ---
 
@@ -800,7 +906,7 @@ remain outside manifest restore.
 
 ## 7. Write Path Invariants
 
-1. **Single-writer rule**: all write SQL lives in the explicit single-writer *layer* — `db/engine.ts` for schema, migrations, lifecycle, and transaction primitives; `db/writers/**` for domain write subsystems; `gsd-db.ts` as the compatibility barrel and remaining mid-migration wrappers; the typed coordination/runtime writer modules `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, and `db/command-queue.ts`; the schema/migration helpers `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, and `db-verification-evidence-schema.ts`; and the ADR migration/backfill helper `memory-backfill.ts`. This is an allowlist, not permission for arbitrary raw writes under `db/`. `unit-ownership.ts` remains excluded because it owns a separate `.gsd/unit-claims.db`. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks this allowlist.
+1. **Single-writer rule**: all write SQL lives in the explicit single-writer *layer* — `db/engine.ts` for schema, migrations, lifecycle, and transaction primitives; `db/writers/**` for domain write subsystems; `gsd-db.ts` as the compatibility barrel and remaining mid-migration wrappers; the typed coordination/runtime writer modules `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, and `db/command-queue.ts`; the schema/migration helpers `db-canonical-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, and `db-verification-evidence-schema.ts`; and the ADR migration/backfill helper `memory-backfill.ts`. This is an allowlist, not permission for arbitrary raw writes under `db/`. `unit-ownership.ts` remains excluded because it owns a separate `.gsd/unit-claims.db`. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks this allowlist.
 
 2. **Transaction wrapping**: every multi-table write uses `transaction()` or `immediateTransaction()` when it needs SQLite's reserved writer lock up front. Rollback on any error. Re-entrant: nested calls increment the shared depth counter; no nested `BEGIN`. `gsd_save_gate_result` commits the `quality_gates` verdict update and matching `gate_runs` ledger insert together, so recovery never sees a completed gate without its audit row.
 

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -346,6 +346,7 @@ unit completes
 | Source File | Tables |
 |------------|--------|
 | `db-base-schema.ts` | schema_version, decisions, requirements, artifacts, memories, memory_processed_units, memory_sources, memory_embeddings, memory_relations, milestones, slices, tasks, verification_evidence, replan_history, assessments, quality_gates, slice_dependencies, gate_runs, turn_git_transactions, milestone_commit_attributions, audit_events, audit_turn_index + all indexes + active_decisions/active_requirements/active_memories views |
+| `db-canonical-foundation-schema.ts` | project_authority, workflow_operations, workflow_domain_events, workflow_outbox + domain-event immutability triggers and canonical-foundation indexes (V31, additive and not runtime-routed yet) |
 | `db-coordination-schema.ts` | workers, milestone_leases, unit_dispatches, cancellation_requests, command_queue |
 | `db-memory-fts-schema.ts` | memories_fts (FTS5 virtual table), memories_ai/ad/au triggers |
 | `db-runtime-kv-schema.ts` | runtime_kv |
@@ -371,7 +372,7 @@ unit completes
 
 | Invariant | Where Enforced |
 |-----------|---------------|
-| Single-writer: all write SQL in the explicit single-writer allowlist (`db/engine.ts`, `db/writers/**`, `gsd-db.ts`, typed coordination/runtime writers `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, `db/command-queue.ts`, schema/migration helpers `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, `db-verification-evidence-schema.ts`, and ADR migration/backfill helper `memory-backfill.ts`); this is not permission for arbitrary writes under `db/`; `unit-ownership.ts` owns separate `.gsd/unit-claims.db`; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (explicit allowlist) |
+| Single-writer: all write SQL in the explicit single-writer allowlist (`db/engine.ts`, `db/writers/**`, `gsd-db.ts`, typed coordination/runtime writers `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, `db/command-queue.ts`, schema/migration helpers `db-canonical-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, `db-verification-evidence-schema.ts`, and ADR migration/backfill helper `memory-backfill.ts`); this is not permission for arbitrary writes under `db/`; `unit-ownership.ts` owns separate `.gsd/unit-claims.db`; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (explicit allowlist) |
 | Cascade on slice complete: pending tasks → skipped | `gsd_slice_complete` transaction |
 | Cascade on milestone reopen: all slices → in_progress, tasks → pending | `gsd_milestone_reopen` transaction |
 | No nested write transactions: `transaction()` and `immediateTransaction()` share one depth counter; read-then-write claims use `immediateTransaction()` and gate verdict + ledger writes commit atomically | `db-transaction.test.ts`, `command-queue.test.ts`, `gate-storage.test.ts` |

--- a/src/resources/extensions/gsd/db-canonical-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-canonical-foundation-schema.ts
@@ -32,6 +32,10 @@ export function createCanonicalFoundationSchemaV31(db: DbAdapter): void {
       expected_revision INTEGER NOT NULL CHECK (expected_revision >= 0),
       resulting_revision INTEGER NOT NULL CHECK (resulting_revision = expected_revision + 1),
       expected_authority_epoch INTEGER NOT NULL CHECK (expected_authority_epoch >= 0),
+      resulting_authority_epoch INTEGER NOT NULL CHECK (
+        resulting_authority_epoch = expected_authority_epoch OR
+        resulting_authority_epoch = expected_authority_epoch + 1
+      ),
       actor_type TEXT NOT NULL,
       actor_id TEXT DEFAULT NULL,
       source_transport TEXT NOT NULL,
@@ -41,7 +45,7 @@ export function createCanonicalFoundationSchemaV31(db: DbAdapter): void {
       created_at TEXT NOT NULL,
       UNIQUE (project_id, idempotency_key),
       UNIQUE (project_id, resulting_revision),
-      UNIQUE (operation_id, project_id, resulting_revision, expected_authority_epoch),
+      UNIQUE (operation_id, project_id, resulting_revision, resulting_authority_epoch),
       FOREIGN KEY (project_id) REFERENCES project_authority(project_id)
     )
   `);
@@ -63,10 +67,25 @@ export function createCanonicalFoundationSchemaV31(db: DbAdapter): void {
       UNIQUE (operation_id, event_index),
       FOREIGN KEY (operation_id, project_id, project_revision, authority_epoch)
         REFERENCES workflow_operations(
-          operation_id, project_id, resulting_revision, expected_authority_epoch
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
         ),
       FOREIGN KEY (caused_by_event_id) REFERENCES workflow_domain_events(event_id)
     )
+  `);
+
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_domain_events_immutable_update
+    BEFORE UPDATE ON workflow_domain_events
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow domain events are immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_domain_events_immutable_delete
+    BEFORE DELETE ON workflow_domain_events
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow domain events are immutable');
+    END
   `);
 
   db.exec(`

--- a/src/resources/extensions/gsd/db-canonical-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-canonical-foundation-schema.ts
@@ -1,0 +1,110 @@
+// Project/App: gsd-pi
+// File Purpose: Additive v31 authority, operation provenance, domain event, and outbox schema.
+
+import type { DbAdapter } from "./db-adapter.js";
+
+/**
+ * v31 mapping:
+ * - schema_version remains DDL compatibility, not the domain revision.
+ * - audit_events remains optional operational telemetry, not domain history.
+ * - milestone_commit_attributions remains Git-specific, not operation provenance.
+ * - command_queue and runtime_kv remain coordination/cache surfaces, not an outbox.
+ */
+export function createCanonicalFoundationSchemaV31(db: DbAdapter): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS project_authority (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      project_id TEXT NOT NULL UNIQUE,
+      project_root_realpath TEXT NOT NULL DEFAULT '',
+      revision INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+      authority_epoch INTEGER NOT NULL DEFAULT 0 CHECK (authority_epoch >= 0),
+      created_at TEXT NOT NULL DEFAULT '',
+      updated_at TEXT NOT NULL DEFAULT ''
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_operations (
+      operation_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      operation_type TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      expected_revision INTEGER NOT NULL CHECK (expected_revision >= 0),
+      resulting_revision INTEGER NOT NULL CHECK (resulting_revision = expected_revision + 1),
+      expected_authority_epoch INTEGER NOT NULL CHECK (expected_authority_epoch >= 0),
+      actor_type TEXT NOT NULL,
+      actor_id TEXT DEFAULT NULL,
+      source_transport TEXT NOT NULL,
+      trace_id TEXT DEFAULT NULL,
+      turn_id TEXT DEFAULT NULL,
+      request_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      UNIQUE (project_id, idempotency_key),
+      UNIQUE (project_id, resulting_revision),
+      UNIQUE (operation_id, project_id, resulting_revision, expected_authority_epoch),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id)
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_domain_events (
+      event_id TEXT PRIMARY KEY,
+      operation_id TEXT NOT NULL,
+      event_index INTEGER NOT NULL DEFAULT 0 CHECK (event_index >= 0),
+      project_id TEXT NOT NULL,
+      project_revision INTEGER NOT NULL CHECK (project_revision > 0),
+      authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 0),
+      event_type TEXT NOT NULL,
+      entity_type TEXT NOT NULL,
+      entity_id TEXT NOT NULL,
+      caused_by_event_id TEXT DEFAULT NULL,
+      payload_json TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      UNIQUE (operation_id, event_index),
+      FOREIGN KEY (operation_id, project_id, project_revision, authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, expected_authority_epoch
+        ),
+      FOREIGN KEY (caused_by_event_id) REFERENCES workflow_domain_events(event_id)
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_outbox (
+      outbox_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id TEXT NOT NULL,
+      destination TEXT NOT NULL,
+      available_at TEXT NOT NULL DEFAULT '',
+      attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+      claimed_by TEXT DEFAULT NULL,
+      claim_expires_at TEXT DEFAULT NULL,
+      delivered_at TEXT DEFAULT NULL,
+      last_error TEXT DEFAULT NULL,
+      UNIQUE (event_id, destination),
+      FOREIGN KEY (event_id) REFERENCES workflow_domain_events(event_id)
+    )
+  `);
+
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_workflow_operations_created
+    ON workflow_operations(project_id, created_at, operation_id)
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_workflow_domain_events_entity
+    ON workflow_domain_events(project_id, entity_type, entity_id, project_revision, event_index)
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_workflow_outbox_pending
+    ON workflow_outbox(delivered_at, available_at, outbox_id)
+  `);
+
+  db.exec(`
+    INSERT OR IGNORE INTO project_authority (
+      singleton, project_id, project_root_realpath,
+      revision, authority_epoch, created_at, updated_at
+    ) VALUES (
+      1, lower(hex(randomblob(16))), '',
+      0, 0, '', ''
+    )
+  `);
+}

--- a/src/resources/extensions/gsd/db-migration-steps.ts
+++ b/src/resources/extensions/gsd/db-migration-steps.ts
@@ -2,6 +2,7 @@
 // File Purpose: Schema migration DDL steps for the GSD database facade.
 
 import type { DbAdapter } from "./db-adapter.js";
+import { createCanonicalFoundationSchemaV31 } from "./db-canonical-foundation-schema.js";
 import { ensureColumn } from "./db-schema-metadata.js";
 
 export function applyMigrationV2Artifacts(db: DbAdapter): void {
@@ -493,4 +494,8 @@ export function applyMigrationV30ReworkBriefs(db: DbAdapter): void {
   `);
   db.exec("CREATE INDEX IF NOT EXISTS idx_rework_briefs_task ON rework_briefs(milestone_id, slice_id, task_id)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_rework_findings_status ON rework_brief_findings(brief_id, severity, status)");
+}
+
+export function applyMigrationV31CanonicalFoundation(db: DbAdapter): void {
+  createCanonicalFoundationSchemaV31(db);
 }

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -47,7 +47,9 @@ import {
   applyMigrationV28MemoryLastHitAt,
   applyMigrationV29RepositoryTargets,
   applyMigrationV30ReworkBriefs,
+  applyMigrationV31CanonicalFoundation,
 } from "../db-migration-steps.js";
+import { createCanonicalFoundationSchemaV31 } from "../db-canonical-foundation-schema.js";
 import {
   isMemoriesFtsAvailableSchema,
   rebuildMemoriesFtsSchemaOnce,
@@ -97,7 +99,7 @@ const providerLoader = createSqliteProviderLoader({
   nodeVersion: process.versions.node,
   writeStderr: (message: string) => process.stderr.write(message),
 });
-export const SCHEMA_VERSION = 30;
+export const SCHEMA_VERSION = 31;
 function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): void {
   const conservativeFilePragmas = fileBacked && _isLikelyWslDrvFsPathForTest(dbPath);
   if (fileBacked) db.exec(conservativeFilePragmas ? "PRAGMA journal_mode=DELETE" : "PRAGMA journal_mode=WAL");
@@ -135,6 +137,7 @@ function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): 
       } else {
         createCoordinationTablesV24(db);
         createRuntimeKvTableV25(db);
+        createCanonicalFoundationSchemaV31(db);
 
         // Fresh install — all tables are created above with the full current schema,
         // so it is safe to create all migration-specific indexes here.  For existing
@@ -386,6 +389,11 @@ function migrateSchema(db: DbAdapter, dbPath: string | null): void {
     if (currentVersion < 30) {
       applyMigrationV30ReworkBriefs(db);
       recordSchemaVersion(db, 30);
+    }
+
+    if (currentVersion < 31) {
+      applyMigrationV31CanonicalFoundation(db);
+      recordSchemaVersion(db, 31);
     }
 
     if (_migrationFaultForTest) throw new Error("migration fault injected for test");

--- a/src/resources/extensions/gsd/tests/db-canonical-foundation.test.ts
+++ b/src/resources/extensions/gsd/tests/db-canonical-foundation.test.ts
@@ -1,0 +1,356 @@
+// Project/App: gsd-pi
+// File Purpose: Executable contract for the additive v31 canonical database foundation.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import {
+  SCHEMA_VERSION,
+  _getAdapter,
+  _setMigrationFaultForTest,
+  closeDatabase,
+  openDatabase,
+} from "../gsd-db.ts";
+
+const require = createRequire(import.meta.url);
+const tempDirs = new Set<string>();
+
+interface RawDb {
+  exec(sql: string): void;
+  prepare(sql: string): {
+    get(...args: unknown[]): Record<string, unknown> | undefined;
+    all(...args: unknown[]): Array<Record<string, unknown>>;
+  };
+  close(): void;
+}
+
+function openRawDatabase(path: string): RawDb {
+  const sqlite = require("node:sqlite") as { DatabaseSync: new (path: string) => RawDb };
+  return new sqlite.DatabaseSync(path);
+}
+
+function createDatabasePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-canonical-foundation-"));
+  tempDirs.add(dir);
+  return join(dir, "gsd.db");
+}
+
+function tableExists(db: RawDb, table: string): boolean {
+  return Boolean(
+    db.prepare("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?").get(table),
+  );
+}
+
+function maxSchemaVersion(db: RawDb): number {
+  return Number(db.prepare("SELECT MAX(version) AS version FROM schema_version").get()?.version);
+}
+
+function rewindToV30(dbPath: string): void {
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+
+  const raw = openRawDatabase(dbPath);
+  try {
+    raw.exec(`
+      DROP TABLE IF EXISTS workflow_outbox;
+      DROP TABLE IF EXISTS workflow_domain_events;
+      DROP TABLE IF EXISTS workflow_operations;
+      DROP TABLE IF EXISTS project_authority;
+      DELETE FROM schema_version;
+      INSERT INTO schema_version (version, applied_at) VALUES (30, '2026-07-12T00:00:00.000Z');
+      INSERT OR IGNORE INTO milestones (id, title, status, created_at)
+      VALUES ('M-LEGACY', 'Preserved legacy milestone', 'active', '2026-07-12T00:00:00.000Z');
+      INSERT OR IGNORE INTO audit_events
+        (event_id, trace_id, category, type, ts, payload_json)
+      VALUES
+        ('audit-legacy', 'trace-legacy', 'workflow', 'legacy', '2026-07-12T00:00:00.000Z', '{"kept":true}');
+    `);
+  } finally {
+    raw.close();
+  }
+}
+
+function inspectFromFreshProcess(dbPath: string): Record<string, unknown> {
+  const moduleHref = pathToFileURL(
+    join(process.cwd(), "src/resources/extensions/gsd/gsd-db.ts"),
+  ).href;
+  const script = [
+    `import { openDatabase, closeDatabase, _getAdapter } from ${JSON.stringify(moduleHref)};`,
+    "const path = process.argv[1];",
+    "if (!openDatabase(path)) throw new Error('database open failed');",
+    "const db = _getAdapter();",
+    "const version = db.prepare('SELECT MAX(version) AS value FROM schema_version').get().value;",
+    "const authority = db.prepare('SELECT project_id, revision, authority_epoch FROM project_authority').get();",
+    "const legacy = db.prepare(\"SELECT title FROM milestones WHERE id = 'M-LEGACY'\").get();",
+    "console.log(JSON.stringify({ version, authority, legacy }));",
+    "closeDatabase();",
+  ].join("\n");
+  const env = { ...process.env };
+  delete env.NODE_TEST_CONTEXT;
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      "./src/resources/extensions/gsd/tests/resolve-ts.mjs",
+      "--experimental-strip-types",
+      "--input-type=module",
+      "-e",
+      script,
+      dbPath,
+    ],
+    { cwd: process.cwd(), encoding: "utf8", env, timeout: 30_000 },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  return JSON.parse(child.stdout) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  _setMigrationFaultForTest(false);
+  closeDatabase();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+test("fresh database creates the v31 authority root and linked operation journal", () => {
+  assert.equal(SCHEMA_VERSION, 31);
+  const dbPath = createDatabasePath();
+  assert.equal(openDatabase(dbPath), true);
+  const db = _getAdapter();
+  assert.ok(db);
+
+  const authority = db.prepare(`
+    SELECT singleton, project_id, project_root_realpath, revision, authority_epoch
+    FROM project_authority
+  `).get();
+  assert.deepEqual(
+    {
+      singleton: authority?.singleton,
+      projectIdLength: String(authority?.project_id ?? "").length,
+      root: authority?.project_root_realpath,
+      revision: authority?.revision,
+      epoch: authority?.authority_epoch,
+    },
+    { singleton: 1, projectIdLength: 32, root: "", revision: 0, epoch: 0 },
+  );
+
+  assert.throws(
+    () => db.exec("INSERT INTO project_authority (singleton, project_id) VALUES (2, 'second')"),
+    /CHECK constraint failed/i,
+  );
+  assert.throws(
+    () => db.exec("UPDATE project_authority SET revision = -1 WHERE singleton = 1"),
+    /CHECK constraint failed/i,
+  );
+  assert.throws(
+    () => db.exec("UPDATE project_authority SET authority_epoch = -1 WHERE singleton = 1"),
+    /CHECK constraint failed/i,
+  );
+
+  db.exec(`
+    INSERT INTO workflow_operations (
+      operation_id, project_id, operation_type, idempotency_key,
+      expected_revision, resulting_revision, expected_authority_epoch,
+      actor_type, actor_id, source_transport, request_hash, created_at
+    )
+    SELECT
+      'op-1', project_id, 'test.operation', 'idem-1',
+      0, 1, 0, 'agent', 'test-agent', 'test', 'request-1', '2026-07-12T00:00:01.000Z'
+    FROM project_authority WHERE singleton = 1;
+
+    INSERT INTO workflow_domain_events (
+      event_id, operation_id, event_index, project_id, project_revision,
+      authority_epoch, event_type, entity_type, entity_id, payload_json, created_at
+    )
+    SELECT
+      'event-1', 'op-1', 0, project_id, 1,
+      0, 'test.started', 'project', project_id, '{"step":1}', '2026-07-12T00:00:02.000Z'
+    FROM project_authority WHERE singleton = 1;
+
+    INSERT INTO workflow_domain_events (
+      event_id, operation_id, event_index, project_id, project_revision,
+      authority_epoch, event_type, entity_type, entity_id, caused_by_event_id,
+      payload_json, created_at
+    )
+    SELECT
+      'event-2', 'op-1', 1, project_id, 1,
+      0, 'test.finished', 'project', project_id, 'event-1',
+      '{"step":2}', '2026-07-12T00:00:03.000Z'
+    FROM project_authority WHERE singleton = 1;
+
+    INSERT INTO workflow_outbox (event_id, destination, available_at)
+    VALUES ('event-2', 'projection', '2026-07-12T00:00:04.000Z');
+  `);
+
+  const chain = db.prepare(`
+    SELECT
+      p.revision AS authority_revision,
+      o.expected_revision,
+      o.resulting_revision,
+      COUNT(DISTINCT e.event_id) AS event_count,
+      COUNT(DISTINCT x.outbox_id) AS outbox_count
+    FROM project_authority p
+    JOIN workflow_operations o ON o.project_id = p.project_id
+    JOIN workflow_domain_events e ON e.operation_id = o.operation_id
+    LEFT JOIN workflow_outbox x ON x.event_id = e.event_id
+    GROUP BY p.revision, o.expected_revision, o.resulting_revision
+  `).get();
+  assert.deepEqual(chain, {
+    authority_revision: 0,
+    expected_revision: 0,
+    resulting_revision: 1,
+    event_count: 2,
+    outbox_count: 1,
+  });
+
+  assert.throws(
+    () => db.exec(`
+      INSERT INTO workflow_operations (
+        operation_id, project_id, operation_type, idempotency_key,
+        expected_revision, resulting_revision, expected_authority_epoch,
+        actor_type, source_transport, request_hash, created_at
+      )
+      SELECT 'op-duplicate', project_id, 'test.operation', 'idem-1', 1, 2, 0,
+             'agent', 'test', 'request-2', '2026-07-12T00:00:05.000Z'
+      FROM project_authority WHERE singleton = 1
+    `),
+    /UNIQUE constraint failed/i,
+  );
+  assert.throws(
+    () => db.exec(`
+      INSERT INTO workflow_operations (
+        operation_id, project_id, operation_type, idempotency_key,
+        expected_revision, resulting_revision, expected_authority_epoch,
+        actor_type, source_transport, request_hash, created_at
+      )
+      SELECT 'op-same-revision', project_id, 'test.operation', 'idem-2', 0, 1, 0,
+             'agent', 'test', 'request-2', '2026-07-12T00:00:05.000Z'
+      FROM project_authority WHERE singleton = 1
+    `),
+    /UNIQUE constraint failed/i,
+  );
+  assert.throws(
+    () => db.exec(`
+      INSERT INTO workflow_domain_events (
+        event_id, operation_id, event_index, project_id, project_revision,
+        authority_epoch, event_type, entity_type, entity_id, payload_json, created_at
+      )
+      SELECT 'event-duplicate-index', 'op-1', 1, project_id, 1, 0,
+             'test.duplicate', 'project', project_id, '{}', '2026-07-12T00:00:06.000Z'
+      FROM project_authority WHERE singleton = 1
+    `),
+    /UNIQUE constraint failed/i,
+  );
+  assert.throws(
+    () => db.exec(`
+      INSERT INTO workflow_domain_events (
+        event_id, operation_id, event_index, project_id, project_revision,
+        authority_epoch, event_type, entity_type, entity_id, payload_json, created_at
+      )
+      SELECT 'event-wrong-revision', 'op-1', 2, project_id, 2, 0,
+             'test.wrong-revision', 'project', project_id, '{}', '2026-07-12T00:00:06.000Z'
+      FROM project_authority WHERE singleton = 1
+    `),
+    /FOREIGN KEY constraint failed/i,
+  );
+  assert.throws(
+    () => db.exec(`
+      INSERT INTO workflow_outbox (event_id, destination, available_at)
+      VALUES ('missing-event', 'projection', '2026-07-12T00:00:07.000Z')
+    `),
+    /FOREIGN KEY constraint failed/i,
+  );
+  assert.throws(
+    () => db.exec(`
+      INSERT INTO workflow_outbox (event_id, destination, available_at)
+      VALUES ('event-2', 'projection', '2026-07-12T00:00:08.000Z')
+    `),
+    /UNIQUE constraint failed/i,
+  );
+});
+
+test("v30 upgrade preserves legacy rows and creates an independently healthy backup", () => {
+  const dbPath = createDatabasePath();
+  rewindToV30(dbPath);
+
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+
+  let projectId = "";
+  const upgraded = openRawDatabase(dbPath);
+  try {
+    assert.equal(maxSchemaVersion(upgraded), 31);
+    assert.equal(tableExists(upgraded, "project_authority"), true);
+    assert.equal(upgraded.prepare("SELECT title FROM milestones WHERE id = 'M-LEGACY'").get()?.title, "Preserved legacy milestone");
+    assert.equal(upgraded.prepare("SELECT payload_json FROM audit_events WHERE event_id = 'audit-legacy'").get()?.payload_json, '{"kept":true}');
+    assert.equal(upgraded.prepare("PRAGMA quick_check").get()?.quick_check, "ok");
+    projectId = String(upgraded.prepare("SELECT project_id FROM project_authority").get()?.project_id);
+  } finally {
+    upgraded.close();
+  }
+
+  const backup = openRawDatabase(`${dbPath}.backup-v30`);
+  try {
+    assert.equal(maxSchemaVersion(backup), 30);
+    assert.equal(tableExists(backup, "project_authority"), false);
+    assert.equal(backup.prepare("SELECT title FROM milestones WHERE id = 'M-LEGACY'").get()?.title, "Preserved legacy milestone");
+    assert.equal(backup.prepare("PRAGMA quick_check").get()?.quick_check, "ok");
+  } finally {
+    backup.close();
+  }
+
+  const reopened = inspectFromFreshProcess(dbPath);
+  assert.deepEqual(reopened, {
+    version: 31,
+    authority: { project_id: projectId, revision: 0, authority_epoch: 0 },
+    legacy: { title: "Preserved legacy milestone" },
+  });
+
+  const restoredPath = join(dirname(dbPath), "restored.db");
+  copyFileSync(`${dbPath}.backup-v30`, restoredPath);
+  const restored = inspectFromFreshProcess(restoredPath);
+  assert.equal(restored.version, 31);
+  assert.deepEqual(restored.legacy, { title: "Preserved legacy milestone" });
+  assert.deepEqual(
+    Object.fromEntries(
+      Object.entries(restored.authority as Record<string, unknown>).filter(([key]) => key !== "project_id"),
+    ),
+    { revision: 0, authority_epoch: 0 },
+  );
+});
+
+test("faulted v30 migration leaves no v31 state and retries cleanly", () => {
+  const dbPath = createDatabasePath();
+  rewindToV30(dbPath);
+
+  _setMigrationFaultForTest(true);
+  assert.throws(() => openDatabase(dbPath), /migration fault injected/);
+  _setMigrationFaultForTest(false);
+
+  const rolledBack = openRawDatabase(dbPath);
+  try {
+    assert.equal(maxSchemaVersion(rolledBack), 30);
+    assert.equal(tableExists(rolledBack, "project_authority"), false);
+    assert.equal(tableExists(rolledBack, "workflow_operations"), false);
+    assert.equal(tableExists(rolledBack, "workflow_domain_events"), false);
+    assert.equal(tableExists(rolledBack, "workflow_outbox"), false);
+  } finally {
+    rolledBack.close();
+  }
+
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+  const retried = openRawDatabase(dbPath);
+  try {
+    assert.equal(maxSchemaVersion(retried), 31);
+    assert.equal(retried.prepare("SELECT COUNT(*) AS count FROM project_authority").get()?.count, 1);
+    assert.equal(retried.prepare("SELECT COUNT(*) AS count FROM milestones WHERE id = 'M-LEGACY'").get()?.count, 1);
+  } finally {
+    retried.close();
+  }
+});

--- a/src/resources/extensions/gsd/tests/db-canonical-foundation.test.ts
+++ b/src/resources/extensions/gsd/tests/db-canonical-foundation.test.ts
@@ -155,12 +155,13 @@ test("fresh database creates the v31 authority root and linked operation journal
   db.exec(`
     INSERT INTO workflow_operations (
       operation_id, project_id, operation_type, idempotency_key,
-      expected_revision, resulting_revision, expected_authority_epoch,
+      expected_revision, resulting_revision,
+      expected_authority_epoch, resulting_authority_epoch,
       actor_type, actor_id, source_transport, request_hash, created_at
     )
     SELECT
       'op-1', project_id, 'test.operation', 'idem-1',
-      0, 1, 0, 'agent', 'test-agent', 'test', 'request-1', '2026-07-12T00:00:01.000Z'
+      0, 1, 0, 0, 'agent', 'test-agent', 'test', 'request-1', '2026-07-12T00:00:01.000Z'
     FROM project_authority WHERE singleton = 1;
 
     INSERT INTO workflow_domain_events (
@@ -212,10 +213,11 @@ test("fresh database creates the v31 authority root and linked operation journal
     () => db.exec(`
       INSERT INTO workflow_operations (
         operation_id, project_id, operation_type, idempotency_key,
-        expected_revision, resulting_revision, expected_authority_epoch,
+        expected_revision, resulting_revision,
+        expected_authority_epoch, resulting_authority_epoch,
         actor_type, source_transport, request_hash, created_at
       )
-      SELECT 'op-duplicate', project_id, 'test.operation', 'idem-1', 1, 2, 0,
+      SELECT 'op-duplicate', project_id, 'test.operation', 'idem-1', 1, 2, 0, 0,
              'agent', 'test', 'request-2', '2026-07-12T00:00:05.000Z'
       FROM project_authority WHERE singleton = 1
     `),
@@ -225,10 +227,11 @@ test("fresh database creates the v31 authority root and linked operation journal
     () => db.exec(`
       INSERT INTO workflow_operations (
         operation_id, project_id, operation_type, idempotency_key,
-        expected_revision, resulting_revision, expected_authority_epoch,
+        expected_revision, resulting_revision,
+        expected_authority_epoch, resulting_authority_epoch,
         actor_type, source_transport, request_hash, created_at
       )
-      SELECT 'op-same-revision', project_id, 'test.operation', 'idem-2', 0, 1, 0,
+      SELECT 'op-same-revision', project_id, 'test.operation', 'idem-2', 0, 1, 0, 0,
              'agent', 'test', 'request-2', '2026-07-12T00:00:05.000Z'
       FROM project_authority WHERE singleton = 1
     `),
@@ -271,6 +274,106 @@ test("fresh database creates the v31 authority root and linked operation journal
       VALUES ('event-2', 'projection', '2026-07-12T00:00:08.000Z')
     `),
     /UNIQUE constraint failed/i,
+  );
+});
+
+test("operations record the resulting authority epoch used by their events", () => {
+  const dbPath = createDatabasePath();
+  assert.equal(openDatabase(dbPath), true);
+  const db = _getAdapter();
+  assert.ok(db);
+
+  db.exec(`
+    INSERT INTO workflow_operations (
+      operation_id, project_id, operation_type, idempotency_key,
+      expected_revision, resulting_revision,
+      expected_authority_epoch, resulting_authority_epoch,
+      actor_type, source_transport, request_hash, created_at
+    )
+    SELECT 'op-cutover', project_id, 'authority.cutover', 'idem-cutover',
+           0, 1, 0, 1, 'agent', 'test', 'request-cutover', '2026-07-12T00:00:01.000Z'
+    FROM project_authority WHERE singleton = 1;
+
+    INSERT INTO workflow_domain_events (
+      event_id, operation_id, event_index, project_id, project_revision,
+      authority_epoch, event_type, entity_type, entity_id, payload_json, created_at
+    )
+    SELECT 'event-cutover', 'op-cutover', 0, project_id, 1, 1,
+           'authority.cutover', 'project', project_id, '{}', '2026-07-12T00:00:02.000Z'
+    FROM project_authority WHERE singleton = 1;
+
+    INSERT INTO workflow_operations (
+      operation_id, project_id, operation_type, idempotency_key,
+      expected_revision, resulting_revision,
+      expected_authority_epoch, resulting_authority_epoch,
+      actor_type, source_transport, request_hash, created_at
+    )
+    SELECT 'op-unchanged-epoch', project_id, 'test.operation', 'idem-unchanged-epoch',
+           1, 2, 1, 1, 'agent', 'test', 'request-unchanged', '2026-07-12T00:00:03.000Z'
+    FROM project_authority WHERE singleton = 1;
+  `);
+
+  assert.throws(
+    () => db.exec(`
+      INSERT INTO workflow_domain_events (
+        event_id, operation_id, event_index, project_id, project_revision,
+        authority_epoch, event_type, entity_type, entity_id, payload_json, created_at
+      )
+      SELECT 'event-stale-epoch', 'op-cutover', 1, project_id, 1, 0,
+             'authority.stale', 'project', project_id, '{}', '2026-07-12T00:00:04.000Z'
+      FROM project_authority WHERE singleton = 1
+    `),
+    /FOREIGN KEY constraint failed/i,
+  );
+  assert.throws(
+    () => db.exec(`
+      INSERT INTO workflow_operations (
+        operation_id, project_id, operation_type, idempotency_key,
+        expected_revision, resulting_revision,
+        expected_authority_epoch, resulting_authority_epoch,
+        actor_type, source_transport, request_hash, created_at
+      )
+      SELECT 'op-epoch-jump', project_id, 'authority.cutover', 'idem-epoch-jump',
+             2, 3, 1, 3, 'agent', 'test', 'request-jump', '2026-07-12T00:00:05.000Z'
+      FROM project_authority WHERE singleton = 1
+    `),
+    /CHECK constraint failed/i,
+  );
+});
+
+test("domain events reject updates and deletes", () => {
+  const dbPath = createDatabasePath();
+  assert.equal(openDatabase(dbPath), true);
+  const db = _getAdapter();
+  assert.ok(db);
+
+  db.exec(`
+    INSERT INTO workflow_operations (
+      operation_id, project_id, operation_type, idempotency_key,
+      expected_revision, resulting_revision,
+      expected_authority_epoch, resulting_authority_epoch,
+      actor_type, source_transport, request_hash, created_at
+    )
+    SELECT 'op-immutable', project_id, 'test.operation', 'idem-immutable',
+           0, 1, 0, 0, 'agent', 'test', 'request-immutable', '2026-07-12T00:00:01.000Z'
+    FROM project_authority WHERE singleton = 1;
+
+    INSERT INTO workflow_domain_events (
+      event_id, operation_id, event_index, project_id, project_revision,
+      authority_epoch, event_type, entity_type, entity_id, payload_json, created_at
+    )
+    SELECT 'event-immutable', 'op-immutable', 0, project_id, 1, 0,
+           'test.recorded', 'project', project_id, '{"original":true}', '2026-07-12T00:00:02.000Z'
+    FROM project_authority WHERE singleton = 1;
+  `);
+
+  assert.throws(
+    () => db.exec(`UPDATE workflow_domain_events SET payload_json = '{}' WHERE event_id = 'event-immutable'`),
+    /workflow domain events are immutable/i,
+  );
+  assert.throws(
+    () => db.exec(`DELETE FROM workflow_domain_events WHERE event_id = 'event-immutable'`),
+    /workflow domain events are immutable/i,
   );
 });
 

--- a/src/resources/extensions/gsd/tests/db-engine-migrate-guards.test.ts
+++ b/src/resources/extensions/gsd/tests/db-engine-migrate-guards.test.ts
@@ -101,9 +101,9 @@ describe('db-engine migrate guards', () => {
       assert.ok(openDatabase(dbPath), 'fresh open should succeed');
       closeDatabase();
 
-      // Rewind the DB to v(SCHEMA_VERSION-1): stamp the prior version and drop
-      // the objects the last migration adds, so the re-run has real work to redo.
-      const startVersion = SCHEMA_VERSION - 2;
+      // Rewind to v28 and remove a v29 column so the multi-step migration has
+      // real work to redo even as later schema versions are added.
+      const startVersion = 28;
       const raw = openRawSqliteForTest(dbPath);
       raw.exec('DELETE FROM schema_version');
       raw.exec(`INSERT INTO schema_version (version, applied_at) VALUES (${startVersion}, '2026-01-01T00:00:00Z')`);

--- a/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
+++ b/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
@@ -51,6 +51,7 @@ const TYPED_DB_WRITER_FILES = new Set([
 ]);
 
 const SCHEMA_DB_WRITER_FILES = new Set([
+  "db-canonical-foundation-schema.ts",
   "db-memory-fts-schema.ts",
   "db-schema-metadata.ts",
   "db-verification-evidence-schema.ts",


### PR DESCRIPTION
## Intent

Complete M002/S01 as the first additive canonical database foundation slice. Bump schema v30 to v31 and add exactly four non-routed correctness primitives: singleton project authority with revision and Authority Epoch, workflow operation provenance/idempotency receipts, immutable domain events linked to the exact operation result revision/epoch, and a durable event outbox. Reuse existing narrower v30 audit/coordination concepts only by explicit mapping; do not repurpose audit_events, command_queue, runtime_kv, turn epochs, lease fencing, or commit attribution. Fresh databases and transactional v30 upgrades must converge; pre-migration WAL backup must remain independently healthy; an injected precommit migration fault must leave version 30 and no v31 objects; retry and fresh-process reopen/restore must succeed. No runtime read/write cutover, import, projection worker, lifecycle API, or legacy deletion. Test-writer evidence: RED 3/3 intended failures on v30, GREEN focused 39/39, mutation removing event-index uniqueness failed the duplicate-event assertion, core build/typecheck and baseline:workflow-authority 4/4 pass. Local verify:merge produced 12,056 passes and only unrelated macOS path-alias, summary-save, and browser PATH/environment failures; hosted CI is required. Direct developer approval governs; GitHub tags and labels are metadata only.

## What Changed

- Bump the GSD database schema to v31 with additive project authority, workflow operation receipt, immutable domain event, and durable outbox tables.
- Apply the canonical foundation to fresh databases and transactional upgrades, including operation result revision/epoch linkage and migration rollback compatibility.
- Document the new schema and add focused coverage for constraints, v30 upgrades and backups, fault recovery, reopen/restore behavior, and single-writer enforcement.

## Risk Assessment

🚨 High: The prior findings are fixed, but the new canonical correctness foundation still allows authority rollback and mutation of operation provenance, so it should not merge without an explicit decision or guards.

## Testing

Focused automated tests and the workflow-authority baseline passed, while direct database verification demonstrated v30→v31 migration, preserved legacy data, healthy independent backup, revision/epoch-linked operation-event-outbox state, rejected invalid mutations, fresh-process reopen and restore, transactional fault rollback, and successful retry. This is database-only work with no rendered UI, so reviewer-visible evidence is provided as a JSON transcript and persisted SQLite databases rather than a screenshot.

<details>
<summary>Evidence: End-to-end canonical foundation transcript</summary>

```text
{
  "upgraded": {
    "schemaVersion": 31,
    "quickCheck": "ok",
    "authority": {
      "singleton": 1,
      "project_id_length": 32,
      "revision": 0,
      "authority_epoch": 0
    },
    "legacyMilestone": {
      "title": "Preserved legacy milestone"
    },
    "legacyAudit": {
      "payload_json": "{\"kept\":true}"
    },
    "canonicalChain": {
      "operation_id": "op-demo",
      "expected_revision": 0,
      "resulting_revision": 1,
      "expected_authority_epoch": 0,
      "resulting_authority_epoch": 1,
      "event_id": "event-demo",
      "event_index": 0,
      "project_revision": 1,
      "authority_epoch": 1,
      "destination": "projection",
      "delivered_at": null
    }
  },
  "rejectedWrites": {
    "duplicateIdempotency": "UNIQUE constraint failed: workflow_operations.project_id, workflow_operations.idempotency_key",
    "staleEventEpoch": "FOREIGN KEY constraint failed",
    "mutateEvent": "workflow domain events are immutable",
    "duplicateOutbox": "UNIQUE constraint failed: workflow_outbox.event_id, workflow_outbox.destination"
  },
  "backupV30": {
    "schemaVersion": 30,
    "quickCheck": "ok",
    "hasV31Authority": false,
    "legacyMilestone": {
      "title": "Preserved legacy milestone"
    }
  },
  "freshProcessReopen": {
    "schemaVersion": 31,
    "quickCheck": "ok",
    "legacyMilestone": {
      "title": "Preserved legacy milestone"
    },
    "authorityCount": 1
  },
  "freshProcessRestore": {
    "schemaVersion": 31,
    "quickCheck": "ok",
    "legacyMilestone": {
      "title": "Preserved legacy milestone"
    },
    "authorityCount": 1
  },
  "afterInjectedFault": {
    "error": "migration fault injected for test",
    "schemaVersion": 30,
    "v31ObjectsPresent": [],
    "quickCheck": "ok"
  },
  "retryInFreshProcess": {
    "schemaVersion": 31,
    "quickCheck": "ok",
    "legacyMilestone": {
      "title": "Preserved legacy milestone"
    },
    "authorityCount": 1
  }
}
```
</details>
- Evidence: Migrated v31 demonstration database (local file: <code>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXA59JZHA12YXKYWZDAGGRP9/canonical-v31-demo.db</code>)
- Evidence: Healthy pre-migration v30 backup (local file: <code>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXA59JZHA12YXKYWZDAGGRP9/canonical-v31-demo.db.backup-v30</code>)
<details>
<summary>Evidence: Reproducible evidence script</summary>

```text
import { copyFileSync, mkdirSync, rmSync } from "node:fs";
import { createRequire } from "node:module";
import { join, resolve } from "node:path";
import { spawnSync } from "node:child_process";
import { pathToFileURL } from "node:url";

const root = process.cwd();
const evidenceDir = "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXA59JZHA12YXKYWZDAGGRP9";
mkdirSync(evidenceDir, { recursive: true });

const dbPath = join(evidenceDir, "canonical-v31-demo.db");
const backupPath = `${dbPath}.backup-v30`;
const restoredPath = join(evidenceDir, "restored-from-v30.db");
const faultPath = join(evidenceDir, "fault-retry.db");
for (const path of [dbPath, backupPath, restoredPath, faultPath]) rmSync(path, { force: true });

const modulePath = resolve(root, "src/resources/extensions/gsd/gsd-db.ts");
const { openDatabase, closeDatabase, _getAdapter, _setMigrationFaultForTest } = await import(pathToFileURL(modulePath));
const require = createRequire(import.meta.url);
const { DatabaseSync } = require("node:sqlite");
const openRaw = (path) => new DatabaseSync(path);
const exists = (db, name) => Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?").get(name));
const version = (db) => Number(db.prepare("SELECT MAX(version) AS value FROM schema_version").get().value);
const check = (db) => db.prepare("PRAGMA quick_check").get().quick_check;

openDatabase(dbPath);
closeDatabase();
{
  const db = openRaw(dbPath);
  db.exec(`
    DROP TABLE workflow_outbox;
    DROP TABLE workflow_domain_events;
    DROP TABLE workflow_operations;
    DROP TABLE project_authority;
    DELETE FROM schema_version;
    INSERT INTO schema_version(version, applied_at) VALUES (30, '2026-07-11T12:00:00Z');
    INSERT OR IGNORE INTO milestones(id, title, status, created_at)
      VALUES ('M-LEGACY', 'Preserved legacy milestone', 'active', '2026-07-11T12:00:00Z');
    INSERT OR IGNORE INTO audit_events(event_id, trace_id, category, type, ts, payload_json)
      VALUES ('audit-legacy', 'trace-legacy', 'workflow', 'legacy', '2026-07-11T12:00:00Z', '{"kept":true}');
  `);
  db.close();
}

openDatabase(dbPath);
{
  const db = _getAdapter();
  db.exec(`
    INSERT INTO workflow_operations (
      operation_id, project_id, operation_type, idempotency_key,
      expected_revision, resulting_revision, expected_authority_epoch, resulting_authority_epoch,
      actor_type, source_transport, request_hash, created_at
    ) SELECT 'op-demo', project_id, 'demo.operation', 'idem-demo',
             0, 1, 0, 1, 'developer', 'local-verification', 'hash-demo', '2026-07-11T12:01:00Z'
      FROM project_authority;
    INSERT INTO workflow_domain_events (
      event_id, operation_id, event_index, project_id, project_revision, authority_epoch,
      event_type, entity_type, entity_id, payload_json, created_at
    ) SELECT 'event-demo', 'op-demo', 0, project_id, 1, 1,
             'demo.completed', 'project', project_id, '{"result":"ok"}', '2026-07-11T12:01:01Z'
      FROM project_authority;
    INSERT INTO workflow_outbox(event_id, destination, available_at)
      VALUES ('event-demo', 'projection', '2026-07-11T12:01:02Z');
  `);
}
closeDatabase();

const rejected = {};
{
  const db = openRaw(dbPath);
  for (const [name, sql] of Object.entries({
    duplicateIdempotency: `INSERT INTO workflow_operations
      (operation_id, project_id, operation_type, idempotency_key, expected_revision, resulting_revision,
       expected_authority_epoch, resulting_authority_epoch, actor_type, source_transport, request_hash, created_at)
      SELECT 'op-duplicate', project_id, 'demo.operation', 'idem-demo', 1, 2, 1, 1,
             'developer', 'local-verification', 'hash-2', '2026-07-11T12:02:00Z' FROM project_authority`,
    staleEventEpoch: `INSERT INTO workflow_domain_events
      (event_id, operation_id, event_index, project_id, project_revision, authority_epoch,
       event_type, entity_type, entity_id, created_at)
      SELECT 'event-stale', 'op-demo', 1, project_id, 1, 0,
             'demo.stale', 'project', project_id, '2026-07-11T12:02:01Z' FROM project_authority`,
    mutateEvent: `UPDATE workflow_domain_events SET payload_json='{}' WHERE event_id='event-demo'`,
    duplicateOutbox: `INSERT INTO workflow_outbox(event_id, destination) VALUES ('event-demo', 'projection')`,
  })) {
    try { db.exec(sql); rejected[name] = "UNEXPECTEDLY ACCEPTED"; }
    catch (error) { rejected[name] = String(error.message); }
  }
  const upgraded = {
    schemaVersion: version(db),
    quickCheck: check(db),
    authority: db.prepare("SELECT singleton, length(project_id) AS project_id_length, revision, authority_epoch FROM project_authority").get(),
    legacyMilestone: db.prepare("SELECT title FROM milestones WHERE id='M-LEGACY'").get(),
    legacyAudit: db.prepare("SELECT payload_json FROM audit_events WHERE event_id='audit-legacy'").get(),
    canonicalChain: db.prepare(`SELECT o.operation_id, o.expected_revision, o.resulting_revision,
      o.expected_authority_epoch, o.resulting_authority_epoch, e.event_id, e.event_index,
      e.project_revision, e.authority_epoch, x.destination, x.delivered_at
      FROM workflow_operations o JOIN workflow_domain_events e ON e.operation_id=o.operation_id
      JOIN workflow_outbox x ON x.event_id=e.event_id WHERE o.operation_id='op-demo'`).get(),
  };
  db.close();

  const backup = openRaw(backupPath);
  const backupState = {
    schemaVersion: version(backup),
    quickCheck: check(backup),
    hasV31Authority: exists(backup, "project_authority"),
    legacyMilestone: backup.prepare("SELECT title FROM milestones WHERE id='M-LEGACY'").get(),
  };
  backup.close();

  const inspectFresh = (path) => {
    const code = `import { openDatabase, closeDatabase, _getAdapter } from ${JSON.stringify(pathToFileURL(modulePath).href)};
      openDatabase(process.argv[1]); const db=_getAdapter();
      console.log(JSON.stringify({schemaVersion:db.prepare('SELECT MAX(version) AS value FROM schema_version').get().value,
        quickCheck:db.prepare('PRAGMA quick_check').get().quick_check,
        legacyMilestone:db.prepare(\"SELECT title FROM milestones WHERE id='M-LEGACY'\").get(),
        authorityCount:db.prepare('SELECT COUNT(*) AS value FROM project_authority').get().value})); closeDatabase();`;
    const child = spawnSync(process.execPath, ["--import", "./src/resources/extensions/gsd/tests/resolve-ts.mjs",
      "--experimental-strip-types", "--input-type=module", "-e", code, path],
      { cwd: root, encoding: "utf8", env: { ...process.env, NODE_TEST_CONTEXT: undefined } });
    if (child.status !== 0) throw new Error(child.stderr || child.stdout);
    return JSON.parse(child.stdout);
  };

  const freshProcessReopen = inspectFresh(dbPath);
  copyFileSync(backupPath, restoredPath);
  const freshProcessRestore = inspectFresh(restoredPath);

  copyFileSync(backupPath, faultPath);
  _setMigrationFaultForTest(true);
  let injectedFault;
  try { openDatabase(faultPath); injectedFault = "UNEXPECTEDLY ACCEPTED"; }
  catch (error) { injectedFault = String(error.message); }
  finally { _setMigrationFaultForTest(false); closeDatabase(); }
  const rolledBackDb = openRaw(faultPath);
  const afterInjectedFault = {
    error: injectedFault,
    schemaVersion: version(rolledBackDb),
    v31ObjectsPresent: ["project_authority", "workflow_operations", "workflow_domain_events", "workflow_outbox"].filter((name) => exists(rolledBackDb, name)),
    quickCheck: check(rolledBackDb),
  };
  rolledBackDb.close();
  const retryInFreshProcess = inspectFresh(faultPath);

  console.log(JSON.stringify({ upgraded, rejectedWrites: rejected, backupV30: backupState,
    freshProcessReopen, freshProcessRestore, afterInjectedFault, retryInFreshProcess }, null, 2));
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 errors</summary>

- 🚨 `src/resources/extensions/gsd/db-canonical-foundation-schema.ts:34` - The operation receipt records only the expected Authority Epoch, and events treat that value as the operation&#39;s resulting epoch. An operation that advances the epoch—such as authority cutover—cannot record both the epoch it fenced against and the epoch it produced, so its events cannot link to the exact operation result. Add a resulting_authority_epoch field and link events to it, with explicit rules for unchanged versus incremented epochs.
- 🚨 `src/resources/extensions/gsd/db-canonical-foundation-schema.ts:50` - The table is described as an immutable domain-event journal, but the schema permits UPDATE and DELETE for events without dependent rows. Add BEFORE UPDATE/DELETE triggers that abort mutations so historical event payloads and provenance cannot be rewritten or removed.

🔧 Fix: Enforce operation epoch results and immutable domain events
2 errors still open:
- 🚨 `src/resources/extensions/gsd/db-canonical-foundation-schema.ts:19` - The authority row permits decreasing `revision` or `authority_epoch`, and it can be deleted before child operations exist. That undermines the monotonic revision/epoch and singleton-authority invariants. Add UPDATE guards preventing decreases and a DELETE guard preserving the singleton, unless enforcement is deliberately deferred to the routed writer.
- 🚨 `src/resources/extensions/gsd/db-canonical-foundation-schema.ts:27` - Operation provenance/idempotency receipts remain mutable and deletable. Rewriting fields such as `idempotency_key`, `request_hash`, actor, or source can defeat retry deduplication and falsify the provenance of linked events. Make operation receipts immutable with UPDATE/DELETE triggers analogous to the domain-event guards, unless later mutation is an explicit requirement.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/db-canonical-foundation.test.ts src/resources/extensions/gsd/tests/db-engine-migrate-guards.test.ts src/resources/extensions/gsd/tests/single-writer-invariant.test.ts`
- `pnpm run baseline:workflow-authority`
- <code>End-to-end evidence: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types …/verify-canonical-foundation.mjs | tee …/canonical-foundation-e2e.json`</code>
- <code>Validated the evidence transcript programmatically and confirmed `git status --short --branch` remained clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces correctness-critical DDL and bumps every DB open/migration path; authority and operation rows remain mutable at the schema layer until follow-up guards or routed writers land.
> 
> **Overview**
> Bumps the GSD workflow database from **schema v30 to v31** with an **additive, schema-only** canonical foundation. Existing `gsd_*` tools and runtime paths are **not** routed through these tables yet; docs call out that manifest restore and worktree reconciliation also stay unchanged for now.
> 
> Adds `db-canonical-foundation-schema.ts` and wires it into **fresh installs** (`initSchema`) and **transactional upgrades** (`applyMigrationV31CanonicalFoundation` in `db/engine.ts`). The new tables are **`project_authority`** (singleton project id, revision, authority epoch), **`workflow_operations`** (idempotency, expected/resulting revision and authority epoch, provenance fields), **`workflow_domain_events`** (immutable via UPDATE/DELETE triggers; FK-linked to the operation’s resulting revision/epoch), and **`workflow_outbox`** (per-event destinations).
> 
> Documentation updates **`db-map.md`** and **`prompt-db-combined-map.md`** (v31 history, table inventory, ERD, single-writer allowlist). **`single-writer-invariant.test.ts`** allowlists the new schema helper. **`db-canonical-foundation.test.ts`** exercises constraints, epoch cutover linkage, v30→v31 migration with backup, fault rollback, and fresh-process reopen; **`db-engine-migrate-guards.test.ts`** rewinds to v28 so rollback tests stay valid as versions advance.
> 
> **Note:** Open review items may still apply—`project_authority` and `workflow_operations` lack the same immutability/monotonicity triggers as domain events in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3f99cc749f11ce45e5d89db0d78420a5a06c85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->