### PR TITLE
fix(issue): [Bug] Flat-phase migration rolls back because `.planning/` projection throws on `legacy-milestone-dir` layout (v1 only implements `flat-phases` writer)

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -940,9 +940,16 @@ export async function renderAllFromDb(basePath: string): Promise<RenderAllResult
     await capturePlanningCompatIfNeeded(basePath);
     const marker = readCompatMarker(basePath);
     if (marker.planning?.active && marker.planning.layout) {
-      const { writePlanningDirectory } = await import("./migrate/planning-writer.js");
-      await writePlanningDirectory(basePath, marker.planning.layout);
-      result.rendered++;
+      if (marker.planning.layout === "flat-phases") {
+        const { writePlanningDirectory } = await import("./migrate/planning-writer.js");
+        await writePlanningDirectory(basePath, marker.planning.layout);
+        result.rendered++;
+      } else {
+        logWarning(
+          "renderer",
+          `planning projection skipped: layout "${marker.planning.layout}" not yet supported (v1 supports flat-phases only)`,
+        );
+      }
     }
   } catch (err) {
     result.errors.push(`planning projection: ${(err as Error).message}`);

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -14,6 +14,7 @@ import {
   pruneStaleFlatPhaseBackups,
 } from "../flat-phase-migration.ts";
 import { openDatabase, closeDatabase, insertArtifact, insertMilestone, insertSlice, insertTask, getAllMilestones, getMilestoneSlices, getSliceTasks, _getAdapter } from "../gsd-db.ts";
+import { writeCompatMarker } from "../compat/compat-marker.ts";
 
 const tmpDirs: string[] = [];
 function makeTmp(options: { withTask?: boolean } = {}): string {
@@ -76,6 +77,24 @@ test("migrateToFlatPhase moves content from milestones/ to phases/", async () =>
 
   assert.ok(existsSync(join(base, ".gsd", "phases")), "phases/ should exist");
   assert.ok(!existsSync(join(base, ".gsd", "milestones")), "milestones/ should be removed");
+});
+
+test("migrateToFlatPhase ignores unsupported .planning projection layout", async () => {
+  const base = makeTmp();
+  mkdirSync(join(base, ".planning", "milestones", "M001", "v1-phases"), { recursive: true });
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "",
+    projections: {},
+    planning: { active: true, layout: "legacy-milestone-dir", projections: {}, passthrough: {} },
+    piVersion: "1.4.0",
+  });
+
+  await migrateToFlatPhase(base);
+
+  assert.ok(existsSync(join(base, ".gsd", "phases", "01-foundation")), "flat phase should render");
+  assert.equal(existsSync(join(base, ".gsd", "milestones")), false, "legacy milestones/ should be removed");
 });
 
 test("migrateToFlatPhase ignores and removes stale phase dirs from prior aborted runs", async () => {


### PR DESCRIPTION
## Summary
- Skipped unsupported `.planning` layouts during render projection and added a flat-phase migration regression test; local syntax and diff checks passed.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1434
- [#1434 [Bug] Flat-phase migration rolls back because `.planning/` projection throws on `legacy-milestone-dir` layout (v1 only implements `flat-phases` writer)](https://github.com/open-gsd/gsd-pi/issues/1434)

## User
- @Azd325

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1434-bug-flat-phase-migration-rolls-back-beca-1783865730`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard around optional `.planning` double-write; core GSD markdown projection unchanged; migration behavior improved with test coverage.
> 
> **Overview**
> **Fixes flat-phase migration failing** when `.planning` is active with a **`legacy-milestone-dir`** (or other non-`flat-phases`) layout: `renderAllFromDb` no longer always calls `writePlanningDirectory` (v1 only implements `flat-phases`). Unsupported layouts get a **warning** and are skipped instead of throwing into `planning projection` errors that could abort migration rollback paths.
> 
> Adds a **regression test** that runs `migrateToFlatPhase` with an active `legacy-milestone-dir` compat marker and asserts `.gsd/phases` still renders and legacy `milestones/` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4105e87752b988c5894fb7838e54b9e1a2e8019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->