### PR TITLE
fix(issue): [Bug]: gsd-auto-orchestrator terminal/pause event leaves sessions table status='running'; /gsd auto deadlocks indefinitely

### DIFF
--- a/packages/daemon/src/event-bridge.test.ts
+++ b/packages/daemon/src/event-bridge.test.ts
@@ -140,7 +140,9 @@ describe('EventBridge', () => {
       assert.ok(sessionManager.listenerCount('session:started') > 0);
       assert.ok(sessionManager.listenerCount('session:event') > 0);
       assert.ok(sessionManager.listenerCount('session:blocked') > 0);
+      assert.ok(sessionManager.listenerCount('session:paused') > 0);
       assert.ok(sessionManager.listenerCount('session:completed') > 0);
+      assert.ok(sessionManager.listenerCount('session:cancelled') > 0);
       assert.ok(sessionManager.listenerCount('session:error') > 0);
       assert.ok(client.listenerCount('messageCreate') > 0);
     });
@@ -152,7 +154,9 @@ describe('EventBridge', () => {
       assert.equal(sessionManager.listenerCount('session:started'), 0);
       assert.equal(sessionManager.listenerCount('session:event'), 0);
       assert.equal(sessionManager.listenerCount('session:blocked'), 0);
+      assert.equal(sessionManager.listenerCount('session:paused'), 0);
       assert.equal(sessionManager.listenerCount('session:completed'), 0);
+      assert.equal(sessionManager.listenerCount('session:cancelled'), 0);
       assert.equal(sessionManager.listenerCount('session:error'), 0);
       assert.equal(client.listenerCount('messageCreate'), 0);
     });
