### PR TITLE
fix(claude-code-cli): stop stream crash on malformed partial frames

### DIFF
--- a/src/resources/extensions/claude-code-cli/partial-builder.ts
+++ b/src/resources/extensions/claude-code-cli/partial-builder.ts
@@ -197,22 +197,35 @@ export class PartialMessageBuilder {
 				if (!block) return null;
 
 				const contentIndex = this.partial.content.length;
-				this.indexMap.set(streamIndex, contentIndex);
 
+				// Record the streamIndex -> content-array mapping ONLY for block
+				// types we actually push below. If indexMap.set ran unconditionally
+				// here, an unhandled block type (e.g. web_search_tool_result,
+				// redacted_thinking) would fall through to `return null` having
+				// pushed nothing, leaving a mapping to an index past the end of
+				// `content`. The paired content_block_stop would then resolve that
+				// mapping (its `=== undefined` guard passes), read
+				// `content[idx] === undefined`, and throw "Cannot read properties of
+				// undefined (reading 'type')" — the exact crash this file guards
+				// against. No mapping means stop/delta no-op via their own guards.
 				if (block.type === "text") {
+					this.indexMap.set(streamIndex, contentIndex);
 					this.partial.content.push({ type: "text", text: "" });
 					return { type: "text_start", contentIndex, partial: this.partial };
 				}
 				if (block.type === "thinking") {
+					this.indexMap.set(streamIndex, contentIndex);
 					this.partial.content.push({ type: "thinking", thinking: "" });
 					return { type: "thinking_start", contentIndex, partial: this.partial };
 				}
 				if (block.type === "tool_use") {
+					this.indexMap.set(streamIndex, contentIndex);
 					this.toolJsonAccum.set(streamIndex, "");
 					this.partial.content.push(toolCallFromBlock(block.id, block.name, {}));
 					return { type: "toolcall_start", contentIndex, partial: this.partial };
 				}
 				if (block.type === "server_tool_use") {
+					this.indexMap.set(streamIndex, contentIndex);
 					this.partial.content.push({
 						type: "serverToolUse",
 						id: block.id,
@@ -254,6 +267,10 @@ export class PartialMessageBuilder {
 				const contentIndex = this.indexMap.get(streamIndex);
 				if (contentIndex === undefined) return null;
 				const block = this.partial.content[contentIndex];
+				// Defense-in-depth: the start-case fix above guarantees this index
+				// resolves to a pushed block, but never dereference `.type` off a
+				// possibly-undefined slot at this trust-boundary read.
+				if (!block) return null;
 
 				if (block.type === "text") {
 					return { type: "text_end", contentIndex, content: block.text, partial: this.partial };

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -2444,6 +2444,24 @@ async function pumpSdkMessages(
 						return;
 					}
 
+					// SDK trust boundary: guard the raw frame before dispatching on its
+					// `.type`. The SDK is expected to read the frame's top-level type
+					// before yielding, but this whole adapter exists because the
+					// subprocess violates its own type contract at runtime (undefined
+					// `.event` payloads, holey content arrays). Guarding the one place
+					// every frame enters removes the last raw-frame `.type` read that
+					// could reproduce the "reading 'type'" crash.
+					if (!msg || typeof msg !== "object" || typeof (msg as { type?: unknown }).type !== "string") {
+						let shape: string;
+						try {
+							shape = JSON.stringify(msg);
+						} catch {
+							shape = String(msg);
+						}
+						console.warn(`[claude-code] dropped malformed SDK message (missing .type): ${shape}`);
+						continue;
+					}
+
 					switch (msg.type) {
 						// -- Init --
 						case "system": {
@@ -2534,8 +2552,17 @@ async function pumpSdkMessages(
 						case "assistant": {
 							const sdkAssistant = msg as SDKAssistantMessage;
 
-							// Capture text content from complete messages
-							for (const block of sdkAssistant.message.content) {
+							// Capture text content from complete messages. The SDK content
+							// array can carry a null/undefined element (a hole); reading
+							// `block.type` on it throws "reading 'type'" and kills the loop.
+							const sdkContent = Array.isArray(sdkAssistant.message?.content)
+								? sdkAssistant.message.content
+								: [];
+							for (const block of sdkContent) {
+								if (!block || typeof block !== "object") {
+									console.warn(`[claude-code] skipped malformed SDK assistant content block: ${String(block)}`);
+									continue;
+								}
 								if (block.type === "text") {
 									lastTextContent = block.text;
 								} else if (block.type === "thinking") {
@@ -2550,6 +2577,13 @@ async function pumpSdkMessages(
 							// Capture content from the completed turn before resetting
 							if (builder) {
 								for (const [contentIndex, block] of builder.message.content.entries()) {
+									// Defense-in-depth: the partial builder only ever pushes
+									// well-formed blocks, so this array is dense today. Guard the
+									// hole/undefined case anyway so a future refactor that breaks
+									// the push-only invariant cannot resurrect the ".type" crash.
+									if (!block || typeof block !== "object") {
+										continue;
+									}
 									if (block.type === "text" && block.text) {
 										lastTextContent = block.text;
 										// Accumulate completed prose in order — a multi-question
@@ -2672,7 +2706,17 @@ async function pumpSdkMessages(
 								api: "anthropic-messages",
 								provider: "claude-code",
 								model: modelId,
-								usage: mapUsage(result.usage, result.total_cost_usd),
+								// SDK trust boundary: a `result` frame missing `.usage` would
+								// make mapUsage read `.input_tokens` off undefined and throw.
+								usage: mapUsage(
+									result.usage ?? {
+										input_tokens: 0,
+										output_tokens: 0,
+										cache_read_input_tokens: 0,
+										cache_creation_input_tokens: 0,
+									},
+									result.total_cost_usd,
+								),
 								stopReason: result.is_error ? "error" : "stop",
 								timestamp: Date.now(),
 							};

--- a/src/resources/extensions/claude-code-cli/tests/malformed-sdk-frames.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/malformed-sdk-frames.test.ts
@@ -1,0 +1,116 @@
+// gsd-pi - Claude Code stream adapter: malformed SDK frame hardening.
+//
+// Regression coverage for the "Cannot read properties of undefined (reading
+// 'type')" crash: the Claude Agent SDK subprocess can yield a `stream_event`
+// with a missing `.event` payload, or an `assistant` message whose content
+// array contains a null/undefined hole. Reading `.type` on those threw and
+// killed the entire provider stream loop, ending the session. The stream
+// adapter must drop the malformed frame (with a warning) and keep going.
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+	streamViaClaudeCode,
+	handleClaudeCodePartialStreamEvent,
+} from "../stream-adapter.ts";
+import type { Context, Message } from "@gsd/pi-ai";
+
+const MODEL = { id: "claude-sonnet-4-6" } as any;
+
+function context(): Context {
+	return { systemPrompt: "sys", messages: [{ role: "user", content: "hi" } as Message] };
+}
+
+async function driveSdkWith(frames: unknown[]): Promise<{ stopReason?: string; errorMessage?: string }> {
+	const cwd = mkdtempSync(join(tmpdir(), "claude-malformed-"));
+	try {
+		const stream = streamViaClaudeCode(MODEL, context(), {
+			cwd,
+			_skipWorkflowMcpPreflightForTest: true,
+			async *_sdkQueryForTest() {
+				for (const frame of frames) yield frame;
+				yield {
+					type: "result", subtype: "success", uuid: "r", session_id: "s",
+					duration_ms: 1, duration_api_ms: 1, is_error: false, num_turns: 1,
+					result: "ok", stop_reason: "end_turn", total_cost_usd: 0,
+					usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+				};
+			},
+		} as any);
+		const message = await stream.result();
+		return { stopReason: (message as any).stopReason, errorMessage: (message as any).errorMessage };
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+}
+
+describe("claude-code stream adapter: malformed SDK frame hardening", () => {
+	test("handleClaudeCodePartialStreamEvent tolerates an undefined event", () => {
+		assert.doesNotThrow(() => {
+			const result = handleClaudeCodePartialStreamEvent(null, undefined as never, "m");
+			assert.equal(result.assistantEvent, null);
+		});
+	});
+
+	test("a stream_event with a missing .event payload does not crash the loop", async () => {
+		const outcome = await driveSdkWith([
+			{ type: "stream_event", event: undefined, parent_tool_use_id: null, uuid: "p", session_id: "s" },
+		]);
+		assert.notEqual(outcome.stopReason, "error");
+		assert.equal(outcome.errorMessage, undefined);
+	});
+
+	test("an assistant message with a null content hole does not crash the loop", async () => {
+		const outcome = await driveSdkWith([
+			{ type: "assistant", uuid: "a", session_id: "s", message: { model: "claude-sonnet-4-6", content: [undefined] } },
+		]);
+		assert.notEqual(outcome.stopReason, "error");
+		assert.equal(outcome.errorMessage, undefined);
+	});
+
+	test("a well-formed content block missing only optional fields still does not crash", async () => {
+		const outcome = await driveSdkWith([
+			{ type: "assistant", uuid: "a", session_id: "s", message: { model: "claude-sonnet-4-6", content: [{}] } },
+		]);
+		assert.notEqual(outcome.stopReason, "error");
+	});
+
+	test("an unhandled streamed block type does not desync the index map and crash", async () => {
+		// content_block_start for a block type the streaming path does not push
+		// (e.g. web_search_tool_result, redacted_thinking) must NOT record an
+		// index mapping; otherwise the paired content_block_stop resolves that
+		// mapping to an unpushed slot and reads `.type` off undefined — the exact
+		// "reading 'type'" crash, from a well-formed frame the guards don't cover.
+		const outcome = await driveSdkWith([
+			{
+				type: "stream_event",
+				event: {
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "web_search_tool_result", tool_use_id: "t", content: [] },
+				},
+				parent_tool_use_id: null, uuid: "p1", session_id: "s",
+			},
+			{
+				type: "stream_event",
+				event: { type: "content_block_stop", index: 0 },
+				parent_tool_use_id: null, uuid: "p2", session_id: "s",
+			},
+		]);
+		assert.notEqual(outcome.stopReason, "error");
+		assert.equal(outcome.errorMessage, undefined);
+	});
+
+	test("a null or type-less top-level SDK frame is dropped, not fatal", async () => {
+		// The raw frame from the for-await loop is dispatched via `switch (msg.type)`;
+		// a null frame or one missing a string `.type` must be dropped, not throw.
+		const outcome = await driveSdkWith([
+			null,
+			{ not_a_type: true },
+		]);
+		assert.notEqual(outcome.stopReason, "error");
+		assert.equal(outcome.errorMessage, undefined);
+	});
+});

--- a/src/resources/extensions/claude-code-cli/turn-assembler.ts
+++ b/src/resources/extensions/claude-code-cli/turn-assembler.ts
@@ -194,6 +194,7 @@ export function attachExternalResultsToToolBlocks(
 	toolResultsById: ReadonlyMap<string, ExternalToolResultPayload>,
 ): void {
 	for (const block of toolBlocks) {
+		if (!block || typeof block !== "object") continue;
 		if (block.type !== "toolCall" && block.type !== "serverToolUse") continue;
 		const externalResult = toolResultsById.get(block.id);
 		if (!externalResult) continue;
@@ -271,6 +272,12 @@ export function buildFinalAssistantContent(params: {
 	}
 	if (params.pendingContent && params.pendingContent.length > 0) {
 		for (const block of params.pendingContent) {
+			// Defense-in-depth: pendingContent comes from the push-only partial
+			// builder and is dense today. Guard the hole/undefined case anyway so a
+			// future refactor cannot reintroduce the ".type" crash here.
+			if (!block || typeof block !== "object") {
+				continue;
+			}
 			if (block.type === "text" || block.type === "thinking") {
 				finalContent.push(block);
 			}
@@ -321,9 +328,11 @@ export function mergePendingToolCalls(
 ): AssistantMessage["content"] {
 	const alreadyIncluded = new Set<string>();
 	for (const block of intermediate) {
+		if (!block || typeof block !== "object") continue;
 		if (block.type === "toolCall") alreadyIncluded.add(block.id);
 	}
 	for (const block of pending) {
+		if (!block || typeof block !== "object") continue;
 		if (block.type !== "toolCall") continue;
 		if (alreadyIncluded.has(block.id)) continue;
 		alreadyIncluded.add(block.id);
@@ -337,6 +346,21 @@ export function handleClaudeCodePartialStreamEvent(
 	event: BetaRawMessageStreamEvent,
 	modelId: string,
 ): { builder: PartialMessageBuilder | null; assistantEvent: AssistantMessageEvent | null } {
+	// SDK trust boundary: the Claude Agent SDK subprocess can yield a
+	// `stream_event` frame whose `.event` payload is missing/undefined. Reading
+	// `event.type` on it throws "Cannot read properties of undefined (reading
+	// 'type')" and kills the entire provider stream loop. Drop the malformed
+	// frame and preserve the upstream signal via a warning rather than crashing.
+	if (!event || typeof event !== "object" || typeof (event as { type?: unknown }).type !== "string") {
+		let shape: string;
+		try {
+			shape = JSON.stringify(event);
+		} catch {
+			shape = String(event);
+		}
+		console.warn(`[claude-code] dropped malformed SDK stream event (missing .type): ${shape}`);
+		return { builder, assistantEvent: null };
+	}
 	if (event.type === "message_start") {
 		// Claude Code can emit repeated SDK message_start events inside one
 		// logical assistant response. Keep appending until a synthetic user


### PR DESCRIPTION
## Linked issue

Not applicable — obvious bug fix.

---

## TL;DR

**What:** Fixes a Claude Code streaming crash on malformed or unsupported partial-message SDK frames.
**Why:** Unsupported content block types could leave stale stream-index mappings that later resolved to missing content slots.
**How:** Maps only stored content blocks, guards stop-event lookups, hardens stream assembly boundaries, and adds malformed-frame regression coverage.

## What

- Updates `src/resources/extensions/claude-code-cli/partial-builder.ts` so stream-index mappings are recorded only for content blocks added to message content.
- Guards `content_block_stop` handling when a stream index does not resolve to a valid content slot.
- Hardens `stream-adapter.ts` and `turn-assembler.ts` against malformed or incomplete SDK stream frames.
- Adds regression tests for undefined events, missing nested events, null content holes, and malformed message frames.

## Why

Malformed or unsupported partial-message frames could throw `Cannot read properties of undefined (reading 'type')` and terminate the provider loop. The failure came from recording an index for a block type that was not added to message content, then reading from the missing slot when the stop event arrived.

## How

The fix keeps the stream-index map aligned with the message content array. It also rejects malformed stop events and incomplete frame shapes at the stream boundary instead of allowing them to fail during downstream assembly.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types src/resources/extensions/claude-code-cli/tests/malformed-sdk-frames.test.ts`
- `git diff --check origin/main..HEAD`
- `pnpm run test:compile`

## AI disclosure

- [x] This PR includes AI-assisted code. The change is covered by the test plan above.
