### PR TITLE
feat(gsd): add lifecycle database foundation

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -24,8 +24,9 @@ gsd-db.ts  ← compatibility barrel over the explicit single-writer allowlist
        ├── db/writers/*.ts  ← the Single Writer Layer (one write subsystem per file)
        ├── db/{milestone-leases,unit-dispatches,auto-workers,runtime-kv,command-queue}.ts
        │                    ← typed coordination/runtime writers
-       ├── db-canonical-foundation-schema.ts, db-memory-fts-schema.ts,
-       │   db-schema-metadata.ts, db-verification-evidence-schema.ts
+       ├── db-canonical-foundation-schema.ts, db-lifecycle-foundation-schema.ts,
+       │   db-memory-fts-schema.ts, db-schema-metadata.ts,
+       │   db-verification-evidence-schema.ts
        │                    ← allowlisted schema/migration helpers
        ├── memory-backfill.ts
        │                    ← allowlisted ADR migration/backfill helper
@@ -65,7 +66,7 @@ After commit: regenerate markdown artifacts → write to disk → invalidate cac
 
 ## 2. Schema Version History
 
-Current version: **V31**
+Current version: **V32**
 
 | Version | What Changed |
 |---------|-------------|
@@ -100,6 +101,7 @@ Current version: **V31**
 | V29 | slices.target_repositories and tasks.target_repositories for multi-repository planning |
 | V30 | rework_briefs and rework_brief_findings for structured task rework gates |
 | V31 | **Additive canonical foundation**: singleton project authority with revision and Authority Epoch, workflow operation provenance/idempotency receipts, immutable revision-linked domain events, and a durable event outbox |
+| V32 | **Additive lifecycle foundation**: canonical lifecycle state, fenced execution Attempts, immutable Attempt Results, human-only Blockers, authorized Waivers, and immutable Requirement Disposition history |
 
 ---
 
@@ -766,6 +768,186 @@ operation provenance, domain history, or an outbox.
 
 ---
 
+### 3f. Additive Lifecycle Foundation (V32)
+
+V32 creates these tables on fresh databases and transactionally upgrades V31
+databases. Like V31, it is schema-only: the existing hierarchy statuses and
+coordination ledgers retain their runtime meaning, and no backfill, dual-write,
+Markdown inference, lifecycle API, or runtime cutover ships with this migration.
+
+#### `workflow_item_lifecycles`
+```
+lifecycle_id          TEXT PRIMARY KEY
+project_id            TEXT NOT NULL
+item_kind             TEXT NOT NULL    ← 'milestone' | 'slice' | 'task'
+milestone_id          TEXT NOT NULL
+slice_id              TEXT DEFAULT NULL
+task_id               TEXT DEFAULT NULL
+lifecycle_status      TEXT NOT NULL    ← 'pending' | 'ready' | 'in_progress' |
+                                         'paused' | 'completed' | 'cancelled'
+state_version         INTEGER NOT NULL DEFAULT 0
+created_at            TEXT NOT NULL
+updated_at            TEXT NOT NULL
+last_operation_id     TEXT NOT NULL
+last_project_revision INTEGER NOT NULL
+last_authority_epoch  INTEGER NOT NULL
+```
+- Partial unique indexes enforce one lifecycle per fully scoped milestone,
+  slice, or task identity. Kind-specific checks require exactly the applicable
+  identity columns.
+- Updates preserve identity, increment `state_version` by one, and permit only
+  `pending → ready|cancelled`, `ready → in_progress|paused|cancelled`,
+  `in_progress → paused|completed|cancelled`, `paused → ready|in_progress|cancelled`,
+  or `completed|cancelled → ready`. Operation/revision/Authority Epoch
+  provenance must advance; deletes are rejected as durable-history loss.
+- Indexes: `idx_workflow_lifecycle_milestone`,
+  `idx_workflow_lifecycle_slice`, and `idx_workflow_lifecycle_task`.
+
+#### `workflow_execution_attempts`
+```
+attempt_id                TEXT PRIMARY KEY
+project_id                TEXT NOT NULL
+lifecycle_id              TEXT NOT NULL
+attempt_number            INTEGER NOT NULL
+retry_of_attempt_id       TEXT DEFAULT NULL
+attempt_state             TEXT NOT NULL    ← 'claimed' | 'running' | 'settled'
+coordination_dispatch_id  INTEGER DEFAULT NULL UNIQUE
+worker_id                 TEXT DEFAULT NULL
+milestone_lease_token     INTEGER DEFAULT NULL
+claimed_at                TEXT NOT NULL
+started_at                TEXT DEFAULT NULL
+ended_at                  TEXT DEFAULT NULL
+claim_operation_id        TEXT NOT NULL
+claim_project_revision    INTEGER NOT NULL
+claim_authority_epoch     INTEGER NOT NULL
+settle_operation_id       TEXT DEFAULT NULL
+settle_project_revision   INTEGER DEFAULT NULL
+settle_authority_epoch    INTEGER DEFAULT NULL
+```
+- `(lifecycle_id, attempt_number)` is unique, attempt numbers are contiguous,
+  and every retry points to the immediately preceding Attempt for that
+  lifecycle. A partial unique index permits only one `claimed` or `running`
+  Attempt per lifecycle.
+- Worker-bound inserts and transitions require the current unexpired held
+  milestone lease. Dispatch attribution must match the lifecycle's complete
+  milestone/slice/task scope, worker, fencing token, and active dispatch state.
+- Only `claimed → running|settled` and `running → settled` are valid.
+  Claim identity and timestamps are preserved, settlement provenance must
+  advance causally, and settled Attempts and all deletes are immutable.
+- Index: `idx_workflow_attempt_active` (lifecycle_id), limited to `claimed` and
+  `running` rows.
+
+#### `workflow_attempt_results`
+```
+result_id         TEXT PRIMARY KEY
+project_id        TEXT NOT NULL
+lifecycle_id      TEXT NOT NULL
+attempt_id        TEXT NOT NULL UNIQUE
+outcome           TEXT NOT NULL    ← 'succeeded' | 'failed' | 'interrupted'
+failure_class     TEXT NOT NULL DEFAULT 'none'
+summary           TEXT NOT NULL DEFAULT ''
+output_json       TEXT NOT NULL DEFAULT '{}'
+created_at        TEXT NOT NULL
+operation_id      TEXT NOT NULL
+project_revision  INTEGER NOT NULL
+authority_epoch   INTEGER NOT NULL
+```
+- Exactly one Result may exist per Attempt, and only after that Attempt is
+  settled. Its operation, revision, and Authority Epoch must exactly match the
+  Attempt's settlement provenance.
+- Updates and deletes are rejected. Result outcome does not mutate lifecycle
+  status or requirement disposition.
+
+#### `workflow_blockers`
+```
+blocker_id               TEXT PRIMARY KEY
+project_id               TEXT NOT NULL
+lifecycle_id             TEXT NOT NULL
+blocker_kind             TEXT NOT NULL    ← 'missing_authority' | 'missing_access' |
+                                              'external_dependency' | 'consent' |
+                                              'ambiguous_intent' | 'subjective_uat' |
+                                              'user_limit'
+resolution_owner         TEXT NOT NULL    ← 'user' | 'external'
+blocker_status           TEXT NOT NULL    ← 'open' | 'resolved' | 'dismissed'
+description              TEXT NOT NULL
+requested_action         TEXT NOT NULL DEFAULT ''
+resolution               TEXT NOT NULL DEFAULT ''
+opened_at                TEXT NOT NULL
+resolved_at              TEXT DEFAULT NULL
+opened_operation_id      TEXT NOT NULL
+opened_project_revision  INTEGER NOT NULL
+opened_authority_epoch   INTEGER NOT NULL
+resolved_operation_id    TEXT DEFAULT NULL
+resolved_project_revision INTEGER DEFAULT NULL
+resolved_authority_epoch INTEGER DEFAULT NULL
+```
+- Blockers represent only user- or external-owned impediments and remain
+  separate from lifecycle and execution outcomes.
+- Opening facts are immutable. An open Blocker may become `resolved` or
+  `dismissed` with causally newer operation provenance; terminal records and
+  deletes are immutable.
+
+#### `workflow_waivers`
+```
+waiver_id              TEXT PRIMARY KEY
+project_id             TEXT NOT NULL
+lifecycle_id           TEXT NOT NULL
+requirement_id         TEXT DEFAULT NULL
+blocker_id             TEXT DEFAULT NULL
+waiver_status          TEXT NOT NULL    ← 'active' | 'revoked' | 'expired'
+scope                  TEXT NOT NULL
+rationale              TEXT NOT NULL
+granted_by_actor_type  TEXT NOT NULL    ← 'user' | 'policy'
+granted_by_actor_id    TEXT DEFAULT NULL
+granted_at             TEXT NOT NULL
+expires_at             TEXT DEFAULT NULL
+ended_at               TEXT DEFAULT NULL
+operation_id           TEXT NOT NULL
+project_revision       INTEGER NOT NULL
+authority_epoch        INTEGER NOT NULL
+ended_operation_id     TEXT DEFAULT NULL
+ended_project_revision INTEGER DEFAULT NULL
+ended_authority_epoch  INTEGER DEFAULT NULL
+```
+- User grants require an actor ID. At most one active Waiver may reference a
+  Blocker, and requirement/blocker references must resolve to canonical rows.
+- Grant facts are immutable. An active Waiver may become `revoked` or
+  `expired` with causally newer provenance; terminal records and deletes are
+  immutable. A Waiver cannot terminate while it still authorizes the current
+  waived disposition.
+- Index: `idx_workflow_waiver_active_blocker` (blocker_id), limited to active
+  rows with a Blocker.
+
+#### `workflow_requirement_dispositions`
+```
+disposition_id             TEXT PRIMARY KEY
+project_id                 TEXT NOT NULL
+requirement_id             TEXT NOT NULL
+disposition                TEXT NOT NULL    ← 'unsatisfied' | 'satisfied' | 'waived'
+waiver_id                  TEXT DEFAULT NULL
+supersedes_disposition_id  TEXT DEFAULT NULL UNIQUE
+rationale                  TEXT NOT NULL
+created_at                 TEXT NOT NULL
+operation_id               TEXT NOT NULL
+project_revision           INTEGER NOT NULL
+authority_epoch            INTEGER NOT NULL
+```
+- Rows form an immutable, single-head history per requirement. Every successor
+  must supersede the current head with causally newer revision/Authority Epoch
+  provenance.
+- Only `waived` rows carry a Waiver. That Waiver must belong to the same
+  project and requirement, be active and unexpired, and precede the disposition
+  revision. Updates and deletes are rejected.
+- Index: `idx_workflow_requirement_disposition_history`
+  (requirement_id, project_revision, disposition_id)
+
+Every V32 table is linked to the V31 authority root and exact
+`workflow_operations` provenance. The separation of lifecycle, execution
+history, Results, Blockers, Waivers, and requirement truth prevents one concept
+from silently fabricating another.
+
+---
+
 ## 4. Entity Relationship Diagram
 
 ```
@@ -814,6 +996,19 @@ workflow_operations ──► workflow_domain_events
   (operation_id + project_id + resulting revision + resulting Authority Epoch)
 workflow_domain_events ──► workflow_domain_events (caused_by_event_id)
 workflow_domain_events ──► workflow_outbox (event_id)
+
+milestones/slices/tasks ──► workflow_item_lifecycles
+workflow_item_lifecycles ──► workflow_execution_attempts
+workflow_execution_attempts ──► workflow_attempt_results
+workflow_item_lifecycles ──► workflow_blockers
+workflow_item_lifecycles ──► workflow_waivers
+requirements ──► workflow_waivers
+requirements ──► workflow_requirement_dispositions
+workflow_waivers ──► workflow_requirement_dispositions
+workflow_blockers ──► workflow_waivers
+
+workflow_operations ──► all V32 lifecycle records
+  (operation + project + revision + Authority Epoch provenance)
 ```
 
 ---
@@ -825,16 +1020,18 @@ artifacts, milestones, slices, tasks, decisions, replan history, assessments,
 quality gates, verification evidence, and milestone commit attributions. Restore
 rebuilds decision mirror memories from the restored decisions and preserves
 optional rows when reading older manifests that predate the extended arrays.
-The additive V31 canonical-foundation tables are not yet part of this legacy
-manifest surface because runtime reads/writes have not cut over to them.
+The additive V31 canonical-foundation and V32 lifecycle-foundation tables are
+not yet part of this legacy manifest surface because runtime reads/writes have
+not cut over to them.
 
 `reconcileWorktreeDb` merges hidden-worktree correctness rows back into the main
 DB, including hierarchy, requirements, artifacts, memories, replan history,
 assessments, quality gates, slice dependencies, verification evidence, gate
 runs, and milestone commit attributions. Runtime-only/audit substrates such as
 `runtime_kv`, `turn_git_transactions`, `audit_events`, and `audit_turn_index`
-remain outside manifest restore. The V31 canonical-foundation tables likewise
-remain outside worktree reconciliation until a later runtime-routing slice.
+remain outside manifest restore. The V31 canonical-foundation and V32
+lifecycle-foundation tables likewise remain outside worktree reconciliation
+until a later runtime-routing slice.
 
 ---
 
@@ -906,7 +1103,7 @@ remain outside worktree reconciliation until a later runtime-routing slice.
 
 ## 7. Write Path Invariants
 
-1. **Single-writer rule**: all write SQL lives in the explicit single-writer *layer* — `db/engine.ts` for schema, migrations, lifecycle, and transaction primitives; `db/writers/**` for domain write subsystems; `gsd-db.ts` as the compatibility barrel and remaining mid-migration wrappers; the typed coordination/runtime writer modules `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, and `db/command-queue.ts`; the schema/migration helpers `db-canonical-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, and `db-verification-evidence-schema.ts`; and the ADR migration/backfill helper `memory-backfill.ts`. This is an allowlist, not permission for arbitrary raw writes under `db/`. `unit-ownership.ts` remains excluded because it owns a separate `.gsd/unit-claims.db`. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks this allowlist.
+1. **Single-writer rule**: all write SQL lives in the explicit single-writer *layer* — `db/engine.ts` for schema, migrations, lifecycle, and transaction primitives; `db/writers/**` for domain write subsystems; `gsd-db.ts` as the compatibility barrel and remaining mid-migration wrappers; the typed coordination/runtime writer modules `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, and `db/command-queue.ts`; the schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, and `db-verification-evidence-schema.ts`; and the ADR migration/backfill helper `memory-backfill.ts`. This is an allowlist, not permission for arbitrary raw writes under `db/`. `unit-ownership.ts` remains excluded because it owns a separate `.gsd/unit-claims.db`. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks this allowlist.
 
 2. **Transaction wrapping**: every multi-table write uses `transaction()` or `immediateTransaction()` when it needs SQLite's reserved writer lock up front. Rollback on any error. Re-entrant: nested calls increment the shared depth counter; no nested `BEGIN`. `gsd_save_gate_result` commits the `quality_gates` verdict update and matching `gate_runs` ledger insert together, so recovery never sees a completed gate without its audit row.
 

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -347,6 +347,7 @@ unit completes
 |------------|--------|
 | `db-base-schema.ts` | schema_version, decisions, requirements, artifacts, memories, memory_processed_units, memory_sources, memory_embeddings, memory_relations, milestones, slices, tasks, verification_evidence, replan_history, assessments, quality_gates, slice_dependencies, gate_runs, turn_git_transactions, milestone_commit_attributions, audit_events, audit_turn_index + all indexes + active_decisions/active_requirements/active_memories views |
 | `db-canonical-foundation-schema.ts` | project_authority, workflow_operations, workflow_domain_events, workflow_outbox + domain-event immutability triggers and canonical-foundation indexes (V31, additive and not runtime-routed yet) |
+| `db-lifecycle-foundation-schema.ts` | workflow_item_lifecycles, workflow_execution_attempts, workflow_attempt_results, workflow_blockers, workflow_waivers, workflow_requirement_dispositions + lifecycle, fencing, provenance, history, and vocabulary constraints (V32, additive and not runtime-routed yet) |
 | `db-coordination-schema.ts` | workers, milestone_leases, unit_dispatches, cancellation_requests, command_queue |
 | `db-memory-fts-schema.ts` | memories_fts (FTS5 virtual table), memories_ai/ad/au triggers |
 | `db-runtime-kv-schema.ts` | runtime_kv |
@@ -372,7 +373,7 @@ unit completes
 
 | Invariant | Where Enforced |
 |-----------|---------------|
-| Single-writer: all write SQL in the explicit single-writer allowlist (`db/engine.ts`, `db/writers/**`, `gsd-db.ts`, typed coordination/runtime writers `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, `db/command-queue.ts`, schema/migration helpers `db-canonical-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, `db-verification-evidence-schema.ts`, and ADR migration/backfill helper `memory-backfill.ts`); this is not permission for arbitrary writes under `db/`; `unit-ownership.ts` owns separate `.gsd/unit-claims.db`; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (explicit allowlist) |
+| Single-writer: all write SQL in the explicit single-writer allowlist (`db/engine.ts`, `db/writers/**`, `gsd-db.ts`, typed coordination/runtime writers `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, `db/command-queue.ts`, schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, `db-verification-evidence-schema.ts`, and ADR migration/backfill helper `memory-backfill.ts`); this is not permission for arbitrary writes under `db/`; `unit-ownership.ts` owns separate `.gsd/unit-claims.db`; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (explicit allowlist) |
 | Cascade on slice complete: pending tasks → skipped | `gsd_slice_complete` transaction |
 | Cascade on milestone reopen: all slices → in_progress, tasks → pending | `gsd_milestone_reopen` transaction |
 | No nested write transactions: `transaction()` and `immediateTransaction()` share one depth counter; read-then-write claims use `immediateTransaction()` and gate verdict + ledger writes commit atomically | `db-transaction.test.ts`, `command-queue.test.ts`, `gate-storage.test.ts` |

--- a/src/resources/extensions/gsd/db-lifecycle-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-lifecycle-foundation-schema.ts
@@ -1,0 +1,597 @@
+// Project/App: gsd-pi
+// File Purpose: Additive v32 lifecycle, Attempt, Result, disposition, Waiver, and Blocker schema.
+
+import type { DbAdapter } from "./db-adapter.js";
+
+/**
+ * The v32 tables are shadow canonical state only. Existing hierarchy status,
+ * dispatch, lease, evidence, gate, and rework records retain their current
+ * runtime meaning until a later cutover.
+ */
+export function createLifecycleFoundationSchemaV32(db: DbAdapter): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_item_lifecycles (
+      lifecycle_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      item_kind TEXT NOT NULL CHECK (item_kind IN ('milestone', 'slice', 'task')),
+      milestone_id TEXT NOT NULL,
+      slice_id TEXT DEFAULT NULL,
+      task_id TEXT DEFAULT NULL,
+      lifecycle_status TEXT NOT NULL CHECK (
+        lifecycle_status IN ('pending', 'ready', 'in_progress', 'paused', 'completed', 'cancelled')
+      ),
+      state_version INTEGER NOT NULL DEFAULT 0 CHECK (state_version >= 0),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_operation_id TEXT NOT NULL,
+      last_project_revision INTEGER NOT NULL CHECK (last_project_revision > 0),
+      last_authority_epoch INTEGER NOT NULL CHECK (last_authority_epoch >= 0),
+      UNIQUE (lifecycle_id, project_id),
+      CHECK (
+        (item_kind = 'milestone' AND slice_id IS NULL AND task_id IS NULL) OR
+        (item_kind = 'slice' AND slice_id IS NOT NULL AND task_id IS NULL) OR
+        (item_kind = 'task' AND slice_id IS NOT NULL AND task_id IS NOT NULL)
+      ),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (milestone_id) REFERENCES milestones(id),
+      FOREIGN KEY (milestone_id, slice_id) REFERENCES slices(milestone_id, id),
+      FOREIGN KEY (milestone_id, slice_id, task_id) REFERENCES tasks(milestone_id, slice_id, id),
+      FOREIGN KEY (last_operation_id, project_id, last_project_revision, last_authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        )
+    )
+  `);
+
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_lifecycle_milestone
+    ON workflow_item_lifecycles(project_id, milestone_id)
+    WHERE item_kind = 'milestone'
+  `);
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_lifecycle_slice
+    ON workflow_item_lifecycles(project_id, milestone_id, slice_id)
+    WHERE item_kind = 'slice'
+  `);
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_lifecycle_task
+    ON workflow_item_lifecycles(project_id, milestone_id, slice_id, task_id)
+    WHERE item_kind = 'task'
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_lifecycle_identity_immutable
+    BEFORE UPDATE ON workflow_item_lifecycles
+    WHEN NEW.lifecycle_id != OLD.lifecycle_id
+      OR NEW.project_id != OLD.project_id
+      OR NEW.item_kind != OLD.item_kind
+      OR NEW.milestone_id != OLD.milestone_id
+      OR NEW.slice_id IS NOT OLD.slice_id
+      OR NEW.task_id IS NOT OLD.task_id
+      OR NEW.created_at != OLD.created_at
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow lifecycle identity is immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_lifecycle_transition
+    BEFORE UPDATE ON workflow_item_lifecycles
+    WHEN NEW.lifecycle_status = OLD.lifecycle_status
+      OR NEW.state_version != OLD.state_version + 1
+      OR NEW.last_project_revision <= OLD.last_project_revision
+      OR NEW.updated_at = OLD.updated_at
+      OR NOT (
+        (OLD.lifecycle_status = 'pending' AND NEW.lifecycle_status IN ('ready', 'cancelled')) OR
+        (OLD.lifecycle_status = 'ready' AND NEW.lifecycle_status IN ('in_progress', 'paused', 'cancelled')) OR
+        (OLD.lifecycle_status = 'in_progress' AND NEW.lifecycle_status IN ('paused', 'completed', 'cancelled')) OR
+        (OLD.lifecycle_status = 'paused' AND NEW.lifecycle_status IN ('ready', 'in_progress', 'cancelled')) OR
+        (OLD.lifecycle_status IN ('completed', 'cancelled') AND NEW.lifecycle_status = 'ready')
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'invalid workflow lifecycle transition');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_lifecycle_delete
+    BEFORE DELETE ON workflow_item_lifecycles
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow lifecycle records are durable history');
+    END
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_execution_attempts (
+      attempt_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      lifecycle_id TEXT NOT NULL,
+      attempt_number INTEGER NOT NULL CHECK (attempt_number > 0),
+      retry_of_attempt_id TEXT DEFAULT NULL,
+      attempt_state TEXT NOT NULL CHECK (attempt_state IN ('claimed', 'running', 'settled')),
+      coordination_dispatch_id INTEGER DEFAULT NULL UNIQUE,
+      worker_id TEXT DEFAULT NULL,
+      milestone_lease_token INTEGER DEFAULT NULL,
+      claimed_at TEXT NOT NULL,
+      started_at TEXT DEFAULT NULL,
+      ended_at TEXT DEFAULT NULL,
+      claim_operation_id TEXT NOT NULL,
+      claim_project_revision INTEGER NOT NULL CHECK (claim_project_revision > 0),
+      claim_authority_epoch INTEGER NOT NULL CHECK (claim_authority_epoch >= 0),
+      settle_operation_id TEXT DEFAULT NULL,
+      settle_project_revision INTEGER DEFAULT NULL,
+      settle_authority_epoch INTEGER DEFAULT NULL,
+      UNIQUE (lifecycle_id, attempt_number),
+      UNIQUE (attempt_id, lifecycle_id),
+      UNIQUE (
+        attempt_id, lifecycle_id,
+        settle_operation_id, settle_project_revision, settle_authority_epoch
+      ),
+      CHECK (
+        (attempt_number = 1 AND retry_of_attempt_id IS NULL) OR
+        (attempt_number > 1 AND retry_of_attempt_id IS NOT NULL)
+      ),
+      CHECK (
+        (worker_id IS NULL AND milestone_lease_token IS NULL) OR
+        (worker_id IS NOT NULL AND milestone_lease_token > 0)
+      ),
+      CHECK (attempt_state != 'running' OR (worker_id IS NOT NULL AND started_at IS NOT NULL)),
+      CHECK (
+        (attempt_state IN ('claimed', 'running') AND ended_at IS NULL
+          AND settle_operation_id IS NULL AND settle_project_revision IS NULL
+          AND settle_authority_epoch IS NULL) OR
+        (attempt_state = 'settled' AND ended_at IS NOT NULL
+          AND settle_operation_id IS NOT NULL AND settle_project_revision > 0
+          AND settle_authority_epoch >= 0)
+      ),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (lifecycle_id, project_id)
+        REFERENCES workflow_item_lifecycles(lifecycle_id, project_id),
+      FOREIGN KEY (retry_of_attempt_id, lifecycle_id)
+        REFERENCES workflow_execution_attempts(attempt_id, lifecycle_id),
+      FOREIGN KEY (coordination_dispatch_id) REFERENCES unit_dispatches(id),
+      FOREIGN KEY (worker_id) REFERENCES workers(worker_id),
+      FOREIGN KEY (claim_operation_id, project_id, claim_project_revision, claim_authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        ),
+      FOREIGN KEY (settle_operation_id, project_id, settle_project_revision, settle_authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        )
+    )
+  `);
+
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_attempt_active
+    ON workflow_execution_attempts(lifecycle_id)
+    WHERE attempt_state IN ('claimed', 'running')
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_fencing
+    BEFORE INSERT ON workflow_execution_attempts
+    WHEN NEW.worker_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1
+      FROM workflow_item_lifecycles lifecycle
+      JOIN milestone_leases lease ON lease.milestone_id = lifecycle.milestone_id
+      WHERE lifecycle.lifecycle_id = NEW.lifecycle_id
+        AND lease.worker_id = NEW.worker_id
+        AND lease.fencing_token = NEW.milestone_lease_token
+        AND lease.status = 'held'
+        AND lease.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow attempt requires the current held lease');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_dispatch_scope
+    BEFORE INSERT ON workflow_execution_attempts
+    WHEN NEW.coordination_dispatch_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1
+      FROM workflow_item_lifecycles lifecycle
+      JOIN unit_dispatches dispatch ON dispatch.id = NEW.coordination_dispatch_id
+      WHERE lifecycle.lifecycle_id = NEW.lifecycle_id
+        AND dispatch.milestone_id = lifecycle.milestone_id
+        AND dispatch.slice_id IS lifecycle.slice_id
+        AND dispatch.task_id IS lifecycle.task_id
+        AND dispatch.worker_id = NEW.worker_id
+        AND dispatch.milestone_lease_token = NEW.milestone_lease_token
+        AND dispatch.status IN ('claimed', 'running')
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'coordination dispatch does not match workflow attempt scope');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_number_sequence
+    BEFORE INSERT ON workflow_execution_attempts
+    WHEN NEW.attempt_number != COALESCE(
+      (SELECT MAX(attempt_number) + 1
+       FROM workflow_execution_attempts
+       WHERE lifecycle_id = NEW.lifecycle_id),
+      1
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'attempt number must be next for lifecycle');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_retry_sequence
+    BEFORE INSERT ON workflow_execution_attempts
+    WHEN NEW.retry_of_attempt_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1
+      FROM workflow_execution_attempts prior
+      WHERE prior.attempt_id = NEW.retry_of_attempt_id
+        AND prior.lifecycle_id = NEW.lifecycle_id
+        AND prior.attempt_number = NEW.attempt_number - 1
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'retry must reference the preceding attempt');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_identity_immutable
+    BEFORE UPDATE ON workflow_execution_attempts
+    WHEN NEW.attempt_id != OLD.attempt_id
+      OR NEW.project_id != OLD.project_id
+      OR NEW.lifecycle_id != OLD.lifecycle_id
+      OR NEW.attempt_number != OLD.attempt_number
+      OR NEW.retry_of_attempt_id IS NOT OLD.retry_of_attempt_id
+      OR NEW.coordination_dispatch_id IS NOT OLD.coordination_dispatch_id
+      OR NEW.worker_id IS NOT OLD.worker_id
+      OR NEW.milestone_lease_token IS NOT OLD.milestone_lease_token
+      OR NEW.claim_operation_id != OLD.claim_operation_id
+      OR NEW.claim_project_revision != OLD.claim_project_revision
+      OR NEW.claim_authority_epoch != OLD.claim_authority_epoch
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow attempt identity is immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_terminal_immutable
+    BEFORE UPDATE ON workflow_execution_attempts
+    WHEN OLD.attempt_state = 'settled'
+    BEGIN
+      SELECT RAISE(ABORT, 'settled workflow attempts are immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_transition
+    BEFORE UPDATE ON workflow_execution_attempts
+    WHEN NOT (
+      (OLD.attempt_state = 'claimed' AND NEW.attempt_state IN ('running', 'settled')) OR
+      (OLD.attempt_state = 'running' AND NEW.attempt_state = 'settled')
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'invalid workflow attempt transition');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_delete
+    BEFORE DELETE ON workflow_execution_attempts
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow attempts are immutable history');
+    END
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_attempt_results (
+      result_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      lifecycle_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL UNIQUE,
+      outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'failed', 'interrupted')),
+      failure_class TEXT NOT NULL DEFAULT 'none',
+      summary TEXT NOT NULL DEFAULT '',
+      output_json TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      operation_id TEXT NOT NULL,
+      project_revision INTEGER NOT NULL CHECK (project_revision > 0),
+      authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 0),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (attempt_id, lifecycle_id)
+        REFERENCES workflow_execution_attempts(attempt_id, lifecycle_id),
+      FOREIGN KEY (attempt_id, lifecycle_id, operation_id, project_revision, authority_epoch)
+        REFERENCES workflow_execution_attempts(
+          attempt_id, lifecycle_id,
+          settle_operation_id, settle_project_revision, settle_authority_epoch
+        ),
+      FOREIGN KEY (operation_id, project_id, project_revision, authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        )
+    )
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_result_requires_settlement
+    BEFORE INSERT ON workflow_attempt_results
+    WHEN NOT EXISTS (
+      SELECT 1 FROM workflow_execution_attempts attempt
+      WHERE attempt.attempt_id = NEW.attempt_id
+        AND attempt.lifecycle_id = NEW.lifecycle_id
+        AND attempt.attempt_state = 'settled'
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'attempt result requires a settled attempt');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_results_immutable_update
+    BEFORE UPDATE ON workflow_attempt_results
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow attempt results are immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_results_immutable_delete
+    BEFORE DELETE ON workflow_attempt_results
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow attempt results are immutable');
+    END
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_blockers (
+      blocker_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      lifecycle_id TEXT NOT NULL,
+      blocker_kind TEXT NOT NULL CHECK (blocker_kind IN (
+        'missing_authority', 'missing_access', 'external_dependency', 'consent',
+        'ambiguous_intent', 'subjective_uat', 'user_limit'
+      )),
+      resolution_owner TEXT NOT NULL CHECK (resolution_owner IN ('user', 'external')),
+      blocker_status TEXT NOT NULL CHECK (blocker_status IN ('open', 'resolved', 'dismissed')),
+      description TEXT NOT NULL,
+      requested_action TEXT NOT NULL DEFAULT '',
+      resolution TEXT NOT NULL DEFAULT '',
+      opened_at TEXT NOT NULL,
+      resolved_at TEXT DEFAULT NULL,
+      opened_operation_id TEXT NOT NULL,
+      opened_project_revision INTEGER NOT NULL CHECK (opened_project_revision > 0),
+      opened_authority_epoch INTEGER NOT NULL CHECK (opened_authority_epoch >= 0),
+      resolved_operation_id TEXT DEFAULT NULL,
+      resolved_project_revision INTEGER DEFAULT NULL,
+      resolved_authority_epoch INTEGER DEFAULT NULL,
+      UNIQUE (blocker_id, lifecycle_id),
+      CHECK (
+        (blocker_status = 'open' AND resolved_at IS NULL
+          AND resolved_operation_id IS NULL AND resolved_project_revision IS NULL
+          AND resolved_authority_epoch IS NULL) OR
+        (blocker_status IN ('resolved', 'dismissed') AND resolved_at IS NOT NULL
+          AND resolved_operation_id IS NOT NULL AND resolved_project_revision > 0
+          AND resolved_authority_epoch >= 0)
+      ),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (lifecycle_id, project_id)
+        REFERENCES workflow_item_lifecycles(lifecycle_id, project_id),
+      FOREIGN KEY (opened_operation_id, project_id, opened_project_revision, opened_authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        ),
+      FOREIGN KEY (resolved_operation_id, project_id, resolved_project_revision, resolved_authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        )
+    )
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_blocker_terminal_immutable
+    BEFORE UPDATE ON workflow_blockers
+    WHEN OLD.blocker_status IN ('resolved', 'dismissed')
+    BEGIN
+      SELECT RAISE(ABORT, 'terminal workflow blockers are immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_blocker_opening_immutable
+    BEFORE UPDATE ON workflow_blockers
+    WHEN NEW.blocker_id != OLD.blocker_id
+      OR NEW.project_id != OLD.project_id
+      OR NEW.lifecycle_id != OLD.lifecycle_id
+      OR NEW.blocker_kind != OLD.blocker_kind
+      OR NEW.resolution_owner != OLD.resolution_owner
+      OR NEW.description != OLD.description
+      OR NEW.requested_action != OLD.requested_action
+      OR NEW.opened_at != OLD.opened_at
+      OR NEW.opened_operation_id != OLD.opened_operation_id
+      OR NEW.opened_project_revision != OLD.opened_project_revision
+      OR NEW.opened_authority_epoch != OLD.opened_authority_epoch
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow blocker opening is immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_blocker_transition
+    BEFORE UPDATE ON workflow_blockers
+    WHEN OLD.blocker_status != 'open'
+      OR NEW.blocker_status NOT IN ('resolved', 'dismissed')
+    BEGIN
+      SELECT RAISE(ABORT, 'invalid workflow blocker transition');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_blocker_delete
+    BEFORE DELETE ON workflow_blockers
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow blockers are durable history');
+    END
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_waivers (
+      waiver_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      lifecycle_id TEXT NOT NULL,
+      requirement_id TEXT DEFAULT NULL,
+      blocker_id TEXT DEFAULT NULL,
+      waiver_status TEXT NOT NULL CHECK (waiver_status IN ('active', 'revoked', 'expired')),
+      scope TEXT NOT NULL,
+      rationale TEXT NOT NULL,
+      granted_by_actor_type TEXT NOT NULL CHECK (granted_by_actor_type IN ('user', 'policy')),
+      granted_by_actor_id TEXT DEFAULT NULL,
+      granted_at TEXT NOT NULL,
+      expires_at TEXT DEFAULT NULL,
+      ended_at TEXT DEFAULT NULL,
+      operation_id TEXT NOT NULL,
+      project_revision INTEGER NOT NULL CHECK (project_revision > 0),
+      authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 0),
+      ended_operation_id TEXT DEFAULT NULL,
+      ended_project_revision INTEGER DEFAULT NULL,
+      ended_authority_epoch INTEGER DEFAULT NULL,
+      UNIQUE (waiver_id, requirement_id),
+      CHECK (granted_by_actor_type != 'user' OR granted_by_actor_id IS NOT NULL),
+      CHECK (
+        (waiver_status = 'active' AND ended_at IS NULL
+          AND ended_operation_id IS NULL AND ended_project_revision IS NULL
+          AND ended_authority_epoch IS NULL) OR
+        (waiver_status IN ('revoked', 'expired') AND ended_at IS NOT NULL
+          AND ended_operation_id IS NOT NULL AND ended_project_revision > 0
+          AND ended_authority_epoch >= 0)
+      ),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (lifecycle_id, project_id)
+        REFERENCES workflow_item_lifecycles(lifecycle_id, project_id),
+      FOREIGN KEY (requirement_id) REFERENCES requirements(id),
+      FOREIGN KEY (blocker_id, lifecycle_id)
+        REFERENCES workflow_blockers(blocker_id, lifecycle_id),
+      FOREIGN KEY (operation_id, project_id, project_revision, authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        ),
+      FOREIGN KEY (ended_operation_id, project_id, ended_project_revision, ended_authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        )
+    )
+  `);
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_waiver_active_blocker
+    ON workflow_waivers(blocker_id)
+    WHERE waiver_status = 'active' AND blocker_id IS NOT NULL
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_waiver_terminal_immutable
+    BEFORE UPDATE ON workflow_waivers
+    WHEN OLD.waiver_status IN ('revoked', 'expired')
+    BEGIN
+      SELECT RAISE(ABORT, 'terminal workflow waivers are immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_waiver_grant_immutable
+    BEFORE UPDATE ON workflow_waivers
+    WHEN NEW.waiver_id != OLD.waiver_id
+      OR NEW.project_id != OLD.project_id
+      OR NEW.lifecycle_id != OLD.lifecycle_id
+      OR NEW.requirement_id IS NOT OLD.requirement_id
+      OR NEW.blocker_id IS NOT OLD.blocker_id
+      OR NEW.scope != OLD.scope
+      OR NEW.rationale != OLD.rationale
+      OR NEW.granted_by_actor_type != OLD.granted_by_actor_type
+      OR NEW.granted_by_actor_id IS NOT OLD.granted_by_actor_id
+      OR NEW.granted_at != OLD.granted_at
+      OR NEW.expires_at IS NOT OLD.expires_at
+      OR NEW.operation_id != OLD.operation_id
+      OR NEW.project_revision != OLD.project_revision
+      OR NEW.authority_epoch != OLD.authority_epoch
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow waiver grant is immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_waiver_transition
+    BEFORE UPDATE ON workflow_waivers
+    WHEN OLD.waiver_status != 'active'
+      OR NEW.waiver_status NOT IN ('revoked', 'expired')
+    BEGIN
+      SELECT RAISE(ABORT, 'invalid workflow waiver transition');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_waiver_delete
+    BEFORE DELETE ON workflow_waivers
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow waivers are durable history');
+    END
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_requirement_dispositions (
+      disposition_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      requirement_id TEXT NOT NULL,
+      disposition TEXT NOT NULL CHECK (disposition IN ('unsatisfied', 'satisfied', 'waived')),
+      waiver_id TEXT DEFAULT NULL,
+      supersedes_disposition_id TEXT DEFAULT NULL UNIQUE,
+      rationale TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      operation_id TEXT NOT NULL,
+      project_revision INTEGER NOT NULL CHECK (project_revision > 0),
+      authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 0),
+      UNIQUE (disposition_id, requirement_id),
+      CHECK (
+        (disposition = 'waived' AND waiver_id IS NOT NULL) OR
+        (disposition IN ('unsatisfied', 'satisfied') AND waiver_id IS NULL)
+      ),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (requirement_id) REFERENCES requirements(id),
+      FOREIGN KEY (waiver_id, requirement_id)
+        REFERENCES workflow_waivers(waiver_id, requirement_id),
+      FOREIGN KEY (supersedes_disposition_id, requirement_id)
+        REFERENCES workflow_requirement_dispositions(disposition_id, requirement_id),
+      FOREIGN KEY (operation_id, project_id, project_revision, authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        )
+    )
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_workflow_requirement_disposition_history
+    ON workflow_requirement_dispositions(requirement_id, project_revision, disposition_id)
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_requirement_disposition_head
+    BEFORE INSERT ON workflow_requirement_dispositions
+    WHEN (
+      NOT EXISTS (
+        SELECT 1 FROM workflow_requirement_dispositions
+        WHERE requirement_id = NEW.requirement_id
+      )
+      AND NEW.supersedes_disposition_id IS NOT NULL
+    ) OR (
+      EXISTS (
+        SELECT 1 FROM workflow_requirement_dispositions
+        WHERE requirement_id = NEW.requirement_id
+      )
+      AND (
+        NEW.supersedes_disposition_id IS NULL OR
+        NOT EXISTS (
+          SELECT 1
+          FROM workflow_requirement_dispositions head
+          WHERE head.requirement_id = NEW.requirement_id
+            AND head.disposition_id = NEW.supersedes_disposition_id
+            AND NOT EXISTS (
+              SELECT 1
+              FROM workflow_requirement_dispositions successor
+              WHERE successor.supersedes_disposition_id = head.disposition_id
+            )
+        )
+      )
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'requirement disposition must supersede the current head');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_requirement_dispositions_immutable_update
+    BEFORE UPDATE ON workflow_requirement_dispositions
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow requirement dispositions are immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_requirement_dispositions_immutable_delete
+    BEFORE DELETE ON workflow_requirement_dispositions
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow requirement dispositions are immutable');
+    END
+  `);
+}

