### PR TITLE
feat(gsd): add transaction-bound lifecycle writers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ Design documents, ADRs, and internal references. Located in [`dev/`](./dev/).
 | [ADR-046: Database-Authoritative Workflow Lifecycle](./dev/ADR-046-database-authoritative-workflow-lifecycle.md) | Accepted database-authoritative lifecycle and migration contract |
 | [RFC: Database-Authoritative Workflow Refactor](./dev/proposals/rfc-database-authoritative-workflow-refactor.md) | Accepted implementation direction, gates, and milestone program |
 | [Domain Operation Runbook](./dev/refactor-foundation-runbook.md) | Revision-checked transaction boundary, focused tests, and no-cutover guardrails |
+| [Lifecycle Command Integration Runbook](./dev/lifecycle-command-integration-runbook.md) | Canonical writer boundary, downstream entry gates, and verification loop |
 | [Context Optimization Opportunities](./dev/pi-context-optimization-opportunities.md) | Analysis of context window usage and optimization strategies |
 | [File System Map](./dev/FILE-SYSTEM-MAP.md) | Complete file system reference |
 | [CI/CD Pipeline](./dev/ci-cd-pipeline.md) | Continuous integration and deployment pipeline |

--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -23,6 +23,8 @@ gsd-db.ts  ← compatibility barrel over the explicit single-writer allowlist
        ├── db/engine.ts     ← connection/handle, schema/migrations, transaction primitives
        ├── db/domain-operation.ts
        │                    ← revision-checked authoritative transaction boundary
