### PR TITLE
fix(issue): v1.11.0: gsd_task_complete re-renders verified ROADMAP.md from stale DB and silently removes remediation criteria

### DIFF
--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -404,7 +404,7 @@ console.log('\n=== complete-task: roadmap expected output is not re-rendered fro
 `;
   fs.writeFileSync(roadmapPath, roadmapContent);
 
-  insertMilestone({ id: 'M001', title: 'Test Milestone', vision: 'Stale DB vision' });
+  insertMilestone({ id: 'M001', title: 'Test Milestone', planning: { vision: 'Stale DB vision' } });
   insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice', risk: 'high', depends: [], demo: 'basic functionality works', sequence: 1 });
   insertTask({
     id: 'T01',

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -383,6 +383,58 @@ console.log('\n=== complete-task: handler happy path ===');
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// complete-task: Roadmap task output is not clobbered by stale DB render
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-task: roadmap expected output is not re-rendered from stale DB ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+
+  const { basePath, planPath } = createTempProject();
+  const phaseDir = path.dirname(planPath);
+  const roadmapPath = path.join(phaseDir, '01-ROADMAP.md');
+  const roadmapContent = `# M001: Test Milestone
+
+## Success Criteria
+- Keep remediation criteria from the verified task output.
+
+## Boundary Map
+- S01 -> terminal: criteria remain documented.
+`;
+  fs.writeFileSync(roadmapPath, roadmapContent);
+
+  insertMilestone({ id: 'M001', title: 'Test Milestone', vision: 'Stale DB vision' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice', risk: 'high', depends: [], demo: 'basic functionality works', sequence: 1 });
+  insertTask({
+    id: 'T01',
+    sliceId: 'S01',
+    milestoneId: 'M001',
+    status: 'pending',
+    title: 'Repair roadmap criteria',
+    planning: {
+      expectedOutput: ['.gsd/phases/01-test/01-ROADMAP.md — remediation criteria'],
+    },
+  });
+
+  const result = await handleCompleteTask({
+    ...makeValidParams(),
+    keyFiles: [],
+    keyDecisions: [],
+  }, basePath);
+
+  assertTrue(!('error' in result), 'handler should succeed without error');
+  assertEq(
+    fs.readFileSync(roadmapPath, 'utf-8'),
+    roadmapContent,
+    'complete-task should not overwrite a roadmap listed as task expected output',
+  );
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // complete-task: Flat-phase duplicate task IDs are slice-qualified
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -11,7 +11,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { basename, isAbsolute, join, relative } from "node:path";
 
 import type { CompleteTaskParams, EscalationArtifact } from "../types.js";
 import { isClosedStatus } from "../status-guards.js";
@@ -39,12 +39,15 @@ import {
   gsdProjectionRoot,
   clearPathCache,
   legacyMilestonesDir,
+  relMilestoneFile,
+  resolveMilestoneFile,
   resolveMilestonePath,
   resolveSlicePath,
+  targetMilestoneFile,
 } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, taskUnitKey } from "../unit-ownership.js";
-import { saveFile, clearParseCache } from "../files.js";
+import { saveFile, clearParseCache, normalizePlannedFileReference } from "../files.js";
 import { invalidateStateCache } from "../state.js";
 import { renderPlanCheckboxes } from "../markdown-renderer.js";
 import {
@@ -136,6 +139,15 @@ async function repairMissingTaskSummaryProjection(
     taskRow.id,
   );
   const summaryMd = renderSummaryContent(taskRow, taskRow.slice_id, taskRow.milestone_id, []);
+  const skipRoadmap = taskReferencesMilestoneRoadmap(
+    artifactBasePath,
+    taskRow.milestone_id,
+    [
+      ...taskRow.expected_output,
+      ...taskRow.files,
+      ...taskRow.key_files,
+    ],
+  );
   let stale = false;
 
   try {
@@ -155,7 +167,7 @@ async function repairMissingTaskSummaryProjection(
   clearParseCache();
 
   try {
-    const rendered = await renderMilestoneShellProjections(artifactBasePath, taskRow.milestone_id);
+    const rendered = await renderMilestoneShellProjections(artifactBasePath, taskRow.milestone_id, { skipRoadmap });
     stale ||= rendered.stale;
   } catch (projErr) {
     stale = true;
@@ -237,6 +249,50 @@ function satisfiesBlockingReworkFinding(resolution: ReturnType<typeof normalizeR
   if (resolution.evidence.trim().length === 0) return false;
   if (resolution.status === "resolved") return true;
   return (resolution.decisionRef ?? "").trim().length > 0;
+}
+
+function normalizeTaskFileReference(value: string, basePath: string): string {
+  const cleaned = normalizePlannedFileReference(value).trim().replace(/^['"]|['"]$/g, "");
+  if (!cleaned) return "";
+
+  if (isAbsolute(cleaned)) {
+    const rel = relative(basePath, cleaned).replace(/\\/g, "/");
+    if (rel && rel !== "." && rel !== ".." && !rel.startsWith("../")) {
+      return rel.replace(/^\.\//, "").toLowerCase();
+    }
+  }
+
+  return cleaned.replace(/\\/g, "/").replace(/^\.\//, "").toLowerCase();
+}
+
+function taskReferencesMilestoneRoadmap(
+  basePath: string,
+  milestoneId: string,
+  references: string[],
+): boolean {
+  if (references.length === 0) return false;
+
+  const milestone = getMilestone(milestoneId);
+  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP")
+    ?? targetMilestoneFile(basePath, milestoneId, "ROADMAP", milestone?.title);
+  if (!existsSync(roadmapPath)) return false;
+
+  const normalizedRoadmapPath = roadmapPath.replace(/\\/g, "/").toLowerCase();
+  const relFromProjectionRoot = relative(gsdProjectionRoot(basePath), roadmapPath)
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "");
+  const exactMatches = new Set([
+    relative(basePath, roadmapPath).replace(/\\/g, "/").replace(/^\.\//, "").toLowerCase(),
+    relMilestoneFile(basePath, milestoneId, "ROADMAP", milestone?.title).replace(/^\.\//, "").toLowerCase(),
+    `.gsd/${relFromProjectionRoot}`.toLowerCase(),
+    normalizedRoadmapPath,
+  ]);
+  const roadmapFileName = basename(roadmapPath).toLowerCase();
+
+  return references.some((reference) => {
+    const normalized = normalizeTaskFileReference(reference, basePath);
+    return exactMatches.has(normalized) || normalized === roadmapFileName;
+  });
 }
 
 function paramsToTaskRow(params: CompleteTaskParams, completedAt: string): TaskRow {
@@ -325,6 +381,7 @@ export async function handleCompleteTask(
   let guardError: string | null = null;
   let summaryMd = "";
   let repairTaskSummaryRow: TaskRow | null = null;
+  let skipRoadmapProjectionAfterCompletion = false;
   const workflowDbPath = getWorkflowDatabasePath();
 
   // ── ADR-011 Phase 2: validate escalation payload BEFORE any side effects ─
@@ -395,6 +452,18 @@ export async function handleCompleteTask(
     }
 
     const existingTask = getTask(params.milestoneId, params.sliceId, params.taskId);
+    // If this task just produced the ROADMAP projection, preserve its verified
+    // content instead of immediately regenerating it from stale DB rows (#1433).
+    skipRoadmapProjectionAfterCompletion = taskReferencesMilestoneRoadmap(
+      artifactBasePath,
+      params.milestoneId,
+      [
+        ...(existingTask?.expected_output ?? []),
+        ...(existingTask?.files ?? []),
+        ...(existingTask?.key_files ?? []),
+        ...normalizeListParam(params.keyFiles),
+      ],
+    );
     const unresolvedRework = getUnresolvedBlockingReworkFindingsForTask(params.milestoneId, params.sliceId, params.taskId);
     const resolvedFindingIds = new Set(
       reworkResolutions
@@ -654,7 +723,9 @@ export async function handleCompleteTask(
   // the event log entry (critical for worktree reconciliation).
   let projectionStale = false;
   try {
-    const rendered = await renderMilestoneShellProjections(artifactBasePath, params.milestoneId);
+    const rendered = await renderMilestoneShellProjections(artifactBasePath, params.milestoneId, {
+      skipRoadmap: skipRoadmapProjectionAfterCompletion,
+    });
     projectionStale = rendered.stale;
   } catch (projErr) {
     projectionStale = true;

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -452,13 +452,16 @@ export async function renderStateProjection(basePath: string): Promise<{ stale: 
 export async function renderMilestoneShellProjections(
   basePath: string,
   milestoneId: string,
+  options: { skipRoadmap?: boolean } = {},
 ): Promise<{ stale: boolean }> {
   let stale = false;
-  try {
-    await renderRoadmapFromDb(basePath, milestoneId);
-  } catch (err) {
-    stale = true;
-    logWarning("projection", `renderRoadmapFromDb failed for ${milestoneId}: ${(err as Error).message}`);
+  if (!options.skipRoadmap) {
+    try {
+      await renderRoadmapFromDb(basePath, milestoneId);
+    } catch (err) {
+      stale = true;
+      logWarning("projection", `renderRoadmapFromDb failed for ${milestoneId}: ${(err as Error).message}`);
+    }
   }
   try {
     renderTopLevelRoadmapFromDb(basePath);


### PR DESCRIPTION
## Summary
- Added a complete-task roadmap projection skip for task-owned ROADMAP outputs with regression coverage; static diff check passed while runtime tests were blocked by missing dependencies/network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1433
- [#1433 v1.11.0: gsd_task_complete re-renders verified ROADMAP.md from stale DB and silently removes remediation criteria](https://github.com/open-gsd/gsd-pi/issues/1433)

## User
- @mik888em

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1433-v1-11-0-gsd-task-complete-re-renders-ver-1783865722`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes projection behavior on a sensitive workflow path (task completion); scope is narrow (roadmap skip only) and covered by a targeted regression test.
> 
> **Overview**
> **`gsd_complete_task` no longer overwrites milestone `ROADMAP.md` right after a task finishes work on that file.** Post-completion shell projections used to always call `renderRoadmapFromDb`, which could replace agent-verified roadmap content (e.g. remediation criteria) with older DB planning fields.
> 
> The handler now detects when the completing task’s `expected_output`, `files`, or `key_files` reference the milestone roadmap (with normalized path matching), and passes **`skipRoadmap`** into `renderMilestoneShellProjections` on the normal completion path and on missing-summary repair. Top-level roadmap, queue, and `STATE.md` projections still run.
> 
> A regression test asserts that completing a task whose expected output lists the phase `ROADMAP.md` leaves the on-disk file unchanged when the DB milestone planning is stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a55531ef0f58d666af16c25f3a42ca79926d00f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->