### PR TITLE
fix(gsd): recover attempts after failed dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,20 @@ AGENTS.md
 # opencode local config
 .opencode/
 test-results/
+
+# ── GSD baseline (auto-generated) ──
+.gsd-worktrees/
+.gsd-backups/
+nul
+nul.*
+con
+con.*
+prn
+prn.*
+aux
+aux.*
+com[1-9]
+com[1-9].*
+lpt[1-9]
+lpt[1-9].*
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -107,20 +107,3 @@ AGENTS.md
 # opencode local config
 .opencode/
 test-results/
-
-# ── GSD baseline (auto-generated) ──
-.gsd-worktrees/
-.gsd-backups/
-nul
-nul.*
-con
-con.*
-prn
-prn.*
-aux
-aux.*
-com[1-9]
-com[1-9].*
-lpt[1-9]
-lpt[1-9].*
-dist/

--- a/src/resources/extensions/gsd/db/writers/task-execution.ts
+++ b/src/resources/extensions/gsd/db/writers/task-execution.ts
@@ -98,18 +98,25 @@ export function terminalizeTaskExecutionDispatch(
   if (Number((result as { changes?: number }).changes ?? 0) === 1) return;
 
   if (input.outcome === "interrupted") {
-    const canceled = getDb().prepare(`
+    const alreadyTerminal = getDb().prepare(`
       SELECT 1 AS present FROM unit_dispatches
       WHERE id = :dispatch_id
         AND worker_id = :worker_id
         AND milestone_lease_token = :lease_token
-        AND status = 'canceled'
+        AND (
+          status = 'canceled'
+          OR (
+            :recovery_interruption = 1
+            AND status IN ('failed', 'stuck', 'paused')
+          )
+        )
     `).get({
       ":dispatch_id": input.dispatchId,
       ":worker_id": input.workerId,
       ":lease_token": input.milestoneLeaseToken,
+      ":recovery_interruption": operationType === "attempt.interrupt" ? 1 : 0,
     });
-    if (canceled) return;
+    if (alreadyTerminal) return;
   }
   throw new Error("Task execution settlement did not terminalize exactly one coordination dispatch");
 }

--- a/src/resources/extensions/gsd/tests/task-execution-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-execution-domain-operation.test.ts
@@ -202,6 +202,23 @@ function seedFixture(): { dispatchId: number } {
   return { dispatchId: Number(row("SELECT id FROM unit_dispatches").id) };
 }
 
+function installReplacementLease(): void {
+  db().exec(`
+    INSERT INTO workers (
+      worker_id, host, pid, started_at, version, last_heartbeat_at, status,
+      project_root_realpath
+    ) VALUES (
+      'worker-2', 'test-host', 2, '2026-07-12T00:01:00.000Z', 'test',
+      '2026-07-12T00:01:00.000Z', 'active', '/tmp/project'
+    );
+    UPDATE milestone_leases
+    SET worker_id = 'worker-2', fencing_token = 8,
+        acquired_at = '2026-07-12T00:01:00.000Z',
+        expires_at = '2099-07-12T00:00:00.000Z', status = 'held'
+    WHERE milestone_id = 'M001';
+  `);
+}
+
 function claimInput(dispatchId: number, key = "task-attempt/claim/1"): ClaimTaskAttemptInput {
   return {
     invocation: invocation(key),
@@ -708,19 +725,8 @@ test("a replacement lease can interrupt the fenced Attempt and a lineage-linked 
     recovery: { workerId: "worker-1", milestoneLeaseToken: 7 },
   }), /lease|current|valid|stale/i);
   assert.deepEqual(executionSnapshot(), beforePrematureRecovery);
+  installReplacementLease();
   db().exec(`
-    INSERT INTO workers (
-      worker_id, host, pid, started_at, version, last_heartbeat_at, status,
-      project_root_realpath
-    ) VALUES (
-      'worker-2', 'test-host', 2, '2026-07-12T00:01:00.000Z', 'test',
-      '2026-07-12T00:01:00.000Z', 'active', '/tmp/project'
-    );
-    UPDATE milestone_leases
-    SET worker_id = 'worker-2', fencing_token = 8,
-        acquired_at = '2026-07-12T00:01:00.000Z',
-        expires_at = '2099-07-12T00:00:00.000Z', status = 'held'
-    WHERE milestone_id = 'M001';
     UPDATE unit_dispatches
     SET status = 'canceled', ended_at = '2026-07-12T00:01:00.000Z',
         exit_reason = 'stale-dispatch-lease-takeover'
@@ -780,4 +786,86 @@ test("a replacement lease can interrupt the fenced Attempt and a lineage-linked 
     { attempt_number: 1, retry_of_attempt_id: null, attempt_state: "settled" },
     { attempt_number: 2, retry_of_attempt_id: first.attemptId, attempt_state: "running" },
   ]);
+});
+
+test("a replacement lease can interrupt an Attempt whose original dispatch already failed", async () => {
+  const { claimTaskAttempt, settleTaskAttempt } = await subject();
+  const { dispatchId } = seedFixture();
+  const claim = claimTaskAttempt(claimInput(dispatchId));
+  installReplacementLease();
+  db().exec(`
+    UPDATE unit_dispatches
+    SET status = 'failed', ended_at = '2026-07-12T00:01:00.000Z',
+        error_summary = 'prior executor session failed after the Attempt claim'
+    WHERE id = ${dispatchId};
+  `);
+
+  const interrupted = settleTaskAttempt({
+    ...settleInput(claim.attemptId, "interrupted", "task-attempt/recover/failed-dispatch"),
+    failureClass: "stale-worker",
+    recovery: { workerId: "worker-2", milestoneLeaseToken: 8 },
+  });
+
+  assert.equal(interrupted.nextStage, "route");
+  assert.deepEqual(row(`
+    SELECT attempt_state, settle_outcome, recovery_worker_id,
+           recovery_milestone_lease_token
+    FROM workflow_execution_attempts
+  `), {
+    attempt_state: "settled",
+    settle_outcome: "interrupted",
+    recovery_worker_id: "worker-2",
+    recovery_milestone_lease_token: 8,
+  });
+  assert.equal(row("SELECT status FROM unit_dispatches").status, "failed");
+});
+
+for (const dispatchStatus of ["stuck", "paused"] as const) {
+  test(`a replacement lease preserves an already ${dispatchStatus} dispatch while interrupting its Attempt`, async () => {
+    const { claimTaskAttempt, settleTaskAttempt } = await subject();
+    const { dispatchId } = seedFixture();
+    const claim = claimTaskAttempt(claimInput(dispatchId));
+    installReplacementLease();
+    db().prepare(`
+      UPDATE unit_dispatches
+      SET status = :status, ended_at = '2026-07-12T00:01:00.000Z'
+      WHERE id = :dispatch_id
+    `).run({ ":status": dispatchStatus, ":dispatch_id": dispatchId });
+
+    const interrupted = settleTaskAttempt({
+      ...settleInput(
+        claim.attemptId,
+        "interrupted",
+        `task-attempt/recover/${dispatchStatus}-dispatch`,
+      ),
+      failureClass: "stale-worker",
+      recovery: { workerId: "worker-2", milestoneLeaseToken: 8 },
+    });
+
+    assert.equal(interrupted.nextStage, "route");
+    assert.equal(row("SELECT attempt_state FROM workflow_execution_attempts").attempt_state, "settled");
+    assert.equal(row("SELECT status FROM unit_dispatches").status, dispatchStatus);
+  });
+}
+
+test("a replacement lease cannot reinterpret a completed dispatch as interrupted", async () => {
+  const { claimTaskAttempt, settleTaskAttempt } = await subject();
+  const { dispatchId } = seedFixture();
+  const claim = claimTaskAttempt(claimInput(dispatchId));
+  installReplacementLease();
+  db().exec(`
+    UPDATE unit_dispatches
+    SET status = 'completed', ended_at = '2026-07-12T00:01:00.000Z'
+    WHERE id = ${dispatchId};
+  `);
+  const before = executionSnapshot();
+
+  assert.throws(() => settleTaskAttempt({
+    ...settleInput(claim.attemptId, "interrupted", "task-attempt/recover/completed-dispatch"),
+    failureClass: "stale-worker",
+    recovery: { workerId: "worker-2", milestoneLeaseToken: 8 },
+  }), /did not terminalize exactly one coordination dispatch/i);
+
+  assert.deepEqual(executionSnapshot(), before);
+  assert.equal(row("SELECT status FROM unit_dispatches").status, "completed");
 });


