### PR TITLE
fix(issue): execute-task post-task commit silently swallows deterministic pre-commit-hook failures, strands task work uncommitted

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -222,6 +222,14 @@ When context usage reaches 70%, GSD sends a wrap-up signal to the agent, nudging
 
 Commits are generated from task summaries — not generic "complete task" messages. Each commit message reflects what was actually built, giving clean `git log` output that reads like a changelog.
 
+### Post-Task Commit Hook Remediation
+
+When turn-level gitops uses the default `uok.gitops.turn_action: commit`, an `execute-task` closeout runs a git commit after host verification passes. If `git commit` exits with hook-owned output, such as a pre-commit hook rejecting lint, formatting, secret, or policy checks, GSD classifies the failure as `hook-content` instead of treating it as a soft closeout warning.
+
+For a single-repository task, or a parent workspace task where no repository has already committed, auto mode injects the hook output back into the same task as a remediation retry so the agent can fix the staged changes and complete the task again. This commit-hook remediation path is capped at 2 attempts. After the cap is exhausted, auto mode pauses and writes the full git error to `.gsd/git-action-failures.log` for operator inspection.
+
+Transient git failures such as `.git/index.lock` contention still use the short git retry path. If a parent workspace partially committed some repositories before another repository's hook rejected the commit, GSD pauses instead of re-running the task, because redoing the task could duplicate work that is already committed in the successful repositories.
+
 ### Stuck Detection
 
 GSD uses a sliding-window analysis to detect stuck loops. Instead of a simple "same unit dispatched twice" counter, the detector examines recent dispatch history for repeated patterns — catching cycles like A→B→A→B as well as single-unit repeats. On detection, GSD retries once with a deep diagnostic prompt. If it fails again, auto mode stops so you can intervene.

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -139,6 +139,14 @@ Replace the path with the exact global bin directory from your pnpm error messag
 
 **Fix:** If the runtime record shows fresh recovery progress, resume with `/gsd auto`; the failsafe defers cancellation while recovery is actively producing durable output. If the journal shows a stopped finalize reason such as a git closeout failure or repeated finalize timeout, inspect `.gsd/git-action-failures.log`, resolve the underlying git issue, then resume.
 
+### Auto mode retries or pauses after a commit hook rejects task changes
+
+**Symptoms:** After an `execute-task` unit passes verification, auto mode reports `Git commit failed... Retrying task remediation (attempt 1/2)` or later reports that git commit failed after 2 remediation attempts and pauses. `.gsd/git-action-failures.log` contains the full hook output.
+
+**Cause:** The post-task `git commit` was rejected by hook-owned content, commonly a pre-commit lint, formatting, secret, or policy check. GSD classifies this path as `hook-content`, injects the hook output into a bounded task remediation retry, and gives the agent up to 2 attempts to fix the committed content. This is separate from transient git lock failures, which use the short git retry path instead.
+
+**Fix:** Inspect `.gsd/git-action-failures.log` and the hook output, fix the failing content or hook configuration, then resume with `/gsd auto`. In parent workspaces, if some repositories already committed before another repository's hook failed, reconcile the partially committed state manually before resuming; GSD pauses that case instead of re-running the task so it does not duplicate already-committed work.
+
 ### Wrong files in worktree
 
 **Symptoms:** Planning artifacts or code appear in the wrong directory.

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -239,6 +239,12 @@ Commands must be directly runnable checks such as `npm run lint`, `npm run test`
 
 If no verification commands are configured and the task plan does not provide a `verify` command, GSD attempts project discovery. It checks `package.json` scripts first, then Python pytest markers through the `python-project` discovery source: a `tests/` directory containing files that match `test_*.py` or `*_test.py` at any nested depth, `pytest.ini`, or pytest configuration sections in `pyproject.toml` such as `[tool.pytest.ini_options]`; equivalent pytest markers under `[tool.pytest]`, `[tool.pytest.*]`, `[pytest]`, or `[tool:pytest]` are also treated as explicit pytest evidence. Browser-facing tasks with no runnable host command can continue to slice UAT only after the canonical executor Result succeeds and no blocking runtime errors are found.
 
+## Post-Task Commit Hook Remediation
+
+When turn-level gitops uses the default `uok.gitops.turn_action: commit`, an `execute-task` closeout commits after host verification passes. If a commit hook rejects the staged task changes, GSD classifies the failure as `hook-content` and retries the task with the hook output injected as remediation context.
+
+This path is capped at 2 remediation attempts. After the cap is exhausted, auto mode pauses and writes the full git error to `.gsd/git-action-failures.log`. Transient git lock failures still use the short git retry path, and parent-workspace partial commits pause instead of re-running the task when one repository has already committed.
+
 ## Slice Discussion Gate
 
 For projects requiring human review before each slice:

--- a/gitbook/reference/troubleshooting.md
+++ b/gitbook/reference/troubleshooting.md
@@ -99,6 +99,12 @@ A unit failed to produce its expected artifact twice.
 
 **Fix:** Check the task plan for clarity. Refine it manually, then `/gsd auto`.
 
+### Auto mode retries or pauses after a commit hook rejects task changes
+
+After an `execute-task` unit passes verification, GSD commits the task when `uok.gitops.turn_action: commit` is active. If a pre-commit or other commit hook rejects the staged content, GSD classifies the failure as `hook-content`, injects the hook output into task remediation, and retries up to 2 times.
+
+**Fix:** Inspect `.gsd/git-action-failures.log`, fix the hook-reported lint/format/secret/policy failure or hook configuration, then resume with `/gsd auto`. If a parent workspace partially committed one repository before another repository's hook failed, reconcile the already-committed repository manually before resuming; GSD pauses that case instead of re-running the task.
+
 ### `command not found: gsd` after install
 
 npm's global bin directory isn't in `$PATH`.

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1340,7 +1340,14 @@ async function runCloseoutGitAction(
           failureClass: gitResult.failureClass,
           failureLogPath,
         });
