### PR TITLE
feat(gsd): add v35 projection and closeout schema foundation

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -1478,7 +1478,8 @@ updated_at                  TEXT NOT NULL
   revision without decreasing the Authority Epoch.
 - Delivery state is `pending | claimed | rendered | dead_letter`. Claims and
   renewals are fenced and versioned; completed attempts increment the durable
-  cumulative count. Superseded rows cannot be claimed or rendered.
+  cumulative count. A retry records a nonempty diagnostic and future backoff;
+  the next claim preserves both. Superseded rows cannot be claimed or rendered.
 - Enqueue provenance binds to the exact V31 Domain Operation. Delivery updates
   are operational mutations and intentionally do not create Domain Operations
   or advance the project revision. Currentness is per logical projection key,
@@ -1522,11 +1523,15 @@ resulting_authority_epoch     INTEGER NOT NULL
 - Preview generation is non-authoritative. One immutable receipt seals the
   versioned preview envelope, ordered source/change fingerprints, raw legacy
   diagnoses, explicit resolutions, and aggregate counts used by application.
+  Envelope metadata, hashes, and counts must exactly match their receipt
+  columns, and the `import.apply` operation request hash must equal the sealed
+  preview hash.
 - Application requires `unresolved_count = 0`, a verified independently
   openable backup with `quick_check = ok`, and backup schema/revision/epoch
   matching the base snapshot.
 - The receipt must bind to an `import.apply` V31 operation whose expected tuple
-  matches the base and whose exact resulting tuple matches the receipt.
+  matches the base, whose request hash matches the preview hash, and whose exact
+  resulting tuple matches the receipt. A receipt makes that operation immutable.
   Updates, deletes, duplicate preview identities, and duplicate preview hashes
   fail.
 

--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -1526,14 +1526,19 @@ resulting_authority_epoch     INTEGER NOT NULL
   Envelope metadata, hashes, and counts must exactly match their receipt
   columns, and the `import.apply` operation request hash must equal the sealed
   preview hash.
-- Application requires `unresolved_count = 0`, a verified independently
-  openable backup with `quick_check = ok`, and backup schema/revision/epoch
-  matching the base snapshot.
+- Application requires `unresolved_count = 0` and records independently
+  verified backup metadata with `quick_check = ok`; the schema requires that
+  metadata's schema/revision/epoch to match the base snapshot. S06 owns opening
+  and hashing the referenced backup before insertion.
 - The receipt must bind to an `import.apply` V31 operation whose expected tuple
   matches the base, whose request hash matches the preview hash, and whose exact
-  resulting tuple matches the receipt. A receipt makes that operation immutable.
-  Updates, deletes, duplicate preview identities, and duplicate preview hashes
-  fail.
+  resulting tuple matches the receipt; its resulting revision is exactly the
+  base revision plus one. A receipt makes that operation immutable. Updates,
+  deletes, duplicate preview identities, and duplicate preview hashes fail.
+- V35 validates lowercase `sha256:` shape and equality between repeated receipt,
+  preview-envelope, and operation fields. SQLite does not recompute SHA-256;
+  S06 must canonicalize the preview and verify its source/change hashes before
+  the receipt transaction.
 
 #### `workflow_kernel_checkpoints`
 ```
@@ -1577,6 +1582,8 @@ authority_epoch             INTEGER NOT NULL
   lineage exists per lifecycle; its head is current.
 - Supersession preserves project/lifecycle and may retain the Attempt or name a
   later Attempt in the same lifecycle. There is no mutable plan status.
+- Tested-source and readiness-basis hashes must use lowercase `sha256:` format;
+  S06 owns canonical input construction and hash verification.
 - Index: `idx_workflow_closeout_plan_head`.
 
 #### `workflow_closeout_effects`
@@ -1601,6 +1608,9 @@ authority_epoch    INTEGER NOT NULL
 - Every effect is born with the exact preparation operation/revision/epoch
   tuple of its plan. Effects cannot be added after the plan is superseded or
   after receipt settlement begins. A plan may have zero host effects.
+- Effect specs must be nonempty JSON objects and their hashes must use lowercase
+  `sha256:` format. S06 and the host adapter own canonicalization, hash
+  verification, and idempotent execution.
 
 #### `workflow_settlement_receipts`
 ```
@@ -1624,6 +1634,9 @@ authority_epoch       INTEGER NOT NULL
   order, causally follow plan creation, and cannot be added to a superseded
   plan. Current plan plus complete receipt coverage is the settlement state;
   V35 adds no settlement aggregate.
+- Receipt proofs must be nonempty JSON objects and their hashes must use
+  lowercase `sha256:` format. S06 owns canonical proof construction and
+  verification before insertion.
 - Index: `idx_workflow_settlement_receipt_scope`.
 
 V35 enforces local shape, provenance, lineage, immutability, delivery fencing,

--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -26,6 +26,7 @@ gsd-db.ts  ← compatibility barrel over the explicit single-writer allowlist
        │                    ← typed coordination/runtime writers
        ├── db-canonical-foundation-schema.ts, db-lifecycle-foundation-schema.ts,
        │   db-conversation-foundation-schema.ts, db-recovery-evidence-foundation-schema.ts,
+       │   db-projection-import-kernel-closeout-foundation-schema.ts,
        │   db-memory-fts-schema.ts, db-schema-metadata.ts, db-verification-evidence-schema.ts
        │                    ← allowlisted schema/migration helpers
        ├── memory-backfill.ts
@@ -66,7 +67,7 @@ After commit: regenerate markdown artifacts → write to disk → invalidate cac
 
 ## 2. Schema Version History
 
-Current version: **V34**
+Current version: **V35**
 
 | Version | What Changed |
 |---------|-------------|
@@ -104,6 +105,7 @@ Current version: **V34**
 | V32 | **Additive lifecycle foundation**: canonical lifecycle state, fenced execution Attempts, immutable Attempt Results, human-only Blockers, authorized Waivers, and immutable Requirement Disposition history |
 | V33 | **Additive guided-conversation foundation**: milestone context and advisory horizons, focused recommendation-first interactions, immutable verbatim Answers and correction-safe Decisions, dependency-targeted impacts, and restart-safe Work Checkpoints |
 | V34 | **Additive recovery and evidence foundation**: immutable Failure Observations and Recovery Actions, immutable count budgets whose use is derived from linked Actions, versioned acceptance criteria, verdict-owned objective evidence, separate subjective Human Acceptance, and immutable remediation routing |
+| V35 | **Additive projection, import, kernel, and closeout foundation**: durable per-target projection delivery, immutable import application receipts, restart-safe kernel checkpoint chains, versioned closeout plans with ordered effects, and success-only settlement receipts |
 
 ---
 
@@ -1437,6 +1439,193 @@ must require bundle completeness before dispatch or closeout. Runtime
 readers/writers, UAT, recovery policy, legacy projections, and lifecycle
 completion do not cut over in V34.
 
+### 3i. Additive Projection, Import, Kernel, And Closeout Foundation (V35)
+
+V35 adds six tables for durable projection delivery, sealed imports,
+restart-safe kernel position, and closeout settlement. It reuses V31–V34
+authority, Lifecycle, Attempt, recovery, and evidence records instead of
+creating parallel project, work-item, execution, or recovery models. The
+migration is additive: it performs no legacy backfill and does not cut runtime
+readers, writers, adapters, or lifecycle completion over to these tables.
+
+#### `workflow_projection_work`
+```
+projection_work_id          TEXT PRIMARY KEY
+project_id                  TEXT NOT NULL
+projection_key              TEXT NOT NULL
+projection_kind             TEXT NOT NULL
+supersedes_projection_work_id TEXT DEFAULT NULL UNIQUE
+source_project_revision     INTEGER NOT NULL
+source_authority_epoch      INTEGER NOT NULL
+renderer_version            TEXT NOT NULL
+delivery_state              TEXT NOT NULL DEFAULT 'pending'
+state_version               INTEGER NOT NULL DEFAULT 0
+claim_owner                 TEXT DEFAULT NULL
+claim_fencing_token         INTEGER NOT NULL DEFAULT 0
+claimed_at                  TEXT DEFAULT NULL
+claim_expires_at            TEXT DEFAULT NULL
+attempt_count               INTEGER NOT NULL DEFAULT 0
+next_attempt_at             TEXT NOT NULL DEFAULT ''
+last_error                  TEXT NOT NULL DEFAULT ''
+rendered_content_hash       TEXT DEFAULT NULL
+rendered_at                 TEXT DEFAULT NULL
+enqueue_operation_id        TEXT NOT NULL
+created_at                  TEXT NOT NULL
+updated_at                  TEXT NOT NULL
+```
+- Each normalized projection key has one immutable desired-work lineage.
+  Successors name the causally older current head and advance the source
+  revision without decreasing the Authority Epoch.
+- Delivery state is `pending | claimed | rendered | dead_letter`. Claims and
+  renewals are fenced and versioned; completed attempts increment the durable
+  cumulative count. Superseded rows cannot be claimed or rendered.
+- Enqueue provenance binds to the exact V31 Domain Operation. Delivery updates
+  are operational mutations and intentionally do not create Domain Operations
+  or advance the project revision. Currentness is per logical projection key,
+  so an unrelated project operation does not stale a rendered projection.
+- Delivery scans use `idx_workflow_projection_delivery`; current-head scans
+  reuse the unique `(project_id, projection_key, source_project_revision)` index.
+
+#### `workflow_import_applications`
+```
+operation_id                  TEXT PRIMARY KEY
+project_id                    TEXT NOT NULL
+import_kind                   TEXT NOT NULL
+importer_version              TEXT NOT NULL
+preview_schema_version        INTEGER NOT NULL
+preview_id                    TEXT NOT NULL UNIQUE
+preview_hash                  TEXT NOT NULL UNIQUE
+base_project_revision         INTEGER NOT NULL
+base_authority_epoch          INTEGER NOT NULL
+base_database_schema_version  INTEGER NOT NULL
+source_set_hash               TEXT NOT NULL
+change_set_hash               TEXT NOT NULL
+create_count                  INTEGER NOT NULL
+update_count                  INTEGER NOT NULL
+delete_count                  INTEGER NOT NULL
+preserve_count                INTEGER NOT NULL
+unparsed_count                INTEGER NOT NULL
+unresolved_count              INTEGER NOT NULL
+preview_json                  TEXT NOT NULL
+backup_ref                    TEXT NOT NULL
+backup_sha256                 TEXT NOT NULL
+backup_byte_size              INTEGER NOT NULL
+backup_schema_version         INTEGER NOT NULL
+backup_project_revision       INTEGER NOT NULL
+backup_authority_epoch        INTEGER NOT NULL
+backup_quick_check            TEXT NOT NULL
+backup_verified_at            TEXT NOT NULL
+applied_at                    TEXT NOT NULL
+resulting_project_revision    INTEGER NOT NULL
+resulting_authority_epoch     INTEGER NOT NULL
+```
+- Preview generation is non-authoritative. One immutable receipt seals the
+  versioned preview envelope, ordered source/change fingerprints, raw legacy
+  diagnoses, explicit resolutions, and aggregate counts used by application.
+- Application requires `unresolved_count = 0`, a verified independently
+  openable backup with `quick_check = ok`, and backup schema/revision/epoch
+  matching the base snapshot.
+- The receipt must bind to an `import.apply` V31 operation whose expected tuple
+  matches the base and whose exact resulting tuple matches the receipt.
+  Updates, deletes, duplicate preview identities, and duplicate preview hashes
+  fail.
+
+#### `workflow_kernel_checkpoints`
+```
+kernel_checkpoint_id          TEXT PRIMARY KEY
+project_id                    TEXT NOT NULL
+lifecycle_id                  TEXT NOT NULL
+attempt_id                    TEXT NOT NULL
+next_stage                    TEXT NOT NULL
+sequence                      INTEGER NOT NULL
+previous_kernel_checkpoint_id TEXT DEFAULT NULL UNIQUE
+created_at                    TEXT NOT NULL
+operation_id                  TEXT NOT NULL
+project_revision              INTEGER NOT NULL
+authority_epoch               INTEGER NOT NULL
+```
+- Absence of a checkpoint means Advance. The first row is sequence one,
+  records Execute, and shares the exact operation/revision/epoch tuple that
+  claimed its V32 Attempt.
+- Checkpoints form one immutable, gap-free, no-fork current-head chain per
+  lifecycle. Stages are `execute | verify | route | closeout | settled`.
+- Ordinary successors retain the Attempt. An Attempt change requires Execute
+  and a descendant retry/reopen Attempt linked to the previous Attempt. S06
+  owns legal stage prerequisites and atomic sibling facts.
+- Current-head scans reuse the unique `(project_id, lifecycle_id, sequence)` index.
+
+#### `workflow_closeout_plans`
+```
+closeout_plan_id            TEXT PRIMARY KEY
+project_id                  TEXT NOT NULL
+lifecycle_id                TEXT NOT NULL
+attempt_id                  TEXT NOT NULL
+tested_source_set_hash      TEXT NOT NULL
+readiness_basis_hash        TEXT NOT NULL
+supersedes_closeout_plan_id TEXT DEFAULT NULL UNIQUE
+prepared_at                 TEXT NOT NULL
+operation_id                TEXT NOT NULL
+project_revision            INTEGER NOT NULL
+authority_epoch             INTEGER NOT NULL
+```
+- A plan requires a causally prior succeeded, settled Attempt. One immutable
+  lineage exists per lifecycle; its head is current.
+- Supersession preserves project/lifecycle and may retain the Attempt or name a
+  later Attempt in the same lifecycle. There is no mutable plan status.
+- Index: `idx_workflow_closeout_plan_head`.
+
+#### `workflow_closeout_effects`
+```
+closeout_effect_id TEXT PRIMARY KEY
+closeout_plan_id   TEXT NOT NULL
+project_id         TEXT NOT NULL
+lifecycle_id       TEXT NOT NULL
+ordinal            INTEGER NOT NULL
+effect_kind        TEXT NOT NULL
+idempotency_key    TEXT NOT NULL
+effect_spec_json   TEXT NOT NULL
+effect_spec_hash   TEXT NOT NULL
+created_at         TEXT NOT NULL
+operation_id       TEXT NOT NULL
+project_revision   INTEGER NOT NULL
+authority_epoch    INTEGER NOT NULL
+```
+- Settlement-critical host effects are immutable and inserted in contiguous
+  ordinal order. Idempotency keys are unique within a plan and may recur on a
+  superseding plan so an adapter can recognize an earlier host result.
+- Every effect is born with the exact preparation operation/revision/epoch
+  tuple of its plan. Effects cannot be added after the plan is superseded or
+  after receipt settlement begins. A plan may have zero host effects.
+
+#### `workflow_settlement_receipts`
+```
+settlement_receipt_id TEXT PRIMARY KEY
+closeout_effect_id    TEXT NOT NULL UNIQUE
+project_id            TEXT NOT NULL
+lifecycle_id          TEXT NOT NULL
+outcome               TEXT NOT NULL
+external_ref          TEXT NOT NULL
+proof_json            TEXT NOT NULL
+proof_hash            TEXT NOT NULL
+settled_at            TEXT NOT NULL
+operation_id          TEXT NOT NULL
+project_revision      INTEGER NOT NULL
+authority_epoch       INTEGER NOT NULL
+```
+- Receipts are immutable success-only facts with outcome `performed |
+  recognized`. Missing receipt means pending; failures remain V34 Failure
+  Observations and Recovery Actions rather than failed receipts.
+- Each effect has at most one receipt. Receipts advance in effect-ordinal
+  order, causally follow plan creation, and cannot be added to a superseded
+  plan. Current plan plus complete receipt coverage is the settlement state;
+  V35 adds no settlement aggregate.
+- Index: `idx_workflow_settlement_receipt_scope`.
+
+V35 enforces local shape, provenance, lineage, immutability, delivery fencing,
+and settlement ordering. S06 owns atomic Domain Operation bundles, adapters,
+queries, stage and readiness prerequisites, runtime cutover, recovery fault
+tests, and final lifecycle completion.
+
 ---
 
 ## 4. Entity Relationship Diagram
@@ -1519,12 +1708,25 @@ workflow_technical_verdicts ──┐
                               ├──► workflow_remediation_links ──► workflow_item_lifecycles
 workflow_human_acceptances ───┘
 
+workflow_operations ──► workflow_projection_work (enqueue provenance)
+workflow_operations ──► workflow_import_applications
+workflow_item_lifecycles ──► workflow_kernel_checkpoints
+workflow_execution_attempts ──► workflow_kernel_checkpoints
+workflow_kernel_checkpoints ──► workflow_kernel_checkpoints (current-head chain)
+workflow_item_lifecycles ──► workflow_closeout_plans
+workflow_execution_attempts ──► workflow_closeout_plans
+workflow_closeout_plans ──► workflow_closeout_plans (supersession lineage)
+workflow_closeout_plans ──► workflow_closeout_effects ──► workflow_settlement_receipts
+
 workflow_operations ──► all V32 lifecycle records
   (operation + project + revision + Authority Epoch provenance)
 workflow_operations ──► all V33 guided-conversation records
   (operation + project + revision + Authority Epoch provenance)
 workflow_operations ──► all V34 recovery/evidence records
   (operation + project + revision + Authority Epoch provenance)
