### PR TITLE
fix(issue): Allow a repaired task to resume after durable recovery abort

### DIFF
--- a/packages/mcp-server/src/workflow-tools-parity.test.ts
+++ b/packages/mcp-server/src/workflow-tools-parity.test.ts
@@ -30,7 +30,14 @@ import {
   _getAdapter,
 } from "../../../src/resources/extensions/gsd/gsd-db.ts";
 import { registerDbTools } from "../../../src/resources/extensions/gsd/bootstrap/db-tools.ts";
-import { claimTaskAttempt } from "../../../src/resources/extensions/gsd/task-execution-domain-operation.ts";
+import {
+  claimTaskAttempt,
+  settleTaskAttempt,
+} from "../../../src/resources/extensions/gsd/task-execution-domain-operation.ts";
+import {
+  readTaskRecoveryRoute,
+  recordFailureAndSelectRecovery,
+} from "../../../src/resources/extensions/gsd/task-recovery-domain-operation.ts";
 import { seedSliceCompletionAuthority } from "../../../src/resources/extensions/gsd/tests/slice-completion-fixture.ts";
 import { createWorkflowAuthorityFixture } from "../../../src/resources/extensions/gsd/tests/workflow-authority-fixture.ts";
 import {
@@ -54,7 +61,7 @@ function seedMilestoneAndSlice(base: string): void {
   );
 }
 
