### PR TITLE
fix(issue): Dashboard ETA wildly off: estimateTimeRemaining mixes global units with current-milestone slice count

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -18,7 +18,7 @@ import type {
 } from "@gsd/pi-coding-agent";
 import type { GSDState } from "./types.js";
 import { getActiveHook } from "./post-unit-hooks.js";
-import { getLedger, getProjectTotals } from "./metrics.js";
+import { filterUnitsForMilestone, getLedger, getProjectTotals } from "./metrics.js";
 import { getErrorMessage } from "./error-utils.js";
 import { nativeIsRepo } from "./native-git-bridge.js";
 import {
@@ -371,7 +371,7 @@ export function estimateTimeRemaining(): string | null {
   if (remainingSlices <= 0) return null;
 
   // Compute average duration per completed slice from the ledger
-  const completedSliceUnits = ledger.units.filter(
+  const completedSliceUnits = filterUnitsForMilestone(ledger.units, sliceProgress.milestoneId).filter(
     u => u.finishedAt > 0 && u.startedAt > 0,
   );
   if (completedSliceUnits.length < 2) return null;
@@ -461,7 +461,7 @@ export function updateSliceProgressCache(base: string, mid: string, activeSid?: 
   }
 }
 
-export function getRoadmapSlicesSync(): { done: number; total: number; activeSliceTasks: { done: number; total: number } | null; taskDetails: CachedTaskDetail[] | null } | null {
+export function getRoadmapSlicesSync(): { done: number; total: number; milestoneId: string; activeSliceTasks: { done: number; total: number } | null; taskDetails: CachedTaskDetail[] | null } | null {
   return cachedSliceProgress;
 }
 

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -21,6 +21,7 @@ import {
   setCompletionProgressWidget,
   getRoadmapSlicesSync,
   clearSliceProgressCache,
+  updateSliceProgressCache,
   getWidgetMode,
   cycleWidgetMode,
   setWidgetMode,

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -53,6 +53,7 @@ import {
   insertSlice,
   insertTask,
 } from "../gsd-db.ts";
+import { initMetrics, resetMetrics, type UnitMetrics } from "../metrics.ts";
 
 function makeTempDir(prefix: string): string {
   return join(
@@ -67,6 +68,21 @@ function cleanup(dir: string): void {
   } catch {
     // best-effort
   }
+}
+
+function makeMetricUnit(id: string, startedAt: number, finishedAt: number): UnitMetrics {
+  return {
+    type: id.split("/").length >= 3 ? "execute-task" : "complete-slice",
+    id,
+    model: "test-model",
+    startedAt,
+    finishedAt,
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    cost: 0,
+    toolCalls: 0,
+    assistantMessages: 0,
+    userMessages: 0,
+  };
 }
 
 type RenderableWidget = { render(width: number): string[]; invalidate(): void; dispose?: () => void };
@@ -496,6 +512,42 @@ test("estimateTimeRemaining returns null when no ledger data", () => {
 
 test("estimateTimeRemaining is exported and callable", () => {
   assert.equal(typeof estimateTimeRemaining, "function");
+});
+
+test("estimateTimeRemaining scopes completed units to the active milestone", (t) => {
+  const dir = makeTempDir("eta-scope");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+
+  t.after(() => {
+    resetMetrics();
+    closeDatabase();
+    clearSliceProgressCache();
+    cleanup(dir);
+  });
+
+  openDatabase(join(dir, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M002", title: "Active", status: "active" });
+  insertSlice({ milestoneId: "M002", id: "S01", title: "Done", status: "complete", sequence: 1 });
+  insertSlice({ milestoneId: "M002", id: "S02", title: "Remaining", status: "pending", sequence: 2 });
+
+  const units = [
+    makeMetricUnit("M001/S01/T01", 1_000, 61_000),
+    makeMetricUnit("M001/S01/T02", 61_000, 121_000),
+    makeMetricUnit("M001/S02/T01", 121_000, 181_000),
+    makeMetricUnit("M001/S02/T02", 181_000, 241_000),
+    makeMetricUnit("M002/S01/T01", 241_000, 301_000),
+    makeMetricUnit("M002/S01/T02", 301_000, 361_000),
+  ];
+  writeFileSync(
+    join(dir, ".gsd", "metrics.json"),
+    JSON.stringify({ version: 1, projectStartedAt: 1_000, units }),
+  );
+
+  initMetrics(dir);
+  clearSliceProgressCache();
+  updateSliceProgressCache(dir, "M002");
+
+  assert.equal(estimateTimeRemaining(), "~2m remaining");
 });
 
 // ─── getAutoDashboardData elapsed guard ──────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/visualizer-data.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-data.test.ts
@@ -13,6 +13,23 @@ import {
 } from "../visualizer-data.ts";
 import { _getAdapter, closeDatabase, openDatabase } from "../gsd-db.ts";
 import { createMemory } from "../memory-store.ts";
+import { generateHtmlReport } from "../export-html.ts";
+import { resetMetrics, type UnitMetrics } from "../metrics.ts";
+
+function makeMetricUnit(id: string, startedAt: number, finishedAt: number): UnitMetrics {
+  return {
+    type: id.split("/").length >= 3 ? "execute-task" : "complete-slice",
+    id,
+    model: "test-model",
+    startedAt,
+    finishedAt,
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    cost: 0,
+    toolCalls: 0,
+    assistantMessages: 0,
+    userMessages: 0,
+  };
+}
 
 test("computeCriticalPath follows milestone dependencies", () => {
   const milestones: VisualizerMilestone[] = [
@@ -81,6 +98,66 @@ test("loadVisualizerData hydrates milestones, captures, stats, and health fields
     assert.ok(data.health);
     assert.ok(data.criticalPath.milestonePath.length >= 1);
   } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("loadVisualizerData scopes ETA rate to active milestone units", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-visualizer-eta-scope-"));
+  try {
+    resetMetrics();
+    const m1Dir = join(base, ".gsd", "milestones", "M001");
+    const m2Dir = join(base, ".gsd", "milestones", "M002");
+    mkdirSync(m1Dir, { recursive: true });
+    mkdirSync(m2Dir, { recursive: true });
+
+    writeFileSync(
+      join(m1Dir, "M001-ROADMAP.md"),
+      [
+        "# M001: Previous",
+        "",
+        "## Slices",
+        "- [x] **S01: Done** `risk:low` `depends:[]`",
+      ].join("\n"),
+    );
+    writeFileSync(join(m1Dir, "M001-SUMMARY.md"), "# M001 Summary\n\nDone.");
+    writeFileSync(
+      join(m2Dir, "M002-ROADMAP.md"),
+      [
+        "# M002: Active",
+        "",
+        "## Slices",
+        "- [x] **S01: Done** `risk:low` `depends:[]`",
+        "- [ ] **S02: Remaining** `risk:low` `depends:[]`",
+      ].join("\n"),
+    );
+
+    const units = [
+      makeMetricUnit("M001/S01/T01", 1_000, 61_000),
+      makeMetricUnit("M001/S01/T02", 61_000, 121_000),
+      makeMetricUnit("M001/S01/T03", 121_000, 181_000),
+      makeMetricUnit("M002/S01/T01", 100_000_000, 100_900_000),
+      makeMetricUnit("M002/S01/T02", 100_900_000, 101_800_000),
+    ];
+    writeFileSync(
+      join(base, ".gsd", "metrics.json"),
+      JSON.stringify({ version: 1, projectStartedAt: 1_000, units }),
+    );
+
+    const data = await loadVisualizerData(base);
+
+    assert.equal(data.milestones.find(m => m.id === "M002")?.status, "active");
+    assert.equal(data.agentActivity?.completionRate, 4);
+
+    const html = generateHtmlReport(data, {
+      projectName: "ETA scope",
+      projectPath: base,
+      gsdVersion: "test",
+    });
+    assert.ok(html.includes("4.0/hr"), "export HTML should use the scoped active-milestone rate");
+  } finally {
+    resetMetrics();
+    closeDatabase();
     rmSync(base, { recursive: true, force: true });
   }
 });

--- a/src/resources/extensions/gsd/tests/visualizer-data.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-data.test.ts
@@ -11,7 +11,7 @@ import {
   loadVisualizerData,
   type VisualizerMilestone,
 } from "../visualizer-data.ts";
-import { _getAdapter, closeDatabase, openDatabase } from "../gsd-db.ts";
+import { _getAdapter, closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 import { createMemory } from "../memory-store.ts";
 import { generateHtmlReport } from "../export-html.ts";
 import { resetMetrics, type UnitMetrics } from "../metrics.ts";
@@ -131,6 +131,17 @@ test("loadVisualizerData scopes ETA rate to active milestone units", async () =>
         "- [ ] **S02: Remaining** `risk:low` `depends:[]`",
       ].join("\n"),
     );
+
+    // Milestone lifecycle is DB-authoritative: seed the DB so M001 derives as
+    // complete and M002 as the active milestone. loadVisualizerData reopens the
+    // project DB after it is closed here.
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Previous", status: "complete" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete", sequence: 1 });
+    insertMilestone({ id: "M002", title: "Active", status: "active" });
+    insertSlice({ milestoneId: "M002", id: "S01", title: "Done", status: "complete", sequence: 1 });
+    insertSlice({ milestoneId: "M002", id: "S02", title: "Remaining", status: "pending", sequence: 2 });
+    closeDatabase();
 
     const units = [
       makeMetricUnit("M001/S01/T01", 1_000, 61_000),

--- a/src/resources/extensions/gsd/visualizer-data.ts
+++ b/src/resources/extensions/gsd/visualizer-data.ts
@@ -19,6 +19,7 @@ import {
   formatTierSavings,
   loadLedgerFromDisk,
   classifyUnitPhase,
+  filterUnitsForMilestone,
 } from './metrics.js';
 import { loadAllCaptures, countPendingCaptures } from './captures.js';
 import { loadEffectiveGSDPreferences } from './preferences.js';
@@ -449,7 +450,7 @@ export function computeCriticalPath(milestones: VisualizerMilestone[]): Critical
 
 // ─── Agent Activity ──────────────────────────────────────────────────────────
 
-function loadAgentActivity(units: UnitMetrics[], milestones: VisualizerMilestone[]): AgentActivityInfo | null {
+function loadAgentActivity(units: UnitMetrics[], milestones: VisualizerMilestone[], activeMilestoneId?: string): AgentActivityInfo | null {
   if (units.length === 0) return null;
 
   // Find currently running unit (finishedAt === 0)
@@ -460,7 +461,7 @@ function loadAgentActivity(units: UnitMetrics[], milestones: VisualizerMilestone
   const totalSlices = milestones.reduce((sum, m) => sum + m.slices.length, 0);
 
   // Completion rate from finished units
-  const finished = units.filter(u => u.finishedAt > 0);
+  const finished = filterUnitsForMilestone(units, activeMilestoneId).filter(u => u.finishedAt > 0);
   let completionRate = 0;
   if (finished.length >= 2) {
     const earliest = Math.min(...finished.map(u => u.startedAt));
@@ -966,7 +967,7 @@ export async function loadVisualizerData(basePath: string): Promise<VisualizerDa
     }
   }
 
-  const agentActivity = loadAgentActivity(units, milestones);
+  const agentActivity = loadAgentActivity(units, milestones, state.activeMilestone?.id);
   const { changelog, verifications: sliceVerifications } = await loadChangelogAndVerifications(basePath, milestones);
 
   const knowledge = loadKnowledge(basePath);


### PR DESCRIPTION
## Summary
- Scoped ETA calculations to active milestone units, added regression coverage, and verified diff cleanliness while test execution was blocked by missing dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1477
- [#1477 Dashboard ETA wildly off: estimateTimeRemaining mixes global units with current-milestone slice count](https://github.com/open-gsd/gsd-pi/issues/1477)

## User
- @klajdo-f

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1477-dashboard-eta-wildly-off-estimatetimerem-1784100023`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to ETA/completion-rate calculations with targeted tests; no auth, data migration, or API surface changes.
> 
> **Overview**
> Fixes **wildly inflated dashboard and visualizer ETAs** when the metrics ledger still contains units from earlier milestones but slice progress is counted only for the **active milestone**.
> 
> **`estimateTimeRemaining`** now averages completed unit durations from **`filterUnitsForMilestone(ledger.units, sliceProgress.milestoneId)`** instead of the full ledger. The slice progress cache exposes **`milestoneId`** on **`getRoadmapSlicesSync()`** so ETA math aligns with the cached roadmap counts.
> 
> The visualizer **`loadAgentActivity`** **completion rate** (units/hr shown in export HTML) uses the same scoping via **`state.activeMilestone?.id`**, so prior-milestone throughput no longer skews the rate.
> 
> Regression tests cover dashboard **`~2m remaining`** with mixed M001/M002 metrics and visualizer **`4.0/hr`** in generated HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb540e358e060661f7f61356b1a3f2e5d34cdcd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->