### PR TITLE
fix(gsd): run verification recovery in fresh task attempts

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -173,6 +173,7 @@ function renderBlockingReworkFindingsBlock(mid: string, sid: string, tid: string
 export function renderTaskRecoveryDispatchContext(
   recovery: PendingTaskRecoveryContext,
 ): string {
+  const isResume = recovery.action === "resume";
   let executionContract: string;
   switch (recovery.action) {
     case "retry":
@@ -189,6 +190,9 @@ export function renderTaskRecoveryDispatchContext(
         ? "The replacement Task plan is durable. Execute that replacement plan; do not repeat the invalid plan."
         : "The current Task plan is superseded. This planning unit must call `gsd_replan_task`, then stop before implementation.";
       break;
+    case "resume":
+      executionContract = "Apply and verify the explicitly authorized repair evidence before continuing the Task.";
+      break;
   }
   return [
     "## Durable Task Recovery",
@@ -200,7 +204,9 @@ export function renderTaskRecoveryDispatchContext(
     `**Failure:** ${recovery.summary}`,
     `**Rationale:** ${recovery.rationale}`,
     `**Work checkpoint:** ${recovery.checkpoint.checkpointId}`,
-    `**Confirmed context:** ${recovery.checkpoint.confirmedContext}`,
+    isResume
+      ? `**Repair summary:** ${recovery.checkpoint.confirmedContext}`
+      : `**Confirmed context:** ${recovery.checkpoint.confirmedContext}`,
     `**Unresolved:** ${recovery.checkpoint.unresolvedSummary}`,
     `**Suggested next action:** ${recovery.checkpoint.suggestedNextAction}`,
     "",
@@ -209,6 +215,16 @@ export function renderTaskRecoveryDispatchContext(
     "```json",
     JSON.stringify(recovery.evidence, null, 2),
     "```",
+    ...(isResume
+      ? [
+          "",
+          "### Authorized Resume Evidence",
+          "",
+          "```json",
+          recovery.checkpoint.evidenceSummary,
+          "```",
+        ]
+      : []),
     "",
     executionContract,
   ].join("\n");

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -128,7 +128,10 @@ import {
   settleTaskAttempt,
 } from "../task-execution-domain-operation.js";
 import { publishVerifiedTaskCompletion } from "../task-completion-compatibility-adapter.js";
-import { recordFailureAndSelectRecovery } from "../task-recovery-domain-operation.js";
+import {
+  readTaskRecoveryRoute,
+  recordFailureAndSelectRecovery,
+} from "../task-recovery-domain-operation.js";
 import { verifyExpectedArtifact } from "../artifact-verification.js";
 
 /**
@@ -208,6 +211,7 @@ const TASK_EXECUTION_CUTOVER_DEPS = {
   claimTaskAttempt,
   readLatestTaskAttempt,
   readTaskAttempt,
+  readTaskRecoveryRoute,
   routeTaskFailure: recordFailureAndSelectRecovery,
   settleTaskAttempt,
 };
@@ -878,6 +882,11 @@ export async function autoLoop(
           unitId: iterData.unitId,
         });
         if (unitPhaseResult.action === "break") {
+          customDispatchSettled = settleDispatchIfNeeded(customDispatchSettled, () =>
+            settleDispatchFailed(customDispatchId, "unit-break", {
+              markFailed: markDispatchFailed,
+              logWriteFailure: logDispatchLedgerWriteFailure,
+            }));
           finishIncompleteIteration({
             status: "stopped",
             reason: unitPhaseResult.reason ?? "unit-break",
@@ -889,6 +898,11 @@ export async function autoLoop(
           break;
         }
         if (unitPhaseResult.action === "retry") {
+          customDispatchSettled = settleDispatchIfNeeded(customDispatchSettled, () =>
+            settleDispatchFailed(customDispatchId, unitPhaseResult.reason, {
+              markFailed: markDispatchFailed,
+              logWriteFailure: logDispatchLedgerWriteFailure,
+            }));
           finishIncompleteIteration({
             status: "retry",
             reason: unitPhaseResult.reason,

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -887,6 +887,9 @@ export async function autoLoop(
               markFailed: markDispatchFailed,
               logWriteFailure: logDispatchLedgerWriteFailure,
             }));
+          if (customDispatchId !== null && !customDispatchSettled) {
+            throw new Error(`Could not terminalize custom-engine dispatch ${customDispatchId} after unit break`);
+          }
           finishIncompleteIteration({
             status: "stopped",
             reason: unitPhaseResult.reason ?? "unit-break",
@@ -903,6 +906,9 @@ export async function autoLoop(
               markFailed: markDispatchFailed,
               logWriteFailure: logDispatchLedgerWriteFailure,
             }));
+          if (customDispatchId !== null && !customDispatchSettled) {
+            throw new Error(`Could not terminalize custom-engine dispatch ${customDispatchId} before unit retry`);
+          }
           finishIncompleteIteration({
             status: "retry",
             reason: unitPhaseResult.reason,

--- a/src/resources/extensions/gsd/auto/task-execution-cutover.ts
+++ b/src/resources/extensions/gsd/auto/task-execution-cutover.ts
@@ -16,6 +16,7 @@ import {
 import type {
   RouteFailureInput,
   TaskRecoveryReceipt,
+  TaskRecoveryRouteSnapshot,
 } from "../task-recovery-domain-operation.js";
 import { classifyFailure } from "../recovery-classification.js";
 import type { PublishVerifiedTaskCompletionInput } from "../task-completion-compatibility-adapter.js";
@@ -36,6 +37,10 @@ export interface TaskExecutionCutoverInput {
 export interface TaskExecutionCutoverDeps {
   readLatestTaskAttempt(task: ClaimTaskAttemptInput["task"]): TaskExecutionAttemptSnapshot | null;
   readTaskAttempt(attemptId: string): TaskExecutionAttemptSnapshot | null;
+  readTaskRecoveryRoute(attemptId: string): Pick<
+    TaskRecoveryRouteSnapshot,
+    "action" | "recoveryOwner" | "resumeAuthorized"
+  > | null;
   claimTaskAttempt(input: ClaimTaskAttemptInput): ClaimTaskAttemptReceipt;
   settleTaskAttempt(input: SettleTaskAttemptInput): SettleTaskAttemptReceipt;
   routeTaskFailure(input: RouteFailureInput): TaskRecoveryReceipt;
@@ -383,26 +388,33 @@ export async function runWithTaskExecutionAttempt(
     }
     if (predecessor.nextStage === "route") {
       if (predecessor.outcome === "succeeded") {
-        return { action: "next", data: {} };
-      }
-      if (!predecessor.resultId) {
-        throw new Error("Task recovery requires the predecessor Result identity");
-      }
-      const summary = predecessor.resultSummary ?? "Task executor recorded a failed Result";
-      const recovery = routeTaskFailure(
-        input,
-        predecessor.attemptId,
-        predecessor.resultId,
-        summary,
-        predecessor.resultRecovery ?? taskRecoveryClassification(
+        const recovery = deps.readTaskRecoveryRoute(predecessor.attemptId);
+        if (recovery?.recoveryOwner !== "agent") {
+          return { action: "next", data: {} };
+        }
+        if (recovery.action === "abort" && !recovery.resumeAuthorized) {
+          return { action: "break", reason: "task-recovery-abort" };
+        }
+      } else {
+        if (!predecessor.resultId) {
+          throw new Error("Task recovery requires the predecessor Result identity");
+        }
+        const summary = predecessor.resultSummary ?? "Task executor recorded a failed Result";
+        const recovery = routeTaskFailure(
           input,
-          predecessor.resultFailureClass ?? "executor-result-failed",
-          new Error(summary),
-        ),
-        deps,
-      );
-      const decision = applyRecoveryDecision(recovery);
-      if (decision.action === "break" || recovery.status === "committed") return decision;
+          predecessor.attemptId,
+          predecessor.resultId,
+          summary,
+          predecessor.resultRecovery ?? taskRecoveryClassification(
+            input,
+            predecessor.resultFailureClass ?? "executor-result-failed",
+            new Error(summary),
+          ),
+          deps,
+        );
+        const decision = applyRecoveryDecision(recovery);
+        if (decision.action === "break" || recovery.status === "committed") return decision;
+      }
     }
     retryOfAttemptId = predecessor.attemptId;
   }

--- a/src/resources/extensions/gsd/auto/workflow-dispatch-ledger.ts
+++ b/src/resources/extensions/gsd/auto/workflow-dispatch-ledger.ts
@@ -6,7 +6,7 @@ interface DispatchLedgerWriteDeps {
 }
 
 interface DispatchLedgerFailDeps extends DispatchLedgerWriteDeps {
-  markFailed: (dispatchId: number, details: { errorSummary: string }) => void;
+  markFailed: (dispatchId: number, details: { errorSummary: string }) => boolean;
 }
 
 interface DispatchLedgerCompleteDeps extends DispatchLedgerWriteDeps {
@@ -28,8 +28,7 @@ export function settleDispatchFailed(
   if (dispatchId === null) return false;
 
   try {
-    deps.markFailed(dispatchId, { errorSummary });
-    return true;
+    return deps.markFailed(dispatchId, { errorSummary });
   } catch (err) {
     deps.logWriteFailure(err);
     return false;

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -328,8 +328,8 @@ export interface FailureOpts {
 }
 
 /** Transition a dispatch into `failed`, optionally scheduling a retry. */
-export function markFailed(dispatchId: number, opts: FailureOpts): void {
-  if (!isDbAvailable()) return;
+export function markFailed(dispatchId: number, opts: FailureOpts): boolean {
+  if (!isDbAvailable()) return false;
   const now = new Date();
   const nowIso = now.toISOString();
   const nextRunIso = opts.retryAfterMs
@@ -362,7 +362,7 @@ export function markFailed(dispatchId: number, opts: FailureOpts): void {
         ? (result as { changes: number }).changes
         : 0;
   });
-  if (changes < 1) return;
+  if (changes < 1) return false;
   insertAuditEvent({
     eventId: randomUUID(),
     traceId: dispatchId.toString(),
@@ -371,6 +371,7 @@ export function markFailed(dispatchId: number, opts: FailureOpts): void {
     ts: nowIso,
     payload: { dispatchId, errorSummary: opts.errorSummary, retryAfterMs: opts.retryAfterMs ?? null },
   });
+  return true;
 }
 
 /** Transition a dispatch into `stuck`. */

--- a/src/resources/extensions/gsd/task-recovery-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-recovery-domain-operation.ts
@@ -113,7 +113,7 @@ export interface TaskRecoveryResumeReceipt {
 }
 
 export interface PendingTaskRecoveryContext {
-  action: Extract<RecoveryDecision["action"], "retry" | "repair" | "remediate" | "replan">;
+  action: Extract<RecoveryDecision["action"], "retry" | "repair" | "remediate" | "replan"> | "resume";
   recoveryActionId: string;
   attemptId: string;
   resultId: string;
@@ -337,7 +337,7 @@ export function readPendingTaskRecoveryContext(
       AND lifecycle.milestone_id = :milestone_id
       AND lifecycle.slice_id = :slice_id
       AND lifecycle.task_id = :task_id
-      AND action.action IN ('retry', 'repair', 'remediate', 'replan')
+      AND action.action IN ('retry', 'repair', 'remediate', 'replan', 'abort')
       AND attempt.attempt_number = (
         SELECT MAX(latest.attempt_number)
         FROM workflow_execution_attempts latest
@@ -350,10 +350,40 @@ export function readPendingTaskRecoveryContext(
     ":task_id": task.taskId,
   }) as Record<string, unknown> | undefined;
   if (!stored) return null;
+  const attemptId = String(stored["attempt_id"]);
+  const storedAction = String(stored["action"]);
+  let checkpoint = stored;
+  if (storedAction === "abort") {
+    if (!isTaskRecoveryResumeAuthorized(attemptId)) return null;
+    const resumed = getDb().prepare(`
+      SELECT checkpoint.checkpoint_id, checkpoint.confirmed_context,
+             checkpoint.unresolved_summary, checkpoint.evidence_summary,
+             checkpoint.suggested_next_action
+      FROM workflow_domain_events event
+      JOIN workflow_work_checkpoints checkpoint
+        ON checkpoint.project_id = event.project_id
+       AND checkpoint.operation_id = event.operation_id
+       AND checkpoint.checkpoint_id = json_extract(event.payload_json, '$.workCheckpointId')
+      WHERE event.event_type = 'task.recovery.resumed'
+        AND json_extract(event.payload_json, '$.recoveryActionId') = :recovery_action_id
+        AND json_extract(event.payload_json, '$.attemptId') = :attempt_id
+        AND json_extract(event.payload_json, '$.resultId') = :result_id
+      ORDER BY event.project_revision DESC
+      LIMIT 1
+    `).get({
+      ":recovery_action_id": String(stored["recovery_action_id"]),
+      ":attempt_id": attemptId,
+      ":result_id": String(stored["result_id"]),
+    }) as Record<string, unknown> | undefined;
+    if (!resumed) throw new Error("Authorized Task recovery resume is missing its Work Checkpoint");
+    checkpoint = resumed;
+  }
   return {
-    action: String(stored["action"]) as PendingTaskRecoveryContext["action"],
+    action: storedAction === "abort"
+      ? "resume"
+      : storedAction as PendingTaskRecoveryContext["action"],
     recoveryActionId: String(stored["recovery_action_id"]),
-    attemptId: String(stored["attempt_id"]),
+    attemptId,
     resultId: String(stored["result_id"]),
     failureKind: String(stored["failure_kind"]),
     summary: String(stored["summary"]),
@@ -361,11 +391,11 @@ export function readPendingTaskRecoveryContext(
     rationale: String(stored["rationale"]),
     replanCompleted: Number(stored["replan_completed"]) === 1,
     checkpoint: {
-      checkpointId: String(stored["checkpoint_id"]),
-      confirmedContext: String(stored["confirmed_context"]),
-      unresolvedSummary: String(stored["unresolved_summary"]),
-      evidenceSummary: String(stored["evidence_summary"]),
-      suggestedNextAction: String(stored["suggested_next_action"]),
+      checkpointId: String(checkpoint["checkpoint_id"]),
+      confirmedContext: String(checkpoint["confirmed_context"]),
+      unresolvedSummary: String(checkpoint["unresolved_summary"]),
+      evidenceSummary: String(checkpoint["evidence_summary"]),
+      suggestedNextAction: String(checkpoint["suggested_next_action"]),
     },
   };
 }

--- a/src/resources/extensions/gsd/task-recovery-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-recovery-domain-operation.ts
@@ -182,6 +182,7 @@ export interface TaskRecoveryRouteSnapshot {
   recoveryOwner: "agent" | "user" | "external";
   failureKind: string;
   blocker: TaskRecoveryBlockerSnapshot | null;
+  resumeAuthorized: boolean;
 }
 
 function taskRecoveryBlockerSnapshot(
@@ -679,6 +680,7 @@ export function readTaskRecoveryRoute(attemptId: string): TaskRecoveryRouteSnaps
     recoveryOwner: String(stored["recovery_owner"]) as TaskRecoveryRouteSnapshot["recoveryOwner"],
     failureKind: String(stored["failure_kind"]),
     blocker,
+    resumeAuthorized: stored["action"] === "abort" && isTaskRecoveryResumeAuthorized(attemptId),
   };
 }
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2223,6 +2223,73 @@ test("custom-engine Task verification bypasses legacy retry counters and aborts 
   }
 });
 
+test("custom-engine recovery break and retry terminalize their dispatch", async (t) => {
+  t.mock.method(CustomWorkflowEngine.prototype, "deriveState", async () => ({
+    phase: "executing",
+    isComplete: false,
+    readySteps: [],
+    blockedSteps: [],
+    completedSteps: [],
+  }) as any);
+  t.mock.method(CustomWorkflowEngine.prototype, "resolveDispatch", async () => ({
+    action: "dispatch",
+    step: {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "execute the Task",
+    },
+  }) as any);
+
+  for (const action of ["break", "retry"] as const) {
+    _resetPendingResolve();
+    const basePath = realpathSync(makeLoopTestBase(`gsd-custom-task-recovery-${action}-`));
+    mkdirSync(join(basePath, ".gsd"), { recursive: true });
+    try {
+      openDatabase(join(basePath, ".gsd", "gsd.db"));
+      insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", status: "active" });
+      insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task One", status: "pending" });
+      const workerId = registerAutoWorker({ projectRootRealpath: basePath });
+      const lease = claimMilestoneLease(workerId, "M001");
+      assert.equal(lease.ok, true);
+      if (!lease.ok) return;
+
+      const ctx = makeMockCtx();
+      ctx.ui.setStatus = () => {};
+      ctx.ui.setWidget = () => {};
+      const pi = makeMockPi();
+      const s = makeLoopSession({
+        activeEngineId: "custom",
+        activeRunDir: basePath,
+        basePath,
+        originalBasePath: basePath,
+        canonicalProjectRoot: basePath,
+        workerId,
+        milestoneLeaseToken: lease.token,
+      });
+      const deps = makeMockDeps({
+        isDbAvailable: () => true,
+        taskExecutionBoundary: async () => {
+          if (action === "retry") s.active = false;
+          return { action, reason: "task-recovery-abort" };
+        },
+      });
+
+      await rawAutoLoop(ctx, pi, s, deps);
+
+      assert.equal(
+        getLatestForUnit("M001/S01/T01")?.status,
+        "failed",
+        `${action} must not leave an active dispatch that blocks a later resume`,
+      );
+      assert.equal(pi.calls.length, 0, `${action} must exit before invoking the agent`);
+    } finally {
+      closeDatabase();
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  }
+});
+
 test("autoLoop publishes a canonical Task only after host verification without legacy dispatch re-settlement", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2290,6 +2290,71 @@ test("custom-engine recovery break and retry terminalize their dispatch", async 
   }
 });
 
+test("custom-engine recovery fails loudly when dispatch terminalization cannot be confirmed", async (t) => {
+  t.mock.method(CustomWorkflowEngine.prototype, "deriveState", async () => ({
+    phase: "executing",
+    isComplete: false,
+    readySteps: [],
+    blockedSteps: [],
+    completedSteps: [],
+  }) as any);
+  t.mock.method(CustomWorkflowEngine.prototype, "resolveDispatch", async () => ({
+    action: "dispatch",
+    step: {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "execute the Task",
+    },
+  }) as any);
+
+  _resetPendingResolve();
+  const basePath = realpathSync(makeLoopTestBase("gsd-custom-task-terminalization-failure-"));
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+  try {
+    openDatabase(join(basePath, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", status: "active" });
+    insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task One", status: "pending" });
+    const workerId = registerAutoWorker({ projectRootRealpath: basePath });
+    const lease = claimMilestoneLease(workerId, "M001");
+    assert.equal(lease.ok, true);
+    if (!lease.ok) return;
+
+    const notifications: string[] = [];
+    const ctx = makeMockCtx();
+    ctx.ui.notify = (message: string) => notifications.push(message);
+    ctx.ui.setStatus = () => {};
+    ctx.ui.setWidget = () => {};
+    const s = makeLoopSession({
+      activeEngineId: "custom",
+      activeRunDir: basePath,
+      basePath,
+      originalBasePath: basePath,
+      canonicalProjectRoot: basePath,
+      workerId,
+      milestoneLeaseToken: lease.token,
+    });
+    const deps = makeMockDeps({
+      isDbAvailable: () => true,
+      taskExecutionBoundary: async () => {
+        s.active = false;
+        closeDatabase();
+        return { action: "break", reason: "task-recovery-abort" };
+      },
+    });
+
+    await rawAutoLoop(ctx, makeMockPi(), s, deps);
+
+    assert.match(
+      notifications.join("\n"),
+      /could not terminalize custom-engine dispatch/i,
+    );
+  } finally {
+    closeDatabase();
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
 test("autoLoop publishes a canonical Task only after host verification without legacy dispatch re-settlement", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
@@ -2,7 +2,8 @@
 // File Purpose: Executable contract for fail-closed canonical Task execution in auto-mode.
 
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
@@ -26,7 +27,13 @@ import {
   readTaskAttempt,
   settleTaskAttempt,
 } from "../task-execution-domain-operation.js";
-import { recordFailureAndSelectRecovery } from "../task-recovery-domain-operation.js";
+import {
+  readTaskRecoveryRoute,
+  recordFailureAndSelectRecovery,
+} from "../task-recovery-domain-operation.js";
+import { recordTaskTechnicalVerdict } from "../task-verification-domain-operation.js";
+import { publishVerifiedTaskCompletion } from "../task-completion-compatibility-adapter.js";
+import { captureVerificationSourceSnapshot } from "../verification-source-integrity.js";
 
 type UnitPhaseResult =
   | { action: "break"; reason: string }
@@ -48,7 +55,7 @@ interface AttemptSnapshot {
   retryOfAttemptId?: string;
   state: "running" | "settled";
   outcome?: "succeeded" | "failed" | "interrupted";
-  nextStage: "execute" | "verify" | "route" | "settled";
+  nextStage: "execute" | "verify" | "route" | "closeout" | "settled";
   coordinationDispatchId: number;
   workerId: string;
   milestoneLeaseToken: number;
@@ -68,6 +75,11 @@ interface CutoverInput {
 interface CutoverDeps {
   readLatestTaskAttempt(task: TaskIdentity): AttemptSnapshot | null;
   readTaskAttempt(attemptId: string): AttemptSnapshot | null;
+  readTaskRecoveryRoute(attemptId: string): {
+    recoveryOwner: "agent" | "user" | "external";
+    action: "retry" | "repair" | "remediate" | "replan" | "abort" | "clarify" | "pause";
+    resumeAuthorized?: boolean;
+  } | null;
   claimTaskAttempt(input: {
     invocation: {
       idempotencyKey: string;
@@ -228,6 +240,10 @@ function fakeDomain() {
       calls.push({ name: "read-attempt", value: attemptId });
       return attempts.find((attempt) => attempt.attemptId === attemptId) ?? null;
     },
+    readTaskRecoveryRoute(attemptId) {
+      calls.push({ name: "read-recovery", value: attemptId });
+      return { recoveryOwner: "agent", action: "retry" };
+    },
     claimTaskAttempt(claim) {
       calls.push({ name: "claim", value: claim });
       claims.push(claim);
@@ -299,7 +315,7 @@ function database() {
   return adapter;
 }
 
-function seedCanonicalTask(): number {
+function seedCanonicalTaskFixture(): { basePath: string; dispatchId: number } {
   const dir = mkdtempSync(join(tmpdir(), "gsd-task-phase-recovery-"));
   tempDirs.add(dir);
   assert.equal(openDatabase(join(dir, "gsd.db")), true);
@@ -308,8 +324,11 @@ function seedCanonicalTask(): number {
     VALUES ('M001', 'Task recovery', 'active', '2026-07-12T00:00:00.000Z');
     INSERT INTO slices (milestone_id, id, title, status, created_at)
     VALUES ('M001', 'S01', 'Recovery', 'active', '2026-07-12T00:00:00.000Z');
-    INSERT INTO tasks (milestone_id, slice_id, id, title, status)
-    VALUES ('M001', 'S01', 'T01', 'Classify failure', 'pending');
+    INSERT INTO tasks (milestone_id, slice_id, id, title, status, full_summary_md)
+    VALUES (
+      'M001', 'S01', 'T01', 'Classify failure', 'pending',
+      '# T01: Classify failure\n\nThe verification failure was remediated.\n'
+    );
     INSERT INTO workers (
       worker_id, host, pid, started_at, version, last_heartbeat_at, status,
       project_root_realpath
@@ -356,7 +375,11 @@ function seedCanonicalTask(): number {
       }],
     };
   });
-  return insertClaimedDispatch(1);
+  return { basePath: dir, dispatchId: insertClaimedDispatch(1) };
+}
+
+function seedCanonicalTask(): number {
+  return seedCanonicalTaskFixture().dispatchId;
 }
 
 function insertClaimedDispatch(attemptNumber: number): number {
@@ -383,6 +406,7 @@ function canonicalDeps(): CutoverDeps {
   return {
     readLatestTaskAttempt,
     readTaskAttempt,
+    readTaskRecoveryRoute,
     claimTaskAttempt,
     settleTaskAttempt,
     routeTaskFailure(route) {
@@ -392,6 +416,229 @@ function canonicalDeps(): CutoverDeps {
     },
   } as CutoverDeps;
 }
+
+test("agent remediation of a failed Technical Verdict runs in a lineage-linked Attempt", async () => {
+  const { publishVerifiedTaskExecution, runWithTaskExecutionAttempt } = await subject();
+  const { basePath, dispatchId: firstDispatchId } = seedCanonicalTaskFixture();
+  const task = { milestoneId: "M001", sliceId: "S01", taskId: "T01" };
+  execFileSync("git", ["init", "-q"], { cwd: basePath });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: basePath });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd: basePath });
+  writeFileSync(join(basePath, ".gitignore"), "gsd.db*\n.gsd/\n");
+  writeFileSync(join(basePath, "tracked.txt"), "verified\n");
+  execFileSync("git", ["add", ".gitignore", "tracked.txt"], { cwd: basePath });
+  execFileSync("git", ["commit", "-qm", "fixture"], { cwd: basePath });
+  const phaseDir = join(basePath, ".gsd", "phases", "01-test");
+  mkdirSync(phaseDir, { recursive: true });
+  writeFileSync(join(phaseDir, "01-01-PLAN.md"), [
+    "# S01: Recovery",
+    "",
+    "## Tasks",
+    "",
+    "- [ ] **T01: Classify failure** `est:30m`",
+    "  - Do: Remediate failed host verification",
+    "  - Verify: pnpm test",
+    "",
+  ].join("\n"));
+
+  await runWithTaskExecutionAttempt(input({ dispatchId: firstDispatchId }), async () => {
+    const attempt = readLatestTaskAttempt(task);
+    assert.ok(attempt);
+    assert.equal(attempt.state, "running");
+    settleTaskAttempt({
+      invocation: {
+        idempotencyKey: "test:verification-remediation:settle:first",
+        sourceTransport: "internal",
+        actorType: "agent",
+      },
+      attemptId: attempt.attemptId,
+      outcome: "succeeded",
+      failureClass: "none",
+      summary: "Candidate implementation is ready for host verification.",
+      output: { changedFiles: ["src/task.ts"] },
+    });
+    return { action: "next", data: {} };
+  }, canonicalDeps());
+
+  const firstAttempt = readLatestTaskAttempt(task);
+  assert.ok(firstAttempt);
+  assert.equal(firstAttempt.state, "settled");
+  assert.equal(firstAttempt.outcome, "succeeded");
+  assert.ok(firstAttempt.resultId);
+  const firstResultId = firstAttempt.resultId;
+  const failedVerdict = recordTaskTechnicalVerdict({
+    invocation: {
+      idempotencyKey: "test:verification-remediation:verdict:fail",
+      sourceTransport: "internal",
+      actorType: "agent",
+    },
+    attemptId: firstAttempt.attemptId,
+    testedSourceRevision: "sha256:failed-source",
+    verdict: "fail",
+    rationale: "The host test failed.",
+    evidence: {
+      evidenceClass: "command",
+      commandOrTool: "pnpm test",
+      workingDirectory: "/tmp/project",
+      startedAt: "2026-07-12T00:02:00.000Z",
+      endedAt: "2026-07-12T00:02:01.000Z",
+      exitCode: 1,
+      observation: "failed",
+      durableOutputRef: "db://host-verification/attempt-1",
+      environment: { runner: "node-test", platform: "test" },
+    },
+  });
+  recordFailureAndSelectRecovery({
+    invocation: {
+      idempotencyKey: "test:verification-remediation:route",
+      sourceTransport: "internal",
+      actorType: "agent",
+    },
+    attemptId: firstAttempt.attemptId,
+    resultId: firstAttempt.resultId,
+    owner: "agent",
+    classification: { failureKind: "verification-failed" },
+    summary: "Host verification failed after successful execution.",
+    evidence: {
+      verdictId: failedVerdict.verdictId,
+      evidenceId: failedVerdict.evidenceId,
+      verdict: "fail",
+    },
+    rationale: "Remediate the failed verification evidence in a new Attempt.",
+  });
+  const immutableHistory = database().prepare(`
+    SELECT result.result_id, result.output_json,
+           verdict.verdict_id, verdict.tested_source_revision,
+           evidence.evidence_id, evidence.durable_output_ref
+    FROM workflow_attempt_results result
+    JOIN workflow_technical_verdicts verdict ON verdict.attempt_id = result.attempt_id
+    JOIN workflow_verification_evidence evidence ON evidence.verdict_id = verdict.verdict_id
+    WHERE result.attempt_id = ?
+  `).get(firstAttempt.attemptId) as Record<string, unknown> | undefined;
+  assert.ok(immutableHistory);
+  assert.deepEqual({
+    resultId: immutableHistory.result_id,
+    verdictId: immutableHistory.verdict_id,
+    evidenceId: immutableHistory.evidence_id,
+  }, {
+    resultId: firstResultId,
+    verdictId: failedVerdict.verdictId,
+    evidenceId: failedVerdict.evidenceId,
+  });
+
+  const secondDispatchId = insertClaimedDispatch(2);
+  let repairRuns = 0;
+  await runWithTaskExecutionAttempt(input({ dispatchId: secondDispatchId }), async () => {
+    repairRuns += 1;
+    const attempt = readLatestTaskAttempt(task);
+    assert.ok(attempt);
+    assert.equal(attempt.state, "running");
+    settleTaskAttempt({
+      invocation: {
+        idempotencyKey: "test:verification-remediation:settle:second",
+        sourceTransport: "internal",
+        actorType: "agent",
+      },
+      attemptId: attempt.attemptId,
+      outcome: "succeeded",
+      failureClass: "none",
+      summary: "The verification failure was remediated.",
+      output: { changedFiles: ["src/task.ts"] },
+    });
+    return { action: "next", data: {} };
+  }, canonicalDeps());
+
+  assert.equal(repairRuns, 1);
+  const secondAttempt = readLatestTaskAttempt(task);
+  assert.ok(secondAttempt);
+  assert.notEqual(secondAttempt.attemptId, firstAttempt.attemptId);
+  const source = captureVerificationSourceSnapshot([{ id: "project", cwd: basePath }]);
+  assert.equal(source.ok, true, source.ok ? undefined : source.error);
+  recordTaskTechnicalVerdict({
+    invocation: {
+      idempotencyKey: "test:verification-remediation:verdict:pass",
+      sourceTransport: "internal",
+      actorType: "agent",
+    },
+    attemptId: secondAttempt.attemptId,
+    testedSourceRevision: source.snapshot.aggregateRevision,
+    verdict: "pass",
+    rationale: "The remediated Result passed host verification.",
+    evidence: {
+      evidenceClass: "command",
+      commandOrTool: "pnpm test",
+      workingDirectory: basePath,
+      startedAt: "2026-07-12T00:04:00.000Z",
+      endedAt: "2026-07-12T00:04:01.000Z",
+      exitCode: 0,
+      observation: "passed",
+      durableOutputRef: "db://host-verification/attempt-2",
+      environment: { runner: "node-test", platform: "test" },
+    },
+  });
+  await publishVerifiedTaskExecution({
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    workerId: "worker-1",
+    traceId: "trace-publication",
+    turnId: "turn-publication",
+    basePath,
+  }, {
+    readLatestTaskAttempt,
+    publishVerifiedTaskCompletion,
+  });
+
+  assert.deepEqual(database().prepare(`
+    SELECT attempt_number, retry_of_attempt_id, attempt_state
+    FROM workflow_execution_attempts
+    ORDER BY attempt_number
+  `).all(), [
+    { attempt_number: 1, retry_of_attempt_id: null, attempt_state: "settled" },
+    {
+      attempt_number: 2,
+      retry_of_attempt_id: firstAttempt.attemptId,
+      attempt_state: "settled",
+    },
+  ]);
+  const observationCount = database().prepare(`
+    SELECT COUNT(*) AS count FROM workflow_failure_observations
+  `).get() as { count: number };
+  assert.equal(observationCount.count, 1);
+  assert.deepEqual(database().prepare(`
+    SELECT attempt_id, verdict FROM workflow_technical_verdicts ORDER BY project_revision
+  `).all(), [
+    { attempt_id: firstAttempt.attemptId, verdict: "fail" },
+    { attempt_id: secondAttempt.attemptId, verdict: "pass" },
+  ]);
+  assert.deepEqual(database().prepare(`
+    SELECT result.result_id, result.output_json,
+           verdict.verdict_id, verdict.tested_source_revision,
+           evidence.evidence_id, evidence.durable_output_ref
+    FROM workflow_attempt_results result
+    JOIN workflow_technical_verdicts verdict ON verdict.attempt_id = result.attempt_id
+    JOIN workflow_verification_evidence evidence ON evidence.verdict_id = verdict.verdict_id
+    WHERE result.attempt_id = ?
+  `).get(firstAttempt.attemptId), immutableHistory);
+  assert.deepEqual(database().prepare(`
+    SELECT lifecycle.lifecycle_status, task.status, checkpoint.next_stage
+    FROM workflow_item_lifecycles lifecycle
+    JOIN tasks task
+      ON task.milestone_id = lifecycle.milestone_id
+     AND task.slice_id = lifecycle.slice_id
+     AND task.id = lifecycle.task_id
+    JOIN workflow_kernel_checkpoints checkpoint
+      ON checkpoint.lifecycle_id = lifecycle.lifecycle_id
+     AND checkpoint.attempt_id = ?
+    WHERE lifecycle.milestone_id = 'M001'
+      AND lifecycle.slice_id = 'S01'
+      AND lifecycle.task_id = 'T01'
+    ORDER BY checkpoint.sequence DESC LIMIT 1
+  `).get(secondAttempt.attemptId), {
+    lifecycle_status: "completed",
+    status: "complete",
+    next_stage: "settled",
+  });
+});
 
 test("non-task units pass through without reading or mutating Task execution authority", async () => {
   const { runWithTaskExecutionAttempt } = await subject();
@@ -834,6 +1081,106 @@ test("a succeeded predecessor awaiting verification resumes verification without
   assert.equal(ran, false);
   assert.equal(domain.claims.length, 0);
 });
+
+test("an unresumed verification abort stops before a replacement claim", async () => {
+  const { runWithTaskExecutionAttempt } = await subject();
+  const domain = fakeDomain();
+  domain.attempts.push({
+    attemptId: "attempt-1",
+    resultId: "result-1",
+    attemptNumber: 1,
+    state: "settled",
+    outcome: "succeeded",
+    nextStage: "route",
+    coordinationDispatchId: 40,
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+  });
+  let ran = false;
+
+  const result = await runWithTaskExecutionAttempt(input(), async () => {
+    ran = true;
+    return { action: "next", data: {} };
+  }, {
+    ...domain.deps,
+    readTaskRecoveryRoute() {
+      return { recoveryOwner: "agent", action: "abort" };
+    },
+  });
+
+  assert.deepEqual(result, { action: "break", reason: "task-recovery-abort" });
+  assert.equal(ran, false);
+  assert.equal(domain.claims.length, 0);
+});
+
+test("an explicitly resumed verification abort claims one lineage-linked Attempt", async () => {
+  const { runWithTaskExecutionAttempt } = await subject();
+  const domain = fakeDomain();
+  domain.attempts.push({
+    attemptId: "attempt-1",
+    resultId: "result-1",
+    attemptNumber: 1,
+    state: "settled",
+    outcome: "succeeded",
+    nextStage: "route",
+    coordinationDispatchId: 40,
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+  });
+  let runs = 0;
+
+  const result = await runWithTaskExecutionAttempt(input({ dispatchId: 42 }), async () => {
+    runs += 1;
+    domain.completeSucceeded("attempt-2");
+    return { action: "next", data: {} };
+  }, {
+    ...domain.deps,
+    readTaskRecoveryRoute() {
+      return { recoveryOwner: "agent", action: "abort", resumeAuthorized: true };
+    },
+  });
+
+  assert.equal(result.action, "next");
+  assert.equal(runs, 1);
+  assert.equal(domain.claims.length, 1);
+  assert.equal(domain.claims[0].retryOfAttemptId, "attempt-1");
+});
+
+for (const [label, recovery] of [
+  ["a user-owned verification route", { recoveryOwner: "user" as const, action: "clarify" as const }],
+  ["a missing verification route", null],
+] as const) {
+  test(`${label} resumes verification without executing again`, async () => {
+    const { runWithTaskExecutionAttempt } = await subject();
+    const domain = fakeDomain();
+    domain.attempts.push({
+      attemptId: "attempt-1",
+      resultId: "result-1",
+      attemptNumber: 1,
+      state: "settled",
+      outcome: "succeeded",
+      nextStage: "route",
+      coordinationDispatchId: 40,
+      workerId: "worker-1",
+      milestoneLeaseToken: 7,
+    });
+    let ran = false;
+
+    const result = await runWithTaskExecutionAttempt(input(), async () => {
+      ran = true;
+      return { action: "next", data: {} };
+    }, {
+      ...domain.deps,
+      readTaskRecoveryRoute() {
+        return recovery;
+      },
+    });
+
+    assert.deepEqual(result, { action: "next", data: {} });
+    assert.equal(ran, false);
+    assert.equal(domain.claims.length, 0);
+  });
+}
 
 test("a retry claim links the immediately preceding settled Attempt", async () => {
   const { runWithTaskExecutionAttempt } = await subject();

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -22,6 +22,7 @@ import {
   cancelTask,
   grantTaskWaiver,
   readPendingTaskRecoveryContext,
+  readTaskRecoveryRoute,
   recordFailureAndSelectRecovery,
   recordTaskRequirementDisposition,
   reopenTask,
@@ -686,6 +687,7 @@ test("durable budget use survives retries and exhausts to agent abort", () => {
   assert.equal(second.action, "retry");
   assert.equal(second.recoveryBudgetId, first.recoveryBudgetId);
   assert.equal(third.action, "abort");
+  assert.equal(readTaskRecoveryRoute(thirdFailure.attemptId)?.resumeAuthorized, false);
   assert.equal(third.recoveryBudgetId, undefined);
   assert.equal(count("workflow_recovery_budgets"), 1);
   assert.equal(count("workflow_recovery_actions"), 3);
@@ -729,6 +731,7 @@ test("durable budget use survives retries and exhausts to agent abort", () => {
   assert.equal(replayed.status, "replayed");
   assert.equal(replayed.operationId, resumed.operationId);
   assert.equal(resumed.recoveryActionId, third.recoveryActionId);
+  assert.equal(readTaskRecoveryRoute(thirdFailure.attemptId)?.resumeAuthorized, true);
   assert.equal(
     route("recovery/budget/3", thirdFailure, summaries[2]).resumeAuthorized,
     true,

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -33,7 +33,7 @@ import {
 import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.ts";
 import { recordTaskTechnicalVerdict } from "../task-verification-domain-operation.ts";
 import type { ExecutionInvocation } from "../execution-invocation.ts";
-import { buildTaskRecoveryReplanPrompt } from "../auto-prompts.ts";
+import { buildExecuteTaskPrompt, buildTaskRecoveryReplanPrompt } from "../auto-prompts.ts";
 import { buildCustomEngineIterationData } from "../auto/workflow-custom-engine-iteration.ts";
 import { handleReplanTask } from "../tools/replan-task.ts";
 import { resolveDispatch } from "../auto-dispatch.ts";
@@ -653,7 +653,7 @@ afterEach(() => {
   tempDirs.clear();
 });
 
-test("durable budget use survives retries and exhausts to agent abort", () => {
+test("durable budget use survives retries and exhausts to agent abort", async () => {
   const firstFailure = seedFailedAttempt();
   const summaries = [
     "Request 481 failed at /private/tmp/run-1: provider reported tool surface unavailable",
@@ -688,6 +688,11 @@ test("durable budget use survives retries and exhausts to agent abort", () => {
   assert.equal(second.recoveryBudgetId, first.recoveryBudgetId);
   assert.equal(third.action, "abort");
   assert.equal(readTaskRecoveryRoute(thirdFailure.attemptId)?.resumeAuthorized, false);
+  assert.equal(readPendingTaskRecoveryContext({
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T01",
+  }), null, "an unresumed abort must not become executable prompt context");
   assert.equal(third.recoveryBudgetId, undefined);
   assert.equal(count("workflow_recovery_budgets"), 1);
   assert.equal(count("workflow_recovery_actions"), 3);
@@ -736,6 +741,73 @@ test("durable budget use survives retries and exhausts to agent abort", () => {
     route("recovery/budget/3", thirdFailure, summaries[2]).resumeAuthorized,
     true,
   );
+  assert.deepEqual(readPendingTaskRecoveryContext({
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T01",
+  }), {
+    action: "resume",
+    recoveryActionId: third.recoveryActionId,
+    attemptId: thirdFailure.attemptId,
+    resultId: thirdFailure.resultId,
+    failureKind: "tool-unavailable",
+    summary: summaries[2],
+    evidence: { diagnostic: summaries[2], source: "executor" },
+    rationale: "apply the durable recovery policy",
+    replanCompleted: false,
+    checkpoint: {
+      checkpointId: resumed.workCheckpointId,
+      confirmedContext: "The missing tool surface was restored in the executor runtime.",
+      unresolvedSummary: "",
+      evidenceSummary: '{"fix":"open-gsd/gsd-pi#1457","verification":"focused recovery tests passed"}',
+      suggestedNextAction: "Claim one new Task Attempt using the recorded repair evidence.",
+    },
+  });
+
+  const milestoneDir = join(firstFailure.basePath, ".gsd", "milestones", "M001");
+  const sliceDir = join(milestoneDir, "slices", "S01");
+  const taskDir = join(sliceDir, "tasks");
+  mkdirSync(taskDir, { recursive: true });
+  writeFileSync(join(milestoneDir, "M001-CONTEXT.md"), "# Recovery context\n");
+  writeFileSync(join(milestoneDir, "M001-RESEARCH.md"), "# Recovery research\n");
+  writeFileSync(join(milestoneDir, "M001-ROADMAP.md"), "# Recovery\n\n- [ ] **S01: Recovery operation**\n");
+  writeFileSync(join(sliceDir, "S01-CONTEXT.md"), "# Slice context\n");
+  writeFileSync(join(sliceDir, "S01-RESEARCH.md"), "# Slice research\n");
+  writeFileSync(join(sliceDir, "S01-PLAN.md"), "# S01\n\n- [ ] **T01: Recover atomically**\n");
+  writeFileSync(join(taskDir, "T01-PLAN.md"), "# T01: Recover atomically\n");
+  const builtInPrompt = await buildExecuteTaskPrompt(
+    "M001", "S01", "Recovery operation", "T01", "Recover atomically", firstFailure.basePath,
+  );
+  const customPrompt = (await buildCustomEngineIterationData({
+    step: {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "Repeat the stale engine plan.",
+    },
+    basePath: firstFailure.basePath,
+    canonicalProjectRoot: firstFailure.basePath,
+    currentMilestoneId: "M001",
+    deriveState: async () => ({
+      activeMilestone: { id: "M001", title: "Recovery" },
+      activeSlice: { id: "S01", title: "Recovery operation" },
+      activeTask: { id: "T01", title: "Recover atomically" },
+      phase: "executing",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      registry: [],
+    }),
+    logPostDerive: () => {},
+  })).prompt;
+  for (const prompt of [builtInPrompt, customPrompt]) {
+    assert.match(prompt, /Required action:\*\* resume/);
+    assert.match(prompt, new RegExp(summaries[2]));
+    assert.match(prompt, /The missing tool surface was restored in the executor runtime/);
+    assert.match(prompt, /open-gsd\/gsd-pi#1457/);
+    assert.match(prompt, /focused recovery tests passed/);
+    assert.match(prompt, /apply and verify the explicitly authorized repair evidence/i);
+  }
+  assert.match(customPrompt, /Non-authoritative Custom Engine Context/);
   assert.deepEqual(row(`
     SELECT event_type, payload_json
     FROM workflow_domain_events
@@ -766,6 +838,11 @@ test("durable budget use survives retries and exhausts to agent abort", () => {
     route("recovery/budget/3", thirdFailure, summaries[2]).resumeAuthorized,
     false,
   );
+  assert.equal(readPendingTaskRecoveryContext({
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T01",
+  }), null, "the successor claim must consume resumed-abort prompt authority");
   assert.throws(() => resumeTaskRecovery({
     invocation: invocation("recovery/resume/stale"),
     recoveryActionId: third.recoveryActionId,

--- a/src/resources/extensions/gsd/tests/workflow-dispatch-ledger.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-dispatch-ledger.test.ts
@@ -29,12 +29,24 @@ test("settleDispatchFailed writes failures and reports settled state", () => {
   const calls: Array<{ dispatchId: number; errorSummary: string }> = [];
 
   const settled = settleDispatchFailed(42, "unit-break", {
-    markFailed: (dispatchId, details) => calls.push({ dispatchId, ...details }),
+    markFailed: (dispatchId, details) => {
+      calls.push({ dispatchId, ...details });
+      return true;
+    },
     logWriteFailure: () => assert.fail("logWriteFailure should not be called"),
   });
 
   assert.equal(settled, true);
   assert.deepEqual(calls, [{ dispatchId: 42, errorSummary: "unit-break" }]);
+});
+
+test("settleDispatchFailed reports a no-op failure write as unsettled", () => {
+  const settled = settleDispatchFailed(42, "unit-break", {
+    markFailed: () => false,
+    logWriteFailure: () => assert.fail("logWriteFailure should not be called"),
+  });
+
+  assert.equal(settled, false);
 });
 
 test("settleDispatchFailed skips null dispatch ids", () => {


### PR DESCRIPTION
## TL;DR

**What:** Recover failed host verification in a fresh lineage-linked Task Attempt and carry durable resume evidence into the next executor prompt.
**Why:** A succeeded executor with a failed Technical Verdict could replay publication or resume without performing the recorded repair.
**How:** Read recovery authority from the database, preserve failed history, claim a replacement Attempt for agent-owned recovery, require a fresh passing verdict, and fail closed when dispatch settlement cannot be confirmed.

## What

- Runs agent-owned verification repair, retry, remediation, replan, and authorized resume work in a new Task Attempt linked to its predecessor.
- Preserves the original Attempt, Result, failed verdict, evidence, and source snapshot as immutable history.
- Publishes canonical Task completion only from the latest succeeded Attempt with a fresh passing Technical Verdict.
- Carries the exact durable correction summary and evidence into built-in and custom-engine execution prompts before the one-use resume claim consumes authority.
- Terminalizes custom-engine break/retry dispatches and stops loudly if the database cannot confirm settlement.

## Why

Host verification can reject an executor Result after the executor itself succeeded. The prior cutover treated that succeeded Attempt as ready to advance, so recorded remediation was not executed in a new Attempt and publication could replay the failed verdict. Explicitly resumed aborts also lacked the correction context that justified resuming.

This keeps the database authoritative, prevents Markdown or replay drift, and lets automated recovery continue unless durable authority requires a stop.

Closes #1463

## How

The cutover now reads the predecessor's durable recovery route before deciding whether to stop, remain at verification, or claim a lineage-linked replacement Attempt. Authorized abort resumes expose a prompt-only resume context derived from the exact correction Work Checkpoint; the immutable Recovery Action remains abort. The replacement claim remains the sole one-use consumer.

Dispatch settlement now reports whether an active row actually transitioned. Custom-engine recovery exits refuse to continue when settlement cannot be confirmed.

## Testing

- RED/GREEN/sabotage coverage for verification remediation, abort resume, correction prompt context, and custom dispatch terminalization.
- Changed-source selection: 201 tests passed.
- Recovery suite: 17/17 passed.
- Prompt suite: 43/43 passed.
- Extension typecheck passed.
- verify:fast passed.
- Hosted build, unit, package, integration, and built-binary E2E checks are required before merge.

## Change type

- [ ] feat - New feature or capability
- [x] fix - Bug fix
- [ ] refactor - Code restructuring (no behavior change)
- [x] test - Adding or updating tests
- [ ] docs - Documentation only
- [ ] chore - Build, CI, or tooling changes

## Breaking changes

None.