-function claimCanonicalTaskAuthority(base: string): void {
+function claimCanonicalTaskAuthority(base: string): string {
   openDatabase(join(base, ".gsd", "gsd.db"));
   const db = _getAdapter();
   assert.ok(db, "DB should be open before claiming canonical task authority");
@@ -93,7 +100,7 @@ function claimCanonicalTaskAuthority(base: string): void {
       'claimed', 1, ?
     )
   `).run(now);
-  claimTaskAttempt({
+  const claim = claimTaskAttempt({
     invocation: {
       idempotencyKey: "fixture:mcp-parity:claim:M001/S01/T01",
       sourceTransport: "internal",
@@ -105,6 +112,42 @@ function claimCanonicalTaskAuthority(base: string): void {
     milestoneLeaseToken: 7,
     coordinationDispatchId: Number(dispatch.lastInsertRowid),
   });
+  return claim.attemptId;
+}
+
+function executionInvocation(key: string) {
+  return {
+    idempotencyKey: `fixture:mcp-parity:${key}`,
+    sourceTransport: "internal" as const,
+    actorType: "agent" as const,
+    traceId: key,
+  };
+}
+
+function seedTaskRecoveryAbort(base: string): { attemptId: string; recoveryActionId: string } {
+  seedMilestoneAndSlice(base);
+  const attemptId = claimCanonicalTaskAuthority(base);
+  const settled = settleTaskAttempt({
+    invocation: executionInvocation("settle-fatal"),
+    attemptId,
+    outcome: "failed",
+    failureClass: "fatal",
+    summary: "The executor runtime is invalid.",
+    output: {},
+  });
+  const abort = recordFailureAndSelectRecovery({
+    invocation: executionInvocation("route-fatal"),
+    attemptId,
+    resultId: settled.resultId,
+    owner: "agent",
+    classification: { failureKind: "fatal" },
+    summary: "The executor runtime is invalid.",
+    evidence: { source: "executor" },
+    rationale: "Stop until the executor is repaired.",
+  });
+  assert.equal(abort.action, "abort");
+  assert.equal(abort.resumeAuthorized, false);
+  return { attemptId, recoveryActionId: abort.recoveryActionId };
 }
 
 function cleanup(base: string): void {
@@ -587,6 +630,130 @@ async function callMcpLifecycleTool(
     _meta: { "io.opengsd/idempotency-key": stableKey },
   });
 }
+
+const TASK_RECOVERY_RESUME_ARGS = {
+  repairSummary: "The executor runtime was rebuilt and verified.",
+  evidence: { pullRequest: 1457, check: "focused recovery tests passed" },
+};
+
+function executorDetails(result: unknown): Record<string, unknown> {
+  const record = result as { details?: unknown; structuredContent?: unknown };
+  const details = record.structuredContent ?? record.details;
+  assert.ok(details && typeof details === "object" && !Array.isArray(details), "executor result must expose details");
+  return details as Record<string, unknown>;
+}
+
+function assertTaskRecoveryResumeDurability(input: {
+  attemptId: string;
+  recoveryActionId: string;
+  firstResult: unknown;
+  replayResult: unknown;
+  expectedIdempotencyKey: string;
+  expectedTransport: "pi-tool" | "workflow-mcp";
+}): Record<string, unknown> {
+  const firstDetails = executorDetails(input.firstResult);
+  const replayDetails = executorDetails(input.replayResult);
+  assert.equal(firstDetails.status, "committed");
+  assert.equal(replayDetails.status, "replayed");
+  assert.equal(replayDetails.operationId, firstDetails.operationId);
+  assert.equal(firstDetails.recoveryActionId, input.recoveryActionId);
+  assert.equal(readTaskRecoveryRoute(input.attemptId)?.resumeAuthorized, true);
+
+  const db = _getAdapter();
+  assert.ok(db, "database must be open after resume replay");
+  assert.deepEqual(db.prepare(`
+    SELECT idempotency_key, source_transport
+    FROM workflow_operations
+    WHERE operation_type = 'task.recovery.resume'
+  `).all(), [{
+    idempotency_key: input.expectedIdempotencyKey,
+    source_transport: input.expectedTransport,
+  }]);
+  const events = db.prepare(`
+    SELECT payload_json
+    FROM workflow_domain_events
+    WHERE event_type = 'task.recovery.resumed'
+  `).all() as Array<{ payload_json: string }>;
+  assert.equal(events.length, 1, "resume replay must not duplicate the durable event");
+  const payload = JSON.parse(events[0].payload_json) as Record<string, unknown>;
+  assert.equal(payload.recoveryActionId, input.recoveryActionId);
+  assert.equal(payload.attemptId, input.attemptId);
+  assert.equal(payload.repairSummary, TASK_RECOVERY_RESUME_ARGS.repairSummary);
+  assert.deepEqual(payload.evidence, TASK_RECOVERY_RESUME_ARGS.evidence);
+
+  return {
+    firstStatus: firstDetails.status,
+    replayStatus: replayDetails.status,
+    operation: "task.recovery.resume",
+    eventType: "task.recovery.resumed",
+    eventCount: events.length,
+    repairSummary: payload.repairSummary,
+    evidence: payload.evidence,
+    resumeAuthorized: true,
+  };
+}
+
+describe("Task recovery resume persistent retry parity", () => {
+  it("Pi and MCP authorize one repaired retry and replay after DB restart", async () => {
+    let baseNative = "";
+    let baseMcp = "";
+    try {
+      baseNative = makeTmpBase();
+      const nativeAbort = seedTaskRecoveryAbort(baseNative);
+      const nativeArgs = {
+        recoveryActionId: nativeAbort.recoveryActionId,
+        ...TASK_RECOVERY_RESUME_ARGS,
+      };
+      const nativeFirst = await runNativeDbTool(baseNative, "gsd_task_recovery_resume", nativeArgs);
+      assert.ok(!(nativeFirst as { isError?: boolean }).isError, "native resume must succeed");
+      closeDatabase();
+      const nativeReplay = await runNativeDbTool(baseNative, "gsd_task_recovery_resume", nativeArgs);
+      assert.ok(!(nativeReplay as { isError?: boolean }).isError, "native resume replay must succeed");
+      const nativeSnapshot = assertTaskRecoveryResumeDurability({
+        ...nativeAbort,
+        firstResult: nativeFirst,
+        replayResult: nativeReplay,
+        expectedIdempotencyKey: "pi:gsd_task_recovery_resume:parity-call",
+        expectedTransport: "pi-tool",
+      });
+      closeDatabase();
+
+      baseMcp = makeTmpBase();
+      const mcpAbort = seedTaskRecoveryAbort(baseMcp);
+      const mcpArgs = {
+        recoveryActionId: mcpAbort.recoveryActionId,
+        ...TASK_RECOVERY_RESUME_ARGS,
+      };
+      const mcpFirst = await callMcpLifecycleTool(
+        baseMcp,
+        "gsd_task_recovery_resume",
+        mcpArgs,
+        "task-recovery-resume",
+      );
+      assert.ok(!(mcpFirst as { isError?: boolean }).isError, "MCP resume must succeed");
+      closeDatabase();
+      const mcpReplay = await callMcpLifecycleTool(
+        baseMcp,
+        "gsd_task_recovery_resume",
+        mcpArgs,
+        "task-recovery-resume",
+      );
+      assert.ok(!(mcpReplay as { isError?: boolean }).isError, "MCP resume replay must succeed");
+      const mcpSnapshot = assertTaskRecoveryResumeDurability({
+        ...mcpAbort,
+        firstResult: mcpFirst,
+        replayResult: mcpReplay,
+        expectedIdempotencyKey: "mcp:gsd_task_recovery_resume:task-recovery-resume",
+        expectedTransport: "workflow-mcp",
+      });
+
+      assert.deepEqual(mcpSnapshot, nativeSnapshot, "Pi and MCP resume behavior must match");
+    } finally {
+      if (baseNative) cleanup(baseNative);
+      if (baseMcp) cleanup(baseMcp);
+    }
+  });
+});
 
 async function runPersistentSliceLifecycleMatrix(
   transport: "pi" | "mcp",

--- a/src/resources/extensions/gsd/task-recovery-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-recovery-domain-operation.ts
@@ -297,7 +297,7 @@ export function readPendingTaskRecoveryContext(
   task: Pick<TaskScope, "milestoneId" | "sliceId" | "taskId">,
 ): PendingTaskRecoveryContext | null {
   const stored = getDb().prepare(`
-    SELECT action.action, action.recovery_action_id,
+    SELECT lifecycle.lifecycle_id, action.action, action.recovery_action_id,
            attempt.attempt_id, observation.result_id,
            observation.failure_kind, observation.summary, observation.evidence_json,
            action.rationale,
@@ -365,22 +365,37 @@ export function readPendingTaskRecoveryContext(
   let checkpoint = stored;
   if (storedAction === "abort") {
     if (!isTaskRecoveryResumeAuthorized(attemptId)) return null;
+    const lifecycleId = String(stored["lifecycle_id"]);
     const resumed = getDb().prepare(`
       SELECT checkpoint.checkpoint_id, checkpoint.confirmed_context,
              checkpoint.unresolved_summary, checkpoint.evidence_summary,
              checkpoint.suggested_next_action
       FROM workflow_domain_events event
+      JOIN workflow_recovery_actions resumed_action
+        ON resumed_action.project_id = event.project_id
+       AND resumed_action.recovery_action_id = json_extract(event.payload_json, '$.recoveryActionId')
       JOIN workflow_work_checkpoints checkpoint
         ON checkpoint.project_id = event.project_id
        AND checkpoint.operation_id = event.operation_id
        AND checkpoint.checkpoint_id = json_extract(event.payload_json, '$.workCheckpointId')
+       AND checkpoint.lifecycle_id = resumed_action.lifecycle_id
       WHERE event.event_type = 'task.recovery.resumed'
-        AND json_extract(event.payload_json, '$.recoveryActionId') = :recovery_action_id
+        AND event.entity_type = 'task'
+        AND event.entity_id = :entity_id
+        AND resumed_action.recovery_action_id = :recovery_action_id
+        AND resumed_action.lifecycle_id = :lifecycle_id
+        AND json_extract(event.payload_json, '$.lifecycleId') = :lifecycle_id
         AND json_extract(event.payload_json, '$.attemptId') = :attempt_id
         AND json_extract(event.payload_json, '$.resultId') = :result_id
       ORDER BY event.project_revision DESC
       LIMIT 1
     `).get({
+      ":entity_id": taskEntity({
+        milestoneId: task.milestoneId,
+        sliceId: task.sliceId,
+        taskId: task.taskId,
+      }),
+      ":lifecycle_id": lifecycleId,
       ":recovery_action_id": String(stored["recovery_action_id"]),
       ":attempt_id": attemptId,
       ":result_id": String(stored["result_id"]),
@@ -596,6 +611,11 @@ function requireResumableAbortScope(recoveryActionId: string): FailedAttemptScop
       ON attempt.project_id = observation.project_id
      AND attempt.lifecycle_id = observation.lifecycle_id
      AND attempt.attempt_id = observation.attempt_id
+    JOIN workflow_attempt_results result
+      ON result.project_id = observation.project_id
+     AND result.lifecycle_id = observation.lifecycle_id
+     AND result.attempt_id = observation.attempt_id
+     AND result.result_id = observation.result_id
     JOIN workflow_item_lifecycles lifecycle
       ON lifecycle.project_id = attempt.project_id
      AND lifecycle.lifecycle_id = attempt.lifecycle_id
@@ -605,6 +625,7 @@ function requireResumableAbortScope(recoveryActionId: string): FailedAttemptScop
       AND observation.recovery_owner = 'agent'
       AND lifecycle.lifecycle_status = 'in_progress'
       AND attempt.attempt_state = 'settled'
+      AND ${CURRENT_TASK_RECOVERY_CAUSAL_AUTHORITY_SQL}
       AND attempt.attempt_number = (
         SELECT MAX(latest.attempt_number)
         FROM workflow_execution_attempts latest

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -1264,7 +1264,21 @@ test("deterministic repair abort resumes after restart and is consumed by one su
     repairSummary: "Recreated the missing worktree root and verified GSD can resolve it.",
     evidence: { command: "gsd doctor", exitCode: 0, verdict: "PASS" },
   });
+  const replayedResume = resumeTaskRecovery({
+    invocation: invocation("recovery/deterministic/resume"),
+    recoveryActionId: second.recoveryActionId,
+    repairSummary: "Recreated the missing worktree root and verified GSD can resolve it.",
+    evidence: { command: "gsd doctor", exitCode: 0, verdict: "PASS" },
+  });
   assert.equal(resumed.status, "committed");
+  assert.equal(replayedResume.status, "replayed");
+  assert.equal(replayedResume.operationId, resumed.operationId);
+  assert.equal(Number(row(`
+    SELECT COUNT(*) AS count
+    FROM workflow_domain_events
+    WHERE event_type = 'task.recovery.resumed'
+      AND json_extract(payload_json, '$.recoveryActionId') = :recovery_action_id
+  `, { ":recovery_action_id": second.recoveryActionId }).count), 1);
 
   closeDatabase();
   assert.equal(openDatabase(firstFailure.dbPath), true);
@@ -1291,6 +1305,17 @@ test("deterministic repair abort resumes after restart and is consumed by one su
     sliceId: "S01",
     taskId: "T01",
   }), null);
+  assert.throws(() => resumeTaskRecovery({
+    invocation: invocation("recovery/deterministic/stale-resume"),
+    recoveryActionId: second.recoveryActionId,
+    repairSummary: "Try to reuse a consumed repaired-abort authorization.",
+    evidence: { command: "gsd doctor", exitCode: 0, verdict: "PASS" },
+  }), /current agent-owned abort/i);
+  assert.equal(Number(row(`
+    SELECT COUNT(*) AS count
+    FROM workflow_execution_attempts
+    WHERE retry_of_attempt_id = :attempt_id
+  `, { ":attempt_id": secondFailure.attemptId }).count), 1);
 });
 
 test("a pre-commit fault leaves no recovery residue and the same request retries cleanly", () => {

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -1223,6 +1223,76 @@ test("durable budget use survives retries and exhausts to agent abort", async ()
   }), /current agent-owned abort/i);
 });
 
