### PR TITLE
fix(issue): fix(pi-tui): #677's scrollback-clamp guard only covers appendedLines=true; same-length reflow still duplicates a boundary line

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -1485,27 +1485,16 @@ export class TUI extends Container {
 		}
 
 		const previousContentViewportTop = getViewportTop(this.previousLines.length);
-		let clampedToViewport = false;
 		if (firstChanged < previousContentViewportTop) {
-			if (appendedLines) {
-				// A mid-buffer insertion (e.g. a markdown code-fence border materialising)
-				// shifted a line across the scrollback/viewport boundary.  Clamping would
-				// leave the displaced line frozen in scrollback AND re-emit it in the live
-				// region, producing a verbatim duplicate.  Fall back to a clean repaint.
-				logRedraw(
-					`firstChanged < viewportTop + buffer grew (${firstChanged} < ${previousContentViewportTop}) — full repaint to avoid duplicate`,
-				);
-				fullRender(true);
-				return;
-			}
-			const newViewportTop = getViewportTop(newLines.length);
-			const clampedFirst = Math.max(0, Math.min(previousContentViewportTop, newViewportTop));
+			// A mid-buffer reflow (for example markdown code-fence borders or prose word-wrap)
+			// shifted a line across the scrollback/viewport boundary. Clamping would leave
+			// the displaced line frozen in scrollback and re-emit it in the live region,
+			// producing a verbatim duplicate. Fall back to a clean repaint.
 			logRedraw(
-				`firstChanged < viewportTop (${firstChanged} < ${previousContentViewportTop}) — repaint from ${clampedFirst}`,
+				`firstChanged < viewportTop (${firstChanged} < ${previousContentViewportTop}) — full repaint to avoid duplicate`,
 			);
-			firstChanged = clampedFirst;
-			lastChanged = Math.max(lastChanged, newLines.length - 1);
-			clampedToViewport = true;
+			fullRender(true);
+			return;
 		}
 
 		let buffer = this.useSynchronizedOutput ? "\x1b[?2026h" : "";
@@ -1560,7 +1549,7 @@ export class TUI extends Container {
 		// Track where cursor ended up after rendering
 		let finalCursorRow = renderEnd;
 
-		if (this.previousLines.length > newLines.length && !clampedToViewport) {
+		if (this.previousLines.length > newLines.length) {
 			const renderEndScreenRow = renderEnd - viewportTop;
 			const ghostLinesVisible = renderEndScreenRow < height - 1;
 			if (ghostLinesVisible) {
@@ -1617,11 +1606,7 @@ export class TUI extends Container {
 		// hardwareCursorRow tracks actual terminal cursor position (for movement)
 		this.cursorRow = Math.max(0, newLines.length - 1);
 		this.hardwareCursorRow = finalCursorRow;
-		if (clampedToViewport && newLines.length < this.maxLinesRendered) {
-			this.maxLinesRendered = newLines.length;
-		} else {
-			this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
-		}
+		this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
 		this.previousViewportTop = getViewportTop(this.maxLinesRendered);
 
 		// Position hardware cursor for IME

--- a/packages/pi-tui/test/tui-render.test.ts
+++ b/packages/pi-tui/test/tui-render.test.ts
@@ -355,6 +355,63 @@ describe("TUI mid-buffer reflow", () => {
 
 		tui.stop();
 	});
+
+	it("triggers full repaint when a same-length reflow shifts a change into committed scrollback", async () => {
+		// 9 lines in a height-5 terminal leaves indices 0-3 in committed scrollback.
+		const terminal = new VirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = [
+			"Line 0",
+			"Line 1",
+			"Line 2",
+			"BOUNDARY",
+			"Line 4",
+			"Line 5",
+			"Line 6",
+			"Line 7",
+			"Line 8",
+		];
+		tui.start();
+		await terminal.waitForRender();
+
+		const redrawsBefore = tui.fullRedraws;
+
+		// Move BOUNDARY from old index 3 (committed scrollback) to new index 4
+		// without changing the total line count. The old clamp path repainted from
+		// index 4 downward and left BOUNDARY duplicated across scrollback + viewport.
+		const reflowedLines = [
+			"Line 0",
+			"Line 1",
+			"REFLOW",
+			"Line 2",
+			"BOUNDARY",
+			"Line 5",
+			"Line 6",
+			"Line 7",
+			"Line 8",
+		];
+		component.lines = reflowedLines;
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.ok(
+			tui.fullRedraws > redrawsBefore,
+			"same-length reflow reaching into committed scrollback must trigger a full repaint",
+		);
+
+		const currentFrame = terminal.getScrollBuffer().slice(-reflowedLines.length);
+		assert.deepStrictEqual(currentFrame, reflowedLines);
+		assert.strictEqual(
+			currentFrame.filter((line) => line === "BOUNDARY").length,
+			1,
+			"moved boundary line should not be duplicated across the current frame",
+		);
+
+		tui.stop();
+	});
 });
 
 describe("TUI differential rendering", () => {


### PR DESCRIPTION
## Summary
- Fixed same-length TUI scrollback reflows to force full repaint and added regression coverage; whitespace verification passed while focused tests were blocked by missing dependencies/network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1486
- [#1486 fix(pi-tui): #677's scrollback-clamp guard only covers appendedLines=true; same-length reflow still duplicates a boundary line](https://github.com/open-gsd/gsd-pi/issues/1486)

## User
- @diakula

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1486-fix-pi-tui-677-s-scrollback-clamp-guard--1784304230`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to pi-tui differential redraw heuristics with a targeted regression test; no auth, data, or API surface impact.
> 
> **Overview**
> Fixes **duplicate boundary lines** when markdown or word-wrap reflows move content across the scrollback/viewport edge **without** growing the buffer—behavior that previously only triggered a full repaint when `appendedLines` was true.
> 
> When `firstChanged` is above committed scrollback (`firstChanged < previousContentViewportTop`), differential rendering now **always** calls `fullRender(true)` instead of clamping the repaint start to the viewport. The old clamp path could leave a line frozen in scrollback while repainting it in the live region.
> 
> Related cleanup removes the `clampedToViewport` branch for ghost-line clearing and `maxLinesRendered` adjustment. A regression test covers same-length reflow that moves a boundary line from scrollback into the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d90e9e002aaea71b9ec8c61354313ff80052cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->