### PR TITLE
fix(gsd): resume isolated host verification safely

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -15,6 +15,7 @@ import { appendEvent } from "./workflow-events.js";
 import { clearParseCache } from "./files.js";
 import {
   isDbAvailable,
+  getDb,
   getTask,
   getSlice,
   getSliceTasks,
@@ -336,6 +337,38 @@ export function writeReactiveExecuteBlocker(
 }
 
 /**
+ * Whether a slice already has canonical Domain-Operation lifecycle history.
+ * Adopted slices are real recovery/cascade territory owned by S05 — this
+ * legacy placeholder must not fabricate their completion (fail-closed).
+ */
+function hasAdoptedSliceHistory(milestoneId: string, sliceId: string): boolean {
+  return Boolean(getDb().prepare(`
+    SELECT 1 AS adopted
+    FROM workflow_item_lifecycles
+    WHERE item_kind = 'slice'
+      AND milestone_id = :milestone_id
+      AND slice_id = :slice_id
+      AND task_id IS NULL
+  `).get({ ":milestone_id": milestoneId, ":slice_id": sliceId }));
+}
+
+/**
+ * Whether a milestone already has canonical Domain-Operation lifecycle
+ * history. Adopted milestones must not have a fabricated blocker slice
+ * inserted to paper over a stuck plan-milestone unit (fail-closed).
+ */
+function hasAdoptedMilestoneHistory(milestoneId: string): boolean {
+  return Boolean(getDb().prepare(`
+    SELECT 1 AS adopted
+    FROM workflow_item_lifecycles
+    WHERE item_kind = 'milestone'
+      AND milestone_id = :milestone_id
+      AND slice_id IS NULL
+      AND task_id IS NULL
+  `).get({ ":milestone_id": milestoneId }));
+}
+
+/**
  * Write a placeholder artifact so the pipeline can advance past a stuck unit.
  * Returns the relative path written, or null if the path couldn't be resolved.
  */
@@ -379,18 +412,26 @@ export function writeBlockerPlaceholder(
     const { milestone: mid, slice: sid } = parseUnitId(unitId);
     const ts = new Date().toISOString();
     if (unitType === "complete-slice" && mid && sid) {
-      try { updateSliceStatus(mid, sid, "complete", ts); } catch (e) { logWarning("recovery", `updateSliceStatus failed during context exhaustion: ${e instanceof Error ? e.message : String(e)}`); }
-      try { appendEvent(base, { cmd: "complete-slice", params: { milestoneId: mid, sliceId: sid }, ts, actor: "system", trigger_reason: "blocker-placeholder-recovery" }); } catch (e) { logWarning("recovery", `appendEvent failed for slice recovery: ${e instanceof Error ? e.message : String(e)}`); }
+      if (hasAdoptedSliceHistory(mid, sid)) {
+        logWarning("recovery", `Skipping fabricated complete-slice recovery for ${mid}/${sid}: adopted canonical slice history exists (fail-closed; see S05 for the real cascade).`);
+      } else {
+        try { updateSliceStatus(mid, sid, "complete", ts); } catch (e) { logWarning("recovery", `updateSliceStatus failed during context exhaustion: ${e instanceof Error ? e.message : String(e)}`); }
+        try { appendEvent(base, { cmd: "complete-slice", params: { milestoneId: mid, sliceId: sid }, ts, actor: "system", trigger_reason: "blocker-placeholder-recovery" }); } catch (e) { logWarning("recovery", `appendEvent failed for slice recovery: ${e instanceof Error ? e.message : String(e)}`); }
+      }
     }
     // Insert a placeholder complete slice so deriveState sees activeMilestoneSlices.length > 0
     // and exits the pre-planning phase. Without this, activeMilestoneSlices stays empty
     // after the blocker ROADMAP.md is written, causing deriveState to return phase:'pre-planning'
     // indefinitely and re-dispatching plan-milestone in an infinite loop (#4378).
     if (unitType === "plan-milestone" && mid) {
-      try {
-        insertSlice({ id: "S00-blocker", milestoneId: mid, title: "Blocker placeholder — planning failed", status: "complete", sequence: 0 });
-      } catch (e) { logWarning("recovery", `insertSlice placeholder failed for plan-milestone recovery: ${e instanceof Error ? e.message : String(e)}`); }
-      try { appendEvent(base, { cmd: "plan-milestone", params: { milestoneId: mid }, ts, actor: "system", trigger_reason: "blocker-placeholder-recovery" }); } catch (e) { logWarning("recovery", `appendEvent failed for plan-milestone recovery: ${e instanceof Error ? e.message : String(e)}`); }
+      if (hasAdoptedMilestoneHistory(mid)) {
+        logWarning("recovery", `Skipping fabricated S00-blocker slice for ${mid}: adopted canonical milestone history exists (fail-closed; see S05 for the real cascade).`);
+      } else {
+        try {
+          insertSlice({ id: "S00-blocker", milestoneId: mid, title: "Blocker placeholder — planning failed", status: "complete", sequence: 0 });
+        } catch (e) { logWarning("recovery", `insertSlice placeholder failed for plan-milestone recovery: ${e instanceof Error ? e.message : String(e)}`); }
+        try { appendEvent(base, { cmd: "plan-milestone", params: { milestoneId: mid }, ts, actor: "system", trigger_reason: "blocker-placeholder-recovery" }); } catch (e) { logWarning("recovery", `appendEvent failed for plan-milestone recovery: ${e instanceof Error ? e.message : String(e)}`); }
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -27,7 +27,10 @@ import {
 import { _clearCurrentResolve } from "./resolve.js";
 import { runGuards } from "./phases.js";
 import { runFinalize } from "./finalize.js";
-import { resetSessionTimeoutState } from "./unit-phase.js";
+import {
+  resetSessionTimeoutState,
+  restoreTaskHostVerificationContext,
+} from "./unit-phase.js";
 import { STUCK_WINDOW_SIZE } from "./dispatch-history.js";
 import { debugLog } from "../debug-logger.js";
 import { isInfrastructureError, isTransientCooldownError, getCooldownRetryAfterMs, COOLDOWN_FALLBACK_WAIT_MS, MAX_COOLDOWN_RETRIES } from "./infra-errors.js";
@@ -113,6 +116,7 @@ import { handleCustomEngineReconcileOutcome } from "./workflow-custom-engine-rec
 import { formatLeaseConflictNotice } from "./lease-conflict-notice.js";
 import { setAutoOutcomeWidget, unitVerb } from "../auto-dashboard.js";
 import {
+  isTaskExecutionReadyForHostVerification,
   publishVerifiedTaskExecution,
   runWithTaskExecutionAttempt,
 } from "./task-execution-cutover.js";
@@ -1584,6 +1588,14 @@ export async function autoLoop(
         unitType: iterData.unitType,
         unitId: iterData.unitId,
       });
+      if (
+        unitPhaseResult.action === "next" &&
+        iterData.unitType === "execute-task" &&
+        !s.currentUnit &&
+        isTaskExecutionReadyForHostVerification(iterData.unitType, iterData.unitId)
+      ) {
+        restoreTaskHostVerificationContext(ic, iterData.unitType, iterData.unitId);
+      }
       if (unitPhaseResult.action === "break") {
         dispatchSettled = settleDispatchIfNeeded(dispatchSettled, () =>
           settleDispatchFailed(dispatchId, "unit-break", {

--- a/src/resources/extensions/gsd/auto/unit-phase.ts
+++ b/src/resources/extensions/gsd/auto/unit-phase.ts
@@ -108,6 +108,47 @@ export function _shouldProceedWithInvalidRepoClassificationForTest(
   return reason === "missing .git" && hasGit;
 }
 
+function observeTaskPlan(s: AutoSession, unitType: string, unitId: string): void {
+  if (unitType !== "execute-task") return;
+  const { milestone, slice, task } = parseUnitId(unitId);
+  if (!milestone || !slice || !task || !isDbAvailable()) return;
+  try {
+    const taskRow = getTask(milestone, slice, task);
+    if (taskRow) s.sourceObservations.observePlanTask(taskRow);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logWarning("prompt", `failed to preload source observations for ${unitId}: ${message}`);
+  }
+}
+
+export function restoreTaskHostVerificationContext(
+  ic: Pick<IterationContext, "s" | "prefs">,
+  unitType: string,
+  unitId: string,
+): void {
+  const { s, prefs } = ic;
+  s.setCurrentUnit({
+    type: unitType,
+    id: unitId,
+    startedAt: Date.now(),
+    workspaceRoot: s.basePath,
+  });
+  observeTaskPlan(s, unitType, unitId);
+  s.rootWriteBaseline = isIsolatedWorktreeSession(s)
+    ? captureRootDirtySnapshot(s.originalBasePath)
+    : null;
+
+  const safetyConfig = resolveSafetyHarnessConfig(
+    prefs?.safety_harness as Record<string, unknown> | undefined,
+  );
+  if (!safetyConfig.enabled || !safetyConfig.evidence_collection) return;
+  resetEvidence();
+  const { milestone, slice, task } = parseUnitId(unitId);
+  if (milestone && slice && task) {
+    loadEvidenceFromDisk(s.basePath, milestone, slice, task);
+  }
+}
+
 // ─── Session timeout auto-resume state ────────────────────────────────────────
 
 let consecutiveSessionTimeouts = 0;
@@ -418,18 +459,7 @@ export async function runUnitPhase(
   const unitStartedAt = Date.now();
   s.unitDispatchCount.set(dispatchKey, nextDispatchCount);
   s.setCurrentUnit({ type: unitType, id: unitId, startedAt: unitStartedAt, workspaceRoot: s.basePath });
-  if (unitType === "execute-task") {
-    const { milestone, slice, task } = parseUnitId(unitId);
-    if (milestone && slice && task && isDbAvailable()) {
-      try {
-        const taskRow = getTask(milestone, slice, task);
-        if (taskRow) s.sourceObservations.observePlanTask(taskRow);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        logWarning("prompt", `failed to preload source observations for ${unitId}: ${message}`);
-      }
-    }
-  }
+  observeTaskPlan(s, unitType, unitId);
   s.rootWriteBaseline = isIsolatedWorktreeSession(s)
     ? captureRootDirtySnapshot(s.originalBasePath)
     : null;

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2455,6 +2455,132 @@ test("autoLoop publishes a canonical Task only after host verification without l
   }
 });
 
+test("autoLoop resumes host verification for a settled succeeded Attempt without rerunning the executor", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.ui.setWidget = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+  const basePath = realpathSync(makeLoopTestBase("gsd-canonical-task-resume-verify-"));
+  execSync("git commit --allow-empty -m initial", { cwd: basePath, stdio: "ignore" });
+  const originalBasePath = realpathSync(makeLoopTestBase("gsd-canonical-task-resume-root-"));
+  execSync("git commit --allow-empty -m initial", { cwd: originalBasePath, stdio: "ignore" });
+  writeFileSync(join(originalBasePath, "preexisting-root-note.txt"), "must not become a restart leak\n");
+  const slicePath = join(basePath, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(join(slicePath, "tasks"), { recursive: true });
+  writeFileSync(join(slicePath, "S01-PLAN.md"), "# Slice Plan\n\n- [ ] **T01:** task one\n");
+  writeFileSync(join(slicePath, "tasks", "T01-PLAN.md"), "# Task Plan\n");
+
+  try {
+    openDatabase(join(basePath, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", status: "active" });
+    insertTask({
+      id: "T01",
+      milestoneId: "M001",
+      sliceId: "S01",
+      title: "Task One",
+      status: "pending",
+      planning: { verify: 'node -e "process.exit(0)"' },
+    });
+    const workerId = registerAutoWorker({ projectRootRealpath: basePath });
+    const lease = claimMilestoneLease(workerId, "M001");
+    assert.equal(lease.ok, true);
+    if (!lease.ok) return;
+
+    const seedDispatch = recordDispatchClaim({
+      traceId: "seed-resume-verification",
+      workerId,
+      milestoneLeaseToken: lease.token,
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+    });
+    assert.equal(seedDispatch.ok, true);
+    if (!seedDispatch.ok) return;
+    const claimed = claimTaskAttempt({
+      invocation: {
+        idempotencyKey: "test:auto-loop:resume-verify:claim",
+        sourceTransport: "internal",
+        actorType: "test",
+      },
+      task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+      workerId,
+      milestoneLeaseToken: lease.token,
+      coordinationDispatchId: seedDispatch.dispatchId,
+    });
+    await stageTaskCompletion({
+      invocation: {
+        idempotencyKey: "test:auto-loop:resume-verify:stage",
+        sourceTransport: "internal",
+        actorType: "agent",
+        actorId: workerId,
+      },
+      basePath,
+      task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+      completion: {
+        oneLiner: "Executor candidate completed before restart",
+        narrative: "Candidate Result awaits restarted host verification.",
+        verification: "Host verification has not run yet.",
+        deviations: "None.",
+        knownIssues: "None.",
+        keyFiles: ["src/task.ts"],
+        keyDecisions: ["Resume at verification without rerunning execution."],
+        blockerDiscovered: false,
+        verificationEvidence: [],
+      },
+    });
+    markCanceled(seedDispatch.dispatchId, "simulated process exit after Attempt settlement");
+    assert.equal(readLatestTaskAttempt({ milestoneId: "M001", sliceId: "S01", taskId: "T01" })?.nextStage, "verify");
+
+    const s = makeLoopSession({
+      basePath,
+      originalBasePath,
+      canonicalProjectRoot: basePath,
+      workerId,
+      milestoneLeaseToken: lease.token,
+    });
+    let verificationCalls = 0;
+    let stopReason: string | undefined;
+    const deps = makeMockDeps({
+      isDbAvailable: () => true,
+      taskExecutionBoundary: runWithTaskExecutionAttempt,
+      taskPublicationBoundary: publishVerifiedTaskExecution,
+      runPostUnitVerification: async (vctx, pauseAuto) => {
+        verificationCalls += 1;
+        return runPostUnitVerification(vctx, pauseAuto);
+      },
+      postUnitPostVerification: async () => {
+        s.active = false;
+        return "continue" as const;
+      },
+      stopAuto: async (_ctx, _pi, reason) => {
+        stopReason = reason;
+        s.active = false;
+      },
+    });
+
+    await autoLoop(ctx, pi, s, deps);
+
+    const attempt = readLatestTaskAttempt({ milestoneId: "M001", sliceId: "S01", taskId: "T01" });
+    assert.equal(attempt?.attemptId, claimed.attemptId, "restart must not claim a successor Attempt");
+    assert.equal(pi.calls.length, 0, "restart must not dispatch the executor again");
+    assert.equal(verificationCalls, 1);
+    assert.equal(attempt?.nextStage, "settled");
+    assert.equal(getTask("M001", "S01", "T01")?.status, "complete");
+    assert.equal(stopReason, undefined, "pre-existing root dirt must not be reported as a resumed-unit leak");
+    assert.equal(getLatestForUnit("M001/S01/T01")?.status, "completed");
+  } finally {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(basePath, { recursive: true, force: true });
+    rmSync(originalBasePath, { recursive: true, force: true });
+  }
+});
+
 test("autoLoop refreshes its milestone lease while an execute-task call is pending and clears the heartbeat on exit", async () => {
   _resetPendingResolve();
   mock.timers.enable({ apis: ["setInterval"] });

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -9,10 +9,17 @@ import { randomUUID } from "node:crypto";
 
 import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, diagnoseWorktreeIntegrityFailure, buildLoopRemediationSteps, writeBlockerPlaceholder, refreshRecoveryDbForArtifact, writeReactiveExecuteBlocker } from "../auto-recovery.ts";
 import { resolveMilestoneFile } from "../paths.ts";
-import { _getAdapter, openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, insertAssessment, getMilestone, getMilestoneCommitAttributionShas, getTask, saveGateResult } from "../gsd-db.ts";
+import { _getAdapter, openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, insertAssessment, getMilestone, getMilestoneCommitAttributionShas, getTask, getSlice, saveGateResult } from "../gsd-db.ts";
 import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.ts";
 import { internalExecutionInvocation } from "../execution-invocation.ts";
 import { readEvents } from "../workflow-events.ts";
+import { executeDomainOperation } from "../db/domain-operation.ts";
+import {
+  adoptOrTransitionLifecycle,
+  readDomainOperationFence,
+  type CanonicalLifecycleStatus,
+  type LifecycleIdentity,
+} from "../db/writers/lifecycle-commands.ts";
 import { clearParseCache } from "../files.ts";
 import { parseRoadmap } from "../parsers-legacy.ts";
 import { invalidateAllCaches } from "../cache.ts";
@@ -2188,6 +2195,116 @@ test("#1343: writeReactiveExecuteBlocker uses slice-qualified summaries in flat-
     assert.deepEqual(recovery!.skippedTaskIds, []);
     assert.deepEqual(recovery!.unchangedTaskIds, ["T03"]);
     assert.equal(getTask("M001", "S02", "T03")?.status, "pending");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+// ─── T05: fail-closed adopted-history guard ──────────────────────────────────
+
+function adoptCanonicalHistory(
+  identity: LifecycleIdentity,
+  lifecycleStatus: CanonicalLifecycleStatus,
+): void {
+  const entityId = [identity.milestoneId, identity.sliceId, identity.taskId]
+    .filter(Boolean)
+    .join("/");
+  const operationType = `test.blocker-placeholder.${identity.itemKind}-adopted`;
+  const fence = readDomainOperationFence();
+  executeDomainOperation({
+    operationType,
+    idempotencyKey: `${operationType}:${entityId}`,
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: "test",
+    sourceTransport: "test",
+    payload: { entityId },
+  }, (context) => {
+    adoptOrTransitionLifecycle(context, {
+      ...identity,
+      lifecycleStatus,
+      adoptedFromStatus: lifecycleStatus,
+    });
+    return {
+      events: [{
+        eventType: operationType,
+        entityType: identity.itemKind,
+        entityId,
+        payload: {},
+        destinations: ["test"],
+      }],
+      projections: [{
+        projectionKey: `test/blocker-placeholder/${identity.itemKind}-adopted`,
+        projectionKind: "test",
+        rendererVersion: "1",
+      }],
+    };
+  });
+}
+
+test("writeBlockerPlaceholder fails closed instead of fabricating slice completion for adopted canonical history", () => {
+  const base = makeTmpBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+    adoptCanonicalHistory(
+      { itemKind: "slice", milestoneId: "M001", sliceId: "S01" },
+      "in_progress",
+    );
+
+    const result = writeBlockerPlaceholder(
+      "complete-slice",
+      "M001/S01",
+      base,
+      "verification retries exhausted",
+    );
+
+    assert.ok(result, "diagnostic placeholder path is still returned");
+    assert.equal(
+      getSlice("M001", "S01")?.status,
+      "pending",
+      "adopted slice must not be fabricated to complete",
+    );
+    const events = readEvents(join(base, ".gsd", "event-log.jsonl"));
+    assert.equal(
+      events.some((e) => e.trigger_reason === "blocker-placeholder-recovery"),
+      false,
+      "no blocker-placeholder-recovery event for an adopted slice",
+    );
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("writeBlockerPlaceholder fails closed instead of inserting an S00-blocker slice for an adopted canonical milestone", () => {
+  const base = makeTmpBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    adoptCanonicalHistory({ itemKind: "milestone", milestoneId: "M001" }, "ready");
+
+    const result = writeBlockerPlaceholder(
+      "plan-milestone",
+      "M001",
+      base,
+      "verification retries exhausted",
+    );
+
+    assert.ok(result, "diagnostic placeholder path is still returned");
+    assert.equal(
+      getSlice("M001", "S00-blocker"),
+      null,
+      "adopted milestone must not get a fabricated S00-blocker slice",
+    );
+    const events = readEvents(join(base, ".gsd", "event-log.jsonl"));
+    assert.equal(
+      events.some((e) => e.trigger_reason === "blocker-placeholder-recovery"),
+      false,
+      "no blocker-placeholder-recovery event for an adopted milestone",
+    );
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -2373,6 +2373,8 @@ test("#4414: verifyExpectedArtifact parallel-research succeeds when all research
 
 test("parallel-research verification accepts canonical project artifacts from a worktree base", () => {
   const base = makeTmpBase();
+  const previousProjectRoot = process.env.GSD_PROJECT_ROOT;
+  delete process.env.GSD_PROJECT_ROOT;
   try {
     const milestoneDir = join(base, ".gsd", "milestones", "M001");
     mkdirSync(join(milestoneDir, "slices", "S02", "tasks"), { recursive: true });
@@ -2408,6 +2410,7 @@ test("parallel-research verification accepts canonical project artifacts from a 
       "worktree verification should use the same canonical artifacts as dispatch",
     );
   } finally {
+    if (previousProjectRoot !== undefined) process.env.GSD_PROJECT_ROOT = previousProjectRoot;
     cleanup(base);
   }
 });

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -432,6 +432,45 @@ describe("verification-gate: execution", () => {
     assert.equal(typeof result.timestamp, "number");
   });
 
+  test("host verification removes GSD control-plane routing while preserving ordinary environment", () => {
+    const routingKeys = [
+      "GSD_PROJECT_ROOT",
+      "GSD_MILESTONE_LOCK",
+      "GSD_PARALLEL_WORKER",
+      "GSD_SLICE_LOCK",
+      "GSD_SLICE_WORKER_TOKEN",
+    ] as const;
+    const previousRouting = new Map(routingKeys.map((key) => [key, process.env[key]]));
+    const previousSentinel = process.env.VERIFICATION_CHILD_SENTINEL;
+    for (const key of routingKeys) process.env[key] = `control-plane:${key}`;
+    process.env.VERIFICATION_CHILD_SENTINEL = "preserved";
+    const probePath = join(tmp, "verification-env-probe.js");
+    writeFileSync(
+      probePath,
+      `process.stdout.write(JSON.stringify({ routing: ${JSON.stringify(routingKeys)}.map((key) => process.env[key]), sentinel: process.env.VERIFICATION_CHILD_SENTINEL }));\n`,
+    );
+    try {
+      const result = runVerificationGate({
+        cwd: tmp,
+        preferenceCommands: ["node verification-env-probe.js"],
+      });
+
+      assert.equal(result.passed, true);
+      assert.deepEqual(JSON.parse(result.checks[0]?.stdout ?? "{}"), {
+        routing: [null, null, null, null, null],
+        sentinel: "preserved",
+      });
+    } finally {
+      for (const key of routingKeys) {
+        const previous = previousRouting.get(key);
+        if (previous === undefined) delete process.env[key];
+        else process.env[key] = previous;
+      }
+      if (previousSentinel === undefined) delete process.env.VERIFICATION_CHILD_SENTINEL;
+      else process.env.VERIFICATION_CHILD_SENTINEL = previousSentinel;
+    }
+  });
+
   test("one command fails → gate fails with exit code + stderr", () => {
     const result = runVerificationGate({
       cwd: tmp,
@@ -848,6 +887,22 @@ test("formatFailureContext: formats a single failure with command, exit code, st
   assert.ok(output.includes("exit code 1"), "should include exit code");
   assert.ok(output.includes("error: unused var"), "should include stderr content");
   assert.ok(output.includes("```stderr"), "should have stderr code block");
+});
+
+test("formatFailureContext: preserves stdout-only failure evidence", () => {
+  const result: import("../types.ts").VerificationResult = {
+    passed: false,
+    checks: [
+      { command: "node --test", exitCode: 1, stdout: "not ok 1 - fixture assertion", stderr: "", durationMs: 500 },
+    ],
+    discoverySource: "task-plan",
+    timestamp: Date.now(),
+  };
+
+  const output = formatFailureContext(result);
+
+  assert.match(output, /not ok 1 - fixture assertion/);
+  assert.match(output, /```stdout/);
 });
 
 test("formatFailureContext: formats multiple failures", () => {

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -200,8 +200,8 @@ function hasPythonTests(dir: string): boolean {
 
 // ─── Failure Context Formatting ──────────────────────────────────────────────
 
-/** Maximum chars of stderr to include per failed check in failure context. */
-const MAX_STDERR_PER_CHECK = 2_000;
+/** Maximum chars of command output to include per failed check. */
+const MAX_FAILURE_OUTPUT_PER_CHECK = 2_000;
 
 /** Maximum total chars for the combined failure context output. */
 const MAX_FAILURE_CONTEXT_CHARS = 10_000;
@@ -222,13 +222,15 @@ export function formatFailureContext(result: VerificationResult): string {
   const blocks: string[] = [];
 
   for (const check of failures) {
-    let stderr = check.stderr ?? "";
-    if (stderr.length > MAX_STDERR_PER_CHECK) {
-      stderr = stderr.slice(0, MAX_STDERR_PER_CHECK) + "\n…[truncated]";
+    const hasStderr = (check.stderr ?? "").trim().length > 0;
+    const outputLabel = hasStderr ? "stderr" : "stdout";
+    let output = hasStderr ? check.stderr ?? "" : check.stdout ?? "";
+    if (output.length > MAX_FAILURE_OUTPUT_PER_CHECK) {
+      output = output.slice(0, MAX_FAILURE_OUTPUT_PER_CHECK) + "\n…[truncated]";
     }
 
     blocks.push(
-      `### ❌ \`${check.command}\` (exit code ${check.exitCode})\n\`\`\`stderr\n${stderr}\n\`\`\``,
+      `### ❌ \`${check.command}\` (exit code ${check.exitCode})\n\`\`\`${outputLabel}\n${output}\n\`\`\``,
     );
   }
 
@@ -488,6 +490,20 @@ export interface VerificationTarget {
   preferenceCommands?: string[];
 }
 
+function verificationChildEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of [
+    "GSD_PROJECT_ROOT",
+    "GSD_MILESTONE_LOCK",
+    "GSD_PARALLEL_WORKER",
+    "GSD_SLICE_LOCK",
+    "GSD_SLICE_WORKER_TOKEN",
+  ]) {
+    delete env[key];
+  }
+  return env;
+}
+
 // When targets use different discovery methods, return the highest-priority
 // source. Precedence: explicit preference > task-plan > package-json >
 // python-project. This avoids a misleading "mixed" label while still
@@ -556,6 +572,7 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
         ];
     const result: SpawnSyncReturns<string> = spawnSync(shellBin, shellArgs, {
       cwd: options.cwd,
+      env: verificationChildEnvironment(),
       stdio: "pipe",
       encoding: "utf-8",
       timeout: options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,


### PR DESCRIPTION
## TL;DR

Resume a settled successful Task Attempt at host verification without rerunning its executor, inheriting control-plane routing, or falsely treating pre-existing project-root dirt as a new worktree leak.

## What changed

- Fail closed when adopted canonical recovery history cannot be refreshed safely.
- Resume the same settled Attempt at host verification and restore its task-plan observations, persisted safety evidence, and isolated-worktree root baseline.
- Remove the five GSD control-plane routing variables from verification child processes while preserving ordinary environment variables.
- Preserve stdout-only failure evidence so recovery prompts retain actionable test assertions.
- Add restart, immutable-history, dispatch-terminalization, environment-isolation, and root-leak regressions.

## Why

A process restart after executor settlement could lose finalize context. Verification could then target the control-plane project, publication could run without a reconstructed current unit, or an already-dirty root could be reported as a new leak. The recovery path must preserve immutable failed verdict history and publish only the same verified Attempt.

## How verified

- 319 focused recovery, verification-gate, and auto-loop tests passed.
- Required sabotage checks failed when environment isolation and baseline restoration were disabled, then passed after restoration.
- `typecheck:extensions` passed.
- `build:core` passed.
- `verify:fast` passed.
- Canonical T05 host verification passed its exact three-suite command with exit 0; Attempt 6 published at project revision 25 and no Attempt 7 exists.
- `verify:merge` reached 12,463 passing tests; three macOS `/var` alias failures reproduce on clean `origin/main`, and the fourth ambient-project failure passes on this branch from a clean detached worktree. Hosted Linux CI is the definitive merge gate.

## Checklist

- [x] Tests cover the changed behavior and fail when the protections are removed.
- [x] No public API or configuration breaking change.
- [x] Branch is current with `main` and the worktree is clean.

Closes #1467

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-loop finalize/resume, recovery DB mutations, and verification subprocess environment—important for correct task publication and worktree leak detection, but scoped with tests and fail-closed guards.
> 
> **Overview**
> After a restart, auto-mode can continue **host verification** for an `execute-task` whose executor already settled successfully, without dispatching the agent again. When the unit phase returns `next` with no `currentUnit` but the canonical Task Attempt is awaiting verify, `autoLoop` calls **`restoreTaskHostVerificationContext`** to rebuild current unit, task-plan observations, isolated-worktree **root dirty baseline**, and persisted safety evidence.
> 
> **`writeBlockerPlaceholder`** now **fails closed** when `workflow_item_lifecycles` shows adopted canonical slice or milestone history: it skips fabricated `complete-slice` DB updates and `S00-blocker` slice insertion (diagnostic placeholder files still written).
> 
> **Verification gate** spawns child processes with **`GSD_*` control-plane env vars stripped** so verify commands run against the real project, not routing overrides. **`formatFailureContext`** includes **stdout** when stderr is empty so test failures stay visible in recovery prompts.
> 
> Regression tests cover resume-without-rerun, adopted-history guards, env isolation, and stdout-only failure formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 971d038af648a635a3834256a06f38991b784d72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->