### PR TITLE
fix(issue): [Bug]: Background Agent() task becomes untraceable (TaskList/TaskOutput/TaskGet all report not-found) after compaction spawns a new claude process — orphaned old process keeps mutating the shared working tree unsupervised

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -23,7 +23,7 @@ import type { ExtensionUIContext } from "@gsd/pi-coding-agent";
 import { EventStream } from "@gsd/pi-ai";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
@@ -111,6 +111,7 @@ interface ClaudeCodeStreamOptions extends SimpleStreamOptions {
 	extensionUIContext?: ExtensionUIContext;
 	onExternalToolCall?: (toolCall: ToolCall) => Promise<void> | void;
 	onExternalToolResult?: (event: { toolCall: ToolCall; result: ExternalToolResultPayload }) => Promise<void> | void;
+	_findConcurrentClaudeCodeProcessesForTest?: (cwd: string) => ConcurrentClaudeCodeProcess[];
 	_sdkQueryForTest?: (args: {
 		prompt: string | AsyncIterable<unknown>;
 		options?: Record<string, unknown>;
@@ -138,6 +139,99 @@ export function serverToolUseToToolCallLike(block: {
 /** Resolve the workspace root for local Claude Code process execution. */
 export function resolveClaudeCodeCwd(options?: SimpleStreamOptions): string {
 	return options?.cwd && options.cwd.trim().length > 0 ? options.cwd : process.cwd();
+}
+
+export interface ConcurrentClaudeCodeProcess {
+	pid: number;
+	cwd: string;
+	command: string;
+}
+
+const warnedConcurrentClaudeCodeCwds = new Set<string>();
+
+function hasArgValue(argv: string[], flag: string, value: string): boolean {
+	return argv.some((arg, index) =>
+		arg === `${flag}=${value}` || (arg === flag && argv[index + 1] === value)
+	);
+}
+
+function referencesClaudeCodeExecutable(argv: string[]): boolean {
+	return argv.some((arg) => {
+		const normalized = arg.replaceAll("\\", "/");
+		return /(?:^|\/)claude(?:\.cmd|\.exe)?$/i.test(normalized)
+			|| /@anthropic-ai\/claude-agent-sdk\/cli\.js$/i.test(normalized);
+	});
+}
+
+export function isClaudeCodeSdkProcessArgv(argv: string[]): boolean {
+	return referencesClaudeCodeExecutable(argv)
+		&& hasArgValue(argv, "--output-format", "stream-json")
+		&& hasArgValue(argv, "--input-format", "stream-json");
+}
+
+function readProcArgv(procRoot: string, pid: string): string[] {
+	const raw = readFileSync(join(procRoot, pid, "cmdline"), "utf-8");
+	return raw.split("\0").filter(Boolean);
+}
+
+export function findConcurrentClaudeCodeProcesses(
+	cwd: string,
+	options: { procRoot?: string; currentPid?: number } = {},
+): ConcurrentClaudeCodeProcess[] {
+	const procRoot = options.procRoot ?? "/proc";
+	if (procRoot === "/proc" && process.platform !== "linux") return [];
+
+	let targetCwd: string;
+	try {
+		targetCwd = realpathSync(cwd);
+	} catch {
+		return [];
+	}
+
+	const entries = (() => {
+		try {
+			return readdirSync(procRoot, { withFileTypes: true });
+		} catch {
+			return undefined;
+		}
+	})();
+	if (!entries) {
+		return [];
+	}
+
+	const currentPid = options.currentPid ?? process.pid;
+	const matches: ConcurrentClaudeCodeProcess[] = [];
+	for (const entry of entries) {
+		if (!entry.isDirectory() || !/^\d+$/.test(entry.name)) continue;
+		const pid = Number(entry.name);
+		if (pid === currentPid) continue;
+
+		let processCwd: string;
+		let argv: string[];
+		try {
+			processCwd = realpathSync(join(procRoot, entry.name, "cwd"));
+			if (processCwd !== targetCwd) continue;
+			argv = readProcArgv(procRoot, entry.name);
+		} catch {
+			continue;
+		}
+
+		if (!isClaudeCodeSdkProcessArgv(argv)) continue;
+		matches.push({ pid, cwd: processCwd, command: argv.join(" ") });
+	}
+
+	return matches.sort((a, b) => a.pid - b.pid);
+}
+
+export function buildConcurrentClaudeCodeProcessWarning(
+	cwd: string,
+	processes: ConcurrentClaudeCodeProcess[],
+): string {
+	const pids = processes.map((processInfo) => processInfo.pid).join(", ");
+	const pidLabel = processes.length === 1 ? `PID ${pids}` : `PIDs ${pids}`;
+	return `Another Claude Code SDK process is already running in ${cwd} (${pidLabel}). ` +
+		`Its in-memory Agent tasks will not appear in this session's TaskList/TaskGet/TaskOutput; ` +
+		`wait for it to finish or stop it before redoing work in this working tree.`;
 }
 
 /** A single selectable option within an SDK elicitation schema field. */
@@ -716,6 +810,35 @@ export function pushWorkflowMcpReadinessProgressEvent(input: {
 	const delta = block.text.length === 0 ? message : `\n${message}`;
 	block.text += delta;
 	stream.push({ type: "text_delta", contentIndex, delta, partial });
+}
+
+function emitConcurrentClaudeCodeProcessWarning(input: {
+	cwd: string;
+	stream: Pick<AssistantMessageEventStream, "push">;
+	partial: AssistantMessage;
+	uiContext: ExtensionUIContext | undefined;
+	findProcesses: (cwd: string) => ConcurrentClaudeCodeProcess[];
+}): void {
+	let resolvedCwd: string;
+	try {
+		resolvedCwd = realpathSync(input.cwd);
+	} catch {
+		resolvedCwd = input.cwd;
+	}
+	if (warnedConcurrentClaudeCodeCwds.has(resolvedCwd)) return;
+
+	const processes = input.findProcesses(input.cwd);
+	if (processes.length === 0) return;
+
+	warnedConcurrentClaudeCodeCwds.add(resolvedCwd);
+	const message = buildConcurrentClaudeCodeProcessWarning(resolvedCwd, processes);
+	pushWorkflowMcpReadinessProgressEvent({
+		stream: input.stream,
+		partial: input.partial,
+		state: {},
+		message,
+	});
+	input.uiContext?.notify(message, "warning");
 }
 
 export function isClaudeCodeAbortErrorMessage(message: string | undefined | null): boolean {
@@ -2357,6 +2480,18 @@ async function pumpSdkMessages(
 			timestamp: Date.now(),
 		};
 		stream.push({ type: "start", partial: initialPartial });
+		const findConcurrentClaudeCodeProcessesForCwd =
+			claudeOptions?._findConcurrentClaudeCodeProcessesForTest
+			?? (sdkQueryForTest ? undefined : findConcurrentClaudeCodeProcesses);
+		if (findConcurrentClaudeCodeProcessesForCwd) {
+			emitConcurrentClaudeCodeProcessWarning({
+				cwd,
+				stream,
+				partial: initialPartial,
+				uiContext,
+				findProcesses: findConcurrentClaudeCodeProcessesForCwd,
+			});
+		}
 		const readinessProgressState: WorkflowMcpReadinessProgressState = {};
 
 		const trackWorkflowMcpSdk = Boolean(workflowMcpServerName && gsdPhase);

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -2,7 +2,7 @@
 import { describe, mock, test } from "node:test";
 import { clearGuidedUnitContext, setGuidedUnitContext } from "../../gsd/guided-unit-context.ts";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -36,6 +36,9 @@ import {
 	parseClaudeLookupOutput,
 	resolveBundledClaudeCliPath,
 	normalizeClaudePathForSdk,
+	isClaudeCodeSdkProcessArgv,
+	findConcurrentClaudeCodeProcesses,
+	buildConcurrentClaudeCodeProcessWarning,
 	roundResultToElicitationContent,
 	autoInitClaudeCodeWorkflowMcp,
 	inferGsdPhaseFromContext,
@@ -152,6 +155,28 @@ const askUserQuestionsRequest = {
 		},
 	},
 };
+
+function makeSdkSuccessResult(result = "done") {
+	return {
+		type: "result",
+		subtype: "success",
+		uuid: "result-1",
+		session_id: "session-1",
+		duration_ms: 1,
+		duration_api_ms: 1,
+		is_error: false,
+		num_turns: 1,
+		result,
+		stop_reason: "end_turn",
+		total_cost_usd: 0,
+		usage: {
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+		},
+	};
+}
 
 // ---------------------------------------------------------------------------
 // Existing tests — exhausted stream fallback (#2575)
@@ -3626,6 +3651,102 @@ describe("stream-adapter — Windows Claude path lookup (#3770)", () => {
 		const resolved = resolveBundledClaudeCliPath();
 		assert.ok(resolved, "expected sdk cli.js to be resolvable in test workspace");
 		assert.match(resolved!, /[\\/]@anthropic-ai[\\/]claude-agent-sdk[\\/]cli\.js$/);
+	});
+});
+
+describe("stream-adapter — concurrent Claude Code process warning (#1464)", () => {
+	test("identifies Claude Code SDK stream-json command lines", () => {
+		assert.equal(
+			isClaudeCodeSdkProcessArgv(["claude", "--output-format", "stream-json", "--input-format", "stream-json"]),
+			true,
+		);
+		assert.equal(
+			isClaudeCodeSdkProcessArgv(["node", "/repo/node_modules/@anthropic-ai/claude-agent-sdk/cli.js", "--output-format=stream-json", "--input-format=stream-json"]),
+			true,
+		);
+		assert.equal(isClaudeCodeSdkProcessArgv(["claude", "--version"]), false);
+	});
+
+	test("finds only other SDK processes in the same cwd from proc entries", () => {
+		const projectRoot = realpathSync(mkdtempSync(join(tmpdir(), "claude-sdk-concurrent-project-")));
+		const otherRoot = realpathSync(mkdtempSync(join(tmpdir(), "claude-sdk-concurrent-other-")));
+		const procRoot = mkdtempSync(join(tmpdir(), "claude-sdk-proc-"));
+
+		function writeProc(pid: number, cwd: string, argv: string[]): void {
+			const dir = join(procRoot, String(pid));
+			mkdirSync(dir, { recursive: true });
+			symlinkSync(cwd, join(dir, "cwd"), process.platform === "win32" ? "junction" : "dir");
+			writeFileSync(join(dir, "cmdline"), `${argv.join("\0")}\0`, "utf-8");
+		}
+
+		try {
+			writeProc(100, projectRoot, ["claude", "--output-format", "stream-json", "--input-format", "stream-json"]);
+			writeProc(101, projectRoot, ["claude", "--version"]);
+			writeProc(102, otherRoot, ["claude", "--output-format", "stream-json", "--input-format", "stream-json"]);
+			writeProc(200, projectRoot, ["claude", "--output-format", "stream-json", "--input-format", "stream-json"]);
+
+			const matches = findConcurrentClaudeCodeProcesses(projectRoot, { procRoot, currentPid: 200 });
+
+			assert.deepEqual(matches.map((processInfo) => processInfo.pid), [100]);
+			assert.equal(matches[0]?.cwd, projectRoot);
+		} finally {
+			rmSync(projectRoot, { recursive: true, force: true });
+			rmSync(otherRoot, { recursive: true, force: true });
+			rmSync(procRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("emits a visible startup warning before continuing the SDK session", async () => {
+		const cwd = realpathSync(mkdtempSync(join(tmpdir(), "claude-sdk-concurrent-warning-")));
+		const events: any[] = [];
+		const notifications: Array<{ message: string; type?: string }> = [];
+
+		try {
+			const stream = streamViaClaudeCode(
+				{ id: "claude-sonnet-4-6" } as any,
+				{ messages: [{ role: "user", content: "Continue." } as Message] },
+				{
+					cwd,
+					extensionUIContext: {
+						notify(message: string, type?: string) {
+							notifications.push({ message, type });
+						},
+					},
+					_findConcurrentClaudeCodeProcessesForTest: () => [{
+						pid: 1234,
+						cwd,
+						command: "claude --output-format stream-json --input-format stream-json",
+					}],
+					async *_sdkQueryForTest() {
+						yield makeSdkSuccessResult("finished");
+					},
+				} as any,
+			);
+
+			for await (const event of stream) {
+				events.push(event);
+			}
+
+			const warningText = events
+				.filter((event) => event.type === "text_delta")
+				.map((event) => event.delta)
+				.join("\n");
+			assert.match(warningText, /Another Claude Code SDK process is already running/);
+			assert.match(warningText, /PID 1234/);
+			assert.match(warningText, /TaskList\/TaskGet\/TaskOutput/);
+			assert.deepEqual(notifications, [{
+				message: buildConcurrentClaudeCodeProcessWarning(cwd, [{
+					pid: 1234,
+					cwd,
+					command: "claude --output-format stream-json --input-format stream-json",
+				}]),
+				type: "warning",
+			}]);
+			const done = events.find((event) => event.type === "done");
+			assert.deepEqual(done?.message.content, [{ type: "text", text: "finished" }]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary
- Added a same-cwd Claude Code SDK process warning and verified syntax/diff checks; dependency-based tests were blocked by sandboxed registry access.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1464
- [#1464 [Bug]: Background Agent() task becomes untraceable (TaskList/TaskOutput/TaskGet all report not-found) after compaction spawns a new claude process — orphaned old process keeps mutating the shared working tree unsupervised](https://github.com/open-gsd/gsd-pi/issues/1464)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1464-bug-background-agent-task-becomes-untrac-1783974563`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is advisory only (no session blocking); production scanning is Linux-specific and failures degrade to no warning. Test-only hooks isolate `/proc` logic from the SDK path.
> 
> **Overview**
> Adds **startup detection** for another Claude Code SDK process (`stream-json` in/out) already running in the same working directory, aimed at the case where compaction or a new session leaves an orphaned process mutating the tree while **TaskList / TaskGet / TaskOutput** only see the current session’s in-memory Agent tasks.
> 
> On **Linux**, the adapter scans `/proc` (cwd + cmdline), matches SDK-style command lines, and **before the SDK session continues** emits a one-time warning per resolved cwd as stream text and an extension UI `warning` notification. The message names the other PID(s) and tells the user to wait or stop that process before redoing work. Non-Linux hosts skip live discovery; tests can inject matches via `_findConcurrentClaudeCodeProcessesForTest`.
> 
> Regression tests cover argv classification, fake `/proc` layout filtering, and end-to-end warning emission with a mocked SDK query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1ea2103f22e8e0483fc5dbfdcb361e2fc29c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->