@@ -587,6 +591,43 @@ describe('EventBridge', () => {
       await tick();
 
       // After cleanup, events for this session are silently ignored
+      sessionManager.emit('session:event', {
+        sessionId: 'sess-1', projectDir: '/test/project',
+        event: { type: 'tool_execution_start', name: 'read' } as SdkAgentEvent,
+      });
+      await tick();
+      assert.equal(mockFn(logger.error).mock.callCount(), 0);
+    });
+  });
+
+  describe('session:paused → cleanup', () => {
+    it('flushes pending events and cleans up', async () => {
+      const { bridge, sessionManager, channelManager, logger } = buildBridge();
+      bridge.start();
+
+      sessionManager.emit('session:started', {
+        sessionId: 'sess-1', projectDir: '/test/project', projectName: 'my-project',
+      });
+      await tick();
+
+      sessionManager.emit('session:event', {
+        sessionId: 'sess-1', projectDir: '/test/project',
+        event: {
+          type: 'extension_ui_request',
+          method: 'notify',
+          message: 'Auto-mode paused (Escape). Type to interact, or /gsd auto to resume.',
+        } as SdkAgentEvent,
+      });
+      sessionManager.emit('session:paused', {
+        sessionId: 'sess-1', projectDir: '/test/project', projectName: 'my-project',
+      });
+      await tick();
+
+      assert.ok(channelManager._sentMessages.length > 0, 'pending pause notification should flush before cleanup');
+      assert.ok(
+        mockFn(logger.info).mock.calls.some((c) => String(c.arguments[0]).includes('session paused')),
+      );
+
       sessionManager.emit('session:event', {
         sessionId: 'sess-1', projectDir: '/test/project',
         event: { type: 'tool_execution_start', name: 'read' } as SdkAgentEvent,

--- a/packages/daemon/src/event-bridge.ts
+++ b/packages/daemon/src/event-bridge.ts
@@ -85,6 +85,7 @@ export class EventBridge {
     started: (...args: unknown[]) => void;
     event: (...args: unknown[]) => void;
     blocked: (...args: unknown[]) => void;
+    paused: (...args: unknown[]) => void;
     completed: (...args: unknown[]) => void;
     cancelled: (...args: unknown[]) => void;
     error: (...args: unknown[]) => void;
@@ -118,6 +119,9 @@ export class EventBridge {
       blocked: (data: unknown) => {
         void this.onSessionBlocked(data as SessionBlockedPayload);
       },
+      paused: (data: unknown) => {
+        void this.onSessionPaused(data as SessionPausedPayload);
+      },
       completed: (data: unknown) => {
         void this.onSessionCompleted(data as SessionCompletedPayload);
       },
@@ -135,6 +139,7 @@ export class EventBridge {
     this.sessionManager.on('session:started', this.boundHandlers.started);
     this.sessionManager.on('session:event', this.boundHandlers.event);
     this.sessionManager.on('session:blocked', this.boundHandlers.blocked);
+    this.sessionManager.on('session:paused', this.boundHandlers.paused);
     this.sessionManager.on('session:completed', this.boundHandlers.completed);
     this.sessionManager.on('session:cancelled', this.boundHandlers.cancelled);
     this.sessionManager.on('session:error', this.boundHandlers.error);
@@ -149,6 +154,7 @@ export class EventBridge {
       this.sessionManager.off('session:started', this.boundHandlers.started);
       this.sessionManager.off('session:event', this.boundHandlers.event);
       this.sessionManager.off('session:blocked', this.boundHandlers.blocked);
+      this.sessionManager.off('session:paused', this.boundHandlers.paused);
       this.sessionManager.off('session:completed', this.boundHandlers.completed);
       this.sessionManager.off('session:cancelled', this.boundHandlers.cancelled);
       this.sessionManager.off('session:error', this.boundHandlers.error);
@@ -281,6 +287,15 @@ export class EventBridge {
     await this.cleanupSession(sessionId);
 
     this.logger.info('bridge: session completed', { sessionId, projectName });
+  }
+
+  private async onSessionPaused(data: SessionPausedPayload): Promise<void> {
+    const { sessionId, projectName } = data;
+    // The pause notification has already gone through session:event. Flush any
+    // pending batch and tear down per-session bridge state so a resumed/fresh
+    // run for the same project can register cleanly.
+    await this.cleanupSession(sessionId);
+    this.logger.info('bridge: session paused', { sessionId, projectName });
   }
 
   private async onSessionCancelled(data: SessionCancelledPayload): Promise<void> {
@@ -527,6 +542,12 @@ interface SessionBlockedPayload {
 }
 
 interface SessionCompletedPayload {
+  sessionId: string;
+  projectDir: string;
+  projectName: string;
+}
+
+interface SessionPausedPayload {
   sessionId: string;
   projectDir: string;
   projectName: string;

--- a/packages/daemon/src/event-bridge.ts
+++ b/packages/daemon/src/event-bridge.ts
@@ -291,10 +291,19 @@ export class EventBridge {
 
   private async onSessionPaused(data: SessionPausedPayload): Promise<void> {
     const { sessionId, projectName } = data;
-    // The pause notification has already gone through session:event. Flush any
-    // pending batch and tear down per-session bridge state so a resumed/fresh
-    // run for the same project can register cleanly.
-    await this.cleanupSession(sessionId);
+    // A paused auto-mode session stays interactive: the SessionManager keeps the
+    // session and its RpcClient so the user can "type to interact" (relayed via
+    // prompt() in handleMessageCreate). Tearing down the channel mapping or the
+    // batcher here would drop those messages and silence resumed output, so the
+    // bridge stays wired. We only release stale blocker collectors, since pause
+    // clears any pending blocker, and flush the pending batch so the pause
+    // notice is delivered promptly without destroying the batcher.
+    const collectorSet = this.collectors.get(sessionId);
+    if (collectorSet) {
+      for (const collector of collectorSet) collector.stop('session-paused');
+      this.collectors.delete(sessionId);
+    }
+    await this.batchers.get(sessionId)?.flush();
     this.logger.info('bridge: session paused', { sessionId, projectName });
   }
 

--- a/packages/daemon/src/message-batcher.ts
+++ b/packages/daemon/src/message-batcher.ts
@@ -89,7 +89,7 @@ export class MessageBatcher {
   start(): void {
     if (this.timer) return; // already running
     this.timer = setInterval(() => {
-      void this.flush();
+      void this.flushBuffer();
     }, this.flushIntervalMs);
     // Don't hold the process open for the timer
     if (this.timer && typeof this.timer === 'object' && 'unref' in this.timer) {
@@ -112,7 +112,7 @@ export class MessageBatcher {
     if (this.destroyed) return;
     this.destroyed = true;
     this.stop();
-    await this.flush();
+    await this.flushBuffer();
     this.logger.debug('Batcher destroyed');
   }
 
@@ -133,7 +133,7 @@ export class MessageBatcher {
     }
     this.buffer.push(formatted);
     if (this.buffer.length >= this.maxBatchSize) {
-      void this.flush();
+      void this.flushBuffer();
     }
   }
 
@@ -144,7 +144,7 @@ export class MessageBatcher {
   async enqueueImmediate(formatted: FormattedEvent): Promise<void> {
     if (this.destroyed) return;
     // Flush pending buffer first so ordering is preserved
-    await this.flush();
+    await this.flushBuffer();
     // Send the priority event immediately, alone
     await this.doSend([formatted]);
   }
@@ -152,6 +152,15 @@ export class MessageBatcher {
   /** Current number of events in the buffer (for testing/diagnostics). */
   get pending(): number {
     return this.buffer.length;
+  }
+
+  /**
+   * Flush the current buffer immediately without stopping the batcher.
+   * Use this to deliver queued output at a boundary (e.g. a session pausing)
+   * while keeping the batcher alive for continued streaming. No-op if empty.
+   */
+  async flush(): Promise<void> {
+    await this.flushBuffer();
   }
 
   // -----------------------------------------------------------------------
@@ -163,7 +172,7 @@ export class MessageBatcher {
    * Multiple embeds are combined into one send() call (Discord supports up to 10).
    * No-op if buffer is empty.
    */
-  private async flush(): Promise<void> {
+  private async flushBuffer(): Promise<void> {
     if (this.buffer.length === 0) return;
     if (this.flushing) return; // prevent re-entrant flush
 

--- a/packages/daemon/src/session-manager.test.ts
+++ b/packages/daemon/src/session-manager.test.ts
@@ -981,6 +981,67 @@ describe('SessionManager', () => {
     assert.equal(cancelled.projectName, 'cancel-emit');
   });
 
+  // ---- Evicting a paused session emits session:cancelled (bridge teardown) ----
+
+  it('evicting a paused session emits session:cancelled so the bridge tears down', async () => {
+    const { manager } = createManager();
+
+    let cancelled: Record<string, unknown> | undefined;
+    manager.on('session:cancelled', (data: Record<string, unknown>) => { cancelled = data; });
+
+    const sessionId = await manager.startSession({ projectDir: '/tmp/evict-paused' });
+    const resolvedDir = resolve('/tmp/evict-paused');
+
+    // Drive the session into 'paused'. A paused session deliberately keeps its
+    // EventBridge state (channel mapping, batcher, collectors) alive for
+    // "type to interact", so it is the only terminal state that still needs
+    // bridge teardown when evicted.
+    manager.lastClient!.emitEvent({
+      type: 'extension_ui_request',
+      method: 'notify',
+      message: 'Auto-mode paused (Escape). Type to interact, or /gsd auto to resume.',
+    });
+    assert.equal(manager.getSessionByDir(resolvedDir)!.status, 'paused');
+
+    // Evicting the paused session (e.g. a fresh startSession for the same dir)
+    // must notify the EventBridge so its stale state on the old sessionId is
+    // torn down instead of stranded.
+    (manager as unknown as { evictSession(dir: string): void }).evictSession(resolvedDir);
+
+    assert.ok(cancelled, 'evicting a paused session should emit session:cancelled');
+    assert.equal(cancelled.sessionId, sessionId);
+    assert.ok(String(cancelled.projectDir).endsWith('evict-paused'));
+    assert.equal(cancelled.projectName, 'evict-paused');
+    // Session is removed from tracking and its child process reclaimed.
+    assert.equal(manager.getSessionByDir(resolvedDir), undefined);
+    assert.ok(manager.lastClient!.stopped);
+  });
+
+  // ---- Evicting a non-paused terminal session does not re-emit teardown ----
+
+  it('evicting a completed session does not emit session:cancelled (already torn down)', async () => {
+    const { manager } = createManager();
+
+    const sessionId = await manager.startSession({ projectDir: '/tmp/evict-completed' });
+    const resolvedDir = resolve('/tmp/evict-completed');
+
+    manager.lastClient!.emitEvent({
+      type: 'extension_ui_request',
+      id: 'n1',
+      method: 'notify',
+      message: 'Auto-mode stopped: completed all tasks',
+    });
+    assert.equal(manager.getSessionByDir(resolvedDir)!.status, 'completed');
+
+    let cancelled = false;
+    manager.on('session:cancelled', () => { cancelled = true; });
+
+    (manager as unknown as { evictSession(dir: string): void }).evictSession(resolvedDir);
+
+    assert.equal(cancelled, false, 'completed sessions already tore down their bridge state on completion');
+    assert.equal(manager.getSessionByDir(resolvedDir), undefined);
+  });
+
   // ---- cleanup empties the sessions map (no retained references) ----
 
   it('cleanup clears the sessions map', async () => {

--- a/packages/daemon/src/session-manager.test.ts
+++ b/packages/daemon/src/session-manager.test.ts
@@ -108,12 +108,19 @@ class TestableSessionManager extends SessionManager {
     const resolvedDir = resolve(projectDir);
     const projectName = basename(resolvedDir);
 
-    // Check duplicate via getSessionByDir
+    // Mirror production duplicate handling: active sessions block, terminal
+    // sessions are evicted so a paused auto-mode run can be resumed.
     const existing = this.getSessionByDir(resolvedDir);
     if (existing) {
-      throw new Error(
-        `Session already active for ${resolvedDir} (sessionId: ${existing.sessionId}, status: ${existing.status})`
-      );
+      if (existing.status === 'paused' || existing.status === 'completed' || existing.status === 'error' || existing.status === 'cancelled') {
+        existing.unsubscribe?.();
+        await existing.client.stop().catch(() => { /* swallow */ });
+        (this as any).sessions.delete(resolvedDir);
+      } else {
+        throw new Error(
+          `Session already active for ${resolvedDir} (sessionId: ${existing.sessionId}, status: ${existing.status})`
+        );
+      }
     }
 
     const client = new MockRpcClient({ cwd: resolvedDir, args: [] });
@@ -537,6 +544,32 @@ describe('SessionManager', () => {
     });
 
     assert.equal(session.status, 'completed');
+  });
+
+  it('detects paused from auto-mode paused notification and permits restart', async () => {
+    const { manager, spy } = createManager();
+    const dir = '/tmp/paused-terminal-test';
+
+    const sessionId = await manager.startSession({ projectDir: dir });
+    const session = manager.getSession(sessionId)!;
+    const firstClient = manager.lastClient!;
+
+    manager.lastClient!.emitEvent({
+      type: 'extension_ui_request',
+      id: 'p1',
+      method: 'notify',
+      message: 'Auto-mode paused (Escape). Type to interact, or /gsd auto to resume.',
+    });
+
+    assert.equal(session.status, 'paused');
+    assert.equal(session.pendingBlocker, null);
+    assert.equal(spy.findCalls('info', 'session paused').length, 1);
+
+    const nextSessionId = await manager.startSession({ projectDir: dir });
+    assert.notEqual(nextSessionId, sessionId);
+    assert.ok(firstClient.stopped);
+    assert.equal(manager.getSession(nextSessionId)!.status, 'running');
+    assert.equal(manager.getSessionByDir(dir)!.sessionId, nextSessionId);
   });
 
   // ---- getAllSessions returns all tracked sessions ----

--- a/packages/daemon/src/session-manager.test.ts
+++ b/packages/daemon/src/session-manager.test.ts
@@ -549,6 +549,8 @@ describe('SessionManager', () => {
   it('detects paused from auto-mode paused notification and permits restart', async () => {
     const { manager, spy } = createManager();
     const dir = '/tmp/paused-terminal-test';
+    let paused: Record<string, unknown> | undefined;
+    manager.on('session:paused', (data: Record<string, unknown>) => { paused = data; });
 
     const sessionId = await manager.startSession({ projectDir: dir });
     const session = manager.getSession(sessionId)!;
@@ -564,11 +566,42 @@ describe('SessionManager', () => {
     assert.equal(session.status, 'paused');
     assert.equal(session.pendingBlocker, null);
     assert.equal(spy.findCalls('info', 'session paused').length, 1);
+    assert.ok(paused, 'pause notification should emit session:paused');
+    assert.equal(paused.sessionId, sessionId);
+    assert.equal(paused.projectName, 'paused-terminal-test');
 
     const nextSessionId = await manager.startSession({ projectDir: dir });
     assert.notEqual(nextSessionId, sessionId);
     assert.ok(firstClient.stopped);
     assert.equal(manager.getSession(nextSessionId)!.status, 'running');
+    assert.equal(manager.getSessionByDir(dir)!.sessionId, nextSessionId);
+  });
+
+  it('detects paused from structured orchestrator terminal pause event', async () => {
+    const { manager } = createManager();
+    const dir = '/tmp/structured-paused-terminal-test';
+    let paused: Record<string, unknown> | undefined;
+    manager.on('session:paused', (data: Record<string, unknown>) => { paused = data; });
+
+    const sessionId = await manager.startSession({ projectDir: dir });
+    const session = manager.getSession(sessionId)!;
+
+    manager.lastClient!.emitEvent({
+      eventType: 'orchestrator-terminal',
+      data: {
+        source: 'auto-orchestrator',
+        name: 'stop',
+        reason: 'pause',
+      },
+    });
+
+    assert.equal(session.status, 'paused');
+    assert.equal(session.pendingBlocker, null);
+    assert.ok(paused, 'structured orchestrator pause should emit session:paused');
+    assert.equal(paused.sessionId, sessionId);
+
+    const nextSessionId = await manager.startSession({ projectDir: dir });
+    assert.notEqual(nextSessionId, sessionId);
     assert.equal(manager.getSessionByDir(dir)!.sessionId, nextSessionId);
   });
 

--- a/packages/daemon/src/session-manager.test.ts
+++ b/packages/daemon/src/session-manager.test.ts
@@ -577,6 +577,33 @@ describe('SessionManager', () => {
     assert.equal(manager.getSessionByDir(dir)!.sessionId, nextSessionId);
   });
 
+  it('keeps the event subscription after pause so resumed output still transitions state', async () => {
+    const { manager } = createManager();
+    const dir = '/tmp/paused-resume-test';
+
+    const sessionId = await manager.startSession({ projectDir: dir });
+    const session = manager.getSession(sessionId)!;
+
+    manager.lastClient!.emitEvent({
+      type: 'extension_ui_request',
+      id: 'p1',
+      method: 'notify',
+      message: 'Auto-mode paused (Escape). Type to interact, or /gsd auto to resume.',
+    });
+    assert.equal(session.status, 'paused');
+
+    // A resumed session ("type to interact") keeps producing events. They must
+    // still reach handleEvent: a later terminal notification transitions the
+    // session to completed rather than being dropped with the subscription.
+    manager.lastClient!.emitEvent({
+      type: 'extension_ui_request',
+      id: 'n1',
+      method: 'notify',
+      message: 'Auto-mode stopped: completed all tasks',
+    });
+    assert.equal(session.status, 'completed');
+  });
+
   it('detects paused from structured orchestrator terminal pause event', async () => {
     const { manager } = createManager();
     const dir = '/tmp/structured-paused-terminal-test';

--- a/packages/daemon/src/session-manager.test.ts
+++ b/packages/daemon/src/session-manager.test.ts
@@ -1019,27 +1019,68 @@ describe('SessionManager', () => {
 
   // ---- Evicting a non-paused terminal session does not re-emit teardown ----
 
-  it('evicting a completed session does not emit session:cancelled (already torn down)', async () => {
-    const { manager } = createManager();
+  it('evicting non-paused terminal sessions does not re-emit session:cancelled', async () => {
+    {
+      const { manager } = createManager();
 
-    const sessionId = await manager.startSession({ projectDir: '/tmp/evict-completed' });
-    const resolvedDir = resolve('/tmp/evict-completed');
+      await manager.startSession({ projectDir: '/tmp/evict-completed' });
+      const resolvedDir = resolve('/tmp/evict-completed');
 
-    manager.lastClient!.emitEvent({
-      type: 'extension_ui_request',
-      id: 'n1',
-      method: 'notify',
-      message: 'Auto-mode stopped: completed all tasks',
-    });
-    assert.equal(manager.getSessionByDir(resolvedDir)!.status, 'completed');
+      manager.lastClient!.emitEvent({
+        type: 'extension_ui_request',
+        id: 'n1',
+        method: 'notify',
+        message: 'Auto-mode stopped: completed all tasks',
+      });
+      assert.equal(manager.getSessionByDir(resolvedDir)!.status, 'completed');
 
-    let cancelled = false;
-    manager.on('session:cancelled', () => { cancelled = true; });
+      let cancelledCount = 0;
+      manager.on('session:cancelled', () => { cancelledCount++; });
 
-    (manager as unknown as { evictSession(dir: string): void }).evictSession(resolvedDir);
+      (manager as unknown as { evictSession(dir: string): void }).evictSession(resolvedDir);
 
-    assert.equal(cancelled, false, 'completed sessions already tore down their bridge state on completion');
-    assert.equal(manager.getSessionByDir(resolvedDir), undefined);
+      assert.equal(cancelledCount, 0, 'completed sessions already tore down their bridge state on completion');
+      assert.equal(manager.getSessionByDir(resolvedDir), undefined);
+    }
+
+    {
+      const { manager } = createManager();
+      const resolvedDir = resolve('/tmp/evict-error');
+
+      manager.nextInitError = new Error('Connection refused');
+      await assert.rejects(
+        () => manager.startSession({ projectDir: '/tmp/evict-error' }),
+        /Failed to start session/
+      );
+      assert.equal(manager.getSessionByDir(resolvedDir)!.status, 'error');
+
+      let cancelledCount = 0;
+      manager.on('session:cancelled', () => { cancelledCount++; });
+
+      (manager as unknown as { evictSession(dir: string): void }).evictSession(resolvedDir);
+
+      assert.equal(cancelledCount, 0, 'error sessions already tore down their bridge state on error');
+      assert.equal(manager.getSessionByDir(resolvedDir), undefined);
+    }
+
+    {
+      const { manager } = createManager();
+
+      const sessionId = await manager.startSession({ projectDir: '/tmp/evict-cancelled' });
+      const resolvedDir = resolve('/tmp/evict-cancelled');
+
+      let cancelledCount = 0;
+      manager.on('session:cancelled', () => { cancelledCount++; });
+
+      await manager.cancelSession(sessionId);
+      assert.equal(manager.getSessionByDir(resolvedDir)!.status, 'cancelled');
+      assert.equal(cancelledCount, 1, 'cancelSession should emit exactly once');
+
+      (manager as unknown as { evictSession(dir: string): void }).evictSession(resolvedDir);
+
+      assert.equal(cancelledCount, 1, 'evicting a cancelled session should not emit a duplicate cancellation');
+      assert.equal(manager.getSessionByDir(resolvedDir), undefined);
+    }
   });
 
   // ---- cleanup empties the sessions map (no retained references) ----

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -50,7 +50,12 @@ const TERMINAL_PREFIXES = [
 function isTerminalNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
   const message = String(event.message ?? '').toLowerCase();
-  return TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix));
+  if (TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix))) return true;
+  return PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix)) && isNonBlockingPauseNotice(message);
+}
+
+function isNonBlockingPauseNotice(message: string): boolean {
+  return message.includes('idempotent advance: unit already active');
 }
 
 function isOrchestratorPausedEvent(event: Record<string, unknown>): boolean {
@@ -58,17 +63,21 @@ function isOrchestratorPausedEvent(event: Record<string, unknown>): boolean {
   const eventType = String(event.eventType ?? '');
   const name = String(data?.name ?? '');
   const reason = String(data?.reason ?? '').toLowerCase();
-  return (
-    eventType === 'orchestrator-guard-block' && name === 'advance-paused'
-  ) || (
-    eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause'
-  );
+  return eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause';
+}
+
+function isOrchestratorBlockedEvent(event: Record<string, unknown>): boolean {
+  const data = event.data as Record<string, unknown> | undefined;
+  const eventType = String(event.eventType ?? '');
+  const name = String(data?.name ?? '');
+  return eventType === 'orchestrator-guard-block' && name === 'advance-paused';
 }
 
 function isPausedEvent(event: Record<string, unknown>): boolean {
   if (isOrchestratorPausedEvent(event)) return true;
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
   const message = String(event.message ?? '').toLowerCase();
+  if (isNonBlockingPauseNotice(message)) return false;
   return PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix));
 }
 
@@ -436,6 +445,25 @@ export class SessionManager extends EventEmitter {
       }
     }
 
+    // Orchestrator guard blocks need operator intervention (headless: blocked).
+    if (isOrchestratorBlockedEvent(event as Record<string, unknown>)) {
+      session.status = 'blocked';
+      session.pendingBlocker = extractOrchestratorBlocker(event as Record<string, unknown>);
+      this.logger.info('session blocked', {
+        sessionId: session.sessionId,
+        projectDir: session.projectDir,
+        blockerId: session.pendingBlocker.id,
+        blockerMethod: session.pendingBlocker.method,
+      });
+      this.emit('session:blocked', {
+        sessionId: session.sessionId,
+        projectDir: session.projectDir,
+        projectName: session.projectName,
+        blocker: session.pendingBlocker,
+      });
+      return;
+    }
+
     // Paused detection — pauseAuto() is resumable and must not leave the
     // session looking active, or duplicate-start prevention will deadlock.
     if (isPausedEvent(event as Record<string, unknown>)) {
@@ -523,4 +551,19 @@ function extractBlocker(event: SdkAgentEvent): PendingBlocker {
     message: String((uiEvent as Record<string, unknown>).title ?? (uiEvent as Record<string, unknown>).message ?? ''),
     event: uiEvent,
   };
+}
+
+function extractOrchestratorBlocker(event: Record<string, unknown>): PendingBlocker {
+  const data = event.data as Record<string, unknown> | undefined;
+  const name = String(data?.name ?? 'advance-paused');
+  const reason = String(data?.reason ?? '');
+  const id = `orchestrator:${name}`;
+  const message = reason || name;
+  const notifyEvent: RpcExtensionUIRequest = {
+    type: 'extension_ui_request',
+    id,
+    method: 'notify',
+    message,
+  };
+  return { id, method: 'notify', message, event: notifyEvent };
 }

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -34,6 +34,11 @@ const FIRE_AND_FORGET_METHODS = new Set([
   'notify', 'setStatus', 'setWidget', 'setTitle', 'set_editor_text',
 ]);
 
+const PAUSED_PREFIXES = [
+  'auto-mode paused',
+  'step-mode paused',
+];
+
 const TERMINAL_PREFIXES = [
   'auto-mode stopped',
   'step-mode stopped',
@@ -46,6 +51,12 @@ function isTerminalNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
   const message = String(event.message ?? '').toLowerCase();
   return TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix));
+}
+
+function isPausedNotification(event: Record<string, unknown>): boolean {
+  if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
+  const message = String(event.message ?? '').toLowerCase();
+  return PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix));
 }
 
 function isBlockedNotification(event: Record<string, unknown>): boolean {
@@ -64,11 +75,11 @@ function isBlockingUIRequest(event: Record<string, unknown>): boolean {
 // SessionManager
 // ---------------------------------------------------------------------------
 
-/** Terminal lifecycle states — work is finished, process may be reclaimed. */
-const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['completed', 'error', 'cancelled']);
+/** Terminal lifecycle states — work is finished or paused, process may be reclaimed. */
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['paused', 'completed', 'error', 'cancelled']);
 
 /**
- * How many terminal (completed/cancelled/errored) sessions to retain for
+ * How many terminal (paused/completed/cancelled/errored) sessions to retain for
  * inspection before evicting the oldest. Bounds heap growth on a daemon that
  * services many distinct project dirs over its lifetime — without this, every
  * session ever run stays resident forever (events buffer + RpcClient ref).
@@ -105,7 +116,7 @@ export class SessionManager extends EventEmitter {
 
     const existing = this.sessions.get(resolvedDir);
     if (existing) {
-      // A terminal session (completed/cancelled/error) is retained only for
+      // A terminal session (paused/completed/cancelled/error) is retained only for
       // inspection — it must not block a fresh start for the same dir. Evict it
       // and reclaim its process before starting anew.
       if (TERMINAL_STATUSES.has(existing.status)) {
@@ -410,6 +421,18 @@ export class SessionManager extends EventEmitter {
         session.cost.tokens.cacheRead = Math.max(session.cost.tokens.cacheRead, costEvent.tokens.cacheRead ?? 0);
         session.cost.tokens.cacheWrite = Math.max(session.cost.tokens.cacheWrite, costEvent.tokens.cacheWrite ?? 0);
       }
+    }
+
+    // Paused detection — pauseAuto() is resumable and must not leave the
+    // session looking active, or duplicate-start prevention will deadlock.
+    if (isPausedNotification(event as Record<string, unknown>)) {
+      session.status = 'paused';
+      session.pendingBlocker = null;
+      session.unsubscribe?.();
+      session.unsubscribe = undefined;
+      this.logger.info('session paused', { sessionId: session.sessionId, projectDir: session.projectDir });
+      this.markTerminal(session.projectDir);
+      return;
     }
 
     // Terminal detection — auto-mode/step-mode stopped

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -53,7 +53,20 @@ function isTerminalNotification(event: Record<string, unknown>): boolean {
   return TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix));
 }
 
-function isPausedNotification(event: Record<string, unknown>): boolean {
+function isOrchestratorPausedEvent(event: Record<string, unknown>): boolean {
+  const data = event.data as Record<string, unknown> | undefined;
+  const eventType = String(event.eventType ?? '');
+  const name = String(data?.name ?? '');
+  const reason = String(data?.reason ?? '').toLowerCase();
+  return (
+    eventType === 'orchestrator-guard-block' && name === 'advance-paused'
+  ) || (
+    eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause'
+  );
+}
+
+function isPausedEvent(event: Record<string, unknown>): boolean {
+  if (isOrchestratorPausedEvent(event)) return true;
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
   const message = String(event.message ?? '').toLowerCase();
   return PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix));
@@ -425,12 +438,17 @@ export class SessionManager extends EventEmitter {
 
     // Paused detection — pauseAuto() is resumable and must not leave the
     // session looking active, or duplicate-start prevention will deadlock.
-    if (isPausedNotification(event as Record<string, unknown>)) {
+    if (isPausedEvent(event as Record<string, unknown>)) {
       session.status = 'paused';
       session.pendingBlocker = null;
       session.unsubscribe?.();
       session.unsubscribe = undefined;
       this.logger.info('session paused', { sessionId: session.sessionId, projectDir: session.projectDir });
+      this.emit('session:paused', {
+        sessionId: session.sessionId,
+        projectDir: session.projectDir,
+        projectName: session.projectName,
+      });
       this.markTerminal(session.projectDir);
       return;
     }

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -395,6 +395,20 @@ export class SessionManager extends EventEmitter {
     if (session) {
       session.unsubscribe?.();
       session.unsubscribe = undefined;
+      // A paused session deliberately keeps its EventBridge state alive (channel
+      // mapping, batcher, blocker collectors) so "type to interact" keeps working.
+      // Evicting it silently would strand that state on the old sessionId while a
+      // fresh start claims a new channel, so emit the teardown event here. The
+      // other terminal states already tore their bridge state down on
+      // completed/cancelled/error, so only 'paused' needs it (and the bridge's
+      // cleanup is idempotent regardless).
+      if (session.status === 'paused') {
+        this.emit('session:cancelled', {
+          sessionId: session.sessionId,
+          projectDir: session.projectDir,
+          projectName: session.projectName,
+        });
+      }
       // The agent child process may still be alive (e.g. a completed session
       // kept for follow-up relay) — reclaim it on eviction.
       void session.client.stop().catch(() => { /* swallow */ });

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -412,6 +412,14 @@ export class SessionManager extends EventEmitter {
       // The agent child process may still be alive (e.g. a completed session
       // kept for follow-up relay) — reclaim it on eviction.
       void session.client.stop().catch(() => { /* swallow */ });
+
+      // Paused sessions keep EventBridge channel mappings alive; notify listeners
+      // so batchers, collectors, and channel maps are torn down before restart.
+      this.emit('session:cancelled', {
+        sessionId: session.sessionId,
+        projectDir: session.projectDir,
+        projectName: session.projectName,
+      });
     }
   }
 

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -412,14 +412,6 @@ export class SessionManager extends EventEmitter {
       // The agent child process may still be alive (e.g. a completed session
       // kept for follow-up relay) — reclaim it on eviction.
       void session.client.stop().catch(() => { /* swallow */ });
-
-      // Paused sessions keep EventBridge channel mappings alive; notify listeners
-      // so batchers, collectors, and channel maps are torn down before restart.
-      this.emit('session:cancelled', {
-        sessionId: session.sessionId,
-        projectDir: session.projectDir,
-        projectName: session.projectName,
-      });
     }
   }
 

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -452,11 +452,13 @@ export class SessionManager extends EventEmitter {
 
     // Paused detection — pauseAuto() is resumable and must not leave the
     // session looking active, or duplicate-start prevention will deadlock.
+    // Keep the RpcClient event subscription: a paused session stays interactive
+    // ("type to interact"), so resumed agent output and later terminal/blocked
+    // notifications must still reach handleEvent to relay and update status.
+    // The subscription is torn down on cleanup/eviction/cancel instead.
     if (isPausedEvent(event as Record<string, unknown>)) {
       session.status = 'paused';
       session.pendingBlocker = null;
-      session.unsubscribe?.();
-      session.unsubscribe = undefined;
       this.logger.info('session paused', { sessionId: session.sessionId, projectDir: session.projectDir });
       this.emit('session:paused', {
         sessionId: session.sessionId,

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -455,7 +455,6 @@ export class SessionManager extends EventEmitter {
         projectDir: session.projectDir,
         projectName: session.projectName,
       });
-      this.markTerminal(session.projectDir);
       return;
     }
 

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -340,7 +340,15 @@ export class SessionManager extends EventEmitter {
 
     for (const session of this.sessions.values()) {
       session.unsubscribe?.();
-      if (session.status === 'running' || session.status === 'starting' || session.status === 'blocked') {
+      // A paused session still owns a live headless child process (its RpcClient
+      // is retained for "type to interact"). On daemon shutdown that process must
+      // be reclaimed too, otherwise pausing then stopping the daemon leaks it.
+      if (
+        session.status === 'running' ||
+        session.status === 'starting' ||
+        session.status === 'blocked' ||
+        session.status === 'paused'
+      ) {
         stopPromises.push(
           session.client.stop().catch(() => { /* swallow */ })
         );

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -63,14 +63,11 @@ function isOrchestratorPausedEvent(event: Record<string, unknown>): boolean {
   const eventType = String(event.eventType ?? '');
   const name = String(data?.name ?? '');
   const reason = String(data?.reason ?? '').toLowerCase();
-  return eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause';
-}
-
-function isOrchestratorBlockedEvent(event: Record<string, unknown>): boolean {
-  const data = event.data as Record<string, unknown> | undefined;
-  const eventType = String(event.eventType ?? '');
-  const name = String(data?.name ?? '');
-  return eventType === 'orchestrator-guard-block' && name === 'advance-paused';
+  return (
+    eventType === 'orchestrator-guard-block' && name === 'advance-paused'
+  ) || (
+    eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause'
+  );
 }
 
 function isPausedEvent(event: Record<string, unknown>): boolean {
@@ -445,25 +442,6 @@ export class SessionManager extends EventEmitter {
       }
     }
 
-    // Orchestrator guard blocks need operator intervention (headless: blocked).
-    if (isOrchestratorBlockedEvent(event as Record<string, unknown>)) {
-      session.status = 'blocked';
-      session.pendingBlocker = extractOrchestratorBlocker(event as Record<string, unknown>);
-      this.logger.info('session blocked', {
-        sessionId: session.sessionId,
-        projectDir: session.projectDir,
-        blockerId: session.pendingBlocker.id,
-        blockerMethod: session.pendingBlocker.method,
-      });
-      this.emit('session:blocked', {
-        sessionId: session.sessionId,
-        projectDir: session.projectDir,
-        projectName: session.projectName,
-        blocker: session.pendingBlocker,
-      });
-      return;
-    }
-
     // Paused detection — pauseAuto() is resumable and must not leave the
     // session looking active, or duplicate-start prevention will deadlock.
     if (isPausedEvent(event as Record<string, unknown>)) {
@@ -553,17 +531,3 @@ function extractBlocker(event: SdkAgentEvent): PendingBlocker {
   };
 }
 
-function extractOrchestratorBlocker(event: Record<string, unknown>): PendingBlocker {
-  const data = event.data as Record<string, unknown> | undefined;
-  const name = String(data?.name ?? 'advance-paused');
-  const reason = String(data?.reason ?? '');
-  const id = `orchestrator:${name}`;
-  const message = reason || name;
-  const notifyEvent: RpcExtensionUIRequest = {
-    type: 'extension_ui_request',
-    id,
-    method: 'notify',
-    message,
-  };
-  return { id, method: 'notify', message, event: notifyEvent };
-}

--- a/packages/daemon/src/types.ts
+++ b/packages/daemon/src/types.ts
@@ -64,7 +64,7 @@ export interface DaemonConfig {
 // Session Status
 // ---------------------------------------------------------------------------
 
-export type SessionStatus = 'starting' | 'running' | 'blocked' | 'completed' | 'error' | 'cancelled';
+export type SessionStatus = 'starting' | 'running' | 'blocked' | 'paused' | 'completed' | 'error' | 'cancelled';
 
 // ---------------------------------------------------------------------------
 // Managed Session

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -368,10 +368,10 @@ describe('SessionManager', () => {
     );
   });
 
-  // #4476: terminal-state sessions (completed/error/cancelled) are evicted so
+  // #4476: terminal-state sessions (paused/completed/error/cancelled) are evicted so
   // the same projectDir can host a fresh session — only starting/running/blocked
   // sessions block re-entry.
-  for (const terminalStatus of ['completed', 'error', 'cancelled'] as const) {
+  for (const terminalStatus of ['paused', 'completed', 'error', 'cancelled'] as const) {
     it(`startSession evicts a prior '${terminalStatus}' session for the same projectDir`, async () => {
       const dir = `/tmp/evict-${terminalStatus}`;
       const firstSessionId = await sm.startSession(dir, { cliPath: '/usr/bin/gsd' });
@@ -592,6 +592,28 @@ describe('SessionManager', () => {
 
     const session = sm.getSession(sessionId)!;
     assert.equal(session.status, 'completed');
+  });
+
+  it('pause detection: auto-mode paused sets status to paused and allows restart', async () => {
+    const dir = '/tmp/terminal-paused';
+    const sessionId = await sm.startSession(dir, { cliPath: '/usr/bin/gsd' });
+    const client = sm.lastClient!;
+
+    client.emitEvent({
+      type: 'extension_ui_request',
+      method: 'notify',
+      message: 'Auto-mode paused (Escape). Type to interact, or /gsd auto to resume.',
+      id: 'pause-1',
+    });
+
+    const session = sm.getSession(sessionId)!;
+    assert.equal(session.status, 'paused');
+    assert.equal(session.pendingBlocker, null);
+
+    const nextSessionId = await sm.startSession(dir, { cliPath: '/usr/bin/gsd' });
+    assert.notEqual(nextSessionId, sessionId);
+    assert.equal(sm.getSessionByDir(dir)!.sessionId, nextSessionId);
+    assert.equal(sm.getSession(nextSessionId)!.status, 'running');
   });
 
   it('terminal detection with blocked: message sets status to blocked', async () => {

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -616,6 +616,29 @@ describe('SessionManager', () => {
     assert.equal(sm.getSession(nextSessionId)!.status, 'running');
   });
 
+  it('pause detection: structured orchestrator terminal pause sets status to paused', async () => {
+    const dir = '/tmp/structured-terminal-paused';
+    const sessionId = await sm.startSession(dir, { cliPath: '/usr/bin/gsd' });
+    const client = sm.lastClient!;
+
+    client.emitEvent({
+      eventType: 'orchestrator-terminal',
+      data: {
+        source: 'auto-orchestrator',
+        name: 'stop',
+        reason: 'pause',
+      },
+    });
+
+    const session = sm.getSession(sessionId)!;
+    assert.equal(session.status, 'paused');
+    assert.equal(session.pendingBlocker, null);
+
+    const nextSessionId = await sm.startSession(dir, { cliPath: '/usr/bin/gsd' });
+    assert.notEqual(nextSessionId, sessionId);
+    assert.equal(sm.getSessionByDir(dir)!.sessionId, nextSessionId);
+  });
+
   it('terminal detection with blocked: message sets status to blocked', async () => {
     const sessionId = await sm.startSession('/tmp/terminal-blocked', { cliPath: '/usr/bin/gsd' });
     const client = sm.lastClient!;

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -173,6 +173,7 @@ class TestableSessionManager extends SessionManager {
         );
       }
       existing.unsubscribe?.();
+      void existing.client.stop().catch(() => { /* swallow */ });
       (this as any).sessions.delete(resolvedDir);
     }
 
@@ -376,11 +377,13 @@ describe('SessionManager', () => {
       const dir = `/tmp/evict-${terminalStatus}`;
       const firstSessionId = await sm.startSession(dir, { cliPath: '/usr/bin/gsd' });
       const first = sm.getSession(firstSessionId)!;
+      const firstClient = sm.lastClient!;
       first.status = terminalStatus;
 
       // Should not throw — terminal session is evicted, fresh one starts.
       const secondSessionId = await sm.startSession(dir, { cliPath: '/usr/bin/gsd' });
       assert.notEqual(secondSessionId, firstSessionId);
+      assert.ok(firstClient.stopped, `evicted '${terminalStatus}' session client should be stopped`);
       const second = sm.getSession(secondSessionId)!;
       assert.equal(second.status, 'running');
       assert.equal(sm.getSessionByDir(dir)!.sessionId, secondSessionId);
@@ -612,8 +615,34 @@ describe('SessionManager', () => {
 
     const nextSessionId = await sm.startSession(dir, { cliPath: '/usr/bin/gsd' });
     assert.notEqual(nextSessionId, sessionId);
+    assert.ok(client.stopped);
     assert.equal(sm.getSessionByDir(dir)!.sessionId, nextSessionId);
     assert.equal(sm.getSession(nextSessionId)!.status, 'running');
+  });
+
+  it('pause detection keeps the event subscription for resumed output', async () => {
+    const dir = '/tmp/terminal-paused-resume';
+    const sessionId = await sm.startSession(dir, { cliPath: '/usr/bin/gsd' });
+    const client = sm.lastClient!;
+
+    client.emitEvent({
+      type: 'extension_ui_request',
+      method: 'notify',
+      message: 'Auto-mode paused (Escape). Type to interact, or /gsd auto to resume.',
+      id: 'pause-1',
+    });
+
+    const session = sm.getSession(sessionId)!;
+    assert.equal(session.status, 'paused');
+
+    client.emitEvent({
+      type: 'extension_ui_request',
+      method: 'notify',
+      message: 'Auto-mode stopped: completed all tasks',
+      id: 'term-1',
+    });
+
+    assert.equal(session.status, 'completed');
   });
 
   it('pause detection: structured orchestrator terminal pause sets status to paused', async () => {

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -27,6 +27,11 @@ const FIRE_AND_FORGET_METHODS = new Set([
   'notify', 'setStatus', 'setWidget', 'setTitle', 'set_editor_text',
 ]);
 
+const PAUSED_PREFIXES = [
+  'auto-mode paused',
+  'step-mode paused',
+];
+
 const TERMINAL_PREFIXES = [
   'auto-mode stopped',
   'step-mode stopped',
@@ -61,6 +66,12 @@ function isTerminalNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
   const message = String(event.message ?? '').toLowerCase();
   return TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix));
+}
+
+function isPausedNotification(event: Record<string, unknown>): boolean {
+  if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
+  const message = String(event.message ?? '').toLowerCase();
+  return PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix));
 }
 
 function isBlockedNotification(event: Record<string, unknown>): boolean {
@@ -100,7 +111,7 @@ export class SessionManager {
     const existing = this.sessions.get(resolvedDir);
     if (existing) {
       // Only block when a genuinely active session is running. Terminal
-      // states (error, completed, cancelled) are evicted so the caller can
+      // states (paused, error, completed, cancelled) are evicted so the caller can
       // start a fresh session for the same projectDir.
       if (existing.status === 'starting' || existing.status === 'running' || existing.status === 'blocked') {
         throw new Error(
@@ -383,6 +394,15 @@ export class SessionManager {
         session.cost.tokens.cacheRead = Math.max(session.cost.tokens.cacheRead, costEvent.tokens.cacheRead ?? 0);
         session.cost.tokens.cacheWrite = Math.max(session.cost.tokens.cacheWrite, costEvent.tokens.cacheWrite ?? 0);
       }
+    }
+
+    // Paused detection — pauseAuto() is resumable and must not leave the
+    // session looking active, or duplicate-start prevention will deadlock.
+    if (isPausedNotification(event as Record<string, unknown>)) {
+      session.status = 'paused';
+      session.pendingBlocker = null;
+      session.unsubscribe?.();
+      return;
     }
 
     // Terminal detection — auto-mode/step-mode stopped

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -68,7 +68,20 @@ function isTerminalNotification(event: Record<string, unknown>): boolean {
   return TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix));
 }
 
-function isPausedNotification(event: Record<string, unknown>): boolean {
+function isOrchestratorPausedEvent(event: Record<string, unknown>): boolean {
+  const data = event.data as Record<string, unknown> | undefined;
+  const eventType = String(event.eventType ?? '');
+  const name = String(data?.name ?? '');
+  const reason = String(data?.reason ?? '').toLowerCase();
+  return (
+    eventType === 'orchestrator-guard-block' && name === 'advance-paused'
+  ) || (
+    eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause'
+  );
+}
+
+function isPausedEvent(event: Record<string, unknown>): boolean {
+  if (isOrchestratorPausedEvent(event)) return true;
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
   const message = String(event.message ?? '').toLowerCase();
   return PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix));
@@ -398,7 +411,7 @@ export class SessionManager {
 
     // Paused detection — pauseAuto() is resumable and must not leave the
     // session looking active, or duplicate-start prevention will deadlock.
-    if (isPausedNotification(event as Record<string, unknown>)) {
+    if (isPausedEvent(event as Record<string, unknown>)) {
       session.status = 'paused';
       session.pendingBlocker = null;
       session.unsubscribe?.();

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -65,7 +65,12 @@ function getPathEnvValue(env: NodeJS.ProcessEnv = process.env): string {
 function isTerminalNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
   const message = String(event.message ?? '').toLowerCase();
-  return TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix));
+  if (TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix))) return true;
+  return PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix)) && isNonBlockingPauseNotice(message);
+}
+
+function isNonBlockingPauseNotice(message: string): boolean {
+  return message.includes('idempotent advance: unit already active');
 }
 
 function isOrchestratorPausedEvent(event: Record<string, unknown>): boolean {
@@ -73,17 +78,21 @@ function isOrchestratorPausedEvent(event: Record<string, unknown>): boolean {
   const eventType = String(event.eventType ?? '');
   const name = String(data?.name ?? '');
   const reason = String(data?.reason ?? '').toLowerCase();
-  return (
-    eventType === 'orchestrator-guard-block' && name === 'advance-paused'
-  ) || (
-    eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause'
-  );
+  return eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause';
+}
+
+function isOrchestratorBlockedEvent(event: Record<string, unknown>): boolean {
+  const data = event.data as Record<string, unknown> | undefined;
+  const eventType = String(event.eventType ?? '');
+  const name = String(data?.name ?? '');
+  return eventType === 'orchestrator-guard-block' && name === 'advance-paused';
 }
 
 function isPausedEvent(event: Record<string, unknown>): boolean {
   if (isOrchestratorPausedEvent(event)) return true;
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
   const message = String(event.message ?? '').toLowerCase();
+  if (isNonBlockingPauseNotice(message)) return false;
   return PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix));
 }
 
@@ -409,6 +418,13 @@ export class SessionManager {
       }
     }
 
+    // Orchestrator guard blocks need operator intervention (headless: blocked).
+    if (isOrchestratorBlockedEvent(event as Record<string, unknown>)) {
+      session.status = 'blocked';
+      session.pendingBlocker = extractOrchestratorBlocker(event as Record<string, unknown>);
+      return;
+    }
+
     // Paused detection — pauseAuto() is resumable and must not leave the
     // session looking active, or duplicate-start prevention will deadlock.
     if (isPausedEvent(event as Record<string, unknown>)) {
@@ -457,4 +473,19 @@ function extractBlocker(event: SdkAgentEvent): PendingBlocker {
     message: String((uiEvent as Record<string, unknown>).title ?? (uiEvent as Record<string, unknown>).message ?? ''),
     event: uiEvent,
   };
+}
+
+function extractOrchestratorBlocker(event: Record<string, unknown>): PendingBlocker {
+  const data = event.data as Record<string, unknown> | undefined;
+  const name = String(data?.name ?? 'advance-paused');
+  const reason = String(data?.reason ?? '');
+  const id = `orchestrator:${name}`;
+  const message = reason || name;
+  const notifyEvent: RpcExtensionUIRequest = {
+    type: 'extension_ui_request',
+    id,
+    method: 'notify',
+    message,
+  };
+  return { id, method: 'notify', message, event: notifyEvent };
 }

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -78,14 +78,11 @@ function isOrchestratorPausedEvent(event: Record<string, unknown>): boolean {
   const eventType = String(event.eventType ?? '');
   const name = String(data?.name ?? '');
   const reason = String(data?.reason ?? '').toLowerCase();
-  return eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause';
-}
-
-function isOrchestratorBlockedEvent(event: Record<string, unknown>): boolean {
-  const data = event.data as Record<string, unknown> | undefined;
-  const eventType = String(event.eventType ?? '');
-  const name = String(data?.name ?? '');
-  return eventType === 'orchestrator-guard-block' && name === 'advance-paused';
+  return (
+    eventType === 'orchestrator-guard-block' && name === 'advance-paused'
+  ) || (
+    eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause'
+  );
 }
 
 function isPausedEvent(event: Record<string, unknown>): boolean {
@@ -418,13 +415,6 @@ export class SessionManager {
       }
     }
 
-    // Orchestrator guard blocks need operator intervention (headless: blocked).
-    if (isOrchestratorBlockedEvent(event as Record<string, unknown>)) {
-      session.status = 'blocked';
-      session.pendingBlocker = extractOrchestratorBlocker(event as Record<string, unknown>);
-      return;
-    }
-
     // Paused detection — pauseAuto() is resumable and must not leave the
     // session looking active, or duplicate-start prevention will deadlock.
     if (isPausedEvent(event as Record<string, unknown>)) {
@@ -475,17 +465,3 @@ function extractBlocker(event: SdkAgentEvent): PendingBlocker {
   };
 }
 
-function extractOrchestratorBlocker(event: Record<string, unknown>): PendingBlocker {
-  const data = event.data as Record<string, unknown> | undefined;
-  const name = String(data?.name ?? 'advance-paused');
-  const reason = String(data?.reason ?? '');
-  const id = `orchestrator:${name}`;
-  const message = reason || name;
-  const notifyEvent: RpcExtensionUIRequest = {
-    type: 'extension_ui_request',
-    id,
-    method: 'notify',
-    message,
-  };
-  return { id, method: 'notify', message, event: notifyEvent };
-}

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -138,6 +138,10 @@ export class SessionManager {
         );
       }
       existing.unsubscribe?.();
+      // Reclaim the evicted session's live headless child process. A paused (or
+      // otherwise terminal) session keeps its RpcClient alive, so deleting the
+      // map entry alone would orphan the child process.
+      void existing.client.stop().catch(() => { /* swallow */ });
       this.sessions.delete(resolvedDir);
     }
 
@@ -425,10 +429,12 @@ export class SessionManager {
 
     // Paused detection — pauseAuto() is resumable and must not leave the
     // session looking active, or duplicate-start prevention will deadlock.
+    // Keep the RpcClient event subscription so resumed output and later
+    // terminal/blocked notifications still reach handleEvent (a paused session
+    // stays resumable); it is torn down on cleanup/eviction instead.
     if (isPausedEvent(event as Record<string, unknown>)) {
       session.status = 'paused';
       session.pendingBlocker = null;
-      session.unsubscribe?.();
       return;
     }
 

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -360,7 +360,15 @@ export class SessionManager {
 
     for (const session of this.sessions.values()) {
       session.unsubscribe?.();
-      if (session.status === 'running' || session.status === 'starting' || session.status === 'blocked') {
+      // A paused session still owns a live headless child process (its RpcClient
+      // is retained for resume). On shutdown that process must be reclaimed too,
+      // otherwise pausing then stopping leaks it.
+      if (
+        session.status === 'running' ||
+        session.status === 'starting' ||
+        session.status === 'blocked' ||
+        session.status === 'paused'
+      ) {
         stopPromises.push(
           session.client.stop().catch(() => { /* swallow */ })
         );

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -13,7 +13,7 @@ import type {
 // Session Status
 // ---------------------------------------------------------------------------
 
-export type SessionStatus = 'starting' | 'running' | 'blocked' | 'completed' | 'error' | 'cancelled';
+export type SessionStatus = 'starting' | 'running' | 'blocked' | 'paused' | 'completed' | 'error' | 'cancelled';
 
 // ---------------------------------------------------------------------------
 // Managed Session

--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -121,6 +121,7 @@ function isBlockingCommandBlock(event: Record<string, unknown>): boolean {
 }
 
 export function isTerminalNotification(event: Record<string, unknown>): boolean {
+  if (isOrchestratorPausedEvent(event)) return true
   if (isBlockingCommandBlock(event)) return true
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
   const message = String(event.message ?? '').toLowerCase()
@@ -137,10 +138,23 @@ export function isTerminalNotification(event: Record<string, unknown>): boolean 
 }
 
 export function isBlockedNotification(event: Record<string, unknown>): boolean {
+  if (isOrchestratorPausedEvent(event)) return true
   if (isBlockingCommandBlock(event)) return true
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
   // Recoverable pauses need operator intervention in headless mode.
   return isBlockedNoticeMessage(String(event.message ?? '').toLowerCase())
+}
+
+function isOrchestratorPausedEvent(event: Record<string, unknown>): boolean {
+  const data = event.data as Record<string, unknown> | undefined
+  const eventType = String(event.eventType ?? '')
+  const name = String(data?.name ?? '')
+  const reason = String(data?.reason ?? '').toLowerCase()
+  return (
+    eventType === 'orchestrator-guard-block' && name === 'advance-paused'
+  ) || (
+    eventType === 'orchestrator-terminal' && name === 'stop' && reason === 'pause'
+  )
 }
 
 export function isMilestoneReadyNotification(event: Record<string, unknown>): boolean {

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -230,6 +230,20 @@ test('isTerminalNotification: idempotent advance pause notifications are termina
   assert.equal(isTerminalNotification(makeNotify('Auto-mode paused: idempotent advance: unit already active')), true)
 })
 
+test('isTerminalNotification: structured orchestrator terminal pause events are terminal', () => {
+  assert.equal(isTerminalNotification({
+    eventType: 'orchestrator-terminal',
+    data: { source: 'auto-orchestrator', name: 'stop', reason: 'pause' },
+  }), true)
+})
+
+test('isTerminalNotification: structured orchestrator advance-paused events are terminal', () => {
+  assert.equal(isTerminalNotification({
+    eventType: 'orchestrator-guard-block',
+    data: { source: 'auto-orchestrator', name: 'advance-paused', reason: 'manual attention' },
+  }), true)
+})
+
 test('isTerminalNotification: manual merge-resolution notifications are terminal', () => {
   assert.equal(isTerminalNotification(makeNotify('Survivor-branch finalization for M001 failed: merge conflict. Resolve manually and re-run /gsd auto.')), true)
 })
@@ -255,6 +269,17 @@ test('isBlockedNotification: pause notifications require intervention in headles
 
 test('isBlockedNotification: idempotent advance pause notifications are not blocked', () => {
   assert.equal(isBlockedNotification(makeNotify('Auto-mode paused: idempotent advance: unit already active')), false)
+})
+
+test('isBlockedNotification: structured orchestrator pause events require intervention', () => {
+  assert.equal(isBlockedNotification({
+    eventType: 'orchestrator-terminal',
+    data: { source: 'auto-orchestrator', name: 'stop', reason: 'pause' },
+  }), true)
+  assert.equal(isBlockedNotification({
+    eventType: 'orchestrator-guard-block',
+    data: { source: 'auto-orchestrator', name: 'advance-paused', reason: 'manual attention' },
+  }), true)
 })
 
 test('isBlockedNotification: manual merge-resolution notifications require intervention', () => {


### PR DESCRIPTION
## Summary
- Added paused session handling for MCP/daemon managers and verified syntax/diff checks; package tests were blocked by missing dependencies and registry ENOTFOUND.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1490
- [#1490 [Bug]: gsd-auto-orchestrator terminal/pause event leaves sessions table status='running'; /gsd auto deadlocks indefinitely](https://github.com/open-gsd/gsd-pi/issues/1490)

## User
- @hermer

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1490-bug-gsd-auto-orchestrator-terminal-pause-1784416051`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session lifecycle, duplicate-start rules, and Discord bridge teardown paths; behavior changes are well-tested but affect orchestration and long-running daemon sessions.
> 
> **Overview**
> Fixes **#1490** where orchestrator pause/terminal events left sessions stuck as `running`, blocking another `/gsd auto` for the same project.
> 
> **Session lifecycle:** Daemon and MCP `SessionManager` now recognize **paused** (notify text, structured `orchestrator-terminal` / `orchestrator-guard-block` events). Status becomes `paused`, blockers are cleared, and the RpcClient subscription stays so resumed output and later completion still work. **Paused** is treated like other terminal states for duplicate starts—eviction stops the old client and, for paused runs, emits `session:cancelled` so Discord bridge state is not stranded. Shutdown **cleanup** also stops paused child processes.
> 
> **Discord bridge:** `EventBridge` listens for `session:paused`, flushes the message batcher (new public `flush()` on `MessageBatcher`), and stops blocker collectors **without** tearing down channel mappings, so “type to interact” and resumed streaming keep working.
> 
> **Headless helpers:** `headless-events` classifies the same orchestrator pause signals as terminal/blocked where appropriate; tests cover daemon, MCP, bridge, and headless behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1ac64dda3a9efcfbfe9a77977dc6191ae8d67e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->