### PR TITLE
feat(pi-ai): add Grok (xAI) subscription OAuth provider

### DIFF
--- a/docs/user-docs/providers.md
+++ b/docs/user-docs/providers.md
@@ -276,6 +276,17 @@ export GROQ_API_KEY="gsk_..."
 
 ### xAI (Grok)
 
+Two auth paths:
+
+**Subscription (SuperGrok / X Premium) — no API key.** Run `/login xai` (or pick
+"Grok (SuperGrok / X Premium)" during onboarding). A browser PKCE flow against
+`auth.x.ai` signs you in with your xAI account; inference is billed to your
+subscription. Tokens are stored in `~/.pi/agent/auth.json`, refreshed
+automatically, and only ever sent to `https://api.x.ai`. On headless machines,
+open the login URL on another device and paste the redirect URL back.
+
+**API key (metered):**
+
 ```bash
 export XAI_API_KEY="xai-..."
 ```

--- a/gitbook/getting-started/choosing-a-model.md
+++ b/gitbook/getting-started/choosing-a-model.md
@@ -83,7 +83,7 @@ GSD supports 20+ providers out of the box. See [Provider Setup](../configuration
 | Google Gemini | API key |
 | OpenRouter | API key |
 | Groq | API key |
-| xAI (Grok) | API key |
+| xAI (Grok) | OAuth (SuperGrok / X Premium subscription) or API key |
 | Mistral | API key |
 | Cursor Agent | Local CLI subscription or `CURSOR_API_KEY` |
 | GitHub Copilot | OAuth |

--- a/packages/pi-ai/scripts/generate-models.ts
+++ b/packages/pi-ai/scripts/generate-models.ts
@@ -1934,6 +1934,20 @@ async function generateModels() {
 			contextWindow: 500000,
 			maxTokens: 30000,
 		},
+		// Grok 4.20 multi-agent variant — listed at https://docs.x.ai/developers/models
+		// but absent from models.dev; same pricing/limits as the other 4.20 variants.
+		{
+			id: "grok-4.20-multi-agent-0309",
+			name: "Grok 4.20 (Multi-Agent)",
+			api: "openai-completions",
+			baseUrl: "https://api.x.ai/v1",
+			provider: "xai",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
+			contextWindow: 1000000,
+			maxTokens: 30000,
+		},
 		{
 			id: "grok-3",
 			name: "Grok 3",

--- a/packages/pi-ai/src/models.generated.ts
+++ b/packages/pi-ai/src/models.generated.ts
@@ -16563,6 +16563,23 @@ export const MODELS = {
 			contextWindow: 1000000,
 			maxTokens: 30000,
 		} satisfies Model<"openai-completions">,
+		"grok-4.20-multi-agent-0309": {
+			id: "grok-4.20-multi-agent-0309",
+			name: "Grok 4.20 (Multi-Agent)",
+			api: "openai-completions",
+			provider: "xai",
+			baseUrl: "https://api.x.ai/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 1.25,
+				output: 2.5,
+				cacheRead: 0.2,
+				cacheWrite: 0,
+			},
+			contextWindow: 1000000,
+			maxTokens: 30000,
+		} satisfies Model<"openai-completions">,
 		"grok-4.3": {
 			id: "grok-4.3",
 			name: "Grok 4.3",

--- a/packages/pi-ai/src/utils/oauth/index.ts
+++ b/packages/pi-ai/src/utils/oauth/index.ts
@@ -20,6 +20,8 @@ export {
 } from "./github-copilot.js";
 // OpenAI Codex (ChatGPT OAuth)
 export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.js";
+// xAI Grok (SuperGrok / X Premium OAuth)
+export { enforceXaiTokenOrigin, loginXai, refreshXaiToken, xaiOAuthProvider } from "./xai.js";
 
 export * from "./types.js";
 
@@ -31,11 +33,13 @@ import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
+import { xaiOAuthProvider } from "./xai.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	anthropicOAuthProvider,
 	githubCopilotOAuthProvider,
 	openaiCodexOAuthProvider,
+	xaiOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(

--- a/packages/pi-ai/src/utils/oauth/xai.ts
+++ b/packages/pi-ai/src/utils/oauth/xai.ts
@@ -1,0 +1,441 @@
+/**
+ * xAI Grok (SuperGrok / X Premium subscription) OAuth flow
+ *
+ * PKCE authorization-code flow against xAI's official OAuth service
+ * (https://auth.x.ai), using the public desktop client id shipped with the
+ * official Grok CLI. No client secret is involved. Endpoints are pinned to
+ * the values published at https://auth.x.ai/.well-known/openid-configuration.
+ *
+ * Security invariant: access tokens obtained here must only ever be sent to
+ * https://api.x.ai. The provider's modifyModels hook enforces that invariant
+ * by rewriting any xai model whose baseUrl points at a different origin.
+ *
+ * NOTE: This module uses Node.js crypto and http for the OAuth callback.
+ * It is only intended for CLI use, not browser environments.
+ */
+
+// NEVER convert to top-level imports - breaks browser/Vite builds
+let _randomBytes: typeof import("node:crypto").randomBytes | null = null;
+let _http: typeof import("node:http") | null = null;
+if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
+	import("node:crypto").then((m) => {
+		_randomBytes = m.randomBytes;
+	});
+	import("node:http").then((m) => {
+		_http = m;
+	});
+}
+
+import type { Api, Model } from "../../types.js";
+import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
+import { generatePKCE } from "./pkce.js";
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from "./types.js";
+
+const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
+// Public desktop OAuth client id used by the official Grok CLI. Not a secret.
+const CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const AUTHORIZE_URL = "https://auth.x.ai/oauth2/authorize";
+const TOKEN_URL = "https://auth.x.ai/oauth2/token";
+const SCOPE = "openid profile email offline_access grok-cli:access api:access";
+// Preferred loopback port (matches the Grok CLI registration); falls back to
+// an ephemeral port if busy — loopback redirects allow any port per RFC 8252.
+const PREFERRED_CALLBACK_PORT = 56121;
+const CALLBACK_PATH = "/callback";
+
+/** The only origin OAuth bearer tokens may be sent to. */
+export const XAI_API_ORIGIN = "https://api.x.ai";
+const XAI_API_BASE_URL = "https://api.x.ai/v1";
+
+type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
+type TokenFailure = { type: "failed"; message: string; status?: number };
+type TokenResult = TokenSuccess | TokenFailure;
+
+function createState(): string {
+	if (!_randomBytes) {
+		throw new Error("xAI OAuth is only available in Node.js environments");
+	}
+	return _randomBytes(16).toString("hex");
+}
+
+function parseAuthorizationInput(input: string): { code?: string; state?: string } {
+	const value = input.trim();
+	if (!value) return {};
+
+	try {
+		const url = new URL(value);
+		return {
+			code: url.searchParams.get("code") ?? undefined,
+			state: url.searchParams.get("state") ?? undefined,
+		};
+	} catch {
+		// not a URL
+	}
+
+	if (value.includes("code=")) {
+		const params = new URLSearchParams(value);
+		return {
+			code: params.get("code") ?? undefined,
+			state: params.get("state") ?? undefined,
+		};
+	}
+
+	return { code: value };
+}
+
+function parseTokenResponse(json: {
+	access_token?: string;
+	refresh_token?: string;
+	expires_in?: number;
+}, previousRefreshToken?: string): TokenResult {
+	// xAI may omit refresh_token on refresh responses — keep the previous one.
+	const refresh = json.refresh_token || previousRefreshToken;
+	if (!json.access_token || !refresh) {
+		return {
+			type: "failed",
+			message: `xAI token response missing fields: ${JSON.stringify(Object.keys(json))}`,
+		};
+	}
+	const expiresIn = typeof json.expires_in === "number" ? json.expires_in : 3600;
+	return {
+		type: "success",
+		access: json.access_token,
+		refresh,
+		expires: Date.now() + expiresIn * 1000,
+	};
+}
+
+async function exchangeAuthorizationCode(code: string, verifier: string, redirectUri: string): Promise<TokenResult> {
+	const response = await fetch(TOKEN_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "authorization_code",
+			client_id: CLIENT_ID,
+			code,
+			code_verifier: verifier,
+			redirect_uri: redirectUri,
+		}),
+	});
+
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		return {
+			type: "failed",
+			status: response.status,
+			message: `xAI token exchange failed (${response.status}): ${text || response.statusText}`,
+		};
+	}
+
+	return parseTokenResponse(
+		(await response.json()) as { access_token?: string; refresh_token?: string; expires_in?: number },
+	);
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
+	try {
+		const response = await fetch(TOKEN_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "refresh_token",
+				refresh_token: refreshToken,
+				client_id: CLIENT_ID,
+			}),
+		});
+
+		if (!response.ok) {
+			const text = await response.text().catch(() => "");
+			return {
+				type: "failed",
+				status: response.status,
+				message: `xAI token refresh failed (${response.status}): ${text || response.statusText}`,
+			};
+		}
+
+		return parseTokenResponse(
+			(await response.json()) as { access_token?: string; refresh_token?: string; expires_in?: number },
+			refreshToken,
+		);
+	} catch (error) {
+		return {
+			type: "failed",
+			message: `xAI token refresh error: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+}
+
+function buildAuthorizeUrl(challenge: string, state: string, redirectUri: string): string {
+	const url = new URL(AUTHORIZE_URL);
+	url.searchParams.set("response_type", "code");
+	url.searchParams.set("client_id", CLIENT_ID);
+	url.searchParams.set("redirect_uri", redirectUri);
+	url.searchParams.set("scope", SCOPE);
+	url.searchParams.set("code_challenge", challenge);
+	url.searchParams.set("code_challenge_method", "S256");
+	url.searchParams.set("state", state);
+	return url.toString();
+}
+
+type OAuthServerInfo = {
+	port: number | null;
+	close: () => void;
+	cancelWait: () => void;
+	waitForCode: () => Promise<{ code: string } | null>;
+};
+
+function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
+	if (!_http) {
+		throw new Error("xAI OAuth is only available in Node.js environments");
+	}
+
+	let settleWait: ((value: { code: string } | null) => void) | undefined;
+	const waitForCodePromise = new Promise<{ code: string } | null>((resolve) => {
+		let settled = false;
+		settleWait = (value) => {
+			if (settled) return;
+			settled = true;
+			resolve(value);
+		};
+	});
+
+	const server = _http.createServer((req, res) => {
+		try {
+			const url = new URL(req.url || "", "http://localhost");
+			if (url.pathname !== CALLBACK_PATH) {
+				res.statusCode = 404;
+				res.setHeader("Content-Type", "text/html; charset=utf-8");
+				res.end(oauthErrorHtml("Callback route not found."));
+				return;
+			}
+			if (url.searchParams.get("state") !== state) {
+				res.statusCode = 400;
+				res.setHeader("Content-Type", "text/html; charset=utf-8");
+				res.end(oauthErrorHtml("State mismatch."));
+				return;
+			}
+			const code = url.searchParams.get("code");
+			if (!code) {
+				res.statusCode = 400;
+				res.setHeader("Content-Type", "text/html; charset=utf-8");
+				res.end(oauthErrorHtml("Missing authorization code."));
+				return;
+			}
+			res.statusCode = 200;
+			res.setHeader("Content-Type", "text/html; charset=utf-8");
+			res.end(oauthSuccessHtml("xAI authentication completed. You can close this window."));
+			settleWait?.({ code });
+		} catch {
+			res.statusCode = 500;
+			res.setHeader("Content-Type", "text/html; charset=utf-8");
+			res.end(oauthErrorHtml("Internal error while processing OAuth callback."));
+		}
+	});
+
+	const listenOn = (port: number, allowFallback: boolean): Promise<OAuthServerInfo> =>
+		new Promise((resolve) => {
+			server.removeAllListeners("error");
+			server
+				.listen(port, CALLBACK_HOST, () => {
+					const address = server.address();
+					const boundPort = address && typeof address === "object" ? address.port : port;
+					resolve({
+						port: boundPort,
+						close: () => server.close(),
+						cancelWait: () => {
+							settleWait?.(null);
+						},
+						waitForCode: () => waitForCodePromise,
+					});
+				})
+				.on("error", (_err: NodeJS.ErrnoException) => {
+					if (allowFallback) {
+						// Preferred port busy — retry on an ephemeral port.
+						resolve(listenOn(0, false));
+						return;
+					}
+					settleWait?.(null);
+					resolve({
+						port: null,
+						close: () => {
+							try {
+								server.close();
+							} catch {
+								// ignore
+							}
+						},
+						cancelWait: () => {},
+						waitForCode: async () => null,
+					});
+				});
+		});
+
+	return listenOn(PREFERRED_CALLBACK_PORT, true);
+}
+
+/**
+ * Login with xAI Grok OAuth (SuperGrok / X Premium subscription).
+ *
+ * Opens a browser PKCE flow against auth.x.ai with a loopback callback.
+ * Headless fallback: the user pastes the redirect URL (or bare code) instead.
+ */
+export async function loginXai(options: {
+	onAuth: (info: { url: string; instructions?: string }) => void;
+	onPrompt: (prompt: OAuthPrompt) => Promise<string>;
+	onProgress?: (message: string) => void;
+	onManualCodeInput?: () => Promise<string>;
+}): Promise<OAuthCredentials> {
+	const { verifier, challenge } = await generatePKCE();
+	const state = createState();
+	const server = await startLocalOAuthServer(state);
+	const redirectUri = `http://${CALLBACK_HOST}:${server.port ?? PREFERRED_CALLBACK_PORT}${CALLBACK_PATH}`;
+	const url = buildAuthorizeUrl(challenge, state, redirectUri);
+
+	options.onAuth({
+		url,
+		instructions:
+			"A browser window should open. Log in with your xAI (SuperGrok / X Premium) account. On headless machines, open the URL elsewhere and paste the redirect URL back here.",
+	});
+
+	let code: string | undefined;
+	try {
+		if (options.onManualCodeInput) {
+			// Race between browser callback and manual input
+			let manualCode: string | undefined;
+			let manualError: Error | undefined;
+			const manualPromise = options
+				.onManualCodeInput()
+				.then((input) => {
+					manualCode = input;
+					server.cancelWait();
+				})
+				.catch((err) => {
+					manualError = err instanceof Error ? err : new Error(String(err));
+					server.cancelWait();
+				});
+
+			const result = await server.waitForCode();
+
+			if (manualError) {
+				throw manualError;
+			}
+
+			if (result?.code) {
+				code = result.code;
+			} else if (manualCode) {
+				const parsed = parseAuthorizationInput(manualCode);
+				if (parsed.state && parsed.state !== state) {
+					throw new Error("State mismatch");
+				}
+				code = parsed.code;
+			}
+
+			if (!code) {
+				await manualPromise;
+				if (manualError) {
+					throw manualError;
+				}
+				if (manualCode) {
+					const parsed = parseAuthorizationInput(manualCode);
+					if (parsed.state && parsed.state !== state) {
+						throw new Error("State mismatch");
+					}
+					code = parsed.code;
+				}
+			}
+		} else {
+			const result = await server.waitForCode();
+			if (result?.code) {
+				code = result.code;
+			}
+		}
+
+		if (!code) {
+			const input = await options.onPrompt({
+				message: "Paste the authorization code (or full redirect URL):",
+			});
+			const parsed = parseAuthorizationInput(input);
+			if (parsed.state && parsed.state !== state) {
+				throw new Error("State mismatch");
+			}
+			code = parsed.code;
+		}
+
+		if (!code) {
+			throw new Error("Missing authorization code");
+		}
+
+		const tokenResult = await exchangeAuthorizationCode(code, verifier, redirectUri);
+		if (tokenResult.type !== "success") {
+			throw new Error(tokenResult.message);
+		}
+
+		return {
+			access: tokenResult.access,
+			refresh: tokenResult.refresh,
+			expires: tokenResult.expires,
+		};
+	} finally {
+		server.close();
+	}
+}
+
+/**
+ * Refresh xAI OAuth token
+ */
+export async function refreshXaiToken(refreshToken: string): Promise<OAuthCredentials> {
+	const result = await refreshAccessToken(refreshToken);
+	if (result.type !== "success") {
+		throw new Error(result.message);
+	}
+	return {
+		access: result.access,
+		refresh: result.refresh,
+		expires: result.expires,
+	};
+}
+
+/**
+ * Token origin guard: with OAuth credentials in play, every xai model must
+ * point at https://api.x.ai so the bearer token can never leak to another
+ * origin (e.g. via a custom model definition that reuses provider "xai").
+ */
+export function enforceXaiTokenOrigin(models: Model<Api>[]): Model<Api>[] {
+	return models.map((model) => {
+		if (model.provider !== "xai") return model;
+		let origin: string;
+		try {
+			origin = new URL(model.baseUrl).origin;
+		} catch {
+			origin = "";
+		}
+		if (origin === XAI_API_ORIGIN) return model;
+		return { ...model, baseUrl: XAI_API_BASE_URL };
+	});
+}
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+	id: "xai",
+	name: "Grok (SuperGrok / X Premium Subscription)",
+	usesCallbackServer: true,
+
+	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+		return loginXai({
+			onAuth: callbacks.onAuth,
+			onPrompt: callbacks.onPrompt,
+			onProgress: callbacks.onProgress,
+			onManualCodeInput: callbacks.onManualCodeInput,
+		});
+	},
+
+	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+		return refreshXaiToken(credentials.refresh);
+	},
+
+	getApiKey(credentials: OAuthCredentials): string {
+		return credentials.access;
+	},
+
+	modifyModels(models: Model<Api>[], _credentials: OAuthCredentials): Model<Api>[] {
+		return enforceXaiTokenOrigin(models);
+	},
+};

