### PR TITLE
fix(issue): [Bug]: Why isn't it generating? 01-RESEARCH.md、01-01-UI-SPEC.md

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -391,15 +391,15 @@ export function registerDbTools(pi: ExtensionAPI): void {
     name: "gsd_summary_save",
     label: "Save Summary",
     description:
-      "Save a summary, research, context, or assessment artifact to the GSD database and write it to disk. " +
+      "Save a summary, research, UI spec, context, or assessment artifact to the GSD database and write it to disk. " +
       "Computes the file path from milestone/slice/task IDs automatically.",
-    promptSnippet: "Save a GSD artifact (summary/research/context/assessment) to DB and disk",
+    promptSnippet: "Save a GSD artifact (summary/research/UI spec/context/assessment) to DB and disk",
     promptGuidelines: [
-      "Use gsd_summary_save to persist structured artifacts (SUMMARY, RESEARCH, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT).",
+      "Use gsd_summary_save to persist structured artifacts (SUMMARY, RESEARCH, UI-SPEC, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT).",
       "milestone_id is required for milestone/slice/task artifacts. Omit milestone_id only for root-level PROJECT/PROJECT-DRAFT/REQUIREMENTS/REQUIREMENTS-DRAFT.",
       "The tool computes the relative path automatically: milestones/M001/M001-SUMMARY.md, milestones/M001/slices/S01/S01-SUMMARY.md, etc.",
       "Root-level artifact paths are PROJECT.md, PROJECT-DRAFT.md, REQUIREMENTS.md, and REQUIREMENTS-DRAFT.md.",
-      "artifact_type must be one of: SUMMARY, RESEARCH, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT.",
+      "artifact_type must be one of: SUMMARY, RESEARCH, UI-SPEC, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT.",
       "Use CONTEXT-DRAFT for incremental draft persistence; use CONTEXT for the final milestone context after depth verification.",
       `Keep each content payload under ${SUMMARY_SAVE_CONTENT_MAX_LENGTH} characters; save large context incrementally with CONTEXT-DRAFT/PROJECT-DRAFT/REQUIREMENTS-DRAFT instead of one oversized call.`,
     ],
@@ -407,7 +407,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       milestone_id: Type.Optional(Type.String({ description: "Milestone ID (e.g. M001). Omit only for root-level PROJECT/PROJECT-DRAFT/REQUIREMENTS/REQUIREMENTS-DRAFT artifacts." })),
       slice_id: Type.Optional(Type.String({ description: "Slice ID (e.g. S01)" })),
       task_id: Type.Optional(Type.String({ description: "Task ID (e.g. T01)" })),
-      artifact_type: StringEnum(["SUMMARY", "RESEARCH", "CONTEXT", "ASSESSMENT", "CONTEXT-DRAFT", "PROJECT", "PROJECT-DRAFT", "REQUIREMENTS", "REQUIREMENTS-DRAFT"], { description: "Artifact type to save" }),
+      artifact_type: StringEnum(["SUMMARY", "RESEARCH", "UI-SPEC", "CONTEXT", "ASSESSMENT", "CONTEXT-DRAFT", "PROJECT", "PROJECT-DRAFT", "REQUIREMENTS", "REQUIREMENTS-DRAFT"], { description: "Artifact type to save" }),
       content: Type.String({
         description: `The full markdown content of the artifact. Maximum ${SUMMARY_SAVE_CONTENT_MAX_LENGTH} characters per save.`,
         maxLength: SUMMARY_SAVE_CONTENT_MAX_LENGTH,

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -181,6 +181,7 @@ export const PLANNING_ARTIFACT_SUFFIXES: readonly string[] = [
   "REPLAN",
   "SUMMARY",
   "RESEARCH",
+  "UI-SPEC",
   "VALIDATION",
   "ASSESSMENT",
   "UAT",

--- a/src/resources/extensions/gsd/prompts/plan-phase.md
+++ b/src/resources/extensions/gsd/prompts/plan-phase.md
@@ -14,7 +14,7 @@ You are running the GSD **plan-phase** workflow — create a detailed plan for a
 
 1. **Load authoritative context.** Read the milestone ROADMAP entry, CONTEXT, RESEARCH, the Decisions Register, and the discuss outcomes. Take a bounded codebase snapshot to ground the plan in current code reality.
 
-2. **Research (unless skipped).** If open questions remain and `--skip-research` is off, run a bounded research pass (grounded in the snapshot, not an open-ended survey). Fold findings into RESEARCH.
+2. **Research (unless skipped).** If open questions remain and `--skip-research` is off, run a bounded research pass (grounded in the snapshot, not an open-ended survey). Before writing the plan, call `gsd_summary_save` with `artifact_type: "RESEARCH"` and the applicable `milestone_id` / `slice_id` so the durable RESEARCH artifact exists.
 
 3. **Decompose into slices/tasks.** Break the milestone into ordered, independently-verifiable slices; break each slice into concrete tasks. Each task has a clear definition of done and a verification method.
 
@@ -22,7 +22,7 @@ You are running the GSD **plan-phase** workflow — create a detailed plan for a
 
 5. **Verification loop.** Self-review the plan for gaps: missing tasks, unclear acceptance, orphaned requirements, unrealistic ordering. Revise until the plan is internally consistent.
 
-6. **Write the plan** to the milestone/slice's plan artifact in `.gsd/`. Record durable decisions via `/gsd knowledge rule`.
+6. **Write the plan** to the milestone/slice's plan artifact in `.gsd/` only after required RESEARCH/UI-SPEC inputs are saved or explicitly skipped. Record durable decisions via `/gsd knowledge rule`.
 
 7. **Route.** Recommend `/gsd dispatch execute` (or `/gsd next`).
 

--- a/src/resources/extensions/gsd/prompts/ui-phase.md
+++ b/src/resources/extensions/gsd/prompts/ui-phase.md
@@ -19,7 +19,7 @@ You are running the GSD **ui-phase** workflow — produce a UI design contract (
 
 4. **Align on constraints.** Brand, type scale, color tokens, spacing system, component library — use existing design tokens where they exist; flag gaps.
 
-5. **Write the UI-SPEC** to the milestone/slice artifact in `.gsd/`. Recommend `/gsd sketch` to prototype high-uncertainty surfaces, or `/gsd plan-phase` to plan implementation.
+5. **Write the UI-SPEC** by calling `gsd_summary_save` with `artifact_type: "UI-SPEC"` and the applicable `milestone_id` / `slice_id`. This persists the milestone/slice UI design contract to the computed `.gsd/` artifact path before implementation planning. Recommend `/gsd sketch` to prototype high-uncertainty surfaces, or `/gsd plan-phase` to plan implementation.
 
 ## Success criteria
 

--- a/src/resources/extensions/gsd/tests/commands-gsd-core.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-gsd-core.test.ts
@@ -601,6 +601,8 @@ describe("Batch 4 handlers dispatch", () => {
     await handlePlanPhase("--research --tdd", ctx as any, pi as any);
     // The research flag line renders the value (research), not the placeholder name.
     assert.match(pi.sent[0].content, /--research` \/ `--skip-research` — research/);
+    assert.match(pi.sent[0].content, /gsd_summary_save/);
+    assert.match(pi.sent[0].content, /artifact_type: "RESEARCH"/);
     assert.match(pi.sent[0].content, /`--tdd` — ON/);
   });
   test("handlePlanPhase skip-research flag", async () => {
@@ -628,6 +630,8 @@ describe("Batch 4 handlers dispatch", () => {
     const pi = createMockPi(); const ctx = createMockCtx();
     await handleUiPhase("", ctx as any, pi as any);
     assert.equal(pi.sent[0].customType, "gsd-ui-phase");
+    assert.match(pi.sent[0].content, /gsd_summary_save/);
+    assert.match(pi.sent[0].content, /artifact_type: "UI-SPEC"/);
   });
   test("handleAiIntegrationPhase default", async () => {
     const pi = createMockPi(); const ctx = createMockCtx();

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -270,6 +270,31 @@ test("executeSummarySave persists artifact and returns computed path", async () 
   }
 });
 
+test("executeSummarySave persists UI-SPEC artifacts at the computed flat-phase path", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    const result = await inProjectDir(base, () => executeSummarySave({
+      milestone_id: "M001",
+      slice_id: "S01",
+      artifact_type: "UI-SPEC",
+      content: "# UI Spec\n\nDesign contract.",
+    }, base));
+
+    assert.equal(result.details.operation, "save_summary");
+    assert.equal(result.details.path, "phases/01-m001/01-01-UI-SPEC.md");
+    assert.equal(result.details.artifact_type, "UI-SPEC");
+
+    const filePath = join(base, ".gsd", "phases", "01-m001", "01-01-UI-SPEC.md");
+    assert.ok(existsSync(filePath), "UI-SPEC artifact should be written to disk");
+    assert.match(readFileSync(filePath, "utf-8"), /Design contract/);
+    assert.equal(getArtifact("phases/01-m001/01-01-UI-SPEC.md")?.artifact_type, "UI-SPEC");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeSummarySave mirrors milestone artifacts into the active worktree projection", async () => {
   const base = makeTmpBase();
   const worktree = join(base, ".gsd", "worktrees", "M001");

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -113,6 +113,7 @@ export type {
 export const SUPPORTED_SUMMARY_ARTIFACT_TYPES = [
   "SUMMARY",
   "RESEARCH",
+  "UI-SPEC",
   "CONTEXT",
   "ASSESSMENT",
   "CONTEXT-DRAFT",


### PR DESCRIPTION
## Summary
- Added UI-SPEC artifact persistence plus RESEARCH/UI-SPEC prompt guidance, with diff validation passing and test execution blocked by unavailable dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1484
- [#1484 [Bug]: Why isn't it generating? 01-RESEARCH.md、01-01-UI-SPEC.md](https://github.com/open-gsd/gsd-pi/issues/1484)

## User
- @wenqian-cai-tuya

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1484-bug-why-isn-t-it-generating-01-research--1784373241`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dd5bdfd17c064d7a6d3775302a2658f64efcdfc5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->