### PR TITLE
fix(issue): mcp_discover hangs when parallel stdio connections open concurrent trust dialogs

### DIFF
--- a/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
@@ -1,10 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
-import {
+import mcpClientExtension, {
+  _assertTrustedStdioServerForTest,
   _buildMcpChildEnvForTest,
   _buildMcpTrustConfirmOptionsForTest,
+  _resetMcpClientStateForTest,
 } from "../../mcp-client/index.ts";
+import type { ManagedMcpServerConfig } from "../../mcp-client/manager.ts";
 
 // Note: four source-grep tests that scanned `mcp-client/index.ts` for
 // Map<> shapes, catch-block structure, and closeAll body were removed
@@ -13,6 +21,101 @@ import {
 // cleanup order) broke the greps without a real regression. Runtime
 // coverage of connectServer/closeAll with a mocked failing transport
 // is tracked as a follow-up.
+
+function makeStdioConfig(name: string): ManagedMcpServerConfig {
+  return {
+    name,
+    transport: "stdio",
+    sourcePath: `/tmp/${name}.mcp.json`,
+    sourceKind: "project-shared",
+    disabled: false,
+    command: "node",
+    args: ["server.js"],
+    envWarnings: [],
+  };
+}
+
+type ConfirmOptions = { timeout?: number; signal?: AbortSignal };
+
+interface CapturedPrompt {
+  title: string;
+  options?: ConfirmOptions;
+  resolve: (approved: boolean) => void;
+  reject: (err: unknown) => void;
+}
+
+function createConfirmHarness(): {
+  ctx: unknown;
+  prompts: CapturedPrompt[];
+  activeCount: () => number;
+  maxActiveCount: () => number;
+} {
+  const prompts: CapturedPrompt[] = [];
+  let active = 0;
+  let maxActive = 0;
+  const ctx = {
+    hasUI: true,
+    ui: {
+      confirm(title: string, _message: string, options?: ConfirmOptions) {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        return new Promise<boolean>((resolve, reject) => {
+          let settled = false;
+          let onAbort = () => {};
+          const finish = (fn: () => void) => {
+            if (settled) return;
+            settled = true;
+            options?.signal?.removeEventListener("abort", onAbort);
+            active -= 1;
+            fn();
+          };
+          onAbort = () => {
+            finish(() => reject(options?.signal?.reason ?? new Error("aborted")));
+          };
+          if (options?.signal?.aborted) {
+            onAbort();
+            return;
+          }
+          options?.signal?.addEventListener("abort", onAbort, { once: true });
+          prompts.push({
+            title,
+            options,
+            resolve: (approved: boolean) => finish(() => resolve(approved)),
+            reject: (err: unknown) => finish(() => reject(err)),
+          });
+        });
+      },
+    },
+  };
+  return {
+    ctx,
+    prompts,
+    activeCount: () => active,
+    maxActiveCount: () => maxActive,
+  };
+}
+
+async function waitForCondition(description: string, condition: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.fail(`Timed out waiting for ${description}`);
+}
+
+function createMockPi(): { pi: unknown; tools: Map<string, any> } {
+  const tools = new Map<string, any>();
+  return {
+    tools,
+    pi: {
+      on() {},
+      registerTool(tool: any) {
+        tools.set(tool.name, tool);
+      },
+    },
+  };
+}
 
 test("MCP stdio child env only includes safe inherited keys plus explicit config env", () => {
   const previousSecret = process.env.SECRET_MCP_TEST_TOKEN;
@@ -44,4 +147,167 @@ test("MCP stdio trust confirmation is abort-aware", () => {
 
   assert.equal(options.timeout, 120_000);
   assert.equal(options.signal, controller.signal);
+});
+
+test("MCP stdio trust confirmations are serialized across different servers", async () => {
+  const harness = createConfirmHarness();
+  try {
+    const first = _assertTrustedStdioServerForTest(makeStdioConfig("server-a"), harness.ctx as any);
+    const second = _assertTrustedStdioServerForTest(makeStdioConfig("server-b"), harness.ctx as any);
+
+    await waitForCondition("first trust prompt", () => harness.prompts.length === 1);
+    assert.equal(harness.activeCount(), 1);
+    assert.equal(harness.maxActiveCount(), 1);
+    assert.match(harness.prompts[0]?.title ?? "", /server-a/);
+
+    harness.prompts[0]?.resolve(true);
+    await waitForCondition("second trust prompt", () => harness.prompts.length === 2);
+    assert.equal(harness.activeCount(), 1);
+    assert.equal(harness.maxActiveCount(), 1);
+    assert.match(harness.prompts[1]?.title ?? "", /server-b/);
+
+    harness.prompts[1]?.resolve(true);
+    const trustKeys = await Promise.all([first, second]);
+    assert.match(trustKeys[0] ?? "", /server-a/);
+    assert.match(trustKeys[1] ?? "", /server-b/);
+  } finally {
+    for (const prompt of harness.prompts) prompt.reject(new Error("test cleanup"));
+    await _resetMcpClientStateForTest();
+  }
+});
+
+test("MCP stdio trust approval aborts while queued and releases the queue", async () => {
+  const harness = createConfirmHarness();
+  try {
+    const first = _assertTrustedStdioServerForTest(makeStdioConfig("queued-a"), harness.ctx as any);
+    await waitForCondition("active first trust prompt", () => harness.prompts.length === 1);
+
+    const controller = new AbortController();
+    const second = _assertTrustedStdioServerForTest(
+      makeStdioConfig("queued-b"),
+      harness.ctx as any,
+      controller.signal,
+    );
+
+    controller.abort(new Error("caller aborted"));
+    await assert.rejects(second, /caller aborted/);
+    assert.equal(harness.prompts.length, 1, "aborted queued approval must not open a prompt");
+
+    harness.prompts[0]?.resolve(true);
+    await first;
+
+    const third = _assertTrustedStdioServerForTest(makeStdioConfig("queued-c"), harness.ctx as any);
+    await waitForCondition("third trust prompt after queued abort", () => harness.prompts.length === 2);
+    harness.prompts[1]?.resolve(true);
+    await third;
+    assert.equal(harness.maxActiveCount(), 1);
+  } finally {
+    for (const prompt of harness.prompts) prompt.reject(new Error("test cleanup"));
+    await _resetMcpClientStateForTest();
+  }
+});
+
+test("MCP stdio trust approval hard timeout rejects and releases the queue", async () => {
+  let hangingPromptCount = 0;
+  const hangingCtx = {
+    hasUI: true,
+    ui: {
+      confirm() {
+        hangingPromptCount += 1;
+        return new Promise<boolean>(() => {});
+      },
+    },
+  };
+
+  try {
+    const timedOut = _assertTrustedStdioServerForTest(
+      makeStdioConfig("timeout-a"),
+      hangingCtx as any,
+      undefined,
+      25,
+    );
+    await waitForCondition("hanging trust prompt", () => hangingPromptCount === 1);
+    await assert.rejects(timedOut, /Timed out waiting for stdio MCP trust approval for "timeout-a"/);
+
+    const harness = createConfirmHarness();
+    const next = _assertTrustedStdioServerForTest(makeStdioConfig("timeout-b"), harness.ctx as any);
+    await waitForCondition("trust prompt after timeout", () => harness.prompts.length === 1);
+    harness.prompts[0]?.resolve(true);
+    await next;
+  } finally {
+    await _resetMcpClientStateForTest();
+  }
+});
+
+test("MCP stdio discover deduplicates concurrent first calls for the same server", async () => {
+  const previousGsdHome = process.env.GSD_HOME;
+  const originalCwd = process.cwd();
+  const projectDir = mkdtempSync(join(tmpdir(), "mcp-client-dedupe-project-"));
+  const gsdHomeDir = mkdtempSync(join(tmpdir(), "mcp-client-dedupe-home-"));
+
+  try {
+    process.env.GSD_HOME = gsdHomeDir;
+    process.chdir(projectDir);
+    mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+
+    const require = createRequire(import.meta.url);
+    const mcpModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/mcp.js")).href;
+    const stdioModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/stdio.js")).href;
+    const startLogPath = join(projectDir, "starts.log");
+    const serverPath = join(projectDir, "dedupe-mcp-server.mjs");
+    writeFileSync(
+      serverPath,
+      [
+        `const { McpServer } = await import(${JSON.stringify(mcpModuleUrl)});`,
+        `const { StdioServerTransport } = await import(${JSON.stringify(stdioModuleUrl)});`,
+        'import { appendFileSync } from "node:fs";',
+        `appendFileSync(${JSON.stringify(startLogPath)}, "start\\n", "utf-8");`,
+        'const server = new McpServer({ name: "fake", version: "1.0.0" }, { capabilities: { tools: {} } });',
+        'server.tool("dedupe_tool", "Deduped tool", {}, async () => ({ content: [{ type: "text", text: "ok" }] }));',
+        'await server.connect(new StdioServerTransport());',
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(
+      join(projectDir, ".mcp.json"),
+      JSON.stringify({ mcpServers: { "dedupe-server": { command: process.execPath, args: [serverPath] } } }),
+      "utf-8",
+    );
+
+    const { pi, tools } = createMockPi();
+    mcpClientExtension(pi as any);
+    const discover = tools.get("mcp_discover");
+    assert.ok(discover, "mcp_discover must be registered");
+
+    let promptCount = 0;
+    const ctx = {
+      hasUI: true,
+      ui: {
+        confirm: async () => {
+          promptCount += 1;
+          return true;
+        },
+      },
+    };
+    const signal = new AbortController().signal;
+    const [first, second] = await Promise.all([
+      discover.execute("call-1", { server: "dedupe-server" }, signal, () => {}, ctx),
+      discover.execute("call-2", { server: "dedupe-server" }, signal, () => {}, ctx),
+    ]);
+
+    assert.equal(promptCount, 1);
+    assert.match(first.content[0]?.text ?? "", /dedupe_tool/);
+    assert.match(second.content[0]?.text ?? "", /dedupe_tool/);
+    const starts = existsSync(startLogPath)
+      ? readFileSync(startLogPath, "utf-8").trim().split("\n").filter(Boolean)
+      : [];
+    assert.equal(starts.length, 1, "concurrent same-server discovery must create one stdio connection");
+  } finally {
+    await _resetMcpClientStateForTest();
+    process.chdir(originalCwd);
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(gsdHomeDir, { recursive: true, force: true });
+  }
 });

--- a/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
@@ -239,6 +239,99 @@ test("MCP stdio trust approval hard timeout rejects and releases the queue", asy
   }
 });
 
+test("MCP stdio trust keeps serializing when a queued caller aborts mid-prompt", async () => {
+  const harness = createConfirmHarness();
+  try {
+    const first = _assertTrustedStdioServerForTest(makeStdioConfig("parallel-a"), harness.ctx as any);
+    await waitForCondition("active first trust prompt", () => harness.prompts.length === 1);
+
+    const controller = new AbortController();
+    const second = _assertTrustedStdioServerForTest(
+      makeStdioConfig("parallel-b"),
+      harness.ctx as any,
+      controller.signal,
+    );
+    controller.abort(new Error("caller aborted"));
+    await assert.rejects(second, /caller aborted/);
+
+    // A third caller enters while the first prompt is STILL active. It must
+    // queue behind it rather than open a concurrent prompt. Regression guard for
+    // the queue-reset-allows-parallel-prompts bug: a queued caller aborting must
+    // not collapse the queue and let a new caller run alongside the live prompt.
+    const third = _assertTrustedStdioServerForTest(makeStdioConfig("parallel-c"), harness.ctx as any);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(harness.prompts.length, 1, "third caller must not open a concurrent prompt");
+    assert.equal(harness.maxActiveCount(), 1);
+
+    harness.prompts[0]?.resolve(true);
+    await first;
+    await waitForCondition("third prompt after first resolves", () => harness.prompts.length === 2);
+    assert.match(harness.prompts[1]?.title ?? "", /parallel-c/);
+    harness.prompts[1]?.resolve(true);
+    await third;
+    assert.equal(harness.maxActiveCount(), 1);
+  } finally {
+    for (const prompt of harness.prompts) prompt.reject(new Error("test cleanup"));
+    await _resetMcpClientStateForTest();
+  }
+});
+
+test("MCP stdio trust timeout does not run while queued behind another prompt", async () => {
+  const harness = createConfirmHarness();
+  try {
+    const first = _assertTrustedStdioServerForTest(makeStdioConfig("timeout-queue-a"), harness.ctx as any);
+    await waitForCondition("active first trust prompt", () => harness.prompts.length === 1);
+
+    // Short timeout on the queued caller. It must NOT fire while queued behind A;
+    // the hard timeout only covers the prompt, not time spent waiting in queue.
+    const second = _assertTrustedStdioServerForTest(
+      makeStdioConfig("timeout-queue-b"),
+      harness.ctx as any,
+      undefined,
+      50,
+    );
+
+    // Hold A active well past B's timeout budget. B must still be queued, not timed out.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.equal(harness.prompts.length, 1, "queued caller must not open a prompt yet");
+
+    harness.prompts[0]?.resolve(true);
+    await first;
+    // B now owns the prompt; only here does its timeout begin.
+    await waitForCondition("second trust prompt after first resolves", () => harness.prompts.length === 2);
+    assert.match(harness.prompts[1]?.title ?? "", /timeout-queue-b/);
+    harness.prompts[1]?.resolve(true);
+    await second;
+    assert.equal(harness.maxActiveCount(), 1);
+  } finally {
+    for (const prompt of harness.prompts) prompt.reject(new Error("test cleanup"));
+    await _resetMcpClientStateForTest();
+  }
+});
+
+test("MCP stdio closeAll aborts queued trust waiters, not just the active prompt", async () => {
+  const harness = createConfirmHarness();
+  try {
+    const first = _assertTrustedStdioServerForTest(makeStdioConfig("close-a"), harness.ctx as any);
+    await waitForCondition("active first trust prompt", () => harness.prompts.length === 1);
+    const second = _assertTrustedStdioServerForTest(makeStdioConfig("close-b"), harness.ctx as any);
+
+    // closeAll (via reset) must cancel BOTH the active prompt and the queued
+    // waiter, so the queued waiter never reaches ui.confirm after shutdown.
+    const firstRejects = assert.rejects(first, /MCP session closed/);
+    const secondRejects = assert.rejects(second, /MCP session closed/);
+    await _resetMcpClientStateForTest();
+    await firstRejects;
+    await secondRejects;
+
+    assert.equal(harness.prompts.length, 1, "queued waiter must not reach ui.confirm after closeAll");
+    assert.equal(harness.maxActiveCount(), 1);
+  } finally {
+    for (const prompt of harness.prompts) prompt.reject(new Error("test cleanup"));
+    await _resetMcpClientStateForTest();
+  }
+});
+
 test("MCP stdio discover deduplicates concurrent first calls for the same server", async () => {
   const previousGsdHome = process.env.GSD_HOME;
   const originalCwd = process.cwd();

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -59,6 +59,7 @@ const MCP_TRUST_CONFIRM_TIMEOUT_MS = 120_000;
 const emptyStdioTrustPromptQueue = Promise.resolve();
 let stdioTrustPromptQueue: Promise<void> = emptyStdioTrustPromptQueue;
 const activeStdioTrustApprovalAborts = new Set<(err: Error) => void>();
+const queuedStdioTrustApprovalAborts = new Set<(err: Error) => void>();
 
 function stdioTrustKey(config: McpServerConfig): string {
 	return JSON.stringify({
@@ -144,6 +145,11 @@ function abortActiveStdioTrustApprovals(err: Error): void {
 	activeStdioTrustApprovalAborts.clear();
 }
 
+function abortQueuedStdioTrustApprovals(err: Error): void {
+	for (const abort of Array.from(queuedStdioTrustApprovalAborts)) abort(err);
+	queuedStdioTrustApprovalAborts.clear();
+}
+
 async function runWithSerializedStdioTrustPrompt<T>(
 	serverName: string,
 	signal: AbortSignal | undefined,
@@ -158,28 +164,39 @@ async function runWithSerializedStdioTrustPrompt<T>(
 	const queued = previous.catch(() => {}).then(() => current);
 	stdioTrustPromptQueue = queued;
 
+	let rejectQueued: (err: Error) => void = () => {};
+	const queuedAborted = new Promise<never>((_resolve, reject) => {
+		rejectQueued = reject;
+	});
+	queuedAborted.catch(() => {});
+	const abortQueued = (err: Error) => rejectQueued(err);
+	queuedStdioTrustApprovalAborts.add(abortQueued);
+
 	try {
 		if (signal?.aborted) {
 			throw trustApprovalAbortError(serverName, signal.reason);
 		}
 		if (signal) {
-			await new Promise<void>((resolve, reject) => {
-				const onAbort = () => {
-					cleanup();
-					reject(trustApprovalAbortError(serverName, signal.reason));
-				};
-				const onPrevious = () => {
-					cleanup();
-					resolve();
-				};
-				const cleanup = () => {
-					signal.removeEventListener("abort", onAbort);
-				};
-				signal.addEventListener("abort", onAbort, { once: true });
-				previous.catch(() => {}).then(onPrevious, onPrevious);
-			});
+			await Promise.race([
+				new Promise<void>((resolve, reject) => {
+					const onAbort = () => {
+						cleanup();
+						reject(trustApprovalAbortError(serverName, signal.reason));
+					};
+					const onPrevious = () => {
+						cleanup();
+						resolve();
+					};
+					const cleanup = () => {
+						signal.removeEventListener("abort", onAbort);
+					};
+					signal.addEventListener("abort", onAbort, { once: true });
+					previous.catch(() => {}).then(onPrevious, onPrevious);
+				}),
+				queuedAborted,
+			]);
 		} else {
-			await previous.catch(() => {});
+			await Promise.race([previous.catch(() => {}), queuedAborted]);
 		}
 
 		const approvalAbort = createTrustApprovalAbort(serverName, signal, timeout);
@@ -189,6 +206,7 @@ async function runWithSerializedStdioTrustPrompt<T>(
 			approvalAbort.cleanup();
 		}
 	} finally {
+		queuedStdioTrustApprovalAborts.delete(abortQueued);
 		releasePrompt();
 	}
 }
@@ -325,7 +343,9 @@ async function connectServer(config: McpServerConfig, signal?: AbortSignal, ctx?
 }
 
 async function closeAll(): Promise<void> {
-	abortActiveStdioTrustApprovals(new Error("MCP session closed while waiting for stdio MCP trust approval."));
+	const sessionClosedError = new Error("MCP session closed while waiting for stdio MCP trust approval.");
+	abortActiveStdioTrustApprovals(sessionClosedError);
+	abortQueuedStdioTrustApprovals(sessionClosedError);
 	stdioTrustPromptQueue = emptyStdioTrustPromptQueue;
 	const closing = Array.from(connections.entries()).map(async ([name, conn]) => {
 		try {

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -158,13 +158,37 @@ async function runWithSerializedStdioTrustPrompt<T>(
 	const queued = previous.catch(() => {}).then(() => current);
 	stdioTrustPromptQueue = queued;
 
-	const approvalAbort = createTrustApprovalAbort(serverName, signal, timeout);
 	try {
-		await Promise.race([previous.catch(() => {}), approvalAbort.aborted]);
-		if (approvalAbort.signal.aborted) await approvalAbort.aborted;
-		return await Promise.race([run(approvalAbort.signal), approvalAbort.aborted]);
+		if (signal?.aborted) {
+			throw trustApprovalAbortError(serverName, signal.reason);
+		}
+		if (signal) {
+			await new Promise<void>((resolve, reject) => {
+				const onAbort = () => {
+					cleanup();
+					reject(trustApprovalAbortError(serverName, signal.reason));
+				};
+				const onPrevious = () => {
+					cleanup();
+					resolve();
+				};
+				const cleanup = () => {
+					signal.removeEventListener("abort", onAbort);
+				};
+				signal.addEventListener("abort", onAbort, { once: true });
+				previous.catch(() => {}).then(onPrevious, onPrevious);
+			});
+		} else {
+			await previous.catch(() => {});
+		}
+
+		const approvalAbort = createTrustApprovalAbort(serverName, signal, timeout);
+		try {
+			return await Promise.race([run(approvalAbort.signal), approvalAbort.aborted]);
+		} finally {
+			approvalAbort.cleanup();
+		}
 	} finally {
-		approvalAbort.cleanup();
 		releasePrompt();
 	}
 }

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -55,6 +55,10 @@ const connections = new Map<string, ManagedConnection>();
 const pendingConnections = new Map<string, Promise<Client>>();
 const toolCache = new Map<string, McpToolSchema[]>();
 const trustedStdioServers = new Set<string>();
+const MCP_TRUST_CONFIRM_TIMEOUT_MS = 120_000;
+const emptyStdioTrustPromptQueue = Promise.resolve();
+let stdioTrustPromptQueue: Promise<void> = emptyStdioTrustPromptQueue;
+const activeStdioTrustApprovalAborts = new Set<(err: Error) => void>();
 
 function stdioTrustKey(config: McpServerConfig): string {
 	return JSON.stringify({
@@ -75,14 +79,102 @@ export function _buildMcpChildEnvForTest(configEnv: Record<string, string> | und
 	return buildMcpChildEnv(configEnv);
 }
 
-export function _buildMcpTrustConfirmOptionsForTest(signal?: AbortSignal): { timeout: number; signal?: AbortSignal } {
-	return signal ? { timeout: 120_000, signal } : { timeout: 120_000 };
+export function _buildMcpTrustConfirmOptionsForTest(
+	signal?: AbortSignal,
+	timeout = MCP_TRUST_CONFIRM_TIMEOUT_MS,
+): { timeout: number; signal?: AbortSignal } {
+	return signal ? { timeout, signal } : { timeout };
+}
+
+function trustApprovalTimeoutError(serverName: string): Error {
+	return new Error(`Timed out waiting for stdio MCP trust approval for "${serverName}"`);
+}
+
+function trustApprovalAbortError(serverName: string, reason?: unknown): Error {
+	if (reason instanceof Error) return reason;
+	if (typeof reason === "string" && reason.length > 0) return new Error(reason);
+	return new Error(`Stdio MCP trust approval for "${serverName}" was aborted.`);
+}
+
+function createTrustApprovalAbort(
+	serverName: string,
+	signal: AbortSignal | undefined,
+	timeout: number,
+): { signal: AbortSignal; aborted: Promise<never>; cleanup: () => void } {
+	const controller = new AbortController();
+	let rejectAborted: (err: Error) => void = () => {};
+	const aborted = new Promise<never>((_resolve, reject) => {
+		rejectAborted = reject;
+	});
+	aborted.catch(() => {});
+
+	const abort = (err: Error) => {
+		if (controller.signal.aborted) return;
+		controller.abort(err);
+		rejectAborted(err);
+	};
+	activeStdioTrustApprovalAborts.add(abort);
+
+	const timeoutId = setTimeout(() => {
+		abort(trustApprovalTimeoutError(serverName));
+	}, timeout);
+
+	const onCallerAbort = () => {
+		abort(trustApprovalAbortError(serverName, signal?.reason));
+	};
+	if (signal?.aborted) {
+		onCallerAbort();
+	} else {
+		signal?.addEventListener("abort", onCallerAbort, { once: true });
+	}
+
+	return {
+		signal: controller.signal,
+		aborted,
+		cleanup: () => {
+			clearTimeout(timeoutId);
+			signal?.removeEventListener("abort", onCallerAbort);
+			activeStdioTrustApprovalAborts.delete(abort);
+		},
+	};
+}
+
+function abortActiveStdioTrustApprovals(err: Error): void {
+	for (const abort of Array.from(activeStdioTrustApprovalAborts)) abort(err);
+	activeStdioTrustApprovalAborts.clear();
+}
+
+async function runWithSerializedStdioTrustPrompt<T>(
+	serverName: string,
+	signal: AbortSignal | undefined,
+	timeout: number,
+	run: (approvalSignal: AbortSignal) => Promise<T>,
+): Promise<T> {
+	const previous = stdioTrustPromptQueue;
+	let releasePrompt = () => {};
+	const current = new Promise<void>((resolve) => {
+		releasePrompt = resolve;
+	});
+	const queued = previous.catch(() => {}).then(() => current);
+	stdioTrustPromptQueue = queued;
+
+	const approvalAbort = createTrustApprovalAbort(serverName, signal, timeout);
+	try {
+		await Promise.race([previous.catch(() => {}), approvalAbort.aborted]);
+		if (approvalAbort.signal.aborted) await approvalAbort.aborted;
+		return await Promise.race([run(approvalAbort.signal), approvalAbort.aborted]);
+	} finally {
+		approvalAbort.cleanup();
+		releasePrompt();
+		if (stdioTrustPromptQueue === queued) stdioTrustPromptQueue = emptyStdioTrustPromptQueue;
+	}
 }
 
 async function assertTrustedStdioServer(
 	config: McpServerConfig,
 	ctx?: ExtensionContext,
 	signal?: AbortSignal,
+	timeout = MCP_TRUST_CONFIRM_TIMEOUT_MS,
 ): Promise<string | undefined> {
 	if (config.transport !== "stdio") return undefined;
 	const trustKey = stdioTrustKey(config);
@@ -100,15 +192,33 @@ async function assertTrustedStdioServer(
 	const envSummary = envKeys.length > 0
 		? `\n\nConfigured environment keys: ${envKeys.join(", ")}`
 		: "\n\nNo explicit environment keys configured.";
-	const approved = await ctx.ui.confirm(
-		`Trust MCP server "${config.name}"?`,
-		`Project config ${config.sourcePath} wants to start:\n\n${commandLine}${envSummary}\n\nOnly approve MCP servers you trust.`,
-		_buildMcpTrustConfirmOptionsForTest(signal),
-	);
-	if (!approved) {
-		throw new Error(`MCP server "${config.name}" was not approved by the user.`);
-	}
-	return trustKey;
+	return runWithSerializedStdioTrustPrompt(config.name, signal, timeout, async (approvalSignal) => {
+		if (trustedStdioServers.has(trustKey)) return undefined;
+		const approved = await ctx.ui.confirm(
+			`Trust MCP server "${config.name}"?`,
+			`Project config ${config.sourcePath} wants to start:\n\n${commandLine}${envSummary}\n\nOnly approve MCP servers you trust.`,
+			_buildMcpTrustConfirmOptionsForTest(approvalSignal, timeout),
+		);
+		if (!approved) {
+			throw new Error(`MCP server "${config.name}" was not approved by the user.`);
+		}
+		return trustKey;
+	});
+}
+
+export function _assertTrustedStdioServerForTest(
+	config: McpServerConfig,
+	ctx?: ExtensionContext,
+	signal?: AbortSignal,
+	timeout = MCP_TRUST_CONFIRM_TIMEOUT_MS,
+): Promise<string | undefined> {
+	return assertTrustedStdioServer(config, ctx, signal, timeout);
+}
+
+export async function _resetMcpClientStateForTest(): Promise<void> {
+	await closeAll();
+	clearMcpConfigCache();
+	stdioTrustPromptQueue = emptyStdioTrustPromptQueue;
 }
 
 // Exported for tests (see tests/server-name-spaces.test.ts).
@@ -192,6 +302,8 @@ async function connectServer(config: McpServerConfig, signal?: AbortSignal, ctx?
 }
 
 async function closeAll(): Promise<void> {
+	abortActiveStdioTrustApprovals(new Error("MCP session closed while waiting for stdio MCP trust approval."));
+	stdioTrustPromptQueue = emptyStdioTrustPromptQueue;
 	const closing = Array.from(connections.entries()).map(async ([name, conn]) => {
 		try {
 			await conn.client.close();

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -166,7 +166,6 @@ async function runWithSerializedStdioTrustPrompt<T>(
 	} finally {
 		approvalAbort.cleanup();
 		releasePrompt();
-		if (stdioTrustPromptQueue === queued) stdioTrustPromptQueue = emptyStdioTrustPromptQueue;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Serialized stdio MCP trust approvals with hard timeout and abort cleanup, added focused regression coverage, and verified syntax/diff checks while full tests were blocked by missing dependencies and network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1449
- [#1449 mcp_discover hangs when parallel stdio connections open concurrent trust dialogs](https://github.com/open-gsd/gsd-pi/issues/1449)

## User
- @rager306

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1449-mcp-discover-hangs-when-parallel-stdio-c-1784416081`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive trust and connection gating for project-local stdio MCP servers; mistakes could block approvals or leave waiters stuck, but scope is limited to the MCP client extension with substantial regression tests.
> 
> **Overview**
> Fixes hangs when parallel stdio MCP connections tried to open **multiple trust dialogs at once** (e.g. concurrent `mcp_discover`).
> 
> Stdio trust approval now runs through a **serialized prompt queue** so only one `ui.confirm` runs at a time. Each waiter gets a **120s hard timeout** that starts when it actually reaches the prompt (not while queued), plus **caller abort** support for both active and queued waiters. **`closeAll`** (session shutdown/switch) rejects active and queued trust waiters with an MCP-session-closed error and resets the queue.
> 
> Adds **behavior-focused tests** (replacing removed grep-style checks): queue ordering, abort/timeout edge cases, shutdown cleanup, and an integration test that concurrent `mcp_discover` for the same server shows one trust prompt and one stdio server start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7efde8c18baea1a31c26e54bcf803f3db3e29f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->