### PR TITLE
fix(gsd): keep milestone leases alive during unit execution

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -43,7 +43,12 @@ import {
   getRecentUnitKeysForProjectRoot,
   markLatestActiveForWorkerCanceled,
 } from "../db/unit-dispatches.js";
-import { claimMilestoneLease, refreshMilestoneLease, forceReleaseLeasesForWorker } from "../db/milestone-leases.js";
+import {
+  claimMilestoneLease,
+  refreshMilestoneLease,
+  forceReleaseLeasesForWorker,
+  milestoneLeaseTtlSeconds,
+} from "../db/milestone-leases.js";
 import { heartbeatAutoWorker, getAutoWorker, markWorkerCrashed } from "../db/auto-workers.js";
 import { getRuntimeKv, setRuntimeKv } from "../db/runtime-kv.js";
 import { resolveUokFlags } from "../uok/flags.js";
@@ -83,7 +88,7 @@ import { createWorkflowPhaseReporter } from "./workflow-phase-reporter.js";
 import { createWorkflowTurnReporter } from "./workflow-turn-reporter.js";
 import { validateWorkflowSessionLock } from "./workflow-session-lock.js";
 import { dequeueSidecarItem } from "./workflow-sidecar-queue.js";
-import { maintainWorkerHeartbeat } from "./workflow-worker-heartbeat.js";
+import { maintainWorkerHeartbeat, runWithWorkerHeartbeat } from "./workflow-worker-heartbeat.js";
 import { gsdRoot } from "../paths.js";
 import {
   measureMemoryPressure,
@@ -196,6 +201,7 @@ function resolveCompletionStopFromOutcome(
 const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
 const MAX_CONSECUTIVE_ALREADY_ACTIVE_SKIPS = 3;
 const MAX_CONSECUTIVE_ORCHESTRATION_SKIPS = 3;
+const WORKER_HEARTBEAT_INTERVAL_MS = milestoneLeaseTtlSeconds() * 500;
 const ORCHESTRATION_MISSING_REASON =
   "Auto Orchestration Module is not wired; cannot dispatch built-in GSD Unit.";
 const TASK_EXECUTION_CUTOVER_DEPS = {
@@ -489,23 +495,28 @@ export async function autoLoop(
   let consecutiveOrchestrationSkips = 0;
   let lastOrchestrationSkipKey: string | null = null;
   const recentErrorMessages: string[] = [];
+  const workerHeartbeatDeps = {
+    heartbeatAutoWorker,
+    refreshMilestoneLease,
+    logHeartbeatFailure: (err: unknown) => debugLog("autoLoop", {
+      phase: "heartbeat-failed",
+      error: err instanceof Error ? err.message : String(err),
+    }),
+    logLeaseRefreshMiss: (details: {
+      workerId: string;
+      milestoneId: string;
+      fencingToken: number;
+    }) => debugLog("autoLoop", {
+      phase: "lease-refresh-missed",
+      ...details,
+    }),
+  };
 
   while (s.active) {
     iteration++;
     debugLog("autoLoop", { phase: "loop-top", iteration });
 
-    maintainWorkerHeartbeat(s, {
-      heartbeatAutoWorker,
-      refreshMilestoneLease,
-      logHeartbeatFailure: err => debugLog("autoLoop", {
-        phase: "heartbeat-failed",
-        error: err instanceof Error ? err.message : String(err),
-      }),
-      logLeaseRefreshMiss: details => debugLog("autoLoop", {
-        phase: "lease-refresh-missed",
-        ...details,
-      }),
-    });
+    maintainWorkerHeartbeat(s, workerHeartbeatDeps);
 
     // ── Journal: per-iteration flow grouping ──
     const flowId = randomUUID();
@@ -818,28 +829,33 @@ export async function autoLoop(
         }
         let unitPhaseResult: Awaited<ReturnType<typeof runUnitPhaseViaContract>>;
         try {
-          unitPhaseResult = await (deps.taskExecutionBoundary ?? runWithTaskExecutionAttempt)(
-            {
-              unitType: iterData.unitType,
-              unitId: iterData.unitId,
-              dispatchId: customDispatchId,
-              workerId: s.workerId,
-              milestoneLeaseToken: s.milestoneLeaseToken,
-              traceId: flowId,
-              turnId,
-              markCanonicalDispatchSettled() {
-                customDispatchSettled = true;
+          unitPhaseResult = await runWithWorkerHeartbeat(
+            s,
+            workerHeartbeatDeps,
+            WORKER_HEARTBEAT_INTERVAL_MS,
+            () => (deps.taskExecutionBoundary ?? runWithTaskExecutionAttempt)(
+              {
+                unitType: iterData.unitType,
+                unitId: iterData.unitId,
+                dispatchId: customDispatchId,
+                workerId: s.workerId,
+                milestoneLeaseToken: s.milestoneLeaseToken,
+                traceId: flowId,
+                turnId,
+                markCanonicalDispatchSettled() {
+                  customDispatchSettled = true;
+                },
               },
-            },
-            () => runUnitPhaseViaContract(
-              dispatchContract,
-              ic,
-              iterData,
-              loopState,
-              undefined,
-              unitDispatchDeps,
+              () => runUnitPhaseViaContract(
+                dispatchContract,
+                ic,
+                iterData,
+                loopState,
+                undefined,
+                unitDispatchDeps,
+              ),
+              TASK_EXECUTION_CUTOVER_DEPS,
             ),
-            TASK_EXECUTION_CUTOVER_DEPS,
           );
         } catch (err) {
           if (err instanceof ModelPolicyDispatchBlockedError) {
@@ -1496,28 +1512,33 @@ export async function autoLoop(
 
       let unitPhaseResult: Awaited<ReturnType<typeof runUnitPhaseViaContract>>;
       try {
-        unitPhaseResult = await (deps.taskExecutionBoundary ?? runWithTaskExecutionAttempt)(
-          {
-            unitType: iterData.unitType,
-            unitId: iterData.unitId,
-            dispatchId,
-            workerId: s.workerId,
-            milestoneLeaseToken: s.milestoneLeaseToken,
-            traceId: flowId,
-            turnId,
-            markCanonicalDispatchSettled() {
-              dispatchSettled = true;
+        unitPhaseResult = await runWithWorkerHeartbeat(
+          s,
+          workerHeartbeatDeps,
+          WORKER_HEARTBEAT_INTERVAL_MS,
+          () => (deps.taskExecutionBoundary ?? runWithTaskExecutionAttempt)(
+            {
+              unitType: iterData.unitType,
+              unitId: iterData.unitId,
+              dispatchId,
+              workerId: s.workerId,
+              milestoneLeaseToken: s.milestoneLeaseToken,
+              traceId: flowId,
+              turnId,
+              markCanonicalDispatchSettled() {
+                dispatchSettled = true;
+              },
             },
-          },
-          () => runUnitPhaseViaContract(
-            dispatchContract,
-            ic,
-            iterData,
-            loopState,
-            sidecarItem,
-            unitDispatchDeps,
+            () => runUnitPhaseViaContract(
+              dispatchContract,
+              ic,
+              iterData,
+              loopState,
+              sidecarItem,
+              unitDispatchDeps,
+            ),
+            TASK_EXECUTION_CUTOVER_DEPS,
           ),
-          TASK_EXECUTION_CUTOVER_DEPS,
         );
       } catch (err) {
         if (err instanceof ModelPolicyDispatchBlockedError) {

--- a/src/resources/extensions/gsd/auto/workflow-worker-heartbeat.ts
+++ b/src/resources/extensions/gsd/auto/workflow-worker-heartbeat.ts
@@ -49,3 +49,20 @@ export function maintainWorkerHeartbeat(
     deps.logHeartbeatFailure(err);
   }
 }
+
+export async function runWithWorkerHeartbeat<T>(
+  session: WorkerHeartbeatSession,
+  deps: MaintainWorkerHeartbeatDeps,
+  intervalMs: number,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (!session.workerId) return run();
+
+  maintainWorkerHeartbeat(session, deps);
+  const handle = setInterval(() => maintainWorkerHeartbeat(session, deps), intervalMs);
+  try {
+    return await run();
+  } finally {
+    clearInterval(handle);
+  }
+}

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -36,9 +36,9 @@ import type { AutoAdvanceResult, AutoOrchestrationModule, AutoStatus, UnitRef } 
 import { WorktreeStateProjection } from "../worktree-state-projection.js";
 import { ModelPolicyDispatchBlockedError } from "../auto-model-selection.js";
 import type { SessionLockStatus } from "../session-lock.js";
-import { openDatabase, closeDatabase, getTask, insertMilestone, insertSlice, insertTask } from "../gsd-db.js";
+import { _getAdapter, openDatabase, closeDatabase, getTask, insertMilestone, insertSlice, insertTask } from "../gsd-db.js";
 import { registerAutoWorker } from "../db/auto-workers.js";
-import { claimMilestoneLease } from "../db/milestone-leases.js";
+import { claimMilestoneLease, getMilestoneLease, milestoneLeaseTtlSeconds } from "../db/milestone-leases.js";
 import { getLatestForUnit, recordDispatchClaim, markCanceled } from "../db/unit-dispatches.js";
 import { setRuntimeKv, getRuntimeKv } from "../db/runtime-kv.js";
 import { SourceObservationStore } from "../source-observations.js";
@@ -2318,6 +2318,126 @@ test("autoLoop publishes a canonical Task only after host verification without l
     assert.equal(attempt.nextStage, "settled");
     assert.equal(getLatestForUnit("M001/S01/T01")?.status, "completed");
   } finally {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
+test("autoLoop refreshes its milestone lease while an execute-task call is pending and clears the heartbeat on exit", async () => {
+  _resetPendingResolve();
+  mock.timers.enable({ apis: ["setInterval"] });
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.ui.setWidget = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+  const basePath = realpathSync(makeLoopTestBase("gsd-task-lease-heartbeat-"));
+  execSync("git commit --allow-empty -m initial", { cwd: basePath, stdio: "ignore" });
+  const slicePath = join(basePath, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(join(slicePath, "tasks"), { recursive: true });
+  writeFileSync(join(slicePath, "S01-PLAN.md"), "# Slice Plan\n\n- [ ] **T01:** task one\n");
+  writeFileSync(join(slicePath, "tasks", "T01-PLAN.md"), "# Task Plan\n");
+
+  try {
+    openDatabase(join(basePath, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", status: "active" });
+    insertTask({
+      id: "T01",
+      milestoneId: "M001",
+      sliceId: "S01",
+      title: "Task One",
+      status: "pending",
+      planning: { verify: 'node -e "process.exit(0)"' },
+    });
+    const workerId = registerAutoWorker({ projectRootRealpath: basePath });
+    const lease = claimMilestoneLease(workerId, "M001");
+    assert.equal(lease.ok, true);
+    if (!lease.ok) return;
+
+    const s = makeLoopSession({
+      basePath,
+      originalBasePath: basePath,
+      canonicalProjectRoot: basePath,
+      workerId,
+      milestoneLeaseToken: lease.token,
+    });
+    const deps = makeMockDeps({
+      isDbAvailable: () => true,
+      taskExecutionBoundary: runWithTaskExecutionAttempt,
+      taskPublicationBoundary: publishVerifiedTaskExecution,
+      runPostUnitVerification,
+      postUnitPostVerification: async () => {
+        s.active = false;
+        return "continue" as const;
+      },
+    });
+
+    const loopPromise = autoLoop(ctx, pi, s, deps);
+    await waitForMicrotasks(
+      () => readLatestTaskAttempt({ milestoneId: "M001", sliceId: "S01", taskId: "T01" })?.state === "running",
+      "canonical Task Attempt claim",
+    );
+
+    const expiredAt = "1970-01-01T00:00:00.000Z";
+    _getAdapter()!.prepare(
+      "UPDATE milestone_leases SET expires_at = :expires_at WHERE milestone_id = :milestone_id",
+    ).run({ ":expires_at": expiredAt, ":milestone_id": "M001" });
+    mock.timers.tick(milestoneLeaseTtlSeconds() * 500);
+
+    const refreshedLease = getMilestoneLease("M001");
+    assert.equal(refreshedLease?.worker_id, workerId);
+    assert.equal(refreshedLease?.fencing_token, lease.token);
+    assert.equal(refreshedLease?.status, "held");
+    const leaseWasRefreshed = Date.parse(refreshedLease?.expires_at ?? "") > Date.now();
+    if (!leaseWasRefreshed) {
+      _getAdapter()!.prepare(
+        "UPDATE milestone_leases SET expires_at = :expires_at WHERE milestone_id = :milestone_id",
+      ).run({
+        ":expires_at": new Date(Date.now() + milestoneLeaseTtlSeconds() * 1000).toISOString(),
+        ":milestone_id": "M001",
+      });
+    }
+
+    await stageTaskCompletion({
+      invocation: {
+        idempotencyKey: "test:auto-loop:heartbeat-stage:T01",
+        sourceTransport: "internal",
+        actorType: "agent",
+        actorId: workerId,
+      },
+      basePath,
+      task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+      completion: {
+        oneLiner: "Executor candidate completed",
+        narrative: "Candidate result awaiting host verification.",
+        verification: "Executor reported success.",
+        deviations: "None.",
+        knownIssues: "None.",
+        keyFiles: ["src/task.ts"],
+        keyDecisions: ["Keep the lease alive while execution is pending."],
+        blockerDiscovered: false,
+        verificationEvidence: [],
+      },
+    });
+
+    resolveAgentEnd(makeEvent());
+    await loopPromise;
+
+    const attempt = readLatestTaskAttempt({ milestoneId: "M001", sliceId: "S01", taskId: "T01" });
+    assert.equal(attempt?.state, "settled");
+    assert.equal(attempt?.outcome, "succeeded");
+    assert.equal(getLatestForUnit("M001/S01/T01")?.status, "completed");
+    assert.equal(leaseWasRefreshed, true, "the in-flight heartbeat must renew the original lease");
+
+    _getAdapter()!.prepare(
+      "UPDATE milestone_leases SET expires_at = :expires_at WHERE milestone_id = :milestone_id",
+    ).run({ ":expires_at": expiredAt, ":milestone_id": "M001" });
+    mock.timers.tick(milestoneLeaseTtlSeconds() * 500);
+    assert.equal(getMilestoneLease("M001")?.expires_at, expiredAt);
+  } finally {
+    mock.timers.reset();
     try { closeDatabase(); } catch { /* noop */ }
     rmSync(basePath, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/workflow-worker-heartbeat.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-worker-heartbeat.test.ts
@@ -2,10 +2,11 @@
 // File Purpose: Unit tests for auto-mode worker heartbeat adapter.
 
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { mock } from "node:test";
 
 import {
   maintainWorkerHeartbeat,
+  runWithWorkerHeartbeat,
   type MaintainWorkerHeartbeatDeps,
   type WorkerHeartbeatSession,
 } from "../auto/workflow-worker-heartbeat.ts";
@@ -151,4 +152,32 @@ test("maintainWorkerHeartbeat clears stale lease tokens when refresh misses", ()
     fencingToken: 7,
   }]);
   assert.equal(session.milestoneLeaseToken, null);
+});
+
+test("runWithWorkerHeartbeat clears its interval when unit execution rejects", async () => {
+  mock.timers.enable({ apis: ["setInterval"] });
+
+  try {
+    const failure = new Error("unit execution failed");
+    const { deps, calls } = makeDeps();
+    const session: WorkerHeartbeatSession = {
+      workerId: "worker-1",
+      currentMilestoneId: "M001",
+      milestoneLeaseToken: 7,
+    };
+
+    await assert.rejects(
+      runWithWorkerHeartbeat(session, deps, 1_000, async () => {
+        throw failure;
+      }),
+      failure,
+    );
+    const callsAfterRejection = calls.length;
+
+    mock.timers.tick(1_000);
+
+    assert.equal(calls.length, callsAfterRejection);
+  } finally {
+    mock.timers.reset();
+  }
 });


### PR DESCRIPTION
## TL;DR

**What:** Keep the active worker and milestone lease alive while an automatic unit is awaiting a long provider call.
**Why:** A healthy task could outlive the 60-second lease TTL and then be rejected by the database when it tried to settle.
**How:** Wrap both automatic execution paths in a half-TTL heartbeat that starts immediately and always stops when the unit resolves or rejects.

## What

- Adds a scoped async heartbeat boundary for long-running units.
- Uses the same behavior in built-in and custom-engine auto execution.
- Adds a real-database regression that expires the original lease while a Task is pending, advances the heartbeat, and proves successful settlement.
- Adds rejection-path coverage proving the interval is cleared after execution errors.

## Why

Auto-mode previously refreshed leases only at the top of its orchestration loop. While it awaited a provider call, the loop could not refresh again. Calls longer than the lease TTL therefore lost settlement authority even when no peer worker took over.

Closes #1460

## How

The existing worker heartbeat is run immediately before the unit boundary and every half-TTL while it remains pending. Cleanup lives in the async wrapper's `finally` block. A missed refresh still clears the session token, so stale or replaced workers continue to fail closed through the existing database fencing trigger.

The database trigger, replacement-lease recovery, and retry policy are unchanged.

## Verification

- RED: real-DB pending Task left the forced-expired lease unchanged on prior behavior.
- GREEN: original worker/token lease renews, Task settles succeeded, dispatch completes, and no refresh occurs after exit.
- Sabotage: delaying the interval beyond the test window fails the renewal assertion.
- Error sabotage: removing cleanup produces extra heartbeat calls after rejection (`4 !== 2`).
- `pnpm run typecheck:extensions`
- `pnpm run test:changed:src` — 139 passed
- `pnpm run verify:fast`
- Independent correctness and simplicity reviews — no findings after follow-up

The local merge-equivalent run passed build, web build, pack/install validation, coverage, and branch-specific tests before its aggregate unit phase encountered unrelated macOS path assertions that reproduce on detached `origin/main`; hosted CI is the clean full-suite gate for this draft.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786553568&installation_id=134682257&pr_number=1461&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1461&signature=82f44e7221e85e1f065067e612c34274486cb3d04951793324838b6aabab4dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-loop coordination and milestone lease fencing during long-running dispatches; behavior is scoped and fail-closed on refresh miss, but incorrect timing or cleanup could still affect settlement authority.
> 
> **Overview**
> Fixes auto-mode losing milestone lease authority when a unit waits on a long provider call longer than the lease TTL (~60s), because heartbeats previously ran only at the top of each orchestration loop.
> 
> Adds **`runWithWorkerHeartbeat`**, which runs an immediate heartbeat and then **`maintainWorkerHeartbeat`** on a **half-TTL** interval (`milestoneLeaseTtlSeconds() * 500` ms) for the duration of an async unit run, with **`clearInterval`** in a `finally` block so the timer stops on success or rejection. Both **built-in** and **custom-engine** paths wrap task execution (`runWithTaskExecutionAttempt` → `runUnitPhaseViaContract`) in this boundary; loop-top heartbeat logic is unchanged but **`workerHeartbeatDeps`** is shared.
> 
> Tests add a real-DB auto-loop case that forces lease expiry while a task is pending, ticks the interval, and asserts renewal and successful settlement, plus a unit test that no further heartbeats run after execution rejects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1978d3ba5a6ad621e961bdbc7c7717417826694a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->