+workflow_operations ──► all V35 import/kernel/closeout records
+  (operation + project + revision + Authority Epoch provenance;
+   projection delivery transitions are operational and do not advance revision)
 ```
 
 ---
@@ -1537,7 +1739,8 @@ quality gates, verification evidence, and milestone commit attributions. Restore
 rebuilds decision mirror memories from the restored decisions and preserves
 optional rows when reading older manifests that predate the extended arrays.
 The additive V31 canonical-foundation, V32 lifecycle-foundation, V33
-guided-conversation, and V34 recovery/evidence tables are
+guided-conversation, V34 recovery/evidence, and V35 projection/import/kernel/
+closeout tables are
 not yet part of this legacy manifest surface because runtime reads/writes have
 not cut over to them.
 
@@ -1547,7 +1750,8 @@ assessments, quality gates, slice dependencies, verification evidence, gate
 runs, and milestone commit attributions. Runtime-only/audit substrates such as
 `runtime_kv`, `turn_git_transactions`, `audit_events`, and `audit_turn_index`
 remain outside manifest restore. The V31 canonical-foundation, V32
-lifecycle-foundation, V33 guided-conversation, and V34 recovery/evidence tables likewise remain outside worktree reconciliation
+lifecycle-foundation, V33 guided-conversation, V34 recovery/evidence, and V35
+projection/import/kernel/closeout tables likewise remain outside worktree reconciliation
 until a later runtime-routing slice.
 
 ---
@@ -1620,7 +1824,7 @@ until a later runtime-routing slice.
 
 ## 7. Write Path Invariants
 
-1. **Single-writer rule**: all write SQL lives in the explicit single-writer *layer* — `db/engine.ts` for schema, migrations, lifecycle, and transaction primitives; `db/writers/**` for domain write subsystems; `gsd-db.ts` as the compatibility barrel and remaining mid-migration wrappers; the typed coordination/runtime writer modules `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, and `db/command-queue.ts`; the schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-conversation-foundation-schema.ts`, `db-recovery-evidence-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, and `db-verification-evidence-schema.ts`; and the ADR migration/backfill helper `memory-backfill.ts`. This is an allowlist, not permission for arbitrary raw writes under `db/`. `unit-ownership.ts` remains excluded because it owns a separate `.gsd/unit-claims.db`. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks this allowlist.
+1. **Single-writer rule**: all write SQL lives in the explicit single-writer *layer* — `db/engine.ts` for schema, migrations, lifecycle, and transaction primitives; `db/writers/**` for domain write subsystems; `gsd-db.ts` as the compatibility barrel and remaining mid-migration wrappers; the typed coordination/runtime writer modules `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, and `db/command-queue.ts`; the schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-conversation-foundation-schema.ts`, `db-recovery-evidence-foundation-schema.ts`, `db-projection-import-kernel-closeout-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, and `db-verification-evidence-schema.ts`; and the ADR migration/backfill helper `memory-backfill.ts`. This is an allowlist, not permission for arbitrary raw writes under `db/`. `unit-ownership.ts` remains excluded because it owns a separate `.gsd/unit-claims.db`. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks this allowlist.
 
 2. **Transaction wrapping**: every multi-table write uses `transaction()` or `immediateTransaction()` when it needs SQLite's reserved writer lock up front. Rollback on any error. Re-entrant: nested calls increment the shared depth counter; no nested `BEGIN`. `gsd_save_gate_result` commits the `quality_gates` verdict update and matching `gate_runs` ledger insert together, so recovery never sees a completed gate without its audit row.
 

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -350,7 +350,7 @@ unit completes
 | `db-lifecycle-foundation-schema.ts` | workflow_item_lifecycles, workflow_execution_attempts, workflow_attempt_results, workflow_blockers, workflow_waivers, workflow_requirement_dispositions + lifecycle, fencing, provenance, history, and vocabulary constraints (V32, additive and not runtime-routed yet) |
 | `db-conversation-foundation-schema.ts` | workflow_milestone_contexts, workflow_open_questions, workflow_question_dependencies, workflow_interactions, workflow_interaction_options, workflow_answers, workflow_conversation_decisions, workflow_decision_impacts, workflow_work_checkpoints + recommendation-first, causal provenance, targeted revalidation, immutability, and single-head history constraints (V33, additive and not runtime-routed yet) |
 | `db-recovery-evidence-foundation-schema.ts` | workflow_failure_observations, workflow_recovery_budgets, workflow_recovery_actions, workflow_acceptance_criteria, workflow_technical_verdicts, workflow_verification_evidence, workflow_human_acceptances, workflow_remediation_links + explicit agent/user/external recovery ownership, immutable count budgets derived from linked Actions, requirement-scoped criterion lineage, verdict-owned objective evidence, separate subjective acceptance, and immutable rework/remediation routing (V34, additive and not runtime-routed yet) |
-| `db-projection-import-kernel-closeout-foundation-schema.ts` | workflow_projection_work, workflow_import_applications, workflow_kernel_checkpoints, workflow_closeout_plans, workflow_closeout_effects, workflow_settlement_receipts + per-key fenced projection delivery, sealed import and backup proof, immutable kernel-stage lineage, versioned closeout plans, ordered idempotent effects, and success-only settlement receipts (V35, additive and not runtime-routed yet) |
+| `db-projection-import-kernel-closeout-foundation-schema.ts` | workflow_projection_work, workflow_import_applications, workflow_kernel_checkpoints, workflow_closeout_plans, workflow_closeout_effects, workflow_settlement_receipts + per-key fenced projection delivery, import receipts carrying preview and verified-backup metadata, immutable kernel-stage lineage, versioned closeout plans, ordered idempotency-keyed effects, and success-only settlement receipts (V35, additive and not runtime-routed yet) |
 | `db-coordination-schema.ts` | workers, milestone_leases, unit_dispatches, cancellation_requests, command_queue |
 | `db-memory-fts-schema.ts` | memories_fts (FTS5 virtual table), memories_ai/ad/au triggers |
 | `db-runtime-kv-schema.ts` | runtime_kv |
@@ -420,17 +420,20 @@ bind to a Domain Operation, while fenced delivery transitions are operational
 and do not advance project revision.
 
 An import preview remains non-authoritative until one immutable application
-receipt seals its exact source/change envelope and independently verified
-backup. The receipt requires its envelope metadata, hashes, and counts to match
-the canonical preview JSON and uses the `import.apply` operation request hash
-as the trusted preview seal; the operation becomes immutable once receipted.
+receipt records its exact source/change envelope and independently verified
+backup metadata. The schema requires repeated envelope metadata, hashes, and
+counts to match the preview JSON, binds the `import.apply` operation request
+hash to `preview_hash`, and makes the operation immutable once receipted. It
+validates lowercase `sha256:` formats but cannot recompute SHA-256; S06 owns
+canonical preview hashing, source/change verification, and opening and hashing
+the referenced backup before insertion.
 Absence of a kernel checkpoint means Advance; the first persisted checkpoint
 is Execute and shares the selected Attempt's claim operation.
 Closeout state is derived from the current immutable plan, its ordered
-idempotent effects, and complete success-only receipts. Missing receipt means
+idempotency-keyed effects, and complete success-only receipts. Missing receipt means
 pending, while failures route through V34 recovery facts rather than failed
 receipts. V35 adds no kernel-run or settlement aggregate.
 
 V35 is still an additive foundation. S06 owns atomic sibling bundles, adapters,
-queries, stage/readiness checks, runtime routing, fault recovery, and final
-lifecycle completion.
+queries, stage/readiness checks, canonical effect/proof hashing, idempotent host
+execution, runtime routing, fault recovery, and final lifecycle completion.

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -421,8 +421,11 @@ and do not advance project revision.
 
 An import preview remains non-authoritative until one immutable application
 receipt seals its exact source/change envelope and independently verified
-backup. Absence of a kernel checkpoint means Advance; the first persisted
-checkpoint is Execute and shares the selected Attempt's claim operation.
+backup. The receipt requires its envelope metadata, hashes, and counts to match
+the canonical preview JSON and uses the `import.apply` operation request hash
+as the trusted preview seal; the operation becomes immutable once receipted.
+Absence of a kernel checkpoint means Advance; the first persisted checkpoint
+is Execute and shares the selected Attempt's claim operation.
 Closeout state is derived from the current immutable plan, its ordered
 idempotent effects, and complete success-only receipts. Missing receipt means
 pending, while failures route through V34 recovery facts rather than failed

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -350,6 +350,7 @@ unit completes
 | `db-lifecycle-foundation-schema.ts` | workflow_item_lifecycles, workflow_execution_attempts, workflow_attempt_results, workflow_blockers, workflow_waivers, workflow_requirement_dispositions + lifecycle, fencing, provenance, history, and vocabulary constraints (V32, additive and not runtime-routed yet) |
 | `db-conversation-foundation-schema.ts` | workflow_milestone_contexts, workflow_open_questions, workflow_question_dependencies, workflow_interactions, workflow_interaction_options, workflow_answers, workflow_conversation_decisions, workflow_decision_impacts, workflow_work_checkpoints + recommendation-first, causal provenance, targeted revalidation, immutability, and single-head history constraints (V33, additive and not runtime-routed yet) |
 | `db-recovery-evidence-foundation-schema.ts` | workflow_failure_observations, workflow_recovery_budgets, workflow_recovery_actions, workflow_acceptance_criteria, workflow_technical_verdicts, workflow_verification_evidence, workflow_human_acceptances, workflow_remediation_links + explicit agent/user/external recovery ownership, immutable count budgets derived from linked Actions, requirement-scoped criterion lineage, verdict-owned objective evidence, separate subjective acceptance, and immutable rework/remediation routing (V34, additive and not runtime-routed yet) |
+| `db-projection-import-kernel-closeout-foundation-schema.ts` | workflow_projection_work, workflow_import_applications, workflow_kernel_checkpoints, workflow_closeout_plans, workflow_closeout_effects, workflow_settlement_receipts + per-key fenced projection delivery, sealed import and backup proof, immutable kernel-stage lineage, versioned closeout plans, ordered idempotent effects, and success-only settlement receipts (V35, additive and not runtime-routed yet) |
 | `db-coordination-schema.ts` | workers, milestone_leases, unit_dispatches, cancellation_requests, command_queue |
 | `db-memory-fts-schema.ts` | memories_fts (FTS5 virtual table), memories_ai/ad/au triggers |
 | `db-runtime-kv-schema.ts` | runtime_kv |
@@ -375,7 +376,7 @@ unit completes
 
 | Invariant | Where Enforced |
 |-----------|---------------|
-| Single-writer: all write SQL in the explicit single-writer allowlist (`db/engine.ts`, `db/writers/**`, `gsd-db.ts`, typed coordination/runtime writers `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, `db/command-queue.ts`, schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-conversation-foundation-schema.ts`, `db-recovery-evidence-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, `db-verification-evidence-schema.ts`, and ADR migration/backfill helper `memory-backfill.ts`); this is not permission for arbitrary writes under `db/`; `unit-ownership.ts` owns separate `.gsd/unit-claims.db`; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (explicit allowlist) |
+| Single-writer: all write SQL in the explicit single-writer allowlist (`db/engine.ts`, `db/writers/**`, `gsd-db.ts`, typed coordination/runtime writers `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, `db/command-queue.ts`, schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-conversation-foundation-schema.ts`, `db-recovery-evidence-foundation-schema.ts`, `db-projection-import-kernel-closeout-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, `db-verification-evidence-schema.ts`, and ADR migration/backfill helper `memory-backfill.ts`); this is not permission for arbitrary writes under `db/`; `unit-ownership.ts` owns separate `.gsd/unit-claims.db`; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (explicit allowlist) |
 | Cascade on slice complete: pending tasks → skipped | `gsd_slice_complete` transaction |
 | Cascade on milestone reopen: all slices → in_progress, tasks → pending | `gsd_milestone_reopen` transaction |
 | No nested write transactions: `transaction()` and `immediateTransaction()` share one depth counter; read-then-write claims use `immediateTransaction()` and gate verdict + ledger writes commit atomically | `db-transaction.test.ts`, `command-queue.test.ts`, `gate-storage.test.ts` |
@@ -410,3 +411,23 @@ restore, or worktree reconciliation over to the new tables. S06 Domain
 Operations must atomically commit failure/action and verdict/evidence bundles,
 plus any applicable remediation links, and require bundle completeness before
 dispatch or closeout.
+
+V35 makes projection delivery, import application, kernel position, and
+closeout settlement restart-safe without creating parallel work or execution
+identities. Markdown remains projection output and never becomes runtime
+authority. Projection currentness is tracked per logical target; enqueue facts
+bind to a Domain Operation, while fenced delivery transitions are operational
+and do not advance project revision.
+
+An import preview remains non-authoritative until one immutable application
+receipt seals its exact source/change envelope and independently verified
+backup. Absence of a kernel checkpoint means Advance; the first persisted
+checkpoint is Execute and shares the selected Attempt's claim operation.
+Closeout state is derived from the current immutable plan, its ordered
+idempotent effects, and complete success-only receipts. Missing receipt means
+pending, while failures route through V34 recovery facts rather than failed
+receipts. V35 adds no kernel-run or settlement aggregate.
+
+V35 is still an additive foundation. S06 owns atomic sibling bundles, adapters,
+queries, stage/readiness checks, runtime routing, fault recovery, and final
+lifecycle completion.

--- a/plans/041-m002-s05-projection-import-kernel-closeout-research.md
+++ b/plans/041-m002-s05-projection-import-kernel-closeout-research.md
@@ -130,7 +130,8 @@ immutable. A successor must name the causally older current head for the same
 project/key and advance source revision without decreasing epoch. Supersession
 is derived from that successor; it is not a mutable state. Only delivery fields
 transition. A failed attempt returns `claimed → pending` while incrementing
-attempt/backoff/error; exhausted work becomes `dead_letter`.
+attempt/backoff/error; the next claim preserves that diagnostic and backoff.
+Exhausted work becomes `dead_letter`.
 
 Currentness is per logical projection key: its lineage head is current when it
 is rendered and its rendered source revision/hash match that desired row. An
@@ -170,9 +171,12 @@ indivisible. A non-authoritative sidecar may retain a preview across restart;
 application re-fingerprints and re-parses every source before the transaction.
 The receipt trigger requires an import-application operation whose expected
 revision/epoch equal the stored base, whose resulting tuple equals the receipt,
-and whose backup schema/revision/epoch equal the base snapshot. `preview_hash`
-covers the complete canonical envelope—scalar metadata plus ordered sources,
-changes, raw values, diagnostics, and resolutions—not only the JSON field.
+whose request hash equals `preview_hash`, and whose backup schema/revision/epoch
+equal the base snapshot. Once receipted, that operation is immutable. The
+canonical JSON repeats the schema-visible envelope metadata, hashes, and counts
+so raw mismatches fail locally. `preview_hash`
+covers that complete canonical envelope—scalar metadata plus ordered sources,
+changes, raw values, diagnostics, and resolutions—not only the nested lists.
 Unparsed material must be explicitly preserved with raw content/reference and
 an accepted disposition or remain unresolved; it may never disappear behind a
 zero aggregate count.

--- a/plans/041-m002-s05-projection-import-kernel-closeout-research.md
+++ b/plans/041-m002-s05-projection-import-kernel-closeout-research.md
@@ -177,6 +177,10 @@ canonical JSON repeats the schema-visible envelope metadata, hashes, and counts
 so raw mismatches fail locally. `preview_hash`
 covers that complete canonical envelope—scalar metadata plus ordered sources,
 changes, raw values, diagnostics, and resolutions—not only the nested lists.
+SQLite validates digest formats and equality of repeated fields but does not
+recompute SHA-256 or open the referenced backup. The S06 application writer
+must canonicalize and hash the preview, re-fingerprint its sources and changes,
+and independently open, check, and hash the backup before inserting the receipt.
 Unparsed material must be explicitly preserved with raw content/reference and
 an accepted disposition or remain unresolved; it may never disappear behind a
 zero aggregate count.
@@ -241,7 +245,9 @@ unique within a plan and may repeat across superseding plans so adapters can
 recognize prior host results. A plan may have zero host effects. Only effects
 whose success is required before closeout belong here,
 typically source commit, worktree integration, merge, or publish. Projection
-and advisory follow-on work are excluded.
+and advisory follow-on work are excluded. V35 validates nonempty JSON and
+lowercase `sha256:` shape; S06 owns canonical spec hashing and idempotent host
+execution.
 
 ### 6. `workflow_settlement_receipts`
 
@@ -265,13 +271,14 @@ replay the same idempotency key, recognize the existing host result, and write
 `recognized`. Old receipts remain valid history after later plan supersession;
 S06 completion queries consider only the current plan. Do not add a settlement
 aggregate: current plan plus receipt coverage plus lifecycle status already
-answer settlement state.
+answer settlement state. V35 validates nonempty proof JSON and lowercase
+`sha256:` shape; S06 owns canonical proof hashing and verification.
 
 ## Local S05 Invariants
 
 1. Every new authoritative fact binds to the exact v31 project/revision/epoch operation tuple.
 2. Projection desired identity/lineage is immutable; delivery transitions are fenced, versioned, and restart-safe without advancing domain revision.
-3. Import application is immutable, unresolved-free, backup-verified, and unique per preview hash.
+3. Import application is immutable, unresolved-free, carries matching verified-backup metadata, and is unique per preview hash; S06 performs external backup and digest verification.
 4. Kernel checkpoints form one immutable, gap-free, no-fork head per lifecycle.
 5. Kernel Attempt changes are restricted to a valid retry/reopen Execute checkpoint.
 6. Closeout plan supersession preserves project/lifecycle, uses the same or a later descendant Attempt, and advances provenance.

--- a/plans/041-m002-s05-projection-import-kernel-closeout-research.md
+++ b/plans/041-m002-s05-projection-import-kernel-closeout-research.md
@@ -1,0 +1,375 @@
+# M002 S05 Projection, Import, Kernel, and Closeout Research
+
+**Status:** Research complete
+**Date:** 2026-07-12
+**Scope:** Additive schema foundation only; S06 owns atomic Domain Operations, adapters, queries, and runtime cutover
+**Final recommendation:** Add six tables and reuse the v31–v34 authority, lifecycle, Attempt, recovery, and evidence facts.
+
+## Outcome
+
+S05 should add only the durable facts that are still missing:
+
+1. one projection work queue;
+2. one immutable import application receipt;
+3. one append-only kernel checkpoint chain;
+4. immutable closeout plans;
+5. immutable ordered closeout effects; and
+6. immutable success-only settlement receipts.
+
+Do not add another project, work item, Attempt, kernel run, closeout session,
+settlement aggregate, effect-attempt ledger, projection-attempt history, import
+preview hierarchy, repository registry, workspace registry, or recovery system.
+Existing canonical records already own those identities or outcomes.
+
+## Research Findings
+
+### Projection drift
+
+- `workflow-projections.ts::renderAllProjections` and
+  `projection-flush.ts::flushWorkflowProjections` are caller-triggered and
+  process-local. A failed render has no durable desired revision, claim,
+  retry, or supersession fact.
+- `workflow-projections.ts::renderStateProjection` consults
+  `state-manifest.json` before writing. A projection therefore influences
+  projection policy even though the database is meant to be authoritative.
+- `commands-maintenance.ts::rebuildMarkdownProjectionsFromDb` refreshes the
+  database from disk before rebuilding Markdown and may delete artifact rows
+  in response to file drift. Rebuild crosses the authority boundary.
+- `worktree-state-projection.ts` copies summaries, assessments, and completed
+  unit trees between roots. Its own comments describe stale assessment files
+  causing UAT redispatch after database rebuild.
+- Task completion currently rolls database state back when projection fails,
+  while slice/milestone completion keeps database completion. This inconsistent
+  behavior is the highest-value negative cutover test.
+- Reuse the pure renderers and atomic file-write helpers. Reuse the v31 outbox
+  claim/retry pattern, but not the generic outbox table: projection work needs
+  a logical target, source revision, rendered hash, and supersession semantics.
+
+### Import drift
+
+- `migrate/plan.ts::createMigrationPlan` and
+  `migrate/preview.ts::generatePreview` return aggregate counts rather than an
+  exact source fingerprint and ordered change set. They cannot prove that the
+  approved input is unchanged.
+- `migrate/execution.ts::executeMigrationWrite` writes Markdown, clears the
+  database, imports the Markdown, and may restore the whole `.gsd` directory
+  after a later error. This reverses the one-way authority rule.
+- `md-importer.ts` derives status and completion from checkboxes, SUMMARY
+  existence, and mtimes, then upserts live state. Parser and transformer code
+  may remain import adapters; their live writers must not be canonical.
+- `workflow-manifest.ts`, JSONL event replay, and reconciliation skip or
+  reinterpret corrupt/unknown history. Import them as diagnosed history only;
+  never replay them as current authority.
+- Reuse `db-migration-backup.ts` mechanics: WAL checkpoint, independent open,
+  schema validation, and `PRAGMA quick_check`. Directory-copy backup semantics
+  are insufficient.
+
+### Kernel and work identity
+
+- `project_authority` already owns the singleton project identity, root, exact
+  revision, and Authority Epoch.
+- `workflow_item_lifecycles` already owns milestone/slice/task work identity.
+  `workflow_execution_attempts` owns execution identity, fencing, retry chains,
+  and one-active-Attempt rules. A second work or kernel-run table would drift.
+- `workflow_work_checkpoints` are narrative conversation/resume records. They
+  are not an execution-stage cursor and should not receive kernel stage kinds.
+- `auto/workflow-kernel.ts` is process-local loop policy; `uok/kernel.ts`
+  selects legacy/UOK paths and writes parity telemetry. Neither is restart
+  authority.
+- The accepted five-stage kernel still includes Advance, but no lifecycle
+  checkpoint exists before work selection: absence of an active checkpoint is
+  the durable Advance state. The first checkpoint records Execute and is
+  created atomically with the selected lifecycle's claimed Attempt. Persisting
+  a pre-claim Advance row would require an invented project-global worker/run
+  identity. A settled checkpoint represents the current cycle, not permanent
+  lifecycle finality, because v32 permits authorized reopen.
+- Worktree paths are ephemeral runtime handles. Repository definitions are
+  preferences-derived today. Closeout effects should snapshot their logical
+  repository/effect inputs rather than introduce repository/workspace tables.
+
+### Closeout and settlement drift
+
+- `unit-closeout.ts`, `auto-unit-closeout.ts`, and the auto orchestrator use
+  different pipelines. Git outcomes, metrics, memory, and process booleans are
+  not one restart-safe settlement fact.
+- `closeout-consistency-gate.ts` may refresh the database from disk and can
+  synthesize a passing validation from SUMMARY presence.
+- `milestone-closeout-proof.ts` and `milestone-settlement.ts` require files and
+  process-local `milestoneMerged` state. Restart continuity is inferred rather
+  than receipted.
+- `turn_git_transactions` and `milestone_commit_attributions` are replaceable
+  audit/compatibility rows without canonical lifecycle, effect, revision, or
+  idempotency identity. They cannot become settlement receipts.
+- Projection, notification, metrics, indexing, and memory are follow-on work.
+  They must not become settlement-critical host effects.
+
+## Final Six-Table Contract
+
+### 1. `workflow_projection_work`
+
+One durable specialized queue; no separate projection-attempt table.
+
+Core fields:
+
+- `projection_work_id`, `project_id`;
+- normalized `projection_key` as the complete logical target identity and
+  `projection_kind` as renderer selection metadata;
+- unique nullable `supersedes_projection_work_id` current-head lineage;
+- enqueue `operation_id`, `source_project_revision`, and
+  `source_authority_epoch` as one exact v31 provenance tuple;
+- `renderer_version` metadata;
+- delivery state `pending | claimed | rendered | dead_letter`;
+- claim owner, `claim_fencing_token`, `claimed_at`, `claim_expires_at`,
+  monotonic `state_version`, `attempt_count`, `next_attempt_at`, and
+  `last_error`;
+- rendered hash/time;
+- causal operation/revision/epoch provenance.
+
+Identity, logical target, renderer version, and enqueue provenance are
+immutable. A successor must name the causally older current head for the same
+project/key and advance source revision without decreasing epoch. Supersession
+is derived from that successor; it is not a mutable state. Only delivery fields
+transition. A failed attempt returns `claimed → pending` while incrementing
+attempt/backoff/error; exhausted work becomes `dead_letter`.
+
+Currentness is per logical projection key: its lineage head is current when it
+is rendered and its rendered source revision/hash match that desired row. An
+unrelated project operation does not stale unaffected projections. A claim or
+render transition must reject a row with a successor. Local DDL validates claim
+shape and monotonic fence/state versions; S06's compare-and-swap writer proves
+the caller presented the current fence. Operational delivery changes do not
+create v31 Domain Operations or advance project revision. Store no absolute
+path as authority. V35 intentionally retains only cumulative attempt count and
+the latest failure; per-attempt delivery history can be added later only if
+operational audit requires it.
+
+### 2. `workflow_import_applications`
+
+One immutable application receipt; preview generation must leave the
+authoritative database byte-identical.
+
+Core fields:
+
+- application `operation_id` primary key, `project_id`, exact resulting
+  revision, and resulting Authority Epoch;
+- import kind, importer version, preview schema version;
+- unique `preview_id` and `preview_hash`;
+- base project revision, Authority Epoch, and database schema version;
+- source-set hash, change-set hash, counts, and `unresolved_count = 0`;
+- canonical versioned `preview_json` containing ordered source fingerprints,
+  parse diagnoses, exact changes, raw legacy values/references, and explicit
+  ambiguity resolutions;
+- backup reference, SHA-256, byte size, schema version, project revision,
+  Authority Epoch, `quick_check = ok`, and verified timestamp;
+- application timestamp and exact resulting revision/epoch.
+
+V31 operations provide actor, expected/resulting revision, idempotency, and
+request hash. V31 domain events provide per-entity result provenance. Child
+preview/source/change tables add no authority because application is
+indivisible. A non-authoritative sidecar may retain a preview across restart;
+application re-fingerprints and re-parses every source before the transaction.
+The receipt trigger requires an import-application operation whose expected
+revision/epoch equal the stored base, whose resulting tuple equals the receipt,
+and whose backup schema/revision/epoch equal the base snapshot. `preview_hash`
+covers the complete canonical envelope—scalar metadata plus ordered sources,
+changes, raw values, diagnostics, and resolutions—not only the JSON field.
+Unparsed material must be explicitly preserved with raw content/reference and
+an accepted disposition or remain unresolved; it may never disappear behind a
+zero aggregate count.
+
+### 3. `workflow_kernel_checkpoints`
+
+One append-only current-head chain per lifecycle.
+
+Core fields:
+
+- `kernel_checkpoint_id`, `project_id`, `lifecycle_id`, `attempt_id`;
+- `next_stage`: `execute | verify | route | closeout | settled`;
+- sequence and unique `previous_kernel_checkpoint_id`;
+- created timestamp and exact operation/revision/epoch provenance.
+
+Absence of a checkpoint means Advance. The first row is sequence 1, has no
+predecessor, records Execute, and names the already-claimed v32 Attempt. A
+second root for the lifecycle is forbidden. Every successor names the current
+head, increments sequence by one, strictly advances revision, and never
+decreases epoch. Ordinary successors retain the Attempt. Any Attempt change
+requires Execute and a new v32 Attempt whose `retry_of_attempt_id` is the
+predecessor checkpoint's Attempt. This covers retry and authorized reopen; do
+not separately hardcode predecessor stages. A settled head may therefore gain
+a later Execute successor. S05 enforces chain, scope, retry identity,
+provenance, and immutability; S06 enforces legal stage prerequisites and writes
+each checkpoint atomically with sibling Result, verdict, recovery, or closeout
+facts. Do not add payload JSON, status text, worker identity, or resume tokens.
+
+### 4. `workflow_closeout_plans`
+
+Immutable prepared plan versions with current-head supersession.
+
+Core fields:
+
+- `closeout_plan_id`, project/lifecycle/Attempt identity;
+- opaque tested source-set hash and deterministic readiness/basis hash;
+- unique `supersedes_closeout_plan_id`;
+- prepared timestamp and exact operation/revision/epoch provenance.
+
+No mutable plan status. There is one root lineage per project/lifecycle, not
+per Attempt, and the lineage head is current. Supersession preserves
+project/lifecycle but may name a later descendant Attempt; v32's larger attempt
+number in the same lifecycle proves descent even if intervening Attempts never
+reached Closeout. S06 revalidates the basis before each host effect and before
+final lifecycle completion.
+
+### 5. `workflow_closeout_effects`
+
+Immutable ordered settlement-critical host effects owned by one plan.
+
+Core fields:
+
+- `closeout_effect_id`, plan/project/lifecycle identity;
+- integer ordinal;
+- normalized effect kind;
+- deterministic idempotency key;
+- canonical effect spec JSON and spec hash;
+- the exact same preparation operation/revision/epoch tuple as the parent plan.
+
+Use one ordinal, not an effect dependency graph. Effect idempotency keys are
+unique within a plan and may repeat across superseding plans so adapters can
+recognize prior host results. A plan may have zero host effects. Only effects
+whose success is required before closeout belong here,
+typically source commit, worktree integration, merge, or publish. Projection
+and advisory follow-on work are excluded.
+
+### 6. `workflow_settlement_receipts`
+
+Immutable success-only receipt, at most one per closeout effect.
+
+Core fields:
+
+- `settlement_receipt_id`, effect/project/lifecycle identity;
+- outcome `performed | recognized`;
+- external identity/reference;
+- canonical proof JSON and proof hash;
+- settled timestamp and exact operation/revision/epoch provenance.
+
+External identity is nonblank for performed and recognized outcomes. Receipt
+provenance is strictly later than plan/effect creation and may not decrease
+epoch. A receipt requires receipts for all lower effect ordinals on the same
+plan and is rejected if that plan already has a successor. Missing receipt
+means pending. Failures are v34 Failure Observations and Recovery Actions,
+never failed receipts. A crash after a host effect but before its receipt must
+replay the same idempotency key, recognize the existing host result, and write
+`recognized`. Old receipts remain valid history after later plan supersession;
+S06 completion queries consider only the current plan. Do not add a settlement
+aggregate: current plan plus receipt coverage plus lifecycle status already
+answer settlement state.
+
+## Local S05 Invariants
+
+1. Every new authoritative fact binds to the exact v31 project/revision/epoch operation tuple.
+2. Projection desired identity/lineage is immutable; delivery transitions are fenced, versioned, and restart-safe without advancing domain revision.
+3. Import application is immutable, unresolved-free, backup-verified, and unique per preview hash.
+4. Kernel checkpoints form one immutable, gap-free, no-fork head per lifecycle.
+5. Kernel Attempt changes are restricted to a valid retry/reopen Execute checkpoint.
+6. Closeout plan supersession preserves project/lifecycle, uses the same or a later descendant Attempt, and advances provenance.
+7. Effects are immutable, born with their plan, uniquely ordered per plan, and carry per-plan deterministic idempotency keys.
+8. Receipts are ordered immutable success facts, unique per effect, causally scoped, and cannot be added after plan supersession.
+9. No new table or trigger changes current lifecycle completion behavior during S05.
+
+## RED, Restart, Migration, and Fault Proofs
+
+### Schema and migration
+
+- Fresh and v34→v35 upgrade create exactly six tables and preserve all legacy/v31–v34 rows.
+- Backup independently opens, reports the prior schema version, and passes `quick_check`.
+- A fault after v35 DDL but before commit leaves no v35 tables and retries cleanly.
+- Older-version rewind fixtures remove every later table and index before stamping the older version.
+
+### Projection
+
+- Claim, lease expiry, retry, failure, rendered hash, and supersession survive reopen.
+- Local transitions reject a missing/malformed claim tuple, a non-increasing
+  fence/state version, an invalid retry/dead-letter transition, and any
+  claim/render of a row with a successor.
+- A second lineage root, fork, stale source revision, or mismatched logical key
+  is rejected; an unrelated project operation does not stale an unaffected
+  rendered lineage head.
+- Projection claims and delivery transitions leave
+  `project_authority.revision` unchanged.
+
+### Import
+
+- Raw receipt inserts reject unresolved, malformed, count/hash-mismatched,
+  wrong-operation-type, expected/resulting revision mismatch, and backup/base
+  mismatch.
+- Application receipts and sealed preview envelopes reject update/delete.
+- The same preview hash or v31 idempotency identity cannot create two
+  applications.
+- Tests compare a stable logical database snapshot—authority revision/epoch,
+  schema, and table contents—rather than incidental SQLite file/WAL bytes.
+
+### Kernel
+
+- Reopen after every checkpoint returns the identical current head and next stage.
+- Reject wrong-lifecycle Attempts, forks, gaps, stale revision/epoch, invalid Attempt changes, update, and delete.
+- Removing runtime files, JSONL, worktree markers, or Markdown does not change the current head.
+- S06 fault tests later prove no checkpoint can commit without its sibling facts.
+
+### Closeout
+
+- Reject a second plan root, a fork, unrelated/lower Attempt supersession,
+  cross-scope effects/receipts, effects outside the plan's preparation
+  operation, and duplicate ordinals/idempotency keys within one plan.
+- Permit the same idempotency key on a superseding plan.
+- Reject out-of-order receipts, receipt mutation/deletion, and receipt insertion
+  after plan supersession.
+- Reopen with partial receipts returns the same first missing ordinal.
+- File summaries, validation artifacts, Git audit rows, process flags, and projections cannot substitute for a receipt.
+- Zero-effect plans are valid and require no synthetic receipt.
+
+## Future S06 Acceptance Tests
+
+- Obstruct a projection target: the domain operation and Projection Work
+  enqueue commit, the worker records retryable failure without rolling domain
+  completion back, removal permits retry, and an obsolete claimant cannot
+  overwrite the newer real file.
+- Delete or contradict Markdown, manifests, JSONL, runtime state, and worktree
+  markers; canonical domain state, projection backlog, and kernel head remain
+  unchanged.
+- Preview generation performs no authoritative write and preserves the logical
+  database snapshot. A one-byte source/base/parser/resolution change invalidates
+  approval. Application faults at validation, domain mutation, event emission,
+  or receipt insertion roll back the whole transaction; idempotent retry yields
+  one application and ordered event set.
+- Crash before a host effect, after the host effect, and after receipt insert.
+  Replaying the deterministic key performs or recognizes one host result and
+  writes one ordered receipt without duplicating the effect.
+- Fault at every kernel sibling write; no checkpoint commits without its
+  Attempt/Result/verdict/recovery/closeout facts.
+
+## Explicit S06 Boundary
+
+S05 lands schema and local invariants only. S06 owns:
+
+- atomic Domain Operations and expected-revision/fencing checks;
+- domain mutation + event + projection-work enqueue;
+- import application writers and entity events;
+- Attempt claim + first kernel checkpoint;
+- Result/failure/evidence/verdict/recovery + kernel transitions;
+- closeout preparation, effect execution/recognition, receipt recording, final completion, and dependency unlock;
+- canonical Query Module reads and idempotent replay;
+- projection worker/adapters and filesystem-obstruction cutover tests;
+- migration/import adapters and the Forward Repair boundary; and
+- removal of file/process authority from auto, interactive, custom, and UOK paths.
+
+S05 must not install triggers that block existing v32 lifecycle completion or
+wire current tools to the new tables. That would create a partial runtime
+cutover before the atomic operation boundary exists.
+
+## Decision Summary
+
+Adopt **six tables**: Projection Work, Import Applications, Kernel Checkpoints,
+Closeout Plans, Closeout Effects, and Settlement Receipts. This is the smallest
+model that makes desired projection revision, applied import provenance,
+restart stage, prepared closeout intent, host effects, and successful external
+settlement independently durable without duplicating existing identities or
+creating new mutable state machines.

--- a/src/resources/extensions/gsd/db-migration-steps.ts
+++ b/src/resources/extensions/gsd/db-migration-steps.ts
@@ -5,6 +5,7 @@ import type { DbAdapter } from "./db-adapter.js";
 import { createCanonicalFoundationSchemaV31 } from "./db-canonical-foundation-schema.js";
 import { createConversationFoundationSchemaV33 } from "./db-conversation-foundation-schema.js";
 import { createLifecycleFoundationSchemaV32 } from "./db-lifecycle-foundation-schema.js";
+import { createProjectionImportKernelCloseoutFoundationSchemaV35 } from "./db-projection-import-kernel-closeout-foundation-schema.js";
 import { createRecoveryEvidenceFoundationSchemaV34 } from "./db-recovery-evidence-foundation-schema.js";
 import { ensureColumn } from "./db-schema-metadata.js";
 
@@ -513,4 +514,8 @@ export function applyMigrationV33ConversationFoundation(db: DbAdapter): void {
 
 export function applyMigrationV34RecoveryEvidenceFoundation(db: DbAdapter): void {
   createRecoveryEvidenceFoundationSchemaV34(db);
+}
+
+export function applyMigrationV35ProjectionImportKernelCloseoutFoundation(db: DbAdapter): void {
+  createProjectionImportKernelCloseoutFoundationSchemaV35(db);
 }

--- a/src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts
@@ -1,0 +1,623 @@
+// Project/App: gsd-pi
+// File Purpose: Additive v35 projection, import, kernel checkpoint, and closeout settlement schema.
+
+import type { DbAdapter } from "./db-adapter.js";
+
+/**
+ * V35 records desired projection work and immutable import/kernel/closeout
+ * facts. Projection delivery is operational and intentionally does not create
+ * workflow operations. S06 owns atomic sibling facts, prerequisite checks,
+ * effect execution, lifecycle completion, and runtime cutover.
+ */
+export function createProjectionImportKernelCloseoutFoundationSchemaV35(db: DbAdapter): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_projection_work (
+      projection_work_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      projection_key TEXT NOT NULL CHECK (
+        length(trim(projection_key)) > 0 AND projection_key = lower(trim(projection_key))
+      ),
+      projection_kind TEXT NOT NULL CHECK (
+        length(trim(projection_kind)) > 0 AND projection_kind = lower(trim(projection_kind))
+      ),
+      supersedes_projection_work_id TEXT DEFAULT NULL UNIQUE,
+      source_project_revision INTEGER NOT NULL CHECK (source_project_revision > 0),
+      source_authority_epoch INTEGER NOT NULL CHECK (source_authority_epoch >= 0),
+      renderer_version TEXT NOT NULL CHECK (length(trim(renderer_version)) > 0),
+      delivery_state TEXT NOT NULL DEFAULT 'pending' CHECK (
+        delivery_state IN ('pending', 'claimed', 'rendered', 'dead_letter')
+      ),
+      state_version INTEGER NOT NULL DEFAULT 0 CHECK (state_version >= 0),
+      claim_owner TEXT DEFAULT NULL,
+      claim_fencing_token INTEGER NOT NULL DEFAULT 0 CHECK (claim_fencing_token >= 0),
+      claimed_at TEXT DEFAULT NULL,
+      claim_expires_at TEXT DEFAULT NULL,
+      attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+      next_attempt_at TEXT NOT NULL DEFAULT '',
+      last_error TEXT NOT NULL DEFAULT '',
+      rendered_content_hash TEXT DEFAULT NULL,
+      rendered_at TEXT DEFAULT NULL,
+      enqueue_operation_id TEXT NOT NULL,
+      created_at TEXT NOT NULL CHECK (length(trim(created_at)) > 0),
+      updated_at TEXT NOT NULL CHECK (length(trim(updated_at)) > 0),
+      UNIQUE (projection_work_id, project_id, projection_key),
+      UNIQUE (project_id, projection_key, source_project_revision),
+      CHECK (
+        (delivery_state = 'pending'
+          AND claim_owner IS NULL AND claimed_at IS NULL AND claim_expires_at IS NULL
+          AND rendered_content_hash IS NULL AND rendered_at IS NULL) OR
+        (delivery_state = 'claimed'
+          AND length(trim(claim_owner)) > 0 AND claim_fencing_token > 0
+          AND julianday(claimed_at) IS NOT NULL AND julianday(claim_expires_at) IS NOT NULL
+          AND julianday(claim_expires_at) > julianday(claimed_at)
+          AND rendered_content_hash IS NULL AND rendered_at IS NULL) OR
+        (delivery_state = 'rendered'
+          AND claim_owner IS NULL AND claimed_at IS NULL AND claim_expires_at IS NULL
+          AND length(rendered_content_hash) = 71
+          AND substr(rendered_content_hash, 1, 7) = 'sha256:'
+          AND rendered_content_hash = lower(rendered_content_hash)
+          AND substr(rendered_content_hash, 8) NOT GLOB '*[^0-9a-f]*'
+          AND rendered_at IS NOT NULL) OR
+        (delivery_state = 'dead_letter'
+          AND claim_owner IS NULL AND claimed_at IS NULL AND claim_expires_at IS NULL
+          AND rendered_content_hash IS NULL AND rendered_at IS NULL
+          AND length(trim(last_error)) > 0)
+      ),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (supersedes_projection_work_id)
+        REFERENCES workflow_projection_work(projection_work_id),
+      FOREIGN KEY (
+        enqueue_operation_id, project_id, source_project_revision, source_authority_epoch
+      ) REFERENCES workflow_operations(
+        operation_id, project_id, resulting_revision, resulting_authority_epoch
+      )
+    );
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_projection_initial_state
+    BEFORE INSERT ON workflow_projection_work
+    WHEN NEW.delivery_state != 'pending'
+      OR NEW.state_version != 0
+      OR NEW.claim_fencing_token != 0
+      OR NEW.attempt_count != 0
+      OR NEW.claim_owner IS NOT NULL
+      OR NEW.claimed_at IS NOT NULL
+      OR NEW.claim_expires_at IS NOT NULL
+      OR NEW.rendered_content_hash IS NOT NULL
+      OR NEW.rendered_at IS NOT NULL
+      OR NEW.next_attempt_at != ''
+      OR NEW.last_error != ''
+      OR NEW.created_at != NEW.updated_at
+    BEGIN
+      SELECT RAISE(ABORT, 'projection work must begin pending and unclaimed');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_projection_lineage
+    BEFORE INSERT ON workflow_projection_work
+    WHEN (
+      NEW.supersedes_projection_work_id IS NULL AND EXISTS (
+        SELECT 1 FROM workflow_projection_work existing
+        WHERE existing.project_id = NEW.project_id
+          AND existing.projection_key = NEW.projection_key
+      )
+    ) OR (
+      NEW.supersedes_projection_work_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM workflow_projection_work previous
+        WHERE previous.projection_work_id = NEW.supersedes_projection_work_id
+          AND previous.project_id = NEW.project_id
+          AND previous.projection_key = NEW.projection_key
+          AND previous.projection_kind = NEW.projection_kind
+          AND previous.source_project_revision < NEW.source_project_revision
+          AND previous.source_authority_epoch <= NEW.source_authority_epoch
+          AND NOT EXISTS (
+            SELECT 1 FROM workflow_projection_work successor
+            WHERE successor.supersedes_projection_work_id = previous.projection_work_id
+          )
+      )
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'projection work must extend the current logical target head');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_projection_identity_immutable
+    BEFORE UPDATE ON workflow_projection_work
+    WHEN NEW.projection_work_id != OLD.projection_work_id
+      OR NEW.project_id != OLD.project_id
+      OR NEW.projection_key != OLD.projection_key
+      OR NEW.projection_kind != OLD.projection_kind
+      OR NEW.supersedes_projection_work_id IS NOT OLD.supersedes_projection_work_id
+      OR NEW.source_project_revision != OLD.source_project_revision
+      OR NEW.source_authority_epoch != OLD.source_authority_epoch
+      OR NEW.renderer_version != OLD.renderer_version
+      OR NEW.enqueue_operation_id != OLD.enqueue_operation_id
+      OR NEW.created_at != OLD.created_at
+    BEGIN
+      SELECT RAISE(ABORT, 'projection desired identity is immutable');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_projection_current_head_update
+    BEFORE UPDATE ON workflow_projection_work
+    WHEN EXISTS (
+      SELECT 1 FROM workflow_projection_work successor
+      WHERE successor.supersedes_projection_work_id = OLD.projection_work_id
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'superseded projection work cannot be delivered');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_projection_delivery_transition
+    BEFORE UPDATE ON workflow_projection_work
+    WHEN NEW.state_version != OLD.state_version + 1
+      OR NEW.updated_at = OLD.updated_at
+      OR NOT (
+        (OLD.delivery_state = 'pending' AND NEW.delivery_state = 'claimed'
+          AND NEW.claim_fencing_token = OLD.claim_fencing_token + 1
+          AND NEW.attempt_count = OLD.attempt_count) OR
+        (OLD.delivery_state = 'claimed' AND NEW.delivery_state = 'claimed'
+          AND NEW.claim_owner = OLD.claim_owner
+          AND NEW.claim_fencing_token = OLD.claim_fencing_token
+          AND NEW.claimed_at = OLD.claimed_at
+          AND julianday(NEW.claim_expires_at) > julianday(OLD.claim_expires_at)
+          AND NEW.next_attempt_at = OLD.next_attempt_at
+          AND NEW.last_error = OLD.last_error
+          AND NEW.attempt_count = OLD.attempt_count) OR
+        (OLD.delivery_state = 'claimed' AND NEW.delivery_state IN ('pending', 'rendered', 'dead_letter')
+          AND NEW.claim_fencing_token = OLD.claim_fencing_token
+          AND NEW.attempt_count = OLD.attempt_count + 1)
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'invalid projection delivery transition');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_projection_delete
+    BEFORE DELETE ON workflow_projection_work
+    BEGIN
+      SELECT RAISE(ABORT, 'projection work is durable history');
+    END;
+
+    CREATE INDEX IF NOT EXISTS idx_workflow_projection_delivery
+      ON workflow_projection_work(project_id, delivery_state, next_attempt_at);
+    CREATE TABLE IF NOT EXISTS workflow_import_applications (
+      operation_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      import_kind TEXT NOT NULL CHECK (
+        length(trim(import_kind)) > 0 AND import_kind = lower(trim(import_kind))
+      ),
+      importer_version TEXT NOT NULL CHECK (length(trim(importer_version)) > 0),
+      preview_schema_version INTEGER NOT NULL CHECK (preview_schema_version > 0),
+      preview_id TEXT NOT NULL UNIQUE CHECK (length(trim(preview_id)) > 0),
+      preview_hash TEXT NOT NULL UNIQUE CHECK (
+        length(preview_hash) = 71 AND substr(preview_hash, 1, 7) = 'sha256:' AND
+        preview_hash = lower(preview_hash) AND substr(preview_hash, 8) NOT GLOB '*[^0-9a-f]*'
+      ),
+      base_project_revision INTEGER NOT NULL CHECK (base_project_revision >= 0),
+      base_authority_epoch INTEGER NOT NULL CHECK (base_authority_epoch >= 0),
+      base_database_schema_version INTEGER NOT NULL CHECK (base_database_schema_version > 0),
+      source_set_hash TEXT NOT NULL CHECK (
+        length(source_set_hash) = 71 AND substr(source_set_hash, 1, 7) = 'sha256:' AND
+        source_set_hash = lower(source_set_hash) AND substr(source_set_hash, 8) NOT GLOB '*[^0-9a-f]*'
+      ),
+      change_set_hash TEXT NOT NULL CHECK (
+        length(change_set_hash) = 71 AND substr(change_set_hash, 1, 7) = 'sha256:' AND
+        change_set_hash = lower(change_set_hash) AND substr(change_set_hash, 8) NOT GLOB '*[^0-9a-f]*'
+      ),
+      create_count INTEGER NOT NULL CHECK (create_count >= 0),
+      update_count INTEGER NOT NULL CHECK (update_count >= 0),
+      delete_count INTEGER NOT NULL CHECK (delete_count >= 0),
+      preserve_count INTEGER NOT NULL CHECK (preserve_count >= 0),
+      unparsed_count INTEGER NOT NULL CHECK (unparsed_count >= 0),
+      unresolved_count INTEGER NOT NULL CHECK (unresolved_count = 0),
+      preview_json TEXT NOT NULL CHECK (
+        json_valid(preview_json) AND json_type(preview_json) = 'object' AND
+        json(preview_json) != '{}'
+      ),
+      backup_ref TEXT NOT NULL CHECK (length(trim(backup_ref)) > 0),
+      backup_sha256 TEXT NOT NULL CHECK (
+        length(backup_sha256) = 71 AND substr(backup_sha256, 1, 7) = 'sha256:' AND
+        backup_sha256 = lower(backup_sha256) AND substr(backup_sha256, 8) NOT GLOB '*[^0-9a-f]*'
+      ),
+      backup_byte_size INTEGER NOT NULL CHECK (backup_byte_size > 0),
+      backup_schema_version INTEGER NOT NULL CHECK (backup_schema_version > 0),
+      backup_project_revision INTEGER NOT NULL CHECK (backup_project_revision >= 0),
+      backup_authority_epoch INTEGER NOT NULL CHECK (backup_authority_epoch >= 0),
+      backup_quick_check TEXT NOT NULL CHECK (backup_quick_check = 'ok'),
+      backup_verified_at TEXT NOT NULL CHECK (length(trim(backup_verified_at)) > 0),
+      applied_at TEXT NOT NULL CHECK (length(trim(applied_at)) > 0),
+      resulting_project_revision INTEGER NOT NULL CHECK (
+        resulting_project_revision = base_project_revision + 1
+      ),
+      resulting_authority_epoch INTEGER NOT NULL CHECK (resulting_authority_epoch >= 0),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (
+        operation_id, project_id, resulting_project_revision, resulting_authority_epoch
+      ) REFERENCES workflow_operations(
+        operation_id, project_id, resulting_revision, resulting_authority_epoch
+      )
+    );
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_import_application_causality
+    BEFORE INSERT ON workflow_import_applications
+    WHEN NEW.backup_schema_version != NEW.base_database_schema_version
+      OR NEW.backup_project_revision != NEW.base_project_revision
+      OR NEW.backup_authority_epoch != NEW.base_authority_epoch
+      OR NOT EXISTS (
+        SELECT 1 FROM workflow_operations operation
+        WHERE operation.operation_id = NEW.operation_id
+          AND operation.project_id = NEW.project_id
+          AND operation.operation_type = 'import.apply'
+          AND operation.expected_revision = NEW.base_project_revision
+          AND operation.resulting_revision = NEW.resulting_project_revision
+          AND operation.expected_authority_epoch = NEW.base_authority_epoch
+          AND operation.resulting_authority_epoch = NEW.resulting_authority_epoch
+      )
+    BEGIN
+      SELECT RAISE(ABORT, 'import application must match its operation and verified base backup');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_import_application_update
+    BEFORE UPDATE ON workflow_import_applications
+    BEGIN
+      SELECT RAISE(ABORT, 'import applications are immutable');
+    END;
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_import_application_delete
+    BEFORE DELETE ON workflow_import_applications
+    BEGIN
+      SELECT RAISE(ABORT, 'import applications are immutable');
+    END;
+
+    CREATE TABLE IF NOT EXISTS workflow_kernel_checkpoints (
+      kernel_checkpoint_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      lifecycle_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      next_stage TEXT NOT NULL CHECK (
+        next_stage IN ('execute', 'verify', 'route', 'closeout', 'settled')
+      ),
+      sequence INTEGER NOT NULL CHECK (sequence > 0),
+      previous_kernel_checkpoint_id TEXT DEFAULT NULL UNIQUE,
+      created_at TEXT NOT NULL CHECK (length(trim(created_at)) > 0),
+      operation_id TEXT NOT NULL,
+      project_revision INTEGER NOT NULL CHECK (project_revision > 0),
+      authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 0),
+      UNIQUE (project_id, lifecycle_id, sequence),
+      UNIQUE (kernel_checkpoint_id, project_id, lifecycle_id, attempt_id),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (lifecycle_id, project_id)
+        REFERENCES workflow_item_lifecycles(lifecycle_id, project_id),
+      FOREIGN KEY (attempt_id, lifecycle_id, project_id)
+        REFERENCES workflow_execution_attempts(attempt_id, lifecycle_id, project_id),
+      FOREIGN KEY (previous_kernel_checkpoint_id)
+        REFERENCES workflow_kernel_checkpoints(kernel_checkpoint_id),
+      FOREIGN KEY (operation_id, project_id, project_revision, authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        )
+    );
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_kernel_checkpoint_chain
+    BEFORE INSERT ON workflow_kernel_checkpoints
+    WHEN (
+      NEW.previous_kernel_checkpoint_id IS NULL AND (
+        NEW.sequence != 1 OR NEW.next_stage != 'execute' OR EXISTS (
+          SELECT 1 FROM workflow_kernel_checkpoints existing
+          WHERE existing.project_id = NEW.project_id
+            AND existing.lifecycle_id = NEW.lifecycle_id
+        )
+      )
+    ) OR (
+      NEW.previous_kernel_checkpoint_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM workflow_kernel_checkpoints previous
+        WHERE previous.kernel_checkpoint_id = NEW.previous_kernel_checkpoint_id
+          AND previous.project_id = NEW.project_id
+          AND previous.lifecycle_id = NEW.lifecycle_id
+          AND NEW.sequence = previous.sequence + 1
+          AND previous.project_revision < NEW.project_revision
+          AND previous.authority_epoch <= NEW.authority_epoch
+          AND NOT EXISTS (
+            SELECT 1 FROM workflow_kernel_checkpoints successor
+            WHERE successor.previous_kernel_checkpoint_id = previous.kernel_checkpoint_id
+          )
+          AND (
+            NEW.attempt_id = previous.attempt_id OR (
+              NEW.next_stage = 'execute' AND EXISTS (
+                SELECT 1 FROM workflow_execution_attempts retry
+                WHERE retry.attempt_id = NEW.attempt_id
+                  AND retry.project_id = NEW.project_id
+                  AND retry.lifecycle_id = NEW.lifecycle_id
+                  AND retry.retry_of_attempt_id = previous.attempt_id
+              )
+            )
+          )
+      )
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'kernel checkpoint must extend the current lifecycle head');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_kernel_checkpoint_attempt_claim
+    BEFORE INSERT ON workflow_kernel_checkpoints
+    WHEN (
+      NEW.previous_kernel_checkpoint_id IS NULL OR EXISTS (
+        SELECT 1 FROM workflow_kernel_checkpoints previous
+        WHERE previous.kernel_checkpoint_id = NEW.previous_kernel_checkpoint_id
+          AND previous.attempt_id != NEW.attempt_id
+      )
+    ) AND NOT EXISTS (
+      SELECT 1 FROM workflow_execution_attempts attempt
+      WHERE attempt.attempt_id = NEW.attempt_id
+        AND attempt.project_id = NEW.project_id
+        AND attempt.lifecycle_id = NEW.lifecycle_id
+        AND attempt.claim_operation_id = NEW.operation_id
+        AND attempt.claim_project_revision = NEW.project_revision
+        AND attempt.claim_authority_epoch = NEW.authority_epoch
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'execute checkpoint must share its Attempt claim operation');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_kernel_checkpoint_update
+    BEFORE UPDATE ON workflow_kernel_checkpoints
+    BEGIN
+      SELECT RAISE(ABORT, 'kernel checkpoints are immutable');
+    END;
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_kernel_checkpoint_delete
+    BEFORE DELETE ON workflow_kernel_checkpoints
+    BEGIN
+      SELECT RAISE(ABORT, 'kernel checkpoints are immutable');
+    END;
+    CREATE TABLE IF NOT EXISTS workflow_closeout_plans (
+      closeout_plan_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      lifecycle_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      tested_source_set_hash TEXT NOT NULL CHECK (
+        length(tested_source_set_hash) = 71 AND
+        substr(tested_source_set_hash, 1, 7) = 'sha256:' AND
+        tested_source_set_hash = lower(tested_source_set_hash) AND
+        substr(tested_source_set_hash, 8) NOT GLOB '*[^0-9a-f]*'
+      ),
+      readiness_basis_hash TEXT NOT NULL CHECK (
+        length(readiness_basis_hash) = 71 AND
+        substr(readiness_basis_hash, 1, 7) = 'sha256:' AND
+        readiness_basis_hash = lower(readiness_basis_hash) AND
+        substr(readiness_basis_hash, 8) NOT GLOB '*[^0-9a-f]*'
+      ),
+      supersedes_closeout_plan_id TEXT DEFAULT NULL UNIQUE,
+      prepared_at TEXT NOT NULL CHECK (length(trim(prepared_at)) > 0),
+      operation_id TEXT NOT NULL,
+      project_revision INTEGER NOT NULL CHECK (project_revision > 0),
+      authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 0),
+      UNIQUE (
+        closeout_plan_id, project_id, lifecycle_id,
+        operation_id, project_revision, authority_epoch
+      ),
+      UNIQUE (closeout_plan_id, project_id, lifecycle_id, attempt_id),
+      FOREIGN KEY (project_id) REFERENCES project_authority(project_id),
+      FOREIGN KEY (lifecycle_id, project_id)
+        REFERENCES workflow_item_lifecycles(lifecycle_id, project_id),
+      FOREIGN KEY (attempt_id, lifecycle_id, project_id)
+        REFERENCES workflow_execution_attempts(attempt_id, lifecycle_id, project_id),
+      FOREIGN KEY (supersedes_closeout_plan_id)
+        REFERENCES workflow_closeout_plans(closeout_plan_id),
+      FOREIGN KEY (operation_id, project_id, project_revision, authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        )
+    );
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_closeout_plan_attempt
+    BEFORE INSERT ON workflow_closeout_plans
+    WHEN NOT EXISTS (
+      SELECT 1
+      FROM workflow_execution_attempts attempt
+      JOIN workflow_attempt_results result ON result.attempt_id = attempt.attempt_id
+      WHERE attempt.attempt_id = NEW.attempt_id
+        AND attempt.project_id = NEW.project_id
+        AND attempt.lifecycle_id = NEW.lifecycle_id
+        AND attempt.attempt_state = 'settled'
+        AND attempt.settle_project_revision < NEW.project_revision
+        AND attempt.settle_authority_epoch <= NEW.authority_epoch
+        AND result.project_id = NEW.project_id
+        AND result.lifecycle_id = NEW.lifecycle_id
+        AND result.outcome = 'succeeded'
+        AND result.project_revision < NEW.project_revision
+        AND result.authority_epoch <= NEW.authority_epoch
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'closeout plan requires a causally prior settled attempt');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_closeout_plan_head
+    BEFORE INSERT ON workflow_closeout_plans
+    WHEN (
+      NEW.supersedes_closeout_plan_id IS NULL AND EXISTS (
+        SELECT 1 FROM workflow_closeout_plans existing
+        WHERE existing.project_id = NEW.project_id
+          AND existing.lifecycle_id = NEW.lifecycle_id
+      )
+    ) OR (
+      NEW.supersedes_closeout_plan_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1
+        FROM workflow_closeout_plans previous
+        JOIN workflow_execution_attempts previous_attempt
+          ON previous_attempt.attempt_id = previous.attempt_id
+        JOIN workflow_execution_attempts next_attempt
+          ON next_attempt.attempt_id = NEW.attempt_id
+        WHERE previous.closeout_plan_id = NEW.supersedes_closeout_plan_id
+          AND previous.project_id = NEW.project_id
+          AND previous.lifecycle_id = NEW.lifecycle_id
+          AND previous.project_revision < NEW.project_revision
+          AND previous.authority_epoch <= NEW.authority_epoch
+          AND NOT EXISTS (
+            SELECT 1 FROM workflow_closeout_plans successor
+            WHERE successor.supersedes_closeout_plan_id = previous.closeout_plan_id
+          )
+          AND (
+            NEW.attempt_id = previous.attempt_id OR
+            next_attempt.attempt_number > previous_attempt.attempt_number
+          )
+      )
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'closeout plan must extend the current lifecycle head');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_closeout_plan_update
+    BEFORE UPDATE ON workflow_closeout_plans
+    BEGIN
+      SELECT RAISE(ABORT, 'closeout plans are immutable');
+    END;
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_closeout_plan_delete
+    BEFORE DELETE ON workflow_closeout_plans
+    BEGIN
+      SELECT RAISE(ABORT, 'closeout plans are immutable');
+    END;
+    CREATE INDEX IF NOT EXISTS idx_workflow_closeout_plan_head
+      ON workflow_closeout_plans(project_id, lifecycle_id, project_revision DESC);
+
+    CREATE TABLE IF NOT EXISTS workflow_closeout_effects (
+      closeout_effect_id TEXT PRIMARY KEY,
+      closeout_plan_id TEXT NOT NULL,
+      project_id TEXT NOT NULL,
+      lifecycle_id TEXT NOT NULL,
+      ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+      effect_kind TEXT NOT NULL CHECK (
+        length(trim(effect_kind)) > 0 AND effect_kind = lower(trim(effect_kind))
+      ),
+      idempotency_key TEXT NOT NULL CHECK (length(trim(idempotency_key)) > 0),
+      effect_spec_json TEXT NOT NULL CHECK (
+        json_valid(effect_spec_json) AND json_type(effect_spec_json) = 'object' AND
+        json(effect_spec_json) != '{}'
+      ),
+      effect_spec_hash TEXT NOT NULL CHECK (
+        length(effect_spec_hash) = 71 AND substr(effect_spec_hash, 1, 7) = 'sha256:' AND
+        effect_spec_hash = lower(effect_spec_hash) AND
+        substr(effect_spec_hash, 8) NOT GLOB '*[^0-9a-f]*'
+      ),
+      created_at TEXT NOT NULL CHECK (length(trim(created_at)) > 0),
+      operation_id TEXT NOT NULL,
+      project_revision INTEGER NOT NULL CHECK (project_revision > 0),
+      authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 0),
+      UNIQUE (closeout_plan_id, ordinal),
+      UNIQUE (closeout_plan_id, idempotency_key),
+      UNIQUE (closeout_effect_id, project_id, lifecycle_id),
+      FOREIGN KEY (
+        closeout_plan_id, project_id, lifecycle_id,
+        operation_id, project_revision, authority_epoch
+      ) REFERENCES workflow_closeout_plans(
+        closeout_plan_id, project_id, lifecycle_id,
+        operation_id, project_revision, authority_epoch
+      )
+    );
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_closeout_effect_current_plan
+    BEFORE INSERT ON workflow_closeout_effects
+    WHEN EXISTS (
+      SELECT 1 FROM workflow_closeout_plans successor
+      WHERE successor.supersedes_closeout_plan_id = NEW.closeout_plan_id
+    ) OR EXISTS (
+      SELECT 1
+      FROM workflow_closeout_effects settled_effect
+      JOIN workflow_settlement_receipts receipt
+        ON receipt.closeout_effect_id = settled_effect.closeout_effect_id
+      WHERE settled_effect.closeout_plan_id = NEW.closeout_plan_id
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'closeout effects must belong to the current plan');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_closeout_effect_ordinal
+    BEFORE INSERT ON workflow_closeout_effects
+    WHEN NEW.ordinal > 1 AND NOT EXISTS (
+      SELECT 1 FROM workflow_closeout_effects previous
+      WHERE previous.closeout_plan_id = NEW.closeout_plan_id
+        AND previous.ordinal = NEW.ordinal - 1
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'closeout effects must be inserted in ordinal order');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_closeout_effect_update
+    BEFORE UPDATE ON workflow_closeout_effects
+    BEGIN
+      SELECT RAISE(ABORT, 'closeout effects are immutable');
+    END;
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_closeout_effect_delete
+    BEFORE DELETE ON workflow_closeout_effects
+    BEGIN
+      SELECT RAISE(ABORT, 'closeout effects are immutable');
+    END;
+
+    CREATE TABLE IF NOT EXISTS workflow_settlement_receipts (
+      settlement_receipt_id TEXT PRIMARY KEY,
+      closeout_effect_id TEXT NOT NULL UNIQUE,
+      project_id TEXT NOT NULL,
+      lifecycle_id TEXT NOT NULL,
+      outcome TEXT NOT NULL CHECK (outcome IN ('performed', 'recognized')),
+      external_ref TEXT NOT NULL CHECK (length(trim(external_ref)) > 0),
+      proof_json TEXT NOT NULL CHECK (
+        json_valid(proof_json) AND json_type(proof_json) = 'object' AND
+        json(proof_json) != '{}'
+      ),
+      proof_hash TEXT NOT NULL CHECK (
+        length(proof_hash) = 71 AND substr(proof_hash, 1, 7) = 'sha256:' AND
+        proof_hash = lower(proof_hash) AND substr(proof_hash, 8) NOT GLOB '*[^0-9a-f]*'
+      ),
+      settled_at TEXT NOT NULL CHECK (length(trim(settled_at)) > 0),
+      operation_id TEXT NOT NULL,
+      project_revision INTEGER NOT NULL CHECK (project_revision > 0),
+      authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 0),
+      UNIQUE (settlement_receipt_id, project_id, lifecycle_id),
+      FOREIGN KEY (closeout_effect_id, project_id, lifecycle_id)
+        REFERENCES workflow_closeout_effects(
+          closeout_effect_id, project_id, lifecycle_id
+        ),
+      FOREIGN KEY (operation_id, project_id, project_revision, authority_epoch)
+        REFERENCES workflow_operations(
+          operation_id, project_id, resulting_revision, resulting_authority_epoch
+        )
+    );
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_settlement_receipt_order
+    BEFORE INSERT ON workflow_settlement_receipts
+    WHEN NOT EXISTS (
+      SELECT 1
+      FROM workflow_closeout_effects effect
+      JOIN workflow_closeout_plans plan ON plan.closeout_plan_id = effect.closeout_plan_id
+      WHERE effect.closeout_effect_id = NEW.closeout_effect_id
+        AND effect.project_id = NEW.project_id
+        AND effect.lifecycle_id = NEW.lifecycle_id
+        AND effect.project_revision < NEW.project_revision
+        AND effect.authority_epoch <= NEW.authority_epoch
+        AND NOT EXISTS (
+          SELECT 1 FROM workflow_closeout_plans successor
+          WHERE successor.supersedes_closeout_plan_id = plan.closeout_plan_id
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM workflow_closeout_effects prior_effect
+          WHERE prior_effect.closeout_plan_id = effect.closeout_plan_id
+            AND prior_effect.ordinal < effect.ordinal
+            AND NOT EXISTS (
+              SELECT 1 FROM workflow_settlement_receipts prior_receipt
+              WHERE prior_receipt.closeout_effect_id = prior_effect.closeout_effect_id
+            )
+        )
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'settlement receipt requires current plan and prior ordinal receipts');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_settlement_receipt_update
+    BEFORE UPDATE ON workflow_settlement_receipts
+    BEGIN
+      SELECT RAISE(ABORT, 'settlement receipts are immutable');
+    END;
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_settlement_receipt_delete
+    BEFORE DELETE ON workflow_settlement_receipts
+    BEGIN
+      SELECT RAISE(ABORT, 'settlement receipts are immutable');
+    END;
+    CREATE INDEX IF NOT EXISTS idx_workflow_settlement_receipt_scope
+      ON workflow_settlement_receipts(project_id, lifecycle_id, closeout_effect_id);
+  `);
+}

--- a/src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts
@@ -45,15 +45,30 @@ export function createProjectionImportKernelCloseoutFoundationSchemaV35(db: DbAd
       CHECK (
         (delivery_state = 'pending'
           AND claim_owner IS NULL AND claimed_at IS NULL AND claim_expires_at IS NULL
-          AND rendered_content_hash IS NULL AND rendered_at IS NULL) OR
+          AND rendered_content_hash IS NULL AND rendered_at IS NULL
+          AND (
+            (attempt_count = 0 AND next_attempt_at = '' AND last_error = '') OR
+            (attempt_count > 0
+              AND length(trim(last_error)) > 0
+              AND julianday(updated_at) IS NOT NULL
+              AND julianday(next_attempt_at) IS NOT NULL
+              AND julianday(next_attempt_at) > julianday(updated_at))
+          )) OR
         (delivery_state = 'claimed'
-          AND length(trim(claim_owner)) > 0 AND claim_fencing_token > 0
+          AND claim_owner IS NOT NULL AND length(trim(claim_owner)) > 0
+          AND claim_fencing_token > 0
           AND julianday(claimed_at) IS NOT NULL AND julianday(claim_expires_at) IS NOT NULL
           AND julianday(claim_expires_at) > julianday(claimed_at)
-          AND rendered_content_hash IS NULL AND rendered_at IS NULL) OR
+          AND rendered_content_hash IS NULL AND rendered_at IS NULL
+          AND (
+            (attempt_count = 0 AND next_attempt_at = '' AND last_error = '') OR
+            (attempt_count > 0
+              AND length(trim(last_error)) > 0
+              AND julianday(next_attempt_at) IS NOT NULL)
+          )) OR
         (delivery_state = 'rendered'
           AND claim_owner IS NULL AND claimed_at IS NULL AND claim_expires_at IS NULL
-          AND length(rendered_content_hash) = 71
+          AND rendered_content_hash IS NOT NULL AND length(rendered_content_hash) = 71
           AND substr(rendered_content_hash, 1, 7) = 'sha256:'
           AND rendered_content_hash = lower(rendered_content_hash)
           AND substr(rendered_content_hash, 8) NOT GLOB '*[^0-9a-f]*'
@@ -151,6 +166,8 @@ export function createProjectionImportKernelCloseoutFoundationSchemaV35(db: DbAd
       OR NOT (
         (OLD.delivery_state = 'pending' AND NEW.delivery_state = 'claimed'
           AND NEW.claim_fencing_token = OLD.claim_fencing_token + 1
+          AND NEW.next_attempt_at = OLD.next_attempt_at
+          AND NEW.last_error = OLD.last_error
           AND NEW.attempt_count = OLD.attempt_count) OR
         (OLD.delivery_state = 'claimed' AND NEW.delivery_state = 'claimed'
           AND NEW.claim_owner = OLD.claim_owner
@@ -208,7 +225,26 @@ export function createProjectionImportKernelCloseoutFoundationSchemaV35(db: DbAd
       unresolved_count INTEGER NOT NULL CHECK (unresolved_count = 0),
       preview_json TEXT NOT NULL CHECK (
         json_valid(preview_json) AND json_type(preview_json) = 'object' AND
-        json(preview_json) != '{}'
+        json_extract(preview_json, '$.preview_schema_version') IS preview_schema_version AND
+        json_extract(preview_json, '$.preview_id') IS preview_id AND
+        json_extract(preview_json, '$.import_kind') IS import_kind AND
+        json_extract(preview_json, '$.importer_version') IS importer_version AND
+        json_extract(preview_json, '$.base_project_revision') IS base_project_revision AND
+        json_extract(preview_json, '$.base_authority_epoch') IS base_authority_epoch AND
+        json_extract(preview_json, '$.base_database_schema_version')
+          IS base_database_schema_version AND
+        json_extract(preview_json, '$.source_set_hash') IS source_set_hash AND
+        json_extract(preview_json, '$.change_set_hash') IS change_set_hash AND
+        json_extract(preview_json, '$.counts.create') IS create_count AND
+        json_extract(preview_json, '$.counts.update') IS update_count AND
+        json_extract(preview_json, '$.counts.delete') IS delete_count AND
+        json_extract(preview_json, '$.counts.preserve') IS preserve_count AND
+        json_extract(preview_json, '$.counts.unparsed') IS unparsed_count AND
+        json_extract(preview_json, '$.counts.unresolved') IS unresolved_count AND
+        json_type(preview_json, '$.sources') IS 'array' AND
+        json_type(preview_json, '$.changes') IS 'array' AND
+        json_type(preview_json, '$.diagnoses') IS 'array' AND
+        json_type(preview_json, '$.resolutions') IS 'array'
       ),
       backup_ref TEXT NOT NULL CHECK (length(trim(backup_ref)) > 0),
       backup_sha256 TEXT NOT NULL CHECK (
@@ -248,9 +284,20 @@ export function createProjectionImportKernelCloseoutFoundationSchemaV35(db: DbAd
           AND operation.resulting_revision = NEW.resulting_project_revision
           AND operation.expected_authority_epoch = NEW.base_authority_epoch
           AND operation.resulting_authority_epoch = NEW.resulting_authority_epoch
+          AND operation.request_hash = NEW.preview_hash
       )
     BEGIN
       SELECT RAISE(ABORT, 'import application must match its operation and verified base backup');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_import_operation_update
+    BEFORE UPDATE ON workflow_operations
+    WHEN EXISTS (
+      SELECT 1 FROM workflow_import_applications application
+      WHERE application.operation_id = OLD.operation_id
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'import application operations are immutable');
     END;
 
     CREATE TRIGGER IF NOT EXISTS trg_workflow_import_application_update

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -51,10 +51,12 @@ import {
   applyMigrationV32LifecycleFoundation,
   applyMigrationV33ConversationFoundation,
   applyMigrationV34RecoveryEvidenceFoundation,
+  applyMigrationV35ProjectionImportKernelCloseoutFoundation,
 } from "../db-migration-steps.js";
 import { createCanonicalFoundationSchemaV31 } from "../db-canonical-foundation-schema.js";
 import { createConversationFoundationSchemaV33 } from "../db-conversation-foundation-schema.js";
 import { createLifecycleFoundationSchemaV32 } from "../db-lifecycle-foundation-schema.js";
+import { createProjectionImportKernelCloseoutFoundationSchemaV35 } from "../db-projection-import-kernel-closeout-foundation-schema.js";
 import { createRecoveryEvidenceFoundationSchemaV34 } from "../db-recovery-evidence-foundation-schema.js";
 import {
   isMemoriesFtsAvailableSchema,
@@ -105,7 +107,7 @@ const providerLoader = createSqliteProviderLoader({
   nodeVersion: process.versions.node,
   writeStderr: (message: string) => process.stderr.write(message),
 });
-export const SCHEMA_VERSION = 34;
+export const SCHEMA_VERSION = 35;
 function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): void {
   const conservativeFilePragmas = fileBacked && _isLikelyWslDrvFsPathForTest(dbPath);
   if (fileBacked) db.exec(conservativeFilePragmas ? "PRAGMA journal_mode=DELETE" : "PRAGMA journal_mode=WAL");
@@ -147,6 +149,7 @@ function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): 
         createLifecycleFoundationSchemaV32(db);
         createConversationFoundationSchemaV33(db);
         createRecoveryEvidenceFoundationSchemaV34(db);
+        createProjectionImportKernelCloseoutFoundationSchemaV35(db);
 
         // Fresh install — all tables are created above with the full current schema,
         // so it is safe to create all migration-specific indexes here.  For existing
@@ -418,6 +421,11 @@ function migrateSchema(db: DbAdapter, dbPath: string | null): void {
     if (currentVersion < 34) {
       applyMigrationV34RecoveryEvidenceFoundation(db);
       recordSchemaVersion(db, 34);
+    }
+
+    if (currentVersion < 35) {
+      applyMigrationV35ProjectionImportKernelCloseoutFoundation(db);
+      recordSchemaVersion(db, 35);
     }
 
     if (_migrationFaultForTest) throw new Error("migration fault injected for test");

--- a/src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts
+++ b/src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts
@@ -29,6 +29,10 @@ function sha256(character: string): string {
   return `sha256:${character.repeat(64)}`;
 }
 
+function previewHash(revision: number): string {
+  return sha256(String(revision));
+}
+
 interface RawDb {
   readonly isOpen: boolean;
   exec(sql: string): void;
@@ -97,6 +101,7 @@ function insertOperation(
   revision: number,
   operationType = "test",
   epoch = 0,
+  requestHash = operationType === "import.apply" ? previewHash(revision) : `hash-op-${revision}`,
 ): void {
   const operationId = `op-${revision}`;
   db.prepare(`