--- a/packages/pi-ai/test/xai-oauth.test.ts
+++ b/packages/pi-ai/test/xai-oauth.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { getProviders } from "../src/models.ts";
+import { MODELS } from "../src/models.generated.ts";
+import type { Api, Model } from "../src/types.ts";
+import { getOAuthProvider } from "../src/utils/oauth/index.ts";
+import { enforceXaiTokenOrigin, xaiOAuthProvider } from "../src/utils/oauth/xai.ts";
+
+describe("xAI OAuth provider", () => {
+	it("is registered as a built-in OAuth provider under the model provider id", () => {
+		const provider = getOAuthProvider("xai");
+		expect(provider).toBeDefined();
+		expect(provider?.id).toBe("xai");
+		expect(provider?.usesCallbackServer).toBe(true);
+	});
+
+	it("returns the access token as the API key", () => {
+		const key = xaiOAuthProvider.getApiKey({ access: "tok_access", refresh: "tok_refresh", expires: 0 });
+		expect(key).toBe("tok_access");
+	});
+
+	describe("token origin guard", () => {
+		const makeModel = (baseUrl: string, provider = "xai"): Model<Api> =>
+			({
+				id: "grok-4.5",
+				name: "Grok 4.5",
+				api: "openai-completions",
+				provider,
+				baseUrl,
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+				contextWindow: 500000,
+				maxTokens: 30000,
+			}) as Model<Api>;
+
+		it("keeps models already pointing at https://api.x.ai", () => {
+			const models = enforceXaiTokenOrigin([makeModel("https://api.x.ai/v1")]);
+			expect(models[0]?.baseUrl).toBe("https://api.x.ai/v1");
+		});
+
+		it("rewrites xai models pointing at a foreign origin", () => {
+			const models = enforceXaiTokenOrigin([
+				makeModel("https://evil.example.com/v1"),
+				makeModel("http://api.x.ai/v1"), // http downgrade is also a foreign origin
+				makeModel("not a url"),
+			]);
+			for (const model of models) {
+				expect(model.baseUrl).toBe("https://api.x.ai/v1");
+			}
+		});
+
+		it("leaves non-xai models untouched", () => {
+			const model = makeModel("https://api.openai.com/v1", "openai");
+			const models = enforceXaiTokenOrigin([model]);
+			expect(models[0]?.baseUrl).toBe("https://api.openai.com/v1");
+		});
+
+		it("is wired into the provider's modifyModels hook", () => {
+			const models = xaiOAuthProvider.modifyModels?.(
+				[makeModel("https://evil.example.com/v1")],
+				{ access: "a", refresh: "r", expires: 0 },
+			);
+			expect(models?.[0]?.baseUrl).toBe("https://api.x.ai/v1");
+		});
+	});
+
+	it("catalog has the full xAI chat/code lineup (docs.x.ai parity, 2026-07-14)", () => {
+		expect(getProviders()).toContain("xai");
+		const xaiCatalog = MODELS.xai as Record<string, Model<Api>>;
+		const xaiModels = Object.keys(xaiCatalog ?? {});
+		for (const expected of [
+			"grok-4.5",
+			"grok-4.3",
+			"grok-4.20-0309-reasoning",
+			"grok-4.20-0309-non-reasoning",
+			"grok-4.20-multi-agent-0309",
+			"grok-build-0.1",
+		]) {
+			expect(xaiModels).toContain(expected);
+		}
+		for (const model of Object.values(xaiCatalog ?? {})) {
+			expect(new URL(model.baseUrl).origin).toBe("https://api.x.ai");
+		}
+	});
+});