+test("deterministic repair abort resumes after restart and is consumed by one successor claim", () => {
+  const firstFailure = seedFailedAttempt();
+  const route = (
+    key: string,
+    failure: { attemptId: string; resultId: string },
+    summary: string,
+  ) =>
+    recordFailureAndSelectRecovery({
+      invocation: invocation(key),
+      ...failure,
+      owner: "agent",
+      classification: { failureKind: "worktree-invalid" },
+      summary,
+      evidence: { source: "executor", diagnostic: summary },
+      rationale: "repair the deterministic worktree fault",
+    });
+
+  const first = route(
+    "recovery/deterministic/1",
+    firstFailure,
+    "Worktree root was missing before the repair.",
+  );
+  assert.equal(first.action, "repair");
+
+  const secondFailure = seedRetryFailure(firstFailure.attemptId, 2);
+  const second = route(
+    "recovery/deterministic/2",
+    secondFailure,
+    "Worktree root was still missing after the repair attempt.",
+  );
+  assert.equal(second.action, "abort");
+  assert.equal(readTaskRecoveryRoute(secondFailure.attemptId)?.resumeAuthorized, false);
+
+  closeDatabase();
+  assert.equal(openDatabase(firstFailure.dbPath), true);
+  const resumed = resumeTaskRecovery({
+    invocation: invocation("recovery/deterministic/resume"),
+    recoveryActionId: second.recoveryActionId,
+    repairSummary: "Recreated the missing worktree root and verified GSD can resolve it.",
+    evidence: { command: "gsd doctor", exitCode: 0, verdict: "PASS" },
+  });
+  assert.equal(resumed.status, "committed");
+
+  closeDatabase();
+  assert.equal(openDatabase(firstFailure.dbPath), true);
+  assert.equal(readTaskRecoveryRoute(secondFailure.attemptId)?.resumeAuthorized, true);
+  assert.equal(readPendingTaskRecoveryContext({
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T01",
+  })?.action, "resume");
+
+  const thirdDispatchId = insertClaimedDispatch(3);
+  const third = claimTaskAttempt({
+    invocation: invocation("recovery/deterministic/claim-after-resume"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+    coordinationDispatchId: thirdDispatchId,
+    retryOfAttemptId: secondFailure.attemptId,
+  });
+  assert.equal(third.attemptNumber, 3);
+  assert.equal(readTaskRecoveryRoute(secondFailure.attemptId)?.resumeAuthorized, false);
+  assert.equal(readPendingTaskRecoveryContext({
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T01",
+  }), null);
+});
+
 test("a pre-commit fault leaves no recovery residue and the same request retries cleanly", () => {
   const scope = seedFailedAttempt();
   const input = {


### PR DESCRIPTION
## Summary
- Added deterministic recovery-resume regression coverage and verified formatting plus dependency-light recovery policy tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1457
- [#1457 Allow a repaired task to resume after durable recovery abort](https://github.com/open-gsd/gsd-pi/issues/1457)

## User
- @jeremymcs

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1457-allow-a-repaired-task-to-resume-after-du-1784416063`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SQL guards on workflow recovery resume and pending-context reads; incorrect joins could block valid resumes or allow stale ones, though scope is limited to abort/resume paths and is heavily tested.
> 
> **Overview**
> Tightens **task recovery resume** so a durable agent **abort** can be repaired and retried only when causal recovery authority still matches, and pending UI/context reflects an authorized **resume** with the correct post-repair checkpoint.
> 
> **`readPendingTaskRecoveryContext`** now scopes resumed-abort lookups by task entity and lifecycle, joining recovery actions and matching `task.recovery.resumed` events to the abort’s attempt/result. **`requireResumableAbortScope`** (used by resume) joins attempt results and applies **`CURRENT_TASK_RECOVERY_CAUSAL_AUTHORITY_SQL`** so stale or superseded failure heads cannot be resumed.
> 
> Adds regression coverage: a domain test for repair→abort→**resume** after DB restart, single successor **claim** consuming authorization; and Pi vs MCP parity for **`gsd_task_recovery_resume`** (idempotent replay, one durable event, matching transports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef04455346041e1badfe060bc07978567d611f67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->