--- a/src/resources/extensions/gsd/db-lifecycle-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-lifecycle-foundation-schema.ts
@@ -91,6 +91,18 @@ export function createLifecycleFoundationSchemaV32(db: DbAdapter): void {
     END
   `);
   db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_lifecycle_causal_provenance
+    BEFORE UPDATE ON workflow_item_lifecycles
+    WHEN NEW.lifecycle_status != OLD.lifecycle_status
+      AND (
+        NEW.last_project_revision <= OLD.last_project_revision
+        OR NEW.last_authority_epoch < OLD.last_authority_epoch
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow lifecycle causal provenance must advance');
+    END
+  `);
+  db.exec(`
     CREATE TRIGGER IF NOT EXISTS trg_workflow_lifecycle_delete
     BEFORE DELETE ON workflow_item_lifecycles
     BEGIN
@@ -201,6 +213,46 @@ export function createLifecycleFoundationSchemaV32(db: DbAdapter): void {
     END
   `);
   db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_transition_fencing
+    BEFORE UPDATE ON workflow_execution_attempts
+    WHEN NEW.attempt_state != OLD.attempt_state
+      AND NEW.worker_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM workflow_item_lifecycles lifecycle
+        JOIN milestone_leases lease ON lease.milestone_id = lifecycle.milestone_id
+        WHERE lifecycle.lifecycle_id = NEW.lifecycle_id
+          AND lease.worker_id = NEW.worker_id
+          AND lease.fencing_token = NEW.milestone_lease_token
+          AND lease.status = 'held'
+          AND lease.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow attempt requires the current held lease');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_transition_dispatch_scope
+    BEFORE UPDATE ON workflow_execution_attempts
+    WHEN NEW.attempt_state != OLD.attempt_state
+      AND NEW.coordination_dispatch_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM workflow_item_lifecycles lifecycle
+        JOIN unit_dispatches dispatch ON dispatch.id = NEW.coordination_dispatch_id
+        WHERE lifecycle.lifecycle_id = NEW.lifecycle_id
+          AND dispatch.milestone_id = lifecycle.milestone_id
+          AND dispatch.slice_id IS lifecycle.slice_id
+          AND dispatch.task_id IS lifecycle.task_id
+          AND dispatch.worker_id = NEW.worker_id
+          AND dispatch.milestone_lease_token = NEW.milestone_lease_token
+          AND dispatch.status IN ('claimed', 'running')
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'coordination dispatch does not match workflow attempt scope');
+    END
+  `);
+  db.exec(`
     CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_number_sequence
     BEFORE INSERT ON workflow_execution_attempts
     WHEN NEW.attempt_number != COALESCE(
@@ -238,6 +290,8 @@ export function createLifecycleFoundationSchemaV32(db: DbAdapter): void {
       OR NEW.coordination_dispatch_id IS NOT OLD.coordination_dispatch_id
       OR NEW.worker_id IS NOT OLD.worker_id
       OR NEW.milestone_lease_token IS NOT OLD.milestone_lease_token
+      OR NEW.claimed_at != OLD.claimed_at
+      OR (OLD.started_at IS NOT NULL AND NEW.started_at IS NOT OLD.started_at)
       OR NEW.claim_operation_id != OLD.claim_operation_id
       OR NEW.claim_project_revision != OLD.claim_project_revision
       OR NEW.claim_authority_epoch != OLD.claim_authority_epoch
@@ -262,6 +316,18 @@ export function createLifecycleFoundationSchemaV32(db: DbAdapter): void {
     )
     BEGIN
       SELECT RAISE(ABORT, 'invalid workflow attempt transition');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_attempt_causal_provenance
+    BEFORE UPDATE ON workflow_execution_attempts
+    WHEN NEW.attempt_state = 'settled'
+      AND (
+        NEW.settle_project_revision <= OLD.claim_project_revision
+        OR NEW.settle_authority_epoch < OLD.claim_authority_epoch
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow attempt causal provenance must advance');
     END
   `);
   db.exec(`
@@ -408,6 +474,18 @@ export function createLifecycleFoundationSchemaV32(db: DbAdapter): void {
     END
   `);
   db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_blocker_causal_provenance
+    BEFORE UPDATE ON workflow_blockers
+    WHEN NEW.blocker_status IN ('resolved', 'dismissed')
+      AND (
+        NEW.resolved_project_revision <= OLD.opened_project_revision
+        OR NEW.resolved_authority_epoch < OLD.opened_authority_epoch
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow blocker causal provenance must advance');
+    END
+  `);
+  db.exec(`
     CREATE TRIGGER IF NOT EXISTS trg_workflow_blocker_delete
     BEFORE DELETE ON workflow_blockers
     BEGIN
@@ -506,6 +584,18 @@ export function createLifecycleFoundationSchemaV32(db: DbAdapter): void {
     END
   `);
   db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_waiver_causal_provenance
+    BEFORE UPDATE ON workflow_waivers
+    WHEN NEW.waiver_status IN ('revoked', 'expired')
+      AND (
+        NEW.ended_project_revision <= OLD.project_revision
+        OR NEW.ended_authority_epoch < OLD.authority_epoch
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow waiver causal provenance must advance');
+    END
+  `);
+  db.exec(`
     CREATE TRIGGER IF NOT EXISTS trg_workflow_waiver_delete
     BEFORE DELETE ON workflow_waivers
     BEGIN
@@ -546,6 +636,42 @@ export function createLifecycleFoundationSchemaV32(db: DbAdapter): void {
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_workflow_requirement_disposition_history
     ON workflow_requirement_dispositions(requirement_id, project_revision, disposition_id)
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_requirement_disposition_waiver_authority
+    BEFORE INSERT ON workflow_requirement_dispositions
+    WHEN NEW.disposition = 'waived'
+      AND NEW.waiver_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM workflow_waivers waiver
+        WHERE waiver.waiver_id = NEW.waiver_id
+          AND waiver.requirement_id = NEW.requirement_id
+          AND waiver.project_id = NEW.project_id
+          AND waiver.waiver_status = 'active'
+          AND (waiver.expires_at IS NULL OR waiver.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+          AND waiver.project_revision < NEW.project_revision
+          AND waiver.authority_epoch <= NEW.authority_epoch
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'waived disposition requires an active unexpired waiver');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_requirement_disposition_causal_provenance
+    BEFORE INSERT ON workflow_requirement_dispositions
+    WHEN NEW.supersedes_disposition_id IS NOT NULL AND EXISTS (
+      SELECT 1
+      FROM workflow_requirement_dispositions prior
+      WHERE prior.disposition_id = NEW.supersedes_disposition_id
+        AND (
+          NEW.project_revision <= prior.project_revision
+          OR NEW.authority_epoch < prior.authority_epoch
+        )
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'workflow disposition causal provenance must advance');
+    END
   `);
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS trg_workflow_requirement_disposition_head
@@ -592,6 +718,26 @@ export function createLifecycleFoundationSchemaV32(db: DbAdapter): void {
     BEFORE DELETE ON workflow_requirement_dispositions
     BEGIN
       SELECT RAISE(ABORT, 'workflow requirement dispositions are immutable');
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_waiver_dependent_disposition
+    BEFORE UPDATE ON workflow_waivers
+    WHEN OLD.waiver_status = 'active'
+      AND NEW.waiver_status IN ('revoked', 'expired')
+      AND EXISTS (
+        SELECT 1
+        FROM workflow_requirement_dispositions disposition
+        WHERE disposition.waiver_id = OLD.waiver_id
+          AND disposition.disposition = 'waived'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM workflow_requirement_dispositions successor
+            WHERE successor.supersedes_disposition_id = disposition.disposition_id
+          )
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'waiver termination must supersede its current waived disposition');
     END
   `);
 }

--- a/src/resources/extensions/gsd/db-migration-steps.ts
+++ b/src/resources/extensions/gsd/db-migration-steps.ts
@@ -3,6 +3,7 @@
 
 import type { DbAdapter } from "./db-adapter.js";
 import { createCanonicalFoundationSchemaV31 } from "./db-canonical-foundation-schema.js";
+import { createLifecycleFoundationSchemaV32 } from "./db-lifecycle-foundation-schema.js";
 import { ensureColumn } from "./db-schema-metadata.js";
 
 export function applyMigrationV2Artifacts(db: DbAdapter): void {
@@ -498,4 +499,8 @@ export function applyMigrationV30ReworkBriefs(db: DbAdapter): void {
 
 export function applyMigrationV31CanonicalFoundation(db: DbAdapter): void {
   createCanonicalFoundationSchemaV31(db);
+}
+
+export function applyMigrationV32LifecycleFoundation(db: DbAdapter): void {
+  createLifecycleFoundationSchemaV32(db);
 }

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -48,8 +48,10 @@ import {
   applyMigrationV29RepositoryTargets,
   applyMigrationV30ReworkBriefs,
   applyMigrationV31CanonicalFoundation,
+  applyMigrationV32LifecycleFoundation,
 } from "../db-migration-steps.js";
 import { createCanonicalFoundationSchemaV31 } from "../db-canonical-foundation-schema.js";
+import { createLifecycleFoundationSchemaV32 } from "../db-lifecycle-foundation-schema.js";
 import {
   isMemoriesFtsAvailableSchema,
   rebuildMemoriesFtsSchemaOnce,
@@ -99,7 +101,7 @@ const providerLoader = createSqliteProviderLoader({
   nodeVersion: process.versions.node,
   writeStderr: (message: string) => process.stderr.write(message),
 });
-export const SCHEMA_VERSION = 31;
+export const SCHEMA_VERSION = 32;
 function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): void {
   const conservativeFilePragmas = fileBacked && _isLikelyWslDrvFsPathForTest(dbPath);
   if (fileBacked) db.exec(conservativeFilePragmas ? "PRAGMA journal_mode=DELETE" : "PRAGMA journal_mode=WAL");
@@ -138,6 +140,7 @@ function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): 
         createCoordinationTablesV24(db);
         createRuntimeKvTableV25(db);
         createCanonicalFoundationSchemaV31(db);
+        createLifecycleFoundationSchemaV32(db);
 
         // Fresh install — all tables are created above with the full current schema,
         // so it is safe to create all migration-specific indexes here.  For existing
@@ -394,6 +397,11 @@ function migrateSchema(db: DbAdapter, dbPath: string | null): void {
     if (currentVersion < 31) {
       applyMigrationV31CanonicalFoundation(db);
       recordSchemaVersion(db, 31);
+    }
+
+    if (currentVersion < 32) {
+      applyMigrationV32LifecycleFoundation(db);
+      recordSchemaVersion(db, 32);
     }
 
     if (_migrationFaultForTest) throw new Error("migration fault injected for test");

--- a/src/resources/extensions/gsd/tests/db-canonical-foundation.test.ts
+++ b/src/resources/extensions/gsd/tests/db-canonical-foundation.test.ts
@@ -118,7 +118,7 @@ afterEach(() => {
 });
 
 test("fresh database creates the v31 authority root and linked operation journal", () => {
-  assert.equal(SCHEMA_VERSION, 31);
+  assert.ok(SCHEMA_VERSION >= 31);
   const dbPath = createDatabasePath();
   assert.equal(openDatabase(dbPath), true);
   const db = _getAdapter();
@@ -387,7 +387,7 @@ test("v30 upgrade preserves legacy rows and creates an independently healthy bac
   let projectId = "";
   const upgraded = openRawDatabase(dbPath);
   try {
-    assert.equal(maxSchemaVersion(upgraded), 31);
+    assert.equal(maxSchemaVersion(upgraded), SCHEMA_VERSION);
     assert.equal(tableExists(upgraded, "project_authority"), true);
     assert.equal(upgraded.prepare("SELECT title FROM milestones WHERE id = 'M-LEGACY'").get()?.title, "Preserved legacy milestone");
     assert.equal(upgraded.prepare("SELECT payload_json FROM audit_events WHERE event_id = 'audit-legacy'").get()?.payload_json, '{"kept":true}');
@@ -409,7 +409,7 @@ test("v30 upgrade preserves legacy rows and creates an independently healthy bac
 
   const reopened = inspectFromFreshProcess(dbPath);
   assert.deepEqual(reopened, {
-    version: 31,
+    version: SCHEMA_VERSION,
     authority: { project_id: projectId, revision: 0, authority_epoch: 0 },
     legacy: { title: "Preserved legacy milestone" },
   });
@@ -417,7 +417,7 @@ test("v30 upgrade preserves legacy rows and creates an independently healthy bac
   const restoredPath = join(dirname(dbPath), "restored.db");
   copyFileSync(`${dbPath}.backup-v30`, restoredPath);
   const restored = inspectFromFreshProcess(restoredPath);
-  assert.equal(restored.version, 31);
+  assert.equal(restored.version, SCHEMA_VERSION);
   assert.deepEqual(restored.legacy, { title: "Preserved legacy milestone" });
   assert.deepEqual(
     Object.fromEntries(
@@ -450,7 +450,7 @@ test("faulted v30 migration leaves no v31 state and retries cleanly", () => {
   closeDatabase();
   const retried = openRawDatabase(dbPath);
   try {
-    assert.equal(maxSchemaVersion(retried), 31);
+    assert.equal(maxSchemaVersion(retried), SCHEMA_VERSION);
     assert.equal(retried.prepare("SELECT COUNT(*) AS count FROM project_authority").get()?.count, 1);
     assert.equal(retried.prepare("SELECT COUNT(*) AS count FROM milestones WHERE id = 'M-LEGACY'").get()?.count, 1);
   } finally {

--- a/src/resources/extensions/gsd/tests/db-lifecycle-foundation.test.ts
+++ b/src/resources/extensions/gsd/tests/db-lifecycle-foundation.test.ts
@@ -75,7 +75,7 @@ function seedHierarchy(db: RawDb): void {
   `);
 }
 
-function insertOperation(db: RawDb, id: string, revision: number): void {
+function insertOperation(db: RawDb, id: string, revision: number, authorityEpoch = 0): void {
   const project = projectId(db);
   db.prepare(`
     INSERT INTO workflow_operations (
@@ -83,13 +83,15 @@ function insertOperation(db: RawDb, id: string, revision: number): void {
       expected_revision, resulting_revision,
       expected_authority_epoch, resulting_authority_epoch,
       actor_type, actor_id, source_transport, request_hash, created_at
-    ) VALUES (?, ?, 'test', ?, ?, ?, 0, 0, 'agent', 'test', 'test', ?, ?)
+    ) VALUES (?, ?, 'test', ?, ?, ?, ?, ?, 'agent', 'test', 'test', ?, ?)
   `).run(
     id,
     project,
     `key-${id}`,
     revision - 1,
     revision,
+    authorityEpoch,
+    authorityEpoch,
     `hash-${id}`,
     `2026-07-12T00:00:${String(revision).padStart(2, "0")}.000Z`,
   );
@@ -108,13 +110,14 @@ function insertTaskLifecycle(
   operationId: string,
   revision: number,
   status = "in_progress",
+  authorityEpoch = 0,
 ): void {
   db.prepare(`
     INSERT INTO workflow_item_lifecycles (
       lifecycle_id, project_id, item_kind, milestone_id, slice_id, task_id,
       lifecycle_status, state_version, created_at, updated_at,
       last_operation_id, last_project_revision, last_authority_epoch
-    ) VALUES (?, ?, 'task', ?, 'S01', 'T01', ?, 0, ?, ?, ?, ?, 0)
+    ) VALUES (?, ?, 'task', ?, 'S01', 'T01', ?, 0, ?, ?, ?, ?, ?)
   `).run(
     lifecycleId,
     projectId(db),
@@ -124,6 +127,7 @@ function insertTaskLifecycle(
     "2026-07-12T00:01:00.000Z",
     operationId,
     revision,
+    authorityEpoch,
   );
 }
 
@@ -135,13 +139,14 @@ function insertAttempt(
   operationId: string,
   revision: number,
   retryOfAttemptId: string | null = null,
+  authorityEpoch = 0,
 ): void {
   db.prepare(`
     INSERT INTO workflow_execution_attempts (
       attempt_id, project_id, lifecycle_id, attempt_number, retry_of_attempt_id,
       attempt_state, claimed_at,
       claim_operation_id, claim_project_revision, claim_authority_epoch
-    ) VALUES (?, ?, ?, ?, ?, 'claimed', ?, ?, ?, 0)
+    ) VALUES (?, ?, ?, ?, ?, 'claimed', ?, ?, ?, ?)
   `).run(
     attemptId,
     projectId(db),
@@ -151,6 +156,7 @@ function insertAttempt(
     `2026-07-12T00:02:${String(attemptNumber).padStart(2, "0")}.000Z`,
     operationId,
     revision,
+    authorityEpoch,
   );
 }
 
@@ -293,7 +299,7 @@ test("lifecycle transitions preserve identity, provenance, and durable history",
     );
     assert.throws(
       () => db.exec("UPDATE workflow_item_lifecycles SET lifecycle_status = 'ready' WHERE lifecycle_id = 'life-a'"),
-      /invalid workflow lifecycle transition/,
+      /causal provenance/,
     );
     assert.throws(
       () => db.exec("DELETE FROM workflow_item_lifecycles WHERE lifecycle_id = 'life-a'"),
@@ -304,11 +310,103 @@ test("lifecycle transitions preserve identity, provenance, and durable history",
   }
 });
 
+test("lifecycle histories reject backward revisions and Authority Epochs", () => {
+  const { db } = openFreshFixture();
+  try {
+    insertOperation(db, "op-1", 1, 0);
+    insertOperation(db, "op-2", 2, 1);
+    insertOperation(db, "op-3", 3, 0);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-2", 2, "in_progress", 1);
+    insertAttempt(db, "attempt-a1", "life-a", 1, "op-2", 2, null, 1);
+    db.prepare(`
+      INSERT INTO workflow_blockers (
+        blocker_id, project_id, lifecycle_id, blocker_kind, resolution_owner,
+        blocker_status, description, opened_at,
+        opened_operation_id, opened_project_revision, opened_authority_epoch
+      ) VALUES ('blocker-a', ?, 'life-a', 'ambiguous_intent', 'user',
+        'open', 'Needs a decision', '', 'op-2', 2, 1)
+    `).run(projectId(db));
+    db.prepare(`
+      INSERT INTO workflow_waivers (
+        waiver_id, project_id, lifecycle_id, requirement_id, waiver_status,
+        scope, rationale, granted_by_actor_type, granted_by_actor_id, granted_at,
+        operation_id, project_revision, authority_epoch
+      ) VALUES ('waiver-a', ?, 'life-a', 'R-A', 'active',
+        'requirement:R-A', 'Exception', 'user', 'maintainer', '', 'op-2', 2, 1)
+    `).run(projectId(db));
+    db.prepare(`
+      INSERT INTO workflow_requirement_dispositions (
+        disposition_id, project_id, requirement_id, disposition,
+        rationale, created_at, operation_id, project_revision, authority_epoch
+      ) VALUES ('disp-a', ?, 'R-A', 'unsatisfied',
+        'Not yet met', '', 'op-2', 2, 1)
+    `).run(projectId(db));
+
+    assert.throws(
+      () => db.exec(`
+        UPDATE workflow_item_lifecycles
+        SET lifecycle_status = 'completed', state_version = 1,
+            updated_at = '2026-07-12T00:04:00.000Z',
+            last_operation_id = 'op-3', last_project_revision = 3,
+            last_authority_epoch = 0
+        WHERE lifecycle_id = 'life-a'
+      `),
+      /causal provenance/,
+    );
+    for (const [operationId, revision] of [["op-1", 1], ["op-3", 3]] as const) {
+      assert.throws(
+        () => db.prepare(`
+          UPDATE workflow_execution_attempts
+          SET attempt_state = 'settled', ended_at = '',
+              settle_operation_id = ?, settle_project_revision = ?,
+              settle_authority_epoch = 0
+          WHERE attempt_id = 'attempt-a1'
+        `).run(operationId, revision),
+        /causal provenance/,
+      );
+      assert.throws(
+        () => db.prepare(`
+          UPDATE workflow_blockers
+          SET blocker_status = 'resolved', resolution = 'answered', resolved_at = '',
+              resolved_operation_id = ?, resolved_project_revision = ?,
+              resolved_authority_epoch = 0
+          WHERE blocker_id = 'blocker-a'
+        `).run(operationId, revision),
+        /causal provenance/,
+      );
+      assert.throws(
+        () => db.prepare(`
+          UPDATE workflow_waivers
+          SET waiver_status = 'revoked', ended_at = '',
+              ended_operation_id = ?, ended_project_revision = ?,
+              ended_authority_epoch = 0
+          WHERE waiver_id = 'waiver-a'
+        `).run(operationId, revision),
+        /causal provenance/,
+      );
+      assert.throws(
+        () => db.prepare(`
+          INSERT INTO workflow_requirement_dispositions (
+            disposition_id, project_id, requirement_id, disposition,
+            supersedes_disposition_id, rationale, created_at,
+            operation_id, project_revision, authority_epoch
+          ) VALUES (?, ?, 'R-A', 'satisfied', 'disp-a',
+            'Now met', '', ?, ?, 0)
+        `).run(`disp-${revision}`, projectId(db), operationId, revision),
+        /causal provenance/,
+      );
+    }
+  } finally {
+    db.close();
+  }
+});
+
 test("Attempt attribution rejects stale fencing and cross-scope dispatches", () => {
   const { db } = openFreshFixture();
   try {
     insertOperation(db, "op-1", 1);
     insertOperation(db, "op-2", 2);
+    insertOperation(db, "op-3", 3);
     insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
     db.prepare(`
       INSERT INTO workflow_item_lifecycles (
@@ -406,14 +504,79 @@ test("Attempt attribution rejects stale fencing and cross-scope dispatches", () 
       `),
       /identity is immutable/,
     );
-    assert.doesNotThrow(() => db.prepare(`
+    db.prepare(`
       INSERT INTO workflow_execution_attempts (
         attempt_id, project_id, lifecycle_id, attempt_number,
-        attempt_state, worker_id, milestone_lease_token, claimed_at,
+        attempt_state, coordination_dispatch_id,
+        worker_id, milestone_lease_token, claimed_at,
         claim_operation_id, claim_project_revision, claim_authority_epoch
       ) VALUES ('attempt-valid', ?, 'life-a', 1,
-        'claimed', 'worker-a', 7, '', 'op-2', 2, 0)
-    `).run(projectId(db)));
+        'claimed', ?, 'worker-a', 7, '', 'op-2', 2, 0)
+    `).run(projectId(db), childDispatchId);
+    db.exec("UPDATE milestone_leases SET expires_at = '2000-01-01T00:00:00.000Z' WHERE milestone_id = 'M-A'");
+    assert.throws(
+      () => db.exec(`
+        UPDATE workflow_execution_attempts
+        SET attempt_state = 'running', started_at = '2026-07-12T00:03:00.000Z'
+        WHERE attempt_id = 'attempt-valid'
+      `),
+      /current held lease/,
+    );
+    db.exec("UPDATE milestone_leases SET expires_at = '2099-01-01T00:00:00.000Z' WHERE milestone_id = 'M-A'");
+    db.exec(`
+      UPDATE workflow_execution_attempts
+      SET attempt_state = 'running', started_at = '2026-07-12T00:03:00.000Z'
+      WHERE attempt_id = 'attempt-valid'
+    `);
+    db.prepare("UPDATE unit_dispatches SET status = 'completed' WHERE id = ?").run(childDispatchId);
+    assert.throws(
+      () => settleAttempt(db, "attempt-valid", "op-3", 3),
+      /does not match workflow attempt scope/,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("Attempt transitions preserve claim and start timestamps", () => {
+  const { db } = openFreshFixture();
+  try {
+    insertOperations(db, 4);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
+    insertTaskLifecycle(db, "life-b", "M-B", "op-1", 1);
+    insertAttempt(db, "attempt-a1", "life-a", 1, "op-2", 2);
+    db.prepare(`
+      INSERT INTO workflow_execution_attempts (
+        attempt_id, project_id, lifecycle_id, attempt_number,
+        attempt_state, claimed_at, started_at,
+        claim_operation_id, claim_project_revision, claim_authority_epoch
+      ) VALUES ('attempt-b1', ?, 'life-b', 1,
+        'claimed', '2026-07-12T00:02:00.000Z', '2026-07-12T00:03:00.000Z',
+        'op-2', 2, 0)
+    `).run(projectId(db));
+
+    assert.throws(
+      () => db.exec(`
+        UPDATE workflow_execution_attempts
+        SET attempt_state = 'settled', claimed_at = 'rewritten',
+            ended_at = '2026-07-12T00:03:00.000Z',
+            settle_operation_id = 'op-3', settle_project_revision = 3,
+            settle_authority_epoch = 0
+        WHERE attempt_id = 'attempt-a1'
+      `),
+      /identity is immutable/,
+    );
+    assert.throws(
+      () => db.exec(`
+        UPDATE workflow_execution_attempts
+        SET attempt_state = 'settled', started_at = 'rewritten',
+            ended_at = '2026-07-12T00:04:00.000Z',
+            settle_operation_id = 'op-4', settle_project_revision = 4,
+            settle_authority_epoch = 0
+        WHERE attempt_id = 'attempt-b1'
+      `),
+      /identity is immutable/,
+    );
   } finally {
     db.close();
   }
@@ -659,17 +822,6 @@ test("Requirement Dispositions require Waivers and remain independent from Block
       /opening is immutable/,
     );
     assert.throws(
-      () => db.exec(`
-        UPDATE workflow_waivers
-        SET rationale = 'rewritten', waiver_status = 'revoked',
-            ended_at = '2026-07-12T00:05:00.000Z',
-            ended_operation_id = 'op-5', ended_project_revision = 5,
-            ended_authority_epoch = 0
-        WHERE waiver_id = 'waiver-a'
-      `),
-      /grant is immutable/,
-    );
-    assert.throws(
       () => db.prepare(`
         INSERT INTO workflow_requirement_dispositions (
           disposition_id, project_id, requirement_id, disposition,
@@ -688,6 +840,16 @@ test("Requirement Dispositions require Waivers and remain independent from Block
         'disp-a', 'new evidence', '', 'op-5', 5, 0)
     `).run(projectId(db));
     assert.throws(
+      () => db.exec(`
+        UPDATE workflow_waivers
+        SET rationale = 'rewritten', waiver_status = 'revoked', ended_at = '',
+            ended_operation_id = 'op-6', ended_project_revision = 6,
+            ended_authority_epoch = 0
+        WHERE waiver_id = 'waiver-a'
+      `),
+      /grant is immutable/,
+    );
+    assert.throws(
       () => db.prepare(`
         INSERT INTO workflow_requirement_dispositions (
           disposition_id, project_id, requirement_id, disposition,
@@ -698,6 +860,90 @@ test("Requirement Dispositions require Waivers and remain independent from Block
       `).run(projectId(db)),
       /current head/,
     );
+  } finally {
+    db.close();
+  }
+});
+
+test("only current active Waivers authorize waived dispositions", () => {
+  const { db } = openFreshFixture();
+  try {
+    insertOperations(db, 10);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
+    const insertWaiver = db.prepare(`
+      INSERT INTO workflow_waivers (
+        waiver_id, project_id, lifecycle_id, requirement_id, waiver_status,
+        scope, rationale, granted_by_actor_type, granted_by_actor_id, granted_at,
+        expires_at, ended_at, operation_id, project_revision, authority_epoch,
+        ended_operation_id, ended_project_revision, ended_authority_epoch
+      ) VALUES (?, ?, 'life-a', 'R-A', ?, 'requirement:R-A', 'Exception',
+        'user', 'maintainer', '', ?, ?, ?, ?, 0, ?, ?, ?)
+    `);
+    insertWaiver.run(
+      "waiver-revoked", projectId(db), "revoked", null, "", "op-2", 2, "op-3", 3, 0,
+    );
+    insertWaiver.run(
+      "waiver-expired", projectId(db), "expired", null, "", "op-4", 4, "op-5", 5, 0,
+    );
+    insertWaiver.run(
+      "waiver-time-expired", projectId(db), "active", "2000-01-01T00:00:00.000Z",
+      null, "op-6", 6, null, null, null,
+    );
+    insertWaiver.run(
+      "waiver-live", projectId(db), "active", "2099-01-01T00:00:00.000Z",
+      null, "op-7", 7, null, null, null,
+    );
+    insertWaiver.run(
+      "waiver-future", projectId(db), "active", "2099-01-01T00:00:00.000Z",
+      null, "op-10", 10, null, null, null,
+    );
+
+    for (const waiverId of [
+      "waiver-revoked", "waiver-expired", "waiver-time-expired", "waiver-future",
+    ]) {
+      assert.throws(
+        () => db.prepare(`
+          INSERT INTO workflow_requirement_dispositions (
+            disposition_id, project_id, requirement_id, disposition, waiver_id,
+            rationale, created_at, operation_id, project_revision, authority_epoch
+          ) VALUES (?, ?, 'R-A', 'waived', ?,
+            'Invalid exception', '', 'op-8', 8, 0)
+        `).run(`disp-${waiverId}`, projectId(db), waiverId),
+        /active unexpired waiver/,
+      );
+    }
+    db.prepare(`
+      INSERT INTO workflow_requirement_dispositions (
+        disposition_id, project_id, requirement_id, disposition, waiver_id,
+        rationale, created_at, operation_id, project_revision, authority_epoch
+      ) VALUES ('disp-live', ?, 'R-A', 'waived', 'waiver-live',
+        'Authorized exception', '', 'op-8', 8, 0)
+    `).run(projectId(db));
+    assert.throws(
+      () => db.exec(`
+        UPDATE workflow_waivers
+        SET waiver_status = 'revoked', ended_at = '',
+            ended_operation_id = 'op-9', ended_project_revision = 9,
+            ended_authority_epoch = 0
+        WHERE waiver_id = 'waiver-live'
+      `),
+      /supersede its current waived disposition/,
+    );
+    db.prepare(`
+      INSERT INTO workflow_requirement_dispositions (
+        disposition_id, project_id, requirement_id, disposition,
+        supersedes_disposition_id, rationale, created_at,
+        operation_id, project_revision, authority_epoch
+      ) VALUES ('disp-satisfied', ?, 'R-A', 'satisfied',
+        'disp-live', 'Requirement met', '', 'op-9', 9, 0)
+    `).run(projectId(db));
+    assert.doesNotThrow(() => db.exec(`
+      UPDATE workflow_waivers
+      SET waiver_status = 'revoked', ended_at = '',
+          ended_operation_id = 'op-10', ended_project_revision = 10,
+          ended_authority_epoch = 0
+      WHERE waiver_id = 'waiver-live'
+    `));
   } finally {
     db.close();
   }

--- a/src/resources/extensions/gsd/tests/db-lifecycle-foundation.test.ts
+++ b/src/resources/extensions/gsd/tests/db-lifecycle-foundation.test.ts
@@ -1,0 +1,779 @@
+// Project/App: gsd-pi
+// File Purpose: Executable contract for the additive v32 lifecycle foundation.
+
+import assert from "node:assert/strict";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, test } from "node:test";
+
+import {
+  SCHEMA_VERSION,
+  _getAdapter,
+  _setMigrationFaultForTest,
+  closeDatabase,
+  openDatabase,
+} from "../gsd-db.ts";
+
+const require = createRequire(import.meta.url);
+const tempDirs = new Set<string>();
+
+interface RawDb {
+  exec(sql: string): void;
+  prepare(sql: string): {
+    run(...args: unknown[]): unknown;
+    get(...args: unknown[]): Record<string, unknown> | undefined;
+    all(...args: unknown[]): Array<Record<string, unknown>>;
+  };
+  close(): void;
+}
+
+function openRawDatabase(path: string): RawDb {
+  const sqlite = require("node:sqlite") as { DatabaseSync: new (path: string) => RawDb };
+  const db = new sqlite.DatabaseSync(path);
+  db.exec("PRAGMA foreign_keys = ON");
+  return db;
+}
+
+function createDatabasePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-lifecycle-foundation-"));
+  tempDirs.add(dir);
+  return join(dir, "gsd.db");
+}
+
+function tableExists(db: RawDb, table: string): boolean {
+  return Boolean(
+    db.prepare("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?").get(table),
+  );
+}
+
+function maxSchemaVersion(db: RawDb): number {
+  return Number(db.prepare("SELECT MAX(version) AS version FROM schema_version").get()?.version);
+}
+
+function projectId(db: RawDb): string {
+  return String(db.prepare("SELECT project_id FROM project_authority WHERE singleton = 1").get()?.project_id);
+}
+
+function seedHierarchy(db: RawDb): void {
+  db.exec(`
+    INSERT OR IGNORE INTO milestones (id, title, status, created_at)
+    VALUES
+      ('M-A', 'First milestone', 'active', '2026-07-12T00:00:00.000Z'),
+      ('M-B', 'Second milestone', 'active', '2026-07-12T00:00:00.000Z');
+    INSERT OR IGNORE INTO slices (milestone_id, id, title, status, created_at)
+    VALUES
+      ('M-A', 'S01', 'First slice', 'active', '2026-07-12T00:00:00.000Z'),
+      ('M-B', 'S01', 'Second slice', 'active', '2026-07-12T00:00:00.000Z');
+    INSERT OR IGNORE INTO tasks (milestone_id, slice_id, id, title, status)
+    VALUES
+      ('M-A', 'S01', 'T01', 'First task', 'in_progress'),
+      ('M-B', 'S01', 'T01', 'Second task', 'in_progress');
+    INSERT OR IGNORE INTO requirements (id, status, description)
+    VALUES ('R-A', 'active', 'A durable requirement');
+  `);
+}
+
+function insertOperation(db: RawDb, id: string, revision: number): void {
+  const project = projectId(db);
+  db.prepare(`
+    INSERT INTO workflow_operations (
+      operation_id, project_id, operation_type, idempotency_key,
+      expected_revision, resulting_revision,
+      expected_authority_epoch, resulting_authority_epoch,
+      actor_type, actor_id, source_transport, request_hash, created_at
+    ) VALUES (?, ?, 'test', ?, ?, ?, 0, 0, 'agent', 'test', 'test', ?, ?)
+  `).run(
+    id,
+    project,
+    `key-${id}`,
+    revision - 1,
+    revision,
+    `hash-${id}`,
+    `2026-07-12T00:00:${String(revision).padStart(2, "0")}.000Z`,
+  );
+}
+
+function insertOperations(db: RawDb, count: number): void {
+  for (let revision = 1; revision <= count; revision += 1) {
+    insertOperation(db, `op-${revision}`, revision);
+  }
+}
+
+function insertTaskLifecycle(
+  db: RawDb,
+  lifecycleId: string,
+  milestoneId: string,
+  operationId: string,
+  revision: number,
+  status = "in_progress",
+): void {
+  db.prepare(`
+    INSERT INTO workflow_item_lifecycles (
+      lifecycle_id, project_id, item_kind, milestone_id, slice_id, task_id,
+      lifecycle_status, state_version, created_at, updated_at,
+      last_operation_id, last_project_revision, last_authority_epoch
+    ) VALUES (?, ?, 'task', ?, 'S01', 'T01', ?, 0, ?, ?, ?, ?, 0)
+  `).run(
+    lifecycleId,
+    projectId(db),
+    milestoneId,
+    status,
+    "2026-07-12T00:01:00.000Z",
+    "2026-07-12T00:01:00.000Z",
+    operationId,
+    revision,
+  );
+}
+
+function insertAttempt(
+  db: RawDb,
+  attemptId: string,
+  lifecycleId: string,
+  attemptNumber: number,
+  operationId: string,
+  revision: number,
+  retryOfAttemptId: string | null = null,
+): void {
+  db.prepare(`
+    INSERT INTO workflow_execution_attempts (
+      attempt_id, project_id, lifecycle_id, attempt_number, retry_of_attempt_id,
+      attempt_state, claimed_at,
+      claim_operation_id, claim_project_revision, claim_authority_epoch
+    ) VALUES (?, ?, ?, ?, ?, 'claimed', ?, ?, ?, 0)
+  `).run(
+    attemptId,
+    projectId(db),
+    lifecycleId,
+    attemptNumber,
+    retryOfAttemptId,
+    `2026-07-12T00:02:${String(attemptNumber).padStart(2, "0")}.000Z`,
+    operationId,
+    revision,
+  );
+}
+
+function settleAttempt(db: RawDb, attemptId: string, operationId: string, revision: number): void {
+  db.prepare(`
+    UPDATE workflow_execution_attempts
+    SET attempt_state = 'settled', ended_at = ?,
+        settle_operation_id = ?, settle_project_revision = ?, settle_authority_epoch = 0
+    WHERE attempt_id = ?
+  `).run("2026-07-12T00:03:00.000Z", operationId, revision, attemptId);
+}
+
+function openFreshFixture(): { dbPath: string; db: RawDb } {
+  const dbPath = createDatabasePath();
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+  const db = openRawDatabase(dbPath);
+  seedHierarchy(db);
+  return { dbPath, db };
+}
+
+function rewindToV31(dbPath: string): void {
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+  const db = openRawDatabase(dbPath);
+  try {
+    seedHierarchy(db);
+    db.exec(`
+      DROP TABLE IF EXISTS workflow_requirement_dispositions;
+      DROP TABLE IF EXISTS workflow_waivers;
+      DROP TABLE IF EXISTS workflow_blockers;
+      DROP TABLE IF EXISTS workflow_attempt_results;
+      DROP TABLE IF EXISTS workflow_execution_attempts;
+      DROP TABLE IF EXISTS workflow_item_lifecycles;
+      DELETE FROM schema_version;
+      INSERT INTO schema_version (version, applied_at)
+      VALUES (31, '2026-07-12T00:00:00.000Z');
+    `);
+  } finally {
+    db.close();
+  }
+}
+
+afterEach(() => {
+  _setMigrationFaultForTest(false);
+  closeDatabase();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+test("fresh databases expose distinct v32 lifecycle concepts with exact vocabularies", () => {
+  assert.equal(SCHEMA_VERSION, 32);
+  const { db } = openFreshFixture();
+  try {
+    for (const table of [
+      "workflow_item_lifecycles",
+      "workflow_execution_attempts",
+      "workflow_attempt_results",
+      "workflow_requirement_dispositions",
+      "workflow_waivers",
+      "workflow_blockers",
+    ]) {
+      assert.equal(tableExists(db, table), true, `${table} should exist`);
+    }
+
+    insertOperation(db, "op-1", 1);
+    for (const [index, status] of [
+      "pending", "ready", "in_progress", "paused", "completed", "cancelled",
+    ].entries()) {
+      const milestone = index % 2 === 0 ? "M-A" : "M-B";
+      db.exec("SAVEPOINT lifecycle_vocabulary");
+      db.prepare(`
+        INSERT INTO workflow_item_lifecycles (
+          lifecycle_id, project_id, item_kind, milestone_id, slice_id, task_id,
+          lifecycle_status, created_at, updated_at,
+          last_operation_id, last_project_revision, last_authority_epoch
+        ) VALUES (?, ?, 'task', ?, 'S01', 'T01', ?, '', '', 'op-1', 1, 0)
+      `).run(`lifecycle-${index}`, projectId(db), milestone, status);
+      db.exec("ROLLBACK TO lifecycle_vocabulary");
+      db.exec("RELEASE lifecycle_vocabulary");
+    }
+    assert.throws(
+      () => insertTaskLifecycle(db, "invalid-lifecycle", "M-A", "op-1", 1, "blocked"),
+      /CHECK constraint failed/,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("database permits at most one active Attempt per fully scoped work item", () => {
+  const { db } = openFreshFixture();
+  try {
+    insertOperation(db, "op-1", 1);
+    insertOperation(db, "op-2", 2);
+    insertOperation(db, "op-3", 3);
+    insertOperation(db, "op-4", 4);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
+    insertTaskLifecycle(db, "life-b", "M-B", "op-2", 2);
+
+    insertAttempt(db, "attempt-a1", "life-a", 1, "op-3", 3);
+    assert.throws(
+      () => insertAttempt(db, "attempt-a-race", "life-a", 2, "op-4", 4, "attempt-a1"),
+      /UNIQUE constraint failed/,
+    );
+    assert.doesNotThrow(() => insertAttempt(db, "attempt-b1", "life-b", 1, "op-4", 4));
+  } finally {
+    db.close();
+  }
+});
+
+test("lifecycle transitions preserve identity, provenance, and durable history", () => {
+  const { db } = openFreshFixture();
+  try {
+    insertOperation(db, "op-1", 1);
+    insertOperation(db, "op-2", 2);
+    insertOperation(db, "op-3", 3);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
+
+    db.prepare(`
+      UPDATE workflow_item_lifecycles
+      SET lifecycle_status = 'completed', state_version = 1,
+          updated_at = '2026-07-12T00:04:00.000Z',
+          last_operation_id = 'op-2', last_project_revision = 2
+      WHERE lifecycle_id = 'life-a'
+    `).run();
+    assert.equal(
+      db.prepare("SELECT lifecycle_status FROM workflow_item_lifecycles WHERE lifecycle_id = 'life-a'").get()?.lifecycle_status,
+      "completed",
+    );
+    assert.throws(
+      () => db.exec(`
+        UPDATE workflow_item_lifecycles
+        SET milestone_id = 'M-B', lifecycle_status = 'ready', state_version = 2,
+            updated_at = '2026-07-12T00:05:00.000Z',
+            last_operation_id = 'op-3', last_project_revision = 3
+        WHERE lifecycle_id = 'life-a'
+      `),
+      /identity is immutable/,
+    );
+    assert.throws(
+      () => db.exec("UPDATE workflow_item_lifecycles SET lifecycle_status = 'ready' WHERE lifecycle_id = 'life-a'"),
+      /invalid workflow lifecycle transition/,
+    );
+    assert.throws(
+      () => db.exec("DELETE FROM workflow_item_lifecycles WHERE lifecycle_id = 'life-a'"),
+      /durable history/,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("Attempt attribution rejects stale fencing and cross-scope dispatches", () => {
+  const { db } = openFreshFixture();
+  try {
+    insertOperation(db, "op-1", 1);
+    insertOperation(db, "op-2", 2);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
+    db.prepare(`
+      INSERT INTO workflow_item_lifecycles (
+        lifecycle_id, project_id, item_kind, milestone_id,
+        lifecycle_status, created_at, updated_at,
+        last_operation_id, last_project_revision, last_authority_epoch
+      ) VALUES ('life-m', ?, 'milestone', 'M-A',
+        'in_progress', '', '', 'op-1', 1, 0)
+    `).run(projectId(db));
+    db.exec(`
+      INSERT INTO workers (
+        worker_id, host, pid, started_at, version,
+        last_heartbeat_at, status, project_root_realpath
+      ) VALUES ('worker-a', 'localhost', 1, '', '1', '', 'active', '/project');
+      INSERT INTO milestone_leases (
+        milestone_id, worker_id, fencing_token, acquired_at, expires_at, status
+      ) VALUES ('M-A', 'worker-a', 7, '', '2099-01-01T00:00:00.000Z', 'held');
+      INSERT INTO unit_dispatches (
+        trace_id, worker_id, milestone_lease_token, milestone_id,
+        slice_id, task_id, unit_type, unit_id, status, started_at
+      ) VALUES (
+        'cross-scope', 'worker-a', 7, 'M-B',
+        'S01', 'T01', 'execute-task', 'M-B/S01/T01', 'claimed', ''
+      );
+      INSERT INTO unit_dispatches (
+        trace_id, worker_id, milestone_lease_token, milestone_id,
+        slice_id, task_id, unit_type, unit_id, status, started_at
+      ) VALUES (
+        'child-scope', 'worker-a', 7, 'M-A',
+        'S01', 'T01', 'execute-task', 'M-A/S01/T01', 'claimed', ''
+      );
+    `);
+    const crossDispatchId = Number(
+      db.prepare("SELECT id FROM unit_dispatches WHERE trace_id = 'cross-scope'").get()?.id,
+    );
+    const childDispatchId = Number(
+      db.prepare("SELECT id FROM unit_dispatches WHERE trace_id = 'child-scope'").get()?.id,
+    );
+
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_execution_attempts (
+          attempt_id, project_id, lifecycle_id, attempt_number,
+          attempt_state, worker_id, milestone_lease_token, claimed_at,
+          claim_operation_id, claim_project_revision, claim_authority_epoch
+        ) VALUES ('attempt-stale', ?, 'life-a', 1,
+          'claimed', 'worker-a', 6, '', 'op-2', 2, 0)
+      `).run(projectId(db)),
+      /current held lease/,
+    );
+    db.exec("UPDATE milestone_leases SET expires_at = '2000-01-01T00:00:00.000Z' WHERE milestone_id = 'M-A'");
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_execution_attempts (
+          attempt_id, project_id, lifecycle_id, attempt_number,
+          attempt_state, worker_id, milestone_lease_token, claimed_at,
+          claim_operation_id, claim_project_revision, claim_authority_epoch
+        ) VALUES ('attempt-expired', ?, 'life-a', 1,
+          'claimed', 'worker-a', 7, '', 'op-2', 2, 0)
+      `).run(projectId(db)),
+      /current held lease/,
+    );
+    db.exec("UPDATE milestone_leases SET expires_at = '2099-01-01T00:00:00.000Z' WHERE milestone_id = 'M-A'");
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_execution_attempts (
+          attempt_id, project_id, lifecycle_id, attempt_number,
+          attempt_state, coordination_dispatch_id,
+          worker_id, milestone_lease_token, claimed_at,
+          claim_operation_id, claim_project_revision, claim_authority_epoch
+        ) VALUES ('attempt-cross', ?, 'life-a', 1,
+          'claimed', ?, 'worker-a', 7, '', 'op-2', 2, 0)
+      `).run(projectId(db), crossDispatchId),
+      /does not match workflow attempt scope/,
+    );
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_execution_attempts (
+          attempt_id, project_id, lifecycle_id, attempt_number,
+          attempt_state, coordination_dispatch_id,
+          worker_id, milestone_lease_token, claimed_at,
+          claim_operation_id, claim_project_revision, claim_authority_epoch
+        ) VALUES ('attempt-parent', ?, 'life-m', 1,
+          'claimed', ?, 'worker-a', 7, '', 'op-2', 2, 0)
+      `).run(projectId(db), childDispatchId),
+      /does not match workflow attempt scope/,
+    );
+    insertAttempt(db, "attempt-workerless", "life-m", 1, "op-2", 2);
+    assert.throws(
+      () => db.exec(`
+        UPDATE workflow_execution_attempts
+        SET attempt_state = 'running', worker_id = 'worker-a',
+            milestone_lease_token = 7, started_at = ''
+        WHERE attempt_id = 'attempt-workerless'
+      `),
+      /identity is immutable/,
+    );
+    assert.doesNotThrow(() => db.prepare(`
+      INSERT INTO workflow_execution_attempts (
+        attempt_id, project_id, lifecycle_id, attempt_number,
+        attempt_state, worker_id, milestone_lease_token, claimed_at,
+        claim_operation_id, claim_project_revision, claim_authority_epoch
+      ) VALUES ('attempt-valid', ?, 'life-a', 1,
+        'claimed', 'worker-a', 7, '', 'op-2', 2, 0)
+    `).run(projectId(db)));
+  } finally {
+    db.close();
+  }
+});
+
+test("v32 rejects conflated vocabularies and orphaned canonical records", () => {
+  const { db } = openFreshFixture();
+  try {
+    insertOperations(db, 4);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
+    insertAttempt(db, "attempt-a1", "life-a", 1, "op-2", 2);
+    settleAttempt(db, "attempt-a1", "op-3", 3);
+
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_attempt_results (
+          result_id, project_id, lifecycle_id, attempt_id, outcome,
+          failure_class, summary, output_json, created_at,
+          operation_id, project_revision, authority_epoch
+        ) VALUES ('result-wrong-operation', ?, 'life-a', 'attempt-a1', 'failed',
+          'test_failure', '', '{}', '', 'op-4', 4, 0)
+      `).run(projectId(db)),
+      /FOREIGN KEY constraint failed/,
+    );
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_attempt_results (
+          result_id, project_id, lifecycle_id, attempt_id, outcome,
+          failure_class, summary, output_json, created_at,
+          operation_id, project_revision, authority_epoch
+        ) VALUES ('result-cancelled', ?, 'life-a', 'attempt-a1', 'cancelled',
+          'none', '', '{}', '', 'op-3', 3, 0)
+      `).run(projectId(db)),
+      /CHECK constraint failed/,
+    );
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_requirement_dispositions (
+          disposition_id, project_id, requirement_id, disposition,
+          rationale, created_at, operation_id, project_revision, authority_epoch
+        ) VALUES ('disp-complete', ?, 'R-A', 'complete', '', '', 'op-4', 4, 0)
+      `).run(projectId(db)),
+      /CHECK constraint failed/,
+    );
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_execution_attempts (
+          attempt_id, project_id, lifecycle_id, attempt_number,
+          attempt_state, claimed_at,
+          claim_operation_id, claim_project_revision, claim_authority_epoch
+        ) VALUES ('attempt-orphan', ?, 'missing-life', 1,
+          'claimed', '', 'op-4', 4, 0)
+      `).run(projectId(db)),
+      /FOREIGN KEY constraint failed/,
+    );
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_blockers (
+          blocker_id, project_id, lifecycle_id, blocker_kind, resolution_owner,
+          blocker_status, description, opened_at,
+          opened_operation_id, opened_project_revision, opened_authority_epoch
+        ) VALUES ('blocker-technical', ?, 'life-a', 'technical', 'user',
+          'open', 'an agent-fixable failure', '', 'op-4', 4, 0)
+      `).run(projectId(db)),
+      /CHECK constraint failed/,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("immutable Attempt Results never fabricate lifecycle or requirement state", () => {
+  const { db } = openFreshFixture();
+  try {
+    insertOperations(db, 5);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
+    insertAttempt(db, "attempt-a1", "life-a", 1, "op-2", 2);
+    settleAttempt(db, "attempt-a1", "op-3", 3);
+
+    db.prepare(`
+      INSERT INTO workflow_attempt_results (
+        result_id, project_id, lifecycle_id, attempt_id, outcome,
+        failure_class, summary, output_json, created_at,
+        operation_id, project_revision, authority_epoch
+      ) VALUES ('result-a1', ?, 'life-a', 'attempt-a1', 'failed',
+        'test_failure', 'tests failed', '{}', '', 'op-3', 3, 0)
+    `).run(projectId(db));
+
+    assert.equal(
+      db.prepare("SELECT lifecycle_status FROM workflow_item_lifecycles WHERE lifecycle_id = 'life-a'").get()?.lifecycle_status,
+      "in_progress",
+    );
+    assert.equal(
+      db.prepare("SELECT status FROM requirements WHERE id = 'R-A'").get()?.status,
+      "active",
+    );
+    assert.throws(
+      () => db.exec("UPDATE workflow_attempt_results SET outcome = 'succeeded' WHERE result_id = 'result-a1'"),
+      /immutable/,
+    );
+    assert.throws(
+      () => db.exec("DELETE FROM workflow_attempt_results WHERE result_id = 'result-a1'"),
+      /immutable/,
+    );
+    assert.throws(
+      () => db.exec(`
+        INSERT INTO workflow_attempt_results (
+          result_id, project_id, lifecycle_id, attempt_id, outcome,
+          failure_class, summary, output_json, created_at,
+          operation_id, project_revision, authority_epoch
+        ) SELECT 'result-a1-duplicate', project_id, lifecycle_id, attempt_id,
+          outcome, failure_class, summary, output_json, created_at,
+          operation_id, project_revision, authority_epoch
+        FROM workflow_attempt_results WHERE result_id = 'result-a1'
+      `),
+      /UNIQUE constraint failed/,
+    );
+    assert.throws(
+      () => db.exec("UPDATE workflow_attempt_results SET outcome = 'cancelled' WHERE result_id = 'result-a1'"),
+      /immutable|CHECK constraint failed/,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("retry after restart preserves settled Attempt and Result history", () => {
+  const { dbPath, db } = openFreshFixture();
+  try {
+    insertOperations(db, 6);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
+    insertAttempt(db, "attempt-a1", "life-a", 1, "op-2", 2);
+    settleAttempt(db, "attempt-a1", "op-3", 3);
+    db.prepare(`
+      INSERT INTO workflow_attempt_results (
+        result_id, project_id, lifecycle_id, attempt_id, outcome,
+        failure_class, summary, output_json, created_at,
+        operation_id, project_revision, authority_epoch
+      ) VALUES ('result-a1', ?, 'life-a', 'attempt-a1', 'interrupted',
+        'process_exit', 'worker stopped', '{}', '', 'op-3', 3, 0)
+    `).run(projectId(db));
+  } finally {
+    db.close();
+  }
+
+  assert.equal(openDatabase(dbPath), true);
+  const reopened = _getAdapter()!;
+  reopened.prepare(`
+    INSERT INTO workflow_execution_attempts (
+      attempt_id, project_id, lifecycle_id, attempt_number, retry_of_attempt_id,
+      attempt_state, claimed_at,
+      claim_operation_id, claim_project_revision, claim_authority_epoch
+    ) SELECT 'attempt-a2', project_id, 'life-a', 2, 'attempt-a1',
+      'claimed', '', 'op-5', 5, 0
+    FROM project_authority WHERE singleton = 1
+  `).run();
+
+  assert.deepEqual(
+    reopened.prepare(`
+      SELECT attempt_id, attempt_number, retry_of_attempt_id
+      FROM workflow_execution_attempts
+      WHERE lifecycle_id = 'life-a'
+      ORDER BY attempt_number
+    `).all(),
+    [
+      { attempt_id: "attempt-a1", attempt_number: 1, retry_of_attempt_id: null },
+      { attempt_id: "attempt-a2", attempt_number: 2, retry_of_attempt_id: "attempt-a1" },
+    ],
+  );
+  assert.equal(
+    reopened.prepare("SELECT outcome FROM workflow_attempt_results WHERE attempt_id = 'attempt-a1'").get()?.outcome,
+    "interrupted",
+  );
+});
+
+test("Requirement Dispositions require Waivers and remain independent from Blockers", () => {
+  const { db } = openFreshFixture();
+  try {
+    insertOperations(db, 6);
+    insertTaskLifecycle(db, "life-a", "M-A", "op-1", 1);
+
+    db.prepare(`
+      INSERT INTO workflow_blockers (
+        blocker_id, project_id, lifecycle_id, blocker_kind, resolution_owner,
+        blocker_status, description, opened_at,
+        opened_operation_id, opened_project_revision, opened_authority_epoch
+      ) VALUES ('blocker-a', ?, 'life-a', 'ambiguous_intent', 'user',
+        'open', 'Two materially different product routes remain', '', 'op-2', 2, 0)
+    `).run(projectId(db));
+
+    assert.equal(
+      db.prepare("SELECT lifecycle_status FROM workflow_item_lifecycles WHERE lifecycle_id = 'life-a'").get()?.lifecycle_status,
+      "in_progress",
+    );
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_requirement_dispositions (
+          disposition_id, project_id, requirement_id, disposition, waiver_id,
+          rationale, created_at, operation_id, project_revision, authority_epoch
+        ) VALUES ('disp-invalid', ?, 'R-A', 'waived', NULL, 'missing waiver', '', 'op-3', 3, 0)
+      `).run(projectId(db)),
+      /CHECK constraint failed/,
+    );
+
+    db.prepare(`
+      INSERT INTO workflow_waivers (
+        waiver_id, project_id, lifecycle_id, requirement_id, blocker_id, waiver_status,
+        scope, rationale, granted_by_actor_type, granted_by_actor_id, granted_at,
+        operation_id, project_revision, authority_epoch
+      ) VALUES ('waiver-a', ?, 'life-a', 'R-A', 'blocker-a', 'active',
+        'requirement:R-A', 'Accepted product exception', 'user', 'maintainer', '',
+        'op-3', 3, 0)
+    `).run(projectId(db));
+    db.prepare(`
+      INSERT INTO workflow_requirement_dispositions (
+        disposition_id, project_id, requirement_id, disposition, waiver_id,
+        rationale, created_at, operation_id, project_revision, authority_epoch
+      ) VALUES ('disp-a', ?, 'R-A', 'waived', 'waiver-a',
+        'Authorized exception', '', 'op-4', 4, 0)
+    `).run(projectId(db));
+
+    assert.equal(
+      db.prepare("SELECT lifecycle_status FROM workflow_item_lifecycles WHERE lifecycle_id = 'life-a'").get()?.lifecycle_status,
+      "in_progress",
+    );
+    assert.equal(
+      db.prepare("SELECT blocker_status FROM workflow_blockers WHERE blocker_id = 'blocker-a'").get()?.blocker_status,
+      "open",
+    );
+    assert.equal(
+      db.prepare("SELECT disposition FROM workflow_requirement_dispositions WHERE disposition_id = 'disp-a'").get()?.disposition,
+      "waived",
+    );
+    assert.throws(
+      () => db.exec(`
+        UPDATE workflow_blockers
+        SET description = 'rewritten', blocker_status = 'resolved', resolution = 'answered',
+            resolved_at = '2026-07-12T00:05:00.000Z',
+            resolved_operation_id = 'op-5', resolved_project_revision = 5,
+            resolved_authority_epoch = 0
+        WHERE blocker_id = 'blocker-a'
+      `),
+      /opening is immutable/,
+    );
+    assert.throws(
+      () => db.exec(`
+        UPDATE workflow_waivers
+        SET rationale = 'rewritten', waiver_status = 'revoked',
+            ended_at = '2026-07-12T00:05:00.000Z',
+            ended_operation_id = 'op-5', ended_project_revision = 5,
+            ended_authority_epoch = 0
+        WHERE waiver_id = 'waiver-a'
+      `),
+      /grant is immutable/,
+    );
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_requirement_dispositions (
+          disposition_id, project_id, requirement_id, disposition,
+          rationale, created_at, operation_id, project_revision, authority_epoch
+        ) VALUES ('disp-root-2', ?, 'R-A', 'satisfied',
+          'competing root', '', 'op-5', 5, 0)
+      `).run(projectId(db)),
+      /current head/,
+    );
+    db.prepare(`
+      INSERT INTO workflow_requirement_dispositions (
+        disposition_id, project_id, requirement_id, disposition,
+        supersedes_disposition_id, rationale, created_at,
+        operation_id, project_revision, authority_epoch
+      ) VALUES ('disp-b', ?, 'R-A', 'satisfied',
+        'disp-a', 'new evidence', '', 'op-5', 5, 0)
+    `).run(projectId(db));
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO workflow_requirement_dispositions (
+          disposition_id, project_id, requirement_id, disposition,
+          supersedes_disposition_id, rationale, created_at,
+          operation_id, project_revision, authority_epoch
+        ) VALUES ('disp-fork', ?, 'R-A', 'unsatisfied',
+          'disp-a', 'stale branch', '', 'op-6', 6, 0)
+      `).run(projectId(db)),
+      /current head/,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("v31 upgrade is additive, backed up, and preserves legacy values", () => {
+  const dbPath = createDatabasePath();
+  rewindToV31(dbPath);
+
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+
+  const upgraded = openRawDatabase(dbPath);
+  try {
+    assert.equal(maxSchemaVersion(upgraded), 32);
+    assert.equal(tableExists(upgraded, "workflow_execution_attempts"), true);
+    assert.equal(upgraded.prepare("SELECT status FROM tasks WHERE milestone_id = 'M-A' AND id = 'T01'").get()?.status, "in_progress");
+    assert.equal(upgraded.prepare("SELECT status FROM requirements WHERE id = 'R-A'").get()?.status, "active");
+    assert.equal(upgraded.prepare("SELECT COUNT(*) AS count FROM workflow_item_lifecycles").get()?.count, 0);
+    assert.equal(upgraded.prepare("PRAGMA quick_check").get()?.quick_check, "ok");
+  } finally {
+    upgraded.close();
+  }
+
+  const backup = openRawDatabase(`${dbPath}.backup-v31`);
+  try {
+    assert.equal(maxSchemaVersion(backup), 31);
+    assert.equal(tableExists(backup, "workflow_item_lifecycles"), false);
+    assert.equal(backup.prepare("SELECT status FROM tasks WHERE milestone_id = 'M-A' AND id = 'T01'").get()?.status, "in_progress");
+    assert.equal(backup.prepare("PRAGMA quick_check").get()?.quick_check, "ok");
+  } finally {
+    backup.close();
+  }
+
+  const restoredPath = join(dirname(dbPath), "restored.db");
+  copyFileSync(`${dbPath}.backup-v31`, restoredPath);
+  assert.equal(openDatabase(restoredPath), true);
+  closeDatabase();
+  const restored = openRawDatabase(restoredPath);
+  try {
+    assert.equal(maxSchemaVersion(restored), 32);
+    assert.equal(restored.prepare("SELECT status FROM tasks WHERE milestone_id = 'M-A' AND id = 'T01'").get()?.status, "in_progress");
+  } finally {
+    restored.close();
+  }
+});
+
+test("faulted v31 migration rolls back all v32 state and retries cleanly", () => {
+  const dbPath = createDatabasePath();
+  rewindToV31(dbPath);
+
+  _setMigrationFaultForTest(true);
+  assert.throws(() => openDatabase(dbPath), /migration fault injected/);
+  _setMigrationFaultForTest(false);
+
+  const rolledBack = openRawDatabase(dbPath);
+  try {
+    assert.equal(maxSchemaVersion(rolledBack), 31);
+    assert.equal(tableExists(rolledBack, "workflow_item_lifecycles"), false);
+    assert.equal(tableExists(rolledBack, "workflow_execution_attempts"), false);
+    assert.equal(tableExists(rolledBack, "workflow_attempt_results"), false);
+    assert.equal(tableExists(rolledBack, "workflow_requirement_dispositions"), false);
+    assert.equal(tableExists(rolledBack, "workflow_waivers"), false);
+    assert.equal(tableExists(rolledBack, "workflow_blockers"), false);
+  } finally {
+    rolledBack.close();
+  }
+
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+  const retried = openRawDatabase(dbPath);
+  try {
+    assert.equal(maxSchemaVersion(retried), 32);
+    assert.equal(tableExists(retried, "workflow_execution_attempts"), true);
+    assert.equal(retried.prepare("SELECT COUNT(*) AS count FROM tasks WHERE milestone_id = 'M-A'").get()?.count, 1);
+  } finally {
+    retried.close();
+  }
+});

--- a/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
+++ b/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
@@ -52,6 +52,7 @@ const TYPED_DB_WRITER_FILES = new Set([
 
 const SCHEMA_DB_WRITER_FILES = new Set([
   "db-canonical-foundation-schema.ts",
+  "db-lifecycle-foundation-schema.ts",
   "db-memory-fts-schema.ts",
   "db-schema-metadata.ts",
   "db-verification-evidence-schema.ts",


### PR DESCRIPTION
## TL;DR

**What:** Adds the additive v32 canonical lifecycle foundation for lifecycle state, Attempts, Results, Requirement Dispositions, Waivers, and Blockers.
**Why:** ADR-046 requires these concepts to remain distinct, durable, revision-attributed, and database-authoritative before any runtime cutover.
**How:** Creates six constrained SQLite tables and a transactional v31-to-v32 migration, with focused migration, restart, fencing, provenance, concurrency, and immutability tests.

## What

- Adds `workflow_item_lifecycles`, `workflow_execution_attempts`, `workflow_attempt_results`, `workflow_blockers`, `workflow_waivers`, and `workflow_requirement_dispositions`.
- Preserves existing hierarchy statuses and coordination ledgers without backfill, dual-write, or runtime routing.
- Enforces exact lifecycle/result/disposition vocabularies, legal transitions, one active Attempt per work item, current lease fencing, precise dispatch attribution, immutable history, causal provenance ordering, active Waiver validity, and authorized Waiver attribution.
- Bumps the schema to v32 for fresh databases and backed-up transactional upgrades.
- Updates the database maps and single-writer schema allowlist.

## Why

This is M002/S02 of the accepted database-authoritative workflow refactor in ADR-046. The current runtime spreads lifecycle, dispatch outcome, blockers, and exceptions across overlapping status fields and compatibility ledgers. The additive foundation establishes the normalized model before later milestones introduce Domain Operations and runtime cutover.

## How

The new schema links authoritative records to v31 operation revision and Authority Epoch provenance. SQLite checks, foreign keys, partial unique indexes, and triggers reject conflated outcomes, stale fencing, invalid transition history, contradictory disposition heads, unauthorized or expired Waivers, and destructive mutation of immutable facts. No existing runtime reader or writer is switched in this PR. S06 remains responsible for the sole atomic settle-plus-Result Domain Operation.

## Verification

- Focused lifecycle/authority/migration/single-writer suite: 30/30 passed before review fixes; expanded focused suites passed in no-mistakes after fixes.
- RED/GREEN and sabotage checks proved active-attempt uniqueness, Result immutability, Waiver linkage, lifecycle identity, fencing, dispatch scope, disposition heads, causal provenance, and migration wiring.
- `pnpm run build:core`: passed.
- `pnpm run typecheck:extensions`: passed.
- Local `verify:merge`: 12,075 passed with 8 pre-existing macOS/browser-environment failures unrelated to this change.
- Hosted Linux CI: build, package validation, unit, package, cloud, integration, built-binary E2E, Docker E2E, Node 22 smoke, and CI gate all passed.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation
- [ ] `chore` — Build, CI, or tooling

No public API, CLI, config, file-authority, or runtime behavior is cut over by this change.
