### PR TITLE
feat(gsd): add atomic domain operation boundary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ Design documents, ADRs, and internal references. Located in [`dev/`](./dev/).
 | [ADR-008: Implementation Plan](./dev/ADR-008-IMPLEMENTATION-PLAN.md) | Implementation plan for ADR-008 |
 | [ADR-046: Database-Authoritative Workflow Lifecycle](./dev/ADR-046-database-authoritative-workflow-lifecycle.md) | Accepted database-authoritative lifecycle and migration contract |
 | [RFC: Database-Authoritative Workflow Refactor](./dev/proposals/rfc-database-authoritative-workflow-refactor.md) | Accepted implementation direction, gates, and milestone program |
+| [Domain Operation Runbook](./dev/refactor-foundation-runbook.md) | Revision-checked transaction boundary, focused tests, and no-cutover guardrails |
 | [Context Optimization Opportunities](./dev/pi-context-optimization-opportunities.md) | Analysis of context window usage and optimization strategies |
 | [File System Map](./dev/FILE-SYSTEM-MAP.md) | Complete file system reference |
 | [CI/CD Pipeline](./dev/ci-cd-pipeline.md) | Continuous integration and deployment pipeline |

--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -21,6 +21,8 @@ tools/workflow-tool-executors.ts  ← business logic
 gsd-db.ts  ← compatibility barrel over the explicit single-writer allowlist
        │
        ├── db/engine.ts     ← connection/handle, schema/migrations, transaction primitives