### PR DESCRIPTION
## Summary

- allow replacement-lease Attempt interruption to preserve an already terminal non-success dispatch
- keep completed dispatches fail-closed because they contradict an interrupted canonical outcome
- cover failed, stuck, paused, and canceled history plus completed-dispatch rollback

## Root cause

The recovery schema permits a newer lease to interrupt a stale running Attempt even after its original coordination dispatch is no longer active. The application writer only recognized canceled history. When an executor error had already marked the dispatch failed, recovery rolled back with a dispatch terminalization error.

## Verification

- exact production regression: failed before fix, passed after fix
- focused execution/writer/cutover suites: 70 passed
- independent strict review suite: 139 passed
- extension typecheck
- fast repository gates
- workflow authority fault baseline: 4/4
- sabotage: admitting completed dispatches makes the rejection test fail
- live canonical replay: stale Attempt 2 settled interrupted under replacement lease while its failed dispatch remained unchanged

Closes #1455

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786541222&installation_id=134682257&pr_number=1456&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1456&signature=027d0b28ae6746771906ab98920af2b2ff3e6511ebbaa3d38be0643d9cd6cfb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordination dispatch terminalization on the task execution critical path; behavior is narrowed to `attempt.interrupt` and explicitly rejects completed dispatches.
> 
> **Overview**
> Fixes **replacement-lease recovery** when a stale running Attempt is interrupted after its coordination dispatch is already terminal.
> 
> `terminalizeTaskExecutionDispatch` used to treat only **`canceled`** dispatch history as a no-op when the interrupt `UPDATE` matched zero rows. **`attempt.interrupt`** recovery now also accepts **`failed`**, **`stuck`**, and **`paused`** so the Attempt can settle as interrupted without rewriting dispatch status. **`completed`** dispatches still fail closed with the existing terminalization error.
> 
> Tests add `installReplacementLease()` and cover failed/stuck/paused preservation plus rollback when the dispatch is already completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8fc4b0d6f4cd62c7c4bec8c955c01f87e341ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->