-        if (opts?.softFailure && turnAction === "commit" && unit.type === "execute-task" && gitResult.failureClass === "hook-content") {
+        const hasPartialCommits = Object.keys(gitResult.commitMessages ?? {}).length > 0;
+        if (
+          opts?.softFailure &&
+          turnAction === "commit" &&
+          unit.type === "execute-task" &&
+          gitResult.failureClass === "hook-content" &&
+          !hasPartialCommits
+        ) {
           const retryKey = gitCommitRemediationRetryKey(unit.type, unit.id);
           const attempt = (s.verificationRetryCount.get(retryKey) ?? 0) + 1;
           if (attempt <= MAX_GIT_COMMIT_REMEDIATION_RETRIES) {

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -122,6 +122,7 @@ const _worktreeProjection = new WorktreeStateProjection();
 
 /** Maximum verification retry attempts before escalating to blocker placeholder (#2653). */
 const MAX_VERIFICATION_RETRIES = 3;
+const MAX_GIT_COMMIT_REMEDIATION_RETRIES = 2;
 /** Keep failure toasts short while still showing concrete examples. */
 const MAX_NOTIFICATION_DETAILS = 3;
 const NOTIFICATION_BULLET = "•";
@@ -395,6 +396,10 @@ function persistGitActionFailure(basePath: string, action: TurnGitActionMode, me
   mkdirSync(logDir, { recursive: true });
   appendFileSync(logPath, entry, "utf-8");
   return logPath;
+}
+
+function gitCommitRemediationRetryKey(unitType: string, unitId: string): string {
+  return `git-commit:${verificationRetryKey(unitType, unitId)}`;
 }
 
 function stripKnownIdPrefix(value: string | undefined | null, id: string): string | undefined {
@@ -1175,14 +1180,14 @@ export async function autoCommitUnit(
  * Execute the turn-level git action (commit, snapshot, or status-only).
  *
  * @param opts.softFailure - Defaults to false. When true, retry git failures,
- * warn, and continue without pausing auto-mode; use for best-effort deferred
- * closeout work where a git failure should not block the run.
+ * warn, and continue only for transient git failures. Deterministic task
+ * commit hook failures are routed through task remediation instead.
  */
 async function runCloseoutGitAction(
   pctx: PostUnitContext,
   unit: NonNullable<AutoSession["currentUnit"]>,
   opts?: { softFailure?: boolean },
-): Promise<"continue" | "dispatched"> {
+): Promise<"continue" | "retry" | "dispatched"> {
   const { s, ctx, pi, pauseAuto } = pctx;
   const prefs = loadEffectiveGSDPreferences()?.preferences;
   const uokFlags = resolveUokFlags(prefs);
@@ -1255,7 +1260,11 @@ async function runCloseoutGitAction(
         taskContext,
         targetRepositories,
       });
-      for (let attempt = 1; gitResult.status === "failed" && attempt < maxAttempts; attempt++) {
+      for (
+        let attempt = 1;
+        gitResult.status === "failed" && gitResult.failureClass === "transient" && attempt < maxAttempts;
+        attempt++
+      ) {
         await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
         gitResult = runTurnGitAction({
           basePath: s.basePath,
@@ -1286,6 +1295,7 @@ async function runCloseoutGitAction(
             commitMessage: gitResult.commitMessage,
             commitMessages: gitResult.commitMessages,
             commitErrors: gitResult.commitErrors,
+            failureClass: gitResult.failureClass,
             skippedRepositories: gitResult.skippedRepositories,
             snapshotLabel: gitResult.snapshotLabel,
           },
@@ -1323,21 +1333,63 @@ async function runCloseoutGitAction(
         }
 
         const failureMsg = `Git ${turnAction} failed: ${fullError.split("\n")[0]} (full details: ${failureLogPath})`;
-        ctx.ui.notify(failureMsg, opts?.softFailure ? "warning" : "error");
         debugLog("postUnit", {
           phase: opts?.softFailure ? "git-action-failed-soft" : "git-action-failed-blocking",
           action: turnAction,
           error: fullError,
+          failureClass: gitResult.failureClass,
           failureLogPath,
         });
-        if (opts?.softFailure) {
+        if (opts?.softFailure && turnAction === "commit" && unit.type === "execute-task" && gitResult.failureClass === "hook-content") {
+          const retryKey = gitCommitRemediationRetryKey(unit.type, unit.id);
+          const attempt = (s.verificationRetryCount.get(retryKey) ?? 0) + 1;
+          if (attempt <= MAX_GIT_COMMIT_REMEDIATION_RETRIES) {
+            s.verificationRetryCount.set(retryKey, attempt);
+            s.pendingVerificationRetry = {
+              unitId: unit.id,
+              failureContext:
+                "Git commit failed after task verification. The commit hook rejected the staged task changes; " +
+                "fix the reported issue and complete the task again so GSD can retry the commit.\n\n" +
+                fullError,
+              signature: `git-commit:${attempt}:${fullError}`,
+              attempt,
+            };
+            ctx.ui.notify(
+              `Git ${turnAction} failed: ${fullError.split("\n")[0]}. Retrying task remediation (attempt ${attempt}/${MAX_GIT_COMMIT_REMEDIATION_RETRIES}).`,
+              "warning",
+            );
+            debugLog("postUnit", {
+              phase: "git-action-remediation-retry",
+              action: turnAction,
+              unitType: unit.type,
+              unitId: unit.id,
+              attempt,
+              failureLogPath,
+            });
+            return "retry";
+          }
+
+          s.pendingVerificationRetry = null;
+          s.verificationRetryCount.delete(retryKey);
+          ctx.ui.notify(
+            `Git ${turnAction} failed after ${MAX_GIT_COMMIT_REMEDIATION_RETRIES} remediation attempts: ${fullError.split("\n")[0]} (full details: ${failureLogPath}). Pausing auto-mode.`,
+            "error",
+          );
+          await pauseAuto(ctx, pi);
+          return "dispatched";
+        }
+        if (opts?.softFailure && gitResult.failureClass === "transient") {
+          ctx.ui.notify(failureMsg, "warning");
           return "continue";
         }
+        ctx.ui.notify(failureMsg, "error");
         await pauseAuto(ctx, pi);
         return "dispatched";
       }
 
       s.lastGitActionStatus = "ok";
+      s.verificationRetryCount.delete(gitCommitRemediationRetryKey(unit.type, unit.id));
+      s.verificationRetryFailureHashes.delete(verificationRetryKey(unit.type, unit.id));
 
       if (turnAction === "commit" && gitResult.commitMessage) {
         ctx.ui.notify(formatPostUnitStatusCard("✓ Commit", gitResult.commitMessage.split("\n")[0]), "info");
@@ -1439,6 +1491,9 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       const gitActionResult = await runCloseoutGitAction(pctx, unit);
       if (gitActionResult === "dispatched") {
         return "dispatched";
+      }
+      if (gitActionResult === "retry") {
+        return "retry";
       }
     }
 
@@ -2425,7 +2480,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
  * Returns:
  * - "continue" — proceed to sidecar drain / normal dispatch
  * - "step-wizard" — step mode, show wizard instead
- * - "retry" — planner-owned pre-execution validation failed; retry the planning unit with injected failure context
+ * - "retry" — verification/pre-execution/git remediation failed; retry the unit with injected failure context
  * - "stopped" — stopAuto/pauseAuto was called
  */
 export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"continue" | "step-wizard" | "retry" | "stopped"> {
@@ -2436,6 +2491,9 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
       const gitActionResult = await runCloseoutGitAction(pctx, s.currentUnit, { softFailure: true });
       if (gitActionResult === "dispatched") {
         return "stopped";
+      }
+      if (gitActionResult === "retry") {
+        return "retry";
       }
     }
 

--- a/src/resources/extensions/gsd/auto/dispatch.ts
+++ b/src/resources/extensions/gsd/auto/dispatch.ts
@@ -30,6 +30,7 @@ import {
   rememberRetryDispatch,
   applyVerificationRetryPolicy,
 } from "./phase-helpers.js";
+import type { PendingVerificationRetry } from "./session.js";
 import type { IterationContext, IterationData, LoopState, PhaseResult, PreDispatchData } from "./types.js";
 
 export function getAlreadyClosedDispatchReason(unitType: string, unitId: string): string | null {
@@ -49,6 +50,18 @@ export function getAlreadyClosedDispatchReason(unitType: string, unitId: string)
       : null;
   }
   return null;
+}
+
+export function shouldBypassAlreadyClosedForVerificationRetry(
+  unitType: string,
+  unitId: string,
+  retryInfo: PendingVerificationRetry | null | undefined,
+): boolean {
+  return (
+    unitType === "execute-task" &&
+    retryInfo?.unitId === unitId &&
+    retryInfo.signature?.startsWith("git-commit:") === true
+  );
 }
 
 function isUnhandledPhaseWarning(dispatchResult: DispatchAction): dispatchResult is Extract<DispatchAction, { action: "stop" }> {
@@ -191,7 +204,10 @@ export async function runDispatch(
   }
 
   const alreadyClosedReason = getAlreadyClosedDispatchReason(unitType, unitId);
-  if (alreadyClosedReason) {
+  if (
+    alreadyClosedReason &&
+    !shouldBypassAlreadyClosedForVerificationRetry(unitType, unitId, s.pendingVerificationRetry)
+  ) {
     s.pendingVerificationRetry = null;
     loopState.recentUnits = [];
     loopState.stuckRecoveryAttempts = Math.max(loopState.stuckRecoveryAttempts, 1);

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -55,14 +55,7 @@ import { createWorkspace, scopeMilestone } from "../workspace.js";
 import { supportsStructuredQuestions } from "../workflow-mcp.js";
 import { getRegisteredToolSnapshot, getToolBaselineSnapshot } from "../auto-model-selection.js";
 import { deriveState } from "../state.js";
-import { parseUnitId } from "../unit-id.js";
 import { isClosedStatus } from "../status-guards.js";
-import {
-  isDbAvailable,
-  getSlice,
-  getTask,
-} from "../gsd-db.js";
-import { refreshWorkflowDatabaseFromDisk } from "../db-workspace.js";
 import { getErrorMessage } from "../error-utils.js";
 import { logWarning } from "../workflow-logger.js";
 import { normalizeRealPath } from "../paths.js";
@@ -76,6 +69,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { evaluateAllCompleteSettlement } from "../milestone-settlement.js";
 import { hasHeldMilestoneLease, reclaimMissingMilestoneLease } from "./milestone-lease-reclaim.js";
+import {
+  getAlreadyClosedDispatchReason as getDispatchAlreadyClosedReason,
+  shouldBypassAlreadyClosedForVerificationRetry,
+} from "./dispatch.js";
 
 type UokFlags = ReturnType<typeof resolveUokFlags>;
 
@@ -145,25 +142,6 @@ export interface DispatchDecisionInput {
   sessionProvider?: string;
   /** Model registry for executor-model lookups inside the budget engine. */
   modelRegistry?: MinimalModelRegistry;
-}
-
-function getAlreadyClosedDispatchReason(unitType: string, unitId: string): string | null {
-  if (!isDbAvailable()) return null;
-  refreshWorkflowDatabaseFromDisk();
-  const { milestone, slice, task } = parseUnitId(unitId);
-  if (unitType === "execute-task" && milestone && slice && task) {
-    const row = getTask(milestone, slice, task);
-    return row && isClosedStatus(row.status)
-      ? `execute-task ${unitId} is already ${row.status}`
-      : null;
-  }
-  if (unitType === "complete-slice" && milestone && slice) {
-    const row = getSlice(milestone, slice);
-    return row && isClosedStatus(row.status)
-      ? `complete-slice ${unitId} is already ${row.status}`
-      : null;
-  }
-  return null;
 }
 
 function shouldAdoptActiveMilestone(
@@ -279,11 +257,18 @@ export async function decideOrchestratorDispatch(
     if (authorityBlocker) {
       return { kind: "blocked", reason: authorityBlocker, action: "stop" };
     }
-    const alreadyClosedReason = getAlreadyClosedDispatchReason(
+    const alreadyClosedReason = getDispatchAlreadyClosedReason(
       pendingRetry.unitType,
       pendingRetry.unitId,
     );
-    if (alreadyClosedReason) {
+    if (
+      alreadyClosedReason &&
+      !shouldBypassAlreadyClosedForVerificationRetry(
+        pendingRetry.unitType,
+        pendingRetry.unitId,
+        session.pendingVerificationRetry,
+      )
+    ) {
       session.pendingOrchestrationDispatch = null;
       session.pendingVerificationRetry = null;
       return { kind: "skipped", reason: alreadyClosedReason };
@@ -330,8 +315,15 @@ export async function decideOrchestratorDispatch(
       reason: action.matchedRule ?? "dispatch-skip",
     };
   }
-  const alreadyClosedReason = getAlreadyClosedDispatchReason(action.unitType, action.unitId);
-  if (alreadyClosedReason) {
+  const alreadyClosedReason = getDispatchAlreadyClosedReason(action.unitType, action.unitId);
+  if (
+    alreadyClosedReason &&
+    !shouldBypassAlreadyClosedForVerificationRetry(
+      action.unitType,
+      action.unitId,
+      session?.pendingVerificationRetry,
+    )
+  ) {
     if (session) {
       session.pendingOrchestrationDispatch = null;
       session.pendingVerificationRetry = null;

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1349,11 +1349,11 @@ function classifyTurnGitActionFailure(action: TurnGitActionMode, err: unknown): 
   const stderr = errorWithStreams.stderr?.trim() ?? "";
   const message = errorWithStreams.message ?? getErrorMessage(err);
   const combined = `${stderr}\n${message}`;
-  if (TRANSIENT_GIT_FAILURE_PATTERNS.some((pattern) => pattern.test(combined))) {
-    return "transient";
-  }
   if (action === "commit" && stderr && errorWithStreams.status === 1) {
     return "hook-content";
+  }
+  if (TRANSIENT_GIT_FAILURE_PATTERNS.some((pattern) => pattern.test(combined))) {
+    return "transient";
   }
   return "unknown";
 }

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1359,6 +1359,12 @@ function classifyTurnGitActionFailure(action: TurnGitActionMode, err: unknown): 
   const stderr = errorWithStreams.stderr?.trim() ?? "";
   const message = errorWithStreams.message ?? getErrorMessage(err);
   const combined = `${stderr}\n${message}`;
+  // A clean exit-1 is git's canonical "a hook rejected the commit" signal, but the
+  // numeric status can be missing or rewritten (wrapped errors, signal kills). When
+  // status is absent, fall back to output shape: git announces its own commit
+  // failures with a leading `fatal:`/`error:` diagnostic, whereas hooks emit
+  // arbitrary stderr. This keeps hook rejections whose status was dropped routing
+  // into bounded git-commit remediation instead of silently pausing as `unknown`.
   const status = errorWithStreams.status;
   const isCommitHookRejection =
     action === "commit" &&

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1359,7 +1359,12 @@ function classifyTurnGitActionFailure(action: TurnGitActionMode, err: unknown): 
   const stderr = errorWithStreams.stderr?.trim() ?? "";
   const message = errorWithStreams.message ?? getErrorMessage(err);
   const combined = `${stderr}\n${message}`;
-  if (action === "commit" && stderr !== "" && errorWithStreams.status === 1) {
+  const status = errorWithStreams.status;
+  const isCommitHookRejection =
+    action === "commit" &&
+    stderr !== "" &&
+    (status === 1 || (status == null && !/(?:^|\n)(?:fatal|error):/i.test(stderr)));
+  if (isCommitHookRejection) {
     if (GIT_OWNED_TRANSIENT_GIT_FAILURE_PATTERNS.some((pattern) => pattern.test(stderr))) {
       return "transient";
     }

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1349,11 +1349,11 @@ function classifyTurnGitActionFailure(action: TurnGitActionMode, err: unknown): 
   const stderr = errorWithStreams.stderr?.trim() ?? "";
   const message = errorWithStreams.message ?? getErrorMessage(err);
   const combined = `${stderr}\n${message}`;
-  if (action === "commit" && stderr && errorWithStreams.status === 1) {
-    return "hook-content";
-  }
   if (TRANSIENT_GIT_FAILURE_PATTERNS.some((pattern) => pattern.test(combined))) {
     return "transient";
+  }
+  if (action === "commit" && stderr && errorWithStreams.status === 1) {
+    return "hook-content";
   }
   return "unknown";
 }

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -119,10 +119,12 @@ export interface CommitOptions {
 }
 
 export type TurnGitActionMode = "commit" | "snapshot" | "status-only";
+export type TurnGitFailureClass = "transient" | "hook-content" | "unknown";
 
 export interface TurnGitActionResult {
   action: TurnGitActionMode;
   status: "ok" | "failed";
+  failureClass?: TurnGitFailureClass;
   commitMessage?: string;
   snapshotLabel?: string;
   dirty?: boolean;
@@ -1328,8 +1330,39 @@ export function handleTurnGitActionError(action: TurnGitActionMode, err: unknown
   return {
     action,
     status: "failed",
+    failureClass: classifyTurnGitActionFailure(action, err),
     error: errorWithStreams.stderr?.trim() || errorWithStreams.message || getErrorMessage(err),
   };
+}
+
+const TRANSIENT_GIT_FAILURE_PATTERNS: readonly RegExp[] = [
+  /index\.lock/i,
+  /another git process/i,
+  /unable to create ['"].*\.lock['"]/i,
+  /could not lock/i,
+  /cannot lock ref/i,
+  /resource temporarily unavailable/i,
+];
+
+function classifyTurnGitActionFailure(action: TurnGitActionMode, err: unknown): TurnGitFailureClass {
+  const errorWithStreams = err as { stderr?: string; message?: string; status?: number };
+  const stderr = errorWithStreams.stderr?.trim() ?? "";
+  const message = errorWithStreams.message ?? getErrorMessage(err);
+  const combined = `${stderr}\n${message}`;
+  if (TRANSIENT_GIT_FAILURE_PATTERNS.some((pattern) => pattern.test(combined))) {
+    return "transient";
+  }
+  if (action === "commit" && stderr && errorWithStreams.status === 1) {
+    return "hook-content";
+  }
+  return "unknown";
+}
+
+function mergeTurnGitFailureClasses(classes: readonly TurnGitFailureClass[]): TurnGitFailureClass {
+  if (classes.includes("unknown")) return "unknown";
+  if (classes.includes("hook-content")) return "hook-content";
+  if (classes.includes("transient")) return "transient";
+  return "unknown";
 }
 
 export function isRepositoryDirty(repoRoot: string): boolean {
@@ -1418,6 +1451,7 @@ function runPerRepositoryCommitAction(args: {
 }): {
   commitMessages: Record<string, string>;
   commitErrors: Record<string, string>;
+  commitFailureClasses: Record<string, TurnGitFailureClass>;
   skippedRepositories: string[];
 } {
   const preferences = loadEffectiveGSDPreferences(args.basePath)?.preferences;
@@ -1426,12 +1460,14 @@ function runPerRepositoryCommitAction(args: {
   const gitPrefs = preferences?.git ?? {};
   const commitMessages: Record<string, string> = {};
   const commitErrors: Record<string, string> = {};
+  const commitFailureClasses: Record<string, TurnGitFailureClass> = {};
   const skippedRepositories: string[] = [];
 
   for (const repoId of repoIds) {
     const repo = registry.byId.get(repoId);
     if (!repo) {
       commitErrors[repoId] = `unknown repository target: ${repoId}`;
+      commitFailureClasses[repoId] = "unknown";
       continue;
     }
     if (repo.commitPolicy === "skip") {
@@ -1453,10 +1489,11 @@ function runPerRepositoryCommitAction(args: {
       }
     } catch (err) {
       commitErrors[repo.id] = getErrorMessage(err);
+      commitFailureClasses[repo.id] = classifyTurnGitActionFailure("commit", err);
     }
   }
 
-  return { commitMessages, commitErrors, skippedRepositories };
+  return { commitMessages, commitErrors, commitFailureClasses, skippedRepositories };
 }
 
 export function runTurnGitAction(args: {
@@ -1499,6 +1536,7 @@ export function runTurnGitAction(args: {
       return {
         action: args.action,
         status: "failed",
+        failureClass: mergeTurnGitFailureClasses(Object.values(repoCommitResult.commitFailureClasses)),
         error: Object.entries(repoCommitResult.commitErrors)
           .map(([repoId, msg]) => `${repoId}: ${msg}`)
           .join("; "),

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1344,25 +1344,25 @@ const TRANSIENT_GIT_FAILURE_PATTERNS: readonly RegExp[] = [
   /resource temporarily unavailable/i,
 ];
 
+const GIT_OWNED_TRANSIENT_GIT_FAILURE_PATTERNS: readonly RegExp[] = [
+  /(?:^|\n)(?:fatal|error):[^\n]*index\.lock/i,
+  /(?:^|\n)(?:fatal|error):[^\n]*another git process/i,
+  /(?:^|\n)(?:fatal|error):[^\n]*unable to create ['"].*\.lock['"]/i,
+  /(?:^|\n)(?:fatal|error):[^\n]*could not lock/i,
+  /(?:^|\n)(?:fatal|error):[^\n]*cannot lock ref/i,
+  /(?:^|\n)(?:fatal|error):[^\n]*resource temporarily unavailable/i,
+  /(?:^|\n)another git process seems to be running/i,
+];
+
 function classifyTurnGitActionFailure(action: TurnGitActionMode, err: unknown): TurnGitFailureClass {
   const errorWithStreams = err as { stderr?: string; message?: string; status?: number };
   const stderr = errorWithStreams.stderr?.trim() ?? "";
   const message = errorWithStreams.message ?? getErrorMessage(err);
   const combined = `${stderr}\n${message}`;
-  // The exit code is the authoritative signal (verified empirically against git):
-  //   - A pre-commit / commit-msg hook rejection aborts `git commit` with exit code 1.
-  //   - Git's own lock/contention failures ("index.lock" held, "cannot lock ref", ...)
-  //     are fatal and exit with code 128, never 1.
-  // A hook's stderr is arbitrary user text and can coincidentally contain a transient
-  // lock phrase (e.g. a hook that guards lock files, or a linter that prints
-  // "could not lock"). Matching those patterns first would mislabel an exit-1 hook
-  // rejection as "transient" and silently warn-and-continue, stranding verified task work
-  // uncommitted (the bug this PR fixes). So a commit that exits 1 with stderr is always a
-  // hook rejection; genuine lock contention exits 128 and never matches this gate, so it
-  // still falls through to the transient patterns below. These branches are mutually
-  // exclusive by exit code — do not "optimize" by moving the transient check first.
-  const isCommitHookRejection = action === "commit" && stderr !== "" && errorWithStreams.status === 1;
-  if (isCommitHookRejection) {
+  if (action === "commit" && stderr !== "" && errorWithStreams.status === 1) {
+    if (GIT_OWNED_TRANSIENT_GIT_FAILURE_PATTERNS.some((pattern) => pattern.test(stderr))) {
+      return "transient";
+    }
     return "hook-content";
   }
   if (TRANSIENT_GIT_FAILURE_PATTERNS.some((pattern) => pattern.test(combined))) {

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1349,11 +1349,24 @@ function classifyTurnGitActionFailure(action: TurnGitActionMode, err: unknown): 
   const stderr = errorWithStreams.stderr?.trim() ?? "";
   const message = errorWithStreams.message ?? getErrorMessage(err);
   const combined = `${stderr}\n${message}`;
+  // The exit code is the authoritative signal (verified empirically against git):
+  //   - A pre-commit / commit-msg hook rejection aborts `git commit` with exit code 1.
+  //   - Git's own lock/contention failures ("index.lock" held, "cannot lock ref", ...)
+  //     are fatal and exit with code 128, never 1.
+  // A hook's stderr is arbitrary user text and can coincidentally contain a transient
+  // lock phrase (e.g. a hook that guards lock files, or a linter that prints
+  // "could not lock"). Matching those patterns first would mislabel an exit-1 hook
+  // rejection as "transient" and silently warn-and-continue, stranding verified task work
+  // uncommitted (the bug this PR fixes). So a commit that exits 1 with stderr is always a
+  // hook rejection; genuine lock contention exits 128 and never matches this gate, so it
+  // still falls through to the transient patterns below. These branches are mutually
+  // exclusive by exit code — do not "optimize" by moving the transient check first.
+  const isCommitHookRejection = action === "commit" && stderr !== "" && errorWithStreams.status === 1;
+  if (isCommitHookRejection) {
+    return "hook-content";
+  }
   if (TRANSIENT_GIT_FAILURE_PATTERNS.some((pattern) => pattern.test(combined))) {
     return "transient";
-  }
-  if (action === "commit" && stderr && errorWithStreams.status === 1) {
-    return "hook-content";
   }
   return "unknown";
 }

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1372,8 +1372,8 @@ function classifyTurnGitActionFailure(action: TurnGitActionMode, err: unknown): 
 }
 
 function mergeTurnGitFailureClasses(classes: readonly TurnGitFailureClass[]): TurnGitFailureClass {
-  if (classes.includes("unknown")) return "unknown";
   if (classes.includes("hook-content")) return "hook-content";
+  if (classes.includes("unknown")) return "unknown";
   if (classes.includes("transient")) return "transient";
   return "unknown";
 }

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -998,15 +998,18 @@ export function nativeCommit(
     });
     return result;
   } catch (err: unknown) {
-    const errObj = err as { stdout?: string; stderr?: string; message?: string };
+    const errObj = err as { stdout?: string; stderr?: string; message?: string; status?: number; signal?: NodeJS.Signals };
     const combined = [errObj.stdout, errObj.stderr, errObj.message].filter(Boolean).join(" ");
     if (combined.includes("nothing to commit") || combined.includes("nothing added to commit") || combined.includes("no changes added")) {
       return null;
     }
     const commitDetail = errObj.stderr?.trim() || errObj.message || "git commit failed";
     const wrapped = new Error(`git commit failed: ${commitDetail}`);
-    (wrapped as Error & { stdout?: string; stderr?: string }).stdout = errObj.stdout;
-    (wrapped as Error & { stdout?: string; stderr?: string }).stderr = errObj.stderr;
+    const typedWrapped = wrapped as Error & { stdout?: string; stderr?: string; status?: number; signal?: NodeJS.Signals };
+    typedWrapped.stdout = errObj.stdout;
+    typedWrapped.stderr = errObj.stderr;
+    typedWrapped.status = errObj.status;
+    typedWrapped.signal = errObj.signal;
     throw wrapped;
   }
 }

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1668,6 +1668,67 @@ test("decideOrchestratorDispatch clears verification retry state when skipping a
   }
 });
 
+test("decideOrchestratorDispatch re-dispatches a closed execute-task for git-commit remediation instead of skipping", async () => {
+  // Regression for #1491 / bugbot 3609601306: after task verification the task
+  // is already `complete` in the DB, but its post-task commit was rejected by a
+  // pre-commit hook. The remediation retry carries a `git-commit:` signature, so
+  // the already-closed dispatch guard must honor it (re-deliver the hook rejection
+  // to the agent) rather than clearing the retry and stranding the uncommitted work.
+  const stateSnapshot = makeState();
+  const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-closed-remediation-"));
+
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "Slice", status: "active" });
+    insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", title: "Task", status: "complete" });
+
+    const ctx = { model: {}, modelRegistry: { getAll: () => [], getAvailable: () => [] } } as never;
+    const pi = { getActiveTools: () => [] } as never;
+    const session = {
+      basePath: base,
+      pendingOrchestrationDispatch: null,
+      pendingVerificationRetryDispatch: {
+        unitType: "execute-task",
+        unitId: "M001/S01/T01",
+        prompt: "retry commit remediation",
+        pauseAfterUatDispatch: false,
+        state: stateSnapshot,
+        mid: "M001",
+        midTitle: "Milestone",
+      },
+      pendingVerificationRetry: {
+        unitId: "M001/S01/T01",
+        failureContext: "Git commit failed after task verification. blocked by test hook",
+        signature: "git-commit:1:blocked by test hook",
+        attempt: 1,
+      },
+    } as never;
+
+    const result = await decideOrchestratorDispatch(ctx, pi, base, session, { stateSnapshot });
+
+    assert.ok(result);
+    if (!result || !("unitType" in result)) assert.fail("expected dispatch decision, not skip");
+    assert.equal(result.unitType, "execute-task");
+    assert.equal(result.unitId, "M001/S01/T01");
+    assert.equal(result.reason, "verification-retry");
+    const sess = session as {
+      pendingVerificationRetry: { unitId?: string } | null;
+      pendingVerificationRetryDispatch: unknown;
+      pendingOrchestrationDispatch: { prompt?: string } | null;
+    };
+    // The retry must survive the already-closed guard (not be cleared) so the
+    // hook rejection is re-delivered to the agent on the next unit run.
+    assert.equal(sess.pendingVerificationRetry?.unitId, "M001/S01/T01");
+    assert.equal(sess.pendingVerificationRetryDispatch, null);
+    assert.equal(sess.pendingOrchestrationDispatch?.prompt, "retry commit remediation");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("decideOrchestratorDispatch preserves stop reason as a blocked decision", async (t) => {
   openDispatchDecisionDatabase(t);
   const stateSnapshot = makeState();

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -1712,6 +1712,94 @@ test("verified task git closeout hook failure pauses after remediation cap", asy
   }
 });
 
+test("verified task git closeout partial multi-repo commit pauses instead of redoing task", async () => {
+  const root = join(tmpdir(), `gsd-deep-project-parent-commit-${randomUUID()}`);
+  const initChildRepo = (dir: string) => {
+    mkdirSync(dir, { recursive: true });
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: dir, stdio: "ignore" });
+    writeFileSync(join(dir, "README.md"), "# child\n");
+    execFileSync("git", ["add", "README.md"], { cwd: dir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
+  };
+  try {
+    mkdirSync(join(root, ".gsd", "milestones"), { recursive: true });
+    writeFileSync(
+      join(root, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "version: 1",
+        "workspace:",
+        "  mode: parent",
+        "  repositories:",
+        "    frontend:",
+        "      path: frontend",
+        "    backend:",
+        "      path: backend",
+        "---",
+        "",
+      ].join("\n"),
+    );
+    execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: root, stdio: "ignore" });
+    writeFileSync(join(root, ".gitignore"), "frontend/\nbackend/\n.gsd/\n");
+    execFileSync("git", ["add", ".gitignore"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: ignore nested repos"], { cwd: root, stdio: "ignore" });
+
+    initChildRepo(join(root, "frontend"));
+    initChildRepo(join(root, "backend"));
+
+    // Only backend rejects the commit via a pre-commit hook; frontend commits cleanly,
+    // producing a partial multi-repo commit state.
+    const backendHook = join(root, "backend", ".git", "hooks", "pre-commit");
+    writeFileSync(backendHook, ["#!/bin/sh", "echo blocked by test hook >&2", "exit 1"].join("\n"));
+    chmodSync(backendHook, 0o755);
+
+    writeFileSync(join(root, "frontend", "feature.txt"), "frontend change\n");
+    writeFileSync(join(root, "backend", "feature.txt"), "backend change\n");
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = root;
+    s.originalBasePath = root;
+    s.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+
+    let pauseCalled = false;
+    const notifications: Array<{ message: string; severity?: string }> = [];
+    const result = await postUnitPostVerification({
+      s,
+      ctx: { ui: { notify: (message: string, severity?: string) => notifications.push({ message, severity }) } } as any,
+      pi: {} as any,
+      buildSnapshotOpts: () => ({}) as any,
+      lockBase: () => root,
+      stopAuto: async () => {},
+      pauseAuto: async () => { pauseCalled = true; },
+      updateProgressWidget: () => {},
+    });
+
+    // Partial multi-repo commit must pause instead of re-dispatching the task, because
+    // some repositories already committed and re-running would duplicate that work.
+    assert.equal(result, "stopped");
+    assert.equal(pauseCalled, true);
+    // No task remediation retry is scheduled when work is already partially committed.
+    assert.equal(s.pendingVerificationRetry, null);
+    assert.equal(s.verificationRetryCount.has("git-commit:execute-task:M001/S01/T01"), false);
+    assert.ok(
+      notifications.some(
+        (entry) => entry.severity === "error" && entry.message.includes("backend"),
+      ),
+      "partial multi-repo commit should surface the failing repository as an error",
+    );
+    // Frontend is committed; backend remains uncommitted (hook rejected it).
+    assert.equal(execFileSync("git", ["status", "--porcelain"], { cwd: join(root, "frontend"), encoding: "utf-8" }).trim(), "");
+    assert.notEqual(execFileSync("git", ["status", "--porcelain"], { cwd: join(root, "backend"), encoding: "utf-8" }).trim(), "");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("deep project setup: approval wait wins over deterministic write-gate placeholder", async () => {
   const base = makeBase();
   try {

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -1600,7 +1600,7 @@ test("deep project setup: discuss-milestone question failure pauses instead of a
   }
 });
 
-test("verified task git closeout failure retries and continues auto-mode", async () => {
+test("verified task git closeout hook failure re-dispatches task remediation", async () => {
   const base = makeBase();
   try {
     execFileSync("git", ["init"], { cwd: base, stdio: "ignore" });
@@ -1642,15 +1642,70 @@ test("verified task git closeout failure retries and continues auto-mode", async
       updateProgressWidget: () => {},
     });
 
-    assert.equal(result, "continue");
+    assert.equal(result, "retry");
     assert.equal(pauseCalled, false);
     assert.equal(s.lastGitActionStatus, "failed");
+    assert.equal(s.pendingVerificationRetry?.unitId, "M001/S01/T01");
+    assert.equal(s.pendingVerificationRetry?.attempt, 1);
+    assert.match(s.pendingVerificationRetry?.failureContext ?? "", /blocked by test hook/);
+    assert.equal(s.verificationRetryCount.get("git-commit:execute-task:M001/S01/T01"), 1);
     const preCommitCount = Number(readFileSync(join(base, ".git", "pre-commit-count"), "utf-8"));
     assert.equal(Number.isFinite(preCommitCount), true);
-    assert.ok(preCommitCount >= 3, "git closeout should retry the failing commit path");
+    assert.equal(preCommitCount, 2, "git closeout should not outer-retry deterministic hook failures");
     assert.ok(
       notifications.some((entry) => entry.severity === "warning" && entry.message.includes("Git commit failed")),
-      "verified task git closeout failure should warn instead of stopping auto-mode",
+      "verified task git closeout failure should warn before retrying task remediation",
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("verified task git closeout hook failure pauses after remediation cap", async () => {
+  const base = makeBase();
+  try {
+    execFileSync("git", ["init"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: base, stdio: "ignore" });
+    const hookPath = join(base, ".git", "hooks", "pre-commit");
+    writeFileSync(
+      hookPath,
+      [
+        "#!/bin/sh",
+        "echo blocked by test hook >&2",
+        "exit 1",
+      ].join("\n"),
+    );
+    chmodSync(hookPath, 0o755);
+    writeFileSync(join(base, "work.txt"), "changed\n");
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.originalBasePath = base;
+    s.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+    s.verificationRetryCount.set("git-commit:execute-task:M001/S01/T01", 2);
+
+    let pauseCalled = false;
+    const notifications: Array<{ message: string; severity?: string }> = [];
+    const result = await postUnitPostVerification({
+      s,
+      ctx: { ui: { notify: (message: string, severity?: string) => notifications.push({ message, severity }) } } as any,
+      pi: {} as any,
+      buildSnapshotOpts: () => ({}) as any,
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto: async () => { pauseCalled = true; },
+      updateProgressWidget: () => {},
+    });
+
+    assert.equal(result, "stopped");
+    assert.equal(pauseCalled, true);
+    assert.equal(s.pendingVerificationRetry, null);
+    assert.equal(s.verificationRetryCount.has("git-commit:execute-task:M001/S01/T01"), false);
+    assert.ok(
+      notifications.some((entry) => entry.severity === "error" && entry.message.includes("after 2 remediation attempts")),
+      "hook commit failure should pause after the remediation cap",
     );
   } finally {
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/post-unit-git-failure.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-git-failure.test.ts
@@ -9,11 +9,18 @@ const source = readFileSync(
   "utf-8",
 );
 
-test("postUnitPreVerification blocks on git action failure", () => {
+test("postUnitPreVerification blocks on non-transient git action failure", () => {
   const failureBlock = extractSourceRegion(source, 'if (gitResult.status === "failed")');
-  assert.ok(failureBlock.includes('ctx.ui.notify(failureMsg, opts?.softFailure ? "warning" : "error")'));
+  // Deterministic / unknown git failures still pause auto-mode instead of silently continuing.
+  assert.ok(failureBlock.includes('ctx.ui.notify(failureMsg, "error")'));
   assert.ok(failureBlock.includes("await pauseAuto(ctx, pi)"));
   assert.ok(failureBlock.includes('return "dispatched"'));
+  // Only transient failures are allowed to warn-and-continue under softFailure.
+  assert.ok(failureBlock.includes('if (opts?.softFailure && gitResult.failureClass === "transient")'));
+  assert.ok(failureBlock.includes('return "continue"'));
+  // Deterministic pre-commit hook rejections on execute-task commits route into bounded remediation retries.
+  assert.ok(failureBlock.includes('gitResult.failureClass === "hook-content"'));
+  assert.ok(failureBlock.includes('return "retry"'));
   assert.ok(!failureBlock.includes("git-action-failed-nonblocking"));
 });
 

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -231,6 +231,30 @@ test("uok gitops turn action classifies hook rejection with lock-like output as 
   assert.equal(result.failureClass, "hook-content");
 });
 
+test("uok gitops turn action classifies hook rejection with missing exit status as hook-content", () => {
+  // A hook aborts the commit but the numeric exit status is dropped or rewritten
+  // (wrapped error, signal kill). Non-git-owned stderr must still route into
+  // bounded git-commit remediation rather than pausing as `unknown`.
+  const missingStatus = Object.assign(new Error("git commit failed: blocked by lint hook"), {
+    stderr: "blocked by lint hook\nrun `pnpm lint --fix` and retry",
+  });
+
+  const missingResult = handleTurnGitActionError("commit", missingStatus);
+  assert.equal(missingResult.status, "failed");
+  assert.equal(missingResult.failureClass, "hook-content");
+
+  // Signal-killed hook: status is null rather than 1.
+  const signalKilled = Object.assign(new Error("git commit failed: pre-commit terminated"), {
+    stderr: "pre-commit checks did not pass",
+    status: null,
+    signal: "SIGTERM",
+  });
+
+  const signalResult = handleTurnGitActionError("commit", signalKilled);
+  assert.equal(signalResult.status, "failed");
+  assert.equal(signalResult.failureClass, "hook-content");
+});
+
 test("uok gitops turn action classifies exit-1 git lock output as transient", () => {
   const err = Object.assign(new Error("git commit failed: fatal: Unable to create '.git/index.lock'"), {
     stderr: [

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -217,6 +217,33 @@ test("uok gitops turn action classifies commit hook failures as hook-content", (
   }
 });
 
+test("uok gitops turn action classifies hook rejection with lock-like output as hook-content", () => {
+  // A pre-commit hook aborts `git commit` with exit code 1 and its stderr is arbitrary
+  // user text that may coincidentally match a transient lock pattern. The exit-1 signal
+  // must win so the failure routes to hook remediation, not silent transient continue.
+  const err = Object.assign(new Error("git commit failed: could not lock config file"), {
+    stderr: "could not lock config file .pre-commit-guard\nblocked by policy",
+    status: 1,
+  });
+
+  const result = handleTurnGitActionError("commit", err);
+  assert.equal(result.status, "failed");
+  assert.equal(result.failureClass, "hook-content");
+});
+
+test("uok gitops turn action classifies exit-128 lock contention as transient", () => {
+  // Git's own lock contention is fatal (exit 128, never 1), so it must remain transient
+  // even though the hook-content gate sits first in the classifier.
+  const err = Object.assign(new Error("fatal: cannot lock ref 'HEAD'"), {
+    stderr: "fatal: cannot lock ref 'HEAD': Unable to create '.git/refs/heads/main.lock': File exists.",
+    status: 128,
+  });
+
+  const result = handleTurnGitActionError("commit", err);
+  assert.equal(result.status, "failed");
+  assert.equal(result.failureClass, "transient");
+});
+
 test("uok gitops turn action commit defaults to child repositories in parent mode", () => {
   const root = mkdtempSync(join(tmpdir(), "gsd-uok-gitops-parent-commit-"));
   try {

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -219,8 +219,8 @@ test("uok gitops turn action classifies commit hook failures as hook-content", (
 
 test("uok gitops turn action classifies hook rejection with lock-like output as hook-content", () => {
   // A pre-commit hook aborts `git commit` with exit code 1 and its stderr is arbitrary
-  // user text that may coincidentally match a transient lock pattern. The exit-1 signal
-  // must win so the failure routes to hook remediation, not silent transient continue.
+  // user text that may coincidentally match a transient lock pattern. Unless the stderr
+  // looks like git's own lock error, route it to hook remediation.
   const err = Object.assign(new Error("git commit failed: could not lock config file"), {
     stderr: "could not lock config file .pre-commit-guard\nblocked by policy",
     status: 1,
@@ -231,9 +231,22 @@ test("uok gitops turn action classifies hook rejection with lock-like output as 
   assert.equal(result.failureClass, "hook-content");
 });
 
+test("uok gitops turn action classifies exit-1 git lock output as transient", () => {
+  const err = Object.assign(new Error("git commit failed: fatal: Unable to create '.git/index.lock'"), {
+    stderr: [
+      "fatal: Unable to create '/tmp/repo/.git/index.lock': File exists.",
+      "",
+      "Another git process seems to be running in this repository.",
+    ].join("\n"),
+    status: 1,
+  });
+
+  const result = handleTurnGitActionError("commit", err);
+  assert.equal(result.status, "failed");
+  assert.equal(result.failureClass, "transient");
+});
+
 test("uok gitops turn action classifies exit-128 lock contention as transient", () => {
-  // Git's own lock contention is fatal (exit 128, never 1), so it must remain transient
-  // even though the hook-content gate sits first in the classifier.
   const err = Object.assign(new Error("fatal: cannot lock ref 'HEAD'"), {
     stderr: "fatal: cannot lock ref 'HEAD': Unable to create '.git/refs/heads/main.lock': File exists.",
     status: 128,

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -309,6 +309,58 @@ workspace:
   }
 });
 
+test("uok gitops turn action preserves hook-content when mixed with unknown parent repo errors", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-uok-gitops-parent-hook-"));
+  try {
+    initRepo(root);
+    mkdirSync(join(root, ".gsd"), { recursive: true });
+    mkdirSync(join(root, "frontend"), { recursive: true });
+    initRepo(join(root, "frontend"));
+    writeFileSync(join(root, ".gitignore"), "frontend/\n", "utf-8");
+    run("git add .gitignore", root);
+    run('git commit -m "chore: ignore nested repos"', root);
+    writeFileSync(join(root, ".gsd", "PREFERENCES.md"), `---
+version: 1
+workspace:
+  mode: parent
+  repositories:
+    frontend:
+      path: frontend
+---
+`, "utf-8");
+    run("git add .gsd/PREFERENCES.md", root);
+    run('git commit -m "chore: configure parent workspace repos"', root);
+
+    const hookPath = join(root, "frontend", ".git", "hooks", "pre-commit");
+    writeFileSync(
+      hookPath,
+      [
+        "#!/bin/sh",
+        "echo blocked by frontend hook >&2",
+        "exit 1",
+      ].join("\n"),
+      "utf-8",
+    );
+    chmodSync(hookPath, 0o755);
+    writeFileSync(join(root, "frontend", "README.md"), "# frontend dirty\n", "utf-8");
+
+    const result = runTurnGitAction({
+      basePath: root,
+      action: "commit",
+      unitType: "execute-task",
+      unitId: "M001/S01/T-parent-hook",
+      targetRepositories: ["frontend", "missing"],
+    });
+
+    assert.equal(result.status, "failed");
+    assert.equal(result.failureClass, "hook-content");
+    assert.match(result.commitErrors?.frontend ?? "", /blocked by frontend hook/);
+    assert.equal(result.commitErrors?.missing, "unknown repository target: missing");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("uok gitops turn action commit reuses the collected dirty status", () => {
   const repo = makeRepo();
   const wrapperDir = mkdtempSync(join(tmpdir(), "gsd-uok-git-wrapper-"));

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -186,6 +186,37 @@ test("uok gitops turn action commit creates commit with unit trailer", () => {
   }
 });
 
+test("uok gitops turn action classifies commit hook failures as hook-content", () => {
+  const repo = makeRepo();
+  try {
+    const hookPath = join(repo, ".git", "hooks", "pre-commit");
+    writeFileSync(
+      hookPath,
+      [
+        "#!/bin/sh",
+        "echo blocked by test hook >&2",
+        "exit 1",
+      ].join("\n"),
+      "utf-8",
+    );
+    chmodSync(hookPath, 0o755);
+    writeFileSync(join(repo, "feature.ts"), "export const x = 1;\n", "utf-8");
+
+    const result = runTurnGitAction({
+      basePath: repo,
+      action: "commit",
+      unitType: "execute-task",
+      unitId: "M001/S01/T-hook",
+    });
+
+    assert.equal(result.status, "failed");
+    assert.equal(result.failureClass, "hook-content");
+    assert.match(result.error ?? "", /blocked by test hook/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 test("uok gitops turn action commit defaults to child repositories in parent mode", () => {
   const root = mkdtempSync(join(tmpdir(), "gsd-uok-gitops-parent-commit-"));
   try {
@@ -388,7 +419,18 @@ test("uok gitops turn action keeps non-infrastructure git failures recoverable",
 
   assert.equal(result.action, "commit");
   assert.equal(result.status, "failed");
+  assert.equal(result.failureClass, "unknown");
   assert.equal(result.error, "nothing to commit");
+});
+
+test("uok gitops turn action classifies git lock failures as transient", () => {
+  const err = Object.assign(new Error("fatal: Unable to create '.git/index.lock': File exists."), {
+    stderr: "fatal: Unable to create '.git/index.lock': File exists.",
+  });
+
+  const result = handleTurnGitActionError("commit", err);
+  assert.equal(result.status, "failed");
+  assert.equal(result.failureClass, "transient");
 });
 
 test("uok gitops turn action prefers stderr details for git failures", () => {
@@ -398,5 +440,6 @@ test("uok gitops turn action prefers stderr details for git failures", () => {
 
   const result = handleTurnGitActionError("commit", err);
   assert.equal(result.status, "failed");
+  assert.equal(result.failureClass, "unknown");
   assert.equal(result.error, "fatal: unable to auto-detect email address");
 });


### PR DESCRIPTION
## Summary
- Routed deterministic execute-task commit hook failures into bounded remediation retries and verified diff and TypeScript syntax checks; full tests were blocked by missing dependencies and restricted network.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1491
- [#1491 execute-task post-task commit silently swallows deterministic pre-commit-hook failures, strands task work uncommitted](https://github.com/open-gsd/gsd-pi/issues/1491)

## User
- @vburghelea

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1491-execute-task-post-task-commit-silently-s-1784416060`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-mode post-verification git closeout and execute-task re-dispatch after DB completion; misclassification could pause too often or retry incorrectly, but behavior is bounded and covered by new integration tests.
> 
> **Overview**
> **Post-task `git commit` failures are classified and handled by cause** instead of treating most closeout commit errors as ignorable soft warnings.
> 
> Turn git actions now attach a `failureClass` (`transient`, `hook-content`, or `unknown`). Lock/contention errors keep the short retry loop; only **transient** failures may warn-and-continue under deferred closeout. Pre-commit and other hook rejections on verified `execute-task` units are **`hook-content`**: auto mode injects the full hook output into `pendingVerificationRetry`, re-dispatches the same task (up to **2** attempts), and pauses with `.gsd/git-action-failures.log` if remediation is exhausted.
> 
> **Dispatch and orchestration** no longer skip an already-`complete` task when the retry signature is `git-commit:*`, so remediation can run after verification already closed the task in the DB. **Parent workspaces** with a partial multi-repo commit (some repos committed, another hook failed) **pause** without task redo to avoid duplicating committed work.
> 
> User docs and GitBook describe the new remediation path and troubleshooting steps. Tests cover classification edge cases, remediation cap, partial commits, and orchestrator bypass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 047d1c9961699a23f6a8d9a823ebc0a40b4ff810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->