### PR TITLE
fix(issue): [Bug]: gsd_uat_result_save rejects valid evidence kinds — prompt documents 1 of 6, validator defaults 3 to opaque path check

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2409,9 +2409,14 @@ const uatExecParams = {
 };
 const uatExecSchema = z.object(uatExecParams);
 
+const uatEvidenceKindValues = ["gsd_uat_exec", "gsd_exec", "screenshot", "log", "url", "browser"] as const;
+const uatEvidenceRefDescription =
+  "Kind-specific evidence ref: gsd_uat_exec/gsd_exec use an evidence id or .gsd/exec/*.meta.json path; " +
+  "screenshot/log use a path under .gsd/exec/, .gsd/uat/, or .artifacts/browser/; " +
+  "url uses an http(s) URL; browser uses an http(s) URL or .artifacts/browser/ path.";
 const uatEvidenceRefSchema = z.object({
-  kind: z.enum(["gsd_uat_exec", "gsd_exec", "screenshot", "log", "url", "browser"]),
-  ref: nonEmptyString("ref"),
+  kind: z.enum(uatEvidenceKindValues).describe(`Evidence kind. Valid values: ${uatEvidenceKindValues.join(", ")}`),
+  ref: nonEmptyString("ref").describe(uatEvidenceRefDescription),
   note: z.string().optional(),
 });
 const uatCheckSchema = z.object({

--- a/packages/pi-ai/src/utils/validation.ts
+++ b/packages/pi-ai/src/utils/validation.ts
@@ -268,6 +268,39 @@ function formatValidationPath(error: TLocalizedValidationError): string {
 	return path || "root";
 }
 
+function quotedEnumValues(values: readonly unknown[]): string {
+	return values
+		.map((value) => typeof value === "string" ? `"${value}"` : JSON.stringify(value))
+		.join(", ");
+}
+
+function enumValuesFromValidationError(error: TLocalizedValidationError): readonly unknown[] {
+	const schemaEnum = (error as { schema?: { enum?: unknown } }).schema?.enum;
+	if (Array.isArray(schemaEnum)) {
+		return schemaEnum;
+	}
+	const params = error.params as { allowedValues?: unknown; allowedValue?: unknown };
+	if (Array.isArray(params.allowedValues)) {
+		return params.allowedValues;
+	}
+	if (params.allowedValue !== undefined) {
+		return [params.allowedValue];
+	}
+	return [];
+}
+
+function formatValidationMessage(error: TLocalizedValidationError): string {
+	const enumValues = enumValuesFromValidationError(error);
+	if (enumValues.length === 0) {
+		return error.message;
+	}
+	const allowedValues = quotedEnumValues(enumValues);
+	if (error.message.includes(allowedValues)) {
+		return error.message;
+	}
+	return `${error.message}; allowed values: ${allowedValues}`;
+}
+
 /**
  * Finds a tool by name and validates the tool call arguments against its TypeBox schema
  * @param tools Array of tool definitions
@@ -319,7 +352,7 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): any {
 	const errors =
 		validator
 			.Errors(args)
-			.map((error) => `  - ${formatValidationPath(error)}: ${error.message}`)
+			.map((error) => `  - ${formatValidationPath(error)}: ${formatValidationMessage(error)}`)
 			.join("\n") || "Unknown validation error";
 
 	const errorMessage = `Validation failed for tool "${toolCall.name}":\n${errors}\n\nReceived arguments:\n${JSON.stringify(toolCall.arguments, null, 2)}`;

--- a/packages/pi-ai/test/validation.test.ts
+++ b/packages/pi-ai/test/validation.test.ts
@@ -113,4 +113,27 @@ describe("validateToolArguments", () => {
 			expect(() => validateToolArguments(tool, toolCall)).toThrow("Validation failed");
 		}
 	});
+
+	it("lists allowed enum values when enum validation fails", () => {
+		const tool: Tool = {
+			name: "save_evidence",
+			description: "Save evidence",
+			parameters: Type.Object({
+				kind: Type.Unsafe({
+					type: "string",
+					enum: ["gsd_uat_exec", "browser", "url"],
+				}),
+			}),
+		};
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "tool-1",
+			name: "save_evidence",
+			arguments: { kind: "artifact" },
+		};
+
+		expect(() => validateToolArguments(tool, toolCall)).toThrow(
+			/allowed values: "gsd_uat_exec", "browser", "url"/,
+		);
+	});
 });

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -105,6 +105,12 @@ function formatToolErrorText(result: any, details: any): string {
   return typeof message === "string" && message.startsWith("Error") ? message : `Error: ${message}`;
 }
 
+const UAT_EVIDENCE_KIND_VALUES = ["gsd_uat_exec", "gsd_exec", "screenshot", "log", "url", "browser"] as const;
+const UAT_EVIDENCE_REF_DESCRIPTION =
+  "Kind-specific evidence ref: gsd_uat_exec/gsd_exec use an evidence id or .gsd/exec/*.meta.json path; " +
+  "screenshot/log use a path under .gsd/exec/, .gsd/uat/, or .artifacts/browser/; " +
+  "url uses an http(s) URL; browser uses an http(s) URL or .artifacts/browser/ path.";
+
 export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_decision_save (formerly gsd_save_decision) ─────────────────────
 
@@ -442,8 +448,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
   };
 
   const uatEvidenceRef = Type.Object({
-    kind: StringEnum(["gsd_uat_exec", "gsd_exec", "screenshot", "log", "url", "browser"], { description: "Evidence kind" }),
-    ref: Type.String({ description: "Evidence ID, approved .gsd path, or URL" }),
+    kind: StringEnum(UAT_EVIDENCE_KIND_VALUES, { description: `Evidence kind. Valid values: ${UAT_EVIDENCE_KIND_VALUES.join(", ")}` }),
+    ref: Type.String({ description: UAT_EVIDENCE_REF_DESCRIPTION }),
     note: Type.Optional(Type.String({ description: "Short evidence note" })),
     unitType: Type.Optional(Type.String({ description: "Unit that produced the evidence" })),
     tool: Type.Optional(Type.String({ description: "Tool that produced the evidence" })),

--- a/src/resources/extensions/gsd/prompts/run-uat.md
+++ b/src/resources/extensions/gsd/prompts/run-uat.md
@@ -57,7 +57,7 @@ The **Tool Surface** block prepended above lists unavailable tools for this unit
 
 For each check, record:
 - The check description (from the UAT file)
-- The evidence mode used: `artifact`, `runtime`, or `human-follow-up`
+- The evidence mode used: `artifact`, `runtime`, `browser`, or `human-follow-up`
 - The command or action taken, including the `gsd_uat_exec` evidence ID for automated checks
 - The actual result observed
 - `PASS`, `FAIL`, or `NEEDS-HUMAN`
@@ -93,10 +93,21 @@ checks: [{
   description: "<check description from the UAT file>",
   mode: "artifact" | "runtime" | "browser" | "human-follow-up",
   result: "PASS" | "FAIL" | "NEEDS-HUMAN",
-  evidence: [{ kind: "gsd_uat_exec", ref: "<evidence id>" }],
+  evidence: [{ kind: "<evidence kind>", ref: "<kind-specific ref>" }],
   notes: "<observed output, evidence, reason, or manual follow-up>",
 }]
 ```
+
+Accepted `evidence.kind` values and `ref` rules:
+
+- `gsd_uat_exec` - `ref` is the `gsd_uat_exec` evidence ID, or a `.meta.json` path under `.gsd/exec/`. The metadata file must exist and be typed as `uat_exec`.
+- `gsd_exec` - `ref` is a `gsd_exec` evidence ID, or a `.meta.json` path under `.gsd/exec/`. The metadata file must exist.
+- `screenshot` - `ref` is a path under `.artifacts/browser/`, `.gsd/exec/`, or `.gsd/uat/`.
+- `log` - `ref` is a path under `.gsd/exec/`, `.gsd/uat/`, or `.artifacts/browser/`.
+- `url` - `ref` is an `http://` or `https://` URL.
+- `browser` - `ref` is either an `http://` or `https://` URL for navigation-backed checks, or a path under `.artifacts/browser/` for screenshot/artifact-backed browser checks.
+
+Do not invent evidence kinds such as `artifact`, `file`, or `executionId`. `artifact`, `runtime`, `browser`, and `human-follow-up` are check `mode` values, not evidence `kind` values.
 
 ---
 

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -148,6 +148,18 @@ test("run-uat prompt lists canonical gsd_uat_exec intent values", () => {
   assert.match(prompt, /do not use `artifact`, `runtime`, or `human-follow-up` as `intent`/i);
 });
 
+test("run-uat prompt documents all UAT result evidence kinds and ref rules", () => {
+  const prompt = readPrompt("run-uat");
+  for (const kind of ["gsd_uat_exec", "gsd_exec", "screenshot", "log", "url", "browser"] as const) {
+    assert.ok(prompt.includes(`\`${kind}\``), `run-uat prompt should document evidence kind ${kind}`);
+  }
+  assert.match(prompt, /\.gsd\/exec\//);
+  assert.match(prompt, /\.gsd\/uat\//);
+  assert.match(prompt, /\.artifacts\/browser\//);
+  assert.match(prompt, /http:\/\/` or `https:\/\//);
+  assert.match(prompt, /`artifact`, `runtime`, `browser`, and `human-follow-up` are check `mode` values/i);
+});
+
 test("run-uat prompt gives the complete UAT result-save presentation contract", () => {
   const prompt = readPrompt("run-uat");
   assert.match(prompt, /Call `gsd_uat_result_save` once after all checks are complete/);

--- a/src/resources/extensions/gsd/tests/uat-run.test.ts
+++ b/src/resources/extensions/gsd/tests/uat-run.test.ts
@@ -1,0 +1,151 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  prepareUatRun,
+  type UatEvidenceRef,
+  type UatResultSaveParams,
+} from "../uat-run.ts";
+import { buildRunUatPresentationForType } from "../tool-presentation-plan.ts";
+
+type EvidenceInput = UatEvidenceRef | { kind: string; ref: string };
+
+function makeTmpBase(): string {
+  return mkdtempSync(join(tmpdir(), "gsd-uat-run-"));
+}
+
+function cleanup(base: string): void {
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* swallow */ }
+}
+
+function writeFreshUatEvidence(base: string, id = "fresh-uat-evidence"): string {
+  const execDir = join(base, ".gsd", "exec");
+  mkdirSync(execDir, { recursive: true });
+  writeFileSync(
+    join(execDir, `${id}.meta.json`),
+    JSON.stringify({ id, metadata: { kind: "uat_exec" } }),
+    "utf-8",
+  );
+  return id;
+}
+
+function buildParams(
+  evidence: EvidenceInput[],
+  options: {
+    uatType?: UatResultSaveParams["uatType"];
+    mode?: UatResultSaveParams["checks"][number]["mode"];
+  } = {},
+): UatResultSaveParams {
+  const uatType = options.uatType ?? "runtime-executable";
+  return {
+    milestoneId: "M001",
+    sliceId: "S01",
+    uatType,
+    verdict: "PASS",
+    checks: [{
+      id: "UAT-01",
+      description: "Evidence contract check",
+      mode: options.mode ?? "runtime",
+      result: "PASS",
+      evidence: evidence as UatEvidenceRef[],
+      notes: "Evidence validation should be explicit.",
+    }],
+    presentation: buildRunUatPresentationForType(uatType),
+    notes: "UAT passed.",
+  };
+}
+
+test("prepareUatRun accepts browser evidence backed by an http URL", () => {
+  const base = makeTmpBase();
+  try {
+    const evidenceId = writeFreshUatEvidence(base);
+    const result = prepareUatRun(base, buildParams([
+      { kind: "gsd_uat_exec", ref: evidenceId },
+      { kind: "browser", ref: "https://example.test/uat/session" },
+    ], { uatType: "browser-executable", mode: "browser" }));
+
+    if (!result.ok) assert.fail(result.error.message);
+    assert.equal(result.run.params.checks[0]?.evidence?.[1]?.kind, "browser");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("prepareUatRun accepts screenshot and log evidence under approved roots", () => {
+  const base = makeTmpBase();
+  try {
+    const evidenceId = writeFreshUatEvidence(base);
+    mkdirSync(join(base, ".artifacts", "browser", "session"), { recursive: true });
+    mkdirSync(join(base, ".gsd", "uat", "M001", "S01"), { recursive: true });
+    writeFileSync(join(base, ".artifacts", "browser", "session", "home.png"), "png", "utf-8");
+    writeFileSync(join(base, ".gsd", "uat", "M001", "S01", "console.log"), "ok", "utf-8");
+
+    const result = prepareUatRun(base, buildParams([
+      { kind: "gsd_uat_exec", ref: evidenceId },
+      { kind: "screenshot", ref: ".artifacts/browser/session/home.png" },
+      { kind: "log", ref: ".gsd/uat/M001/S01/console.log" },
+    ], { uatType: "artifact-driven", mode: "artifact" }));
+
+    if (!result.ok) assert.fail(result.error.message);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("prepareUatRun rejects unknown evidence kinds with the accepted kind list", () => {
+  const base = makeTmpBase();
+  try {
+    const evidenceId = writeFreshUatEvidence(base);
+    const result = prepareUatRun(base, buildParams([
+      { kind: "gsd_uat_exec", ref: evidenceId },
+      { kind: "artifact", ref: ".gsd/uat/M001/S01/readme.md" },
+    ]));
+
+    assert.equal(result.ok, false);
+    if (result.ok) assert.fail("expected invalid evidence");
+    assert.match(result.error.message, /evidence\.kind must be one of: "gsd_uat_exec", "gsd_exec", "screenshot", "log", "url", "browser"/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("prepareUatRun rejects log refs outside approved roots with recovery details", () => {
+  const base = makeTmpBase();
+  try {
+    const evidenceId = writeFreshUatEvidence(base);
+    const result = prepareUatRun(base, buildParams([
+      { kind: "gsd_uat_exec", ref: evidenceId },
+      { kind: "log", ref: "AGENTS.md#Security.External-access" },
+    ]));
+
+    assert.equal(result.ok, false);
+    if (result.ok) assert.fail("expected invalid evidence");
+    assert.match(result.error.message, /log evidence ref must be a path under approved evidence locations/);
+    assert.match(result.error.message, /\.gsd\/exec\//);
+    assert.match(result.error.message, /\.gsd\/uat\//);
+    assert.match(result.error.message, /\.artifacts\/browser\//);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("prepareUatRun rejects browser filesystem refs outside browser artifacts", () => {
+  const base = makeTmpBase();
+  try {
+    const evidenceId = writeFreshUatEvidence(base);
+    const result = prepareUatRun(base, buildParams([
+      { kind: "gsd_uat_exec", ref: evidenceId },
+      { kind: "browser", ref: ".gsd/uat/M001/S01/browser.json" },
+    ], { uatType: "browser-executable", mode: "browser" }));
+
+    assert.equal(result.ok, false);
+    if (result.ok) assert.fail("expected invalid evidence");
+    assert.match(result.error.message, /browser evidence ref must be an http:\/\/ or https:\/\/ URL/);
+    assert.match(result.error.message, /\.artifacts\/browser\//);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/uat-run.ts
+++ b/src/resources/extensions/gsd/uat-run.ts
@@ -2,7 +2,7 @@
 // File Purpose: Owns the durable UAT run lifecycle behind gsd_uat_result_save.
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, normalize, resolve } from "node:path";
 
 import {
   hasUatBrowserToolSurface,
@@ -27,8 +27,22 @@ import { saveFile } from "./files.js";
 import { relSliceFile, resolveGsdPathContract } from "./paths.js";
 import { buildManualValidationGuidance, resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 
+export const UAT_EVIDENCE_KINDS = [
+  "gsd_uat_exec",
+  "gsd_exec",
+  "screenshot",
+  "log",
+  "url",
+  "browser",
+] as const;
+export type UatEvidenceKind = typeof UAT_EVIDENCE_KINDS[number];
+
+const UAT_EVIDENCE_KIND_SET = new Set<string>(UAT_EVIDENCE_KINDS);
+const APPROVED_EVIDENCE_REF_ROOTS = [".gsd/exec/", ".gsd/uat/", ".artifacts/browser/"] as const;
+const APPROVED_BROWSER_EVIDENCE_REF_ROOTS = [".artifacts/browser/"] as const;
+
 export interface UatEvidenceRef {
-  kind: "gsd_uat_exec" | "gsd_exec" | "screenshot" | "log" | "url" | "browser";
+  kind: UatEvidenceKind;
   ref: string;
   note?: string;
   unitType?: string;
@@ -193,6 +207,37 @@ function pushUnique(paths: string[], candidate: string): void {
   if (!paths.includes(candidate)) paths.push(candidate);
 }
 
+function quoteList(values: readonly string[]): string {
+  return values.map((value) => `"${value}"`).join(", ");
+}
+
+function approvedRootsText(roots: readonly string[] = APPROVED_EVIDENCE_REF_ROOTS): string {
+  return roots.join(", ");
+}
+
+function isUatEvidenceKind(value: unknown): value is UatEvidenceKind {
+  return typeof value === "string" && UAT_EVIDENCE_KIND_SET.has(value);
+}
+
+function isHttpUrlRef(ref: string): boolean {
+  try {
+    const parsed = new URL(ref);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeEvidenceRef(ref: string): string {
+  return normalize(ref).replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, "");
+}
+
+function relativeRefStartsWithin(root: string, ref: string): boolean {
+  const normalizedRoot = root.replace(/\\/g, "/").replace(/\/+$/, "");
+  const normalizedRef = normalizeEvidenceRef(ref);
+  return normalizedRef === normalizedRoot || normalizedRef.startsWith(`${normalizedRoot}/`);
+}
+
 function execMetaPathCandidates(basePath: string, ref: string): string[] {
   const trimmed = ref.trim();
   const candidates: string[] = [];
@@ -245,24 +290,35 @@ export function readUatExecEvidenceMetadata(
 }
 
 function evidencePathIsApproved(basePath: string, ref: string): boolean {
-  const normalizedRef = ref.replace(/\\/g, "/");
-  if (normalizedRef.startsWith(".gsd/exec/") || normalizedRef.startsWith(".gsd/uat/")) return true;
-  if (normalizedRef.startsWith(".artifacts/browser/")) {
-    const resolvedRef = resolve(basePath, ref);
-    return approvedBrowserArtifactRoots(basePath).some((root) => pathStartsWithin(root, resolvedRef));
+  if (APPROVED_EVIDENCE_REF_ROOTS.some((root) => relativeRefStartsWithin(root, ref))) {
+    return true;
   }
+  const resolvedRef = isAbsolute(ref) ? resolve(ref) : resolve(basePath, ref);
   const gsdEvidenceApproved = approvedEvidenceRoots(basePath).some((root) => {
-    return pathStartsWithin(join(root, "exec"), ref) || pathStartsWithin(join(root, "uat"), ref);
+    return pathStartsWithin(join(root, "exec"), resolvedRef) || pathStartsWithin(join(root, "uat"), resolvedRef);
   });
   if (gsdEvidenceApproved) return true;
-  return approvedBrowserArtifactRoots(basePath).some((root) => pathStartsWithin(root, ref));
+  return approvedBrowserArtifactRoots(basePath).some((root) => pathStartsWithin(root, resolvedRef));
+}
+
+function browserArtifactPathIsApproved(basePath: string, ref: string): boolean {
+  if (!APPROVED_BROWSER_EVIDENCE_REF_ROOTS.some((root) => relativeRefStartsWithin(root, ref)) && !isAbsolute(ref)) {
+    return false;
+  }
+  const resolvedRef = isAbsolute(ref) ? resolve(ref) : resolve(basePath, ref);
+  return approvedBrowserArtifactRoots(basePath).some((root) => pathStartsWithin(root, resolvedRef));
 }
 
 function validateEvidenceRef(basePath: string, evidence: UatEvidenceRef): string | null {
+  if (!isUatEvidenceKind(evidence.kind)) {
+    return `evidence.kind must be one of: ${quoteList(UAT_EVIDENCE_KINDS)}`;
+  }
   if (!isNonEmptyString(evidence.ref)) return "evidence.ref is required";
   if (evidence.kind === "gsd_uat_exec" || evidence.kind === "gsd_exec") {
     const path = resolveExecMetaPath(basePath, evidence.ref.trim());
-    if (!path) return `missing gsd_exec metadata for evidence id "${evidence.ref}"`;
+    if (!path) {
+      return `${evidence.kind} evidence ref "${evidence.ref}" must resolve to an existing .meta.json file under .gsd/exec/`;
+    }
     if (evidence.kind === "gsd_uat_exec") {
       try {
         const meta = JSON.parse(readFileSync(path, "utf-8")) as { metadata?: { kind?: unknown } };
@@ -274,18 +330,20 @@ function validateEvidenceRef(basePath: string, evidence: UatEvidenceRef): string
     return null;
   }
   if (evidence.kind === "url") {
-    try {
-      const parsed = new URL(evidence.ref);
-      return parsed.protocol === "http:" || parsed.protocol === "https:"
-        ? null
-        : `invalid URL evidence ref "${evidence.ref}"`;
-    } catch {
-      return `invalid URL evidence ref "${evidence.ref}"`;
-    }
+    return isHttpUrlRef(evidence.ref)
+      ? null
+      : `url evidence ref must be an http:// or https:// URL; got "${evidence.ref}"`;
   }
-  return evidencePathIsApproved(basePath, evidence.ref)
-    ? null
-    : `evidence ref "${evidence.ref}" is outside approved evidence locations`;
+  if (evidence.kind === "screenshot" || evidence.kind === "log") {
+    return evidencePathIsApproved(basePath, evidence.ref)
+      ? null
+      : `${evidence.kind} evidence ref must be a path under approved evidence locations (${approvedRootsText()}); got "${evidence.ref}"`;
+  }
+  if (evidence.kind === "browser") {
+    if (isHttpUrlRef(evidence.ref) || browserArtifactPathIsApproved(basePath, evidence.ref)) return null;
+    return `browser evidence ref must be an http:// or https:// URL, or a path under ${approvedRootsText(APPROVED_BROWSER_EVIDENCE_REF_ROOTS)}; got "${evidence.ref}"`;
+  }
+  return null;
 }
 
 function validateUatChecks(basePath: string, params: UatResultSaveParams): string | null {


### PR DESCRIPTION
## Summary
- Fixed UAT evidence prompt and validation contracts with syntax/diff checks passing; full tests were blocked by missing dependencies after registry ENOTFOUND.

## Bugs Addressed
- [x] **run-uat prompt omits accepted evidence kinds**
- [x] **browser evidence validation does not accept URL refs**
- [x] **evidence validation errors omit recovery details**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1479
- [#1479 [Bug]: gsd_uat_result_save rejects valid evidence kinds — prompt documents 1 of 6, validator defaults 3 to opaque path check](https://github.com/open-gsd/gsd-pi/issues/1479)

## User
- @klajdo-f

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1479-bug-gsd-uat-result-save-rejects-valid-ev-1784416070`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to UAT evidence validation, prompts, and tool error formatting; behavior is tightened with new tests and should reduce false rejections rather than alter unrelated workflow paths.
> 
> **Overview**
> Aligns **UAT evidence** contracts across prompts, tool schemas, runtime validation, and agent-facing errors so `gsd_uat_result_save` accepts the documented kinds and rejects mistakes with actionable messages.
> 
> **`uat-run.ts`** now validates evidence **per kind**: `url` and `browser` accept `http(s)` URLs; `browser` also allows `.artifacts/browser/` paths; `screenshot`/`log` require approved roots (`.gsd/exec/`, `.gsd/uat/`, `.artifacts/browser/`). Unknown kinds (e.g. confusing check `mode` `artifact` with evidence `kind`) fail with the full allowed list; bad refs include recovery hints instead of a generic “outside approved locations” message.
> 
> **Tool schemas** (MCP `workflow-tools.ts`, native `db-tools.ts`) and **`run-uat.md`** document all six evidence kinds and kind-specific `ref` rules, including that `browser` is a check mode and not an invented evidence kind.
> 
> **`pi-ai` validation** appends **allowed enum values** to tool validation failures when enums fail, with a unit test.
> 
> New **`uat-run.test.ts`** and prompt contract tests lock in URL browser evidence, approved paths, and rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de33923c13d0ad1d144dc093f9a21a01764bdd16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->