@@ -115,7 +120,7 @@ function insertOperation(
     revision,
     epoch,
     epoch,
-    `hash-${operationId}`,
+    requestHash,
     `2026-07-12T00:00:${String(revision).padStart(2, "0")}.000Z`,
   );
 }
@@ -341,6 +346,31 @@ function insertImportApplication(
   },
 ): void {
   const baseRevision = input.revision - 1;
+  const sourceSetHash = sha256("b");
+  const changeSetHash = sha256("c");
+  const previewJson = input.previewJson ?? JSON.stringify({
+    preview_schema_version: 1,
+    preview_id: input.previewId,
+    import_kind: "markdown",
+    importer_version: "v1",
+    base_project_revision: baseRevision,
+    base_authority_epoch: 0,
+    base_database_schema_version: 35,
+    source_set_hash: sourceSetHash,
+    change_set_hash: changeSetHash,
+    counts: {
+      create: 1,
+      update: 0,
+      delete: 0,
+      preserve: 0,
+      unparsed: 0,
+      unresolved: 0,
+    },
+    sources: [],
+    changes: [],
+    diagnoses: [],
+    resolutions: [],
+  });
   db.prepare(`
     INSERT INTO workflow_import_applications (
       operation_id, project_id, import_kind, importer_version, preview_schema_version,
@@ -359,11 +389,11 @@ function insertImportApplication(
     `op-${input.revision}`,
     projectId(db),
     input.previewId,
-    input.previewHash ?? sha256(String(input.revision)),
+    input.previewHash ?? previewHash(input.revision),
     baseRevision,
-    sha256("b"),
-    sha256("c"),
-    input.previewJson ?? '{"sources":[],"changes":[]}',
+    sourceSetHash,
+    changeSetHash,
+    previewJson,
     sha256("d"),
     baseRevision,
     input.revision,
@@ -549,6 +579,81 @@ test("projection lineage and fenced delivery survive reopen without changing pro
   ).get()?.revision, revisionBefore);
 });
 
+test("projection state rejects nullable claim and render fields", (t) => {
+  const { db } = openFreshFixture(t);
+  insertOperation(db, 1);
+  insertProjection(db, { id: "projection-null-state", revision: 1 });
+
+  assert.throws(() => db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'claimed', claim_fencing_token = 1,
+        claimed_at = '2026-07-12T00:01:00.000Z',
+        claim_expires_at = '2026-07-12T00:02:00.000Z',
+        state_version = 1, updated_at = '2026-07-12T00:01:00.000Z'
+    WHERE projection_work_id = 'projection-null-state'
+  `));
+
+  db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'claimed', claim_owner = 'worker-1', claim_fencing_token = 1,
+        claimed_at = '2026-07-12T00:01:00.000Z',
+        claim_expires_at = '2026-07-12T00:02:00.000Z',
+        state_version = 1, updated_at = '2026-07-12T00:01:00.000Z'
+    WHERE projection_work_id = 'projection-null-state'
+  `);
+  assert.throws(() => db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'rendered', claim_owner = NULL,
+        claimed_at = NULL, claim_expires_at = NULL,
+        state_version = 2, attempt_count = 1,
+        rendered_at = '2026-07-12T00:02:00.000Z',
+        updated_at = '2026-07-12T00:02:00.000Z'
+    WHERE projection_work_id = 'projection-null-state'
+  `));
+});
+
+test("projection retry requires diagnostic backoff and preserves it on claim", (t) => {
+  const { db } = openFreshFixture(t);
+  insertOperation(db, 1);
+  insertProjection(db, { id: "projection-retry", revision: 1 });
+  db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'claimed', claim_owner = 'worker-1', claim_fencing_token = 1,
+        claimed_at = '2026-07-12T00:01:00.000Z',
+        claim_expires_at = '2026-07-12T00:02:00.000Z',
+        state_version = 1, updated_at = '2026-07-12T00:01:00.000Z'
+    WHERE projection_work_id = 'projection-retry'
+  `);
+
+  assert.throws(() => db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'pending', claim_owner = NULL,
+        claimed_at = NULL, claim_expires_at = NULL,
+        state_version = 2, attempt_count = 1,
+        updated_at = '2026-07-12T00:02:00.000Z'
+    WHERE projection_work_id = 'projection-retry'
+  `));
+
+  db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'pending', claim_owner = NULL,
+        claimed_at = NULL, claim_expires_at = NULL,
+        state_version = 2, attempt_count = 1,
+        next_attempt_at = '2026-07-12T00:03:00.000Z', last_error = 'disk full',
+        updated_at = '2026-07-12T00:02:00.000Z'
+    WHERE projection_work_id = 'projection-retry'
+  `);
+  assert.throws(() => db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'claimed', claim_owner = 'worker-2', claim_fencing_token = 2,
+        claimed_at = '2026-07-12T00:03:00.000Z',
+        claim_expires_at = '2026-07-12T00:04:00.000Z',
+        state_version = 3, next_attempt_at = '', last_error = '',
+        updated_at = '2026-07-12T00:03:00.000Z'
+    WHERE projection_work_id = 'projection-retry'
+  `));
+});
+
 test("import application receipt binds asserted operation and backup metadata and is immutable", (t) => {
   const { db } = openFreshFixture(t);
   insertOperation(db, 1, "import.apply");
@@ -558,6 +663,9 @@ test("import application receipt binds asserted operation and backup metadata an
   ));
   assert.throws(() => db.exec(
     "DELETE FROM workflow_import_applications WHERE operation_id = 'op-1'",
+  ));
+  assert.throws(() => db.exec(
+    "UPDATE workflow_operations SET request_hash = 'changed' WHERE operation_id = 'op-1'",
   ));
 
   insertOperation(db, 2, "test");
@@ -570,6 +678,40 @@ test("import application receipt binds asserted operation and backup metadata an
   insertOperation(db, 4, "import.apply");
   assert.throws(() => insertImportApplication(db, {
     revision: 4, previewId: "preview-bad-json", previewJson: "[]",
+  }));
+
+  insertOperation(db, 5, "import.apply");
+  assert.throws(() => insertImportApplication(db, {
+    revision: 5,
+    previewId: "preview-mismatched-envelope",
+    previewJson: JSON.stringify({
+      preview_schema_version: 1,
+      preview_id: "preview-mismatched-envelope",
+      import_kind: "markdown",
+      importer_version: "v1",
+      base_project_revision: 4,
+      base_authority_epoch: 0,
+      base_database_schema_version: 35,
+      source_set_hash: sha256("f"),
+      change_set_hash: sha256("c"),
+      counts: {
+        create: 99,
+        update: 0,
+        delete: 0,
+        preserve: 0,
+        unparsed: 0,
+        unresolved: 0,
+      },
+      sources: [],
+      changes: [],
+      diagnoses: [],
+      resolutions: [],
+    }),
+  }));
+
+  insertOperation(db, 6, "import.apply", 0, sha256("f"));
+  assert.throws(() => insertImportApplication(db, {
+    revision: 6, previewId: "preview-unsealed", previewHash: previewHash(6),
   }));
 });
 