+       ├── db/domain-operation.ts
+       │                    ← revision-checked authoritative transaction boundary
        ├── db/writers/*.ts  ← the Single Writer Layer (one write subsystem per file)
        ├── db/{milestone-leases,unit-dispatches,auto-workers,runtime-kv,command-queue}.ts
        │                    ← typed coordination/runtime writers
@@ -679,10 +681,11 @@ Non-correctness-critical state: UI cursors, dashboard caches, resume pointers. S
 
 ### 3e. Additive Canonical Foundation (V31)
 
-V31 creates these tables on fresh databases and transactionally upgrades V30
-databases. It is schema-only in this release: existing runtime read/write paths
-are not routed through these tables yet, and no import, projection worker,
-lifecycle API, or legacy deletion ships with this migration.
+V31 created these tables on fresh databases and transactionally upgraded V30
+databases. The current v35 codebase also exposes an additive Domain Operation
+transaction over them, but existing production handlers and runtime authority
+are not routed through that boundary yet. No import application, projection
+worker, lifecycle API, or legacy deletion ships with it.
 
 #### `project_authority`
 ```
@@ -762,6 +765,10 @@ last_error       TEXT DEFAULT NULL
 FOREIGN KEY event_id → workflow_domain_events(event_id)
 ```
 - `(event_id, destination)` is unique.
+- Inserts whose generated identity exceeds JavaScript's maximum safe integer
+  abort with `outbox identity exceeds safe integer range`.
+- Delete attempts abort with `outbox rows are durable history`; delivery fields
+  remain operationally mutable.
 - Index: `idx_workflow_outbox_pending` (delivered_at, available_at, outbox_id)
 
 These four tables are deliberately distinct from existing narrower concepts:
@@ -769,6 +776,33 @@ These four tables are deliberately distinct from existing narrower concepts:
 `milestone_commit_attributions` remains Git-specific attribution, and
 `command_queue`/`runtime_kv` remain coordination/cache surfaces rather than
 operation provenance, domain history, or an outbox.
+
+#### Domain Operation boundary
+
+`executeDomainOperation(request, mutate)` is exported through `gsd-db.ts`. A
+fresh request must provide an operation type, project-scoped idempotency key,
+expected revision and Authority Epoch, actor and transport provenance, and a
+JSON-compatible semantic payload. The callback receives a frozen context and
+must return at least one ordered event with an outbox destination plus at least
+one normalized Projection Work target. It may compose deterministic typed
+database writers, but filesystem, network, routing, retry, and swallowed-error
+behavior are outside the transaction boundary.
+
+One `BEGIN IMMEDIATE` transaction records the operation, mutation rows, ordered
+events, outbox destinations, per-key Projection Work successor rows, and the
+authority compare-and-swap. Exact retries return the original `replayed`
+receipt without invoking `mutate`; a changed request under the same key raises
+`GSD_IDEMPOTENCY_CONFLICT`. Stale revision, stale epoch, authority-CAS failure,
+or writer contention raises `GSD_REVISION_CONFLICT`. The receipt contains the
+operation/project identity, resulting revision and epoch, canonical `sha256:`
+request hash, and ordered event, outbox, and projection-work identities.
+
+The boundary requires safe non-negative revision/epoch integers, canonical
+finite JSON numbers, unique destinations per event, backward-only event causal
+links, lowercase normalized projection keys/kinds, unique projection keys, and
+at most 10,000 projection targets. It must own the outer transaction. Production
+command adapters, projection delivery, import, closeout, lifecycle policy, and
+runtime authority cutover remain deferred.
 
 ---
 
@@ -1433,11 +1467,12 @@ guarantee that every Failure Observation has a Recovery Action or that every
 Technical Verdict has its Evidence: SQLite immediate insert constraints cannot
 safely enforce those circular bundle-completeness rules.
 
-S06 Domain Operations must atomically commit each failure/action bundle, each
-verdict/evidence bundle, and any applicable remediation links. Kernel queries
-must require bundle completeness before dispatch or closeout. Runtime
-readers/writers, UAT, recovery policy, legacy projections, and lifecycle
-completion do not cut over in V34.
+Later command-specific writers must use the S06 Domain Operation boundary to
+atomically commit each failure/action bundle, each verdict/evidence bundle, and
+any applicable remediation links. Kernel queries must require bundle
+completeness before dispatch or closeout. Runtime readers/writers, UAT,
+recovery policy, legacy projections, and lifecycle completion do not cut over
+in V34.
 
 ### 3i. Additive Projection, Import, Kernel, And Closeout Foundation (V35)
 
@@ -1528,8 +1563,9 @@ resulting_authority_epoch     INTEGER NOT NULL
   preview hash.
 - Application requires `unresolved_count = 0` and records independently
   verified backup metadata with `quick_check = ok`; the schema requires that
-  metadata's schema/revision/epoch to match the base snapshot. S06 owns opening
-  and hashing the referenced backup before insertion.
+  metadata's schema/revision/epoch to match the base snapshot. The deferred
+  import application writer owns opening and hashing the referenced backup
+  before insertion.
 - The receipt must bind to an `import.apply` V31 operation whose expected tuple
   matches the base, whose request hash matches the preview hash, and whose exact
   resulting tuple matches the receipt; its resulting revision is exactly the
@@ -1583,7 +1619,8 @@ authority_epoch             INTEGER NOT NULL
 - Supersession preserves project/lifecycle and may retain the Attempt or name a
   later Attempt in the same lifecycle. There is no mutable plan status.
 - Tested-source and readiness-basis hashes must use lowercase `sha256:` format;
-  S06 owns canonical input construction and hash verification.
+  the deferred closeout writer owns canonical input construction and hash
+  verification.
 - Index: `idx_workflow_closeout_plan_head`.
 
 #### `workflow_closeout_effects`
@@ -1635,14 +1672,15 @@ authority_epoch       INTEGER NOT NULL
   plan. Current plan plus complete receipt coverage is the settlement state;
   V35 adds no settlement aggregate.
 - Receipt proofs must be nonempty JSON objects and their hashes must use
-  lowercase `sha256:` format. S06 owns canonical proof construction and
-  verification before insertion.
+  lowercase `sha256:` format. The deferred settlement writer owns canonical
+  proof construction and verification before insertion.
 - Index: `idx_workflow_settlement_receipt_scope`.
 
 V35 enforces local shape, provenance, lineage, immutability, delivery fencing,
-and settlement ordering. S06 owns atomic Domain Operation bundles, adapters,
-queries, stage and readiness prerequisites, runtime cutover, recovery fault
-tests, and final lifecycle completion.
+and settlement ordering. The S06 Domain Operation boundary now owns the base
+atomic provenance/event/outbox/Projection Work bundle and authority CAS. Later
+milestones own command-specific adapters and sibling facts, queries, stage and
+readiness prerequisites, runtime cutover, and final lifecycle completion.
 
 ---
 
@@ -1842,9 +1880,9 @@ until a later runtime-routing slice.
 
 ## 7. Write Path Invariants
 
-1. **Single-writer rule**: all write SQL lives in the explicit single-writer *layer* — `db/engine.ts` for schema, migrations, lifecycle, and transaction primitives; `db/writers/**` for domain write subsystems; `gsd-db.ts` as the compatibility barrel and remaining mid-migration wrappers; the typed coordination/runtime writer modules `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, and `db/command-queue.ts`; the schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-conversation-foundation-schema.ts`, `db-recovery-evidence-foundation-schema.ts`, `db-projection-import-kernel-closeout-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, and `db-verification-evidence-schema.ts`; and the ADR migration/backfill helper `memory-backfill.ts`. This is an allowlist, not permission for arbitrary raw writes under `db/`. `unit-ownership.ts` remains excluded because it owns a separate `.gsd/unit-claims.db`. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks this allowlist.
+1. **Single-writer rule**: all write SQL lives in the explicit single-writer *layer* — `db/engine.ts` for schema, migrations, lifecycle, and transaction primitives; `db/domain-operation.ts` for revision-checked authoritative transactions; `db/writers/**` for domain write subsystems; `gsd-db.ts` as the compatibility barrel and remaining mid-migration wrappers; the typed coordination/runtime writer modules `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, and `db/command-queue.ts`; the schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-conversation-foundation-schema.ts`, `db-recovery-evidence-foundation-schema.ts`, `db-projection-import-kernel-closeout-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, and `db-verification-evidence-schema.ts`; and the ADR migration/backfill helper `memory-backfill.ts`. This is an allowlist, not permission for arbitrary raw writes under `db/`. `unit-ownership.ts` remains excluded because it owns a separate `.gsd/unit-claims.db`. `db/queries.ts` is the read-only Query Module and must contain no write SQL. No raw write SQL escapes to the adapter from anywhere else. Enforced by the structural `single-writer-invariant.test.ts`, which checks this allowlist.
 
-2. **Transaction wrapping**: every multi-table write uses `transaction()` or `immediateTransaction()` when it needs SQLite's reserved writer lock up front. Rollback on any error. Re-entrant: nested calls increment the shared depth counter; no nested `BEGIN`. `gsd_save_gate_result` commits the `quality_gates` verdict update and matching `gate_runs` ledger insert together, so recovery never sees a completed gate without its audit row.
+2. **Transaction wrapping**: every multi-table write uses `transaction()` or `immediateTransaction()` when it needs SQLite's reserved writer lock up front. Rollback on any error. Re-entrant callers normally increment the shared depth counter with no nested `BEGIN`; `executeDomainOperation()` is the exception and rejects an existing outer transaction so it owns the reserved-writer boundary. `gsd_save_gate_result` commits the `quality_gates` verdict update and matching `gate_runs` ledger insert together, so recovery never sees a completed gate without its audit row.
 
 3. **Cascade semantics**: hierarchy status cascades are named **Domain Write Operations** in `db/writers/cascades.ts`, each owning its own `transaction()` so the milestone/slice/task subtree transitions atomically (callers keep only projection/file-cleanup/event logic):
    - `gsd_slice_complete` (`completeSliceCascade`) cascades `pending` tasks → `skipped`

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -33,6 +33,8 @@ GSD stores runtime workflow state in the project-root SQLite database. Auto mode
 
 Milestone queue position has one explicit file contract: `.gsd/QUEUE-ORDER.json`. `/gsd rethink` and `/gsd phase` use it as a durable reorder record, and state derivation mirrors that order into `milestones.sequence` before selecting the active milestone. Other generated `.gsd` artifacts remain projections unless an explicit import or recovery command reads them.
 
+The additive `db/domain-operation.ts` boundary is the future authoritative write seam. `executeDomainOperation()` owns a `BEGIN IMMEDIATE` transaction that revision- and Authority-Epoch-checks a request, reserves a project-scoped idempotency key, records provenance and ordered events, enqueues their outbox destinations and Projection Work, then advances authority with a compare-and-swap. Exact retries return the durable receipt without rerunning the mutation. Production handlers and file-derived readiness, completion, UAT, and reconciliation paths are not routed through this boundary yet; schema remains v35 and Markdown remains projection output rather than workflow authority.
+
 ### Two-File Loader Pattern
 
 `loader.ts` sets all environment variables with zero SDK imports, then dynamically imports `cli.ts` which does static SDK imports. This ensures `PI_PACKAGE_DIR` is set before any SDK code evaluates.
@@ -178,6 +180,7 @@ Model routing (complexity classification, budget pressure, routing history, capa
 | `memory-extractor.ts` | Extract reusable knowledge from session transcripts |
 | `memory-store.ts` | Persistent memory store for cross-session knowledge |
 | `queue-order.ts` | Durable milestone queue ordering contract and DB sequence mirroring |
+| `db/domain-operation.ts` | Additive revision-checked Domain Operation transaction and durable replay receipt boundary |
 | `context-masker.ts` | Context masking for model routing optimization |
 | `phase-anchor.ts` | Phase anchoring for dispatch pipeline |
 | `slice-parallel-orchestrator.ts` | Slice-level parallelism with dependency-aware dispatch |

--- a/docs/dev/refactor-foundation-runbook.md
+++ b/docs/dev/refactor-foundation-runbook.md
@@ -1,0 +1,175 @@
+# Refactor Foundation Domain Operation Runbook
+
+Project/App: gsd-pi
+Scope: M002 S06, revision-checked Domain Operation foundation
+
+## Boundary
+
+S06 adds one database transaction primitive. A fresh request checks project
+revision and Authority Epoch, reserves idempotency, runs one deterministic
+database-only mutation, records provenance/events/outbox/Projection Work, and
+advances authority in one `BEGIN IMMEDIATE` transaction. An exact replay
+returns the stored receipt without rerunning the mutation.
+
+This slice does **not** cut over production authority. Schema stays at v35. Do
+not change runtime handlers, command routing, file-derived readiness,
+completion, UAT or reconciliation reads, implicit import behavior, projection
+delivery, closeout effects, lifecycle policy, or legacy compatibility. Those
+are later milestones. Any such change is a stop condition, not incidental S06
+cleanup.
+
+## Focused loop
+
+Use the same command for RED and GREEN. RED must fail for the missing Domain
+Operation behavior before implementation; GREEN must pass without weakening
+the test.
+
+```bash
+node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
+  --experimental-strip-types --test \
+  src/resources/extensions/gsd/tests/domain-operation.test.ts
+```
+
+Run fault and lost-response cases alone while changing transaction ordering:
+
+```bash
+node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
+  --experimental-strip-types --test \
+  --test-name-pattern='fault|lost response' \
+  src/resources/extensions/gsd/tests/domain-operation.test.ts
+```
+
+Run the real two-process writer race alone while changing reservation or CAS
+behavior:
+
+```bash
+node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
+  --experimental-strip-types --test \
+  --test-name-pattern='two real processes racing' \
+  src/resources/extensions/gsd/tests/domain-operation.test.ts
+```
+
+Fault coverage must include `after-operation`, `after-mutation`,
+`after-events`, `after-outbox`, `after-projections`, and `before-cas`. Each
+pre-commit fault must leave the exact pre-operation snapshot. The
+`after-commit` case must replay the original receipt after a simulated lost
+response.
+
+## Foundation matrix
+
+Run all M002 schema families together. These suites cover fresh databases,
+v30-to-v35 upgrades, intermediate migrations, backups, restored-backup
+upgrades, rollback/retry, restart, and constraint failures.
+
+```bash
+node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
+  --experimental-strip-types --test \
+  src/resources/extensions/gsd/tests/db-canonical-foundation.test.ts \
+  src/resources/extensions/gsd/tests/db-lifecycle-foundation.test.ts \
+  src/resources/extensions/gsd/tests/db-conversation-foundation.test.ts \
+  src/resources/extensions/gsd/tests/db-recovery-evidence-foundation.test.ts \
+  src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts \
+  src/resources/extensions/gsd/tests/db-engine-migrate-guards.test.ts \
+  src/resources/extensions/gsd/tests/db-migration-backup.test.ts \
+  src/resources/extensions/gsd/tests/domain-operation.test.ts \
+  src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
+```
+
+Run the extension typecheck and unchanged authority baseline:
+
+```bash
+pnpm run typecheck:extensions
+pnpm run baseline:workflow-authority
+pnpm --silent run baseline:workflow-authority -- --json \
+  | jq 'del(.durationMs) | .invariants |= map(del(.durationMs))' \
+  > /tmp/gsd-m002-s06-authority.stable.json
+```
+
+Before review, run the local PR-blocking parity verification:
+
+```bash
+pnpm run verify:merge
+```
+
+Do not commit temporary databases, backups, TAP output, or captured JSON.
+
+## UAT evidence
+
+Record automated UAT with this stable field set. Preserve array order, omit
+durations and machine paths, and use exact commands from this runbook.
+
+```json
+{
+  "schemaVersion": 1,
+  "milestoneId": "M002",
+  "sliceId": "S06",
+  "gitCommit": "<full commit sha>",
+  "verdict": "pass",
+  "noCutover": true,
+  "checks": [
+    { "id": "domain-operation", "command": "<command>", "verdict": "pass", "exitCode": 0 },
+    { "id": "foundation-matrix", "command": "<command>", "verdict": "pass", "exitCode": 0 },
+    { "id": "typecheck-extensions", "command": "pnpm run typecheck:extensions", "verdict": "pass", "exitCode": 0 },
+    { "id": "workflow-authority", "command": "pnpm run baseline:workflow-authority", "verdict": "pass", "exitCode": 0 },
+    { "id": "verify-merge", "command": "pnpm run verify:merge", "verdict": "pass", "exitCode": 0 }
+  ],
+  "receipt": {
+    "statuses": ["committed", "replayed"],
+    "requestHashFormat": "sha256:<64 lowercase hex>",
+    "stableFields": [
+      "operationId",
+      "projectId",
+      "resultingRevision",
+      "resultingAuthorityEpoch",
+      "requestHash",
+      "eventIds",
+      "outboxIds",
+      "projectionWorkIds"
+    ],
+    "reopenIdentityPreserved": true
+  },
+  "faults": {
+    "precommitPoints": [
+      "after-operation",
+      "after-mutation",
+      "after-events",
+      "after-outbox",
+      "after-projections",
+      "before-cas"
+    ],
+    "precommitResidueCount": 0,
+    "lostResponseReplayPassed": true
+  },
+  "race": { "committed": 1, "stale": 1, "sqliteBusy": 0 },
+  "migration": {
+    "freshV35": "pass",
+    "v30ToV35": "pass",
+    "restoredBackupToV35": "pass",
+    "openImportedCanonicalRows": 0
+  },
+  "failures": []
+}
+```
+
+The baseline JSON retains its existing v1 fields and invariant order. Remove
+only `durationMs` before comparison; do not rewrite failed rows.
+
+## Stop conditions
+
+Stop promotion and repair locally when any of these occurs:
+
+- stale revision or epoch commits, replay invokes mutation, or a reused key
+  accepts changed semantics;
+- a pre-commit fault leaves residue, receipt identity changes after reopen, or
+  projection work falls outside the operation transaction;
+- the writer race produces zero or two commits, exposes `SQLITE_BUSY`, or
+  leaves orphan operations, events, outbox rows, or projections;
+- migration/restore changes preserved rows, imports canonical rows merely by
+  opening the database, produces an unhealthy backup, or fails `quick_check`;
+- the authority baseline, foundation matrix, typecheck, or `verify:merge`
+  regresses; or
+- the diff crosses the no-cutover boundary above.
+
+Escalate to the developer only for missing authority/access, irreversible or
+public action, or a genuinely ambiguous product route. Test failures, races,
+migration faults, and baseline regressions are agent-remediated work.

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -58,6 +58,14 @@ See also:
 
 `QUEUE-ORDER.json` is the exception to the usual generated-artifact projection rule. `/gsd rethink` and related phase-management flows write it as the durable milestone reorder contract, and state derivation mirrors it into `milestones.sequence` before dispatch so stale DB sequence can be repaired without importing arbitrary markdown projections.
 
+`db/domain-operation.ts` now provides the additive future authoritative write
+seam: a project-scoped, revision- and Authority-Epoch-checked `BEGIN IMMEDIATE`
+transaction that atomically stores provenance, ordered events, outbox
+destinations, Projection Work, and the authority CAS. Exact retries return a
+durable receipt without rerunning mutation. The prompt/tool flow above is not
+routed through this seam yet, and file-derived readiness, completion, UAT, and
+reconciliation behavior remains unchanged.
+
 ---
 
 ## 2. Prompt → DB Read/Write Reference
@@ -346,7 +354,7 @@ unit completes
 | Source File | Tables |
 |------------|--------|
 | `db-base-schema.ts` | schema_version, decisions, requirements, artifacts, memories, memory_processed_units, memory_sources, memory_embeddings, memory_relations, milestones, slices, tasks, verification_evidence, replan_history, assessments, quality_gates, slice_dependencies, gate_runs, turn_git_transactions, milestone_commit_attributions, audit_events, audit_turn_index + all indexes + active_decisions/active_requirements/active_memories views |
-| `db-canonical-foundation-schema.ts` | project_authority, workflow_operations, workflow_domain_events, workflow_outbox + domain-event immutability triggers and canonical-foundation indexes (V31, additive and not runtime-routed yet) |
+| `db-canonical-foundation-schema.ts` | project_authority, workflow_operations, workflow_domain_events, workflow_outbox + domain-event immutability, durable-outbox deletion, safe-integer identity triggers, and canonical-foundation indexes (V31; production handlers are not runtime-routed yet) |
 | `db-lifecycle-foundation-schema.ts` | workflow_item_lifecycles, workflow_execution_attempts, workflow_attempt_results, workflow_blockers, workflow_waivers, workflow_requirement_dispositions + lifecycle, fencing, provenance, history, and vocabulary constraints (V32, additive and not runtime-routed yet) |
 | `db-conversation-foundation-schema.ts` | workflow_milestone_contexts, workflow_open_questions, workflow_question_dependencies, workflow_interactions, workflow_interaction_options, workflow_answers, workflow_conversation_decisions, workflow_decision_impacts, workflow_work_checkpoints + recommendation-first, causal provenance, targeted revalidation, immutability, and single-head history constraints (V33, additive and not runtime-routed yet) |
 | `db-recovery-evidence-foundation-schema.ts` | workflow_failure_observations, workflow_recovery_budgets, workflow_recovery_actions, workflow_acceptance_criteria, workflow_technical_verdicts, workflow_verification_evidence, workflow_human_acceptances, workflow_remediation_links + explicit agent/user/external recovery ownership, immutable count budgets derived from linked Actions, requirement-scoped criterion lineage, verdict-owned objective evidence, separate subjective acceptance, and immutable rework/remediation routing (V34, additive and not runtime-routed yet) |
@@ -376,10 +384,10 @@ unit completes
 
 | Invariant | Where Enforced |
 |-----------|---------------|
-| Single-writer: all write SQL in the explicit single-writer allowlist (`db/engine.ts`, `db/writers/**`, `gsd-db.ts`, typed coordination/runtime writers `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, `db/command-queue.ts`, schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-conversation-foundation-schema.ts`, `db-recovery-evidence-foundation-schema.ts`, `db-projection-import-kernel-closeout-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, `db-verification-evidence-schema.ts`, and ADR migration/backfill helper `memory-backfill.ts`); this is not permission for arbitrary writes under `db/`; `unit-ownership.ts` owns separate `.gsd/unit-claims.db`; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (explicit allowlist) |
+| Single-writer: all write SQL in the explicit single-writer allowlist (`db/engine.ts`, authoritative transaction boundary `db/domain-operation.ts`, `db/writers/**`, `gsd-db.ts`, typed coordination/runtime writers `db/milestone-leases.ts`, `db/unit-dispatches.ts`, `db/auto-workers.ts`, `db/runtime-kv.ts`, `db/command-queue.ts`, schema/migration helpers `db-canonical-foundation-schema.ts`, `db-lifecycle-foundation-schema.ts`, `db-conversation-foundation-schema.ts`, `db-recovery-evidence-foundation-schema.ts`, `db-projection-import-kernel-closeout-foundation-schema.ts`, `db-memory-fts-schema.ts`, `db-schema-metadata.ts`, `db-verification-evidence-schema.ts`, and ADR migration/backfill helper `memory-backfill.ts`); this is not permission for arbitrary writes under `db/`; `unit-ownership.ts` owns separate `.gsd/unit-claims.db`; `db/queries.ts` is read-only | structural test `single-writer-invariant.test.ts` (explicit allowlist) |
 | Cascade on slice complete: pending tasks → skipped | `gsd_slice_complete` transaction |
 | Cascade on milestone reopen: all slices → in_progress, tasks → pending | `gsd_milestone_reopen` transaction |
-| No nested write transactions: `transaction()` and `immediateTransaction()` share one depth counter; read-then-write claims use `immediateTransaction()` and gate verdict + ledger writes commit atomically | `db-transaction.test.ts`, `command-queue.test.ts`, `gate-storage.test.ts` |
+| No nested write transactions: `transaction()` and `immediateTransaction()` share one depth counter; `executeDomainOperation()` rejects an existing outer transaction so it owns the reserved-writer boundary; read-then-write claims use `immediateTransaction()` and gate verdict + ledger writes commit atomically | `db-transaction.test.ts`, `domain-operation.test.ts`, `command-queue.test.ts`, `gate-storage.test.ts` |
 | Workspace isolation: one DB per project root, shared across worktrees via WAL | `db-connection-cache.ts` identityKey |
 | Coordination: one active dispatch per unit_id at a time | `idx_unit_dispatches_active_per_unit` unique partial index |
 | Memory FTS fallback: LIKE scan if FTS5 unavailable | `tryCreateMemoriesFtsSchema` onUnavailable callback |
@@ -407,10 +415,10 @@ Legacy `verification_evidence`, assessments, quality gates, gate runs, UAT
 files, rework briefs, dispatch retry fields, runtime JSON/KV, and process-local
 counters are not repurposed or backfilled by V34. V34 also does not cut runtime
 recovery, verification, UAT, lifecycle completion, projections, manifest
-restore, or worktree reconciliation over to the new tables. S06 Domain
-Operations must atomically commit failure/action and verdict/evidence bundles,
-plus any applicable remediation links, and require bundle completeness before
-dispatch or closeout.
+restore, or worktree reconciliation over to the new tables. Later
+command-specific writers must use the S06 Domain Operation boundary to commit
+failure/action and verdict/evidence bundles plus any applicable remediation
+links atomically, and require bundle completeness before dispatch or closeout.
 
 V35 makes projection delivery, import application, kernel position, and
 closeout settlement restart-safe without creating parallel work or execution
@@ -424,9 +432,9 @@ receipt records its exact source/change envelope and independently verified
 backup metadata. The schema requires repeated envelope metadata, hashes, and
 counts to match the preview JSON, binds the `import.apply` operation request
 hash to `preview_hash`, and makes the operation immutable once receipted. It
-validates lowercase `sha256:` formats but cannot recompute SHA-256; S06 owns
-canonical preview hashing, source/change verification, and opening and hashing
-the referenced backup before insertion.
+validates lowercase `sha256:` formats but cannot recompute SHA-256; the deferred
+import application writer owns canonical preview hashing, source/change
+verification, and opening and hashing the referenced backup before insertion.
 Absence of a kernel checkpoint means Advance; the first persisted checkpoint
 is Execute and shares the selected Attempt's claim operation.
 Closeout state is derived from the current immutable plan, its ordered
@@ -434,6 +442,8 @@ idempotency-keyed effects, and complete success-only receipts. Missing receipt m
 pending, while failures route through V34 recovery facts rather than failed
 receipts. V35 adds no kernel-run or settlement aggregate.
 
-V35 is still an additive foundation. S06 owns atomic sibling bundles, adapters,
-queries, stage/readiness checks, canonical effect/proof hashing, idempotent host
-execution, runtime routing, fault recovery, and final lifecycle completion.
+V35 is still an additive foundation. The S06 boundary owns the base atomic
+provenance/event/outbox/Projection Work bundle and authority CAS. Later
+milestones own command-specific sibling bundles and adapters, queries,
+stage/readiness checks, effect/proof hashing, idempotent host execution, runtime
+routing, and final lifecycle completion.

--- a/plans/042-m002-s06-domain-operation-research.md
+++ b/plans/042-m002-s06-domain-operation-research.md
@@ -1,0 +1,153 @@
+# M002 S06 — Revision-checked Domain Operation research
+
+**Status:** Converged implementation contract
+**Scope:** Additive transaction primitive only; no production handler or authority cutover
+
+## Decision
+
+S06 adds one deep Domain Operation module with one public execution method. The
+module hides transaction ordering, authority compare-and-swap, transport
+idempotency, provenance, immutable events, durable outbox rows, and Projection
+Work enqueueing behind a small interface.
+
+The module does not expose a database adapter. A fresh operation invokes one
+deterministic database-only mutation callback with a frozen operation context.
+The callback may compose existing typed writers inside the outer transaction
+and returns only ordered event and projection intents. A replay never invokes
+the callback and returns the original stored receipt.
+
+This keeps the transaction seam useful for the command-specific writers that
+later milestones add without teaching S06 every lifecycle, conversation,
+recovery, import, and closeout command prematurely.
+
+## Public interface
+
+```ts
+executeDomainOperation(
+  request: DomainOperationRequest,
+  mutate: (context: Readonly<DomainOperationContext>) => DomainOperationMutation,
+): DomainOperationResult
+```
+
+`DomainOperationRequest` contains:
+
+- operation type and project-scoped idempotency key;
+- expected project revision and Authority Epoch;
+- actor type/id, source transport, and optional trace/turn identifiers;
+- a JSON-compatible payload that completely describes the requested domain
+  intent; and
+- whether this operation explicitly advances the Authority Epoch.
+
+The module canonicalizes and hashes the semantic request. Callers cannot supply
+or spoof `request_hash`.
+
+`DomainOperationMutation` contains:
+
+- one or more ordered domain events;
+- one or more durable outbox destinations attached to each event; and
+- one or more logical Projection Work targets.
+
+The result contains only a durable receipt:
+
+- `committed | replayed`;
+- operation/project identity;
+- resulting revision and Authority Epoch;
+- request hash; and
+- stored event, outbox, and projection identities.
+
+There is no arbitrary callback return value because v31 stores no generic
+response payload that could be reconstructed after a lost response.
+
+## Commit algorithm
+
+Inside one `BEGIN IMMEDIATE` transaction:
+
+1. Read the singleton project authority and look up the project-scoped
+   idempotency key before checking current revision.
+2. On an existing key, require the same operation type, canonical request hash,
+   actor, transport, and expected revision/epoch. Return the stored receipt
+   without running the mutation. Any mismatch is an idempotency conflict.
+3. On a fresh key, require the exact expected revision and Authority Epoch.
+4. Derive `resulting_revision = expected_revision + 1`; retain the epoch unless
+   the request explicitly advances it by exactly one.
+5. Insert the immutable operation provenance row.
+6. Invoke the deterministic mutation exactly once with a frozen context.
+7. Insert a gap-free event sequence, its event-linked outbox destinations, and
+   per-logical-key Projection Work successors using the same operation tuple.
+8. Advance `project_authority` with a revision-and-epoch CAS and require exactly
+   one changed row.
+9. Commit and return the stored receipt.
+
+Any validation, mutation, event, outbox, projection, or CAS failure rolls the
+whole operation back. Database mutation errors are never caught inside the
+transaction.
+
+## Deterministic ownership
+
+The Domain Operation module owns:
+
+- canonical JSON and `sha256:` request hashing;
+- exact stale revision/epoch and idempotency-conflict errors;
+- one reserved-writer transaction;
+- operation/event/outbox/projection identity and ordering;
+- per-key projection supersession; and
+- receipt reconstruction after restart.
+
+Command-specific typed writers own:
+
+- lifecycle and stage prerequisites;
+- exact sibling facts for Attempts, conversation, recovery, verification,
+  import, and closeout;
+- policy classification and bounded recovery choice; and
+- semantic event vocabulary and projection targets.
+
+Database constraints continue to reject impossible local facts. They do not
+select policy or simulate the Lifecycle Kernel.
+
+## RED and fault contract
+
+The focused test must prove:
+
+1. A successful operation advances revision once and atomically creates one
+   operation, gap-free events, linked outbox rows, and Projection Work.
+2. A second operation for the same projection key extends the current head.
+3. Stale revision and stale Authority Epoch fail loudly with zero residue.
+4. Exact replay returns the original receipt and never reruns the mutation.
+5. Reusing a key with changed semantic input is a hard conflict.
+6. Faults after operation insert, mutation, events, outbox, projections, or
+   before CAS leave the exact pre-operation snapshot.
+7. A simulated lost response after commit replays the original receipt.
+8. Two independent writers racing the same expected tuple produce one commit
+   and one stale result, never orphan rows or an exposed `SQLITE_BUSY` result.
+9. Independent close/reopen preserves replay and receipt identity.
+10. Explicit epoch advance increments by one; ordinary operations retain it.
+11. The same contract works after a v30-to-v35 upgrade and restored-backup
+    upgrade without importing canonical rows merely by opening the database.
+
+Sabotage targets are transaction removal, weakened revision/epoch CAS,
+idempotency replay without request-hash comparison, callback execution during
+replay, and projection enqueue after commit.
+
+## Deferred cutover map
+
+S06 does not change handlers or runtime authority. Later milestones add, in
+order:
+
+1. command-specific lifecycle/Attempt/Result/checkpoint writers;
+2. a fenced Projection Worker and removal of projection rollback behavior;
+3. explicit Import Preview/Application with verified backup and no implicit
+   disk import;
+4. shared prepare/settle closeout and idempotent host-effect adapters;
+5. auto, interactive, guided, UOK, custom, and legacy adapters over one Kernel;
+6. removal of file-derived readiness, completion, UAT, and reconciliation
+   authority after shadow evidence and compatibility windows pass.
+
+## Expected files
+
+- `src/resources/extensions/gsd/db/domain-operation.ts`
+- `src/resources/extensions/gsd/tests/domain-operation.test.ts`
+- `src/resources/extensions/gsd/gsd-db.ts`
+- `src/resources/extensions/gsd/tests/single-writer-invariant.test.ts`
+- `docs/dev/refactor-foundation-runbook.md`
+
+Schema version remains v35.

--- a/src/resources/extensions/gsd/db-canonical-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-canonical-foundation-schema.ts
@@ -3,6 +3,23 @@
 
 import type { DbAdapter } from "./db-adapter.js";
 
+export function ensureCanonicalOutboxInvariantsV31(db: DbAdapter): void {
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_outbox_safe_identity
+    AFTER INSERT ON workflow_outbox
+    WHEN NEW.outbox_id > 9007199254740991
+    BEGIN
+      SELECT RAISE(ABORT, 'outbox identity exceeds safe integer range');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS trg_workflow_outbox_delete
+    BEFORE DELETE ON workflow_outbox
+    BEGIN
+      SELECT RAISE(ABORT, 'outbox rows are durable history');
+    END
+  `);
+}
+
 /**
  * v31 mapping:
  * - schema_version remains DDL compatibility, not the domain revision.
@@ -103,6 +120,7 @@ export function createCanonicalFoundationSchemaV31(db: DbAdapter): void {
       FOREIGN KEY (event_id) REFERENCES workflow_domain_events(event_id)
     )
   `);
+  ensureCanonicalOutboxInvariantsV31(db);
 
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_workflow_operations_created

--- a/src/resources/extensions/gsd/db-conversation-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-conversation-foundation-schema.ts
@@ -7,8 +7,9 @@ import type { DbAdapter } from "./db-adapter.js";
  * The v33 tables are canonical conversation facts, but no runtime flow reads
  * them yet. Existing prompts, files, and caches retain their current behavior
  * until the later cutover migration. V33 validates individual facts and
- * transitions; S06 Domain Operations will atomically commit the related
- * question bundle and answer/decision/impact/checkpoint bundle.
+ * transitions; later command writers must use the S06 Domain Operation
+ * boundary to commit each question or answer/decision/impact/checkpoint bundle
+ * atomically.
  */
 export function createConversationFoundationSchemaV33(db: DbAdapter): void {
   db.exec(`

--- a/src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-projection-import-kernel-closeout-foundation-schema.ts
@@ -6,8 +6,9 @@ import type { DbAdapter } from "./db-adapter.js";
 /**
  * V35 records desired projection work and immutable import/kernel/closeout
  * facts. Projection delivery is operational and intentionally does not create
- * workflow operations. S06 owns atomic sibling facts, prerequisite checks,
- * effect execution, lifecycle completion, and runtime cutover.
+ * workflow operations. The S06 boundary owns the base atomic operation bundle;
+ * later command writers own sibling facts, prerequisites, effects, lifecycle
+ * completion, and runtime cutover.
  */
 export function createProjectionImportKernelCloseoutFoundationSchemaV35(db: DbAdapter): void {
   db.exec(`

--- a/src/resources/extensions/gsd/db-recovery-evidence-foundation-schema.ts
+++ b/src/resources/extensions/gsd/db-recovery-evidence-foundation-schema.ts
@@ -5,10 +5,10 @@ import type { DbAdapter } from "./db-adapter.js";
 
 /**
  * V34 records durable recovery allocations and immutable proof facts without
- * cutting runtime readers or writers over to them. S06 Domain Operations must
- * atomically commit failure/action and verdict/evidence bundles, plus any
- * applicable remediation links, and must enforce bundle completeness before
- * dispatch or lifecycle closeout.
+ * cutting runtime readers or writers over to them. Later command-specific
+ * writers must use the S06 Domain Operation boundary to commit failure/action
+ * and verdict/evidence bundles plus any applicable remediation links
+ * atomically, and enforce bundle completeness before dispatch or closeout.
  */
 export function createRecoveryEvidenceFoundationSchemaV34(db: DbAdapter): void {
   db.exec(`

--- a/src/resources/extensions/gsd/db/domain-operation.ts
+++ b/src/resources/extensions/gsd/db/domain-operation.ts
@@ -1,0 +1,574 @@
+// Project/App: gsd-pi
+// File Purpose: Atomic, revision-checked Domain Operation writer boundary.
+
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  GSD_IDEMPOTENCY_CONFLICT,
+  GSD_REVISION_CONFLICT,
+  GSDError,
+} from "../errors.js";
+import { getDb, immediateTransaction, isInTransaction } from "./engine.js";
+
+export type DomainJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | DomainJsonValue[]
+  | { [key: string]: DomainJsonValue };
+
+export interface DomainOperationRequest {
+  operationType: string;
+  idempotencyKey: string;
+  expectedRevision: number;
+  expectedAuthorityEpoch: number;
+  actorType: string;
+  actorId?: string;
+  sourceTransport: string;
+  traceId?: string;
+  turnId?: string;
+  payload: DomainJsonValue;
+  advanceAuthorityEpoch?: boolean;
+}
+
+export interface DomainOperationEventInput {
+  eventType: string;
+  entityType: string;
+  entityId: string;
+  payload: DomainJsonValue;
+  destinations: string[];
+  causedByEventIndex?: number;
+}
+
+export interface DomainOperationProjectionInput {
+  projectionKey: string;
+  projectionKind: string;
+  rendererVersion: string;
+}
+
+export interface DomainOperationMutation {
+  events: DomainOperationEventInput[];
+  projections: DomainOperationProjectionInput[];
+}
+
+export interface DomainOperationContext {
+  operationId: string;
+  projectId: string;
+  resultingRevision: number;
+  resultingAuthorityEpoch: number;
+}
+
+export interface DomainOperationResult {
+  status: "committed" | "replayed";
+  operationId: string;
+  projectId: string;
+  resultingRevision: number;
+  resultingAuthorityEpoch: number;
+  requestHash: string;
+  eventIds: string[];
+  outboxIds: number[];
+  projectionWorkIds: string[];
+}
+
+export type DomainOperationFaultPoint =
+  | "after-operation"
+  | "after-mutation"
+  | "after-events"
+  | "after-outbox"
+  | "after-projections"
+  | "before-cas"
+  | "after-commit";
+
+interface AuthorityRow {
+  project_id: string;
+  revision: number;
+  authority_epoch: number;
+}
+
+interface OperationRow {
+  operation_id: string;
+  project_id: string;
+  operation_type: string;
+  idempotency_key: string;
+  expected_revision: number;
+  resulting_revision: number;
+  expected_authority_epoch: number;
+  resulting_authority_epoch: number;
+  actor_type: string;
+  actor_id: string | null;
+  source_transport: string;
+  trace_id: string | null;
+  turn_id: string | null;
+  request_hash: string;
+  created_at: string;
+}
+
+let faultPoint: DomainOperationFaultPoint | null = null;
+
+export function _setDomainOperationFaultForTest(point: DomainOperationFaultPoint | null): void {
+  faultPoint = point;
+}
+
+function hitFault(point: DomainOperationFaultPoint): void {
+  if (faultPoint === point) throw new Error(`domain operation fault: ${point}`);
+}
+
+function requireNonBlank(value: string, field: string): void {
+  if (value.trim().length === 0) throw new Error(`${field} must not be blank`);
+}
+
+function requireNonNegativeSafeInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative safe integer`);
+  }
+}
+
+function canonicalJson(value: DomainJsonValue): string {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("domain operation JSON numbers must be finite");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  if (typeof value !== "object") throw new Error("domain operation payload must be JSON-compatible");
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error("domain operation payload must contain plain JSON objects");
+  }
+  const entries = Object.entries(value).sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`).join(",")}}`;
+}
+
+function validateRequestScalars(request: DomainOperationRequest): void {
+  requireNonBlank(request.operationType, "operationType");
+  requireNonBlank(request.idempotencyKey, "idempotencyKey");
+  requireNonBlank(request.actorType, "actorType");
+  requireNonBlank(request.sourceTransport, "sourceTransport");
+  if (request.actorId !== undefined) requireNonBlank(request.actorId, "actorId");
+  if (request.traceId !== undefined) requireNonBlank(request.traceId, "traceId");
+  if (request.turnId !== undefined) requireNonBlank(request.turnId, "turnId");
+  requireNonNegativeSafeInteger(request.expectedRevision, "expectedRevision");
+  requireNonNegativeSafeInteger(request.expectedAuthorityEpoch, "expectedAuthorityEpoch");
+  if (request.expectedRevision === Number.MAX_SAFE_INTEGER) {
+    throw new Error("expectedRevision requires safe integer increment headroom");
+  }
+  if (request.advanceAuthorityEpoch !== undefined && typeof request.advanceAuthorityEpoch !== "boolean") {
+    throw new Error("advanceAuthorityEpoch must be a boolean");
+  }
+  if (request.advanceAuthorityEpoch === true && request.expectedAuthorityEpoch === Number.MAX_SAFE_INTEGER) {
+    throw new Error("expectedAuthorityEpoch requires safe integer increment headroom");
+  }
+}
+
+function requestHash(request: DomainOperationRequest): string {
+  const canonical = canonicalJson({
+    operationType: request.operationType,
+    expectedRevision: request.expectedRevision,
+    expectedAuthorityEpoch: request.expectedAuthorityEpoch,
+    actorType: request.actorType,
+    actorId: request.actorId ?? null,
+    sourceTransport: request.sourceTransport,
+    traceId: request.traceId ?? null,
+    turnId: request.turnId ?? null,
+    payload: request.payload,
+    advanceAuthorityEpoch: request.advanceAuthorityEpoch === true,
+  });
+  return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+}
+
+function validateMutation(mutation: DomainOperationMutation): string[] {
+  if (mutation.events.length === 0) throw new Error("domain operation requires at least one event");
+  if (mutation.projections.length === 0) {
+    throw new Error("domain operation requires at least one projection target");
+  }
+  if (mutation.projections.length > 10_000) {
+    throw new Error("domain operation projection limit is 10,000 targets");
+  }
+
+  const eventPayloads = mutation.events.map((event, eventIndex) => {
+    requireNonBlank(event.eventType, `events[${eventIndex}].eventType`);
+    requireNonBlank(event.entityType, `events[${eventIndex}].entityType`);
+    requireNonBlank(event.entityId, `events[${eventIndex}].entityId`);
+    const payload = canonicalJson(event.payload);
+    if (event.destinations.length === 0) {
+      throw new Error(`events[${eventIndex}] requires at least one outbox destination`);
+    }
+    const destinations = new Set<string>();
+    for (const destination of event.destinations) {
+      requireNonBlank(destination, `events[${eventIndex}].destinations`);
+      if (destinations.has(destination)) {
+        throw new Error(`events[${eventIndex}] contains duplicate destination ${destination}`);
+      }
+      destinations.add(destination);
+    }
+    if (
+      event.causedByEventIndex !== undefined &&
+      (!Number.isInteger(event.causedByEventIndex) ||
+        event.causedByEventIndex < 0 ||
+        event.causedByEventIndex >= eventIndex)
+    ) {
+      throw new Error(`events[${eventIndex}].causedByEventIndex must reference an earlier event`);
+    }
+    return payload;
+  });
+
+  const projectionKeys = new Set<string>();
+  mutation.projections.forEach((projection, projectionIndex) => {
+    requireNonBlank(projection.projectionKey, `projections[${projectionIndex}].projectionKey`);
+    requireNonBlank(projection.projectionKind, `projections[${projectionIndex}].projectionKind`);
+    requireNonBlank(projection.rendererVersion, `projections[${projectionIndex}].rendererVersion`);
+    if (projection.projectionKey !== projection.projectionKey.trim().toLowerCase()) {
+      throw new Error(`projections[${projectionIndex}].projectionKey must be normalized lowercase`);
+    }
+    if (projection.projectionKind !== projection.projectionKind.trim().toLowerCase()) {
+      throw new Error(`projections[${projectionIndex}].projectionKind must be normalized lowercase`);
+    }
+    if (projectionKeys.has(projection.projectionKey)) {
+      throw new Error(`duplicate projection key ${projection.projectionKey}`);
+    }
+    projectionKeys.add(projection.projectionKey);
+  });
+  return eventPayloads;
+}
+
+function loadReceipt(operation: OperationRow, status: DomainOperationResult["status"]): DomainOperationResult {
+  const db = getDb();
+  const eventIds = db.prepare(`
+    SELECT event_id FROM workflow_domain_events
+    WHERE operation_id = :operation_id ORDER BY event_index
+  `).all({ ":operation_id": operation.operation_id }).map((row) => String(row["event_id"]));
+  const outboxIds = db.prepare(`
+    SELECT outbox.outbox_id
+    FROM workflow_outbox outbox
+    JOIN workflow_domain_events event ON event.event_id = outbox.event_id
+    WHERE event.operation_id = :operation_id
+    ORDER BY outbox.outbox_id
+  `).all({ ":operation_id": operation.operation_id }).map((row) => Number(row["outbox_id"]));
+  const projectionWorkIds = db.prepare(`
+    SELECT projection_work_id FROM workflow_projection_work
+    WHERE enqueue_operation_id = :operation_id ORDER BY projection_work_id
+  `).all({ ":operation_id": operation.operation_id })
+    .map((row) => String(row["projection_work_id"]));
+
+  return {
+    status,
+    operationId: operation.operation_id,
+    projectId: operation.project_id,
+    resultingRevision: operation.resulting_revision,
+    resultingAuthorityEpoch: operation.resulting_authority_epoch,
+    requestHash: operation.request_hash,
+    eventIds,
+    outboxIds,
+    projectionWorkIds,
+  };
+}
+
+function operationMatchesRequest(
+  operation: OperationRow,
+  request: DomainOperationRequest,
+  hash: string,
+): boolean {
+  return (
+    operation.operation_type === request.operationType &&
+    operation.idempotency_key === request.idempotencyKey &&
+    operation.request_hash === hash &&
+    operation.expected_revision === request.expectedRevision &&
+    operation.expected_authority_epoch === request.expectedAuthorityEpoch &&
+    operation.actor_type === request.actorType &&
+    operation.actor_id === (request.actorId ?? null) &&
+    operation.source_transport === request.sourceTransport &&
+    operation.trace_id === (request.traceId ?? null) &&
+    operation.turn_id === (request.turnId ?? null)
+  );
+}
+
+function requireReplayMatch(
+  operation: OperationRow,
+  request: DomainOperationRequest,
+  hash: string,
+): void {
+  if (!operationMatchesRequest(operation, request, hash)) {
+    throw new GSDError(
+      GSD_IDEMPOTENCY_CONFLICT,
+      `domain operation idempotency conflict for key ${request.idempotencyKey}`,
+    );
+  }
+}
+
+function loadOperation(operationId: string): OperationRow | undefined {
+  return getDb().prepare(`
+    SELECT operation_id, project_id, operation_type, idempotency_key,
+           expected_revision, resulting_revision,
+           expected_authority_epoch, resulting_authority_epoch,
+           actor_type, actor_id, source_transport, trace_id, turn_id, request_hash,
+           created_at
+    FROM workflow_operations WHERE operation_id = :operation_id
+  `).get({ ":operation_id": operationId }) as unknown as OperationRow | undefined;
+}
+
+function requireCommittedProvenance(
+  operation: OperationRow | undefined,
+  request: DomainOperationRequest,
+  hash: string,
+  context: DomainOperationContext,
+  createdAt: string,
+): OperationRow {
+  if (!operation) throw new Error("domain operation provenance row is missing");
+  const matches =
+    operationMatchesRequest(operation, request, hash) &&
+    operation.operation_id === context.operationId &&
+    operation.project_id === context.projectId &&
+    operation.resulting_revision === context.resultingRevision &&
+    operation.resulting_authority_epoch === context.resultingAuthorityEpoch &&
+    operation.created_at === createdAt;
+  if (!matches) throw new Error("domain operation provenance changed during mutation");
+  return operation;
+}
+
+function staleAuthority(request: DomainOperationRequest, authority: AuthorityRow): never {
+  if (authority.revision !== request.expectedRevision) {
+    throw new GSDError(
+      GSD_REVISION_CONFLICT,
+      `stale project revision: expected ${request.expectedRevision}, current ${authority.revision}`,
+    );
+  }
+  throw new GSDError(
+    GSD_REVISION_CONFLICT,
+    `stale authority epoch: expected ${request.expectedAuthorityEpoch}, current ${authority.authority_epoch}`,
+  );
+}
+
+export function executeDomainOperation(
+  request: DomainOperationRequest,
+  /**
+   * Compose deterministic typed writers only. Sibling tables must enforce the
+   * supplied operation/revision context through their foreign keys; filesystem,
+   * network, routing, retry, and error-swallowing behavior do not belong here.
+   */
+  mutate: (context: Readonly<DomainOperationContext>) => DomainOperationMutation,
+): DomainOperationResult {
+  validateRequestScalars(request);
+  if (isInTransaction()) {
+    throw new Error("Domain Operation must own the outer transaction");
+  }
+  const hash = requestHash(request);
+
+  const result = immediateTransaction((): DomainOperationResult => {
+    const db = getDb();
+    const authority = db.prepare(`
+      SELECT project_id, revision, authority_epoch
+      FROM project_authority WHERE singleton = 1
+    `).get() as unknown as AuthorityRow | undefined;
+    if (!authority) throw new Error("project authority is missing");
+    requireNonNegativeSafeInteger(authority.revision, "stored project revision");
+    requireNonNegativeSafeInteger(authority.authority_epoch, "stored authority epoch");
+
+    const existing = db.prepare(`
+      SELECT operation_id, project_id, operation_type, idempotency_key,
+             expected_revision, resulting_revision,
+             expected_authority_epoch, resulting_authority_epoch,
+             actor_type, actor_id, source_transport, trace_id, turn_id, request_hash,
+             created_at
+      FROM workflow_operations
+      WHERE project_id = :project_id AND idempotency_key = :idempotency_key
+    `).get({
+      ":project_id": authority.project_id,
+      ":idempotency_key": request.idempotencyKey,
+    }) as unknown as OperationRow | undefined;
+    if (existing) {
+      requireReplayMatch(existing, request, hash);
+      return loadReceipt(existing, "replayed");
+    }
+
+    if (
+      authority.revision !== request.expectedRevision ||
+      authority.authority_epoch !== request.expectedAuthorityEpoch
+    ) {
+      staleAuthority(request, authority);
+    }
+
+    const now = new Date().toISOString();
+    const operationId = randomUUID();
+    const resultingRevision = request.expectedRevision + 1;
+    const resultingAuthorityEpoch =
+      request.expectedAuthorityEpoch + (request.advanceAuthorityEpoch === true ? 1 : 0);
+    const context = Object.freeze({
+      operationId,
+      projectId: authority.project_id,
+      resultingRevision,
+      resultingAuthorityEpoch,
+    });
+
+    db.prepare(`
+      INSERT INTO workflow_operations (
+        operation_id, project_id, operation_type, idempotency_key,
+        expected_revision, resulting_revision,
+        expected_authority_epoch, resulting_authority_epoch,
+        actor_type, actor_id, source_transport, trace_id, turn_id,
+        request_hash, created_at
+      ) VALUES (
+        :operation_id, :project_id, :operation_type, :idempotency_key,
+        :expected_revision, :resulting_revision,
+        :expected_authority_epoch, :resulting_authority_epoch,
+        :actor_type, :actor_id, :source_transport, :trace_id, :turn_id,
+        :request_hash, :created_at
+      )
+    `).run({
+      ":operation_id": operationId,
+      ":project_id": authority.project_id,
+      ":operation_type": request.operationType,
+      ":idempotency_key": request.idempotencyKey,
+      ":expected_revision": request.expectedRevision,
+      ":resulting_revision": resultingRevision,
+      ":expected_authority_epoch": request.expectedAuthorityEpoch,
+      ":resulting_authority_epoch": resultingAuthorityEpoch,
+      ":actor_type": request.actorType,
+      ":actor_id": request.actorId ?? null,
+      ":source_transport": request.sourceTransport,
+      ":trace_id": request.traceId ?? null,
+      ":turn_id": request.turnId ?? null,
+      ":request_hash": hash,
+      ":created_at": now,
+    });
+    hitFault("after-operation");
+
+    const mutation = mutate(context);
+    const eventPayloads = validateMutation(mutation);
+    const storedOperation = requireCommittedProvenance(
+      loadOperation(operationId),
+      request,
+      hash,
+      context,
+      now,
+    );
+    hitFault("after-mutation");
+
+    const eventIds: string[] = [];
+    mutation.events.forEach((event, eventIndex) => {
+      const eventId = randomUUID();
+      const causedByEventId =
+        event.causedByEventIndex === undefined ? null : eventIds[event.causedByEventIndex];
+      db.prepare(`
+        INSERT INTO workflow_domain_events (
+          event_id, operation_id, event_index, project_id, project_revision,
+          authority_epoch, event_type, entity_type, entity_id,
+          caused_by_event_id, payload_json, created_at
+        ) VALUES (
+          :event_id, :operation_id, :event_index, :project_id, :project_revision,
+          :authority_epoch, :event_type, :entity_type, :entity_id,
+          :caused_by_event_id, :payload_json, :created_at
+        )
+      `).run({
+        ":event_id": eventId,
+        ":operation_id": operationId,
+        ":event_index": eventIndex,
+        ":project_id": authority.project_id,
+        ":project_revision": resultingRevision,
+        ":authority_epoch": resultingAuthorityEpoch,
+        ":event_type": event.eventType,
+        ":entity_type": event.entityType,
+        ":entity_id": event.entityId,
+        ":caused_by_event_id": causedByEventId,
+        ":payload_json": eventPayloads[eventIndex],
+        ":created_at": now,
+      });
+      eventIds.push(eventId);
+    });
+    hitFault("after-events");
+
+    mutation.events.forEach((event, eventIndex) => {
+      for (const destination of event.destinations) {
+        db.prepare(`
+          INSERT INTO workflow_outbox (event_id, destination, available_at)
+          VALUES (:event_id, :destination, :available_at)
+        `).run({
+          ":event_id": eventIds[eventIndex],
+          ":destination": destination,
+          ":available_at": now,
+        });
+      }
+    });
+    hitFault("after-outbox");
+
+    mutation.projections.forEach((projection, projectionIndex) => {
+      const previous = db.prepare(`
+        SELECT current.projection_work_id
+        FROM workflow_projection_work current
+        WHERE current.project_id = :project_id
+          AND current.projection_key = :projection_key
+          AND NOT EXISTS (
+            SELECT 1 FROM workflow_projection_work successor
+            WHERE successor.supersedes_projection_work_id = current.projection_work_id
+          )
+      `).get({
+        ":project_id": authority.project_id,
+        ":projection_key": projection.projectionKey,
+      });
+      db.prepare(`
+        INSERT INTO workflow_projection_work (
+          projection_work_id, project_id, projection_key, projection_kind,
+          supersedes_projection_work_id, source_project_revision,
+          source_authority_epoch, renderer_version, enqueue_operation_id,
+          created_at, updated_at
+        ) VALUES (
+          :projection_work_id, :project_id, :projection_key, :projection_kind,
+          :supersedes_projection_work_id, :source_project_revision,
+          :source_authority_epoch, :renderer_version, :enqueue_operation_id,
+          :created_at, :updated_at
+        )
+      `).run({
+        ":projection_work_id": `${operationId}:${String(projectionIndex).padStart(4, "0")}`,
+        ":project_id": authority.project_id,
+        ":projection_key": projection.projectionKey,
+        ":projection_kind": projection.projectionKind,
+        ":supersedes_projection_work_id": previous?.["projection_work_id"] ?? null,
+        ":source_project_revision": resultingRevision,
+        ":source_authority_epoch": resultingAuthorityEpoch,
+        ":renderer_version": projection.rendererVersion,
+        ":enqueue_operation_id": operationId,
+        ":created_at": now,
+        ":updated_at": now,
+      });
+    });
+    hitFault("after-projections");
+    hitFault("before-cas");
+
+    const update = db.prepare(`
+      UPDATE project_authority
+      SET revision = :resulting_revision,
+          authority_epoch = :resulting_authority_epoch,
+          updated_at = :updated_at
+      WHERE singleton = 1
+        AND project_id = :project_id
+        AND revision = :expected_revision
+        AND authority_epoch = :expected_authority_epoch
+    `).run({
+      ":resulting_revision": resultingRevision,
+      ":resulting_authority_epoch": resultingAuthorityEpoch,
+      ":updated_at": now,
+      ":project_id": authority.project_id,
+      ":expected_revision": request.expectedRevision,
+      ":expected_authority_epoch": request.expectedAuthorityEpoch,
+    });
+    const changes =
+      typeof (update as { changes?: unknown }).changes === "number"
+        ? (update as { changes: number }).changes
+        : 0;
+    if (changes !== 1) {
+      throw new GSDError(GSD_REVISION_CONFLICT, "domain operation authority CAS failed");
+    }
+
+    return loadReceipt(storedOperation, "committed");
+  });
+
+  hitFault("after-commit");
+  return result;
+}