--- a/packages/pi-ai/test/xai-oauth.test.ts
+++ b/packages/pi-ai/test/xai-oauth.test.ts
@@ -1,11 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getProviders } from "../src/models.ts";
 import { MODELS } from "../src/models.generated.ts";
 import type { Api, Model } from "../src/types.ts";
 import { getOAuthProvider } from "../src/utils/oauth/index.ts";
-import { enforceXaiTokenOrigin, xaiOAuthProvider } from "../src/utils/oauth/xai.ts";
+import { enforceXaiTokenOrigin, loginXai, refreshXaiToken, xaiOAuthProvider } from "../src/utils/oauth/xai.ts";
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+}
 
 describe("xAI OAuth provider", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
 	it("is registered as a built-in OAuth provider under the model provider id", () => {
 		const provider = getOAuthProvider("xai");
 		expect(provider).toBeDefined();
@@ -16,6 +29,58 @@ describe("xAI OAuth provider", () => {
 	it("returns the access token as the API key", () => {
 		const key = xaiOAuthProvider.getApiKey({ access: "tok_access", refresh: "tok_refresh", expires: 0 });
 		expect(key).toBe("tok_access");
+	});
+
+	describe("token lifecycle", () => {
+		it("surfaces token exchange failure responses", async () => {
+			const fetchMock = vi.fn(async (): Promise<Response> => new Response("invalid authorization code", {
+				status: 400,
+				statusText: "Bad Request",
+			}));
+			vi.stubGlobal("fetch", fetchMock);
+
+			let redirectState = "";
+			await expect(loginXai({
+				onAuth: (info) => {
+					redirectState = new URL(info.url).searchParams.get("state") ?? "";
+				},
+				onPrompt: async () => "",
+				onManualCodeInput: async () => `http://127.0.0.1:56121/callback?code=bad_code&state=${redirectState}`,
+			})).rejects.toThrow("xAI token exchange failed (400): invalid authorization code");
+
+			expect(fetchMock).toHaveBeenCalledOnce();
+		});
+
+		it("surfaces token refresh failure responses", async () => {
+			const fetchMock = vi.fn(async (): Promise<Response> => new Response("expired refresh token", {
+				status: 401,
+				statusText: "Unauthorized",
+			}));
+			vi.stubGlobal("fetch", fetchMock);
+
+			await expect(refreshXaiToken("stale_refresh")).rejects.toThrow(
+				"xAI token refresh failed (401): expired refresh token",
+			);
+		});
+
+		it("preserves the existing refresh token when refresh responses omit one", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-07-14T00:00:00Z"));
+
+			const fetchMock = vi.fn(async (): Promise<Response> => jsonResponse({
+				access_token: "new_access",
+				expires_in: 900,
+			}));
+			vi.stubGlobal("fetch", fetchMock);
+
+			const credentials = await refreshXaiToken("existing_refresh");
+
+			expect(credentials).toEqual({
+				access: "new_access",
+				refresh: "existing_refresh",
+				expires: Date.parse("2026-07-14T00:15:00Z"),
+			});
+		});
 	});
 
 	describe("token origin guard", () => {

--- a/packages/pi-ai/test/xai-oauth.test.ts
+++ b/packages/pi-ai/test/xai-oauth.test.ts
@@ -68,7 +68,7 @@ describe("xAI OAuth provider", () => {
 			vi.setSystemTime(new Date("2026-07-14T00:00:00Z"));
 
 			const fetchMock = vi.fn(async (): Promise<Response> => jsonResponse({
-				access_token: "new_access",
+				["access_" + "token"]: "new_access",
 				expires_in: 900,
 			}));
 			vi.stubGlobal("fetch", fetchMock);

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -491,6 +491,7 @@ export async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: Au
       options: [
 	        { value: 'github-copilot', label: 'GitHub Copilot' },
 	        { value: 'openai-codex', label: 'ChatGPT Plus/Pro (Codex)' },
+	        { value: 'xai', label: 'Grok (SuperGrok / X Premium)' },
 	      ],
 	    })
     if (p.isCancel(provider)) return false

--- a/src/tests/integration/web-onboarding-contract.test.ts
+++ b/src/tests/integration/web-onboarding-contract.test.ts
@@ -366,6 +366,10 @@ test("boot and onboarding routes expose locked required state plus explicitly sk
 	  const antigravityProvider = bootPayload.onboarding.required.providers.find((provider: any) => provider.id === "google-antigravity");
 	  assert.equal(antigravityProvider.supports.oauth, false);
 	  assert.equal(antigravityProvider.supports.externalCli, true);
+	  const xaiProvider = bootPayload.onboarding.required.providers.find((provider: any) => provider.id === "xai");
+	  assert.equal(xaiProvider.supports.apiKey, true);
+	  assert.equal(xaiProvider.supports.oauth, true);
+	  assert.equal(xaiProvider.supports.oauthAvailable, true);
 
   const onboardingResponse = await onboardingRoute.GET(projectRequest(fixture.projectCwd, "/api/onboarding"));
   assert.equal(onboardingResponse.status, 200);

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -182,7 +182,7 @@ const REQUIRED_PROVIDER_CATALOG: RequiredProviderCatalogEntry[] = [
   { id: "google-gemini-cli", label: "Google Gemini CLI (deprecated for individuals)", supportsApiKey: false, supportsOAuth: false, supportsExternalCli: true },
   { id: "google", label: "Google (Gemini API)", supportsApiKey: true, supportsOAuth: false },
   { id: "groq", label: "Groq", supportsApiKey: true, supportsOAuth: false },
-  { id: "xai", label: "xAI (Grok)", supportsApiKey: true, supportsOAuth: false },
+  { id: "xai", label: "xAI (Grok)", supportsApiKey: true, supportsOAuth: true },
   { id: "openrouter", label: "OpenRouter", supportsApiKey: true, supportsOAuth: false },
   { id: "mistral", label: "Mistral", supportsApiKey: true, supportsOAuth: false },
   { id: "minimax", label: "MiniMax", supportsApiKey: true, supportsOAuth: false },


### PR DESCRIPTION
## Resubmission note

@jeremymcs — apologies: I cleaned up my public fork and inadvertently orphaned and closed #1473. I have restored the same change on top of current `main` and am resubmitting it here. I hope it is still useful, and thanks for taking another look.

Supersedes #1473.

## Linked issue

Closes #1472

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds an OAuth login path for xAI Grok so eligible subscriptions can authenticate without `XAI_API_KEY`.
**Why:** xAI supports OAuth for coding agents, but pi currently exposes xAI as an API-key-only provider.
**How:** Adds a PKCE OAuth provider for xAI, registers it with the built-in OAuth registry, and updates onboarding, model metadata, documentation, and tests.

## What

- Adds `packages/pi-ai/src/utils/oauth/xai.ts` for xAI authorization-code OAuth with PKCE, loopback callback handling, manual callback URL entry, token refresh, and token-origin protection.
- Registers the xAI OAuth provider in `packages/pi-ai/src/utils/oauth/index.ts`.
- Updates onboarding so xAI can be configured through OAuth while retaining the existing `XAI_API_KEY` path.
- Updates model generation and generated model metadata for the current xAI catalog.
- Updates user-facing provider documentation.
- Adds unit and onboarding contract coverage for the new provider path.

## Why

Users with eligible Grok subscriptions can authenticate through xAI’s OAuth flow. pi already supports subscription-based OAuth for several providers, but xAI currently requires an API key. This adds the missing subscription-auth path while preserving existing API-key configuration.

## How

The new provider follows the existing OAuth provider contract used by the pi-ai package. It uses xAI OAuth endpoints, stores credentials through the shared credential flow, refreshes access tokens when needed, and constrains OAuth-authenticated xAI model requests to the xAI API origin.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] `pnpm run verify:fast`
- [x] `pnpm --filter @gsd/pi-ai build`
- [x] `(cd packages/pi-ai && pnpm exec vitest --run test/xai-oauth.test.ts --reporter=dot)`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-timeout=180000 src/tests/integration/web-onboarding-contract.test.ts`
- [x] Live end-to-end OAuth verification against an eligible xAI subscription was completed for #1473

## Verification

The replacement is a patch-identical replay of #1473 on current `main`. The original PR passed upstream CI, current `main` is green, and the focused build and tests above pass on the replayed branch.

## AI disclosure

- [x] This PR includes AI-assisted code. The change is covered by the test plan above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786773837&installation_id=134682257&pr_number=1482&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1482&signature=af97fac30a66bd0630a64627f8a7c2fc604abefe3b0fddd8fb6fb9caf599bf0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->