+       ├── db/lifecycle-shadow-comparison.ts
+       │                    ← pure legacy/canonical lifecycle comparison
        ├── db/writers/*.ts  ← the Single Writer Layer (one write subsystem per file)
        ├── db/{milestone-leases,unit-dispatches,auto-workers,runtime-kv,command-queue}.ts
        │                    ← typed coordination/runtime writers
@@ -683,9 +685,10 @@ Non-correctness-critical state: UI cursors, dashboard caches, resume pointers. S
 
 V31 created these tables on fresh databases and transactionally upgraded V30
 databases. The current v35 codebase also exposes an additive Domain Operation
-transaction over them, but existing production handlers and runtime authority
-are not routed through that boundary yet. No import application, projection
-worker, lifecycle API, or legacy deletion ships with it.
+transaction over them plus dormant lifecycle command primitives, but existing
+production handlers and runtime authority are not routed through that boundary
+yet. No import application, projection worker, production lifecycle adapter, or
+legacy deletion ships with it.
 
 #### `project_authority`
 ```
@@ -804,14 +807,36 @@ at most 10,000 projection targets. It must own the outer transaction. Production
 command adapters, projection delivery, import, closeout, lifecycle policy, and
 runtime authority cutover remain deferred.
 
+#### Dormant lifecycle command primitives
+
+`db/writers/lifecycle-commands.ts`, exported through `gsd-db.ts`, composes with
+`executeDomainOperation()` but does not start a transaction or emit events and
+Projection Work itself. `readDomainOperationFence()` returns the current fence,
+or the original expected fence for an existing idempotency key. Inside the
+active callback, `adoptOrTransitionLifecycle()` creates or advances one
+canonical lifecycle head, `claimRunningAttempt()` creates a running Attempt and
+its first `execute` checkpoint, `settleAttemptWithResult()` settles that Attempt
+with one immutable Result, and `appendKernelCheckpoint()` extends the current
+checkpoint head.
+
+The schema triggers continue to enforce transition legality, live lease and
+optional dispatch fencing, retry order, provenance, and checkpoint lineage.
+`db/lifecycle-shadow-comparison.ts` separately provides pure legacy/canonical
+status normalization and classifies exact matches, accepted semantic deltas,
+missing or extra shadow rows, and mismatches while preserving both raw values.
+Production callers remain blocked until lease-loss recovery, Kernel stage
+policy, and terminal-reopen convergence are proven.
+
 ---
 
 ### 3f. Additive Lifecycle Foundation (V32)
 
 V32 creates these tables on fresh databases and transactionally upgrades V31
-databases. Like V31, it is schema-only: the existing hierarchy statuses and
-coordination ledgers retain their runtime meaning, and no backfill, dual-write,
-Markdown inference, lifecycle API, or runtime cutover ships with this migration.
+databases. The migration itself remains additive, and the existing hierarchy
+statuses and coordination ledgers retain their runtime meaning. Dormant typed
+writers now exercise lifecycle, Attempt, Result, and Kernel facts inside Domain
+Operations, but no production dual-write, backfill, Markdown inference, or
+runtime cutover ships with them.
 
 #### `workflow_item_lifecycles`
 ```

--- a/docs/dev/FILE-SYSTEM-MAP.md
+++ b/docs/dev/FILE-SYSTEM-MAP.md
@@ -505,6 +505,9 @@
 | gsd/state/derive/from-db.ts | State Machine | DB-to-GSDState projection and active unit selection |
 | gsd/state/derive/cache.ts | State Machine | Derive-state cache and telemetry |
 | gsd/state/derive/db-open.ts | State Machine | Workflow DB opening and DB-unavailable state construction |
+| gsd/db/domain-operation.ts | Database, State Machine | Revision-checked Domain Operation transaction and durable replay receipt boundary |
+| gsd/db/lifecycle-shadow-comparison.ts | Database, State Machine | Pure legacy-to-canonical lifecycle normalization and semantic shadow comparison |
+| gsd/db/writers/lifecycle-commands.ts | Database, State Machine | Dormant transaction-bound lifecycle, Attempt, Result, replay-fence, and Kernel checkpoint writers |
 | gsd/history.ts | State Machine | State history and versioning |
 | gsd/json-persistence.ts | State Machine | JSON-based persistence layer |
 | gsd/memory-store.ts | State Machine | In-memory state storage |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -33,7 +33,7 @@ GSD stores runtime workflow state in the project-root SQLite database. Auto mode
 
 Milestone queue position has one explicit file contract: `.gsd/QUEUE-ORDER.json`. `/gsd rethink` and `/gsd phase` use it as a durable reorder record, and state derivation mirrors that order into `milestones.sequence` before selecting the active milestone. Other generated `.gsd` artifacts remain projections unless an explicit import or recovery command reads them.
 
-The additive `db/domain-operation.ts` boundary is the future authoritative write seam. `executeDomainOperation()` owns a `BEGIN IMMEDIATE` transaction that revision- and Authority-Epoch-checks a request, reserves a project-scoped idempotency key, records provenance and ordered events, enqueues their outbox destinations and Projection Work, then advances authority with a compare-and-swap. Exact retries return the durable receipt without rerunning the mutation. Production handlers and file-derived readiness, completion, UAT, and reconciliation paths are not routed through this boundary yet; schema remains v35 and Markdown remains projection output rather than workflow authority.
+The additive `db/domain-operation.ts` boundary is the future authoritative write seam. `executeDomainOperation()` owns a `BEGIN IMMEDIATE` transaction that revision- and Authority-Epoch-checks a request, reserves a project-scoped idempotency key, records provenance and ordered events, enqueues their outbox destinations and Projection Work, then advances authority with a compare-and-swap. Exact retries return the durable receipt without rerunning the mutation. Transaction-bound lifecycle writers can now adopt or transition canonical lifecycle heads, claim and settle Attempts with immutable Results, and append Kernel checkpoints. A pure shadow comparator normalizes legacy statuses without hiding exact deltas. These primitives remain dormant: production handlers and file-derived readiness, completion, UAT, and reconciliation paths are not routed through them yet; schema remains v35 and Markdown remains projection output rather than workflow authority.
 
 ### Two-File Loader Pattern
 
@@ -181,6 +181,8 @@ Model routing (complexity classification, budget pressure, routing history, capa
 | `memory-store.ts` | Persistent memory store for cross-session knowledge |
 | `queue-order.ts` | Durable milestone queue ordering contract and DB sequence mirroring |
 | `db/domain-operation.ts` | Additive revision-checked Domain Operation transaction and durable replay receipt boundary |
+| `db/lifecycle-shadow-comparison.ts` | Pure legacy-to-canonical lifecycle status normalization and semantic shadow comparison |
+| `db/writers/lifecycle-commands.ts` | Transaction-bound lifecycle, Attempt, Result, replay-fence, and Kernel checkpoint primitives |
 | `context-masker.ts` | Context masking for model routing optimization |
 | `phase-anchor.ts` | Phase anchoring for dispatch pipeline |
 | `slice-parallel-orchestrator.ts` | Slice-level parallelism with dependency-aware dispatch |

--- a/docs/dev/lifecycle-command-integration-runbook.md
+++ b/docs/dev/lifecycle-command-integration-runbook.md
@@ -1,0 +1,61 @@
+<!-- Project/App: gsd-pi -->
+<!-- File Purpose: Integration and verification runbook for canonical lifecycle command writers. -->
+
+# Lifecycle command integration runbook
+
+This runbook governs the dormant command primitives introduced in M003/S01.
+They write canonical lifecycle, Attempt, Result, and Kernel checkpoint facts only
+inside an active Domain Operation. Legacy hierarchy reads and responses remain
+authoritative until a later, separately proven cutover.
+
+## Command boundary
+
+1. Read the current or replay fence with `readDomainOperationFence`.
+2. Start one semantic Domain Operation with that expected revision and Authority
+   Epoch.
+3. Run the legacy compatibility mutation and the matching canonical writer in
+   the same callback.
+4. Compare legacy and canonical states with `compareLifecycleShadow`; preserve
+   the raw statuses even when the normalized states agree.
+5. Return the legacy response during M003. Projection delivery follows the
+   committed operation and cannot compensate canonical state backward.
+
+Handlers must use `normalizeLegacyLifecycleStatus` and the exported
+`CanonicalLifecycleStatus` type. Do not duplicate alias tables in tools,
+commands, or orchestration modules.
+
+## Entry gates for later slices
+
+- S02 must introduce automation-aware, typed failure routing before handlers
+  depend on command errors.
+- S03 must prove a schema-authorized interrupted settlement and retry after the
+  original lease expires or is replaced. Until then, no production handler may
+  call `claimRunningAttempt`.
+- Kernel stage policy remains outside S01. Do not call
+  `appendKernelCheckpoint` directly from production until S03 defines the
+  allowed stage/state matrix.
+- S04-S06 must make terminal reopen ordering explicit. Canonical
+  `completed/cancelled -> ready -> in_progress` cannot be represented as exact
+  one-revision parity with legacy complete-to-active/pending cascades.
+
+## Verification loop
+
+Run the smallest focused gate while editing, then the adjacent contract matrix:
+
+```sh
+pnpm exec tsx --test src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts
+pnpm exec tsx --test \
+  src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts \
+  src/resources/extensions/gsd/tests/db-lifecycle-foundation.test.ts \
+  src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts \
+  src/resources/extensions/gsd/tests/domain-operation.test.ts \
+  src/resources/extensions/gsd/tests/single-writer-invariant.test.ts
+pnpm run typecheck:extensions
+pnpm run baseline:workflow-authority
+pnpm run baseline:refactor:gate
+pnpm run test:changed:src
+```
+
+Before merging, also run `pnpm run verify:merge`. For every new invariant, prove
+the corresponding test fails under a temporary sabotage, restore the source,
+and rerun the focused gate.

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -66,6 +66,15 @@ durable receipt without rerunning mutation. The prompt/tool flow above is not
 routed through this seam yet, and file-derived readiness, completion, UAT, and
 reconciliation behavior remains unchanged.
 
+Dormant command primitives under `db/writers/lifecycle-commands.ts` can compose
+canonical lifecycle, Attempt, Result, and Kernel checkpoint facts inside that
+transaction. `readDomainOperationFence()` recovers either the current fence or
+an existing idempotency key's original expected fence, while
+`db/lifecycle-shadow-comparison.ts` compares normalized legacy and canonical
+statuses without discarding exact values. No production prompt or tool handler
+calls these primitives yet; Attempt integration remains blocked on proven
+lease-loss recovery.
+
 ---
 
 ## 2. Prompt → DB Read/Write Reference

--- a/plans/043-m003-s01-lifecycle-writer-research.md
+++ b/plans/043-m003-s01-lifecycle-writer-research.md
@@ -1,0 +1,152 @@
+# M003 S01 — Lifecycle command writer research
+
+Status: converged implementation contract
+Scope: database-only typed primitives; no production handler or read-authority cutover
+
+## Decision
+
+M003 reuses the v31-v35 canonical tables. S01 adds narrow writers that can run
+only inside `executeDomainOperation`; it does not add v36, expose a database
+adapter, start nested transactions, or import tool handlers.
+
+The public primitives are:
+
+- `readDomainOperationFence(idempotencyKey?)`
+- `adoptOrTransitionLifecycle(context, input)`
+- `claimRunningAttempt(context, input)`
+- `settleAttemptWithResult(context, input)`
+- `appendKernelCheckpoint(context, input)` for later same-Attempt stages
+- `compareLifecycleShadow(legacyStatus, canonicalStatus)`
+
+The Domain Operation caller continues to own semantic events and Projection
+Work. Generated writer identities are returned for composition inside the
+callback; replayed callers recover durable state by query rather than rerunning
+the callback.
+
+## Replay fence
+
+For a fresh or omitted idempotency key, `readDomainOperationFence` returns the
+current project id, revision, Authority Epoch, and `replay: false`. For an
+existing project-scoped key it returns that operation's original expected
+revision and epoch with `replay: true`. This lets a lost-response retry rebuild
+the original request after project revision has advanced.
+
+A concurrent fresh request can still become stale between the read and write;
+`executeDomainOperation` remains the compare-and-swap authority and fails the
+loser without residue.
+
+## Lifecycle adoption and transition
+
+The legacy milestone/slice/task row must already exist because v32 lifecycle
+rows carry exact hierarchy foreign keys. Adoption inserts one lifecycle head at
+state version zero with the supplied canonical status and the current operation
+tuple. It returns `adopted: true`; this marker is not fabricated as historical
+Attempts or Results.
+
+An existing head either:
+
+- returns a no-op result when the requested status already matches; or
+- changes status once, increments `state_version` by one, and advances exact
+  operation/revision/epoch provenance.
+
+The schema permits only:
+
+- pending -> ready or cancelled;
+- ready -> in_progress, paused, or cancelled;
+- in_progress -> paused, completed, or cancelled;
+- paused -> ready, in_progress, or cancelled; and
+- completed/cancelled -> ready.
+
+The writer does not weaken these triggers or map a terminal reopen directly to
+`in_progress`.
+
+## Attempt and Result ordering
+
+v32 records claim and settlement provenance but has no start-operation tuple.
+S01 therefore uses `claimRunningAttempt`, which atomically:
+
+1. verifies the lifecycle, worker, live held lease, and optional dispatch scope;
+2. derives the next gap-free Attempt number and immediate retry predecessor;
+3. inserts the Attempt directly in `running` with `claimed_at` and `started_at`;
+4. inserts the first `execute` Kernel checkpoint with the same claim operation.
+
+A separate claimed-to-running command is deferred unless a later explicit
+migration adds start provenance. Dispatch integration also remains deferred;
+its existing claim API does not validate lease expiry, while the Attempt trigger
+does.
+
+Settlement runs in a later Domain Operation. It updates the running Attempt to
+`settled`, sets its exact settlement tuple, and then inserts one immutable
+Result whose tuple must equal the settlement. Typed validation rejects blank
+timestamps, invalid JSON values, and blank failure classes even where v32 DDL
+is deliberately looser. A later handler adapter transitions the lifecycle and
+marks the coordination dispatch terminal in the same outer operation.
+
+## Kernel checkpoint contract
+
+The root checkpoint is sequence one, stage `execute`, has no predecessor, and
+shares the Attempt claim tuple. A retry's new `execute` checkpoint extends the
+current lifecycle head and uses an Attempt whose `retry_of_attempt_id` is the
+previous checkpoint's Attempt. Later same-Attempt stages extend the current
+head by one revision. Full execute/verify/route/closeout policy belongs to the
+Lifecycle Kernel milestone, not this writer primitive.
+
+## Semantic comparison
+
+`compareLifecycleShadow` is pure and returns one of:
+
+- `match`
+- `semantic_match_exact_delta`
+- `missing_shadow`
+- `extra_shadow`
+- `status_mismatch`
+
+Every result preserves raw and normalized statuses. Legacy aliases normalize
+as follows:
+
+- pending/queued/planned -> pending, accepting canonical pending or ready;
+- active/in_progress/in-progress -> in_progress, accepting in_progress or
+  ready for the terminal-reopen ambiguity;
+- parked/blocked -> paused;
+- complete/done/closed -> completed; and
+- skipped/deferred -> cancelled.
+
+Unknown or blank legacy values are `status_mismatch`; they are never cast into
+a canonical status. `ready` is a semantic match only for the two legacy
+vocabularies that cannot distinguish dependency waiting from dispatchable or
+newly reopened work. The exact delta remains visible.
+
+## RED and verification contract
+
+The executable contract proves:
+
+1. adoption and legal transition with exact operation provenance;
+2. current and replay fence selection after revision advance;
+3. running Attempt claim, failed settlement Result, and deterministic retry;
+4. one first `execute` checkpoint per new Attempt;
+5. invalid retry and forged context rollback with no residue;
+6. close/reopen durability;
+7. all five comparison classifications with exact values;
+8. a real two-process same-fence race; and
+9. module loading without any production tool-handler import.
+
+Later GREEN verification adds fault injection, migration/restore, single-writer,
+typecheck, authority baseline, and sabotage gates. Production handlers, routing,
+legacy reads/responses, import/reconciliation, projection delivery, and closeout
+remain unchanged throughout S01.
+
+## Blocking downstream entry gates
+
+These writers are dormant foundations in S01. No production handler may call
+`claimRunningAttempt` until S03 proves a lease-loss recovery path. The v32
+transition fence requires the original worker and live lease token to settle an
+Attempt; after expiry or takeover, that Attempt otherwise remains `running` and
+the active-Attempt uniqueness rule prevents retry. S03 must design and test a
+schema-authorized recovery/interrupt settlement before enabling the first claim
+integration.
+
+S04-S06 must also resolve reopen convergence explicitly. Legacy reopen cascades
+land directly on active/pending states, while canonical terminal lifecycles must
+first reopen to `ready`. Integration must choose and test an ordered follow-up
+operation or a deliberate observable shadow delta; it must not silently claim
+exact parity in one revision.

--- a/src/resources/extensions/gsd/db/domain-operation.ts
+++ b/src/resources/extensions/gsd/db/domain-operation.ts
@@ -124,7 +124,7 @@ function requireNonNegativeSafeInteger(value: number, field: string): void {
   }
 }
 
-function canonicalJson(value: DomainJsonValue): string {
+export function canonicalDomainJson(value: DomainJsonValue): string {
   if (value === null || typeof value === "boolean" || typeof value === "string") {
     return JSON.stringify(value);
   }
@@ -133,7 +133,7 @@ function canonicalJson(value: DomainJsonValue): string {
     return JSON.stringify(value);
   }
   if (Array.isArray(value)) {
-    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+    return `[${value.map((entry) => canonicalDomainJson(entry)).join(",")}]`;
   }
   if (typeof value !== "object") throw new Error("domain operation payload must be JSON-compatible");
 
@@ -144,7 +144,7 @@ function canonicalJson(value: DomainJsonValue): string {
   const entries = Object.entries(value).sort(([left], [right]) =>
     left < right ? -1 : left > right ? 1 : 0,
   );
-  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`).join(",")}}`;
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalDomainJson(entry)}`).join(",")}}`;
 }
 
 function validateRequestScalars(request: DomainOperationRequest): void {
@@ -169,7 +169,7 @@ function validateRequestScalars(request: DomainOperationRequest): void {
 }
 
 function requestHash(request: DomainOperationRequest): string {
-  const canonical = canonicalJson({
+  const canonical = canonicalDomainJson({
     operationType: request.operationType,
     expectedRevision: request.expectedRevision,
     expectedAuthorityEpoch: request.expectedAuthorityEpoch,
@@ -197,7 +197,7 @@ function validateMutation(mutation: DomainOperationMutation): string[] {
     requireNonBlank(event.eventType, `events[${eventIndex}].eventType`);
     requireNonBlank(event.entityType, `events[${eventIndex}].entityType`);
     requireNonBlank(event.entityId, `events[${eventIndex}].entityId`);
-    const payload = canonicalJson(event.payload);
+    const payload = canonicalDomainJson(event.payload);
     if (event.destinations.length === 0) {
       throw new Error(`events[${eventIndex}] requires at least one outbox destination`);
     }

--- a/src/resources/extensions/gsd/db/lifecycle-shadow-comparison.ts
+++ b/src/resources/extensions/gsd/db/lifecycle-shadow-comparison.ts
@@ -28,7 +28,6 @@ const LEGACY_STATUS_MAP: Readonly<Record<string, CanonicalLifecycleStatus>> = {
   pending: "pending",
   queued: "pending",
   planned: "pending",
-  ready: "ready",
   active: "in_progress",
   in_progress: "in_progress",
   "in-progress": "in_progress",

--- a/src/resources/extensions/gsd/db/lifecycle-shadow-comparison.ts
+++ b/src/resources/extensions/gsd/db/lifecycle-shadow-comparison.ts
@@ -1,0 +1,105 @@
+// Project/App: gsd-pi
+// File Purpose: Pure semantic comparison between legacy hierarchy and canonical lifecycle statuses.
+
+export type LifecycleShadowComparisonKind =
+  | "match"
+  | "semantic_match_exact_delta"
+  | "missing_shadow"
+  | "extra_shadow"
+  | "status_mismatch";
+
+export type CanonicalLifecycleStatus =
+  | "pending"
+  | "ready"
+  | "in_progress"
+  | "paused"
+  | "completed"
+  | "cancelled";
+
+export interface LifecycleShadowComparison {
+  kind: LifecycleShadowComparisonKind;
+  legacyStatus: string | null;
+  canonicalStatus: string | null;
+  normalizedLegacyStatus: string | null;
+  normalizedCanonicalStatus: string | null;
+}
+
+const LEGACY_STATUS_MAP: Readonly<Record<string, CanonicalLifecycleStatus>> = {
+  pending: "pending",
+  queued: "pending",
+  planned: "pending",
+  ready: "ready",
+  active: "in_progress",
+  in_progress: "in_progress",
+  "in-progress": "in_progress",
+  blocked: "paused",
+  parked: "paused",
+  complete: "completed",
+  done: "completed",
+  closed: "completed",
+  skipped: "cancelled",
+  deferred: "cancelled",
+};
+
+const CANONICAL_STATUSES: ReadonlySet<string> = new Set([
+  "pending",
+  "ready",
+  "in_progress",
+  "paused",
+  "completed",
+  "cancelled",
+]);
+
+export function normalizeLegacyLifecycleStatus(status: string | null): CanonicalLifecycleStatus | null {
+  if (status === null) return null;
+  return LEGACY_STATUS_MAP[status] ?? null;
+}
+
+export function normalizeCanonicalLifecycleStatus(status: string | null): CanonicalLifecycleStatus | null {
+  if (status === null || !CANONICAL_STATUSES.has(status)) return null;
+  return status as CanonicalLifecycleStatus;
+}
+
+function isSemanticMatch(
+  normalizedLegacyStatus: string | null,
+  normalizedCanonicalStatus: string | null,
+): boolean {
+  if (normalizedLegacyStatus === null || normalizedCanonicalStatus === null) return false;
+  if (normalizedLegacyStatus === normalizedCanonicalStatus) return true;
+  return normalizedCanonicalStatus === "ready" && (
+    normalizedLegacyStatus === "pending" || normalizedLegacyStatus === "in_progress"
+  );
+}
+
+export function compareLifecycleShadow(
+  legacyStatus: string | null,
+  canonicalStatus: string | null,
+): LifecycleShadowComparison {
+  const normalizedLegacyStatus = normalizeLegacyLifecycleStatus(legacyStatus);
+  const normalizedCanonicalStatus = normalizeCanonicalLifecycleStatus(canonicalStatus);
+  let kind: LifecycleShadowComparisonKind;
+
+  if (legacyStatus !== null && canonicalStatus === null) {
+    kind = "missing_shadow";
+  } else if (legacyStatus === null && canonicalStatus !== null) {
+    kind = "extra_shadow";
+  } else if (
+    legacyStatus === canonicalStatus &&
+    normalizedLegacyStatus !== null &&
+    normalizedCanonicalStatus !== null
+  ) {
+    kind = "match";
+  } else if (isSemanticMatch(normalizedLegacyStatus, normalizedCanonicalStatus)) {
+    kind = "semantic_match_exact_delta";
+  } else {
+    kind = "status_mismatch";
+  }
+
+  return {
+    kind,
+    legacyStatus,
+    canonicalStatus,
+    normalizedLegacyStatus,
+    normalizedCanonicalStatus,
+  };
+}

--- a/src/resources/extensions/gsd/db/writers/lifecycle-commands.ts
+++ b/src/resources/extensions/gsd/db/writers/lifecycle-commands.ts
@@ -1,0 +1,587 @@
+// Project/App: gsd-pi
+// File Purpose: Context-bound canonical lifecycle, Attempt, Result, and checkpoint writers.
+
+import { randomUUID } from "node:crypto";
+
+import {
+  canonicalDomainJson,
+  type DomainJsonValue,
+  type DomainOperationContext,
+} from "../domain-operation.js";
+import { getDb, isInTransaction } from "../engine.js";
+import type { CanonicalLifecycleStatus } from "../lifecycle-shadow-comparison.js";
+export {
+  type CanonicalLifecycleStatus,
+  compareLifecycleShadow,
+  type LifecycleShadowComparison,
+  type LifecycleShadowComparisonKind,
+  normalizeCanonicalLifecycleStatus,
+  normalizeLegacyLifecycleStatus,
+} from "../lifecycle-shadow-comparison.js";
+
+const ITEM_KINDS = new Set(["milestone", "slice", "task"]);
+const LIFECYCLE_STATUSES = new Set([
+  "pending",
+  "ready",
+  "in_progress",
+  "paused",
+  "completed",
+  "cancelled",
+]);
+const ATTEMPT_OUTCOMES = new Set(["succeeded", "failed", "interrupted"]);
+const KERNEL_STAGES = new Set(["execute", "verify", "route", "closeout", "settled"]);
+
+export interface DomainOperationFence {
+  projectId: string;
+  revision: number;
+  authorityEpoch: number;
+  replay: boolean;
+}
+
+export interface LifecycleCommandInput {
+  itemKind: "milestone" | "slice" | "task";
+  milestoneId: string;
+  sliceId?: string;
+  taskId?: string;
+  lifecycleStatus: CanonicalLifecycleStatus;
+  occurredAt?: string;
+}
+
+export interface LifecycleCommandResult {
+  lifecycleId: string;
+  lifecycleStatus: CanonicalLifecycleStatus;
+  stateVersion: number;
+  adopted: boolean;
+}
+
+export interface ClaimRunningAttemptInput {
+  lifecycleId: string;
+  retryOfAttemptId?: string;
+  coordinationDispatchId?: number;
+  workerId: string;
+  milestoneLeaseToken: number;
+  claimedAt?: string;
+  startedAt?: string;
+}
+
+export interface ClaimRunningAttemptResult {
+  attemptId: string;
+  attemptNumber: number;
+  retryOfAttemptId: string | null;
+  attemptState: "running";
+  kernelCheckpointId: string;
+}
+
+export interface SettleAttemptInput {
+  attemptId: string;
+  outcome: "succeeded" | "failed" | "interrupted";
+  failureClass: string;
+  summary: string;
+  output: DomainJsonValue;
+  endedAt?: string;
+  createdAt?: string;
+}
+
+export interface SettleAttemptResult {
+  attemptId: string;
+  resultId: string;
+  attemptState: "settled";
+  outcome: "succeeded" | "failed" | "interrupted";
+}
+
+export interface AppendKernelCheckpointInput {
+  lifecycleId: string;
+  attemptId: string;
+  nextStage: "execute" | "verify" | "route" | "closeout" | "settled";
+  previousKernelCheckpointId?: string | null;
+  createdAt?: string;
+}
+
+export interface AppendKernelCheckpointResult {
+  kernelCheckpointId: string;
+  sequence: number;
+  attemptId: string;
+  nextStage: AppendKernelCheckpointInput["nextStage"];
+  previousKernelCheckpointId: string | null;
+}
+
+interface LifecycleRow {
+  lifecycle_id: string;
+  lifecycle_status: string;
+  state_version: number;
+  updated_at: string;
+}
+
+interface AttemptRow {
+  attempt_id: string;
+  attempt_number: number;
+  attempt_state: string;
+}
+
+interface KernelHeadRow {
+  kernel_checkpoint_id: string;
+  attempt_id: string;
+  sequence: number;
+}
+
+function requireNonBlank(value: string, field: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} must not be blank`);
+  }
+}
+
+function requireTimestamp(value: string, field: string): string {
+  requireNonBlank(value, field);
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) throw new Error(`${field} must be a valid timestamp`);
+  return new Date(timestamp).toISOString();
+}
+
+function changes(result: unknown): number {
+  const value = (result as { changes?: unknown })?.changes;
+  return typeof value === "number" ? value : 0;
+}
+
+function requireActiveContext(context: Readonly<DomainOperationContext>): void {
+  if (!isInTransaction()) {
+    throw new Error("lifecycle writer requires an active Domain Operation context");
+  }
+  const active = getDb().prepare(`
+    SELECT 1 AS active
+    FROM workflow_operations operation
+    JOIN project_authority authority ON authority.project_id = operation.project_id
+    WHERE operation.operation_id = :operation_id
+      AND operation.project_id = :project_id
+      AND operation.resulting_revision = :resulting_revision
+      AND operation.resulting_authority_epoch = :resulting_authority_epoch
+      AND authority.revision = operation.expected_revision
+      AND authority.authority_epoch = operation.expected_authority_epoch
+  `).get({
+    ":operation_id": context.operationId,
+    ":project_id": context.projectId,
+    ":resulting_revision": context.resultingRevision,
+    ":resulting_authority_epoch": context.resultingAuthorityEpoch,
+  });
+  if (!active) throw new Error("lifecycle writer context is not the active Domain Operation provenance");
+}
+
+function validateLifecycleIdentity(input: LifecycleCommandInput): void {
+  if (!ITEM_KINDS.has(input.itemKind)) throw new Error("invalid lifecycle item kind");
+  requireNonBlank(input.milestoneId, "milestoneId");
+  if (!LIFECYCLE_STATUSES.has(input.lifecycleStatus)) {
+    throw new Error(`invalid lifecycle status ${input.lifecycleStatus}`);
+  }
+  const hasSlice = typeof input.sliceId === "string" && input.sliceId.trim().length > 0;
+  const hasTask = typeof input.taskId === "string" && input.taskId.trim().length > 0;
+  if (input.itemKind === "milestone" && (input.sliceId !== undefined || input.taskId !== undefined)) {
+    throw new Error("milestone lifecycle identity shape cannot include sliceId or taskId");
+  }
+  if (input.itemKind === "slice" && (!hasSlice || input.taskId !== undefined)) {
+    throw new Error("slice lifecycle identity shape requires sliceId and no taskId");
+  }
+  if (input.itemKind === "task" && (!hasSlice || !hasTask)) {
+    throw new Error("task lifecycle identity shape requires sliceId and taskId");
+  }
+}
+
+function requireHierarchyRow(input: LifecycleCommandInput): void {
+  const db = getDb();
+  let hierarchy: Record<string, unknown> | undefined;
+  if (input.itemKind === "milestone") {
+    hierarchy = db.prepare("SELECT 1 AS present FROM milestones WHERE id = :milestone_id").get({
+      ":milestone_id": input.milestoneId,
+    });
+  } else if (input.itemKind === "slice") {
+    hierarchy = db.prepare(`
+      SELECT 1 AS present FROM slices
+      WHERE milestone_id = :milestone_id AND id = :slice_id
+    `).get({ ":milestone_id": input.milestoneId, ":slice_id": input.sliceId });
+  } else {
+    hierarchy = db.prepare(`
+      SELECT 1 AS present FROM tasks
+      WHERE milestone_id = :milestone_id AND slice_id = :slice_id AND id = :task_id
+    `).get({
+      ":milestone_id": input.milestoneId,
+      ":slice_id": input.sliceId,
+      ":task_id": input.taskId,
+    });
+  }
+  if (!hierarchy) throw new Error(`${input.itemKind} hierarchy row is missing`);
+}
+
+function findLifecycle(context: Readonly<DomainOperationContext>, input: LifecycleCommandInput): LifecycleRow | undefined {
+  return getDb().prepare(`
+    SELECT lifecycle_id, lifecycle_status, state_version, updated_at
+    FROM workflow_item_lifecycles
+    WHERE project_id = :project_id
+      AND item_kind = :item_kind
+      AND milestone_id = :milestone_id
+      AND slice_id IS :slice_id
+      AND task_id IS :task_id
+  `).get({
+    ":project_id": context.projectId,
+    ":item_kind": input.itemKind,
+    ":milestone_id": input.milestoneId,
+    ":slice_id": input.sliceId ?? null,
+    ":task_id": input.taskId ?? null,
+  }) as unknown as LifecycleRow | undefined;
+}
+
+export function readDomainOperationFence(idempotencyKey?: string): DomainOperationFence {
+  if (idempotencyKey !== undefined) requireNonBlank(idempotencyKey, "idempotency key");
+  const db = getDb();
+  const authority = db.prepare(`
+    SELECT project_id, revision, authority_epoch
+    FROM project_authority WHERE singleton = 1
+  `).get() as Record<string, unknown> | undefined;
+  if (!authority) throw new Error("project authority is missing");
+
+  if (idempotencyKey !== undefined) {
+    const operation = db.prepare(`
+      SELECT expected_revision, expected_authority_epoch
+      FROM workflow_operations
+      WHERE project_id = :project_id AND idempotency_key = :idempotency_key
+    `).get({
+      ":project_id": authority["project_id"],
+      ":idempotency_key": idempotencyKey,
+    }) as Record<string, unknown> | undefined;
+    if (operation) {
+      return {
+        projectId: String(authority["project_id"]),
+        revision: Number(operation["expected_revision"]),
+        authorityEpoch: Number(operation["expected_authority_epoch"]),
+        replay: true,
+      };
+    }
+  }
+
+  return {
+    projectId: String(authority["project_id"]),
+    revision: Number(authority["revision"]),
+    authorityEpoch: Number(authority["authority_epoch"]),
+    replay: false,
+  };
+}
+
+export function adoptOrTransitionLifecycle(
+  context: Readonly<DomainOperationContext>,
+  input: LifecycleCommandInput,
+): LifecycleCommandResult {
+  requireActiveContext(context);
+  validateLifecycleIdentity(input);
+  requireHierarchyRow(input);
+  const now = requireTimestamp(input.occurredAt ?? new Date().toISOString(), "occurredAt");
+  const existing = findLifecycle(context, input);
+
+  if (!existing) {
+    const lifecycleId = randomUUID();
+    getDb().prepare(`
+      INSERT INTO workflow_item_lifecycles (
+        lifecycle_id, project_id, item_kind, milestone_id, slice_id, task_id,
+        lifecycle_status, state_version, created_at, updated_at,
+        last_operation_id, last_project_revision, last_authority_epoch
+      ) VALUES (
+        :lifecycle_id, :project_id, :item_kind, :milestone_id, :slice_id, :task_id,
+        :lifecycle_status, 0, :created_at, :updated_at,
+        :operation_id, :project_revision, :authority_epoch
+      )
+    `).run({
+      ":lifecycle_id": lifecycleId,
+      ":project_id": context.projectId,
+      ":item_kind": input.itemKind,
+      ":milestone_id": input.milestoneId,
+      ":slice_id": input.sliceId ?? null,
+      ":task_id": input.taskId ?? null,
+      ":lifecycle_status": input.lifecycleStatus,
+      ":created_at": now,
+      ":updated_at": now,
+      ":operation_id": context.operationId,
+      ":project_revision": context.resultingRevision,
+      ":authority_epoch": context.resultingAuthorityEpoch,
+    });
+    return { lifecycleId, lifecycleStatus: input.lifecycleStatus, stateVersion: 0, adopted: true };
+  }
+
+  if (existing.lifecycle_status === input.lifecycleStatus) {
+    return {
+      lifecycleId: existing.lifecycle_id,
+      lifecycleStatus: existing.lifecycle_status,
+      stateVersion: existing.state_version,
+      adopted: false,
+    };
+  }
+
+  const previousTimestamp = Date.parse(existing.updated_at);
+  const requestedTimestamp = Date.parse(now);
+  if (input.occurredAt !== undefined && requestedTimestamp <= previousTimestamp) {
+    throw new Error("occurredAt must be after the current lifecycle timestamp");
+  }
+  const updatedAt = requestedTimestamp <= previousTimestamp
+    ? new Date(previousTimestamp + 1).toISOString()
+    : now;
+
+  const result = getDb().prepare(`
+    UPDATE workflow_item_lifecycles
+    SET lifecycle_status = :lifecycle_status,
+        state_version = state_version + 1,
+        updated_at = :updated_at,
+        last_operation_id = :operation_id,
+        last_project_revision = :project_revision,
+        last_authority_epoch = :authority_epoch
+    WHERE lifecycle_id = :lifecycle_id AND project_id = :project_id
+  `).run({
+    ":lifecycle_status": input.lifecycleStatus,
+    ":updated_at": updatedAt,
+    ":operation_id": context.operationId,
+    ":project_revision": context.resultingRevision,
+    ":authority_epoch": context.resultingAuthorityEpoch,
+    ":lifecycle_id": existing.lifecycle_id,
+    ":project_id": context.projectId,
+  });
+  if (changes(result) !== 1) throw new Error("lifecycle transition did not update exactly one row");
+  return {
+    lifecycleId: existing.lifecycle_id,
+    lifecycleStatus: input.lifecycleStatus,
+    stateVersion: existing.state_version + 1,
+    adopted: false,
+  };
+}
+
+function loadKernelHead(projectId: string, lifecycleId: string): KernelHeadRow | undefined {
+  return getDb().prepare(`
+    SELECT head.kernel_checkpoint_id, head.attempt_id, head.sequence
+    FROM workflow_kernel_checkpoints head
+    WHERE head.project_id = :project_id AND head.lifecycle_id = :lifecycle_id
+      AND NOT EXISTS (
+        SELECT 1 FROM workflow_kernel_checkpoints successor
+        WHERE successor.previous_kernel_checkpoint_id = head.kernel_checkpoint_id
+      )
+  `).get({ ":project_id": projectId, ":lifecycle_id": lifecycleId }) as unknown as KernelHeadRow | undefined;
+}
+
+export function appendKernelCheckpoint(
+  context: Readonly<DomainOperationContext>,
+  input: AppendKernelCheckpointInput,
+): AppendKernelCheckpointResult {
+  requireActiveContext(context);
+  requireNonBlank(input.lifecycleId, "lifecycleId");
+  requireNonBlank(input.attemptId, "attemptId");
+  if (!KERNEL_STAGES.has(input.nextStage)) throw new Error(`invalid Kernel stage ${input.nextStage}`);
+  const now = requireTimestamp(input.createdAt ?? new Date().toISOString(), "createdAt");
+  const head = loadKernelHead(context.projectId, input.lifecycleId);
+  const expectedPrevious = head?.kernel_checkpoint_id ?? null;
+  const suppliedPrevious = input.previousKernelCheckpointId ?? null;
+  if (suppliedPrevious !== expectedPrevious) {
+    throw new Error("Kernel checkpoint must extend the current head");
+  }
+  const checkpointId = randomUUID();
+  const sequence = (head?.sequence ?? 0) + 1;
+  getDb().prepare(`
+    INSERT INTO workflow_kernel_checkpoints (
+      kernel_checkpoint_id, project_id, lifecycle_id, attempt_id,
+      next_stage, sequence, previous_kernel_checkpoint_id, created_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES (
+      :checkpoint_id, :project_id, :lifecycle_id, :attempt_id,
+      :next_stage, :sequence, :previous_checkpoint_id, :created_at,
+      :operation_id, :project_revision, :authority_epoch
+    )
+  `).run({
+    ":checkpoint_id": checkpointId,
+    ":project_id": context.projectId,
+    ":lifecycle_id": input.lifecycleId,
+    ":attempt_id": input.attemptId,
+    ":next_stage": input.nextStage,
+    ":sequence": sequence,
+    ":previous_checkpoint_id": suppliedPrevious,
+    ":created_at": now,
+    ":operation_id": context.operationId,
+    ":project_revision": context.resultingRevision,
+    ":authority_epoch": context.resultingAuthorityEpoch,
+  });
+  return {
+    kernelCheckpointId: checkpointId,
+    sequence,
+    attemptId: input.attemptId,
+    nextStage: input.nextStage,
+    previousKernelCheckpointId: suppliedPrevious,
+  };
+}
+
+export function claimRunningAttempt(
+  context: Readonly<DomainOperationContext>,
+  input: ClaimRunningAttemptInput,
+): ClaimRunningAttemptResult {
+  requireActiveContext(context);
+  requireNonBlank(input.lifecycleId, "lifecycleId");
+  requireNonBlank(input.workerId, "workerId");
+  if (!Number.isSafeInteger(input.milestoneLeaseToken) || input.milestoneLeaseToken <= 0) {
+    throw new Error("milestoneLeaseToken must be a positive safe integer");
+  }
+  if (
+    input.coordinationDispatchId !== undefined &&
+    (!Number.isSafeInteger(input.coordinationDispatchId) || input.coordinationDispatchId <= 0)
+  ) {
+    throw new Error("coordinationDispatchId must be a positive safe integer");
+  }
+  const now = new Date().toISOString();
+  const claimedAt = requireTimestamp(input.claimedAt ?? now, "claimedAt");
+  const startedAt = requireTimestamp(input.startedAt ?? now, "startedAt");
+  if (Date.parse(startedAt) < Date.parse(claimedAt)) {
+    throw new Error("startedAt must not precede claimedAt");
+  }
+  const lifecycle = getDb().prepare(`
+    SELECT lifecycle_id, lifecycle_status
+    FROM workflow_item_lifecycles
+    WHERE lifecycle_id = :lifecycle_id AND project_id = :project_id
+  `).get({
+    ":lifecycle_id": input.lifecycleId,
+    ":project_id": context.projectId,
+  }) as Record<string, unknown> | undefined;
+  if (!lifecycle) throw new Error("Attempt lifecycle is missing");
+  if (lifecycle["lifecycle_status"] !== "in_progress") {
+    throw new Error(`Attempt claim requires lifecycle in_progress, found ${String(lifecycle["lifecycle_status"])}`);
+  }
+
+  const prior = getDb().prepare(`
+    SELECT attempt_id, attempt_number, attempt_state
+    FROM workflow_execution_attempts
+    WHERE lifecycle_id = :lifecycle_id
+    ORDER BY attempt_number DESC LIMIT 1
+  `).get({ ":lifecycle_id": input.lifecycleId }) as unknown as AttemptRow | undefined;
+  if (!prior && input.retryOfAttemptId !== undefined) {
+    throw new Error("retry Attempt has no predecessor");
+  }
+  if (prior && prior.attempt_state !== "settled") {
+    throw new Error("lifecycle already has an active running Attempt");
+  }
+  if (prior && input.retryOfAttemptId !== prior.attempt_id) {
+    throw new Error("retry must reference the immediate predecessor Attempt");
+  }
+
+  const attemptId = randomUUID();
+  const attemptNumber = (prior?.attempt_number ?? 0) + 1;
+  const retryOfAttemptId = prior?.attempt_id ?? null;
+  getDb().prepare(`
+    INSERT INTO workflow_execution_attempts (
+      attempt_id, project_id, lifecycle_id, attempt_number, retry_of_attempt_id,
+      attempt_state, coordination_dispatch_id, worker_id, milestone_lease_token,
+      claimed_at, started_at, ended_at,
+      claim_operation_id, claim_project_revision, claim_authority_epoch,
+      settle_operation_id, settle_project_revision, settle_authority_epoch
+    ) VALUES (
+      :attempt_id, :project_id, :lifecycle_id, :attempt_number, :retry_of_attempt_id,
+      'running', :dispatch_id, :worker_id, :lease_token,
+      :claimed_at, :started_at, NULL,
+      :operation_id, :project_revision, :authority_epoch,
+      NULL, NULL, NULL
+    )
+  `).run({
+    ":attempt_id": attemptId,
+    ":project_id": context.projectId,
+    ":lifecycle_id": input.lifecycleId,
+    ":attempt_number": attemptNumber,
+    ":retry_of_attempt_id": retryOfAttemptId,
+    ":dispatch_id": input.coordinationDispatchId ?? null,
+    ":worker_id": input.workerId,
+    ":lease_token": input.milestoneLeaseToken,
+    ":claimed_at": claimedAt,
+    ":started_at": startedAt,
+    ":operation_id": context.operationId,
+    ":project_revision": context.resultingRevision,
+    ":authority_epoch": context.resultingAuthorityEpoch,
+  });
+
+  const head = loadKernelHead(context.projectId, input.lifecycleId);
+  const checkpoint = appendKernelCheckpoint(context, {
+    lifecycleId: input.lifecycleId,
+    attemptId,
+    nextStage: "execute",
+    previousKernelCheckpointId: head?.kernel_checkpoint_id ?? null,
+    createdAt: claimedAt,
+  });
+  return {
+    attemptId,
+    attemptNumber,
+    retryOfAttemptId,
+    attemptState: "running",
+    kernelCheckpointId: checkpoint.kernelCheckpointId,
+  };
+}
+
+export function settleAttemptWithResult(
+  context: Readonly<DomainOperationContext>,
+  input: SettleAttemptInput,
+): SettleAttemptResult {
+  requireActiveContext(context);
+  requireNonBlank(input.attemptId, "attemptId");
+  if (!ATTEMPT_OUTCOMES.has(input.outcome)) throw new Error(`invalid Attempt outcome ${input.outcome}`);
+  requireNonBlank(input.failureClass, "failureClass");
+  if (typeof input.summary !== "string") throw new Error("summary must be a string");
+  const endedAt = requireTimestamp(input.endedAt ?? new Date().toISOString(), "endedAt");
+  const createdAt = requireTimestamp(input.createdAt ?? endedAt, "createdAt");
+  const outputJson = canonicalDomainJson(input.output);
+  const attempt = getDb().prepare(`
+    SELECT attempt_id, lifecycle_id, attempt_state, started_at
+    FROM workflow_execution_attempts
+    WHERE attempt_id = :attempt_id AND project_id = :project_id
+  `).get({
+    ":attempt_id": input.attemptId,
+    ":project_id": context.projectId,
+  }) as Record<string, unknown> | undefined;
+  if (!attempt) throw new Error("Attempt is missing");
+  if (attempt["attempt_state"] === "settled") throw new Error("Attempt is already settled and terminal");
+  if (attempt["attempt_state"] !== "running") throw new Error("only a running Attempt can settle");
+  if (Date.parse(endedAt) < Date.parse(String(attempt["started_at"]))) {
+    throw new Error("endedAt must not precede startedAt");
+  }
+
+  const updated = getDb().prepare(`
+    UPDATE workflow_execution_attempts
+    SET attempt_state = 'settled', ended_at = :ended_at,
+        settle_operation_id = :operation_id,
+        settle_project_revision = :project_revision,
+        settle_authority_epoch = :authority_epoch
+    WHERE attempt_id = :attempt_id AND project_id = :project_id AND attempt_state = 'running'
+  `).run({
+    ":ended_at": endedAt,
+    ":operation_id": context.operationId,
+    ":project_revision": context.resultingRevision,
+    ":authority_epoch": context.resultingAuthorityEpoch,
+    ":attempt_id": input.attemptId,
+    ":project_id": context.projectId,
+  });
+  if (changes(updated) !== 1) throw new Error("Attempt settlement did not update exactly one row");
+
+  const resultId = randomUUID();
+  getDb().prepare(`
+    INSERT INTO workflow_attempt_results (
+      result_id, project_id, lifecycle_id, attempt_id, outcome,
+      failure_class, summary, output_json, created_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES (
+      :result_id, :project_id, :lifecycle_id, :attempt_id, :outcome,
+      :failure_class, :summary, :output_json, :created_at,
+      :operation_id, :project_revision, :authority_epoch
+    )
+  `).run({
+    ":result_id": resultId,
+    ":project_id": context.projectId,
+    ":lifecycle_id": attempt["lifecycle_id"],
+    ":attempt_id": input.attemptId,
+    ":outcome": input.outcome,
+    ":failure_class": input.failureClass,
+    ":summary": input.summary,
+    ":output_json": outputJson,
+    ":created_at": createdAt,
+    ":operation_id": context.operationId,
+    ":project_revision": context.resultingRevision,
+    ":authority_epoch": context.resultingAuthorityEpoch,
+  });
+  return {
+    attemptId: input.attemptId,
+    resultId,
+    attemptState: "settled",
+    outcome: input.outcome,
+  };
+}

--- a/src/resources/extensions/gsd/db/writers/lifecycle-commands.ts
+++ b/src/resources/extensions/gsd/db/writers/lifecycle-commands.ts
@@ -9,7 +9,10 @@ import {
   type DomainOperationContext,
 } from "../domain-operation.js";
 import { getDb, isInTransaction } from "../engine.js";
-import type { CanonicalLifecycleStatus } from "../lifecycle-shadow-comparison.js";
+import {
+  type CanonicalLifecycleStatus,
+  normalizeCanonicalLifecycleStatus,
+} from "../lifecycle-shadow-comparison.js";
 export {
   type CanonicalLifecycleStatus,
   compareLifecycleShadow,
@@ -20,14 +23,6 @@ export {
 } from "../lifecycle-shadow-comparison.js";
 
 const ITEM_KINDS = new Set(["milestone", "slice", "task"]);
-const LIFECYCLE_STATUSES = new Set([
-  "pending",
-  "ready",
-  "in_progress",
-  "paused",
-  "completed",
-  "cancelled",
-]);
 const ATTEMPT_OUTCOMES = new Set(["succeeded", "failed", "interrupted"]);
 const KERNEL_STAGES = new Set(["execute", "verify", "route", "closeout", "settled"]);
 
@@ -168,7 +163,7 @@ function requireActiveContext(context: Readonly<DomainOperationContext>): void {
 function validateLifecycleIdentity(input: LifecycleCommandInput): void {
   if (!ITEM_KINDS.has(input.itemKind)) throw new Error("invalid lifecycle item kind");
   requireNonBlank(input.milestoneId, "milestoneId");
-  if (!LIFECYCLE_STATUSES.has(input.lifecycleStatus)) {
+  if (normalizeCanonicalLifecycleStatus(input.lifecycleStatus) === null) {
     throw new Error(`invalid lifecycle status ${input.lifecycleStatus}`);
   }
   const hasSlice = typeof input.sliceId === "string" && input.sliceId.trim().length > 0;

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -56,6 +56,7 @@ import { immediateTransaction, transaction, getDb, getDbOrNull } from "./db/engi
 export * from "./db/writers/memory.js";
 export * from "./db/writers/reconcile.js";
 export * from "./db/writers/import-restore.js";
+export * from "./db/writers/lifecycle-commands.js";
 export { executeDomainOperation } from "./db/domain-operation.js";
 export type {
   DomainJsonValue,

--- a/src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts
+++ b/src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts
@@ -721,7 +721,7 @@ test("restart preserves the fence, lifecycle head, and Attempt sequence", (t) =>
 test("semantic comparison reports normalized parity without hiding exact legacy values", () => {
   const cases = [
     ["pending", "pending", "match", "pending", "pending"],
-    ["ready", "ready", "match", "ready", "ready"],
+    ["ready", "ready", "status_mismatch", null, "ready"],
     ["in_progress", "in_progress", "match", "in_progress", "in_progress"],
     ["complete", "completed", "semantic_match_exact_delta", "completed", "completed"],
     ["done", "completed", "semantic_match_exact_delta", "completed", "completed"],
@@ -799,10 +799,15 @@ interface ConcurrentWriter {
   start: () => void;
 }
 
-function runConcurrentWriter(path: string, id: string): ConcurrentWriter {
+function runConcurrentWriter(
+  path: string,
+  id: string,
+  writerHref = pathToFileURL(
+    join(process.cwd(), "src/resources/extensions/gsd/db/writers/lifecycle-commands.ts"),
+  ).href,
+): ConcurrentWriter {
   const dbHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/gsd-db.ts")).href;
   const domainHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/db/domain-operation.ts")).href;
-  const writerHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/db/writers/lifecycle-commands.ts")).href;
   const script = `
     import { openDatabase, closeDatabase } from ${JSON.stringify(dbHref)};
     import { executeDomainOperation } from ${JSON.stringify(domainHref)};
@@ -834,7 +839,12 @@ function runConcurrentWriter(path: string, id: string): ConcurrentWriter {
   const env = { ...process.env };
   delete env.NODE_TEST_CONTEXT;
   let readyResolve!: () => void;
-  const ready = new Promise<void>((resolve) => { readyResolve = resolve; });
+  let readyReject!: (error: Error) => void;
+  let isReady = false;
+  const ready = new Promise<void>((resolve, reject) => {
+    readyResolve = resolve;
+    readyReject = reject;
+  });
   const child = spawn(process.execPath, [
     "--import", "./src/resources/extensions/gsd/tests/resolve-ts.mjs",
     "--experimental-strip-types", "--input-type=module", "-e", script,
@@ -844,13 +854,21 @@ function runConcurrentWriter(path: string, id: string): ConcurrentWriter {
   let stderr = "";
   child.stdout.setEncoding("utf8").on("data", (chunk) => {
     stdout += chunk;
-    if (stdout.includes("READY\n")) readyResolve();
+    if (stdout.includes("READY\n")) {
+      isReady = true;
+      readyResolve();
+    }
   });
   child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
   const result = new Promise<Record<string, unknown>>((resolve, reject) => {
-    child.once("error", reject);
+    child.once("error", (error) => {
+      readyReject(error);
+      reject(error);
+    });
     child.once("close", (code) => {
-      if (code !== 0) return reject(new Error(stderr || stdout || `child exited ${code}`));
+      const error = new Error(stderr || stdout || `child exited ${code}`);
+      if (!isReady) readyReject(error);
+      if (code !== 0) return reject(error);
       const payload = stdout.split("\n").find((line) => line.startsWith("{"));
       try { resolve(JSON.parse(payload ?? "") as Record<string, unknown>); }
       catch { reject(new Error(`invalid child output: ${stdout}\n${stderr}`)); }
@@ -862,6 +880,16 @@ function runConcurrentWriter(path: string, id: string): ConcurrentWriter {
     start: () => child.stdin?.end("go\n"),
   };
 }
+
+test("concurrent writer readiness rejects when the child exits during startup", { timeout: 5_000 }, async () => {
+  const missingWriterHref = pathToFileURL(join(process.cwd(), "missing-lifecycle-writer.ts")).href;
+  const writer = runConcurrentWriter(databasePath(), "startup-failure", missingWriterHref);
+
+  await Promise.all([
+    assert.rejects(writer.ready, /cannot find|module not found|ERR_MODULE_NOT_FOUND/i),
+    assert.rejects(writer.result, /cannot find|module not found|ERR_MODULE_NOT_FOUND/i),
+  ]);
+});
 
 test("two processes cannot advance one lifecycle from the same fence", async (t) => {
   const path = openFixture(t);

--- a/src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts
+++ b/src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts
@@ -793,7 +793,13 @@ test("rejects malformed timestamps and prevents lifecycle audit time from moving
   });
 });
 
-function runConcurrentWriter(path: string, id: string, startAt: number): Promise<Record<string, unknown>> {
+interface ConcurrentWriter {
+  ready: Promise<void>;
+  result: Promise<Record<string, unknown>>;
+  start: () => void;
+}
+
+function runConcurrentWriter(path: string, id: string): ConcurrentWriter {
   const dbHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/gsd-db.ts")).href;
   const domainHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/db/domain-operation.ts")).href;
   const writerHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/db/writers/lifecycle-commands.ts")).href;
@@ -801,10 +807,11 @@ function runConcurrentWriter(path: string, id: string, startAt: number): Promise
     import { openDatabase, closeDatabase } from ${JSON.stringify(dbHref)};
     import { executeDomainOperation } from ${JSON.stringify(domainHref)};
     import { adoptOrTransitionLifecycle, readDomainOperationFence } from ${JSON.stringify(writerHref)};
-    const [path, id, startAt] = process.argv.slice(1);
+    const [path, id] = process.argv.slice(1);
     if (!openDatabase(path)) throw new Error('open failed');
     const fence = readDomainOperationFence();
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(0, Number(startAt) - Date.now()));
+    console.log('READY');
+    await new Promise((resolve) => process.stdin.once('data', resolve));
     try {
       const receipt = executeDomainOperation({
         operationType: 'lifecycle.ready', idempotencyKey: 'race/' + id,
@@ -826,34 +833,44 @@ function runConcurrentWriter(path: string, id: string, startAt: number): Promise
   `;
   const env = { ...process.env };
   delete env.NODE_TEST_CONTEXT;
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [
-      "--import", "./src/resources/extensions/gsd/tests/resolve-ts.mjs",
-      "--experimental-strip-types", "--input-type=module", "-e", script,
-      path, id, String(startAt),
-    ], { cwd: process.cwd(), env, stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
-    child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+  let readyResolve!: () => void;
+  const ready = new Promise<void>((resolve) => { readyResolve = resolve; });
+  const child = spawn(process.execPath, [
+    "--import", "./src/resources/extensions/gsd/tests/resolve-ts.mjs",
+    "--experimental-strip-types", "--input-type=module", "-e", script,
+    path, id,
+  ], { cwd: process.cwd(), env, stdio: ["pipe", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8").on("data", (chunk) => {
+    stdout += chunk;
+    if (stdout.includes("READY\n")) readyResolve();
+  });
+  child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+  const result = new Promise<Record<string, unknown>>((resolve, reject) => {
     child.once("error", reject);
     child.once("close", (code) => {
       if (code !== 0) return reject(new Error(stderr || stdout || `child exited ${code}`));
-      try { resolve(JSON.parse(stdout.trim()) as Record<string, unknown>); }
+      const payload = stdout.split("\n").find((line) => line.startsWith("{"));
+      try { resolve(JSON.parse(payload ?? "") as Record<string, unknown>); }
       catch { reject(new Error(`invalid child output: ${stdout}\n${stderr}`)); }
     });
   });
+  return {
+    ready,
+    result,
+    start: () => child.stdin?.end("go\n"),
+  };
 }
 
 test("two processes cannot advance one lifecycle from the same fence", async (t) => {
   const path = openFixture(t);
   adoptTask();
   closeDatabase();
-  const startAt = Date.now() + 1_000;
-  const outcomes = await Promise.all([
-    runConcurrentWriter(path, "a", startAt),
-    runConcurrentWriter(path, "b", startAt),
-  ]);
+  const writers = [runConcurrentWriter(path, "a"), runConcurrentWriter(path, "b")];
+  await Promise.all(writers.map((writer) => writer.ready));
+  for (const writer of writers) writer.start();
+  const outcomes = await Promise.all(writers.map((writer) => writer.result));
   assert.equal(outcomes.filter((outcome) => outcome.kind === "committed").length, 1, JSON.stringify(outcomes));
   const rejected = outcomes.filter((outcome) => outcome.kind === "error");
   assert.equal(rejected.length, 1, JSON.stringify(outcomes));

--- a/src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts
+++ b/src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts
@@ -1,0 +1,949 @@
+// Project/App: gsd-pi
+// File Purpose: Executable contract for lifecycle and Attempt command writers.
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, extname, join, resolve } from "node:path";
+import { afterEach, test, type TestContext } from "node:test";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+import {
+  _getAdapter,
+  closeDatabase,
+  openDatabase,
+} from "../gsd-db.ts";
+import {
+  executeDomainOperation,
+  type DomainOperationContext,
+  type DomainOperationMutation,
+  type DomainOperationResult,
+} from "../db/domain-operation.ts";
+import {
+  adoptOrTransitionLifecycle,
+  appendKernelCheckpoint,
+  type CanonicalLifecycleStatus,
+  claimRunningAttempt,
+  compareLifecycleShadow,
+  readDomainOperationFence,
+  settleAttemptWithResult,
+} from "../db/writers/lifecycle-commands.ts";
+
+const tempDirs = new Set<string>();
+
+function databasePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-lifecycle-commands-"));
+  tempDirs.add(dir);
+  return join(dir, "gsd.db");
+}
+
+function openFixture(t: TestContext): string {
+  const path = databasePath();
+  assert.equal(openDatabase(path), true);
+  seedHierarchyAndCoordination();
+  t.after(closeDatabase);
+  return path;
+}
+
+function db() {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  return adapter;
+}
+
+function rows(sql: string): Array<Record<string, unknown>> {
+  return db().prepare(sql).all();
+}
+
+function row(sql: string): Record<string, unknown> {
+  return db().prepare(sql).get() ?? {};
+}
+
+function seedHierarchyAndCoordination(): void {
+  db().exec(`
+    INSERT INTO milestones (id, title, status, created_at)
+    VALUES ('M001', 'Lifecycle commands', 'active', '2026-07-12T00:00:00.000Z');
+    INSERT INTO slices (milestone_id, id, title, status, created_at)
+    VALUES ('M001', 'S01', 'Typed writers', 'active', '2026-07-12T00:00:00.000Z');
+    INSERT INTO tasks (milestone_id, slice_id, id, title, status)
+    VALUES
+      ('M001', 'S01', 'T01', 'Implement writers', 'pending'),
+      ('M001', 'S01', 'T02', 'Sibling task', 'pending'),
+      ('M001', 'S01', 'T03', 'Terminal bootstrap task', 'pending');
+    INSERT INTO workers (
+      worker_id, host, pid, started_at, version, last_heartbeat_at, status,
+      project_root_realpath
+    ) VALUES (
+      'worker-1', 'test-host', 1, '2026-07-12T00:00:00.000Z', 'test',
+      '2026-07-12T00:00:00.000Z', 'active', '/tmp/project'
+    );
+    INSERT INTO milestone_leases (
+      milestone_id, worker_id, fencing_token, acquired_at, expires_at, status
+    ) VALUES (
+      'M001', 'worker-1', 7, '2026-07-12T00:00:00.000Z',
+      '2099-07-12T00:00:00.000Z', 'held'
+    );
+    INSERT INTO unit_dispatches (
+      trace_id, turn_id, worker_id, milestone_lease_token,
+      milestone_id, slice_id, task_id, unit_type, unit_id,
+      status, attempt_n, started_at
+    ) VALUES (
+      'trace-dispatch', 'turn-dispatch', 'worker-1', 7,
+      'M001', 'S01', 'T01', 'execute-task', 'M001/S01/T01',
+      'running', 1, '2026-07-12T00:00:00.000Z'
+    );
+    INSERT INTO unit_dispatches (
+      trace_id, turn_id, worker_id, milestone_lease_token,
+      milestone_id, slice_id, task_id, unit_type, unit_id,
+      status, attempt_n, started_at
+    ) VALUES (
+      'trace-sibling', 'turn-sibling', 'worker-1', 7,
+      'M001', 'S01', 'T02', 'execute-task', 'M001/S01/T02',
+      'running', 1, '2026-07-12T00:00:00.000Z'
+    );
+  `);
+}
+
+function operationMutation(type: string, entityId = "M001/S01/T01"): DomainOperationMutation {
+  return {
+    events: [{
+      eventType: type,
+      entityType: "task",
+      entityId,
+      payload: { entityId },
+      destinations: ["projection"],
+    }],
+    projections: [{
+      projectionKey: `status/${entityId.toLowerCase()}`,
+      projectionKind: "markdown",
+      rendererVersion: "v1",
+    }],
+  };
+}
+
+function executeAtFence<T>(
+  operationType: string,
+  idempotencyKey: string,
+  write: (context: Readonly<DomainOperationContext>) => T,
+): { receipt: DomainOperationResult; value: T } {
+  const fence = readDomainOperationFence();
+  assert.equal(fence.replay, false);
+  let value!: T;
+  const receipt = executeDomainOperation({
+    operationType,
+    idempotencyKey,
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: "agent",
+    actorId: "test-agent",
+    sourceTransport: "test",
+    payload: { operationType, idempotencyKey },
+  }, (context) => {
+    value = write(context);
+    return operationMutation(operationType);
+  });
+  return { receipt, value };
+}
+
+function adoptTask(status: CanonicalLifecycleStatus = "pending") {
+  return executeAtFence("lifecycle.adopt", `adopt/${status}`, (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      lifecycleStatus: status,
+    }));
+}
+
+function snapshot(): Record<string, unknown> {
+  return {
+    authority: row("SELECT revision, authority_epoch FROM project_authority"),
+    operations: rows("SELECT operation_id FROM workflow_operations ORDER BY resulting_revision"),
+    lifecycles: rows("SELECT * FROM workflow_item_lifecycles ORDER BY lifecycle_id"),
+    attempts: rows("SELECT * FROM workflow_execution_attempts ORDER BY lifecycle_id, attempt_number"),
+    results: rows("SELECT * FROM workflow_attempt_results ORDER BY result_id"),
+    checkpoints: rows("SELECT * FROM workflow_kernel_checkpoints ORDER BY sequence"),
+    events: rows("SELECT event_id FROM workflow_domain_events ORDER BY project_revision, event_index"),
+    projections: rows("SELECT projection_work_id FROM workflow_projection_work ORDER BY source_project_revision"),
+  };
+}
+
+afterEach(() => {
+  closeDatabase();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+test("adopts a hierarchy row once and advances its lifecycle with operation provenance", (t) => {
+  openFixture(t);
+  const adopted = adoptTask();
+  assert.equal(adopted.receipt.status, "committed");
+  assert.deepEqual(adopted.value, {
+    lifecycleId: adopted.value.lifecycleId,
+    lifecycleStatus: "pending",
+    stateVersion: 0,
+    adopted: true,
+  });
+
+  const transitioned = executeAtFence("lifecycle.ready", "ready/T01", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      lifecycleStatus: "ready",
+    }));
+  assert.deepEqual(transitioned.value, {
+    lifecycleId: adopted.value.lifecycleId,
+    lifecycleStatus: "ready",
+    stateVersion: 1,
+    adopted: false,
+  });
+  assert.deepEqual(row(`
+    SELECT lifecycle_status, state_version, last_operation_id,
+           last_project_revision, last_authority_epoch
+    FROM workflow_item_lifecycles
+  `), {
+    lifecycle_status: "ready",
+    state_version: 1,
+    last_operation_id: transitioned.receipt.operationId,
+    last_project_revision: transitioned.receipt.resultingRevision,
+    last_authority_epoch: transitioned.receipt.resultingAuthorityEpoch,
+  });
+});
+
+test("same-status adoption is a lifecycle no-op while the outer operation still commits", (t) => {
+  openFixture(t);
+  const adopted = adoptTask();
+  const original = row(`
+    SELECT lifecycle_status, state_version, last_operation_id,
+           last_project_revision, last_authority_epoch
+    FROM workflow_item_lifecycles
+  `);
+  const repeated = executeAtFence("lifecycle.observe", "observe/pending", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "pending",
+    }));
+
+  assert.equal(repeated.receipt.status, "committed");
+  assert.equal(repeated.receipt.resultingRevision, 2);
+  assert.deepEqual(repeated.value, {
+    lifecycleId: adopted.value.lifecycleId,
+    lifecycleStatus: "pending",
+    stateVersion: 0,
+    adopted: false,
+  });
+  assert.deepEqual(row(`
+    SELECT lifecycle_status, state_version, last_operation_id,
+           last_project_revision, last_authority_epoch
+    FROM workflow_item_lifecycles
+  `), original);
+});
+
+test("terminal lifecycles reopen only through ready and reject a direct in-progress jump", (t) => {
+  openFixture(t);
+  adoptTask();
+  const transition = (status: CanonicalLifecycleStatus, key: string) => executeAtFence(
+    `lifecycle.${status}`,
+    key,
+    (context) => adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: status,
+    }),
+  );
+
+  transition("ready", "chain/ready-1");
+  transition("in_progress", "chain/in-progress-1");
+  transition("completed", "chain/completed");
+  const beforeIllegal = snapshot();
+  assert.throws(() => transition("in_progress", "chain/illegal-terminal-jump"), /transition|completed|ready/i);
+  assert.deepEqual(snapshot(), beforeIllegal);
+  transition("ready", "chain/reopen-completed");
+  transition("in_progress", "chain/in-progress-2");
+  transition("cancelled", "chain/cancelled");
+  transition("ready", "chain/reopen-cancelled");
+
+  assert.deepEqual(row("SELECT lifecycle_status, state_version FROM workflow_item_lifecycles"), {
+    lifecycle_status: "ready",
+    state_version: 7,
+  });
+});
+
+test("reads the original expected fence for an idempotency replay after revision advances", (t) => {
+  openFixture(t);
+  const initialFence = readDomainOperationFence();
+  assert.equal(initialFence.replay, false);
+  let calls = 0;
+  const committedRequest = {
+    operationType: "lifecycle.adopt",
+    idempotencyKey: "replay/adopt",
+    expectedRevision: initialFence.revision,
+    expectedAuthorityEpoch: initialFence.authorityEpoch,
+    actorType: "agent",
+    actorId: "test-agent",
+    sourceTransport: "test",
+    payload: { item: "M001/S01/T01" },
+  } as const;
+  const committed = executeDomainOperation(committedRequest, (context) => {
+    calls += 1;
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "pending",
+    });
+    return operationMutation("lifecycle.adopt");
+  });
+  const beforeReplay = snapshot();
+  assert.deepEqual(readDomainOperationFence(), {
+    projectId: committed.projectId,
+    revision: 1,
+    authorityEpoch: 0,
+    replay: false,
+  });
+
+  const replayFence = readDomainOperationFence("replay/adopt");
+  assert.deepEqual(replayFence, {
+    projectId: committed.projectId,
+    revision: initialFence.revision,
+    authorityEpoch: initialFence.authorityEpoch,
+    replay: true,
+  });
+  const replayed = executeDomainOperation({
+    ...committedRequest,
+    expectedRevision: replayFence.revision,
+    expectedAuthorityEpoch: replayFence.authorityEpoch,
+  }, () => {
+    calls += 1;
+    throw new Error("replay must not invoke lifecycle writers");
+  });
+  assert.equal(calls, 1);
+  assert.deepEqual(replayed, { ...committed, status: "replayed" });
+  assert.deepEqual(snapshot(), beforeReplay);
+});
+
+test("fence lookup rejects blank keys and a replay fence cannot excuse changed semantics", (t) => {
+  openFixture(t);
+  const initial = snapshot();
+  assert.throws(() => readDomainOperationFence("   "), /idempotency|blank|key/i);
+  assert.deepEqual(snapshot(), initial);
+
+  const fence = readDomainOperationFence();
+  const baseRequest = {
+    operationType: "lifecycle.adopt",
+    idempotencyKey: "replay/semantic-conflict",
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: "agent",
+    actorId: "test-agent",
+    sourceTransport: "test",
+    payload: { status: "pending" },
+  } as const;
+  executeDomainOperation(baseRequest, (context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "pending",
+    });
+    return operationMutation("lifecycle.adopt");
+  });
+  const replayFence = readDomainOperationFence(baseRequest.idempotencyKey);
+  assert.equal(replayFence.replay, true);
+  const beforeConflict = snapshot();
+  assert.throws(() => executeDomainOperation({
+    ...baseRequest,
+    expectedRevision: replayFence.revision,
+    expectedAuthorityEpoch: replayFence.authorityEpoch,
+    payload: { status: "completed" },
+  }, () => {
+    throw new Error("semantic conflict must be detected before mutation");
+  }), /idempotency conflict/i);
+  assert.deepEqual(snapshot(), beforeConflict);
+});
+
+test("claims running Attempts, settles immutable Results, and claims a running retry", (t) => {
+  openFixture(t);
+  const adopted = adoptTask();
+  executeAtFence("lifecycle.ready", "ready/attempts", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "ready",
+    }));
+
+  const claim = executeAtFence("attempt.claim", "attempt/1/claim", (context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "in_progress",
+    });
+    return claimRunningAttempt(context, {
+      lifecycleId: adopted.value.lifecycleId,
+      coordinationDispatchId: 1,
+      workerId: "worker-1",
+      milestoneLeaseToken: 7,
+    });
+  });
+  assert.equal(claim.value.attemptNumber, 1);
+  assert.equal(claim.value.retryOfAttemptId, null);
+  assert.equal(claim.value.attemptState, "running");
+  assert.match(claim.value.attemptId, /\S/);
+  assert.match(claim.value.kernelCheckpointId, /\S/);
+
+  const failed = executeAtFence("attempt.settle", "attempt/1/settle", (context) =>
+    settleAttemptWithResult(context, {
+      attemptId: claim.value.attemptId,
+      outcome: "failed",
+      failureClass: "test_failure",
+      summary: "verification failed",
+      output: { a: 1, Z: 2, nested: { é: 3, b: 4 } },
+    }));
+  assert.equal(failed.value.attemptState, "settled");
+  assert.equal(failed.value.outcome, "failed");
+  assert.match(failed.value.resultId, /\S/);
+
+  const retry = executeAtFence("attempt.claim", "attempt/2/claim", (context) =>
+    claimRunningAttempt(context, {
+      lifecycleId: adopted.value.lifecycleId,
+      retryOfAttemptId: claim.value.attemptId,
+      workerId: "worker-1",
+      milestoneLeaseToken: 7,
+    }));
+  assert.equal(retry.value.attemptNumber, 2);
+  assert.equal(retry.value.retryOfAttemptId, claim.value.attemptId);
+  assert.equal(retry.value.attemptState, "running");
+
+  assert.deepEqual(rows(`
+    SELECT attempt_id, attempt_number, retry_of_attempt_id, attempt_state,
+           claim_operation_id, settle_operation_id
+    FROM workflow_execution_attempts ORDER BY attempt_number
+  `), [
+    {
+      attempt_id: claim.value.attemptId,
+      attempt_number: 1,
+      retry_of_attempt_id: null,
+      attempt_state: "settled",
+      claim_operation_id: claim.receipt.operationId,
+      settle_operation_id: failed.receipt.operationId,
+    },
+    {
+      attempt_id: retry.value.attemptId,
+      attempt_number: 2,
+      retry_of_attempt_id: claim.value.attemptId,
+      attempt_state: "running",
+      claim_operation_id: retry.receipt.operationId,
+      settle_operation_id: null,
+    },
+  ]);
+  assert.deepEqual(rows(`
+    SELECT sequence, attempt_id, next_stage, operation_id, project_revision
+    FROM workflow_kernel_checkpoints ORDER BY sequence
+  `), [
+    { sequence: 1, attempt_id: claim.value.attemptId, next_stage: "execute", operation_id: claim.receipt.operationId, project_revision: claim.receipt.resultingRevision },
+    { sequence: 2, attempt_id: retry.value.attemptId, next_stage: "execute", operation_id: retry.receipt.operationId, project_revision: retry.receipt.resultingRevision },
+  ]);
+  assert.deepEqual(row(`
+    SELECT attempt_id, outcome, failure_class, summary, output_json,
+           operation_id, project_revision, authority_epoch
+    FROM workflow_attempt_results
+  `), {
+    attempt_id: claim.value.attemptId,
+    outcome: "failed",
+    failure_class: "test_failure",
+    summary: "verification failed",
+    output_json: '{"Z":2,"a":1,"nested":{"b":4,"é":3}}',
+    operation_id: failed.receipt.operationId,
+    project_revision: failed.receipt.resultingRevision,
+    authority_epoch: failed.receipt.resultingAuthorityEpoch,
+  });
+  const settledTuple = row(`
+    SELECT attempt_state, ended_at, settle_operation_id,
+           settle_project_revision, settle_authority_epoch
+    FROM workflow_execution_attempts WHERE attempt_id = '${claim.value.attemptId}'
+  `);
+  assert.equal(settledTuple.attempt_state, "settled");
+  assert.match(String(settledTuple.ended_at), /\S/);
+  assert.deepEqual({
+    operationId: settledTuple.settle_operation_id,
+    revision: settledTuple.settle_project_revision,
+    epoch: settledTuple.settle_authority_epoch,
+  }, {
+    operationId: failed.receipt.operationId,
+    revision: failed.receipt.resultingRevision,
+    epoch: failed.receipt.resultingAuthorityEpoch,
+  });
+
+  const beforeDoubleSettle = snapshot();
+  assert.throws(() => executeAtFence("attempt.settle", "attempt/1/settle-again", (context) =>
+    settleAttemptWithResult(context, {
+      attemptId: claim.value.attemptId,
+      outcome: "succeeded",
+      failureClass: "none",
+      summary: "must not replace the first result",
+      output: {},
+    })), /settled|result|terminal/i);
+  assert.deepEqual(snapshot(), beforeDoubleSettle);
+  assert.equal(row("SELECT COUNT(*) AS count FROM workflow_attempt_results").count, 1);
+});
+
+test("appends a later same-Attempt kernel head and rejects a stale branch", (t) => {
+  openFixture(t);
+  const adopted = adoptTask();
+  executeAtFence("lifecycle.ready", "checkpoint/ready", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "ready",
+    }));
+  const claim = executeAtFence("attempt.claim", "checkpoint/claim", (context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "in_progress",
+    });
+    return claimRunningAttempt(context, {
+      lifecycleId: adopted.value.lifecycleId,
+      coordinationDispatchId: 1, workerId: "worker-1", milestoneLeaseToken: 7,
+    });
+  });
+  const verify = executeAtFence("kernel.checkpoint", "checkpoint/verify", (context) =>
+    appendKernelCheckpoint(context, {
+      lifecycleId: adopted.value.lifecycleId,
+      attemptId: claim.value.attemptId,
+      nextStage: "verify",
+      previousKernelCheckpointId: claim.value.kernelCheckpointId,
+    }));
+  assert.deepEqual(verify.value, {
+    kernelCheckpointId: verify.value.kernelCheckpointId,
+    sequence: 2,
+    attemptId: claim.value.attemptId,
+    nextStage: "verify",
+    previousKernelCheckpointId: claim.value.kernelCheckpointId,
+  });
+
+  const beforeStale = snapshot();
+  assert.throws(() => executeAtFence("kernel.checkpoint", "checkpoint/stale-route", (context) =>
+    appendKernelCheckpoint(context, {
+      lifecycleId: adopted.value.lifecycleId,
+      attemptId: claim.value.attemptId,
+      nextStage: "route",
+      previousKernelCheckpointId: claim.value.kernelCheckpointId,
+    })), /checkpoint|current|head|stale/i);
+  assert.deepEqual(snapshot(), beforeStale);
+});
+
+test("writer failures roll back lifecycle facts and the surrounding Domain Operation", (t) => {
+  openFixture(t);
+  const adopted = adoptTask();
+  const before = snapshot();
+  assert.throws(() => executeAtFence("attempt.claim", "attempt/invalid", (context) =>
+    claimRunningAttempt(context, {
+      lifecycleId: adopted.value.lifecycleId,
+      retryOfAttemptId: "missing-attempt",
+      coordinationDispatchId: 1,
+      workerId: "worker-1",
+      milestoneLeaseToken: 7,
+    })), /retry|attempt/i);
+  assert.deepEqual(snapshot(), before);
+});
+
+test("adoption rejects missing hierarchy and invalid identity shapes but permits explicit terminal bootstrap", (t) => {
+  openFixture(t);
+  const initial = snapshot();
+  assert.throws(() => executeAtFence("lifecycle.adopt", "adopt/missing", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T99",
+      lifecycleStatus: "pending",
+    })), /task|hierarchy|missing/i);
+  assert.deepEqual(snapshot(), initial);
+  assert.throws(() => executeAtFence("lifecycle.adopt", "adopt/bad-shape", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "milestone", milestoneId: "M001", sliceId: "S01",
+      lifecycleStatus: "pending",
+    })), /identity|shape|slice/i);
+  assert.deepEqual(snapshot(), initial);
+
+  const terminal = executeAtFence("lifecycle.bootstrap", "adopt/terminal", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T03",
+      lifecycleStatus: "completed",
+    }));
+  assert.equal(terminal.value.lifecycleStatus, "completed");
+  assert.equal(terminal.value.stateVersion, 0);
+  assert.equal(terminal.value.adopted, true);
+});
+
+test("paused and terminal lifecycles cannot claim an Attempt and leave no residue", (t) => {
+  openFixture(t);
+  const paused = adoptTask();
+  executeAtFence("lifecycle.ready", "claim-guard/ready", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "ready",
+    }));
+  executeAtFence("lifecycle.pause", "claim-guard/paused", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "paused",
+    }));
+  let before = snapshot();
+  assert.throws(() => executeAtFence("attempt.claim", "claim-guard/paused-attempt", (context) =>
+    claimRunningAttempt(context, {
+      lifecycleId: paused.value.lifecycleId,
+      coordinationDispatchId: 1, workerId: "worker-1", milestoneLeaseToken: 7,
+    })), /paused|ready|in.progress|claim/i);
+  assert.deepEqual(snapshot(), before);
+
+  const terminal = executeAtFence("lifecycle.bootstrap", "claim-guard/terminal", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T03",
+      lifecycleStatus: "completed",
+    }));
+  before = snapshot();
+  assert.throws(() => executeAtFence("attempt.claim", "claim-guard/terminal-attempt", (context) =>
+    claimRunningAttempt(context, {
+      lifecycleId: terminal.value.lifecycleId,
+      workerId: "worker-1", milestoneLeaseToken: 7,
+    })), /completed|ready|in.progress|claim/i);
+  assert.deepEqual(snapshot(), before);
+});
+
+test("Attempt claims reject bad lease, dispatch, active duplication, and retry predecessor without residue", (t) => {
+  openFixture(t);
+  const adopted = adoptTask();
+  executeAtFence("lifecycle.ready", "negative/ready", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "ready",
+    }));
+  executeAtFence("lifecycle.in-progress", "negative/in-progress", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "in_progress",
+    }));
+
+  const rejectWithoutResidue = (key: string, input: Parameters<typeof claimRunningAttempt>[1], message: RegExp) => {
+    const before = snapshot();
+    assert.throws(() => executeAtFence("attempt.claim", key, (context) =>
+      claimRunningAttempt(context, input)), message);
+    assert.deepEqual(snapshot(), before, `${key} left residue`);
+  };
+  rejectWithoutResidue("negative/lease", {
+    lifecycleId: adopted.value.lifecycleId,
+    workerId: "worker-1", milestoneLeaseToken: 8,
+  }, /lease|fencing/i);
+  rejectWithoutResidue("negative/dispatch", {
+    lifecycleId: adopted.value.lifecycleId,
+    coordinationDispatchId: 2, workerId: "worker-1", milestoneLeaseToken: 7,
+  }, /dispatch|scope/i);
+
+  const claim = executeAtFence("attempt.claim", "negative/valid", (context) =>
+    claimRunningAttempt(context, {
+      lifecycleId: adopted.value.lifecycleId,
+      coordinationDispatchId: 1, workerId: "worker-1", milestoneLeaseToken: 7,
+    }));
+  rejectWithoutResidue("negative/active", {
+    lifecycleId: adopted.value.lifecycleId,
+    workerId: "worker-1", milestoneLeaseToken: 7,
+  }, /active|running|attempt/i);
+
+  executeAtFence("attempt.settle", "negative/settle", (context) =>
+    settleAttemptWithResult(context, {
+      attemptId: claim.value.attemptId,
+      outcome: "failed", failureClass: "test", summary: "failed", output: {},
+    }));
+  rejectWithoutResidue("negative/retry-predecessor", {
+    lifecycleId: adopted.value.lifecycleId,
+    retryOfAttemptId: "not-the-predecessor",
+    workerId: "worker-1", milestoneLeaseToken: 7,
+  }, /retry|predecessor|attempt/i);
+});
+
+test("writers reject caller-spoofed provenance outside a committed Domain Operation", (t) => {
+  openFixture(t);
+  const before = snapshot();
+  assert.throws(() => adoptOrTransitionLifecycle({
+    operationId: "forged-operation",
+    projectId: String(row("SELECT project_id FROM project_authority").project_id),
+    resultingRevision: 1,
+    resultingAuthorityEpoch: 0,
+  }, {
+    itemKind: "task",
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T01",
+    lifecycleStatus: "pending",
+  }), /foreign key|operation|provenance/i);
+  assert.deepEqual(snapshot(), before);
+
+  let committedContext!: Readonly<DomainOperationContext>;
+  executeAtFence("lifecycle.adopt", "provenance/real-context", (context) => {
+    committedContext = context;
+    return adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "pending",
+    });
+  });
+  const afterCommit = snapshot();
+  assert.throws(() => adoptOrTransitionLifecycle(committedContext, {
+    itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+    lifecycleStatus: "ready",
+  }), /active domain operation|context|provenance|revision/i);
+  assert.deepEqual(snapshot(), afterCommit);
+});
+
+test("restart preserves the fence, lifecycle head, and Attempt sequence", (t) => {
+  const path = openFixture(t);
+  const adopted = adoptTask();
+  executeAtFence("lifecycle.ready", "ready/restart", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "ready",
+    }));
+  const before = readDomainOperationFence();
+  closeDatabase();
+  assert.equal(openDatabase(path), true);
+  assert.deepEqual(readDomainOperationFence(), before);
+  assert.equal(row("SELECT lifecycle_id FROM workflow_item_lifecycles").lifecycle_id, adopted.value.lifecycleId);
+
+  const claim = executeAtFence("attempt.claim", "attempt/restart", (context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task", milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      lifecycleStatus: "in_progress",
+    });
+    return claimRunningAttempt(context, {
+      lifecycleId: adopted.value.lifecycleId,
+      coordinationDispatchId: 1,
+      workerId: "worker-1",
+      milestoneLeaseToken: 7,
+    });
+  });
+  assert.equal(claim.value.attemptNumber, 1);
+});
+
+test("semantic comparison reports normalized parity without hiding exact legacy values", () => {
+  const cases = [
+    ["pending", "pending", "match", "pending", "pending"],
+    ["ready", "ready", "match", "ready", "ready"],
+    ["in_progress", "in_progress", "match", "in_progress", "in_progress"],
+    ["complete", "completed", "semantic_match_exact_delta", "completed", "completed"],
+    ["done", "completed", "semantic_match_exact_delta", "completed", "completed"],
+    ["planned", "pending", "semantic_match_exact_delta", "pending", "pending"],
+    ["queued", "ready", "semantic_match_exact_delta", "pending", "ready"],
+    ["pending", "ready", "semantic_match_exact_delta", "pending", "ready"],
+    ["active", "ready", "semantic_match_exact_delta", "in_progress", "ready"],
+    ["skipped", "cancelled", "semantic_match_exact_delta", "cancelled", "cancelled"],
+    ["deferred", "cancelled", "semantic_match_exact_delta", "cancelled", "cancelled"],
+    ["blocked", "paused", "semantic_match_exact_delta", "paused", "paused"],
+    ["parked", "paused", "semantic_match_exact_delta", "paused", "paused"],
+    ["completed", "completed", "status_mismatch", null, "completed"],
+    ["mystery", "ready", "status_mismatch", null, "ready"],
+    ["active", "completed", "status_mismatch", "in_progress", "completed"],
+    ["pending", null, "missing_shadow", "pending", null],
+    [null, "pending", "extra_shadow", null, "pending"],
+  ] as const;
+
+  for (const [legacyStatus, canonicalStatus, kind, normalizedLegacyStatus, normalizedCanonicalStatus] of cases) {
+    assert.deepEqual(compareLifecycleShadow(legacyStatus, canonicalStatus), {
+      kind,
+      legacyStatus,
+      canonicalStatus,
+      normalizedLegacyStatus,
+      normalizedCanonicalStatus,
+    });
+  }
+});
+
+test("rejects malformed timestamps and prevents lifecycle audit time from moving backward", (t) => {
+  openFixture(t);
+  const adopted = executeAtFence("lifecycle.adopt", "timestamp/adopt", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      lifecycleStatus: "pending",
+      occurredAt: "2026-07-12T12:00:00.000Z",
+    }));
+
+  assert.throws(() => executeAtFence("lifecycle.ready", "timestamp/malformed", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      lifecycleStatus: "ready",
+      occurredAt: "not-a-date",
+    })), /timestamp|occurredAt|date/i);
+  assert.throws(() => executeAtFence("lifecycle.ready", "timestamp/backward", (context) =>
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      lifecycleStatus: "ready",
+      occurredAt: "2026-07-12T11:59:59.999Z",
+    })), /after|monotonic|occurredAt/i);
+
+  assert.deepEqual(row(`
+    SELECT lifecycle_id, lifecycle_status, state_version, updated_at
+    FROM workflow_item_lifecycles
+  `), {
+    lifecycle_id: adopted.value.lifecycleId,
+    lifecycle_status: "pending",
+    state_version: 0,
+    updated_at: "2026-07-12T12:00:00.000Z",
+  });
+});
+
+function runConcurrentWriter(path: string, id: string, startAt: number): Promise<Record<string, unknown>> {
+  const dbHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/gsd-db.ts")).href;
+  const domainHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/db/domain-operation.ts")).href;
+  const writerHref = pathToFileURL(join(process.cwd(), "src/resources/extensions/gsd/db/writers/lifecycle-commands.ts")).href;
+  const script = `
+    import { openDatabase, closeDatabase } from ${JSON.stringify(dbHref)};
+    import { executeDomainOperation } from ${JSON.stringify(domainHref)};
+    import { adoptOrTransitionLifecycle, readDomainOperationFence } from ${JSON.stringify(writerHref)};
+    const [path, id, startAt] = process.argv.slice(1);
+    if (!openDatabase(path)) throw new Error('open failed');
+    const fence = readDomainOperationFence();
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(0, Number(startAt) - Date.now()));
+    try {
+      const receipt = executeDomainOperation({
+        operationType: 'lifecycle.ready', idempotencyKey: 'race/' + id,
+        expectedRevision: fence.revision, expectedAuthorityEpoch: fence.authorityEpoch,
+        actorType: 'agent', actorId: id, sourceTransport: 'process', payload: { id },
+      }, (context) => {
+        adoptOrTransitionLifecycle(context, {
+          itemKind: 'task', milestoneId: 'M001', sliceId: 'S01', taskId: 'T01', lifecycleStatus: 'ready',
+        });
+        return {
+          events: [{ eventType: 'lifecycle.ready', entityType: 'task', entityId: 'M001/S01/T01', payload: { id }, destinations: ['projection'] }],
+          projections: [{ projectionKey: 'status/m001/s01/t01', projectionKind: 'markdown', rendererVersion: 'v1' }],
+        };
+      });
+      console.log(JSON.stringify({ kind: 'committed', revision: receipt.resultingRevision }));
+    } catch (error) {
+      console.log(JSON.stringify({ kind: 'error', code: error?.code ?? null, message: String(error?.message ?? error) }));
+    } finally { closeDatabase(); }
+  `;
+  const env = { ...process.env };
+  delete env.NODE_TEST_CONTEXT;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [
+      "--import", "./src/resources/extensions/gsd/tests/resolve-ts.mjs",
+      "--experimental-strip-types", "--input-type=module", "-e", script,
+      path, id, String(startAt),
+    ], { cwd: process.cwd(), env, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code !== 0) return reject(new Error(stderr || stdout || `child exited ${code}`));
+      try { resolve(JSON.parse(stdout.trim()) as Record<string, unknown>); }
+      catch { reject(new Error(`invalid child output: ${stdout}\n${stderr}`)); }
+    });
+  });
+}
+
+test("two processes cannot advance one lifecycle from the same fence", async (t) => {
+  const path = openFixture(t);
+  adoptTask();
+  closeDatabase();
+  const startAt = Date.now() + 1_000;
+  const outcomes = await Promise.all([
+    runConcurrentWriter(path, "a", startAt),
+    runConcurrentWriter(path, "b", startAt),
+  ]);
+  assert.equal(outcomes.filter((outcome) => outcome.kind === "committed").length, 1, JSON.stringify(outcomes));
+  const rejected = outcomes.filter((outcome) => outcome.kind === "error");
+  assert.equal(rejected.length, 1, JSON.stringify(outcomes));
+  assert.match(String(rejected[0]?.message), /stale project revision|writer contention/i);
+
+  assert.equal(openDatabase(path), true);
+  assert.deepEqual(row("SELECT lifecycle_status, state_version FROM workflow_item_lifecycles"), {
+    lifecycle_status: "ready",
+    state_version: 1,
+  });
+  assert.deepEqual({
+    revision: row("SELECT revision FROM project_authority").revision,
+    operations: row("SELECT COUNT(*) AS count FROM workflow_operations").count,
+    lifecycles: row("SELECT COUNT(*) AS count FROM workflow_item_lifecycles").count,
+    events: row("SELECT COUNT(*) AS count FROM workflow_domain_events").count,
+    projections: row("SELECT COUNT(*) AS count FROM workflow_projection_work").count,
+  }, {
+    revision: 2,
+    operations: 2,
+    lifecycles: 1,
+    events: 2,
+    projections: 2,
+  });
+});
+
+function importSpecifiers(path: string): string[] {
+  const source = ts.createSourceFile(
+    path,
+    readFileSync(path, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const specifiers: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+    if (
+      ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 && ts.isStringLiteral(node.arguments[0]!)
+    ) {
+      specifiers.push(node.arguments[0].text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return specifiers;
+}
+
+function tsFilesBelow(path: string): string[] {
+  if (!statSync(path).isDirectory()) return extname(path) === ".ts" ? [path] : [];
+  return readdirSync(path).flatMap((entry) => tsFilesBelow(join(path, entry)));
+}
+
+test("lifecycle writers and pure comparison remain below handlers and orchestration", () => {
+  const gsdRoot = resolve("src/resources/extensions/gsd");
+  const writerPath = join(gsdRoot, "db/writers/lifecycle-commands.ts");
+  const comparisonPath = join(gsdRoot, "db/lifecycle-shadow-comparison.ts");
+  const writerLeafAllowlist = new Set([
+    "node:crypto",
+    "../engine.js",
+    "../domain-operation.js",
+    "../lifecycle-shadow-comparison.js",
+  ]);
+  const writerImports = importSpecifiers(writerPath);
+  assert.deepEqual(
+    writerImports.filter((specifier) => !writerLeafAllowlist.has(specifier)),
+    [],
+    `lifecycle writer crossed its leaf boundary: ${writerImports.join(", ")}`,
+  );
+  assert.deepEqual(
+    importSpecifiers(comparisonPath),
+    [],
+    "the semantic comparator must remain a pure import-free leaf",
+  );
+
+  const handlerFiles = [
+    ...tsFilesBelow(join(gsdRoot, "tools")),
+    ...tsFilesBelow(join(gsdRoot, "bootstrap")),
+    ...readdirSync(gsdRoot)
+      .filter((name) => /^commands.*\.ts$/.test(name))
+      .map((name) => join(gsdRoot, name)),
+  ];
+  const reverseImports = handlerFiles.flatMap((path) =>
+    importSpecifiers(path)
+      .filter((specifier) => specifier.includes("lifecycle-shadow-comparison"))
+      .map((specifier) => ({ path, specifier })));
+  assert.deepEqual(reverseImports, [], "handlers must not import the pure shadow comparator during S01");
+});


### PR DESCRIPTION
## Intent

Refactor gsd-pi toward a database-authoritative lifecycle with Markdown as projection only. For M003 S01, add dormant transaction-bound lifecycle, Attempt, Result, Kernel checkpoint, replay-fence, and semantic shadow-comparison primitives; keep legacy reads and responses authoritative and do not wire production handlers yet. Preserve natural automation goals by blocking future Attempt integration until lease-loss recovery is proven, make reopen semantic drift explicit, automate verification, avoid speculative schema changes, and keep the design simple and reusable for later command integrations.

## What Changed

- Add transaction-bound GSD writers for lifecycle transitions, Attempt claims and settlement, immutable Results, Kernel checkpoints, and replay-aware operation fences.
- Add canonical lifecycle normalization and semantic shadow comparison while keeping legacy reads and responses authoritative and production handlers unwired.
- Export the new primitives, document their integration gates and architecture, and add focused coverage for concurrency, rollback, restart, replay, provenance, and validation behavior.

## Risk Assessment

⚠️ Medium: The dormant writers appear correctly transaction-bound with no current production callers, but the automated guard does not fully enforce the documented prohibition against premature production integration.

## Testing

No pre-run baseline result was supplied. Focused and adjacent database contracts passed, and a manual persisted-state exercise demonstrated restart durability, immutable settlement history, retry sequencing, replay without callback execution, semantic shadow comparison, and unchanged legacy status. The first evidence attempt correctly rejected an incomplete fixture lacking a held lease; after adding the required worker/lease, it passed. No screenshot was captured because this change intentionally exposes no UI or production handler surface; reviewer-visible JSON and SQLite artifacts show the actual dormant database behavior.

<details>
<summary>Evidence: Persisted lifecycle end-to-end evidence</summary>

```text
{
  "surface": "dormant database lifecycle primitives (production handlers intentionally not wired)",
  "legacy_projection_boundary": {
    "legacy_task_status": "pending",
    "canonical_lifecycle_status": "in_progress",
    "semantic_shadow_ready_example": {
      "kind": "semantic_match_exact_delta",
      "legacyStatus": "pending",
      "canonicalStatus": "ready",
      "normalizedLegacyStatus": "pending",
      "normalizedCanonicalStatus": "ready"
    }
  },
  "durable_authority": {
    "revision": 5,
    "authority_epoch": 0
  },
  "lifecycle": {
    "item_kind": "task",
    "milestone_id": "M001",
    "slice_id": "S01",
    "task_id": "T01",
    "lifecycle_status": "in_progress",
    "state_version": 2,
    "last_project_revision": 3,
    "last_authority_epoch": 0
  },
  "attempts": [
    {
      "attempt_number": 1,
      "attempt_state": "settled",
      "milestone_lease_token": 7,
      "retries_previous_attempt": null
    },
    {
      "attempt_number": 2,
      "attempt_state": "running",
      "milestone_lease_token": 7,
      "retries_previous_attempt": 1
    }
  ],
  "immutable_result": {
    "outcome": "failed",
    "failure_class": "verification_failure",
    "summary": "Focused verification requested retry",
    "output_json": "{\"passed\":false,\"tests\":[\"lifecycle\"]}",
    "project_revision": 4,
    "authority_epoch": 0
  },
  "kernel_chain": [
    {
      "sequence": 1,
      "next_stage": "execute",
      "is_root": 1
    },
    {
      "sequence": 2,
      "next_stage": "execute",
      "is_root": 0
    }
  ],
  "replay_fence": {
    "replay": true,
    "original_expected_revision": 0,
    "current_revision": 5,
    "receipt_status": "replayed",
    "callback_ran": false,
    "operation_count_unchanged": true
  },
  "restart_check": {
    "database_reopened": true,
    "attempt_count": 2,
    "result_count": 1,
    "checkpoint_count": 2
  },
  "latest_retry": {
    "attempt_number": 2,
    "state": "running",
    "retries_previous_attempt": true
  },
  "first_settlement": {
    "state": "settled",
    "outcome": "failed"
  }
}
```
</details>
- Evidence: Reopenable SQLite lifecycle evidence (local file: <code>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KXBCF96KFHAACS3JZVXDBNEV/lifecycle-e2e.db</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `src/resources/extensions/gsd/db/lifecycle-shadow-comparison.ts:31` - The comparator accepts legacy `ready` and reports `ready`/`ready` as an exact match, but the S01 contract does not define `ready` as a legacy status and limits canonical `ready` equivalence to pending/queued/planned and active/in_progress vocabularies. Confirm whether this deliberate test-backed behavior should override the written contract; otherwise remove the alias so unsupported legacy values remain visible as drift.
- ⚠️ `src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts:845` - The child `ready` promise only resolves from stdout and never rejects when the subprocess errors or exits before printing `READY`. Since the test awaits readiness before awaiting the result, startup/import failures can hang until an outer timeout. Reject `ready` on child error or early close.
- ℹ️ `src/resources/extensions/gsd/db/writers/lifecycle-commands.ts:23` - The lifecycle status vocabulary is duplicated here and in the shadow-comparison module, creating a future drift point in a central contract. Reuse the canonical normalizer or export one shared predicate/source of truth.

🔧 Fix: Fix lifecycle status drift and writer readiness
1 warning still open:
- ⚠️ `src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts:982` - The “remain below handlers and orchestration” guard scans only `tools/`, `bootstrap/`, and `commands*.ts`, omitting `auto/` and root orchestration modules. It also checks only direct comparator imports, so production code could call the newly exported claim/checkpoint writers through `gsd-db.ts` without violating this gate. Extend the guard to detect forbidden lifecycle-writer usage across all production GSD modules until the S03 entry gate is satisfied.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec tsx --test src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts`
- `pnpm exec tsx --test src/resources/extensions/gsd/tests/lifecycle-command-writers.test.ts src/resources/extensions/gsd/tests/db-lifecycle-foundation.test.ts src/resources/extensions/gsd/tests/db-projection-closeout-foundation.test.ts src/resources/extensions/gsd/tests/domain-operation.test.ts src/resources/extensions/gsd/tests/single-writer-invariant.test.ts`
- <code>Manual Node lifecycle harness: adopted and transitioned a task, claimed and settled an Attempt, persisted an immutable Result, claimed a retry, verified the Kernel chain and replay fence, reopened SQLite, and captured queried state to `lifecycle-e2e.json` and `lifecycle-e2e.db`</code>
- <code>Validated the evidence JSON programmatically and confirmed the worktree remained clean with `git status --short --branch`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New DB write paths touch authoritative lifecycle tables but are transaction-scoped and unused by production callers today; incorrect future wiring could diverge from legacy state before shadow comparison is enforced everywhere.
> 
> **Overview**
> Adds **dormant** canonical lifecycle command primitives for M003 S01: writers that only run inside an active `executeDomainOperation()` callback, plus a pure legacy/canonical shadow comparator. **Legacy hierarchy reads and tool responses stay authoritative**; nothing in production handlers is wired to these APIs yet.
> 
> **`db/writers/lifecycle-commands.ts`** (re-exported from `gsd-db.ts`) introduces `readDomainOperationFence()` (current fence or replay fence for an idempotency key), `adoptOrTransitionLifecycle()`, `claimRunningAttempt()`, `settleAttemptWithResult()`, and `appendKernelCheckpoint()`, all bound to Domain Operation provenance and v32 schema triggers (leases, dispatch scope, retry order, checkpoint head).
> 
> **`db/lifecycle-shadow-comparison.ts`** normalizes legacy status aliases and classifies shadow rows (`match`, semantic delta with raw values preserved, missing/extra shadow, mismatch) for future dual-write checks.
> 
> **`canonicalDomainJson`** is exported from `domain-operation.ts` for shared canonical JSON in settlement output. Docs gain a lifecycle integration runbook, db-map/architecture updates, and an implementation research plan; **`lifecycle-command-writers.test.ts`** covers adoption, replay fences, attempts/results/retries, concurrency, rollback, restart, and module layering guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1fb1ca7344884c9124655183a18319d4885e7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->