### PR TITLE
fix(issue): [Bug]: Blocking gate on slice-level hooks never finds the flat-phase slice-prefixed artifact (NN-SS-<ARTIFACT>.md) — false "missing required gate artifact" + cycle budget exhaustion

### DIFF
--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -24,15 +24,27 @@ import { resolvePostUnitHooks, resolvePreDispatchHooks } from "./preferences.js"
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { parseUnitId } from "./unit-id.js";
-import { resolveMilestonePath } from "./paths.js";
+import {
+  buildFlatTaskFileName,
+  resolveMilestonePath,
+  targetMilestoneFile,
+  targetSliceFile,
+} from "./paths.js";
 import { queryJournal, type JournalEntry } from "./journal.js";
 import { readUnitRuntimeRecord, type UnitRuntimePhase } from "./unit-runtime.js";
 import { extractFrontmatterVerdict } from "./verdict-parser.js";
 
 // ─── Artifact Path Resolution ──────────────────────────────────────────────
 
+function artifactNameToSuffix(artifactName: string): string | null {
+  if (artifactName.includes("/") || artifactName.includes("\\")) return null;
+  const match = artifactName.match(/^(.*)\.md$/i);
+  return match?.[1] ? match[1] : null;
+}
+
 export function resolveHookArtifactPath(basePath: string, unitId: string, artifactName: string): string {
   const { milestone, slice, task } = parseUnitId(unitId);
+  const artifactSuffix = artifactNameToSuffix(artifactName);
 
   // Prefer the active phase directory (flat-phase layout: .gsd/phases/<NN>-.../).
   // Configured gate artifacts are canonical phase-level files (e.g.
@@ -44,8 +56,18 @@ export function resolveHookArtifactPath(basePath: string, unitId: string, artifa
     && !(dirname(phaseDir).endsWith("/milestones") || dirname(phaseDir).endsWith("\\milestones"));
   if (isFlatPhaseDir) {
     candidates.push(join(phaseDir, artifactName));
+    if (artifactSuffix !== null) {
+      if (slice !== undefined) {
+        candidates.push(targetSliceFile(basePath, milestone, slice, artifactSuffix));
+      } else {
+        candidates.push(targetMilestoneFile(basePath, milestone, artifactSuffix));
+      }
+    }
     if (task !== undefined) {
       candidates.push(join(phaseDir, `${task}-${artifactName}`));
+      if (slice !== undefined && artifactSuffix !== null) {
+        candidates.push(join(phaseDir, buildFlatTaskFileName(slice, task, artifactSuffix)));
+      }
     }
   }
 
@@ -71,7 +93,19 @@ export function resolveHookArtifactPath(basePath: string, unitId: string, artifa
   // Nothing on disk yet: prefer the active phase path when the phase dir is
   // known, otherwise fall back to the legacy default (preserves pre-flat-phase
   // behavior for missing-artifact diagnostics).
-  return isFlatPhaseDir ? join(phaseDir!, artifactName) : legacyDefault;
+  if (isFlatPhaseDir) {
+    if (artifactSuffix !== null) {
+      if (task !== undefined && slice !== undefined) {
+        return join(phaseDir!, buildFlatTaskFileName(slice, task, artifactSuffix));
+      }
+      if (slice !== undefined) {
+        return targetSliceFile(basePath, milestone, slice, artifactSuffix);
+      }
+      return targetMilestoneFile(basePath, milestone, artifactSuffix);
+    }
+    return join(phaseDir!, artifactName);
+  }
+  return legacyDefault;
 }
 
 // ─── Dispatch Rule Conversion ──────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/rule-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/rule-registry.test.ts
@@ -567,6 +567,67 @@ describe("resolveHookArtifactPath", () => {
     }
   });
 
+  test("resolves canonical flat-phase scoped artifact names", () => {
+    const originalGsdHome = process.env.GSD_HOME;
+    const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-flat-scope-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-hook-home-"));
+    try {
+      process.env.GSD_HOME = tempGsdHome;
+      const phaseDir = join(realpathSync(projectRoot), ".gsd", "phases", "50-some-phase");
+      mkdirSync(phaseDir, { recursive: true });
+      const milestoneArtifactPath = join(phaseDir, "50-PLAN-REVIEW.md");
+      const sliceArtifactPath = join(phaseDir, "50-02-PLAN-REVIEW.md");
+      const taskArtifactPath = join(phaseDir, "S02-T01-REVIEW.md");
+      writeFileSync(milestoneArtifactPath, "---\nverdict: pass\n---\n", "utf-8");
+      writeFileSync(sliceArtifactPath, "---\nverdict: needs-attention\n---\n", "utf-8");
+      writeFileSync(taskArtifactPath, "---\nverdict: advisory\n---\n", "utf-8");
+
+      assert.equal(
+        resolveHookArtifactPath(projectRoot, "M050", "PLAN-REVIEW.md"),
+        milestoneArtifactPath,
+        "resolves the canonical milestone-prefixed flat artifact",
+      );
+      assert.equal(
+        resolveHookArtifactPath(projectRoot, "M050/S02", "PLAN-REVIEW.md"),
+        sliceArtifactPath,
+        "resolves the canonical slice-prefixed flat artifact",
+      );
+      assert.equal(
+        resolveHookArtifactPath(projectRoot, "M050/S02/T01", "REVIEW.md"),
+        taskArtifactPath,
+        "resolves the canonical slice/task-prefixed flat artifact",
+      );
+    } finally {
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
+  });
+
+  test("flat-phase missing slice artifact fallback points at the canonical slice path", () => {
+    const originalGsdHome = process.env.GSD_HOME;
+    const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-flat-slice-miss-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-hook-home-"));
+    try {
+      process.env.GSD_HOME = tempGsdHome;
+      const phaseDir = join(realpathSync(projectRoot), ".gsd", "phases", "50-some-phase");
+      mkdirSync(phaseDir, { recursive: true });
+
+      const resolved = resolveHookArtifactPath(projectRoot, "M050/S02", "PLAN-REVIEW.md");
+      assert.equal(
+        resolved,
+        join(phaseDir, "50-02-PLAN-REVIEW.md"),
+        "diagnostic fallback uses the collision-free slice-prefixed path",
+      );
+    } finally {
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
+  });
+
   test("falls back to the legacy milestones/slices/tasks layout", () => {
     const originalGsdHome = process.env.GSD_HOME;
     const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-legacy-"));


### PR DESCRIPTION
## Summary
- Fixed flat-phase hook artifact resolution for canonical scoped names and verified syntax/diff checks, with test execution blocked by registry access.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1428
- [#1428 [Bug]: Blocking gate on slice-level hooks never finds the flat-phase slice-prefixed artifact (NN-SS-<ARTIFACT>.md) — false "missing required gate artifact" + cycle budget exhaustion](https://github.com/open-gsd/gsd-pi/issues/1428)

## User
- @astarktc

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1428-bug-blocking-gate-on-slice-level-hooks-n-1783835196`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes path resolution for blocking gate hooks in flat-phase layouts; incorrect candidates could still mis-route verdict reads, but legacy nested layout behavior is preserved and coverage is added for the new paths.
> 
> **Overview**
> Fixes **blocking post-unit gates** that looked for hook artifacts only by the raw configured filename (e.g. `PLAN-REVIEW.md`) in the flat-phase directory, so slice-level files like `50-02-PLAN-REVIEW.md` were never found and gates reported missing artifacts until cycle budgets ran out.
> 
> `resolveHookArtifactPath` now derives a `.md` suffix from the configured artifact name and adds **canonical flat-phase candidates** via `targetMilestoneFile`, `targetSliceFile`, and `buildFlatTaskFileName`, including task-prefixed variants. When nothing exists on disk yet, missing-artifact diagnostics point at those same scoped paths instead of the unscoped phase file.
> 
> Tests cover resolving milestone-, slice-, and task-scoped flat artifacts and the slice-level missing-file fallback path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff8cb5a5eb7a368b5ec4a7eeb09b91f983bba5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->