--- a/src/resources/extensions/gsd/db/domain-operation.ts
+++ b/src/resources/extensions/gsd/db/domain-operation.ts
@@ -245,6 +245,18 @@ function loadReceipt(operation: OperationRow, status: DomainOperationResult["sta
     SELECT event_id FROM workflow_domain_events
     WHERE operation_id = :operation_id ORDER BY event_index
   `).all({ ":operation_id": operation.operation_id }).map((row) => String(row["event_id"]));
+  const unsafeOutbox = db.prepare(`
+    SELECT EXISTS (
+      SELECT 1
+      FROM workflow_outbox outbox
+      JOIN workflow_domain_events event ON event.event_id = outbox.event_id
+      WHERE event.operation_id = :operation_id
+        AND outbox.outbox_id > 9007199254740991
+    ) AS unsafe
+  `).get({ ":operation_id": operation.operation_id });
+  if (unsafeOutbox?.["unsafe"] === 1) {
+    throw new Error("stored outbox identity exceeds safe integer range");
+  }
   const outboxIds = db.prepare(`
     SELECT outbox.outbox_id
     FROM workflow_outbox outbox
@@ -346,6 +358,27 @@ function staleAuthority(request: DomainOperationRequest, authority: AuthorityRow
   );
 }
 
+function isSqliteBusyError(error: unknown): boolean {
+  const code = String((error as { code?: unknown })?.code ?? "");
+  const message = String((error as { message?: unknown })?.message ?? error);
+  return code.includes("SQLITE_BUSY") || /SQLITE_BUSY|database is locked/i.test(message);
+}
+
+function runDomainOperationTransaction(fn: () => DomainOperationResult): DomainOperationResult {
+  try {
+    return immediateTransaction(fn);
+  } catch (error) {
+    if (isSqliteBusyError(error)) {
+      throw new GSDError(
+        GSD_REVISION_CONFLICT,
+        "domain operation writer contention; retry the request",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
 export function executeDomainOperation(
   request: DomainOperationRequest,
   /**
@@ -361,7 +394,7 @@ export function executeDomainOperation(
   }
   const hash = requestHash(request);
 
-  const result = immediateTransaction((): DomainOperationResult => {
+  const result = runDomainOperationTransaction((): DomainOperationResult => {
     const db = getDb();
     const authority = db.prepare(`
       SELECT project_id, revision, authority_epoch

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -53,7 +53,10 @@ import {
   applyMigrationV34RecoveryEvidenceFoundation,
   applyMigrationV35ProjectionImportKernelCloseoutFoundation,
 } from "../db-migration-steps.js";
-import { createCanonicalFoundationSchemaV31 } from "../db-canonical-foundation-schema.js";
+import {
+  createCanonicalFoundationSchemaV31,
+  ensureCanonicalOutboxInvariantsV31,
+} from "../db-canonical-foundation-schema.js";
 import { createConversationFoundationSchemaV33 } from "../db-conversation-foundation-schema.js";
 import { createLifecycleFoundationSchemaV32 } from "../db-lifecycle-foundation-schema.js";
 import { createProjectionImportKernelCloseoutFoundationSchemaV35 } from "../db-projection-import-kernel-closeout-foundation-schema.js";
@@ -175,6 +178,7 @@ function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): 
   }
 
   migrateSchema(db, dbPath);
+  ensureCanonicalOutboxInvariantsV31(db);
   rebuildMemoriesFtsSchemaOnce(db, {
     onRebuildFailed: (message) => logWarning("db", message),
   });

--- a/src/resources/extensions/gsd/errors.ts
+++ b/src/resources/extensions/gsd/errors.ts
@@ -15,6 +15,8 @@ export const GSD_GIT_ERROR = "GSD_GIT_ERROR";
 export const GSD_MERGE_CONFLICT = "GSD_MERGE_CONFLICT";
 export const GSD_PARSE_ERROR = "GSD_PARSE_ERROR";
 export const GSD_IO_ERROR = "GSD_IO_ERROR";
+export const GSD_REVISION_CONFLICT = "GSD_REVISION_CONFLICT";
+export const GSD_IDEMPOTENCY_CONFLICT = "GSD_IDEMPOTENCY_CONFLICT";
 
 // ─── Base Error ───────────────────────────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -56,6 +56,7 @@ import { immediateTransaction, transaction, getDb, getDbOrNull } from "./db/engi
 export * from "./db/writers/memory.js";
 export * from "./db/writers/reconcile.js";
 export * from "./db/writers/import-restore.js";
+export * from "./db/domain-operation.js";
 // Query Module (read-only seam) — extracted from the single-writer file.
 export * from "./db/queries.js";
 // Domain Write Operations (Hierarchy Status Cascades).

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -56,7 +56,16 @@ import { immediateTransaction, transaction, getDb, getDbOrNull } from "./db/engi
 export * from "./db/writers/memory.js";
 export * from "./db/writers/reconcile.js";
 export * from "./db/writers/import-restore.js";
-export * from "./db/domain-operation.js";
+export { executeDomainOperation } from "./db/domain-operation.js";
+export type {
+  DomainJsonValue,
+  DomainOperationContext,
+  DomainOperationEventInput,
+  DomainOperationMutation,
+  DomainOperationProjectionInput,
+  DomainOperationRequest,
+  DomainOperationResult,
+} from "./db/domain-operation.js";
 // Query Module (read-only seam) — extracted from the single-writer file.
 export * from "./db/queries.js";
 // Domain Write Operations (Hierarchy Status Cascades).

--- a/src/resources/extensions/gsd/tests/domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/domain-operation.test.ts
@@ -1,0 +1,679 @@
+// Project/App: gsd-pi
+// File Purpose: Executable contract for revision-checked, idempotent domain operations.
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, test, type TestContext } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import {
+  SCHEMA_VERSION,
+  _getAdapter,
+  closeDatabase,
+  openDatabase,
+  transaction,
+} from "../gsd-db.ts";
+import {
+  _setDomainOperationFaultForTest,
+  executeDomainOperation,
+  type DomainOperationContext,
+  type DomainOperationMutation,
+  type DomainOperationRequest,
+  type DomainOperationResult,
+} from "../db/domain-operation.ts";
+import {
+  GSD_IDEMPOTENCY_CONFLICT,
+  GSD_REVISION_CONFLICT,
+} from "../errors.ts";
+
+const tempDirs = new Set<string>();
+const POST_V30_TABLES = [
+  "workflow_settlement_receipts",
+  "workflow_closeout_effects",
+  "workflow_closeout_plans",
+  "workflow_kernel_checkpoints",
+  "workflow_import_applications",
+  "workflow_projection_work",
+  "workflow_remediation_links",
+  "workflow_human_acceptances",
+  "workflow_verification_evidence",
+  "workflow_technical_verdicts",
+  "workflow_acceptance_criteria",
+  "workflow_recovery_actions",
+  "workflow_recovery_budgets",
+  "workflow_failure_observations",
+  "workflow_decision_impacts",
+  "workflow_work_checkpoints",
+  "workflow_conversation_decisions",
+  "workflow_answers",
+  "workflow_interaction_options",
+  "workflow_interactions",
+  "workflow_question_dependencies",
+  "workflow_open_questions",
+  "workflow_milestone_contexts",
+  "workflow_requirement_dispositions",
+  "workflow_waivers",
+  "workflow_blockers",
+  "workflow_attempt_results",
+  "workflow_execution_attempts",
+  "workflow_item_lifecycles",
+  "workflow_outbox",
+  "workflow_domain_events",
+  "workflow_operations",
+  "project_authority",
+] as const;
+
+function databasePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-domain-operation-"));
+  tempDirs.add(dir);
+  return join(dir, "gsd.db");
+}
+
+function openFixture(t: TestContext): string {
+  const path = databasePath();
+  assert.equal(openDatabase(path), true);
+  t.after(closeDatabase);
+  return path;
+}
+
+function createV30Backup(): string {
+  const sourcePath = databasePath();
+  assert.equal(openDatabase(sourcePath), true);
+  const db = _getAdapter();
+  assert.ok(db);
+  db.exec("PRAGMA foreign_keys = OFF");
+  for (const table of POST_V30_TABLES) db.exec(`DROP TABLE IF EXISTS ${table}`);
+  db.exec(`
+    DELETE FROM schema_version;
+    INSERT INTO schema_version (version, applied_at)
+    VALUES (30, '2026-07-12T00:00:00.000Z');
+    INSERT OR IGNORE INTO milestones (id, title, status, created_at)
+    VALUES ('M-LEGACY', 'Preserved from v30', 'active', '2026-07-12T00:00:00.000Z');
+    INSERT OR IGNORE INTO audit_events
+      (event_id, trace_id, category, type, ts, payload_json)
+    VALUES
+      ('audit-v30', 'trace-v30', 'workflow', 'legacy',
+       '2026-07-12T00:00:00.000Z', '{"preserved":true}');
+  `);
+  closeDatabase();
+  const backupPath = join(dirname(sourcePath), "v30-backup.db");
+  copyFileSync(sourcePath, backupPath);
+  return backupPath;
+}
+
+function request(overrides: Partial<DomainOperationRequest> = {}): DomainOperationRequest {
+  return {
+    operationType: "milestone.describe",
+    idempotencyKey: "transport/request-1",
+    expectedRevision: 0,
+    expectedAuthorityEpoch: 0,
+    actorType: "user",
+    actorId: "developer",
+    sourceTransport: "test",
+    traceId: "trace-1",
+    turnId: "turn-1",
+    payload: { milestoneId: "M001", title: "Domain operation" },
+    advanceAuthorityEpoch: false,
+    ...overrides,
+  };
+}
+
+function mutation(
+  projectionKey = "status/project",
+  entityId = "M001",
+): DomainOperationMutation {
+  return {
+    events: [
+      {
+        eventType: "milestone.description.started",
+        entityType: "milestone",
+        entityId,
+        payload: { milestoneId: entityId, step: 1 },
+        destinations: ["projection", "telemetry"],
+      },
+      {
+        eventType: "milestone.description.completed",
+        entityType: "milestone",
+        entityId,
+        payload: { milestoneId: entityId, step: 2 },
+        destinations: ["projection"],
+      },
+    ],
+    projections: [
+      {
+        projectionKey,
+        projectionKind: "markdown",
+        rendererVersion: "v1",
+      },
+    ],
+  };
+}
+
+function execute(
+  operationRequest: DomainOperationRequest = request(),
+  mutate: (context: Readonly<DomainOperationContext>) => DomainOperationMutation = () => mutation(),
+): DomainOperationResult {
+  return executeDomainOperation(operationRequest, mutate);
+}
+
+function rows(sql: string): Array<Record<string, unknown>> {
+  const db = _getAdapter();
+  assert.ok(db);
+  return db.prepare(sql).all();
+}
+
+function row(sql: string): Record<string, unknown> {
+  const db = _getAdapter();
+  assert.ok(db);
+  return db.prepare(sql).get() ?? {};
+}
+
+function durableSnapshot(): Record<string, unknown> {
+  return {
+    authority: row("SELECT revision, authority_epoch FROM project_authority WHERE singleton = 1"),
+    operations: rows("SELECT * FROM workflow_operations ORDER BY resulting_revision"),
+    events: rows("SELECT * FROM workflow_domain_events ORDER BY project_revision, event_index"),
+    outbox: rows("SELECT * FROM workflow_outbox ORDER BY outbox_id"),
+    projections: rows("SELECT * FROM workflow_projection_work ORDER BY source_project_revision"),
+    callbackResidue: rows("SELECT scope, scope_id, key, value_json FROM runtime_kv WHERE key = 'domain-operation-fault-probe'"),
+  };
+}
+
+function assertCommittedReceipt(result: DomainOperationResult, revision: number, epoch = 0): void {
+  assert.equal(result.status, "committed");
+  assert.equal(result.resultingRevision, revision);
+  assert.equal(result.resultingAuthorityEpoch, epoch);
+  assert.match(result.operationId, /\S/);
+  assert.match(result.projectId, /\S/);
+  assert.match(result.requestHash, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(result.eventIds.length, 2);
+  assert.equal(new Set(result.eventIds).size, 2);
+  assert.equal(result.outboxIds.length, 3);
+  assert.ok(result.outboxIds.every((id) => Number.isInteger(id) && id > 0));
+  assert.equal(result.projectionWorkIds.length, 1);
+}
+
+function assertErrorCode(
+  fn: () => unknown,
+  code: string,
+  message: RegExp,
+): void {
+  assert.throws(fn, (error: unknown) => {
+    assert.equal((error as { code?: unknown }).code, code);
+    assert.match(String((error as Error).message), message);
+    return true;
+  });
+}
+
+afterEach(() => {
+  _setDomainOperationFaultForTest(null);
+  closeDatabase();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+test("one operation atomically commits provenance, ordered events, outbox, projection, and authority", (t) => {
+  openFixture(t);
+  let contextSeen: Readonly<DomainOperationContext> | undefined;
+
+  const result = execute(request(), (context) => {
+    contextSeen = context;
+    assert.equal(Object.isFrozen(context), true);
+    assert.equal(context.resultingRevision, 1);
+    assert.equal(context.resultingAuthorityEpoch, 0);
+    return mutation();
+  });
+
+  assertCommittedReceipt(result, 1);
+  assert.equal(contextSeen?.operationId, result.operationId);
+  assert.deepEqual(row("SELECT revision, authority_epoch FROM project_authority"), {
+    revision: 1,
+    authority_epoch: 0,
+  });
+  assert.deepEqual(
+    rows("SELECT operation_id, event_index, project_revision, authority_epoch FROM workflow_domain_events ORDER BY event_index"),
+    [
+      { operation_id: result.operationId, event_index: 0, project_revision: 1, authority_epoch: 0 },
+      { operation_id: result.operationId, event_index: 1, project_revision: 1, authority_epoch: 0 },
+    ],
+  );
+  assert.deepEqual(
+    rows("SELECT event_id, destination FROM workflow_outbox ORDER BY outbox_id").map(({ event_id, destination }) => ({ event_id, destination })),
+    [
+      { event_id: result.eventIds[0], destination: "projection" },
+      { event_id: result.eventIds[0], destination: "telemetry" },
+      { event_id: result.eventIds[1], destination: "projection" },
+    ],
+  );
+  assert.deepEqual(
+    row("SELECT projection_key, source_project_revision, source_authority_epoch, enqueue_operation_id, supersedes_projection_work_id, delivery_state FROM workflow_projection_work"),
+    {
+      projection_key: "status/project",
+      source_project_revision: 1,
+      source_authority_epoch: 0,
+      enqueue_operation_id: result.operationId,
+      supersedes_projection_work_id: null,
+      delivery_state: "pending",
+    },
+  );
+});
+
+test("exact idempotency replay returns the original receipt without rerunning mutation", (t) => {
+  const dbPath = openFixture(t);
+  let calls = 0;
+  const original = execute(request(), () => {
+    calls += 1;
+    return mutation();
+  });
+  const before = durableSnapshot();
+
+  const replay = execute(
+    request({ payload: { title: "Domain operation", milestoneId: "M001" } }),
+    () => {
+      calls += 1;
+      throw new Error("replay must not invoke mutation");
+    },
+  );
+
+  assert.equal(calls, 1);
+  assert.deepEqual(replay, { ...original, status: "replayed" });
+  assert.deepEqual(durableSnapshot(), before);
+
+  closeDatabase();
+  assert.equal(openDatabase(dbPath), true);
+  const reopened = execute(request(), () => {
+    throw new Error("reopened replay must not invoke mutation");
+  });
+  assert.deepEqual(reopened, replay);
+  assert.deepEqual(durableSnapshot(), before);
+});
+
+test("replay rejects damaged duplicated trace provenance", (t) => {
+  openFixture(t);
+  const original = execute();
+  const db = _getAdapter();
+  assert.ok(db);
+  db.prepare(`
+    UPDATE workflow_operations SET trace_id = 'damaged-trace'
+    WHERE operation_id = :operation_id
+  `).run({ ":operation_id": original.operationId });
+
+  assertErrorCode(
+    () => execute(),
+    GSD_IDEMPOTENCY_CONFLICT,
+    /idempotency conflict/i,
+  );
+});
+
+test("same idempotency key rejects every mismatched semantic tuple before stale checks", (t) => {
+  openFixture(t);
+  execute();
+  const before = durableSnapshot();
+  const mismatches: DomainOperationRequest[] = [
+    request({ payload: { milestoneId: "M001", title: "Changed" } }),
+    request({ operationType: "milestone.rename" }),
+    request({ actorId: "someone-else" }),
+    request({ sourceTransport: "other" }),
+    request({ expectedRevision: 1 }),
+    request({ expectedAuthorityEpoch: 1 }),
+  ];
+
+  for (const mismatched of mismatches) {
+    assertErrorCode(
+      () => execute(mismatched),
+      GSD_IDEMPOTENCY_CONFLICT,
+      /idempotency conflict/i,
+    );
+    assert.deepEqual(durableSnapshot(), before);
+  }
+});
+
+test("stale revision and stale Authority Epoch fail loudly with no residue", (t) => {
+  openFixture(t);
+  const initial = durableSnapshot();
+  assertErrorCode(
+    () => execute(request({ expectedRevision: 1 })),
+    GSD_REVISION_CONFLICT,
+    /stale project revision/i,
+  );
+  assert.deepEqual(durableSnapshot(), initial);
+  assertErrorCode(
+    () => execute(request({ expectedAuthorityEpoch: 1 })),
+    GSD_REVISION_CONFLICT,
+    /stale authority epoch/i,
+  );
+  assert.deepEqual(durableSnapshot(), initial);
+});
+
+test("revision and Authority Epoch inputs require safe increment headroom", (t) => {
+  openFixture(t);
+  const initial = durableSnapshot();
+  const unsafeInteger = Number.MAX_SAFE_INTEGER + 1;
+  const invalidRequests: DomainOperationRequest[] = [
+    request({ expectedRevision: unsafeInteger }),
+    request({ expectedRevision: Number.MAX_SAFE_INTEGER }),
+    request({ expectedAuthorityEpoch: unsafeInteger }),
+    request({
+      expectedAuthorityEpoch: Number.MAX_SAFE_INTEGER,
+      advanceAuthorityEpoch: true,
+    }),
+  ];
+
+  for (const invalidRequest of invalidRequests) {
+    assert.throws(
+      () => execute(invalidRequest),
+      /safe integer|increment headroom/i,
+    );
+    assert.deepEqual(durableSnapshot(), initial);
+  }
+});
+
+test("advanceAuthorityEpoch rejects malformed non-boolean runtime input", (t) => {
+  openFixture(t);
+  const initial = durableSnapshot();
+  const malformed = request({
+    advanceAuthorityEpoch: "true" as unknown as boolean,
+  });
+
+  assert.throws(
+    () => execute(malformed),
+    /advanceAuthorityEpoch.*boolean/i,
+  );
+  assert.deepEqual(durableSnapshot(), initial);
+});
+
+test("the Domain Operation owns the outer reserved-writer transaction", (t) => {
+  openFixture(t);
+  const before = durableSnapshot();
+  assert.throws(
+    () => transaction(() => execute()),
+    /must own the outer transaction/i,
+  );
+  assert.deepEqual(durableSnapshot(), before);
+});
+
+test("every pre-commit fault rolls back the operation, callback mutation, intents, and CAS", (t) => {
+  openFixture(t);
+  const faultPoints = [
+    "after-operation",
+    "after-mutation",
+    "after-events",
+    "after-outbox",
+    "after-projections",
+    "before-cas",
+  ] as const;
+
+  for (const point of faultPoints) {
+    const before = durableSnapshot();
+    _setDomainOperationFaultForTest(point);
+    assert.throws(
+      () => execute(request({ idempotencyKey: `fault/${point}` }), () => {
+        const db = _getAdapter();
+        assert.ok(db);
+        db.prepare(`
+          INSERT INTO runtime_kv (scope, scope_id, key, value_json, updated_at)
+          VALUES ('project', '', 'domain-operation-fault-probe', '{}', '2026-07-12T00:00:00.000Z')
+        `).run();
+        return mutation();
+      }),
+      new RegExp(point),
+    );
+    _setDomainOperationFaultForTest(null);
+    assert.deepEqual(durableSnapshot(), before, `${point} left durable residue`);
+  }
+});
+
+test("lost response after commit replays the original durable receipt", (t) => {
+  openFixture(t);
+  const operationRequest = request({ idempotencyKey: "lost-response" });
+  _setDomainOperationFaultForTest("after-commit");
+  assert.throws(() => execute(operationRequest), /after-commit/);
+  _setDomainOperationFaultForTest(null);
+
+  const committed = durableSnapshot();
+  assert.equal((committed.authority as Record<string, unknown>).revision, 1);
+  const replay = execute(operationRequest, () => {
+    throw new Error("lost-response replay must not run mutation");
+  });
+
+  assert.equal(replay.status, "replayed");
+  assert.equal(replay.resultingRevision, 1);
+  assert.equal(replay.eventIds.length, 2);
+  assert.equal(replay.outboxIds.length, 3);
+  assert.equal(replay.projectionWorkIds.length, 1);
+  assert.deepEqual(durableSnapshot(), committed);
+});
+
+test("successive operations supersede only the current projection head", (t) => {
+  openFixture(t);
+  const first = execute();
+  const second = execute(
+    request({ idempotencyKey: "transport/request-2", expectedRevision: 1, payload: { milestoneId: "M001", title: "Second" } }),
+    () => mutation("status/project", "M001"),
+  );
+
+  assertCommittedReceipt(second, 2);
+  assert.deepEqual(
+    rows("SELECT projection_work_id, supersedes_projection_work_id, source_project_revision FROM workflow_projection_work ORDER BY source_project_revision"),
+    [
+      { projection_work_id: first.projectionWorkIds[0], supersedes_projection_work_id: null, source_project_revision: 1 },
+      { projection_work_id: second.projectionWorkIds[0], supersedes_projection_work_id: first.projectionWorkIds[0], source_project_revision: 2 },
+    ],
+  );
+});
+
+test("projection receipt identities preserve mutation order", (t) => {
+  openFixture(t);
+  const result = execute(request({ idempotencyKey: "ordered-projections" }), () => ({
+    events: mutation().events,
+    projections: [
+      { projectionKey: "status/project", projectionKind: "markdown", rendererVersion: "v1" },
+      { projectionKey: "status/requirements", projectionKind: "markdown", rendererVersion: "v1" },
+    ],
+  }));
+
+  assert.deepEqual(result.projectionWorkIds, [
+    `${result.operationId}:0000`,
+    `${result.operationId}:0001`,
+  ]);
+  assert.deepEqual(
+    rows("SELECT projection_key FROM workflow_projection_work ORDER BY projection_work_id"),
+    [{ projection_key: "status/project" }, { projection_key: "status/requirements" }],
+  );
+});
+
+test("more than 10,000 projection targets are rejected without durable residue", (t) => {
+  openFixture(t);
+  const initial = durableSnapshot();
+  const projections = Array.from({ length: 10_001 }, (_, index) => ({
+    projectionKey: `status/generated-${String(index).padStart(5, "0")}`,
+    projectionKind: "markdown",
+    rendererVersion: "v1",
+  }));
+
+  assert.throws(
+    () => execute(request({ idempotencyKey: "too-many-projections" }), () => ({
+      events: mutation().events,
+      projections,
+    })),
+    /projection.*(?:limit|10,?000|too many)/i,
+  );
+  assert.deepEqual(durableSnapshot(), initial);
+});
+
+test("callback mutation of operation provenance aborts the whole Domain Operation", (t) => {
+  openFixture(t);
+  const initial = durableSnapshot();
+
+  for (const [column, value] of [
+    ["request_hash", `sha256:${"0".repeat(64)}`],
+    ["created_at", "2000-01-01T00:00:00.000Z"],
+  ] as const) {
+    assert.throws(
+      () => execute(request({ idempotencyKey: `mutated-provenance/${column}` }), (context) => {
+        const db = _getAdapter();
+        assert.ok(db);
+        db.prepare(`
+          UPDATE workflow_operations
+          SET ${column} = :value
+          WHERE operation_id = :operation_id
+        `).run({ ":value": value, ":operation_id": context.operationId });
+        return mutation();
+      }),
+      /operation.*provenance/i,
+    );
+    assert.deepEqual(durableSnapshot(), initial);
+  }
+});
+
+test("ordinary operations retain the epoch and explicit authority handoff advances it once", (t) => {
+  openFixture(t);
+  const ordinary = execute();
+  assertCommittedReceipt(ordinary, 1, 0);
+
+  const handoff = execute(request({
+    operationType: "authority.handoff",
+    idempotencyKey: "authority/handoff-1",
+    expectedRevision: 1,
+    expectedAuthorityEpoch: 0,
+    payload: { reason: "new owner" },
+    advanceAuthorityEpoch: true,
+  }));
+  assertCommittedReceipt(handoff, 2, 1);
+
+  const retained = execute(request({
+    idempotencyKey: "transport/request-3",
+    expectedRevision: 2,
+    expectedAuthorityEpoch: 1,
+    payload: { milestoneId: "M001", title: "After handoff" },
+  }));
+  assertCommittedReceipt(retained, 3, 1);
+  assert.deepEqual(row("SELECT revision, authority_epoch FROM project_authority"), {
+    revision: 3,
+    authority_epoch: 1,
+  });
+});
+
+test("a restored v30 backup upgrades without inventing canonical history before its first operation", (t) => {
+  const backupPath = createV30Backup();
+  const restoredPath = join(dirname(backupPath), "restored-v30.db");
+  copyFileSync(backupPath, restoredPath);
+
+  assert.equal(openDatabase(restoredPath), true);
+  t.after(closeDatabase);
+  assert.equal(SCHEMA_VERSION, 35);
+  assert.deepEqual(row("SELECT MAX(version) AS version FROM schema_version"), { version: 35 });
+  assert.deepEqual(row("SELECT title, status FROM milestones WHERE id = 'M-LEGACY'"), {
+    title: "Preserved from v30",
+    status: "active",
+  });
+  assert.deepEqual(row("SELECT payload_json FROM audit_events WHERE event_id = 'audit-v30'"), {
+    payload_json: '{"preserved":true}',
+  });
+  assert.deepEqual(row("SELECT revision, authority_epoch FROM project_authority"), {
+    revision: 0,
+    authority_epoch: 0,
+  });
+  for (const table of [
+    "workflow_operations",
+    "workflow_domain_events",
+    "workflow_outbox",
+    "workflow_projection_work",
+  ]) {
+    assert.equal(row(`SELECT COUNT(*) AS count FROM ${table}`).count, 0, `${table} must begin empty`);
+  }
+
+  const result = execute(request({
+    idempotencyKey: "restored-v30/first-operation",
+    payload: { milestoneId: "M-LEGACY", title: "First canonical change" },
+  }), () => mutation("status/project", "M-LEGACY"));
+
+  assertCommittedReceipt(result, 1);
+  assert.equal(row("SELECT COUNT(*) AS count FROM workflow_operations").count, 1);
+  assert.equal(row("SELECT COUNT(*) AS count FROM workflow_domain_events").count, 2);
+  assert.equal(row("SELECT COUNT(*) AS count FROM workflow_outbox").count, 3);
+  assert.equal(row("SELECT COUNT(*) AS count FROM workflow_projection_work").count, 1);
+  assert.deepEqual(row("SELECT revision, authority_epoch FROM project_authority"), {
+    revision: 1,
+    authority_epoch: 0,
+  });
+  assert.deepEqual(row("SELECT title FROM milestones WHERE id = 'M-LEGACY'"), {
+    title: "Preserved from v30",
+  });
+});
+
+function runWriter(dbPath: string, id: string, startAt: number): Promise<Record<string, unknown>> {
+  const dbHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/gsd-db.ts")).href;
+  const operationHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/db/domain-operation.ts")).href;
+  const script = `
+    import { openDatabase, closeDatabase } from ${JSON.stringify(dbHref)};
+    import { executeDomainOperation } from ${JSON.stringify(operationHref)};
+    const [dbPath, id, startAt] = process.argv.slice(1);
+    if (!openDatabase(dbPath)) throw new Error('database open failed');
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(0, Number(startAt) - Date.now()));
+    try {
+      const result = executeDomainOperation({
+        operationType: 'race', idempotencyKey: 'race/' + id,
+        expectedRevision: 0, expectedAuthorityEpoch: 0,
+        actorType: 'agent', actorId: id, sourceTransport: 'process',
+        payload: { id }, advanceAuthorityEpoch: false,
+      }, () => ({
+        events: [{ eventType: 'race.won', entityType: 'project', entityId: id, payload: { id }, destinations: ['projection'] }],
+        projections: [{ projectionKey: 'race/' + id, projectionKind: 'markdown', rendererVersion: 'v1' }],
+      }));
+      console.log(JSON.stringify({ kind: 'result', status: result.status, operationId: result.operationId }));
+    } catch (error) {
+      console.log(JSON.stringify({ kind: 'error', message: String(error?.message ?? error), code: error?.code ?? null }));
+    } finally { closeDatabase(); }
+  `;
+  const env = { ...process.env };
+  delete env.NODE_TEST_CONTEXT;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [
+      "--import", "./src/resources/extensions/gsd/tests/resolve-ts.mjs",
+      "--experimental-strip-types", "--input-type=module", "-e", script,
+      dbPath, id, String(startAt),
+    ], { cwd: process.cwd(), env, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code !== 0) return reject(new Error(stderr || stdout || `writer exited ${code}`));
+      try { resolve(JSON.parse(stdout.trim()) as Record<string, unknown>); }
+      catch { reject(new Error(`invalid writer output: ${stdout}\n${stderr}`)); }
+    });
+  });
+}
+
+test("two real processes racing one expected tuple yield one commit and one stale result", async (t) => {
+  const dbPath = openFixture(t);
+  closeDatabase();
+  const startAt = Date.now() + 1_000;
+  const outcomes = await Promise.all([
+    runWriter(dbPath, "writer-a", startAt),
+    runWriter(dbPath, "writer-b", startAt),
+  ]);
+
+  const committed = outcomes.filter((outcome) => outcome.kind === "result");
+  const rejected = outcomes.filter((outcome) => outcome.kind === "error");
+  assert.equal(committed.length, 1, JSON.stringify(outcomes));
+  assert.equal(rejected.length, 1, JSON.stringify(outcomes));
+  assert.equal(rejected[0]?.code, GSD_REVISION_CONFLICT);
+  assert.match(String(rejected[0]?.message), /stale project revision/i);
+  assert.doesNotMatch(String(rejected[0]?.message), /SQLITE_BUSY|database is locked/i);
+
+  assert.equal(openDatabase(dbPath), true);
+  assert.deepEqual(row("SELECT revision, authority_epoch FROM project_authority"), {
+    revision: 1,
+    authority_epoch: 0,
+  });
+  assert.equal(row("SELECT COUNT(*) AS count FROM workflow_operations").count, 1);
+  assert.equal(row("SELECT COUNT(*) AS count FROM workflow_domain_events").count, 1);
+  assert.equal(row("SELECT COUNT(*) AS count FROM workflow_outbox").count, 1);
+  assert.equal(row("SELECT COUNT(*) AS count FROM workflow_projection_work").count, 1);
+});

--- a/src/resources/extensions/gsd/tests/domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/domain-operation.test.ts
@@ -13,6 +13,7 @@ import {
   SCHEMA_VERSION,
   _getAdapter,
   closeDatabase,
+  openIsolatedDatabase,
   openDatabase,
   transaction,
 } from "../gsd-db.ts";
@@ -215,6 +216,12 @@ afterEach(() => {
   tempDirs.clear();
 });
 
+test("the public database barrel does not expose the fault injection hook", async () => {
+  const publicDatabase = await import("../gsd-db.ts");
+
+  assert.equal("_setDomainOperationFaultForTest" in publicDatabase, false);
+});
+
 test("one operation atomically commits provenance, ordered events, outbox, projection, and authority", (t) => {
   openFixture(t);
   let contextSeen: Readonly<DomainOperationContext> | undefined;
@@ -289,6 +296,25 @@ test("exact idempotency replay returns the original receipt without rerunning mu
   });
   assert.deepEqual(reopened, replay);
   assert.deepEqual(durableSnapshot(), before);
+});
+
+test("outbox receipt identities remain durable on an existing v35 database", (t) => {
+  const dbPath = openFixture(t);
+  const original = execute();
+  const db = _getAdapter();
+  assert.ok(db);
+  db.exec("DROP TRIGGER IF EXISTS trg_workflow_outbox_delete");
+  closeDatabase();
+  assert.equal(openDatabase(dbPath), true);
+
+  assert.throws(
+    () => _getAdapter()?.exec("DELETE FROM workflow_outbox WHERE outbox_id = 1"),
+    /outbox.*durable history/i,
+  );
+  const replay = execute(request(), () => {
+    throw new Error("durable receipt replay must not invoke mutation");
+  });
+  assert.deepEqual(replay, { ...original, status: "replayed" });
 });
 
 test("replay rejects damaged duplicated trace provenance", (t) => {
@@ -371,6 +397,21 @@ test("revision and Authority Epoch inputs require safe increment headroom", (t) 
   }
 });
 
+test("outbox identities outside the safe integer range abort the operation", (t) => {
+  openFixture(t);
+  const db = _getAdapter();
+  assert.ok(db);
+  db.prepare("INSERT INTO sqlite_sequence (name, seq) VALUES ('workflow_outbox', :seq)")
+    .run({ ":seq": Number.MAX_SAFE_INTEGER });
+  const before = durableSnapshot();
+
+  assert.throws(
+    () => execute(request({ idempotencyKey: "unsafe-outbox-id" })),
+    /outbox.*safe integer/i,
+  );
+  assert.deepEqual(durableSnapshot(), before);
+});
+
 test("advanceAuthorityEpoch rejects malformed non-boolean runtime input", (t) => {
   openFixture(t);
   const initial = durableSnapshot();
@@ -393,6 +434,24 @@ test("the Domain Operation owns the outer reserved-writer transaction", (t) => {
     /must own the outer transaction/i,
   );
   assert.deepEqual(durableSnapshot(), before);
+});
+
+test("writer lock exhaustion surfaces as a revision conflict", (t) => {
+  const dbPath = openFixture(t);
+  const blocker = openIsolatedDatabase(dbPath);
+  assert.ok(blocker);
+  blocker.exec("BEGIN IMMEDIATE");
+  t.after(() => {
+    blocker.exec("ROLLBACK");
+    blocker.close();
+  });
+  _getAdapter()?.exec("PRAGMA busy_timeout = 1");
+
+  assertErrorCode(
+    () => execute(request({ idempotencyKey: "writer-contention" })),
+    GSD_REVISION_CONFLICT,
+    /writer contention/i,
+  );
 });
 
 test("every pre-commit fault rolls back the operation, callback mutation, intents, and CAS", (t) => {

--- a/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
+++ b/src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
@@ -8,6 +8,7 @@
 // Allowlist:
 // - gsd-db.ts itself — compatibility barrel and remaining mid-migration wrappers
 // - db/engine.ts — schema, migrations, lifecycle, and transaction primitives
+// - db/domain-operation.ts — revision-checked authoritative transaction seam
 // - db/writers/** — domain writers
 // - typed coordination/runtime writer modules listed in TYPED_DB_WRITER_FILES
 // - schema/migration helper modules listed in SCHEMA_DB_WRITER_FILES
@@ -33,6 +34,7 @@ const gsdDir = join(process.cwd(), "src/resources/extensions/gsd");
 // filename. Write SQL may live only in:
 //   - db/engine.ts — connection lifecycle, schema/migrations (DDL), and the
 //     BEGIN/COMMIT transaction primitives. The shared handle every writer reads.
+//   - db/domain-operation.ts — revision-checked Domain Operations.
 //   - db/writers/**.ts — the Single Writer Layer: one cohesive write subsystem
 //     per file.
 //   - gsd-db.ts — the barrel that re-exports the layer (still holds wrappers
@@ -45,6 +47,7 @@ const gsdDir = join(process.cwd(), "src/resources/extensions/gsd");
 const TYPED_DB_WRITER_FILES = new Set([
   "db/auto-workers.ts",
   "db/command-queue.ts",
+  "db/domain-operation.ts",
   "db/milestone-leases.ts",
   "db/runtime-kv.ts",
   "db/unit-dispatches.ts",
@@ -343,6 +346,7 @@ test("gsd-db.ts exports the expected single-writer wrappers", async () => {
     "markMemoryUnitProcessed",
     "decayMemoriesBefore",
     "supersedeLowestRankedMemories",
+    "executeDomainOperation",
   ];
 
   for (const name of expected) {


### PR DESCRIPTION
## Intent

Refactor gsd-pi toward database-first workflow authority by adding the M002 S06 additive Domain Operation transaction boundary. A request must be revision- and Authority-Epoch-checked, project-scoped idempotent, provenance-audited, and atomically commit ordered domain events, outbox destinations, Projection Work, and the authority CAS; exact retries must return a durable receipt without rerunning mutation. Keep schema v35 and do not cut over production handlers, routing, file-derived authority, delivery, import, closeout, or lifecycle policy yet. Research came first; tests cover rollback fault points, lost responses, provenance corruption, unsafe integers, true two-process contention, v30-to-v35 restored backups, and adjacent v31-v35 invariants. Markdown is documentation/projection only, not workflow authority.

## What Changed

- Add a revision- and Authority Epoch-checked `executeDomainOperation` API that atomically records provenance, ordered domain events, outbox destinations, Projection Work, and authority updates.
- Support project-scoped idempotent replay with durable receipts, rollback guarantees, contention handling, safe outbox identities, and typed conflict errors.
- Add focused operation-boundary coverage and synchronize the database maps, architecture guidance, research, and refactor runbook.

## Risk Assessment

🚨 High: The change should not merge until mutable outbox and operation identities are addressed because they undermine its central durable-replay and immutable-provenance guarantees.

## Testing

Repository guidance and intent were inspected; focused automated tests passed across atomic rollback, lost-response replay, corrupted provenance, unsafe integers, restored v30 upgrades, adjacent schema invariants, and real two-process contention; an end-to-end public-API exercise produced an inspectable SQLite database and transcript proving durable commit/replay behavior. No visual artifact was captured because this additive boundary intentionally has no UI or production-handler cutover.

<details>
<summary>Evidence: Domain operation commit/replay and durable-state transcript</summary>

```text
{
  "userFlow": {
    "committedReceipt": {
      "status": "committed",
      "operationId": "8339c88f-6435-4353-88a6-c5fb382725b9",
      "projectId": "9879f872f9b3f91a27b28438de84523b",
      "resultingRevision": 1,
      "resultingAuthorityEpoch": 0,
      "requestHash": "sha256:541b2c6dda954c86cdd1c0035a2c687c54086db2e1314be117962b793f6f765a",
      "eventIds": [
        "9457c9e3-bf50-4ce5-95cb-4235f82b930a",
        "a1f67024-b560-4502-b9c1-d1a747cbc38a"
      ],
      "outboxIds": [
        1,
        2,
        3
      ],
      "projectionWorkIds": [
        "8339c88f-6435-4353-88a6-c5fb382725b9:0000"
      ]
    },
    "replayedReceipt": {
      "status": "replayed",
      "operationId": "8339c88f-6435-4353-88a6-c5fb382725b9",
      "projectId": "9879f872f9b3f91a27b28438de84523b",
      "resultingRevision": 1,
      "resultingAuthorityEpoch": 0,
      "requestHash": "sha256:541b2c6dda954c86cdd1c0035a2c687c54086db2e1314be117962b793f6f765a",
      "eventIds": [
        "9457c9e3-bf50-4ce5-95cb-4235f82b930a",
        "a1f67024-b560-4502-b9c1-d1a747cbc38a"
      ],
      "outboxIds": [
        1,
        2,
        3
      ],
      "projectionWorkIds": [
        "8339c88f-6435-4353-88a6-c5fb382725b9:0000"
      ]
    },
    "mutationCalls": 1,
    "receiptIdentityPreserved": true,
    "staleRejection": {
      "code": "GSD_REVISION_CONFLICT",
      "message": "stale project revision: expected 0, current 1"
    }
  },
  "durableState": {
    "schemaVersion": 35,
    "integrity": "ok",
    "authority": {
      "project_id": "9879f872f9b3f91a27b28438de84523b",
      "revision": 1,
      "authority_epoch": 0
    },
    "operations": [
      {
        "operation_type": "milestone.rename",
        "idempotency_key": "cli/request-42",
        "expected_revision": 0,
        "resulting_revision": 1,
        "expected_authority_epoch": 0,
        "resulting_authority_epoch": 0,
        "actor_type": "human",
        "actor_id": "reviewer",
        "source_transport": "cli",
        "trace_id": "trace-evidence-42",
        "request_hash": "sha256:541b2c6dda954c86cdd1c0035a2c687c54086db2e1314be117962b793f6f765a"
      }
    ],
    "events": [
      {
        "event_index": 0,
        "project_revision": 1,
        "authority_epoch": 0,
        "event_type": "milestone.renamed",
        "entity_type": "milestone",
        "entity_id": "M001",
        "has_cause": 0,
        "payload_json": "{\"title\":\"Database-first authority\"}"
      },
      {
        "event_index": 1,
        "project_revision": 1,
        "authority_epoch": 0,
        "event_type": "project.summary-invalidated",
        "entity_type": "project",
        "entity_id": "project",
        "has_cause": 1,
        "payload_json": "{\"reason\":\"milestone renamed\"}"
      }
    ],
    "outbox": [
      {
        "event_index": 0,
        "destination": "projection",
        "attempt_count": 0,
        "delivered": 0
      },
      {
        "event_index": 0,
        "destination": "telemetry",
        "attempt_count": 0,
        "delivered": 0
      },
      {
        "event_index": 1,
        "destination": "projection",
        "attempt_count": 0,
        "delivered": 0
      }
    ],
    "projections": [
      {
        "projection_key": "status/project",
        "projection_kind": "markdown",
        "source_project_revision": 1,
        "source_authority_epoch": 0,
        "renderer_version": "v1",
        "delivery_state": "pending"
      }
    ]
  }
}
```
</details>
- Evidence: Resulting inspectable SQLite v35 database (local file: <code>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXB591Y3RZVYF81X5EQRJGPH/domain-operation-evidence.db</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 issues (2 errors, 1 warning)</summary>

- ⚠️ `src/resources/extensions/gsd/gsd-db.ts:59` - The wildcard barrel export exposes `_setDomainOperationFaultForTest`, a process-global switch that can force production callers to throw—including after a successful commit. Explicitly export only `executeDomainOperation` and its public types; tests can import the hook directly.
- ⚠️ `src/resources/extensions/gsd/db/domain-operation.ts:248` - Replay reconstructs `outboxIds` from current outbox rows, but the schema permits those rows to be deleted. Cleanup or corruption can therefore make an exact retry return a shortened receipt instead of the original durable receipt. Decide whether outbox rows must be retained or receipt identities must be stored separately and validated.
- ⚠️ `src/resources/extensions/gsd/db/domain-operation.ts:254` - Converting SQLite `INTEGER` outbox IDs with `Number(...)` can silently lose precision above `Number.MAX_SAFE_INTEGER`, collapsing distinct durable identities. Reject unsafe values before returning the receipt or use a lossless representation.
- ⚠️ `src/resources/extensions/gsd/db/domain-operation.ts:364` - The operation relies directly on `BEGIN IMMEDIATE`; after the connection&#39;s 5-second busy timeout, a competing writer still surfaces raw `SQLITE_BUSY`. That violates the stated invariant that races resolve as committed/replayed/stale rather than database-lock errors. Add bounded deterministic lock acquisition/retry or translate exhaustion into the domain conflict contract.

🔧 Fix: Harden domain operation replay and contention guarantees
3 issues (2 errors, 1 warning) still open:
- 🚨 `src/resources/extensions/gsd/db-canonical-foundation-schema.ts:15` - The durability trigger blocks deletion but still permits updates to `outbox_id`, `event_id`, and `destination`. Reassigning an outbox row can change an operation’s reconstructed receipt or durable destinations on replay. Add an identity-immutability update trigger while allowing delivery-state fields to change.
- 🚨 `src/resources/extensions/gsd/db/domain-operation.ts:443` - The provenance row is verified only immediately after the mutation callback. After commit, its actor, transport, hash, and other provenance fields remain updateable, causing an exact retry to conflict instead of returning its durable receipt. Enforce general workflow-operation provenance immutability.
- ⚠️ `src/resources/extensions/gsd/db/domain-operation.ts:136` - Canonicalizing a sparse array skips its holes and produces invalid JSON such as `[,1]`; event payloads can therefore commit malformed `payload_json`. Reject sparse arrays or canonicalize holes consistently to `null`.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `CONTRIBUTING.md`, the base-to-target diff, research contract, public API, implementation, and focused tests.</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/domain-operation.test.ts src/resources/extensions/gsd/tests/db-canonical-foundation.test.ts src/resources/extensions/gsd/tests/single-writer-invariant.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXB591Y3RZVYF81X5EQRJGPH/domain-operation-evidence.mjs > /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXB591Y3RZVYF81X5EQRJGPH/domain-operation-transcript.json`
- `Manually inspected the generated transcript for the committed receipt, identical restart replay, one mutation invocation, stale-revision rejection, schema version 35, SQLite integrity, authority CAS, provenance, ordered events, outbox destinations, and pending Projection Work.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is the future authoritative write path for workflow state; receipt replay and outbox/operation immutability must be bulletproof before any cutover, and open review items highlight gaps (mutable outbox identity fields, updatable operation provenance, sparse-array canonicalization) that could break durable replay guarantees.
> 
> **Overview**
> Introduces the **M002 S06 Domain Operation** primitive: `executeDomainOperation(request, mutate)` runs one reserved-writer transaction that checks project revision and Authority Epoch, reserves a project-scoped idempotency key, inserts operation provenance, runs a deterministic DB-only mutation callback, records ordered domain events with outbox destinations, enqueues per-key Projection Work successors, and CAS-advances `project_authority`. Exact retries return a **`replayed`** receipt (same event/outbox/projection identities) without calling `mutate`; semantic key reuse raises **`GSD_IDEMPOTENCY_CONFLICT`**, and stale tuple, CAS failure, or lock contention map to **`GSD_REVISION_CONFLICT`**.
> 
> Supporting changes tighten the **canonical outbox** (durable-history delete guard, safe-integer identity abort), export the API and types from **`gsd-db.ts`**, extend the **single-writer allowlist**, and add **`domain-operation.test.ts`** plus a **refactor runbook** and doc map updates. Schema stays **v35**; auto dispatch, markdown-derived readiness, import/closeout cutover, and projection delivery are explicitly **out of scope** for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf1974bf37b2d419814e08ffec91b4495f1c549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->