--- a/src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts
+++ b/src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts
@@ -1,0 +1,784 @@
+// Project/App: gsd-pi
+// File Purpose: Executable contract for the additive v35 projection, import, kernel, and closeout foundation.
+
+import assert from "node:assert/strict";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test, type TestContext } from "node:test";
+
+import {
+  SCHEMA_VERSION,
+  _setMigrationFaultForTest,
+  closeDatabase,
+  openDatabase,
+} from "../gsd-db.ts";
+
+const require = createRequire(import.meta.url);
+const V35_TABLES = [
+  "workflow_projection_work",
+  "workflow_import_applications",
+  "workflow_kernel_checkpoints",
+  "workflow_closeout_plans",
+  "workflow_closeout_effects",
+  "workflow_settlement_receipts",
+] as const;
+
+function sha256(character: string): string {
+  return `sha256:${character.repeat(64)}`;
+}
+
+interface RawDb {
+  readonly isOpen: boolean;
+  exec(sql: string): void;
+  prepare(sql: string): {
+    run(...args: unknown[]): unknown;
+    get(...args: unknown[]): Record<string, unknown> | undefined;
+    all(...args: unknown[]): Array<Record<string, unknown>>;
+  };
+  close(): void;
+}
+
+function openRawDatabase(path: string): RawDb {
+  const sqlite = require("node:sqlite") as { DatabaseSync: new (path: string) => RawDb };
+  const db = new sqlite.DatabaseSync(path);
+  db.exec("PRAGMA foreign_keys = ON");
+  return db;
+}
+
+function createDatabasePath(t: TestContext): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-projection-closeout-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return join(dir, "gsd.db");
+}
+
+function openFreshFixture(t: TestContext): { dbPath: string; db: RawDb } {
+  const dbPath = createDatabasePath(t);
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+  const db = openRawDatabase(dbPath);
+  t.after(() => {
+    if (db.isOpen) db.close();
+    closeDatabase();
+    _setMigrationFaultForTest(false);
+  });
+  seedHierarchy(db);
+  return { dbPath, db };
+}
+
+function tableExists(db: RawDb, table: string): boolean {
+  return Boolean(db.prepare(
+    "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).get(table));
+}
+
+function maxSchemaVersion(db: RawDb): number {
+  return Number(db.prepare("SELECT MAX(version) AS version FROM schema_version").get()?.version);
+}
+
+function projectId(db: RawDb): string {
+  return String(db.prepare(
+    "SELECT project_id FROM project_authority WHERE singleton = 1",
+  ).get()?.project_id);
+}
+
+function seedHierarchy(db: RawDb): void {
+  db.exec(`
+    INSERT OR IGNORE INTO milestones (id, title, status, created_at)
+    VALUES
+      ('M-CLOSEOUT', 'Closeout foundation', 'active', ''),
+      ('M-OTHER', 'Other scope', 'active', '');
+  `);
+}
+
+function insertOperation(
+  db: RawDb,
+  revision: number,
+  operationType = "test",
+  epoch = 0,
+): void {
+  const operationId = `op-${revision}`;
+  db.prepare(`
+    INSERT INTO workflow_operations (
+      operation_id, project_id, operation_type, idempotency_key,
+      expected_revision, resulting_revision,
+      expected_authority_epoch, resulting_authority_epoch,
+      actor_type, actor_id, source_transport, request_hash, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'user', 'developer', 'test', ?, ?)
+  `).run(
+    operationId,
+    projectId(db),
+    operationType,
+    `key-${operationId}`,
+    revision - 1,
+    revision,
+    epoch,
+    epoch,
+    `hash-${operationId}`,
+    `2026-07-12T00:00:${String(revision).padStart(2, "0")}.000Z`,
+  );
+}
+
+function insertOperations(db: RawDb, count: number): void {
+  for (let revision = 1; revision <= count; revision += 1) insertOperation(db, revision);
+}
+
+function insertLifecycle(
+  db: RawDb,
+  lifecycleId = "life-closeout",
+  revision = 1,
+  milestoneId = "M-CLOSEOUT",
+): void {
+  db.prepare(`
+    INSERT INTO workflow_item_lifecycles (
+      lifecycle_id, project_id, item_kind, milestone_id, lifecycle_status,
+      created_at, updated_at, last_operation_id, last_project_revision, last_authority_epoch
+    ) VALUES (?, ?, 'milestone', ?, 'in_progress', '', '', ?, ?, 0)
+  `).run(lifecycleId, projectId(db), milestoneId, `op-${revision}`, revision);
+}
+
+function insertSettledAttempt(
+  db: RawDb,
+  attemptId: string,
+  attemptNumber: number,
+  claimRevision: number,
+  settleRevision: number,
+  retryOf: string | null = null,
+): void {
+  db.prepare(`
+    INSERT INTO workflow_execution_attempts (
+      attempt_id, project_id, lifecycle_id, attempt_number, retry_of_attempt_id,
+      attempt_state, claimed_at, ended_at,
+      claim_operation_id, claim_project_revision, claim_authority_epoch,
+      settle_operation_id, settle_project_revision, settle_authority_epoch
+    ) VALUES (?, ?, 'life-closeout', ?, ?, 'settled', '', '', ?, ?, 0, ?, ?, 0)
+  `).run(
+    attemptId,
+    projectId(db),
+    attemptNumber,
+    retryOf,
+    `op-${claimRevision}`,
+    claimRevision,
+    `op-${settleRevision}`,
+    settleRevision,
+  );
+  db.prepare(`
+    INSERT INTO workflow_attempt_results (
+      result_id, project_id, lifecycle_id, attempt_id, outcome,
+      failure_class, summary, output_json, created_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES (?, ?, 'life-closeout', ?, 'succeeded', 'none',
+      'Attempt succeeded', '{}', '2026-07-12T00:00:00.000Z', ?, ?, 0)
+  `).run(
+    `result-${attemptId}`,
+    projectId(db),
+    attemptId,
+    `op-${settleRevision}`,
+    settleRevision,
+  );
+}
+
+function insertProjection(
+  db: RawDb,
+  input: {
+    id: string;
+    revision: number;
+    supersedes?: string | null;
+    key?: string;
+    state?: string;
+  },
+): void {
+  db.prepare(`
+    INSERT INTO workflow_projection_work (
+      projection_work_id, project_id, projection_key, projection_kind,
+      supersedes_projection_work_id, source_project_revision, source_authority_epoch,
+      renderer_version, delivery_state, state_version, attempt_count,
+      enqueue_operation_id, created_at, updated_at
+    ) VALUES (?, ?, ?, 'markdown', ?, ?, 0, 'v1', ?, 0, 0, ?,
+      '2026-07-12T00:00:00.000Z', '2026-07-12T00:00:00.000Z')
+  `).run(
+    input.id,
+    projectId(db),
+    input.key ?? "status/project",
+    input.supersedes ?? null,
+    input.revision,
+    input.state ?? "pending",
+    `op-${input.revision}`,
+  );
+}
+
+function insertKernelCheckpoint(
+  db: RawDb,
+  input: {
+    id: string;
+    sequence: number;
+    stage: string;
+    revision: number;
+    attemptId: string;
+    previous?: string | null;
+  },
+): void {
+  db.prepare(`
+    INSERT INTO workflow_kernel_checkpoints (
+      kernel_checkpoint_id, project_id, lifecycle_id, attempt_id,
+      next_stage, sequence, previous_kernel_checkpoint_id,
+      created_at, operation_id, project_revision, authority_epoch
+    ) VALUES (?, ?, 'life-closeout', ?, ?, ?, ?,
+      '2026-07-12T00:00:00.000Z', ?, ?, 0)
+  `).run(
+    input.id,
+    projectId(db),
+    input.attemptId,
+    input.stage,
+    input.sequence,
+    input.previous ?? null,
+    `op-${input.revision}`,
+    input.revision,
+  );
+}
+
+function insertCloseoutPlan(
+  db: RawDb,
+  input: {
+    id: string;
+    attemptId: string;
+    revision: number;
+    supersedes?: string | null;
+    sourceHash?: string;
+  },
+): void {
+  db.prepare(`
+    INSERT INTO workflow_closeout_plans (
+      closeout_plan_id, project_id, lifecycle_id, attempt_id,
+      tested_source_set_hash, readiness_basis_hash, supersedes_closeout_plan_id,
+      prepared_at, operation_id, project_revision, authority_epoch
+    ) VALUES (?, ?, 'life-closeout', ?, ?, ?, ?,
+      '2026-07-12T00:00:00.000Z', ?, ?, 0)
+  `).run(
+    input.id,
+    projectId(db),
+    input.attemptId,
+    input.sourceHash ?? sha256(input.id === "plan-1" ? "a" : "b"),
+    sha256(input.id === "plan-1" ? "c" : "d"),
+    input.supersedes ?? null,
+    `op-${input.revision}`,
+    input.revision,
+  );
+}
+
+function insertEffect(
+  db: RawDb,
+  input: {
+    id: string;
+    planId: string;
+    ordinal: number;
+    key: string;
+    revision: number;
+    specJson?: string;
+  },
+): void {
+  db.prepare(`
+    INSERT INTO workflow_closeout_effects (
+      closeout_effect_id, closeout_plan_id, project_id, lifecycle_id,
+      ordinal, effect_kind, idempotency_key, effect_spec_json, effect_spec_hash,
+      created_at, operation_id, project_revision, authority_epoch
+    ) VALUES (?, ?, ?, 'life-closeout', ?, 'source_commit', ?, ?, ?,
+      '2026-07-12T00:00:00.000Z', ?, ?, 0)
+  `).run(
+    input.id,
+    input.planId,
+    projectId(db),
+    input.ordinal,
+    input.key,
+    input.specJson ?? '{"kind":"source_commit"}',
+    sha256(input.id === "effect-1" ? "1" : "2"),
+    `op-${input.revision}`,
+    input.revision,
+  );
+}
+
+function insertReceipt(
+  db: RawDb,
+  input: {
+    id: string;
+    effectId: string;
+    outcome: string;
+    revision: number;
+    lifecycleId?: string;
+    proofJson?: string;
+  },
+): void {
+  db.prepare(`
+    INSERT INTO workflow_settlement_receipts (
+      settlement_receipt_id, closeout_effect_id, project_id, lifecycle_id,
+      outcome, external_ref, proof_json, proof_hash, settled_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES (
+      ?, ?, ?, ?, ?, ?, ?, ?, '2026-07-12T00:00:00.000Z', ?, ?, 0
+    )
+  `).run(
+    input.id,
+    input.effectId,
+    projectId(db),
+    input.lifecycleId ?? "life-closeout",
+    input.outcome,
+    `external-${input.id}`,
+    input.proofJson ?? '{"verified":true}',
+    sha256(input.id === "receipt-1" ? "3" : "4"),
+    `op-${input.revision}`,
+    input.revision,
+  );
+}
+
+function insertImportApplication(
+  db: RawDb,
+  input: {
+    revision: number;
+    previewId: string;
+    previewHash?: string;
+    previewJson?: string;
+  },
+): void {
+  const baseRevision = input.revision - 1;
+  db.prepare(`
+    INSERT INTO workflow_import_applications (
+      operation_id, project_id, import_kind, importer_version, preview_schema_version,
+      preview_id, preview_hash, base_project_revision, base_authority_epoch,
+      base_database_schema_version, source_set_hash, change_set_hash,
+      create_count, update_count, delete_count, preserve_count, unparsed_count, unresolved_count,
+      preview_json, backup_ref, backup_sha256, backup_byte_size, backup_schema_version,
+      backup_project_revision, backup_authority_epoch, backup_quick_check, backup_verified_at,
+      applied_at, resulting_project_revision, resulting_authority_epoch
+    ) VALUES (
+      ?, ?, 'markdown', 'v1', 1, ?, ?, ?, 0, 35, ?, ?,
+      1, 0, 0, 0, 0, 0, ?, 'backup.db', ?, 42, 35, ?, 0, 'ok',
+      '2026-07-12T00:00:00.000Z', '2026-07-12T00:00:01.000Z', ?, 0
+    )
+  `).run(
+    `op-${input.revision}`,
+    projectId(db),
+    input.previewId,
+    input.previewHash ?? sha256(String(input.revision)),
+    baseRevision,
+    sha256("b"),
+    sha256("c"),
+    input.previewJson ?? '{"sources":[],"changes":[]}',
+    sha256("d"),
+    baseRevision,
+    input.revision,
+  );
+}
+
+function reopenRaw(dbPath: string, db: RawDb): RawDb {
+  if (db.isOpen) db.close();
+  return openRawDatabase(dbPath);
+}
+
+function rewindToV34(t: TestContext, dbPath: string): void {
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+  const db = openRawDatabase(dbPath);
+  try {
+    seedHierarchy(db);
+    for (const table of [...V35_TABLES].reverse()) db.exec(`DROP TABLE IF EXISTS ${table}`);
+    db.exec(`
+      DELETE FROM schema_version;
+      INSERT INTO schema_version (version, applied_at)
+      VALUES (34, '2026-07-12T00:00:00.000Z');
+    `);
+  } finally {
+    db.close();
+  }
+  t.after(() => {
+    closeDatabase();
+    _setMigrationFaultForTest(false);
+  });
+}
+
+test("fresh v35 databases expose exactly the six projection and closeout tables and vocabularies", (t) => {
+  assert.equal(SCHEMA_VERSION, 35);
+  const { db } = openFreshFixture(t);
+  for (const table of V35_TABLES) assert.equal(tableExists(db, table), true, `${table} should exist`);
+
+  insertOperations(db, 5);
+  insertLifecycle(db);
+  insertSettledAttempt(db, "attempt-1", 1, 2, 3);
+  insertProjection(db, { id: "projection-1", revision: 4 });
+  insertKernelCheckpoint(db, {
+    id: "kernel-1", sequence: 1, stage: "execute", revision: 2, attemptId: "attempt-1",
+  });
+  assert.throws(() => insertCloseoutPlan(db, {
+    id: "bad-plan-hash", attemptId: "attempt-1", revision: 4, sourceHash: "not-a-digest",
+  }));
+  insertCloseoutPlan(db, { id: "plan-1", attemptId: "attempt-1", revision: 4 });
+  assert.throws(() => insertEffect(db, {
+    id: "bad-effect-json", planId: "plan-1", ordinal: 1,
+    key: "bad-spec", revision: 4, specJson: "[]",
+  }));
+  insertEffect(db, { id: "effect-1", planId: "plan-1", ordinal: 1, key: "commit", revision: 4 });
+  assert.throws(() => insertReceipt(db, {
+    id: "bad-proof-json", effectId: "effect-1", outcome: "performed",
+    revision: 5, proofJson: "{}",
+  }));
+
+  for (const state of ["failed", "superseded", "complete"]) {
+    assert.throws(() => insertProjection(db, { id: `bad-projection-${state}`, revision: 4, state }));
+  }
+  for (const stage of ["advance", "done", "failed"]) {
+    assert.throws(() => insertKernelCheckpoint(db, {
+      id: `bad-kernel-${stage}`, sequence: 2, stage, revision: 4,
+      attemptId: "attempt-1", previous: "kernel-1",
+    }));
+  }
+  for (const outcome of ["failed", "pending", "skipped"]) {
+    assert.throws(() => insertReceipt(db, {
+      id: `bad-receipt-${outcome}`, effectId: "effect-1", outcome, revision: 4,
+    }));
+  }
+});
+
+test("projection lineage and fenced delivery survive reopen without changing project revision", (t) => {
+  const { dbPath, db } = openFreshFixture(t);
+  insertOperations(db, 5);
+  const revisionBefore = db.prepare(
+    "SELECT revision FROM project_authority WHERE singleton = 1",
+  ).get()?.revision;
+  insertProjection(db, { id: "projection-1", revision: 1 });
+  db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'claimed', claim_owner = 'worker-1', claim_fencing_token = 1,
+        claimed_at = '2026-07-12T00:01:00.000Z', claim_expires_at = '2026-07-12T00:02:00.000Z',
+        state_version = 1, updated_at = '2026-07-12T00:01:00.000Z'
+    WHERE projection_work_id = 'projection-1';
+    UPDATE workflow_projection_work
+    SET delivery_state = 'pending', claim_owner = NULL,
+        claimed_at = NULL, claim_expires_at = NULL,
+        state_version = 2, attempt_count = 1,
+        next_attempt_at = '2026-07-12T00:03:00.000Z', last_error = 'disk full',
+        updated_at = '2026-07-12T00:02:00.000Z'
+    WHERE projection_work_id = 'projection-1';
+    UPDATE workflow_projection_work
+    SET delivery_state = 'claimed', claim_owner = 'worker-2', claim_fencing_token = 2,
+        claimed_at = '2026-07-12T00:04:00.000Z', claim_expires_at = '2026-07-12T00:05:00.000Z',
+        state_version = 3, updated_at = '2026-07-12T00:04:00.000Z'
+    WHERE projection_work_id = 'projection-1';
+    UPDATE workflow_projection_work
+    SET delivery_state = 'dead_letter', claim_owner = NULL,
+        claimed_at = NULL, claim_expires_at = NULL,
+        state_version = 4, attempt_count = 2, next_attempt_at = '',
+        last_error = 'permission denied', updated_at = '2026-07-12T00:05:00.000Z'
+    WHERE projection_work_id = 'projection-1';
+  `);
+  insertProjection(db, { id: "projection-2", revision: 2, supersedes: "projection-1" });
+  assert.throws(() => db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'claimed', claim_owner = 'invalid-worker', claim_fencing_token = 1,
+        claimed_at = '', claim_expires_at = '9999', state_version = 1,
+        updated_at = '2026-07-12T00:01:00.000Z'
+    WHERE projection_work_id = 'projection-2'
+  `));
+  assert.throws(() => db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'claimed', claim_owner = 'stale-worker', claim_fencing_token = 3,
+        claimed_at = '', claim_expires_at = '9999', state_version = 5
+    WHERE projection_work_id = 'projection-1'
+  `));
+  assert.throws(() => insertProjection(db, {
+    id: "projection-fork", revision: 3, supersedes: "projection-1",
+  }));
+  db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'claimed', claim_owner = 'worker-3', claim_fencing_token = 1,
+        claimed_at = '2026-07-12T00:06:00.000Z', claim_expires_at = '2026-07-12T00:07:00.000Z',
+        state_version = 1, updated_at = '2026-07-12T00:06:00.000Z'
+    WHERE projection_work_id = 'projection-2';
+  `);
+  assert.throws(() => db.exec(`
+    UPDATE workflow_projection_work
+    SET delivery_state = 'rendered', claim_owner = NULL,
+        claimed_at = NULL, claim_expires_at = NULL,
+        state_version = 2, attempt_count = 1,
+        rendered_content_hash = 'not-a-digest',
+        rendered_at = '2026-07-12T00:06:30.000Z',
+        updated_at = '2026-07-12T00:06:30.000Z'
+    WHERE projection_work_id = 'projection-2';
+  `));
+  assert.throws(() => db.exec(`
+    UPDATE workflow_projection_work
+    SET claim_owner = 'different-worker', claim_expires_at = '2026-07-12T00:08:00.000Z',
+        state_version = 2, updated_at = '2026-07-12T00:06:30.000Z'
+    WHERE projection_work_id = 'projection-2';
+  `));
+  db.exec(`
+    UPDATE workflow_projection_work
+    SET claim_expires_at = '2026-07-12T00:08:00.000Z',
+        state_version = 2, updated_at = '2026-07-12T00:06:30.000Z'
+    WHERE projection_work_id = 'projection-2';
+    UPDATE workflow_projection_work
+    SET delivery_state = 'rendered', claim_owner = NULL,
+        claimed_at = NULL, claim_expires_at = NULL,
+        state_version = 3, attempt_count = 1,
+        rendered_content_hash = '${sha256("e")}',
+        rendered_at = '2026-07-12T00:07:00.000Z',
+        updated_at = '2026-07-12T00:07:00.000Z'
+    WHERE projection_work_id = 'projection-2';
+  `);
+  insertProjection(db, { id: "unrelated", revision: 5, key: "status/other" });
+
+  const reopened = reopenRaw(dbPath, db);
+  t.after(() => { if (reopened.isOpen) reopened.close(); });
+  assert.deepEqual(
+    { ...reopened.prepare(`
+      SELECT projection_work_id, supersedes_projection_work_id, delivery_state,
+             state_version, attempt_count, claim_fencing_token, last_error
+      FROM workflow_projection_work WHERE projection_work_id = 'projection-1'
+    `).get() },
+    {
+      projection_work_id: "projection-1",
+      supersedes_projection_work_id: null,
+      delivery_state: "dead_letter",
+      state_version: 4,
+      attempt_count: 2,
+      claim_fencing_token: 2,
+      last_error: "permission denied",
+    },
+  );
+  assert.equal(reopened.prepare(
+    "SELECT revision FROM project_authority WHERE singleton = 1",
+  ).get()?.revision, revisionBefore);
+});
+
+test("import application receipt binds asserted operation and backup metadata and is immutable", (t) => {
+  const { db } = openFreshFixture(t);
+  insertOperation(db, 1, "import.apply");
+  insertImportApplication(db, { revision: 1, previewId: "preview-1" });
+  assert.throws(() => db.exec(
+    "UPDATE workflow_import_applications SET importer_version = 'v2' WHERE operation_id = 'op-1'",
+  ));
+  assert.throws(() => db.exec(
+    "DELETE FROM workflow_import_applications WHERE operation_id = 'op-1'",
+  ));
+
+  insertOperation(db, 2, "test");
+  assert.throws(() => insertImportApplication(db, { revision: 2, previewId: "preview-2" }));
+
+  insertOperation(db, 3, "import.apply");
+  assert.throws(() => insertImportApplication(db, {
+    revision: 3, previewId: "preview-bad-hash", previewHash: "not-a-digest",
+  }));
+  insertOperation(db, 4, "import.apply");
+  assert.throws(() => insertImportApplication(db, {
+    revision: 4, previewId: "preview-bad-json", previewJson: "[]",
+  }));
+});
+
+test("kernel checkpoint chain has one root and head and admits only v32 retry or reopen attempts", (t) => {
+  const { dbPath, db } = openFreshFixture(t);
+  insertOperations(db, 16);
+  insertLifecycle(db);
+  insertSettledAttempt(db, "attempt-1", 1, 2, 3);
+  insertSettledAttempt(db, "attempt-2", 2, 6, 7, "attempt-1");
+  insertSettledAttempt(db, "attempt-3", 3, 11, 12, "attempt-2");
+  insertSettledAttempt(db, "attempt-4", 4, 13, 14, "attempt-3");
+  insertKernelCheckpoint(db, {
+    id: "kernel-1", sequence: 1, stage: "execute", revision: 2, attemptId: "attempt-1",
+  });
+  insertKernelCheckpoint(db, {
+    id: "kernel-2", sequence: 2, stage: "verify", revision: 4,
+    attemptId: "attempt-1", previous: "kernel-1",
+  });
+  insertKernelCheckpoint(db, {
+    id: "kernel-3", sequence: 3, stage: "execute", revision: 6,
+    attemptId: "attempt-2", previous: "kernel-2",
+  });
+  insertKernelCheckpoint(db, {
+    id: "kernel-4", sequence: 4, stage: "settled", revision: 9,
+    attemptId: "attempt-2", previous: "kernel-3",
+  });
+  insertKernelCheckpoint(db, {
+    id: "kernel-5", sequence: 5, stage: "execute", revision: 11,
+    attemptId: "attempt-3", previous: "kernel-4",
+  });
+  assert.throws(() => insertKernelCheckpoint(db, {
+    id: "wrong-claim-operation", sequence: 6, stage: "execute", revision: 15,
+    attemptId: "attempt-4", previous: "kernel-5",
+  }));
+  assert.throws(() => insertKernelCheckpoint(db, {
+    id: "second-root", sequence: 1, stage: "execute", revision: 14, attemptId: "attempt-3",
+  }));
+  assert.throws(() => insertKernelCheckpoint(db, {
+    id: "fork", sequence: 3, stage: "route", revision: 10,
+    attemptId: "attempt-1", previous: "kernel-2",
+  }));
+
+  const reopened = reopenRaw(dbPath, db);
+  t.after(() => { if (reopened.isOpen) reopened.close(); });
+  assert.deepEqual({ ...reopened.prepare(`
+    SELECT kernel_checkpoint_id, sequence, next_stage, attempt_id
+    FROM workflow_kernel_checkpoints
+    WHERE lifecycle_id = 'life-closeout'
+      AND NOT EXISTS (
+        SELECT 1 FROM workflow_kernel_checkpoints successor
+        WHERE successor.previous_kernel_checkpoint_id = workflow_kernel_checkpoints.kernel_checkpoint_id
+      )
+  `).get() }, {
+    kernel_checkpoint_id: "kernel-5", sequence: 5, next_stage: "execute", attempt_id: "attempt-3",
+  });
+  assert.throws(() => reopened.exec(
+    "UPDATE workflow_kernel_checkpoints SET next_stage = 'verify' WHERE kernel_checkpoint_id = 'kernel-5'",
+  ));
+  assert.throws(() => reopened.exec(
+    "DELETE FROM workflow_kernel_checkpoints WHERE kernel_checkpoint_id = 'kernel-5'",
+  ));
+});
+
+test("closeout effects share plan provenance and idempotency is scoped per plan", (t) => {
+  const { db } = openFreshFixture(t);
+  insertOperations(db, 10);
+  insertLifecycle(db);
+  insertLifecycle(db, "life-other", 1, "M-OTHER");
+  insertSettledAttempt(db, "attempt-1", 1, 2, 3);
+  insertSettledAttempt(db, "attempt-2", 2, 6, 7, "attempt-1");
+  insertCloseoutPlan(db, { id: "plan-1", attemptId: "attempt-1", revision: 4 });
+  insertEffect(db, { id: "effect-1", planId: "plan-1", ordinal: 1, key: "commit", revision: 4 });
+  assert.throws(() => db.prepare(`
+    INSERT INTO workflow_closeout_effects (
+      closeout_effect_id, closeout_plan_id, project_id, lifecycle_id,
+      ordinal, effect_kind, idempotency_key, effect_spec_json, effect_spec_hash,
+      created_at, operation_id, project_revision, authority_epoch
+    ) VALUES ('wrong-scope', 'plan-1', ?, 'life-other', 2, 'merge', 'merge', '{}',
+      'spec-wrong-scope', '', 'op-4', 4, 0)
+  `).run(projectId(db)));
+  assert.throws(() => insertEffect(db, {
+    id: "wrong-operation", planId: "plan-1", ordinal: 2, key: "merge", revision: 5,
+  }));
+  assert.throws(() => insertEffect(db, {
+    id: "duplicate-key", planId: "plan-1", ordinal: 2, key: "commit", revision: 4,
+  }));
+  insertReceipt(db, {
+    id: "receipt-before-late-effect", effectId: "effect-1", outcome: "performed", revision: 5,
+  });
+  assert.throws(() => insertEffect(db, {
+    id: "late-after-receipt", planId: "plan-1", ordinal: 2, key: "merge", revision: 4,
+  }));
+  insertCloseoutPlan(db, {
+    id: "plan-2", attemptId: "attempt-2", revision: 8, supersedes: "plan-1",
+  });
+  insertEffect(db, { id: "effect-2", planId: "plan-2", ordinal: 1, key: "commit", revision: 8 });
+  assert.throws(() => insertEffect(db, {
+    id: "late-old-effect", planId: "plan-1", ordinal: 2, key: "publish", revision: 4,
+  }));
+  assert.throws(() => db.exec(
+    "UPDATE workflow_closeout_plans SET readiness_basis_hash = 'changed' WHERE closeout_plan_id = 'plan-2'",
+  ));
+  assert.throws(() => db.exec(
+    "DELETE FROM workflow_closeout_effects WHERE closeout_effect_id = 'effect-2'",
+  ));
+});
+
+test("settlement receipts are ordered, immutable, and reject superseded plans", (t) => {
+  const { dbPath, db } = openFreshFixture(t);
+  insertOperations(db, 12);
+  insertLifecycle(db);
+  insertLifecycle(db, "life-other", 1, "M-OTHER");
+  insertSettledAttempt(db, "attempt-1", 1, 2, 3);
+  insertSettledAttempt(db, "attempt-2", 2, 9, 10, "attempt-1");
+  insertCloseoutPlan(db, { id: "plan-1", attemptId: "attempt-1", revision: 4 });
+  insertEffect(db, { id: "effect-1", planId: "plan-1", ordinal: 1, key: "commit", revision: 4 });
+  insertEffect(db, { id: "effect-2", planId: "plan-1", ordinal: 2, key: "merge", revision: 4 });
+  insertEffect(db, { id: "effect-3", planId: "plan-1", ordinal: 3, key: "publish", revision: 4 });
+  assert.throws(() => insertReceipt(db, {
+    id: "wrong-scope", effectId: "effect-1", outcome: "performed", revision: 5,
+    lifecycleId: "life-other",
+  }));
+  assert.throws(() => insertReceipt(db, {
+    id: "receipt-2-early", effectId: "effect-2", outcome: "performed", revision: 5,
+  }));
+  insertReceipt(db, { id: "receipt-1", effectId: "effect-1", outcome: "performed", revision: 5 });
+  insertReceipt(db, { id: "receipt-2", effectId: "effect-2", outcome: "recognized", revision: 6 });
+  assert.throws(() => db.exec(
+    "UPDATE workflow_settlement_receipts SET proof_hash = 'changed' WHERE settlement_receipt_id = 'receipt-1'",
+  ));
+  assert.throws(() => db.exec(
+    "DELETE FROM workflow_settlement_receipts WHERE settlement_receipt_id = 'receipt-1'",
+  ));
+
+  insertCloseoutPlan(db, {
+    id: "plan-2", attemptId: "attempt-2", revision: 11, supersedes: "plan-1",
+  });
+  insertEffect(db, { id: "effect-4", planId: "plan-2", ordinal: 1, key: "publish", revision: 11 });
+  assert.throws(() => insertReceipt(db, {
+    id: "late-old-receipt", effectId: "effect-3", outcome: "recognized", revision: 12,
+  }));
+
+  const reopened = reopenRaw(dbPath, db);
+  t.after(() => { if (reopened.isOpen) reopened.close(); });
+  assert.equal(reopened.prepare(`
+    SELECT MIN(effect.ordinal) AS ordinal
+    FROM workflow_closeout_effects effect
+    LEFT JOIN workflow_settlement_receipts receipt
+      ON receipt.closeout_effect_id = effect.closeout_effect_id
+    WHERE effect.closeout_plan_id = 'plan-2' AND receipt.settlement_receipt_id IS NULL
+  `).get()?.ordinal, 1);
+});
+
+test("v34 upgrade backs up, rolls back a fault, and retries v35 without losing legacy rows", (t) => {
+  assert.equal(SCHEMA_VERSION, 35);
+  const dbPath = createDatabasePath(t);
+  rewindToV34(t, dbPath);
+  const before = openRawDatabase(dbPath);
+  before.exec(`
+    INSERT OR IGNORE INTO decisions (
+      id, when_context, scope, decision, choice, rationale, revisable, made_by, source
+    ) VALUES ('D-V34', 'upgrade', 'project', 'Preserve me', 'yes', 'legacy row', 'yes', 'user', 'discussion')
+  `);
+  before.close();
+
+  _setMigrationFaultForTest(true);
+  assert.throws(() => openDatabase(dbPath), /migration fault/i);
+  closeDatabase();
+  _setMigrationFaultForTest(false);
+
+  const backupPath = `${dbPath}.backup-v34`;
+  const faultBackup = openRawDatabase(backupPath);
+  assert.equal(maxSchemaVersion(faultBackup), 34);
+  for (const table of V35_TABLES) assert.equal(tableExists(faultBackup, table), false);
+  assert.equal(faultBackup.prepare("SELECT choice FROM decisions WHERE id = 'D-V34'").get()?.choice, "yes");
+  assert.equal(faultBackup.prepare("PRAGMA quick_check").get()?.quick_check, "ok");
+  faultBackup.close();
+
+  const rolledBack = openRawDatabase(dbPath);
+  assert.equal(maxSchemaVersion(rolledBack), 34);
+  for (const table of V35_TABLES) assert.equal(tableExists(rolledBack, table), false);
+  assert.equal(rolledBack.prepare("SELECT choice FROM decisions WHERE id = 'D-V34'").get()?.choice, "yes");
+  assert.equal(rolledBack.prepare("PRAGMA quick_check").get()?.quick_check, "ok");
+  rolledBack.close();
+
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+  const upgraded = openRawDatabase(dbPath);
+  t.after(() => { if (upgraded.isOpen) upgraded.close(); });
+  assert.equal(maxSchemaVersion(upgraded), 35);
+  for (const table of V35_TABLES) {
+    assert.equal(tableExists(upgraded, table), true);
+    assert.equal(upgraded.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()?.count, 0);
+  }
+  assert.equal(upgraded.prepare("SELECT choice FROM decisions WHERE id = 'D-V34'").get()?.choice, "yes");
+  assert.equal(upgraded.prepare("PRAGMA quick_check").get()?.quick_check, "ok");
+  upgraded.close();
+
+  const restoredPath = join(dirname(dbPath), "restored-backup.db");
+  copyFileSync(backupPath, restoredPath);
+  assert.equal(openDatabase(restoredPath), true);
+  closeDatabase();
+  const restored = openRawDatabase(restoredPath);
+  t.after(() => { if (restored.isOpen) restored.close(); });
+  assert.equal(maxSchemaVersion(restored), 35);
+  for (const table of V35_TABLES) {
+    assert.equal(tableExists(restored, table), true);
+    assert.equal(restored.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()?.count, 0);
+  }
+  assert.equal(restored.prepare("SELECT choice FROM decisions WHERE id = 'D-V34'").get()?.choice, "yes");
+  assert.equal(restored.prepare("PRAGMA quick_check").get()?.quick_check, "ok");
+});

