### PR TITLE
test(gsd): stabilize context-store latency test

### DIFF
--- a/src/resources/extensions/gsd/tests/context-store.test.ts
+++ b/src/resources/extensions/gsd/tests/context-store.test.ts
@@ -315,7 +315,7 @@ describe("context-store: formatRequirementsForPrompt", () => {
 describe("context-store: sub-5ms query timing", () => {
   afterEach(() => closeDatabase());
 
-  test("queries complete under 5ms for 50+50 rows", () => {
+  test("median CPU time and minimum latency stay under the query threshold for 50+50 rows", () => {
     openDatabase(':memory:');
 
     // Insert 50 decisions

--- a/src/resources/extensions/gsd/tests/context-store.test.ts
+++ b/src/resources/extensions/gsd/tests/context-store.test.ts
@@ -357,17 +357,22 @@ describe("context-store: sub-5ms query timing", () => {
     queryDecisions();
     queryRequirements();
 
-    const start = performance.now();
-    const decisions = queryDecisions();
-    const requirements = queryRequirements();
-    const elapsed = performance.now() - start;
+    const samples = Array.from({ length: 7 }, () => {
+      const start = performance.now();
+      const decisions = queryDecisions();
+      const requirements = queryRequirements();
+      const elapsed = performance.now() - start;
 
-    assert.strictEqual(decisions.length, 50, `got ${decisions.length} decisions (expected 50)`);
-    assert.strictEqual(requirements.length, 50, `got ${requirements.length} requirements (expected 50)`);
+      assert.strictEqual(decisions.length, 50, `got ${decisions.length} decisions (expected 50)`);
+      assert.strictEqual(requirements.length, 50, `got ${requirements.length} requirements (expected 50)`);
+      return elapsed;
+    });
+    const sortedSamples = [...samples].sort((a, b) => a - b);
+    const median = sortedSamples[Math.floor(sortedSamples.length / 2)];
     const maxLatencyMs = process.env.NODE_V8_COVERAGE ? 15 : 5;
     assert.ok(
-      elapsed < maxLatencyMs,
-      `query latency ${elapsed.toFixed(2)}ms should be < ${maxLatencyMs}ms`,
+      median < maxLatencyMs,
+      `median query latency ${median.toFixed(2)}ms should be < ${maxLatencyMs}ms (samples: ${samples.map((sample) => sample.toFixed(2)).join(", ")}ms)`,
     );
   });
 });

--- a/src/resources/extensions/gsd/tests/context-store.test.ts
+++ b/src/resources/extensions/gsd/tests/context-store.test.ts
@@ -358,21 +358,21 @@ describe("context-store: sub-5ms query timing", () => {
     queryRequirements();
 
     const samples = Array.from({ length: 7 }, () => {
-      const start = performance.now();
+      const start = process.cpuUsage();
       const decisions = queryDecisions();
       const requirements = queryRequirements();
-      const elapsed = performance.now() - start;
+      const { user, system } = process.cpuUsage(start);
 
       assert.strictEqual(decisions.length, 50, `got ${decisions.length} decisions (expected 50)`);
       assert.strictEqual(requirements.length, 50, `got ${requirements.length} requirements (expected 50)`);
-      return elapsed;
+      return (user + system) / 1_000;
     });
     const sortedSamples = [...samples].sort((a, b) => a - b);
     const median = sortedSamples[Math.floor(sortedSamples.length / 2)];
     const maxLatencyMs = process.env.NODE_V8_COVERAGE ? 15 : 5;
     assert.ok(
       median < maxLatencyMs,
-      `median query latency ${median.toFixed(2)}ms should be < ${maxLatencyMs}ms (samples: ${samples.map((sample) => sample.toFixed(2)).join(", ")}ms)`,
+      `median query CPU time ${median.toFixed(2)}ms should be < ${maxLatencyMs}ms (samples: ${samples.map((sample) => sample.toFixed(2)).join(", ")}ms)`,
     );
   });
 });

--- a/src/resources/extensions/gsd/tests/context-store.test.ts
+++ b/src/resources/extensions/gsd/tests/context-store.test.ts
@@ -309,7 +309,7 @@ describe("context-store: formatRequirementsForPrompt", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// context-store: sub-5ms median CPU-time assertion
+// context-store: sub-5ms timing assertion
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("context-store: sub-5ms query timing", () => {
@@ -353,26 +353,32 @@ describe("context-store: sub-5ms query timing", () => {
       });
     }
 
-    // Warm first. CPU time excludes scheduler stalls; the median still exposes persistent query regressions.
     queryDecisions();
     queryRequirements();
 
     const samples = Array.from({ length: 7 }, () => {
-      const start = process.cpuUsage();
+      const cpuStart = process.cpuUsage();
+      const elapsedStart = performance.now();
       const decisions = queryDecisions();
       const requirements = queryRequirements();
-      const { user, system } = process.cpuUsage(start);
+      const elapsedTimeMs = performance.now() - elapsedStart;
+      const { user, system } = process.cpuUsage(cpuStart);
 
       assert.strictEqual(decisions.length, 50, `got ${decisions.length} decisions (expected 50)`);
       assert.strictEqual(requirements.length, 50, `got ${requirements.length} requirements (expected 50)`);
-      return (user + system) / 1_000;
+      return { cpuTimeMs: (user + system) / 1_000, elapsedTimeMs };
     });
-    const sortedSamples = [...samples].sort((a, b) => a - b);
-    const median = sortedSamples[Math.floor(sortedSamples.length / 2)];
+    const cpuTimeSamplesMs = samples.map(({ cpuTimeMs }) => cpuTimeMs).sort((a, b) => a - b);
+    const medianCpuTimeMs = cpuTimeSamplesMs[Math.floor(cpuTimeSamplesMs.length / 2)];
+    const minElapsedTimeMs = Math.min(...samples.map(({ elapsedTimeMs }) => elapsedTimeMs));
     const maxLatencyMs = process.env.NODE_V8_COVERAGE ? 15 : 5;
     assert.ok(
-      median < maxLatencyMs,
-      `median query CPU time ${median.toFixed(2)}ms should be < ${maxLatencyMs}ms (samples: ${samples.map((sample) => sample.toFixed(2)).join(", ")}ms)`,
+      medianCpuTimeMs < maxLatencyMs,
+      `median query CPU time ${medianCpuTimeMs.toFixed(2)}ms should be < ${maxLatencyMs}ms (samples: ${samples.map(({ cpuTimeMs }) => cpuTimeMs.toFixed(2)).join(", ")}ms)`,
+    );
+    assert.ok(
+      minElapsedTimeMs < maxLatencyMs,
+      `minimum query latency ${minElapsedTimeMs.toFixed(2)}ms should be < ${maxLatencyMs}ms (samples: ${samples.map(({ elapsedTimeMs }) => elapsedTimeMs.toFixed(2)).join(", ")}ms)`,
     );
   });
 });

--- a/src/resources/extensions/gsd/tests/context-store.test.ts
+++ b/src/resources/extensions/gsd/tests/context-store.test.ts
@@ -309,7 +309,7 @@ describe("context-store: formatRequirementsForPrompt", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// context-store: sub-5ms timing assertion
+// context-store: sub-5ms median CPU-time assertion
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("context-store: sub-5ms query timing", () => {
@@ -353,7 +353,7 @@ describe("context-store: sub-5ms query timing", () => {
       });
     }
 
-    // Time the queries — warm up first
+    // Warm first. CPU time excludes scheduler stalls; the median still exposes persistent query regressions.
     queryDecisions();
     queryRequirements();
 


### PR DESCRIPTION
## Intent

Make the context-store sub-5ms performance test deterministic under scheduler contention while preserving detection of persistent query regressions.

## What Changed

- Replace the single wall-clock latency measurement with seven warmed query samples, checking median CPU time and minimum elapsed time against the existing threshold.
- Validate decision and requirement counts for every sample and report all timings when an assertion fails.
- Rename the test to document its CPU-time and wall-latency contract.

## Risk Assessment

🚨 High: The follow-up restores persistent blocking-regression coverage but still contradicts the required scheduler-contention determinism under sustained contention.

## Testing

Repository checks, focused execution, 20 heavily contended repetitions, pre-change RED reproduction, persistent-regression sabotage, and the complete context-store test file all behaved as intended; evidence transcripts were captured and the final worktree remained clean.

<details>
<summary>Evidence: Contention stability transcript</summary>

```text
Context-store latency stability under scheduler contention
logical_cpus=10 cpu_bound_contenders=40 repeated_runs=20 threshold_ms=5
run=01 result=PASS
run=02 result=PASS
run=03 result=PASS
run=04 result=PASS
run=05 result=PASS
run=06 result=PASS
run=07 result=PASS
run=08 result=PASS
run=09 result=PASS
run=10 result=PASS
run=11 result=PASS
run=12 result=PASS
run=13 result=PASS
run=14 result=PASS
run=15 result=PASS
run=16 result=PASS
run=17 result=PASS
run=18 result=PASS
run=19 result=PASS
run=20 result=PASS
aggregate=20/20 passed
```
</details>
<details>
<summary>Evidence: Pre-change contention failure</summary>

```text
Pre-change wall-clock assertion under scheduler contention (expected RED)
logical_cpus=10 cpu_bound_contenders=40 repeated_runs=20 threshold_ms=5
run=01 result=PASS
run=02 result=PASS
run=03 result=PASS
run=04 result=PASS
run=05 result=PASS
run=06 result=PASS
run=07 result=PASS
run=08 result=PASS
run=09 result=PASS
run=10 result=PASS
run=11 result=PASS
run=12 result=PASS
run=13 result=PASS
run=14 result=PASS
run=15 result=PASS
run=16 result=PASS
run=17 result=FAIL
run=18 result=PASS
run=19 result=PASS
run=20 result=PASS
aggregate=19/20 passed; 1/20 failed as expected
observed_assertions:
  AssertionError [ERR_ASSERTION]: query latency 69.64ms should be < 5ms
```
</details>
<details>
<summary>Evidence: Persistent-regression detection</summary>

```text
Persistent query regression sabotage (expected RED)
sabotage=queryDecisions consumes at least 6ms CPU per call threshold_ms=5 exit_code=1
  AssertionError [ERR_ASSERTION]: median query CPU time 6.25ms should be < 5ms (samples: 7.05, 6.23, 6.22, 6.26, 6.33, 6.25, 6.22ms)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `src/resources/extensions/gsd/tests/context-store.test.ts:361` - The required criterion says to preserve “detection of persistent query regressions,” but the diff replaces elapsed wall time with `process.cpuUsage()`. CPU time excludes synchronous waiting, so a persistent regression caused by database locking, filesystem I/O, or another blocking dependency could exceed 5ms while this test still passes. Please confirm that only CPU-bound regressions are in scope, or retain a contention-tolerant elapsed-time signal as well.

🔧 Fix: Preserve wall-latency regression detection under contention
1 error still open:
- 🚨 `src/resources/extensions/gsd/tests/context-store.test.ts:380` - The intent requires the test to be “deterministic under scheduler contention,” but the new `minElapsedTimeMs &lt; maxLatencyMs` assertion still fails whenever contention delays all seven wall-clock samples. Taking the minimum reduces the probability of a false failure without removing scheduler dependence; please confirm probabilistic tolerance is acceptable or use a persistent-regression signal that cannot be tripped by descheduling.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 023e6537d8afcd74af7981c635b35827338f90b8..01433e6ee1f06a92e7bcc2b8772187f79a53b505 -- src/resources/extensions/gsd/tests/context-store.test.ts` and confirmed the target is not merged into `origin/main`.</code>
- <code>Ran `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern=&#39;sub-5ms|under 5ms&#39; src/resources/extensions/gsd/tests/context-store.test.ts`.</code>
- <code>Ran 20 focused-test invocations while 40 instances of `node -e &#39;let x=1; for (;;) x=Math.sqrt(x+1)&#39;` contended for 10 logical CPUs; all completed successfully.</code>
- <code>Temporarily restored the base commit’s wall-clock assertion and repeated the contention harness; it reproduced the flake with `query latency 69.64ms should be &lt; 5ms`, then was restored.</code>
- <code>Temporarily injected a persistent 6,000µs CPU delay into `queryDecisions` and reran the focused test; the target test rejected it with a 6.25ms median, then the sabotage was removed.</code>
- <code>Ran `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/context-store.test.ts`.</code>
- <code>Ran `git diff --exit-code`, `git status --short --branch`, and checked for leftover contention processes.</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `src/resources/extensions/gsd/tests/context-store.test.ts:318` - The test title says queries generally complete under 5ms, but the new contract only requires the median CPU sample and minimum wall-clock sample across seven runs to meet the threshold. Renaming this test would clarify the authoritative contract, but test-source edits are outside this documentation/doc-comment-only pass.

🔧 Fix: Clarify context-store latency test contract
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to timing methodology; no production query or context-store behavior is modified.
> 
> **Overview**
> **Stabilizes** the context-store “sub-5ms” performance test so it is less flaky under heavy CPU contention while still catching real query slowdowns.
> 
> The test no longer uses one post-warmup `performance.now()` window. It runs **seven** paired `queryDecisions` + `queryRequirements` samples on 50+50 in-memory rows, checks row counts on every sample, and enforces the existing threshold (5ms, or 15ms when `NODE_V8_COVERAGE` is set) on **median `process.cpuUsage()`** and on the **minimum** elapsed time across samples. Assertion failures now list all CPU and wall-clock sample values. The test name was updated to match that contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e066398fb4dec6c8f3c20363de62320d659e47ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->