--- a/src/resources/extensions/gsd/tests/db-recovery-evidence-foundation.test.ts
+++ b/src/resources/extensions/gsd/tests/db-recovery-evidence-foundation.test.ts
@@ -27,6 +27,14 @@ const V34_TABLES = [
   "workflow_human_acceptances",
   "workflow_remediation_links",
 ] as const;
+const V35_TABLES = [
+  "workflow_projection_work",
+  "workflow_import_applications",
+  "workflow_kernel_checkpoints",
+  "workflow_closeout_plans",
+  "workflow_closeout_effects",
+  "workflow_settlement_receipts",
+] as const;
 const V34_PARENT_INDEXES = [
   "idx_workflow_attempt_scope_v34",
   "idx_workflow_result_scope_v34",
@@ -322,6 +330,7 @@ function rewindToV33(dbPath: string): void {
   const db = openRawDatabase(dbPath);
   try {
     seedLegacyRows(db);
+    for (const table of [...V35_TABLES].reverse()) db.exec(`DROP TABLE IF EXISTS ${table}`);
     for (const table of [...V34_TABLES].reverse()) db.exec(`DROP TABLE IF EXISTS ${table}`);
     for (const index of V34_PARENT_INDEXES) db.exec(`DROP INDEX IF EXISTS ${index}`);
     db.exec(`
@@ -342,7 +351,7 @@ afterEach(() => {
 });
 
 test("fresh v34 databases expose exactly the recovery and evidence tables and vocabularies", (t) => {
-  assert.equal(SCHEMA_VERSION, 34);
+  assert.ok(SCHEMA_VERSION >= 34);
   const { db } = openFreshFixture();
   t.after(() => {
     if (db.isOpen) db.close();
@@ -1164,7 +1173,7 @@ test("v33 upgrade is additive, backed up, and leaves v34 tables empty", (t) => {
     if (upgraded.isOpen) upgraded.close();
   });
   {
-    assert.equal(maxSchemaVersion(upgraded), 34);
+    assert.equal(maxSchemaVersion(upgraded), SCHEMA_VERSION);
     assert.equal(upgraded.prepare("SELECT decision FROM decisions WHERE id = 'D-LEGACY'").get()?.decision, "Preserve legacy meaning");
     for (const table of V34_TABLES) {
       assert.equal(upgraded.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()?.count, 0);
@@ -1196,7 +1205,7 @@ test("v33 upgrade is additive, backed up, and leaves v34 tables empty", (t) => {
     if (restored.isOpen) restored.close();
   });
   {
-    assert.equal(maxSchemaVersion(restored), 34);
+    assert.equal(maxSchemaVersion(restored), SCHEMA_VERSION);
     for (const table of V34_TABLES) {
       assert.equal(restored.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()?.count, 0);
     }
@@ -1238,7 +1247,7 @@ test("faulted v33 migration rolls back every v34 table and retries cleanly", (t)
     if (retried.isOpen) retried.close();
   });
   {
-    assert.equal(maxSchemaVersion(retried), 34);
+    assert.equal(maxSchemaVersion(retried), SCHEMA_VERSION);
     for (const table of V34_TABLES) assert.equal(tableExists(retried, table), true);
     for (const index of V34_PARENT_INDEXES) assert.equal(indexExists(retried, index), true);
   }

--- a/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
+++ b/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
@@ -54,6 +54,7 @@ const SCHEMA_DB_WRITER_FILES = new Set([
   "db-canonical-foundation-schema.ts",
   "db-conversation-foundation-schema.ts",
   "db-lifecycle-foundation-schema.ts",
+  "db-projection-import-kernel-closeout-foundation-schema.ts",
   "db-recovery-evidence-foundation-schema.ts",
   "db-memory-fts-schema.ts",
   "db-schema-metadata.ts",


### PR DESCRIPTION
## Intent

Refactor gsd-pi toward database authority with Markdown as projection only. For M002 S05, add the additive v35 projection/import/kernel/closeout schema foundation after research: durable per-logical-key projection work whose delivery mutations do not advance domain revision; one immutable import application receipt binding preview and verified backup metadata to import.apply; restart-safe kernel checkpoint chains where absence means Advance and the first persisted Execute checkpoint shares the Attempt claim operation; immutable closeout plan lineages with same-operation ordered effects; and success-only ordered settlement receipts. Enforce local shape, provenance, fencing, immutability, causality, strict SHA-256/JSON proof formats, migration backup/rollback/restore, and preserve v31-v34 data. Deliberately defer writers, adapters, atomic sibling bundles, prerequisite routing, runtime cutover, and final lifecycle completion to S06. Keep the implementation simple, additive, and fully documented/tested.

## What Changed

- Add the additive GSD v35 migration with durable projection work, import application receipts, kernel checkpoints, closeout plans and effects, and settlement receipts.
- Enforce lineage, provenance, fencing, retry, immutability, ordering, and schema-level validation constraints across the new records.
- Document the v35 authority boundaries and add focused coverage for fresh databases, upgrades, rollback/retry recovery, and legacy-data preservation.

## Risk Assessment

🚨 High: The change should not merge without confirming and enforcing the trust boundary for immutable import and settlement proofs, because currently stored hashes and envelope counts can authenticate unrelated content.

## Testing

Preflight confirmed the requested target was not contained in `origin/main`; focused v35 and predecessor v34 database suites exercised schema shape, migration backup/rollback/restore, preserved legacy data, projection fencing and revision neutrality, sealed imports, kernel chains, immutable closeout lineages, and ordered settlement, while a reopened SQLite artifact demonstrated persisted projection behavior and rejected stale mutation; a sabotage check proved the digest assertion is sensitive, cleanup left the worktree clean, and no screenshot was captured because S05 is deliberately schema-only with runtime/UI surfaces deferred to S06.

<details>
<summary>Evidence: v35 end-to-end evidence</summary>

`Schema v35, quick_check ok, all six foundation tables present, projection persisted across reopen after two fenced attempts, domain revision unchanged, and stale mutation rejected.`

```text
{
  "schemaVersion": 35,
  "quickCheck": "ok",
  "v35Tables": [
    "workflow_closeout_effects",
    "workflow_closeout_plans",
    "workflow_import_applications",
    "workflow_kernel_checkpoints",
    "workflow_projection_work",
    "workflow_settlement_receipts"
  ],
  "projectionAfterReopen": {
    "projection_work_id": "projection-evidence",
    "delivery_state": "rendered",
    "state_version": 4,
    "attempt_count": 2,
    "claim_fencing_token": 2,
    "next_attempt_at": "2026-07-12T00:03:00.000Z",
    "last_error": "disk full",
    "rendered_content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
  },
  "domainRevision": {
    "beforeDelivery": 0,
    "afterDelivery": 0,
    "unchanged": true
  },
  "staleMutationRejected": true,
  "staleMutationError": "invalid projection delivery transition"
}
```
</details>
- Evidence: Persisted SQLite evidence database (local file: <code>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXAZNEQASAHMBPEM8X3YDG2R/v35-end-to-end.db</code>)
<details>
<summary>Evidence: Evidence reproduction script</summary>

```text
import { writeFileSync } from "node:fs";
import { createRequire } from "node:module";

import {
  closeDatabase,
  openDatabase,
} from "/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KXAZNEQASAHMBPEM8X3YDG2R/src/resources/extensions/gsd/gsd-db.ts";

const evidenceDir = "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXAZNEQASAHMBPEM8X3YDG2R";
const dbPath = `${evidenceDir}/v35-end-to-end.db`;
const outputPath = `${evidenceDir}/v35-end-to-end.json`;
const require = createRequire(import.meta.url);
const { DatabaseSync } = require("node:sqlite");
const digest = (character) => `sha256:${character.repeat(64)}`;

openDatabase(dbPath);
closeDatabase();

let db = new DatabaseSync(dbPath);
db.exec("PRAGMA foreign_keys = ON");
const projectId = db.prepare(
  "SELECT project_id FROM project_authority WHERE singleton = 1",
).get().project_id;

db.prepare(`
  INSERT INTO workflow_operations (
    operation_id, project_id, operation_type, idempotency_key,
    expected_revision, resulting_revision,
    expected_authority_epoch, resulting_authority_epoch,
    actor_type, actor_id, source_transport, request_hash, created_at
  ) VALUES ('op-projection', ?, 'projection.enqueue', 'projection-key',
    0, 1, 0, 0, 'system', 'evidence', 'test', 'projection-request',
    '2026-07-12T00:00:00.000Z')
`).run(projectId);
db.prepare(`
  INSERT INTO workflow_projection_work (
    projection_work_id, project_id, projection_key, projection_kind,
    source_project_revision, source_authority_epoch, renderer_version,
    enqueue_operation_id, created_at, updated_at
  ) VALUES ('projection-evidence', ?, 'status/m002', 'status', 1, 0, 'v1',
    'op-projection', '2026-07-12T00:00:00.000Z', '2026-07-12T00:00:00.000Z')
`).run(projectId);
const revisionBeforeDelivery = db.prepare(
  "SELECT revision FROM project_authority WHERE singleton = 1",
).get().revision;
db.exec(`
  UPDATE workflow_projection_work
  SET delivery_state = 'claimed', claim_owner = 'renderer-1', claim_fencing_token = 1,
      claimed_at = '2026-07-12T00:01:00.000Z', claim_expires_at = '2026-07-12T00:02:00.000Z',
      state_version = 1, updated_at = '2026-07-12T00:01:00.000Z'
  WHERE projection_work_id = 'projection-evidence';
  UPDATE workflow_projection_work
  SET delivery_state = 'pending', claim_owner = NULL, claimed_at = NULL, claim_expires_at = NULL,
      attempt_count = 1, next_attempt_at = '2026-07-12T00:03:00.000Z',
      last_error = 'disk full', state_version = 2,
      updated_at = '2026-07-12T00:02:00.000Z'
  WHERE projection_work_id = 'projection-evidence';
  UPDATE workflow_projection_work
  SET delivery_state = 'claimed', claim_owner = 'renderer-2', claim_fencing_token = 2,
      claimed_at = '2026-07-12T00:03:00.000Z', claim_expires_at = '2026-07-12T00:04:00.000Z',
      state_version = 3, updated_at = '2026-07-12T00:03:00.000Z'
  WHERE projection_work_id = 'projection-evidence';
  UPDATE workflow_projection_work
  SET delivery_state = 'rendered', claim_owner = NULL, claimed_at = NULL, claim_expires_at = NULL,
      attempt_count = 2, rendered_content_hash = '${digest("a")}',
      rendered_at = '2026-07-12T00:04:00.000Z', state_version = 4,
      updated_at = '2026-07-12T00:04:00.000Z'
  WHERE projection_work_id = 'projection-evidence';
`);
db.close();

db = new DatabaseSync(dbPath);
db.exec("PRAGMA foreign_keys = ON");
const v35Tables = db.prepare(`
  SELECT name FROM sqlite_master
  WHERE type = 'table' AND name IN (
    'workflow_projection_work', 'workflow_import_applications',
    'workflow_kernel_checkpoints', 'workflow_closeout_plans',
    'workflow_closeout_effects', 'workflow_settlement_receipts'
  ) ORDER BY name
`).all().map(({ name }) => name);
const projectionAfterReopen = db.prepare(`
  SELECT projection_work_id, delivery_state, state_version, attempt_count,
         claim_fencing_token, next_attempt_at, last_error, rendered_content_hash
  FROM workflow_projection_work WHERE projection_work_id = 'projection-evidence'
`).get();
const revisionAfterDelivery = db.prepare(
  "SELECT revision FROM project_authority WHERE singleton = 1",
).get().revision;
let staleMutationRejected = false;
let staleMutationError = "";
try {
  db.exec(`
    UPDATE workflow_projection_work
    SET delivery_state = 'claimed', claim_owner = 'stale-renderer',
        claim_fencing_token = 1, claimed_at = '2026-07-12T00:05:00.000Z',
        claim_expires_at = '2026-07-12T00:06:00.000Z', state_version = 5,
        rendered_content_hash = NULL, rendered_at = NULL,
        updated_at = '2026-07-12T00:05:00.000Z'
    WHERE projection_work_id = 'projection-evidence'
  `);
} catch (error) {
  staleMutationRejected = true;
  staleMutationError = String(error.message);
}
const evidence = {
  schemaVersion: db.prepare("SELECT MAX(version) AS version FROM schema_version").get().version,
  quickCheck: db.prepare("PRAGMA quick_check").get().quick_check,
  v35Tables,
  projectionAfterReopen,
  domainRevision: {
    beforeDelivery: revisionBeforeDelivery,
    afterDelivery: revisionAfterDelivery,
    unchanged: revisionBeforeDelivery === revisionAfterDelivery,
  },
  staleMutationRejected,
  staleMutationError,
};
db.close();
writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
console.log(JSON.stringify(evidence, null, 2));
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 4 issues (2 errors, 2 warnings)</summary>

- 🚨 `src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts:45` - SQLite accepts CHECK expressions that evaluate to NULL. Because `claim_owner` and `rendered_content_hash` are nullable, a claimed row can omit its owner and a rendered row can omit its content hash. Add explicit `IS NOT NULL` predicates for both fields so malformed claim/render transitions are rejected.
- 🚨 `src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts:188` - Import receipts do not actually seal the approved preview: the schema only verifies that hashes look like SHA-256 strings and that `preview_json` is a nonempty object. Arbitrary counts, JSON, and unrelated valid-looking hashes can therefore be combined despite the specification requiring raw count/hash mismatches to fail. Choose and enforce an authentication boundary, such as schema-visible envelope fields plus hash verification or a trusted sealing mechanism.
- ⚠️ `src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts:163` - The `claimed -&gt; pending` retry transition only increments `attempt_count`; it accepts an empty `last_error` and `next_attempt_at`, and the following claim may rewrite both. Require a nonempty error and valid backoff timestamp on retry, then preserve them while claiming, so failures remain diagnosable and cannot create an immediate retry loop.

🔧 Fix: Seal import receipts and harden projection retries
4 issues (2 errors, 2 warnings) still open:
- 🚨 `src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts:244` - The sealed import envelope only repeats scalar counts/hashes inside JSON; it never validates them against the actual arrays. The current happy-path fixture even accepts `create_count = 1` with `changes: []`, so exact changes or unparsed material can disappear behind matching outer counters. Choose a trusted envelope verifier or enforce the array/count semantics before treating the receipt as authoritative.
- 🚨 `src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts:604` - Authoritative effect and settlement records do not bind their SHA-256 fields to the stored canonical JSON. An immutable receipt can therefore pair `proof_json` with a syntactically valid hash of unrelated bytes. Establish a trusted canonicalization/hash-verification boundary for preview, effect-spec, and proof JSON.
- ⚠️ `src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts:167` - The retry transition preserves `next_attempt_at`, but pending-to-claimed never checks that the backoff is due. A retry can be reclaimed immediately with `claimed_at` earlier than `next_attempt_at`; require retried claims to occur at or after the preserved backoff.
- ⚠️ `src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts:414` - The rewind helper drops V35 tables but leaves `trg_workflow_import_operation_update`, which is attached to `workflow_operations`. The simulated V34 database and its backup therefore retain a dangling V35 schema object. Explicitly drop this trigger here and in the V33 rewind helper.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short --branch`, `git log -1 --oneline --decorate`, and `git diff --name-status 25d44cc5..3b3b65b8`</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts src/resources/extensions/gsd/tests/db-recovery-evidence-foundation.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXAZNEQASAHMBPEM8X3YDG2R/v35-evidence.mjs`
- <code>Sensitivity check: temporarily removed strict rendered SHA-256 validation, then ran `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern=&#39;projection lineage and fenced delivery&#39; src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts`; it failed with `Missing expected exception` at the invalid-digest assertion</code>
- `Restored the SHA-256 constraint and reran the same focused selector successfully`
- <code>`git status --short` confirmed the temporary sabotage was fully restored and testing left no worktree changes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large additive DDL on authority-adjacent tables (import receipts, settlement proofs, projection delivery); schema validates hash shape and envelope consistency but does not recompute SHA-256 or fully seal preview arrays—incorrect trust boundaries could admit mismatched sealed content until S06 writers enforce canonical hashing.
> 
> **Overview**
> Adds **GSD schema V35** as an additive foundation only: six new tables, migration wiring, documentation, research notes, and contract tests. Runtime writers, adapters, and lifecycle cutover stay deferred to S06.
> 
> **`db-projection-import-kernel-closeout-foundation-schema.ts`** defines durable **`workflow_projection_work`** (per-key lineage, fenced claim/retry/render without advancing `project_authority.revision`), immutable **`workflow_import_applications`** (sealed preview + verified backup bound to `import.apply` operations), append-only **`workflow_kernel_checkpoints`** (Advance = no row; first Execute shares Attempt claim), and closeout **`workflow_closeout_plans`**, **`workflow_closeout_effects`**, and **`workflow_settlement_receipts`** with triggers enforcing lineage, immutability, ordering, and provenance against V31–V34 tables.
> 
> **`db/engine.ts`** bumps **`SCHEMA_VERSION` to 35**, runs V35 on fresh installs and `currentVersion < 35` upgrades, and registers the new schema helper in the single-writer allowlist (`single-writer-invariant.test.ts`, `docs/db-map.md`, `docs/prompt-db-combined-map.md`).
> 
> **`db-projection-closeout-foundation.test.ts`** exercises vocabulary, projection fencing/reopen, import receipt immutability, kernel chains, closeout/settlement ordering, and V34→V35 backup/rollback/retry with legacy row preservation; **`db-recovery-evidence-foundation.test.ts`** is updated so rewind fixtures drop V35 objects and assert migrations land on the current schema version.
> 
> **`plans/041-m002-s05-projection-import-kernel-closeout-research.md`** records the six-table contract and explicit S05/S06 boundary (no partial runtime cutover).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f791df604bba847e9f08a83b9114fe64585ccd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->