### PR TITLE
feat(gsd-cloud): publish readiness, E2E harness, service install, live session events

### DIFF
--- a/docs/dev/cloud-live-e2e-runbook.md
+++ b/docs/dev/cloud-live-e2e-runbook.md
@@ -1,0 +1,136 @@
+# Cloud live E2E runbook — publish-day verification
+
+Manual end-to-end verification of the GSD Cloud agent path against the
+production service (cloud.opengsd.net). Run this on publish day after the
+`@opengsd/gsd-cloud` npm release and the cloud deployment are both live.
+
+The automated, no-production equivalent of this runbook is the local harness:
+`pnpm --filter @opengsd/gsd-cloud run test:e2e` (see
+`packages/gsd-cloud/e2e/README.md`). The local harness covers the pairing-code
+path; this runbook covers the browser device-flow path, which only exists on
+the SaaS (`/api/device/*` endpoints are not part of the standalone gateway).
+
+## Prerequisites
+
+- Node.js >= 22 on the test machine.
+- The `gsd` CLI (`@opengsd/gsd-pi`) installed and on `PATH` (or exported via
+  `GSD_CLI_PATH`).
+- A local GSD project directory (contains `.gsd/`). `cd` into it — it becomes
+  the advertised project.
+- A cloud.opengsd.net account you can log into in a browser.
+- The published version you are verifying:
+  `npm view @opengsd/gsd-cloud version`.
+
+## 1. Login (device flow)
+
+```bash
+npx @opengsd/gsd-cloud@latest login
+```
+
+Expected terminal output:
+
+- A `gsd-cloud: Cloud Login` banner with a verification URL
+  (`https://cloud.opengsd.net/...?user_code=...`) and a `Your code: XXXX-XXXX`
+  line.
+- A `Waiting for approval...` spinner with an expiry countdown (~10 minutes).
+
+If the CLI instead errors immediately, check the message: plain-HTTP gateways
+are rejected unless loopback, and unreachable hosts surface as network errors —
+both point at environment, not the release.
+
+## 2. Approve in the browser
+
+- Open the verification URL (or go to cloud.opengsd.net and enter the code
+  manually).
+- Sign in if prompted, review the requested device name, and approve.
+
+Expected: the CLI spinner is replaced by `gsd-cloud: Authorization approved!`,
+then `gsd-cloud: cloud runtime rt_<id> paired — connecting...`, then
+`connected in the background (PID <n>)` with the advertised project path and
+log file path. The shell prompt returns; the runtime stays up in the
+background.
+
+Denying the request instead must print `Device request denied by user.` and
+exit 1 — verify this path once if the approval UI changed in this release.
+
+## 3. Machine appears online on the dashboard
+
+- In the browser, open the cloud.opengsd.net dashboard (machines/devices
+  view).
+
+Expected:
+
+- The new machine appears with the runtime name (default: machine hostname)
+  and shows **online** within ~30 seconds of the CLI reporting `connected`.
+- The advertised project (the directory you ran `login` from) is listed under
+  the machine.
+
+If the machine shows offline, check the runtime log first (path printed by
+`login`, also shown by `status`), then the gateway health:
+`curl -s https://cloud.opengsd.net/healthz` should return `{"ok":true}`.
+
+## 4. Status shows connected
+
+```bash
+npx @opengsd/gsd-cloud@latest status
+```
+
+Expected JSON output:
+
+- `configured: true`, `enabled: true`, `gateway_url` pointing at the resolved
+  gateway, `runtime_id: "rt_<id>"`, and `device_token: "[redacted]"` (never a
+  raw token).
+- `background.running: true` with the background PID.
+- `telemetry` present (connection state / traffic counters); no secrets in it.
+
+## 5. Exercise a cloud read path
+
+From the dashboard, open the advertised project and trigger a read-only view
+that goes through the gateway → runtime → local `gsd --mode mcp` loop (project
+state/roadmap view). Expected: project state renders; the runtime log on the
+machine records the forwarded tool call and its `tool_result`.
+
+This is the production equivalent of the local harness's forwarded
+`gsd_query` assertion.
+
+## 6. Cleanup
+
+```bash
+# Stop the background runtime, keep pairing (reconnectable via `connect`).
+npx @opengsd/gsd-cloud@latest stop
+
+# Full cleanup: stop the runtime and remove local cloud credentials.
+npx @opengsd/gsd-cloud@latest disconnect
+```
+
+Expected after `disconnect`:
+
+- CLI prints `background runtime stopped and cloud credentials removed.`
+- `status` shows `configured: false` and `background.running: false`.
+- The dashboard marks the machine **offline** within ~1 minute (heartbeat
+  sweep) — verify this, it is the production teardown signal.
+- `~/.gsd/daemon.yaml` no longer contains a `cloud:` section.
+
+If the verification machine is throwaway, also remove any test project
+directories you created.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+| --- | --- | --- |
+| `login` spinner never completes | Approval not given, or code expired (10 min TTL) | Re-run `login`; approve promptly. |
+| `Authorization approved!` then immediate exit | `gateway_url` returned by the server failed CLI validation | Check stderr for `ignoring invalid server-supplied relay URL`; verify the deployment's relay URL config. |
+| `connected in the background` but machine offline on dashboard | WebSocket to relay rejected (device token) or relay unreachable | Read the runtime log from `status`; check `https://cloud.opengsd.net/healthz`. |
+| `status` shows `running: false` after `login` | Background child died after ready | Read the log file path from `status`; look for executor spawn errors (`gsd` missing from `PATH` → set `GSD_CLI_PATH`). |
+| Dashboard project view errors | Local `gsd --mode mcp` failed in the project dir | Run `gsd --mode mcp` manually in the project dir and check it initializes. |
+
+## Rollback signals
+
+Stop the publish and investigate if any of these fail in a clean environment:
+
+1. `login` cannot complete an approved device flow.
+2. An approved machine never appears online on the dashboard.
+3. `disconnect` leaves the machine showing online after the heartbeat sweep.
+
+Do not attempt fixes from this runbook; capture the CLI output, the runtime
+log, and the dashboard state, and hand them to the release owner.

--- a/docs/dev/gsd-cloud-publish-runbook.md
+++ b/docs/dev/gsd-cloud-publish-runbook.md
@@ -1,0 +1,120 @@
+# @opengsd/gsd-cloud publish runbook
+
+Human-run steps for publishing `@opengsd/gsd-cloud` (and the `@opengsd/daemon`
+release it ships alongside) to public npm. The publish itself always runs through
+`.github/workflows/npm-publish.yml` (OIDC trusted publishing) — **never** run
+`npm publish` from a laptop: that bypasses the version bump, the changelog, the
+workspace-resolution step, and the pre-release registry gate.
+
+## What publishes, and how versions work
+
+- Both packages are version-locked to the repo release version (e.g. root
+  `1.11.0` → `@opengsd/daemon@1.11.0`, `@opengsd/gsd-cloud@1.11.0`). They have no
+  independent version numbers.
+- `scripts/lib/version-sync.cjs` (`RELEASE_WORKSPACE_PACKAGE_DIRS`) includes
+  `packages/daemon` and `packages/gsd-cloud`, so any version bump — manual
+  (`node scripts/bump-version.mjs <X.Y.Z>`) or the release workflow's
+  `pipeline:version-stamp` / `bump-version.mjs` steps — updates both.
+- `@opengsd/gsd-cloud` is **self-contained**: its only runtime dependencies are
+  `ws` and `yaml`. It deliberately does NOT depend on `@opengsd/daemon` (the
+  v1.5 Phase-24 doc assumed a thin wrapper; the shipped package re-implements
+  the runtime standalone). `scripts/validate-gsd-cloud-tarball.mjs` enforces
+  this contract, so a future dependency addition fails the tarball gate loudly
+  instead of silently shipping an unresolvable publish.
+
+## Pre-flight checklist (before dispatching anything)
+
+1. Everything intended for the release is merged to `main`, and `ci.yml` is
+   green on that exact SHA — the publish workflow builds both packages
+   (`build:core` → `build:daemon` + `build:gsd-cloud`) but does not re-run their
+   unit suites; `ci.yml`'s `test:cloud-packages` step is the unit-test gate.
+2. Local sanity (optional but recommended after touching either package):
+   ```bash
+   pnpm install --frozen-lockfile
+   pnpm --filter @opengsd/gsd-cloud run build
+   pnpm --filter @opengsd/gsd-cloud run test
+   pnpm --filter @opengsd/gsd-cloud run validate:tarball   # npm pack gate
+   ```
+   The tarball gate must print `OK — N gates passed; tarball is publishable.`
+3. `pnpm run verify:version-sync` passes (all package.json versions equal root).
+
+## Publish day
+
+1. **Prerelease smoke (recommended):**
+   ```bash
+   gh workflow run npm-publish.yml -f channel=dev
+   ```
+   Wait for the `prerelease-publish` + `prerelease-verify` jobs to go green.
+   Note: `dev`/`next` channels publish only the root `@opengsd/gsd-pi` tarball
+   (which bundles `packages/*/dist`); workspace packages publish on `latest`.
+2. **Production:**
+   ```bash
+   gh workflow run npm-publish.yml -f channel=latest
+   ```
+   The `prod-release` job then runs, in order: changelog + version bump commit →
+   build → native engine packages → **workspace packages in dependency order**
+   (`scripts/publish-workspace-packages.sh`, auto-discovered from each package's
+   `publishConfig` — daemon and gsd-cloud need no workflow edits) → root
+   `@opengsd/gsd-pi` → `verify-npm-release.mjs` (hard gate: every required
+   package visible on npm at the release version) → push commit + tag → GitHub
+   Release.
+3. If the workflow fails at "Require token auth for native packages not on npm
+   yet", re-run with `-f publish_auth=token` and the `NPM_TOKEN` repo secret set
+   (first-publish bootstrap for the native engine packages only).
+
+## Trusted publishing / provenance
+
+- Auth is npm **trusted publishing** (GitHub OIDC, `id-token: write`) — there is
+  no long-lived npm token in CI. npm emits **provenance statements** for each
+  package published this way.
+- The workflow enforces the toolchain npm requires for this: Node ≥ 22.14 and
+  npm ≥ 11.5.1, on GitHub-hosted `ubuntu-latest` runners (provenance is not
+  supported from self-hosted/Blacksmith runners).
+- npm accepts **one** trusted-publishing workflow filename per package on
+  npmjs.com; that is why `dev`, `next`, and `latest` all live in
+  `npm-publish.yml`. Do not add a second publish workflow.
+- `@opengsd/gsd-cloud` and `@opengsd/daemon` are already on npm (first published
+  July 2026), so `channel=latest` works as-is. For a *brand-new* workspace
+  package, trusted publishing must be configured on npmjs.com for that package
+  name before the first publish, or the first publish must go out with
+  `publish_auth=token` + `NPM_TOKEN` and trusted publishing configured after.
+
+## Post-publish verification
+
+Run these yourself after `prod-release` succeeds (allow a few minutes for
+registry propagation):
+
+```bash
+npm view @opengsd/gsd-cloud version          # == release version
+npm view @opengsd/daemon version             # == release version
+npm view @opengsd/gsd-cloud dependencies     # exactly: ws, yaml (nothing else)
+
+# npx smoke — the bin must run from a clean install:
+npx -y @opengsd/gsd-cloud@<version> --help   # lists login/pair/status/connect/stop/disconnect
+```
+
+A deeper live smoke (the v1.5 CAGT-05 acceptance loop) is: from a GSD project
+directory, `npx @opengsd/gsd-cloud login` (no `--gateway`), approve the device
+in the browser at cloud.opengsd.net, then confirm the machine shows online on
+the dashboard and `npx @opengsd/gsd-cloud status` reports connected.
+
+## Rollback / the 72-hour rule
+
+Publishing is irreversible in practice — plan around `npm deprecate`, not
+`npm unpublish`.
+
+- **Within 72 hours of publish:** a version *can* be unpublished
+  (`npm unpublish <pkg>@<version>`), which permanently removes it. Only do this
+  for a dangerously broken tarball (leaked secret, malicious/broken code), and
+  never for a version other packages depend on. It cannot be re-published — the
+  version number is burned.
+- **Any time:** the standard recovery is
+  `npm deprecate <pkg>@<version> "broken <channel> build; use <previous-good>"`
+  followed by a fixed patch release. If `@latest` points at the bad version,
+  re-point it: `npm dist-tag add <pkg>@<previous-good> latest`.
+- Note: trusted publishing authenticates `npm publish` only — **not**
+  `dist-tag` mutation or `deprecate`. Those need a local `npm login` (or
+  `NPM_TOKEN`) with publish rights on the `@opengsd` org. The workflow's error
+  messages call this out when a tag move is required.
+- After any rollback action, re-run the post-publish verification above against
+  the corrected version.

--- a/packages/gsd-cloud/README.md
+++ b/packages/gsd-cloud/README.md
@@ -45,6 +45,25 @@ counters, per-project activity) read from the runtime's status file — this is
 the same file the GSD Cloud Monitor macOS app polls. See
 [`apps/gsd-cloud-monitor`](../../apps/gsd-cloud-monitor/README.md).
 
+## Live session events
+
+While connected, the runtime also streams `session_event` frames over the same
+WebSocket so the dashboard can render GSD sessions live. For each advertised
+project it polls `gsd_status` every 3 seconds (via that project's
+`gsd --mode mcp` client) and normalizes the deltas into a fixed event
+vocabulary: `session_started`, `turn_started`, `assistant_text`, `tool_call`,
+`tool_result`, `blocker_pending`, `blocker_resolved`, `session_idle`,
+`session_ended`, and `error`, plus a `snapshot` every 30 seconds per active
+session. Each frame carries a per-session monotonically increasing `seq`
+(starts at 1); the last 500 events per session are buffered and a bounded tail
+is re-sent after reconnects — the relay deduplicates on
+`(device, session, seq)`. Events are capped at 8 KB after JSON serialization
+(long strings are truncated; frames that still do not fit are skipped and
+logged), and at most 20 sessions are tracked concurrently per runtime (extras
+are skipped and logged). Tool-call forwarding is unchanged. Set
+`GSD_CLOUD_SESSION_EVENTS=0` (or `false`, or `cloud.session_events: false` in
+`~/.gsd/daemon.yaml`) to disable; it is on by default.
+
 ## Environment
 
 - `GSD_CLOUD_PROJECTS` — path-delimiter separated list of project directories to
@@ -52,6 +71,8 @@ the same file the GSD Cloud Monitor macOS app polls. See
 - `GSD_CLI_PATH` — path to the `gsd` binary (default: `gsd` on `PATH`).
 - `GSD_CLOUD_EXECUTOR` — backend adapter: `gsd-pi` (default). `codex` and
   `claude` adapters are stubbed for future use.
+- `GSD_CLOUD_SESSION_EVENTS` — live session-event streaming: `0` or `false`
+  disables it (default: on). See "Live session events" above.
 
 The project directory used by `login` is persisted in `~/.gsd/daemon.yaml`.
 Set `GSD_CLOUD_PROJECTS` before `login` to advertise more than one project. Use

--- a/packages/gsd-cloud/README.md
+++ b/packages/gsd-cloud/README.md
@@ -45,6 +45,42 @@ counters, per-project activity) read from the runtime's status file — this is
 the same file the GSD Cloud Monitor macOS app polls. See
 [`apps/gsd-cloud-monitor`](../../apps/gsd-cloud-monitor/README.md).
 
+## Run as a background service
+
+`connect` detaches the runtime from your terminal, but it does not start again
+after a logout/reboot or a crash. To keep the cloud agent always running —
+start at login and restart on failure — install it as an OS service (macOS and
+Linux only):
+
+```bash
+# Install and start the service: a launchd LaunchAgent on macOS
+# (~/Library/LaunchAgents/net.opengsd.gsd-cloud.plist, RunAtLoad + KeepAlive)
+# or a systemd user unit on Linux
+# (~/.config/systemd/user/gsd-cloud.service, Restart=on-failure).
+npx @opengsd/gsd-cloud service install
+
+# Show whether the service is installed, loaded, and running.
+npx @opengsd/gsd-cloud service status
+
+# Stop and remove the service. Pairing and credentials are kept.
+npx @opengsd/gsd-cloud service uninstall
+```
+
+Pair with `login` first — the service runs `connect --foreground`, so `status`
+and `stop` see the service-managed runtime exactly like a `connect` session.
+On macOS the service appends stdout/stderr to the same `cloud-runtime.log`
+artifact that `connect` uses; on Linux it logs to the journal
+(`journalctl --user -u gsd-cloud`). On headless Linux servers, run
+`loginctl enable-linger` once so the user unit starts at boot without an
+interactive login.
+
+A clean stop (`stop`/`disconnect`) exits successfully, so neither supervisor
+restarts the runtime afterwards. If you installed the service and want to
+disconnect permanently, run `service uninstall` before `disconnect` — otherwise
+the service supervisor starts the runtime again at the next login. On
+unsupported platforms (e.g. Windows) `service` exits with a clear error; use
+`connect` there instead.
+
 ## Environment
 
 - `GSD_CLOUD_PROJECTS` — path-delimiter separated list of project directories to

--- a/packages/gsd-cloud/e2e/README.md
+++ b/packages/gsd-cloud/e2e/README.md
@@ -1,0 +1,62 @@
+# gsd-cloud local E2E harness (CAGT-05)
+
+Automated end-to-end verification of the local cloud agent path, with **no
+network access beyond 127.0.0.1** and no production dependency.
+
+## Run
+
+```sh
+pnpm --filter @opengsd/gsd-cloud run test:e2e
+```
+
+The script builds `@opengsd/cloud-mcp-gateway` (and its workspace dependency
+chain) and `@opengsd/gsd-cloud` first, then runs `e2e/run-e2e.mjs`.
+
+This is intentionally **not** part of `pnpm test` (the unit-test run); it is a
+separate gate you opt into locally or in CI.
+
+## What it covers
+
+1. Starts the real gateway (`createGatewayServer`) on an ephemeral loopback
+   port with a temp `FileAuthStore` seeded with a random user token.
+2. Mints a pairing code over `POST /pairing-codes` (user bearer token).
+3. Runs the real CLI `gsd-cloud pair --gateway http://127.0.0.1:<port>` with a
+   temp `HOME` and temp `--config`, asserting the device token + runtime id are
+   written to the config.
+4. Runs the real CLI `gsd-cloud connect --foreground` with
+   `GSD_CLOUD_PROJECTS` pointing at a fixture project (minimal `.gsd`) and
+   `GSD_CLI_PATH` pointing at `fixture-gsd-mcp.mjs`, a stand-in for
+   `gsd --mode mcp` that speaks the executor's newline-delimited MCP stdio
+   protocol.
+5. Asserts the runtime registers in the gateway registry (alias, canonical
+   path, `online: true`, `gsd` marker).
+6. Drives the `/mcp` Streamable HTTP endpoint: `initialize`, `tools/list`
+   (asserts `gsd_cloud_projects` and `gsd_query` are advertised),
+   `gsd_cloud_projects` (asserts the fixture project is listed), and a
+   forwarded `gsd_query` tool call (asserts the fixture's marker response came
+   back through gateway → websocket → runtime → executor → stdio MCP → and
+   return).
+7. SIGTERMs the runtime, asserts a clean exit code and that the registry
+   detaches, then tears everything down.
+
+## Environment switches
+
+| Variable | Effect |
+| --- | --- |
+| `GSD_CLOUD_E2E=0` / `false` | Skip the harness (exit 0) — for CI jobs that cannot build the full chain. |
+| `GSD_CLOUD_E2E_TIMEOUT_MS` | Global watchdog timeout (default `120000`). |
+| `GSD_CLOUD_E2E_GSD_CLI` | Path to a real `gsd` binary to use instead of the fixture (full-stack mode; the fixture project must then satisfy `gsd --mode mcp`). |
+| `GSD_CLOUD_E2E_KEEP_TMP=1` | Keep the temp root for debugging (the path is printed in the summary). |
+
+## CI notes
+
+- Loopback only: the gateway binds `127.0.0.1` on an ephemeral port; the CLI's
+  SSRF guard allows plain HTTP exactly for loopback, so nothing leaves the
+  machine.
+- Hard timeouts: a global watchdog plus per-step timeouts bound the run; the
+  runtime child is SIGKILLed on failure paths.
+- Temp dirs (`$TMPDIR/gsd-cloud-e2e-*`) are removed in teardown unless
+  `GSD_CLOUD_E2E_KEEP_TMP=1`.
+
+For the manual production verification against cloud.opengsd.net, see
+[`docs/dev/cloud-live-e2e-runbook.md`](../../../docs/dev/cloud-live-e2e-runbook.md).

--- a/packages/gsd-cloud/e2e/fixture-gsd-mcp.mjs
+++ b/packages/gsd-cloud/e2e/fixture-gsd-mcp.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Project/App: Open GSD
+// File Purpose: E2E fixture standing in for the `gsd` binary.
+//
+// The gsd-pi executor drives a real `gsd --mode mcp` child over newline-delimited
+// JSON-RPC on stdio. This fixture speaks exactly that protocol subset so the E2E
+// harness can exercise the full cloud path (gateway -> WS relay -> cloud runtime
+// -> executor -> stdio MCP) without building the entire gsd CLI. It is selected
+// via GSD_CLI_PATH; set GSD_CLOUD_E2E_GSD_CLI to a real gsd binary for a
+// full-stack run instead.
+//
+// Protocol contract (mirrors what McpStdioClient sends/reads):
+//   <- {"jsonrpc":"2.0","id":N,"method":"initialize","params":{...}}
+//   -> {"jsonrpc":"2.0","id":N,"result":{protocolVersion,capabilities,serverInfo}}
+//   <- {"jsonrpc":"2.0","method":"notifications/initialized"}   (no response)
+//   <- {"jsonrpc":"2.0","id":N,"method":"tools/call","params":{name,arguments}}
+//   -> {"jsonrpc":"2.0","id":N,"result":{content:[{type:"text",text}]}}
+//
+// stdout carries protocol frames ONLY; diagnostics go to stderr.
+
+import { createInterface } from "node:readline";
+
+const FIXTURE_MARKER = "GSD_CLOUD_E2E_FIXTURE";
+const PROTOCOL_VERSION = "2024-11-05";
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let message;
+  try {
+    message = JSON.parse(trimmed);
+  } catch {
+    return; // Stray non-JSON input — ignore like a tolerant server would.
+  }
+  if (!message || typeof message !== "object") return;
+  const { id, method, params } = message;
+
+  // Notifications (no id) never get a response.
+  if (id === undefined || id === null) return;
+
+  if (method === "initialize") {
+    return respond(id, {
+      protocolVersion: params?.protocolVersion ?? PROTOCOL_VERSION,
+      capabilities: { tools: {} },
+      serverInfo: { name: "gsd-cloud-e2e-fixture", version: "1.0.0" },
+    });
+  }
+
+  if (method === "ping") {
+    return respond(id, {});
+  }
+
+  if (method === "tools/list") {
+    return respond(id, {
+      tools: [{
+        name: "gsd_query",
+        description: "Fixture stand-in for the gsd_query reader tool.",
+        inputSchema: { type: "object", properties: {}, required: [] },
+      }],
+    });
+  }
+
+  if (method === "tools/call") {
+    const name = typeof params?.name === "string" ? params.name : "";
+    const args = params?.arguments && typeof params.arguments === "object" ? params.arguments : {};
+    if (name === "gsd_query") {
+      const projectDir = typeof args.projectDir === "string" ? args.projectDir : "<none>";
+      const query = typeof args.query === "string" ? args.query : "<none>";
+      return respond(id, {
+        content: [{
+          type: "text",
+          text: `${FIXTURE_MARKER} gsd_query ok projectDir=${projectDir} query=${query}`,
+        }],
+      });
+    }
+    return respond(id, {
+      content: [{ type: "text", text: `${FIXTURE_MARKER} unhandled tool: ${name || "<missing>"}` }],
+    });
+  }
+
+  respondError(id, -32601, `Method not found: ${method}`);
+});
+
+function respond(id, result) {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+}
+
+function respondError(id, code, message) {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } })}\n`);
+}

--- a/packages/gsd-cloud/e2e/run-e2e.mjs
+++ b/packages/gsd-cloud/e2e/run-e2e.mjs
@@ -1,0 +1,511 @@
+#!/usr/bin/env node
+// Project/App: Open GSD
+// File Purpose: CAGT-05 local end-to-end verification harness for the cloud agent.
+//
+// Exercises the full local cloud path against an in-process gateway, with no
+// network access beyond 127.0.0.1:
+//
+//   1. Start @opengsd/cloud-mcp-gateway on an ephemeral port with a temp
+//      FileAuthStore (seeded user token).
+//   2. POST /pairing-codes (user bearer token) to mint a pairing code.
+//   3. Run the real gsd-cloud CLI `pair` against it (temp HOME + temp config).
+//   4. Run the real gsd-cloud CLI `connect --foreground` with GSD_CLOUD_PROJECTS
+//      pointing at a fixture project dir (minimal .gsd) and GSD_CLI_PATH pointing
+//      at a fixture MCP stdio server standing in for `gsd --mode mcp`.
+//   5. Assert the runtime registers (gateway registry lists the fixture project).
+//   6. Drive the /mcp endpoint (Streamable HTTP): initialize, tools/list,
+//      gsd_cloud_projects, and a forwarded gsd_query tool call.
+//   7. SIGTERM the runtime, assert clean exit and registry detach, tear down.
+//
+// This script is intentionally NOT part of `pnpm test` (which is unit-test only).
+// Run it via `pnpm --filter @opengsd/gsd-cloud run test:e2e` — that script builds
+// gsd-cloud and the gateway chain first.
+//
+// Environment:
+//   GSD_CLOUD_E2E=0|false        Skip (exit 0) — for CI jobs without a full build.
+//   GSD_CLOUD_E2E_TIMEOUT_MS     Global watchdog timeout (default 120000).
+//   GSD_CLOUD_E2E_GSD_CLI        Use a real gsd binary instead of the fixture
+//                                (fixture project must then satisfy gsd --mode mcp).
+//   GSD_CLOUD_E2E_KEEP_TMP=1     Keep the temp root for debugging (path is printed).
+
+import { randomBytes } from "node:crypto";
+import { spawn } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const E2E_DIR = dirname(fileURLToPath(import.meta.url));
+const PKG_DIR = join(E2E_DIR, "..");
+const REPO_ROOT = join(PKG_DIR, "..", "..");
+const CLI_BIN = join(PKG_DIR, "bin", "gsd-cloud.js");
+const CLI_DIST = join(PKG_DIR, "dist", "cli.js");
+const GATEWAY_DIST = join(REPO_ROOT, "packages", "cloud-mcp-gateway", "dist", "index.js");
+const FIXTURE_GSD_BIN = join(E2E_DIR, "fixture-gsd-mcp.mjs");
+const FIXTURE_MARKER = "GSD_CLOUD_E2E_FIXTURE";
+
+const HTTP_TIMEOUT_MS = 10_000;
+const PAIR_TIMEOUT_MS = 30_000;
+const CONNECT_READY_TIMEOUT_MS = 45_000;
+const REGISTRY_APPEAR_TIMEOUT_MS = 15_000;
+const REGISTRY_DETACH_TIMEOUT_MS = 10_000;
+const CHILD_STOP_TIMEOUT_MS = 15_000;
+
+const steps = [];
+let tmpRoot = "";
+let gatewayServer;
+let connectChild;
+let connectOutput = { stdout: "", stderr: "" };
+
+// ---------------------------------------------------------------------------
+// Entry
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (process.env.GSD_CLOUD_E2E === "0" || process.env.GSD_CLOUD_E2E === "false") {
+    process.stdout.write("gsd-cloud e2e: SKIPPED (GSD_CLOUD_E2E is disabled)\n");
+    return false;
+  }
+
+  const watchdogMs = Number(process.env.GSD_CLOUD_E2E_TIMEOUT_MS ?? 120_000);
+  const watchdog = setTimeout(() => {
+    failHard(`global watchdog fired after ${watchdogMs}ms`);
+  }, watchdogMs);
+  try {
+    await runAllSteps();
+  } finally {
+    clearTimeout(watchdog);
+  }
+  return true;
+}
+
+async function runAllSteps() {
+  await step("prerequisites: gsd-cloud + gateway build outputs present", checkPrereqs);
+
+  const { createGatewayServer } = await import(pathToFileURL(GATEWAY_DIST).href);
+  const userToken = `e2e-user-${randomBytes(8).toString("hex")}`;
+  const userId = "e2e-user";
+
+  const ctx = { createGatewayServer, userToken, userId };
+
+  await step("gateway listening on ephemeral port with temp auth store", () => startGateway(ctx));
+  await step("GET /healthz responds ok", () => checkHealth(ctx));
+  await step("POST /pairing-codes mints a code for the user token", () => mintPairingCode(ctx));
+  await step("CLI `pair` exchanges the code and writes temp config", () => runPair(ctx));
+  await step("CLI `connect --foreground` establishes the runtime websocket", () => runConnect(ctx));
+  await step("gateway registry lists the advertised fixture project", () => assertRegistered(ctx));
+  await step("MCP initialize + tools/list over /mcp", () => assertMcpHandshake(ctx));
+  await step("MCP gsd_cloud_projects returns the fixture project", () => assertCloudProjects(ctx));
+  await step("MCP gsd_query is forwarded to the runtime and back", () => assertForwardedQuery(ctx));
+  await step("runtime shuts down cleanly and detaches from the registry", () => assertShutdown(ctx));
+}
+
+// ---------------------------------------------------------------------------
+// Steps
+// ---------------------------------------------------------------------------
+
+function checkPrereqs() {
+  if (!existsSync(CLI_DIST)) {
+    throw new Error(`missing ${CLI_DIST} — run \`pnpm --filter @opengsd/gsd-cloud run test:e2e\` (it builds first)`);
+  }
+  if (!existsSync(GATEWAY_DIST)) {
+    throw new Error(`missing ${GATEWAY_DIST} — run \`pnpm --filter @opengsd/gsd-cloud run test:e2e\` (it builds first)`);
+  }
+
+  tmpRoot = mkdtempSync(join(tmpdir(), "gsd-cloud-e2e-"));
+  mkdirSync(join(tmpRoot, "home"), { recursive: true });
+
+  // Fixture project with a minimal .gsd so the executor advertises a gsd marker.
+  const projectDir = join(tmpRoot, "fixture-project");
+  mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+  writeFileSync(join(projectDir, ".gsd", "STATE.md"), "# State\n\nE2E fixture project.\n");
+  writeFileSync(join(projectDir, ".gsd", "PROJECT.md"), "# Project\n\ngsd-cloud e2e fixture.\n");
+
+  // The fixture must be executable regardless of how git materialized file modes.
+  chmodSync(FIXTURE_GSD_BIN, 0o755);
+}
+
+async function startGateway(ctx) {
+  const authStorePath = join(tmpRoot, "gateway-auth-store.json");
+  const { server, registry } = ctx.createGatewayServer({
+    userToken: ctx.userToken,
+    userId: ctx.userId,
+    authStorePath,
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string" || !address.port) {
+    throw new Error("gateway did not bind an ephemeral port");
+  }
+  gatewayServer = server;
+  ctx.registry = registry;
+  ctx.gatewayUrl = `http://127.0.0.1:${address.port}`;
+}
+
+async function checkHealth(ctx) {
+  const res = await fetch(`${ctx.gatewayUrl}/healthz`, { signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) });
+  const body = await res.json();
+  if (res.status !== 200 || body.ok !== true) {
+    throw new Error(`/healthz returned ${res.status}: ${JSON.stringify(body)}`);
+  }
+}
+
+async function mintPairingCode(ctx) {
+  const res = await fetch(`${ctx.gatewayUrl}/pairing-codes`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${ctx.userToken}` },
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+  });
+  const body = await res.json();
+  if (res.status !== 200 || typeof body.code !== "string" || !/^[0-9A-F]{8,}$/.test(body.code)) {
+    throw new Error(`/pairing-codes returned ${res.status}: ${JSON.stringify(body)}`);
+  }
+  if (typeof body.expiresAt !== "number" || body.expiresAt <= Date.now()) {
+    throw new Error(`pairing code expiry is not in the future: ${JSON.stringify(body)}`);
+  }
+  ctx.pairingCode = body.code;
+}
+
+async function runPair(ctx) {
+  const configPath = join(tmpRoot, "daemon.yaml");
+  ctx.configPath = configPath;
+  const result = await runProcess(
+    process.execPath,
+    [CLI_BIN, "pair", "--gateway", ctx.gatewayUrl, "--code", ctx.pairingCode,
+      "--runtime-name", "e2e-runtime", "--config", configPath],
+    { env: ctx.childEnv = childEnv(), timeoutMs: PAIR_TIMEOUT_MS },
+  );
+  if (result.code !== 0) {
+    throw new Error(`pair exited ${result.code}:\n${result.stdout}\n${result.stderr}`);
+  }
+  if (!/paired cloud runtime rt_/.test(result.stdout)) {
+    throw new Error(`pair stdout did not confirm pairing: ${result.stdout}`);
+  }
+
+  const configText = readFileSync(configPath, "utf8");
+  const runtimeId = /runtime_id:\s*(\S+)/.exec(configText)?.[1];
+  if (!runtimeId || !runtimeId.startsWith("rt_")) {
+    throw new Error(`config missing runtime_id:\n${configText}`);
+  }
+  if (!configText.includes("device_token_encrypted:")) {
+    throw new Error(`config missing device_token_encrypted:\n${configText}`);
+  }
+  ctx.runtimeId = runtimeId;
+}
+
+async function runConnect(ctx) {
+  connectChild = spawn(
+    process.execPath,
+    [CLI_BIN, "connect", "--config", ctx.configPath, "--foreground", "--verbose"],
+    { env: ctx.childEnv, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  connectChild.stdout.on("data", (chunk) => { connectOutput.stdout += chunk; });
+  connectChild.stderr.on("data", (chunk) => { connectOutput.stderr += chunk; });
+
+  const readyPattern = /connected to http:\/\/127\.0\.0\.1:\d+/;
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(
+        `connect did not report ready within ${CONNECT_READY_TIMEOUT_MS}ms\n` +
+        `stdout:\n${connectOutput.stdout}\nstderr:\n${connectOutput.stderr}`,
+      ));
+    }, CONNECT_READY_TIMEOUT_MS);
+    const onData = () => {
+      if (readyPattern.test(connectOutput.stdout)) { cleanup(); resolve(); }
+    };
+    const onExit = (code) => {
+      cleanup();
+      reject(new Error(
+        `connect exited (${code ?? "unknown"}) before connecting\n` +
+        `stdout:\n${connectOutput.stdout}\nstderr:\n${connectOutput.stderr}`,
+      ));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      connectChild.stdout.removeListener("data", onData);
+      connectChild.removeListener("exit", onExit);
+    };
+    connectChild.stdout.on("data", onData);
+    connectChild.once("exit", onExit);
+  });
+}
+
+async function assertRegistered(ctx) {
+  const expectedPath = realpathSync(join(tmpRoot, "fixture-project"));
+  const project = await pollFor(
+    () => ctx.registry.listProjects(ctx.userId)
+      .find((entry) => entry.runtimeId === ctx.runtimeId),
+    REGISTRY_APPEAR_TIMEOUT_MS,
+    "fixture project to appear in the gateway registry",
+  );
+  if (project.alias !== "fixture-project") {
+    throw new Error(`unexpected project alias: ${JSON.stringify(project)}`);
+  }
+  if (project.path !== expectedPath) {
+    throw new Error(`unexpected project path ${project.path} (expected ${expectedPath})`);
+  }
+  if (project.online !== true) {
+    throw new Error(`project is not online: ${JSON.stringify(project)}`);
+  }
+  if (!Array.isArray(project.markers) || !project.markers.includes("gsd")) {
+    throw new Error(`project missing the gsd marker: ${JSON.stringify(project)}`);
+  }
+}
+
+async function assertMcpHandshake(ctx) {
+  const init = await mcpRpc(ctx, 1, "initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "gsd-cloud-e2e", version: "1.0.0" },
+  });
+  if (!init.result?.protocolVersion || init.result?.serverInfo?.name !== "gsd-cloud-gateway") {
+    throw new Error(`unexpected initialize result: ${JSON.stringify(init)}`);
+  }
+
+  // Note: no notifications/initialized — the gateway creates a fresh stateless
+  // MCP server per HTTP request, so the notification carries no state.
+  const list = await mcpRpc(ctx, 2, "tools/list", {});
+  const toolNames = (list.result?.tools ?? []).map((tool) => tool.name);
+  for (const required of ["gsd_cloud_projects", "gsd_query"]) {
+    if (!toolNames.includes(required)) {
+      throw new Error(`tools/list missing ${required}: ${toolNames.join(", ")}`);
+    }
+  }
+}
+
+async function assertCloudProjects(ctx) {
+  const response = await mcpRpc(ctx, 3, "tools/call", {
+    name: "gsd_cloud_projects",
+    arguments: {},
+  });
+  const text = response.result?.content?.[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error(`gsd_cloud_projects returned no text content: ${JSON.stringify(response)}`);
+  }
+  const parsed = JSON.parse(text);
+  const project = (parsed.projects ?? []).find((entry) => entry.runtimeId === ctx.runtimeId);
+  if (!project || project.alias !== "fixture-project" || project.online !== true) {
+    throw new Error(`fixture project missing from gsd_cloud_projects: ${text}`);
+  }
+}
+
+async function assertForwardedQuery(ctx) {
+  const response = await mcpRpc(ctx, 4, "tools/call", {
+    name: "gsd_query",
+    arguments: { query: "state", projectAlias: "fixture-project" },
+  });
+  const text = response.result?.content?.[0]?.text;
+  if (typeof text !== "string" || !text.includes(`${FIXTURE_MARKER} gsd_query ok`)) {
+    throw new Error(`forwarded gsd_query did not reach the fixture: ${JSON.stringify(response)}`);
+  }
+  const expectedPath = realpathSync(join(tmpRoot, "fixture-project"));
+  if (!text.includes(`projectDir=${expectedPath}`) || !text.includes("query=state")) {
+    throw new Error(`forwarded gsd_query args were not routed as expected: ${text}`);
+  }
+}
+
+async function assertShutdown(ctx) {
+  connectChild.kill("SIGTERM");
+  const exit = await waitForExit(connectChild, CHILD_STOP_TIMEOUT_MS);
+  connectChild = undefined;
+  if (exit.timedOut) {
+    throw new Error(`runtime did not stop within ${CHILD_STOP_TIMEOUT_MS}ms of SIGTERM`);
+  }
+  if (exit.code !== 0) {
+    throw new Error(
+      `runtime exited with code ${exit.code} (signal ${exit.signal ?? "none"})\n` +
+      `stdout:\n${connectOutput.stdout}\nstderr:\n${connectOutput.stderr}`,
+    );
+  }
+
+  await pollFor(
+    () => (ctx.registry.listProjects(ctx.userId).length === 0 ? true : undefined),
+    REGISTRY_DETACH_TIMEOUT_MS,
+    "fixture project to detach from the gateway registry",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function childEnv() {
+  return {
+    ...process.env,
+    HOME: join(tmpRoot, "home"),
+    // Deterministic device-token encryption key — pair and connect run as
+    // separate processes and must derive the same key.
+    GSD_CLOUD_TOKEN_KEY: "gsd-cloud-e2e-token-key",
+    GSD_CLOUD_PROJECTS: join(tmpRoot, "fixture-project"),
+    GSD_CLI_PATH: process.env.GSD_CLOUD_E2E_GSD_CLI ?? FIXTURE_GSD_BIN,
+  };
+}
+
+function runProcess(command, args, { env, timeoutMs }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { env, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`process timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}\n${stdout}\n${stderr}`));
+    }, timeoutMs);
+    child.once("error", (err) => { clearTimeout(timer); reject(err); });
+    child.once("exit", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
+  });
+}
+
+function waitForExit(child, timeoutMs) {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      return resolve({ code: child.exitCode, signal: child.signalCode, timedOut: false });
+    }
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve({ code: null, signal: null, timedOut: true });
+    }, timeoutMs);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal, timedOut: false });
+    });
+  });
+}
+
+async function pollFor(produce, timeoutMs, description) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = produce();
+    if (value !== undefined && value !== false) return value;
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${description}`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+/** One stateless JSON-RPC call against the gateway's /mcp endpoint. */
+async function mcpRpc(ctx, id, method, params) {
+  const res = await fetch(`${ctx.gatewayUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${ctx.userToken}`,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+  });
+  if (res.status !== 200) {
+    throw new Error(`MCP ${method} returned HTTP ${res.status}: ${await res.text()}`);
+  }
+  const contentType = res.headers.get("content-type") ?? "";
+  const body = await res.text();
+  const messages = contentType.includes("text/event-stream")
+    ? parseSseMessages(body)
+    : [JSON.parse(body)];
+  const match = messages.find((message) => message && message.id === id);
+  if (!match) {
+    throw new Error(`MCP ${method} response missing id ${id}: ${body}`);
+  }
+  if (match.error) {
+    throw new Error(`MCP ${method} returned an error: ${JSON.stringify(match.error)}`);
+  }
+  return match;
+}
+
+function parseSseMessages(body) {
+  const messages = [];
+  let dataLines = [];
+  for (const line of body.split(/\r?\n/)) {
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trimStart());
+    } else if (line.trim() === "" && dataLines.length > 0) {
+      messages.push(JSON.parse(dataLines.join("\n")));
+      dataLines = [];
+    }
+  }
+  if (dataLines.length > 0) messages.push(JSON.parse(dataLines.join("\n")));
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Reporting + teardown
+// ---------------------------------------------------------------------------
+
+async function step(name, fn) {
+  const startedAt = Date.now();
+  try {
+    await fn();
+  } catch (err) {
+    steps.push({ name, ok: false, ms: Date.now() - startedAt });
+    await teardown();
+    process.stdout.write(`FAIL ${name} (${Date.now() - startedAt}ms)\n`);
+    process.stdout.write(`  ${err instanceof Error ? err.message : String(err)}\n`);
+    printSummary(false);
+    process.exit(1);
+  }
+  steps.push({ name, ok: true, ms: Date.now() - startedAt });
+  process.stdout.write(`PASS ${name} (${Date.now() - startedAt}ms)\n`);
+}
+
+async function teardown() {
+  if (connectChild) {
+    connectChild.kill("SIGKILL");
+    connectChild = undefined;
+  }
+  const server = gatewayServer;
+  gatewayServer = undefined;
+  if (server) {
+    try { server.closeAllConnections?.(); } catch { /* best effort */ }
+    await Promise.race([
+      new Promise((resolve) => server.close(() => resolve())),
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+  }
+  if (tmpRoot && process.env.GSD_CLOUD_E2E_KEEP_TMP !== "1") {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+function printSummary(ok) {
+  const passed = steps.filter((entry) => entry.ok).length;
+  const totalMs = steps.reduce((sum, entry) => sum + entry.ms, 0);
+  process.stdout.write(`\nE2E SUMMARY: ${ok ? "PASS" : "FAIL"} — ${passed}/${steps.length} steps passed in ${(totalMs / 1000).toFixed(1)}s\n`);
+  if (process.env.GSD_CLOUD_E2E_KEEP_TMP === "1" && tmpRoot) {
+    process.stdout.write(`temp root kept: ${tmpRoot}\n`);
+  }
+}
+
+function failHard(message) {
+  process.stderr.write(`gsd-cloud e2e: fatal: ${message}\n`);
+  if (connectChild) connectChild.kill("SIGKILL");
+  process.exit(2);
+}
+
+process.once("unhandledRejection", (err) => {
+  failHard(`unhandled rejection: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+});
+
+try {
+  const ran = await main();
+  await teardown();
+  if (ran) printSummary(true);
+  process.exit(0);
+} catch (err) {
+  await teardown();
+  process.stderr.write(`gsd-cloud e2e: fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(2);
+}

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js",
+    "test:e2e": "pnpm --filter @opengsd/cloud-mcp-gateway... run build && pnpm run build && node e2e/run-e2e.mjs"
   },
   "dependencies": {
     "ws": "^8.21.0",

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -8,16 +8,36 @@
     "url": "git+https://github.com/open-gsd/gsd-pi.git",
     "directory": "packages/gsd-cloud"
   },
+  "homepage": "https://github.com/open-gsd/gsd-pi/tree/main/packages/gsd-cloud#readme",
+  "bugs": {
+    "url": "https://github.com/open-gsd/gsd-pi/issues"
+  },
+  "keywords": [
+    "gsd",
+    "gsd-cloud",
+    "agent",
+    "cli",
+    "remote-control"
+  ],
   "publishConfig": {
     "access": "public"
   },
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "bin": {
     "gsd-cloud": "./bin/gsd-cloud.js"
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js",
+    "validate:tarball": "node ../../scripts/validate-gsd-cloud-tarball.mjs"
   },
   "dependencies": {
     "ws": "^8.21.0",

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/background-cli.test.js dist/session-events.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
   },
   "dependencies": {
     "ws": "^8.21.0",

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/service-install.test.js dist/background-cli.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js"
   },
   "dependencies": {
     "ws": "^8.21.0",

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -301,6 +301,7 @@ async function handleServiceCommand(argv: string[], binaryName: string): Promise
       nodePath: process.execPath,
       binaryPath,
       configPath,
+      ...(process.env["GSD_CLI_PATH"] ? { gsdCliPath: process.env["GSD_CLI_PATH"] } : {}),
     });
     process.stdout.write(`${binaryName}: ${installed.manager} service installed and started.\n`);
     process.stdout.write(`${binaryName}: unit ${installed.unitPath}\n`);

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -28,6 +28,7 @@ import {
   writeRuntimeState,
 } from "./runtime-process.js";
 import { clearRuntimeTelemetry, readRuntimeTelemetry, RuntimeTelemetryStore } from "./runtime-telemetry.js";
+import { installService, serviceStatus, uninstallService } from "./service-install.js";
 import type { DaemonConfig } from "./types.js";
 
 export async function handleCloudCommand(argv: string[], opts: {
@@ -39,6 +40,12 @@ export async function handleCloudCommand(argv: string[], opts: {
   }
 
   const command = argv[0];
+
+  if (command === "service") {
+    handleServiceCommand(argv.slice(1), opts.binaryName);
+    return;
+  }
+
   const { values } = parseArgs({
     args: argv.slice(1),
     options: {
@@ -259,6 +266,69 @@ async function startAndReportBackgroundRuntime(
   process.stdout.write(`${binaryName}: logs ${status.log_file}\n`);
 }
 
+function handleServiceCommand(argv: string[], binaryName: string): void {
+  const subcommand = argv[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    process.stdout.write(formatServiceUsage(binaryName));
+    return;
+  }
+  const { values } = parseArgs({
+    args: argv.slice(1),
+    options: {
+      config: { type: "string", short: "c" },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    strict: true,
+  });
+  if (values.help) {
+    process.stdout.write(formatServiceUsage(binaryName));
+    return;
+  }
+
+  if (subcommand === "install") {
+    const configPath = resolveConfigPath(values.config);
+    const binaryPath = process.argv[1];
+    if (!binaryPath) throw new Error("could not resolve the gsd-cloud executable path");
+    const installed = installService({
+      nodePath: process.execPath,
+      binaryPath,
+      configPath,
+    });
+    process.stdout.write(`${binaryName}: ${installed.manager} service installed and started.\n`);
+    process.stdout.write(`${binaryName}: unit ${installed.unitPath}\n`);
+    process.stdout.write(installed.logPath
+      ? `${binaryName}: the runtime now starts at login and restarts on crash; logs ${installed.logPath}\n`
+      : `${binaryName}: the runtime now starts at login and restarts on crash; logs \`journalctl --user -u gsd-cloud\`\n`);
+    return;
+  }
+
+  if (subcommand === "uninstall") {
+    const removed = uninstallService();
+    process.stdout.write(removed.removed
+      ? `${binaryName}: ${removed.manager} service uninstalled (${removed.unitPath} removed).\n`
+      : `${binaryName}: service is not installed.\n`);
+    return;
+  }
+
+  if (subcommand === "status") {
+    const status = serviceStatus();
+    if (!status.installed) {
+      process.stdout.write(`${binaryName}: service is not installed (no ${status.manager} unit at ${status.unitPath}).\n`);
+      return;
+    }
+    const state = status.running
+      ? `running (PID ${status.pid})`
+      : status.loaded
+        ? `loaded but not running${status.lastExitStatus != null ? ` (last exit status: ${status.lastExitStatus})` : ""}`
+        : "installed but not loaded";
+    process.stdout.write(`${binaryName}: ${status.manager} service ${status.label} is ${state}.\n`);
+    process.stdout.write(`${binaryName}: unit ${status.unitPath}\n`);
+    return;
+  }
+
+  throw new Error(`Unknown service command: ${subcommand} (expected install, uninstall, or status)`);
+}
+
 function selectedProjectDirs(savedProjectDirs: string[]): string[] {
   const configured = process.env["GSD_CLOUD_PROJECTS"];
   if (configured?.trim()) {
@@ -304,6 +374,9 @@ export function formatUsage(binaryName: string): string {
        ${binaryName} connect [--config <path>] [--verbose] [--foreground]
        ${binaryName} stop [--config <path>]
        ${binaryName} disconnect [--config <path>]
+       ${binaryName} service install [--config <path>]
+       ${binaryName} service uninstall
+       ${binaryName} service status
 
 Commands:
   login      (Recommended) Browser-based pairing — opens an approval URL, then
@@ -314,6 +387,9 @@ Commands:
   connect    Start a background connection using saved credentials and projects.
   stop       Stop the background runtime without removing saved credentials.
   disconnect Stop the background runtime and remove local cloud credentials.
+  service    Manage the OS background service (launchd on macOS, systemd user
+             unit on Linux) that starts the runtime at login and restarts it
+             on crash. See \`${binaryName} service --help\`.
 
 Options:
   --config <path>        Path to YAML config file (default: ~/.gsd/daemon.yaml)
@@ -329,5 +405,24 @@ Environment:
                          (default: current working directory)
   GSD_CLI_PATH           Path to the gsd binary (default: gsd on PATH)
   GSD_CLOUD_EXECUTOR     Backend adapter: gsd-pi (default), codex, claude
+`;
+}
+
+function formatServiceUsage(binaryName: string): string {
+  return `Usage: ${binaryName} service install [--config <path>]
+       ${binaryName} service uninstall
+       ${binaryName} service status
+
+Commands:
+  install    Install and start the OS service for the cloud runtime — a
+             launchd LaunchAgent on macOS (starts at login, KeepAlive on crash)
+             or a systemd user unit on Linux (starts at login, Restart=on-failure).
+             Pair with \`${binaryName} login\` first.
+  uninstall  Stop and remove the OS service. Pairing and credentials are kept.
+  status     Show whether the OS service is installed, loaded, and running.
+
+Options:
+  --config <path>  Path to YAML config file (default: ~/.gsd/daemon.yaml)
+  --help           Show this help message and exit
 `;
 }

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -132,13 +132,14 @@ export async function handleCloudCommand(argv: string[], opts: {
       code: values.code,
       runtimeName,
     });
+    const projectDirs = selectedProjectDirs([]);
     saveCloudConfig(configPath, {
       gateway_url: values.gateway,
       device_token: result.deviceToken,
       runtime_id: result.runtimeId,
       ...(runtimeName ? { runtime_name: runtimeName } : {}),
       enabled: true,
-    });
+    }, projectDirs);
     process.stdout.write(`${opts.binaryName}: paired cloud runtime ${result.runtimeId}.\n`);
     return;
   }
@@ -287,6 +288,12 @@ function handleServiceCommand(argv: string[], binaryName: string): void {
 
   if (subcommand === "install") {
     const configPath = resolveConfigPath(values.config);
+    const config = loadConfig(configPath);
+    if (!config.cloud?.device_token || !config.cloud.runtime_id) {
+      throw new Error("cloud runtime is not paired; run `login` or `pair` first");
+    }
+    const projectDirs = selectedProjectDirs(config.projects.scan_roots);
+    saveCloudConfig(configPath, config.cloud, projectDirs);
     const binaryPath = process.argv[1];
     if (!binaryPath) throw new Error("could not resolve the gsd-cloud executable path");
     const installed = installService({

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -132,7 +132,8 @@ export async function handleCloudCommand(argv: string[], opts: {
       code: values.code,
       runtimeName,
     });
-    const projectDirs = selectedProjectDirs([]);
+    const config = loadConfig(configPath);
+    const projectDirs = selectedProjectDirs(config.projects.scan_roots);
     saveCloudConfig(configPath, {
       gateway_url: values.gateway,
       device_token: result.deviceToken,

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -8,7 +8,7 @@
 import { parseArgs } from "node:util";
 import { realpathSync } from "node:fs";
 import { delimiter, resolve } from "node:path";
-import { resolveConfigPath, loadConfig } from "./config.js";
+import { resolveConfigPath, loadConfig, loadScanRoots } from "./config.js";
 import { Logger } from "./logger.js";
 import {
   clearCloudConfig,
@@ -132,8 +132,7 @@ export async function handleCloudCommand(argv: string[], opts: {
       code: values.code,
       runtimeName,
     });
-    const config = loadConfig(configPath);
-    const projectDirs = selectedProjectDirs(config.projects.scan_roots);
+    const projectDirs = selectedProjectDirs(loadScanRoots(configPath));
     saveCloudConfig(configPath, {
       gateway_url: values.gateway,
       device_token: result.deviceToken,

--- a/packages/gsd-cloud/src/cli.ts
+++ b/packages/gsd-cloud/src/cli.ts
@@ -42,7 +42,7 @@ export async function handleCloudCommand(argv: string[], opts: {
   const command = argv[0];
 
   if (command === "service") {
-    handleServiceCommand(argv.slice(1), opts.binaryName);
+    await handleServiceCommand(argv.slice(1), opts.binaryName);
     return;
   }
 
@@ -267,7 +267,7 @@ async function startAndReportBackgroundRuntime(
   process.stdout.write(`${binaryName}: logs ${status.log_file}\n`);
 }
 
-function handleServiceCommand(argv: string[], binaryName: string): void {
+async function handleServiceCommand(argv: string[], binaryName: string): Promise<void> {
   const subcommand = argv[0];
   if (!subcommand || subcommand === "--help" || subcommand === "-h") {
     process.stdout.write(formatServiceUsage(binaryName));
@@ -294,6 +294,7 @@ function handleServiceCommand(argv: string[], binaryName: string): void {
     }
     const projectDirs = selectedProjectDirs(config.projects.scan_roots);
     saveCloudConfig(configPath, config.cloud, projectDirs);
+    await stopBackgroundRuntime(configPath);
     const binaryPath = process.argv[1];
     if (!binaryPath) throw new Error("could not resolve the gsd-cloud executable path");
     const installed = installService({

--- a/packages/gsd-cloud/src/cloud-config.ts
+++ b/packages/gsd-cloud/src/cloud-config.ts
@@ -72,8 +72,12 @@ export function saveCloudConfig(
   } catch {
     raw = {};
   }
+  const existingCloud = raw.cloud != null && typeof raw.cloud === "object"
+    ? raw.cloud as Record<string, unknown>
+    : {};
   const { device_token: deviceToken, ...cloud } = nextCloud;
   raw.cloud = {
+    ...existingCloud,
     ...cloud,
     gateway_url: parseCloudGatewayUrl(nextCloud.gateway_url).toString(),
     ...(deviceToken ? { device_token_encrypted: protectCloudDeviceToken(deviceToken) } : {}),

--- a/packages/gsd-cloud/src/cloud-config.ts
+++ b/packages/gsd-cloud/src/cloud-config.ts
@@ -75,9 +75,10 @@ export function saveCloudConfig(
   const existingCloud = raw.cloud != null && typeof raw.cloud === "object"
     ? raw.cloud as Record<string, unknown>
     : {};
+  const { device_token: _legacyDeviceToken, ...preservedCloud } = existingCloud;
   const { device_token: deviceToken, ...cloud } = nextCloud;
   raw.cloud = {
-    ...existingCloud,
+    ...preservedCloud,
     ...cloud,
     gateway_url: parseCloudGatewayUrl(nextCloud.gateway_url).toString(),
     ...(deviceToken ? { device_token_encrypted: protectCloudDeviceToken(deviceToken) } : {}),

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -248,7 +248,7 @@ export class CloudRuntime {
           sessionId ? { sessionId } : {},
           project.path,
         ),
-        send: (frame, projectPath) => this.send(frame, projectPath),
+        send: (frame, projectPath) => this.sendSessionEvent(frame, projectPath),
         logger: this.logger,
       });
     }
@@ -381,6 +381,17 @@ export class CloudRuntime {
     if (!deferred) return;
     this.firstConnectDeferred = undefined;
     deferred.reject(err);
+  }
+
+  /** Live session events are dropped while disconnected; the producer's replay
+   * buffer re-sends a bounded tail on reconnect. Keeping them out of the
+   * shared offline outbox avoids evicting tool_result frames. */
+  private sendSessionEvent(frame: unknown, projectPath?: string): void {
+    const text = JSON.stringify(frame);
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      this.socket.send(text);
+      this.telemetry.sent(text, projectPath);
+    }
   }
 
   private send(message: unknown, projectPath?: string): void {

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -226,6 +226,10 @@ export class CloudRuntime {
     const projects = await this.executor.advertisedProjects();
     this.advertisedProjects = projects;
     this.telemetry.projectsAdvertised(projects);
+    // The hello and session-event producer are tied to this connection. If the
+    // socket closed while advertisedProjects() was in flight, skip — the next
+    // open will re-advertise and start polling with a replay.
+    if (this.socket?.readyState !== WebSocket.OPEN) return;
     this.send({
       type: "hello",
       runtimeId: this.cloud.runtime_id,

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -3,6 +3,7 @@ import type { Logger } from "./logger.js";
 import type { DaemonConfig } from "./types.js";
 import type { AdvertisedProject, Executor } from "./executors/executor.js";
 import { createGatewayLookup, parseCloudGatewayUrl, validateGatewayNetworkTarget } from "./cloud-config.js";
+import { SessionEventProducer } from "./session-events.js";
 import {
   noopRuntimeTelemetry,
   type RuntimeTelemetryReporter,
@@ -50,6 +51,9 @@ export class CloudRuntime {
   private stopped = false;
   private firstConnectDeferred: PromiseWithResolvers<void> | undefined;
   private initialConnectAttempts = 0;
+  // Kept across reconnects so per-session seq counters and replay buffers
+  // survive; polling pauses while the socket is down.
+  private sessionEvents: SessionEventProducer | undefined;
 
   constructor(
     private readonly cloud: NonNullable<DaemonConfig["cloud"]>,
@@ -86,6 +90,7 @@ export class CloudRuntime {
     this.reconnect = undefined;
     if (this.heartbeat) clearInterval(this.heartbeat);
     this.heartbeat = undefined;
+    this.sessionEvents?.stopPolling();
     this.inFlight.clear();
     this.outbox = [];
     const socket = this.socket;
@@ -181,6 +186,9 @@ export class CloudRuntime {
     if (this.heartbeat) clearInterval(this.heartbeat);
     this.heartbeat = undefined;
     this.socket = undefined;
+    // Pause the producer while disconnected; its seq counters and replay
+    // buffers persist so the stream resumes on the next hello.
+    this.sessionEvents?.stopPolling();
     if (this.stopped) return;
     this.telemetry.disconnected();
     if (this.firstConnectDeferred) {
@@ -224,6 +232,27 @@ export class CloudRuntime {
       runtimeName: this.cloud.runtime_name,
       projects,
     });
+    // Only after the hello has been accepted does the live session-event
+    // producer start polling gsd_status and streaming session_event frames.
+    this.startSessionEvents();
+  }
+
+  private startSessionEvents(): void {
+    if (this.cloud.session_events === false) return;
+    if (!this.sessionEvents) {
+      this.sessionEvents = new SessionEventProducer({
+        runtimeId: this.cloud.runtime_id ?? "",
+        projects: () => this.advertisedProjects,
+        poll: (project, sessionId) => this.executor.execute(
+          "gsd_status",
+          sessionId ? { sessionId } : {},
+          project.path,
+        ),
+        send: (frame, projectPath) => this.send(frame, projectPath),
+        logger: this.logger,
+      });
+    }
+    this.sessionEvents.start();
   }
 
   private async handleMessage(text: string): Promise<void> {

--- a/packages/gsd-cloud/src/config.ts
+++ b/packages/gsd-cloud/src/config.ts
@@ -143,6 +143,20 @@ export function validateConfig(raw: unknown): DaemonConfig {
 }
 
 /**
+ * Read project scan_roots from a config file.
+ * Missing file or malformed YAML yields an empty list (does not throw).
+ */
+export function loadScanRoots(configPath: string): string[] {
+  if (!existsSync(configPath)) return [];
+  try {
+    const parsed = parseYaml(readFileSync(configPath, 'utf-8'));
+    return validateConfig(parsed).projects.scan_roots;
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Load and validate a DaemonConfig from a YAML file.
  * If the file doesn't exist, returns defaults. If the file is malformed YAML, throws.
  */

--- a/packages/gsd-cloud/src/config.ts
+++ b/packages/gsd-cloud/src/config.ts
@@ -64,6 +64,7 @@ export function validateConfig(raw: unknown): DaemonConfig {
       ...(typeof c['runtime_id'] === 'string' ? { runtime_id: c['runtime_id'] } : {}),
       ...(typeof c['runtime_name'] === 'string' ? { runtime_name: c['runtime_name'] } : {}),
       ...(typeof c['enabled'] === 'boolean' ? { enabled: c['enabled'] } : {}),
+      ...(typeof c['session_events'] === 'boolean' ? { session_events: c['session_events'] } : {}),
     };
   }
 
@@ -124,6 +125,13 @@ export function validateConfig(raw: unknown): DaemonConfig {
     } else {
       discord = { ...discord, token: envToken };
     }
+  }
+
+  // --- env override: GSD_CLOUD_SESSION_EVENTS (default on; 0/false disables) ---
+  const envSessionEvents = process.env['GSD_CLOUD_SESSION_EVENTS'];
+  if (envSessionEvents !== undefined && cloud) {
+    const normalized = envSessionEvents.trim().toLowerCase();
+    cloud = { ...cloud, session_events: normalized !== '0' && normalized !== 'false' };
   }
 
   return {

--- a/packages/gsd-cloud/src/service-install.test.ts
+++ b/packages/gsd-cloud/src/service-install.test.ts
@@ -1,0 +1,449 @@
+// Project/App: Open GSD
+// File Purpose: Unit coverage for OS service unit rendering, platform dispatch, and failure paths.
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { formatUsage, handleCloudCommand } from "./cli.js";
+import { runtimeLogPath } from "./runtime-process.js";
+import {
+  escapeXml,
+  generateLaunchdPlist,
+  generateSystemdUnit,
+  installService,
+  LAUNCHD_LABEL,
+  launchdPlistPath,
+  serviceManagerForPlatform,
+  serviceStatus,
+  SYSTEMD_UNIT_NAME,
+  systemdUnitPath,
+  uninstallService,
+  type RunServiceCommandFn,
+  type ServiceInstallOptions,
+} from "./service-install.js";
+
+function tmpHome(t: TestContext): string {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-service-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function baseInstallOpts(home: string, overrides?: Partial<ServiceInstallOptions>): ServiceInstallOptions {
+  return {
+    nodePath: "/usr/local/bin/node",
+    binaryPath: "/usr/local/lib/node_modules/@opengsd/gsd-cloud/bin/gsd-cloud.js",
+    configPath: join(home, ".gsd", "daemon.yaml"),
+    homeDir: home,
+    ...overrides,
+  };
+}
+
+/** A runCommand mock that records argv arrays and serves canned responses. */
+function mockRunCommand(responder?: (args: string[]) => string): {
+  calls: string[][];
+  run: RunServiceCommandFn;
+} {
+  const calls: string[][] = [];
+  return {
+    calls,
+    run: (args: string[]) => {
+      calls.push(args);
+      return responder ? responder(args) : "";
+    },
+  };
+}
+
+// --------------- platform dispatch ---------------
+
+test("service manager dispatch maps macOS and Linux, rejects other platforms", () => {
+  assert.equal(serviceManagerForPlatform("darwin"), "launchd");
+  assert.equal(serviceManagerForPlatform("linux"), "systemd");
+  assert.throws(() => serviceManagerForPlatform("win32"), /not supported on win32/);
+  assert.throws(() => serviceManagerForPlatform("freebsd"), /macOS \(launchd\) and Linux \(systemd user units\)/);
+});
+
+test("unsupported platforms fail every service operation with a clear error", () => {
+  assert.throws(() => installService(baseInstallOpts("/tmp/nowhere", { platform: "win32" })), /not supported on win32/);
+  assert.throws(() => uninstallService({ platform: "win32" }), /not supported on win32/);
+  assert.throws(() => serviceStatus({ platform: "win32" }), /not supported on win32/);
+});
+
+test("unit paths live under the user's home directory", (t) => {
+  const home = tmpHome(t);
+  assert.equal(
+    launchdPlistPath(home),
+    join(home, "Library", "LaunchAgents", `${LAUNCHD_LABEL}.plist`),
+  );
+  assert.equal(
+    systemdUnitPath(home),
+    join(home, ".config", "systemd", "user", SYSTEMD_UNIT_NAME),
+  );
+});
+
+// --------------- launchd plist rendering ---------------
+
+test("launchd plist renders label, program arguments, and supervision policy", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home);
+  const xml = generateLaunchdPlist(opts);
+
+  assert.ok(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>'));
+  assert.ok(xml.includes("<plist version=\"1.0\">"));
+  assert.ok(xml.includes(`<string>${LAUNCHD_LABEL}</string>`));
+  assert.ok(xml.includes(`<string>${opts.nodePath}</string>`));
+  assert.ok(xml.includes(`<string>${opts.binaryPath}</string>`));
+  // The service runs the foreground runtime so PID/state files stay shared.
+  for (const argument of ["connect", "--foreground", "--config", opts.configPath]) {
+    assert.ok(xml.includes(`<string>${argument}</string>`), `missing ${argument}`);
+  }
+  assert.ok(xml.includes("<key>KeepAlive</key>"));
+  assert.ok(xml.includes("<key>SuccessfulExit</key>"));
+  assert.ok(xml.includes("<false/>"));
+  assert.ok(xml.includes("<key>RunAtLoad</key>"));
+  assert.ok(xml.includes("<true/>"));
+});
+
+test("launchd plist logs to the runtime artifact log and carries an NVM-aware PATH", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, {
+    nodePath: "/home/user/.nvm/versions/node/v22.0.0/bin/node",
+  });
+  const xml = generateLaunchdPlist(opts);
+
+  const logPath = runtimeLogPath(opts.configPath);
+  assert.equal(logPath, join(home, ".gsd", "cloud-runtime.log"));
+  assert.equal(xml.split(`<string>${logPath}</string>`).length - 1, 2);
+  assert.ok(xml.includes("/home/user/.nvm/versions/node/v22.0.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"));
+  assert.ok(xml.includes(`<key>HOME</key>\n\t\t<string>${home}</string>`));
+  assert.ok(xml.includes(`<key>WorkingDirectory</key>\n\t<string>${home}</string>`));
+});
+
+test("launchd plist escapes XML-special characters in paths", (t) => {
+  const home = tmpHome(t);
+  const configPath = join(home, "configs", "John & Jane.yaml");
+  const xml = generateLaunchdPlist(baseInstallOpts(home, { configPath }));
+  assert.ok(xml.includes("John &amp; Jane.yaml"));
+  assert.ok(!xml.includes("John & Jane.yaml"));
+  assert.equal(escapeXml('a&b<c>d"e\'f'), "a&amp;b&lt;c&gt;d&quot;e&apos;f");
+});
+
+// --------------- systemd unit rendering ---------------
+
+test("systemd unit renders exec line, restart policy, environment, and journal logging", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home);
+  const unit = generateSystemdUnit(opts);
+
+  assert.ok(unit.includes("Description=GSD Cloud runtime agent (gsd-cloud)"));
+  assert.ok(unit.includes(
+    `ExecStart="${opts.nodePath}" "${opts.binaryPath}" connect --foreground --config "${opts.configPath}"`,
+  ));
+  assert.ok(unit.includes("Restart=on-failure"));
+  assert.ok(unit.includes("RestartSec=5"));
+  assert.ok(unit.includes(`Environment="HOME=${home}"`));
+  assert.ok(unit.includes(`Environment="PATH=/usr/local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"`));
+  assert.ok(unit.includes("StandardOutput=journal"));
+  assert.ok(unit.includes("StandardError=journal"));
+  assert.ok(unit.includes("SyslogIdentifier=gsd-cloud"));
+  assert.ok(unit.includes("WantedBy=default.target"));
+});
+
+test("systemd unit quotes arguments containing spaces", (t) => {
+  const home = tmpHome(t);
+  const configPath = join(home, "my configs", "daemon.yaml");
+  const unit = generateSystemdUnit(baseInstallOpts(home, { configPath }));
+  assert.ok(unit.includes(`--config "${configPath}"`));
+  assert.ok(!unit.includes(`--config ${configPath}\n`));
+});
+
+// --------------- install ---------------
+
+test("installService writes the launchd plist, loads it, and verifies registration", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, { platform: "darwin" });
+  const { calls, run } = mockRunCommand();
+
+  const installed = installService(opts, run);
+
+  const plistPath = launchdPlistPath(home);
+  assert.equal(installed.manager, "launchd");
+  assert.equal(installed.unitPath, plistPath);
+  assert.equal(installed.logPath, runtimeLogPath(opts.configPath));
+  assert.equal(existsSync(plistPath), true);
+  assert.equal(readFileSync(plistPath, "utf8"), generateLaunchdPlist(opts));
+  assert.deepEqual(calls, [
+    ["launchctl", "load", plistPath],
+    ["launchctl", "list", LAUNCHD_LABEL],
+  ]);
+});
+
+test("installService unloads a pre-existing launchd agent before reloading", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, { platform: "darwin" });
+  const plistPath = launchdPlistPath(home);
+  const { calls, run } = mockRunCommand();
+
+  installService(opts, run);
+  installService(opts, run);
+
+  const unloads = calls.filter((args) => args[1] === "unload");
+  assert.equal(unloads.length, 1);
+  assert.deepEqual(unloads[0], ["launchctl", "unload", plistPath]);
+  // Tolerates "already unloaded" errors during the idempotent unload.
+  const tolerant = mockRunCommand((args) => {
+    if (args[1] === "unload") throw new Error("Could not find specified service");
+    return "";
+  });
+  installService(opts, tolerant.run);
+  assert.ok(tolerant.calls.some((args) => args[1] === "load"));
+});
+
+test("installService throws when launchctl load fails", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, { platform: "darwin" });
+  const { run } = mockRunCommand((args) => {
+    if (args[1] === "load") throw Object.assign(new Error("launchctl failed"), { stderr: "Bootstrap failed: 5" });
+    return "";
+  });
+
+  assert.throws(() => installService(opts, run), /launchctl load failed.*Bootstrap failed: 5/);
+});
+
+test("installService throws when the launchd agent cannot be verified after load", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, { platform: "darwin" });
+  const { run } = mockRunCommand((args) => {
+    if (args[1] === "list") throw new Error("Could not find service");
+    return "";
+  });
+
+  assert.throws(() => installService(opts, run), /the service may not have started/);
+});
+
+test("installService writes the systemd unit and enables it immediately", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, { platform: "linux" });
+  const { calls, run } = mockRunCommand();
+
+  const installed = installService(opts, run);
+
+  const unitPath = systemdUnitPath(home);
+  assert.equal(installed.manager, "systemd");
+  assert.equal(installed.unitPath, unitPath);
+  assert.equal(installed.logPath, null);
+  assert.equal(existsSync(unitPath), true);
+  assert.equal(readFileSync(unitPath, "utf8"), generateSystemdUnit(opts));
+  assert.deepEqual(calls, [
+    ["systemctl", "--user", "daemon-reload"],
+    ["systemctl", "--user", "enable", "--now", SYSTEMD_UNIT_NAME],
+  ]);
+});
+
+test("installService surfaces systemctl failures with user-session guidance", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, { platform: "linux" });
+  const { run } = mockRunCommand(() => {
+    throw Object.assign(new Error("systemctl failed"), { stderr: "Failed to connect to bus: No medium found" });
+  });
+
+  assert.throws(
+    () => installService(opts, run),
+    /Failed to connect to bus: No medium found.*loginctl enable-linger/s,
+  );
+});
+
+// --------------- uninstall ---------------
+
+test("uninstallService unloads and removes the launchd plist", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, { platform: "darwin" });
+  installService(opts, mockRunCommand().run);
+  const plistPath = launchdPlistPath(home);
+  assert.equal(existsSync(plistPath), true);
+
+  const { calls, run } = mockRunCommand();
+  const removed = uninstallService({ platform: "darwin", homeDir: home }, run);
+
+  assert.equal(removed.removed, true);
+  assert.equal(removed.unitPath, plistPath);
+  assert.equal(existsSync(plistPath), false);
+  assert.deepEqual(calls, [["launchctl", "unload", plistPath]]);
+});
+
+test("uninstallService disables and removes the systemd unit, then reloads the manager", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, { platform: "linux" });
+  installService(opts, mockRunCommand().run);
+  const unitPath = systemdUnitPath(home);
+
+  const { calls, run } = mockRunCommand();
+  const removed = uninstallService({ platform: "linux", homeDir: home }, run);
+
+  assert.equal(removed.removed, true);
+  assert.equal(existsSync(unitPath), false);
+  assert.deepEqual(calls, [
+    ["systemctl", "--user", "disable", "--now", SYSTEMD_UNIT_NAME],
+    ["systemctl", "--user", "daemon-reload"],
+  ]);
+});
+
+test("uninstallService is a graceful no-op when the unit file is missing", (t) => {
+  const home = tmpHome(t);
+  for (const platform of ["darwin", "linux"] as const) {
+    const { calls, run } = mockRunCommand();
+    const removed = uninstallService({ platform, homeDir: home }, run);
+    assert.equal(removed.removed, false);
+    assert.deepEqual(calls, []);
+  }
+});
+
+test("uninstallService tolerates service-manager errors and still removes the unit", (t) => {
+  const home = tmpHome(t);
+  for (const platform of ["darwin", "linux"] as const) {
+    const opts = baseInstallOpts(home, { platform });
+    installService(opts, mockRunCommand().run);
+    const { run } = mockRunCommand(() => {
+      throw new Error("service manager unavailable");
+    });
+    const removed = uninstallService({ platform, homeDir: home }, run);
+    assert.equal(removed.removed, true);
+    assert.equal(existsSync(removed.unitPath), false);
+  }
+});
+
+// --------------- status ---------------
+
+test("serviceStatus reports not installed without touching the service manager", (t) => {
+  const home = tmpHome(t);
+  for (const platform of ["darwin", "linux"] as const) {
+    const { calls, run } = mockRunCommand();
+    const status = serviceStatus({ platform, homeDir: home }, run);
+    assert.equal(status.installed, false);
+    assert.equal(status.loaded, false);
+    assert.equal(status.running, false);
+    assert.equal(status.pid, null);
+    assert.deepEqual(calls, []);
+  }
+});
+
+test("serviceStatus parses tabular launchctl list output", (t) => {
+  const home = tmpHome(t);
+  installService(baseInstallOpts(home, { platform: "darwin" }), mockRunCommand().run);
+  const { run } = mockRunCommand(() => `PID\tStatus\tLabel\n1234\t0\t${LAUNCHD_LABEL}\n`);
+
+  const status = serviceStatus({ platform: "darwin", homeDir: home }, run);
+
+  assert.equal(status.installed, true);
+  assert.equal(status.loaded, true);
+  assert.equal(status.running, true);
+  assert.equal(status.pid, 1234);
+  assert.equal(status.lastExitStatus, 0);
+});
+
+test("serviceStatus parses dict-style launchctl list output for a stopped agent", (t) => {
+  const home = tmpHome(t);
+  installService(baseInstallOpts(home, { platform: "darwin" }), mockRunCommand().run);
+  const { run } = mockRunCommand(() => `{\n\t"Label" = "${LAUNCHD_LABEL}";\n\t"LastExitStatus" = 1;\n};`);
+
+  const status = serviceStatus({ platform: "darwin", homeDir: home }, run);
+
+  assert.equal(status.loaded, true);
+  assert.equal(status.running, false);
+  assert.equal(status.pid, null);
+  assert.equal(status.lastExitStatus, 1);
+});
+
+test("serviceStatus reports installed-but-unloaded when launchctl does not know the label", (t) => {
+  const home = tmpHome(t);
+  installService(baseInstallOpts(home, { platform: "darwin" }), mockRunCommand().run);
+  const { run } = mockRunCommand(() => {
+    throw new Error(`Could not find service "${LAUNCHD_LABEL}" in domain for port`);
+  });
+
+  const status = serviceStatus({ platform: "darwin", homeDir: home }, run);
+
+  assert.equal(status.installed, true);
+  assert.equal(status.loaded, false);
+  assert.equal(status.running, false);
+  assert.equal(status.pid, null);
+});
+
+test("serviceStatus parses systemctl show output for a running unit", (t) => {
+  const home = tmpHome(t);
+  installService(baseInstallOpts(home, { platform: "linux" }), mockRunCommand().run);
+  const { calls, run } = mockRunCommand(() => "LoadState=loaded\nActiveState=active\nMainPID=4321\n");
+
+  const status = serviceStatus({ platform: "linux", homeDir: home }, run);
+
+  assert.equal(status.installed, true);
+  assert.equal(status.loaded, true);
+  assert.equal(status.running, true);
+  assert.equal(status.pid, 4321);
+  assert.deepEqual(calls, [[
+    "systemctl", "--user", "show", SYSTEMD_UNIT_NAME,
+    "--no-page", "--property=LoadState,ActiveState,MainPID",
+  ]]);
+});
+
+test("serviceStatus parses systemctl show output for an inactive unit", (t) => {
+  const home = tmpHome(t);
+  installService(baseInstallOpts(home, { platform: "linux" }), mockRunCommand().run);
+  const { run } = mockRunCommand(() => "LoadState=loaded\nActiveState=failed\nMainPID=0\n");
+
+  const status = serviceStatus({ platform: "linux", homeDir: home }, run);
+
+  assert.equal(status.loaded, true);
+  assert.equal(status.running, false);
+  assert.equal(status.pid, null);
+});
+
+test("serviceStatus falls back to on-disk truth when the systemd user bus is unavailable", (t) => {
+  const home = tmpHome(t);
+  installService(baseInstallOpts(home, { platform: "linux" }), mockRunCommand().run);
+  const { run } = mockRunCommand(() => {
+    throw new Error("Failed to connect to bus");
+  });
+
+  const status = serviceStatus({ platform: "linux", homeDir: home }, run);
+
+  assert.equal(status.installed, true);
+  assert.equal(status.loaded, false);
+  assert.equal(status.running, false);
+});
+
+// --------------- CLI wiring ---------------
+
+test("service command rejects unknown subcommands", async () => {
+  await assert.rejects(
+    handleCloudCommand(["service", "bogus"], { binaryName: "gsd-cloud" }),
+    /Unknown service command: bogus \(expected install, uninstall, or status\)/,
+  );
+});
+
+test("service command without a subcommand prints service usage", async (t) => {
+  const writes: string[] = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((chunk: unknown) => {
+    writes.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  t.after(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  await handleCloudCommand(["service"], { binaryName: "gsd-cloud" });
+
+  const usage = writes.join("");
+  assert.match(usage, /gsd-cloud service install/);
+  assert.match(usage, /gsd-cloud service uninstall/);
+  assert.match(usage, /gsd-cloud service status/);
+});
+
+test("top-level usage documents the service commands", () => {
+  const usage = formatUsage("gsd-cloud");
+  assert.match(usage, /gsd-cloud service install \[--config <path>\]/);
+  assert.match(usage, /gsd-cloud service uninstall/);
+  assert.match(usage, /gsd-cloud service status/);
+  assert.match(usage, /service --help/);
+});

--- a/packages/gsd-cloud/src/service-install.ts
+++ b/packages/gsd-cloud/src/service-install.ts
@@ -33,6 +33,8 @@ export interface ServiceInstallOptions extends ServiceTargetOptions {
   configPath: string;
   /** Log file override (launchd only; defaults to the runtime artifact log). */
   logPath?: string;
+  /** Path to the `gsd` binary for the executor (from GSD_CLI_PATH at install time). */
+  gsdCliPath?: string;
 }
 
 export interface InstalledService {
@@ -161,7 +163,9 @@ export function generateLaunchdPlist(opts: ServiceInstallOptions): string {
 \t\t<key>PATH</key>
 \t\t<string>${escapeXml(envPath)}</string>
 \t\t<key>HOME</key>
-\t\t<string>${escapeXml(home)}</string>
+\t\t<string>${escapeXml(home)}</string>${opts.gsdCliPath ? `
+\t\t<key>GSD_CLI_PATH</key>
+\t\t<string>${escapeXml(opts.gsdCliPath)}</string>` : ""}
 \t</dict>
 
 \t<key>WorkingDirectory</key>
@@ -192,7 +196,8 @@ ExecStart=${systemdArg(opts.nodePath)} ${systemdArg(opts.binaryPath)} connect --
 Restart=on-failure
 RestartSec=${SYSTEMD_RESTART_DELAY_SECONDS}
 Environment=${systemdArg(`HOME=${home}`)}
-Environment=${systemdArg(`PATH=${envPath}`)}
+Environment=${systemdArg(`PATH=${envPath}`)}${opts.gsdCliPath ? `
+Environment=${systemdArg(`GSD_CLI_PATH=${opts.gsdCliPath}`)}` : ""}
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=gsd-cloud

--- a/packages/gsd-cloud/src/service-install.ts
+++ b/packages/gsd-cloud/src/service-install.ts
@@ -1,0 +1,418 @@
+// Project/App: Open GSD
+// File Purpose: OS service install/uninstall/status for the gsd-cloud runtime.
+//
+// macOS installs a launchd LaunchAgent (~/Library/LaunchAgents/net.opengsd.gsd-cloud.plist)
+// and Linux installs a systemd user unit (~/.config/systemd/user/gsd-cloud.service).
+// Both run `gsd-cloud connect --foreground`, so the service-managed runtime shares
+// the PID/state files and log artifacts with CLI-managed sessions: a clean
+// SIGTERM stop exits 0, which both supervisors respect (KeepAlive only fires on
+// unsuccessful exits; Restart=on-failure only fires on non-zero exits).
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { runtimeLogPath } from "./runtime-process.js";
+
+export type ServiceManager = "launchd" | "systemd";
+
+export interface ServiceTargetOptions {
+  /** Platform override (testing). Defaults to process.platform. */
+  platform?: NodeJS.Platform;
+  /** Home directory override (testing). Defaults to os.homedir(). */
+  homeDir?: string;
+  /** Unit file path override (testing). */
+  unitPath?: string;
+}
+
+export interface ServiceInstallOptions extends ServiceTargetOptions {
+  /** Absolute path to the Node.js binary (usually process.execPath). */
+  nodePath: string;
+  /** Absolute path to the gsd-cloud CLI script (bin/gsd-cloud.js). */
+  binaryPath: string;
+  /** Absolute path to the YAML config file. */
+  configPath: string;
+  /** Log file override (launchd only; defaults to the runtime artifact log). */
+  logPath?: string;
+}
+
+export interface InstalledService {
+  manager: ServiceManager;
+  unitPath: string;
+  /** launchd log file; null on systemd, which logs to the journal. */
+  logPath: string | null;
+}
+
+export interface RemovedService {
+  manager: ServiceManager;
+  unitPath: string;
+  removed: boolean;
+}
+
+export interface ServiceStatus {
+  manager: ServiceManager;
+  label: string;
+  unitPath: string;
+  /** Unit file exists on disk. */
+  installed: boolean;
+  /** Registered with the service manager (launchctl list / LoadState=loaded). */
+  loaded: boolean;
+  running: boolean;
+  pid: number | null;
+  /** launchd only; always null on systemd. */
+  lastExitStatus: number | null;
+}
+
+export type RunServiceCommandFn = (args: string[]) => string;
+
+export const LAUNCHD_LABEL = "net.opengsd.gsd-cloud";
+const LAUNCHD_PLIST_FILENAME = `${LAUNCHD_LABEL}.plist`;
+export const SYSTEMD_UNIT_NAME = "gsd-cloud.service";
+const SYSTEMD_RESTART_DELAY_SECONDS = 5;
+
+// --------------- platform dispatch ---------------
+
+export function serviceManagerForPlatform(
+  platform: NodeJS.Platform = process.platform,
+): ServiceManager {
+  if (platform === "darwin") return "launchd";
+  if (platform === "linux") return "systemd";
+  throw new Error(
+    `gsd-cloud service install is not supported on ${platform}; `
+    + "supported platforms are macOS (launchd) and Linux (systemd user units). "
+    + "Use `connect` to run the runtime in the background instead.",
+  );
+}
+
+export function launchdPlistPath(homeDir: string = homedir()): string {
+  return join(homeDir, "Library", "LaunchAgents", LAUNCHD_PLIST_FILENAME);
+}
+
+export function systemdUnitPath(homeDir: string = homedir()): string {
+  return join(homeDir, ".config", "systemd", "user", SYSTEMD_UNIT_NAME);
+}
+
+function resolveUnitPath(manager: ServiceManager, opts: ServiceTargetOptions): string {
+  if (opts.unitPath) return opts.unitPath;
+  const home = opts.homeDir ?? homedir();
+  return manager === "launchd" ? launchdPlistPath(home) : systemdUnitPath(home);
+}
+
+// --------------- unit file rendering ---------------
+
+/** Escape special XML characters in a string. */
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Build the NVM-aware PATH string. Includes the directory containing the Node
+ * binary so the service can find node (and a PATH-local `gsd`) even when
+ * launched outside a shell session where NVM isn't sourced.
+ */
+function buildEnvPath(nodePath: string): string {
+  const nodeBinDir = dirname(nodePath);
+  return `${nodeBinDir}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`;
+}
+
+/** Quote one argument for a systemd unit line (no shell is involved). */
+function systemdArg(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"")}"`;
+}
+
+/** Generate the launchd plist XML for the gsd-cloud runtime. */
+export function generateLaunchdPlist(opts: ServiceInstallOptions): string {
+  const home = opts.homeDir ?? homedir();
+  const logPath = opts.logPath ?? runtimeLogPath(opts.configPath);
+  const envPath = buildEnvPath(opts.nodePath);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>Label</key>
+\t<string>${escapeXml(LAUNCHD_LABEL)}</string>
+
+\t<key>ProgramArguments</key>
+\t<array>
+\t\t<string>${escapeXml(opts.nodePath)}</string>
+\t\t<string>${escapeXml(opts.binaryPath)}</string>
+\t\t<string>connect</string>
+\t\t<string>--foreground</string>
+\t\t<string>--config</string>
+\t\t<string>${escapeXml(opts.configPath)}</string>
+\t</array>
+
+\t<key>KeepAlive</key>
+\t<dict>
+\t\t<key>SuccessfulExit</key>
+\t\t<false/>
+\t</dict>
+
+\t<key>RunAtLoad</key>
+\t<true/>
+
+\t<key>EnvironmentVariables</key>
+\t<dict>
+\t\t<key>PATH</key>
+\t\t<string>${escapeXml(envPath)}</string>
+\t\t<key>HOME</key>
+\t\t<string>${escapeXml(home)}</string>
+\t</dict>
+
+\t<key>WorkingDirectory</key>
+\t<string>${escapeXml(home)}</string>
+
+\t<key>StandardOutPath</key>
+\t<string>${escapeXml(logPath)}</string>
+
+\t<key>StandardErrorPath</key>
+\t<string>${escapeXml(logPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+/** Generate the systemd user unit for the gsd-cloud runtime. */
+export function generateSystemdUnit(opts: ServiceInstallOptions): string {
+  const home = opts.homeDir ?? homedir();
+  const envPath = buildEnvPath(opts.nodePath);
+
+  return `[Unit]
+Description=GSD Cloud runtime agent (gsd-cloud)
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=${systemdArg(opts.nodePath)} ${systemdArg(opts.binaryPath)} connect --foreground --config ${systemdArg(opts.configPath)}
+Restart=on-failure
+RestartSec=${SYSTEMD_RESTART_DELAY_SECONDS}
+Environment=${systemdArg(`HOME=${home}`)}
+Environment=${systemdArg(`PATH=${envPath}`)}
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=gsd-cloud
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+// --------------- install / uninstall / status ---------------
+
+function defaultRunServiceCommand(args: string[]): string {
+  return execFileSync(args[0]!, args.slice(1), {
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+function commandErrorDetail(error: unknown): string {
+  if (error && typeof error === "object" && "stderr" in error) {
+    const stderr = (error as { stderr?: unknown }).stderr;
+    if (typeof stderr === "string" && stderr.trim()) return stderr.trim();
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Install the OS service: write the unit file and load/enable + start it.
+ * Idempotent — an existing launchd agent is unloaded first; systemd enable is
+ * naturally idempotent.
+ */
+export function installService(
+  opts: ServiceInstallOptions,
+  runCommand: RunServiceCommandFn = defaultRunServiceCommand,
+): InstalledService {
+  const manager = serviceManagerForPlatform(opts.platform);
+  const unitPath = resolveUnitPath(manager, opts);
+  const logPath = manager === "launchd" ? (opts.logPath ?? runtimeLogPath(opts.configPath)) : null;
+  mkdirSync(dirname(unitPath), { recursive: true });
+
+  if (manager === "launchd") {
+    if (existsSync(unitPath)) {
+      try {
+        runCommand(["launchctl", "unload", unitPath]);
+      } catch {
+        // already unloaded — fine
+      }
+    }
+    mkdirSync(dirname(logPath!), { recursive: true });
+    writeFileSync(unitPath, generateLaunchdPlist(opts), "utf8");
+    chmodSync(unitPath, 0o644);
+    try {
+      runCommand(["launchctl", "load", unitPath]);
+    } catch (error) {
+      throw new Error(`launchctl load failed for ${unitPath}: ${commandErrorDetail(error)}`);
+    }
+    try {
+      runCommand(["launchctl", "list", LAUNCHD_LABEL]);
+    } catch {
+      throw new Error(
+        `the plist was written to ${unitPath} and launchctl load succeeded, `
+        + `but launchctl list ${LAUNCHD_LABEL} failed; the service may not have started`,
+      );
+    }
+  } else {
+    writeFileSync(unitPath, generateSystemdUnit(opts), "utf8");
+    chmodSync(unitPath, 0o644);
+    try {
+      runCommand(["systemctl", "--user", "daemon-reload"]);
+      runCommand(["systemctl", "--user", "enable", "--now", SYSTEMD_UNIT_NAME]);
+    } catch (error) {
+      throw new Error(
+        `systemctl --user failed while enabling ${SYSTEMD_UNIT_NAME}: ${commandErrorDetail(error)}. `
+        + "A systemd user session is required — on headless servers, log in once "
+        + "or enable lingering with `loginctl enable-linger`.",
+      );
+    }
+  }
+
+  return { manager, unitPath, logPath };
+}
+
+/**
+ * Uninstall the OS service: unload/disable + stop it and remove the unit file.
+ * Graceful — does not throw when the service was never installed.
+ */
+export function uninstallService(
+  opts: ServiceTargetOptions = {},
+  runCommand: RunServiceCommandFn = defaultRunServiceCommand,
+): RemovedService {
+  const manager = serviceManagerForPlatform(opts.platform);
+  const unitPath = resolveUnitPath(manager, opts);
+  if (!existsSync(unitPath)) return { manager, unitPath, removed: false };
+
+  if (manager === "launchd") {
+    try {
+      runCommand(["launchctl", "unload", unitPath]);
+    } catch {
+      // already unloaded — fine
+    }
+  } else {
+    try {
+      runCommand(["systemctl", "--user", "disable", "--now", SYSTEMD_UNIT_NAME]);
+    } catch {
+      // already disabled/stopped or no user bus — still remove the unit file
+    }
+  }
+  unlinkSync(unitPath);
+
+  if (manager === "systemd") {
+    try {
+      runCommand(["systemctl", "--user", "daemon-reload"]);
+    } catch {
+      // unit file is gone; a stale manager cache is harmless
+    }
+  }
+  return { manager, unitPath, removed: true };
+}
+
+/** Query the service manager for the gsd-cloud service status. */
+export function serviceStatus(
+  opts: ServiceTargetOptions = {},
+  runCommand: RunServiceCommandFn = defaultRunServiceCommand,
+): ServiceStatus {
+  const manager = serviceManagerForPlatform(opts.platform);
+  const unitPath = resolveUnitPath(manager, opts);
+  const label = manager === "launchd" ? LAUNCHD_LABEL : SYSTEMD_UNIT_NAME;
+  const installed = existsSync(unitPath);
+
+  if (manager === "launchd") {
+    const queried = installed ? queryLaunchd(runCommand) : null;
+    return {
+      manager,
+      label,
+      unitPath,
+      installed,
+      loaded: queried?.registered ?? false,
+      running: queried?.pid != null,
+      pid: queried?.pid ?? null,
+      lastExitStatus: queried?.lastExitStatus ?? null,
+    };
+  }
+
+  if (!installed) {
+    return { manager, label, unitPath, installed, loaded: false, running: false, pid: null, lastExitStatus: null };
+  }
+  try {
+    const output = runCommand([
+      "systemctl", "--user", "show", SYSTEMD_UNIT_NAME,
+      "--no-page", "--property=LoadState,ActiveState,MainPID",
+    ]);
+    const properties = parseSystemdShow(output);
+    const mainPid = Number.parseInt(properties.get("MainPID") ?? "", 10);
+    const pid = Number.isInteger(mainPid) && mainPid > 0 ? mainPid : null;
+    return {
+      manager,
+      label,
+      unitPath,
+      installed,
+      loaded: properties.get("LoadState") === "loaded",
+      running: properties.get("ActiveState") === "active",
+      pid,
+      lastExitStatus: null,
+    };
+  } catch {
+    // No systemd user bus (headless/SSH-less session) — report the on-disk truth.
+    return { manager, label, unitPath, installed, loaded: false, running: false, pid: null, lastExitStatus: null };
+  }
+}
+
+interface LaunchdQueryResult {
+  registered: boolean;
+  pid: number | null;
+  lastExitStatus: number | null;
+}
+
+/**
+ * Parse `launchctl list <label>` output. Handles both the tabular format
+ * ("PID\tStatus\tLabel") and the JSON-style dict format ("PID" = 1234;).
+ */
+function queryLaunchd(runCommand: RunServiceCommandFn): LaunchdQueryResult {
+  try {
+    const output = runCommand(["launchctl", "list", LAUNCHD_LABEL]);
+
+    for (const line of output.trim().split("\n")) {
+      const parts = line.trim().split(/\t+/);
+      if (parts.length >= 3 && parts[2] === LAUNCHD_LABEL) {
+        const pid = parts[0] === "-" ? null : Number.parseInt(parts[0]!, 10);
+        const lastExitStatus = Number.parseInt(parts[1]!, 10);
+        return {
+          registered: true,
+          pid: pid != null && Number.isNaN(pid) ? null : pid,
+          lastExitStatus: Number.isNaN(lastExitStatus) ? null : lastExitStatus,
+        };
+      }
+    }
+
+    const pidMatch = /"PID"\s*=\s*(\d+)\s*;/.exec(output);
+    const exitMatch = /"LastExitStatus"\s*=\s*(\d+)\s*;/.exec(output);
+    if (pidMatch || exitMatch) {
+      return {
+        registered: true,
+        pid: pidMatch ? Number.parseInt(pidMatch[1]!, 10) : null,
+        lastExitStatus: exitMatch ? Number.parseInt(exitMatch[1]!, 10) : null,
+      };
+    }
+
+    return { registered: true, pid: null, lastExitStatus: null };
+  } catch {
+    // launchctl list exits non-zero when the label isn't loaded
+    return { registered: false, pid: null, lastExitStatus: null };
+  }
+}
+
+function parseSystemdShow(output: string): Map<string, string> {
+  const properties = new Map<string, string>();
+  for (const line of output.split("\n")) {
+    const separator = line.indexOf("=");
+    if (separator <= 0) continue;
+    properties.set(line.slice(0, separator).trim(), line.slice(separator + 1).trim());
+  }
+  return properties;
+}

--- a/packages/gsd-cloud/src/session-events.test.ts
+++ b/packages/gsd-cloud/src/session-events.test.ts
@@ -569,6 +569,35 @@ test("per-session poll failure surfaces an error event", async (t) => {
   assert.match(error.event.data.message as string, /timed out/);
 });
 
+test("per-session poll failure racing stopPolling does not emit onto the next connection", async (t) => {
+  let stopDuringS2 = false;
+  let producerRef: SessionEventProducer | undefined;
+  const { producer, sent } = makeProducer(t, {
+    poll: async (_project, sessionId) => {
+      if (!sessionId) {
+        return mcpError("Multiple tracked GSD sessions; pass sessionId or projectDir. Tracked sessions: s1 /work/one; s2 /work/one");
+      }
+      if (sessionId === "s2" && stopDuringS2) {
+        // The WebSocket drops while this per-session poll is in flight:
+        // stopPolling() bumps the generation before the poll settles.
+        producerRef!.stopPolling();
+        throw new Error("MCP request timed out");
+      }
+      return mcpResult(statusPayload({ sessionId }));
+    },
+  });
+  producerRef = producer;
+  await producer.pollOnce(); // track s1 + s2
+  stopDuringS2 = true;
+  await producer.pollOnce();
+
+  assert.equal(
+    sent.filter((frame) => frame.event.kind === "error").length,
+    0,
+    "a poll failure that outlives stopPolling must not emit a stale error frame",
+  );
+});
+
 test("project-level poll failure logs and does not end tracked sessions", async (t) => {
   let result: unknown = mcpResult(statusPayload());
   const { producer, sent, warnings } = makeProducer(t, { poll: async () => result });

--- a/packages/gsd-cloud/src/session-events.test.ts
+++ b/packages/gsd-cloud/src/session-events.test.ts
@@ -470,6 +470,56 @@ test("event window overflow reports the gap without re-emitting an overlapping t
   );
 });
 
+test("a server counter reset realigns the cursor instead of re-streaming the window", async (t) => {
+  // When gsd_status reports a lower eventCount than we tracked (the session
+  // object was rebuilt server-side and counts from a lower base), deltaEvents
+  // re-streams the visible window once. The cursor must realign DOWN to the new
+  // count; pinning it at the prior high-water mark would re-emit the whole
+  // window on every later poll under fresh seqs the relay's (device, session,
+  // seq) dedupe cannot catch.
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce(); // baseline: eventCount 0, session_started
+
+  payload = statusPayload({
+    progress: { eventCount: 3, toolCalls: 0 },
+    recentEvents: [
+      { type: "tool_use", name: "a1" },
+      { type: "tool_use", name: "a2" },
+      { type: "tool_use", name: "a3" },
+    ],
+  });
+  await producer.pollOnce(); // streams a1, a2, a3; cursor at 3
+
+  // Server counter resets to a lower base (session rebuilt); one new event.
+  payload = statusPayload({
+    progress: { eventCount: 1, toolCalls: 0 },
+    recentEvents: [{ type: "tool_use", name: "b1" }],
+  });
+  await producer.pollOnce(); // re-streams the window once: b1
+
+  // Counter moves forward from the reset base; only the new tail is new.
+  payload = statusPayload({
+    progress: { eventCount: 2, toolCalls: 0 },
+    recentEvents: [
+      { type: "tool_use", name: "b1" },
+      { type: "tool_use", name: "b2" },
+    ],
+  });
+  await producer.pollOnce(); // must emit only b2, not b1 again
+
+  const toolNames = sent
+    .filter((frame) => frame.event.kind === "tool_call")
+    .map((frame) => frame.event.data.name);
+  assert.deepEqual(
+    toolNames,
+    ["a1", "a2", "a3", "b1", "b2"],
+    "the cursor realigns after the reset; no event is re-streamed",
+  );
+  const seqs = sent.map((frame) => frame.seq);
+  assert.deepEqual(seqs, [...new Set(seqs)], "seqs stay unique");
+});
+
 test("concurrent session bound: extra sessions are skipped and logged once", async (t) => {
   const payloads: Record<string, unknown> = {
     s1: statusPayload({ sessionId: "s1" }),

--- a/packages/gsd-cloud/src/session-events.test.ts
+++ b/packages/gsd-cloud/src/session-events.test.ts
@@ -1,0 +1,589 @@
+// Project/App: Open GSD
+// File Purpose: Unit tests for the live session-event producer — normalization
+// of gsd_status deltas into session_event frames, per-session seq monotonicity,
+// replay buffer behavior, size/session bounds, the enable flag, and the
+// CloudRuntime wiring (producer starts after hello, stops on close).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import WebSocket from "ws";
+import { CloudRuntime } from "./cloud-runtime.js";
+import { validateConfig } from "./config.js";
+import { SessionEventProducer, type SessionEventFrame } from "./session-events.js";
+
+const PROJECT = { alias: "one", path: "/work/one", repoIdentity: "repo-one", markers: [".gsd"] };
+
+function makeLogger(warnings: Array<Record<string, unknown>> = []) {
+  return {
+    info: () => undefined,
+    warn: (_msg: string, data?: Record<string, unknown>) => {
+      if (data) warnings.push(data);
+      return undefined;
+    },
+    error: () => undefined,
+    debug: () => undefined,
+  };
+}
+
+/** MCP-shaped success result, as returned by the Executor seam. */
+function mcpResult(payload: unknown) {
+  return { content: [{ type: "text", text: JSON.stringify(payload) }] };
+}
+
+/** MCP-shaped error result. */
+function mcpError(text: string) {
+  return { isError: true, content: [{ type: "text", text }] };
+}
+
+function statusPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: "s1",
+    projectDir: "/work/one",
+    status: "running",
+    progress: { eventCount: 0, toolCalls: 0 },
+    recentEvents: [],
+    pendingBlocker: null,
+    cost: { totalCost: 0, tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+    durationMs: 1,
+    ...overrides,
+  };
+}
+
+function makeProducer(
+  t: test.TestContext,
+  opts: {
+    poll: (project: unknown, sessionId?: string) => Promise<unknown>;
+    options?: Record<string, unknown>;
+  },
+) {
+  const sent: SessionEventFrame[] = [];
+  const warnings: Array<Record<string, unknown>> = [];
+  const producer = new SessionEventProducer({
+    runtimeId: "runtime",
+    projects: () => [PROJECT],
+    poll: opts.poll as never,
+    send: (frame) => sent.push(frame),
+    logger: makeLogger(warnings) as never,
+    ...(opts.options ?? {}),
+  });
+  t.after(() => producer.stopPolling());
+  return { producer, sent, warnings };
+}
+
+const kinds = (sent: SessionEventFrame[]) => sent.map((frame) => frame.event.kind);
+
+test("first observation emits session_started with a spec-shaped frame", async (t) => {
+  const { producer, sent } = makeProducer(t, {
+    poll: async () => mcpResult(statusPayload()),
+  });
+  await producer.pollOnce();
+
+  assert.equal(sent.length, 1);
+  const frame = sent[0]!;
+  assert.equal(frame.type, "session_event");
+  assert.equal(frame.runtimeId, "runtime");
+  assert.equal(frame.projectAlias, "one");
+  assert.equal(frame.sessionId, "s1");
+  assert.equal(frame.seq, 1);
+  assert.equal(frame.event.kind, "session_started");
+  assert.deepEqual(frame.event.data, {});
+  assert.ok(!Number.isNaN(Date.parse(frame.event.at)), "event.at must be ISO-8601");
+});
+
+test("normalizes turn, assistant text, tool call, and tool result deltas", async (t) => {
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce(); // baseline: session_started only
+
+  payload = statusPayload({
+    progress: { eventCount: 4, toolCalls: 1 },
+    recentEvents: [
+      { type: "turn_start", turnIndex: 0 },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hello world" }] } },
+      { type: "tool_execution_start", toolCallId: "tc1", toolName: "Read", args: { path: "/x/file.ts" } },
+      { type: "tool_execution_end", toolCallId: "tc1", toolName: "Read", result: { content: [{ type: "text", text: "file body" }] }, isError: false },
+    ],
+  });
+  await producer.pollOnce();
+
+  assert.deepEqual(kinds(sent), ["session_started", "turn_started", "assistant_text", "tool_call", "tool_result"]);
+  assert.deepEqual(sent[1]!.event.data, { turn: 0 });
+  assert.deepEqual(sent[2]!.event.data, { text: "hello world" });
+  assert.deepEqual(sent[3]!.event.data, { name: "Read", summary: JSON.stringify({ path: "/x/file.ts" }) });
+  assert.deepEqual(sent[4]!.event.data, { name: "Read", ok: true, summary: "file body" });
+  assert.deepEqual(sent.map((frame) => frame.seq), [1, 2, 3, 4, 5]);
+});
+
+test("tool_use alias maps to tool_call; failing tool result maps ok:false", async (t) => {
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce();
+
+  payload = statusPayload({
+    progress: { eventCount: 2, toolCalls: 1 },
+    recentEvents: [
+      { type: "tool_use", name: "Bash", args: { command: "rm -rf /tmp/x" } },
+      { type: "tool_execution_end", toolName: "Bash", result: "boom", isError: true },
+    ],
+  });
+  await producer.pollOnce();
+
+  assert.deepEqual(kinds(sent), ["session_started", "tool_call", "tool_result"]);
+  assert.equal(sent[1]!.event.data.name, "Bash");
+  assert.deepEqual(sent[2]!.event.data, { name: "Bash", ok: false, summary: "boom" });
+});
+
+test("non-assistant messages and unknown raw events are ignored", async (t) => {
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce();
+
+  payload = statusPayload({
+    progress: { eventCount: 4, toolCalls: 0 },
+    recentEvents: [
+      { type: "message_end", message: { role: "user", content: "hi" } },
+      { type: "message_update", message: { role: "assistant" } },
+      { type: "cost_update", cumulativeCost: 1 },
+      { type: "agent_end", messages: [] },
+    ],
+  });
+  await producer.pollOnce();
+
+  assert.deepEqual(kinds(sent), ["session_started"]);
+});
+
+test("blocker lifecycle: pending on appearance, resolved on disappearance, idle once quiet", async (t) => {
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce();
+
+  payload = statusPayload({
+    status: "blocked",
+    pendingBlocker: { id: "b1", method: "select", message: "Proceed with deletion?" },
+  });
+  await producer.pollOnce();
+
+  payload = statusPayload({ status: "running" });
+  await producer.pollOnce();
+
+  await producer.pollOnce(); // quiet after activity → idle
+  await producer.pollOnce(); // still quiet → no second idle
+
+  assert.deepEqual(kinds(sent), [
+    "session_started",
+    "blocker_pending",
+    "blocker_resolved",
+    "session_idle",
+  ]);
+  assert.deepEqual(sent[1]!.event.data, { blockerId: "b1", question: "Proceed with deletion?" });
+  assert.deepEqual(sent[2]!.event.data, { blockerId: "b1" });
+  assert.deepEqual(sent[3]!.event.data, {});
+});
+
+test("a blocked session is not reported idle", async (t) => {
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce(); // baseline
+
+  payload = statusPayload({
+    progress: { eventCount: 1, toolCalls: 0 },
+    recentEvents: [{ type: "turn_start", turnIndex: 0 }],
+  });
+  await producer.pollOnce(); // turn_started → activity
+
+  payload = statusPayload({
+    status: "blocked",
+    progress: { eventCount: 1, toolCalls: 0 },
+    pendingBlocker: { id: "b1", method: "confirm", message: "OK?" },
+  });
+  await producer.pollOnce(); // blocker_pending
+  await producer.pollOnce(); // quiet but blocked → no idle
+
+  assert.deepEqual(kinds(sent), ["session_started", "turn_started", "blocker_pending"]);
+});
+
+test("terminal statuses map to session_ended reasons; later repeats are ignored", async (t) => {
+  for (const [status, reason] of [["completed", "completed"], ["cancelled", "cancelled"]] as const) {
+    let payload = statusPayload();
+    const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+    await producer.pollOnce();
+
+    payload = statusPayload({ status });
+    await producer.pollOnce();
+    await producer.pollOnce(); // server still returns the ended session — no flap
+
+    assert.deepEqual(kinds(sent), ["session_started", "session_ended"]);
+    assert.deepEqual(sent[1]!.event.data, { reason });
+  }
+});
+
+test("error status emits an error event before session_ended", async (t) => {
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce();
+
+  payload = statusPayload({ status: "error", errorMessage: "agent process crashed" });
+  await producer.pollOnce();
+
+  assert.deepEqual(kinds(sent), ["session_started", "error", "session_ended"]);
+  assert.deepEqual(sent[1]!.event.data, { message: "agent process crashed" });
+  assert.deepEqual(sent[2]!.event.data, { reason: "error" });
+});
+
+test("a session that vanishes from the project is ended", async (t) => {
+  let result: unknown = mcpResult(statusPayload());
+  const { producer, sent } = makeProducer(t, { poll: async () => result });
+  await producer.pollOnce();
+
+  result = mcpError("No tracked GSD sessions. Call gsd_execute first, or pass projectDir for a session tracked by this server.");
+  await producer.pollOnce();
+
+  assert.deepEqual(kinds(sent), ["session_started", "session_ended"]);
+  assert.deepEqual(sent[1]!.event.data, { reason: "completed" });
+});
+
+test("snapshot fires every 30s with status, open tool, pending blocker, and lastSeq", async (t) => {
+  let now = 1_000_000;
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, {
+    poll: async () => mcpResult(payload),
+    options: { now: () => now },
+  });
+  await producer.pollOnce();
+  assert.deepEqual(kinds(sent), ["session_started"]); // no snapshot at t0
+
+  now += 31_000;
+  payload = statusPayload({
+    status: "blocked",
+    progress: { eventCount: 1, toolCalls: 1 },
+    recentEvents: [{ type: "tool_execution_start", toolCallId: "tc1", toolName: "Edit", args: {} }],
+    pendingBlocker: { id: "b9", method: "input", message: "Which file?" },
+  });
+  await producer.pollOnce();
+
+  const snapshot = sent.at(-1)!;
+  assert.equal(snapshot.event.kind, "snapshot");
+  assert.deepEqual(snapshot.event.data, {
+    status: "blocked",
+    activeTool: "Edit",
+    pendingBlockerId: "b9",
+    lastSeq: snapshot.seq, // the snapshot's own seq is the high-water mark
+  });
+});
+
+test("seq stays monotonic across many cycles and never repeats", async (t) => {
+  let eventCount = 0;
+  const { producer, sent } = makeProducer(t, {
+    poll: async () => {
+      eventCount += 1;
+      return mcpResult(statusPayload({
+        progress: { eventCount, toolCalls: 0 },
+        recentEvents: [{ type: "turn_start", turnIndex: eventCount }],
+      }));
+    },
+  });
+  for (let cycle = 0; cycle < 25; cycle += 1) {
+    await producer.pollOnce();
+  }
+  const seqs = sent.map((frame) => frame.seq);
+  assert.deepEqual(seqs, Array.from({ length: seqs.length }, (_, index) => index + 1));
+});
+
+test("replay buffer keeps the last 500 events and replays a bounded tail on restart", async (t) => {
+  let eventCount = 0;
+  const events: Array<Record<string, unknown>> = [];
+  const { producer, sent } = makeProducer(t, {
+    poll: async () => mcpResult(statusPayload({
+      progress: { eventCount, toolCalls: 0 },
+      recentEvents: events,
+    })),
+  });
+  await producer.pollOnce(); // baseline: session_started only
+  // 505 assistant texts + session_started = 506 frames → buffer trimmed to 500.
+  for (let index = 0; index < 505; index += 1) {
+    events.push({ type: "message_end", message: { role: "assistant", content: `msg ${index}` } });
+  }
+  eventCount = 505;
+  await producer.pollOnce();
+  assert.equal(sent.length, 506);
+
+  const internals = producer as unknown as { sessions: Map<string, { replay: SessionEventFrame[] }> };
+  const buffer = [...internals.sessions.values()][0]!.replay;
+  assert.equal(buffer.length, 500);
+  assert.equal(buffer[0]!.seq, 7); // session_started + first five texts dropped
+
+  await producer.pollOnce(); // consume the idle transition so restart replay is exact
+  assert.equal(sent.length, 507);
+  producer.stopPolling();
+  sent.length = 0;
+
+  producer.start();
+  await new Promise((resolve) => setImmediate(resolve)); // flush start()'s immediate poll
+  assert.equal(sent.length, 100, "reconnect replays a bounded tail, not the whole buffer");
+  assert.deepEqual(
+    sent.map((frame) => frame.seq),
+    buffer.slice(-100).map((frame) => frame.seq),
+  );
+});
+
+test("assistant text is truncated to 2000 chars and frames stay under 8KB", async (t) => {
+  const big = "x".repeat(50_000);
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce(); // baseline
+
+  payload = statusPayload({
+    progress: { eventCount: 2, toolCalls: 1 },
+    recentEvents: [
+      { type: "message_end", message: { role: "assistant", content: big } },
+      { type: "tool_execution_start", toolCallId: "tc1", toolName: "Write", args: { content: big } },
+    ],
+  });
+  await producer.pollOnce();
+
+  const assistant = sent.find((frame) => frame.event.kind === "assistant_text")!;
+  assert.equal((assistant.event.data.text as string).length, 2_000);
+  const toolCall = sent.find((frame) => frame.event.kind === "tool_call")!;
+  assert.equal((toolCall.event.data.summary as string).length, 500);
+  for (const frame of sent) {
+    assert.ok(Buffer.byteLength(JSON.stringify(frame)) <= 8 * 1024);
+  }
+});
+
+test("pathologically oversized frames are skipped without burning a seq", async (t) => {
+  let payload = statusPayload();
+  const { producer, sent, warnings } = makeProducer(t, {
+    poll: async () => mcpResult(payload),
+    // Tiny bound: session_started/turn_started still fit, but a blocker payload
+    // whose capped options array alone exceeds it can never be truncated to fit.
+    options: { maxEventBytes: 400 },
+  });
+  await producer.pollOnce(); // session_started fits
+  assert.deepEqual(kinds(sent), ["session_started"]);
+
+  payload = statusPayload({
+    status: "blocked",
+    pendingBlocker: {
+      id: "b1",
+      method: "select",
+      message: "q".repeat(100),
+      options: Array.from({ length: 10 }, () => "o".repeat(500)),
+    },
+  });
+  await producer.pollOnce();
+
+  assert.deepEqual(kinds(sent), ["session_started"], "oversized frame is dropped");
+  assert.ok(warnings.some((data) => data.kind === "blocker_pending"));
+
+  payload = statusPayload({
+    status: "blocked", // blocker still pending server-side; not re-announced
+    progress: { eventCount: 1, toolCalls: 0 },
+    recentEvents: [{ type: "turn_start", turnIndex: 0 }],
+    pendingBlocker: {
+      id: "b1",
+      method: "select",
+      message: "q".repeat(100),
+      options: Array.from({ length: 10 }, () => "o".repeat(500)),
+    },
+  });
+  await producer.pollOnce();
+
+  assert.deepEqual(kinds(sent), ["session_started", "turn_started"]);
+  assert.deepEqual(sent.map((frame) => frame.seq), [1, 2], "no seq gap from the dropped frame");
+});
+
+test("concurrent session bound: extra sessions are skipped and logged once", async (t) => {
+  const payloads: Record<string, unknown> = {
+    s1: statusPayload({ sessionId: "s1" }),
+    s2: statusPayload({ sessionId: "s2" }),
+    s3: statusPayload({ sessionId: "s3" }),
+  };
+  const { producer, sent, warnings } = makeProducer(t, {
+    poll: async (_project, sessionId) => {
+      if (!sessionId) {
+        return mcpError(
+          "Multiple tracked GSD sessions; pass sessionId or projectDir. Tracked sessions: s1 /work/one; s2 /work/one; s3 /work/one",
+        );
+      }
+      return mcpResult(payloads[sessionId]);
+    },
+    options: { maxSessions: 2 },
+  });
+  await producer.pollOnce();
+  await producer.pollOnce();
+
+  assert.deepEqual(
+    sent.filter((frame) => frame.event.kind === "session_started").map((frame) => frame.sessionId),
+    ["s1", "s2"],
+  );
+  const boundWarnings = warnings.filter((data) => data.maxSessions === 2);
+  assert.equal(boundWarnings.length, 1, "skip is logged once, not every cycle");
+  assert.equal(boundWarnings[0]!.sessionId, "s3");
+});
+
+test("per-session poll failure surfaces an error event", async (t) => {
+  let failS2 = false;
+  const { producer, sent } = makeProducer(t, {
+    poll: async (_project, sessionId) => {
+      if (!sessionId) {
+        return mcpError("Multiple tracked GSD sessions; pass sessionId or projectDir. Tracked sessions: s1 /work/one; s2 /work/one");
+      }
+      if (sessionId === "s2" && failS2) throw new Error("MCP request timed out");
+      return mcpResult(statusPayload({ sessionId }));
+    },
+  });
+  await producer.pollOnce(); // track s1 + s2
+  failS2 = true;
+  await producer.pollOnce();
+
+  const error = sent.find((frame) => frame.event.kind === "error")!;
+  assert.equal(error.sessionId, "s2");
+  assert.match(error.event.data.message as string, /timed out/);
+});
+
+test("project-level poll failure logs and does not end tracked sessions", async (t) => {
+  let result: unknown = mcpResult(statusPayload());
+  const { producer, sent, warnings } = makeProducer(t, { poll: async () => result });
+  await producer.pollOnce();
+
+  result = mcpError("gsd MCP request 'tools/call' timed out after 1800000ms");
+  await producer.pollOnce();
+
+  assert.deepEqual(kinds(sent), ["session_started"], "no spurious session_ended on poll failure");
+  assert.ok(warnings.some((data) => typeof data.error === "string"));
+});
+
+test("disabled producer emits zero frames", async (t) => {
+  const { producer, sent } = makeProducer(t, {
+    poll: async () => mcpResult(statusPayload()),
+    options: { enabled: false },
+  });
+  producer.start();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(sent.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Config flag parsing
+// ---------------------------------------------------------------------------
+
+test("GSD_CLOUD_SESSION_EVENTS env override: 0/false disable, anything else enables", (t) => {
+  const original = process.env["GSD_CLOUD_SESSION_EVENTS"];
+  t.after(() => {
+    if (original === undefined) delete process.env["GSD_CLOUD_SESSION_EVENTS"];
+    else process.env["GSD_CLOUD_SESSION_EVENTS"] = original;
+  });
+  const base = { cloud: { gateway_url: "https://cloud.example.net" } };
+
+  process.env["GSD_CLOUD_SESSION_EVENTS"] = "0";
+  assert.equal(validateConfig(base).cloud?.session_events, false);
+  process.env["GSD_CLOUD_SESSION_EVENTS"] = "false";
+  assert.equal(validateConfig(base).cloud?.session_events, false);
+  process.env["GSD_CLOUD_SESSION_EVENTS"] = "1";
+  assert.equal(validateConfig(base).cloud?.session_events, true);
+  delete process.env["GSD_CLOUD_SESSION_EVENTS"];
+  assert.equal(validateConfig(base).cloud?.session_events, undefined, "unset means default-on");
+  assert.equal(
+    validateConfig({ cloud: { gateway_url: "https://cloud.example.net", session_events: false } }).cloud?.session_events,
+    false,
+    "yaml flag is honored when the env var is unset",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// CloudRuntime wiring
+// ---------------------------------------------------------------------------
+
+const noopLogger = { info: () => undefined, warn: () => undefined, error: () => undefined, debug: () => undefined };
+
+type FakeSocket = { readyState: number; sent: string[]; send: (t: string) => void; close: () => void };
+function fakeSocket(readyState: number = WebSocket.OPEN): FakeSocket {
+  const sent: string[] = [];
+  return { readyState, sent, send: (t: string) => sent.push(t), close: () => undefined };
+}
+
+function makeWiredRuntime(cloud: Record<string, unknown>, executor: Record<string, unknown>) {
+  const runtime = new CloudRuntime(
+    { gateway_url: "wss://cloud.example.net", device_token: "fixture", runtime_id: "runtime", ...cloud } as never,
+    executor as never,
+    noopLogger as never,
+  );
+  const internals = runtime as unknown as {
+    socket: FakeSocket | undefined;
+    handleSocketOpen: (socket: unknown) => void;
+    handleSocketClose: (socket: unknown) => void;
+    sessionEvents: SessionEventProducer | undefined;
+  };
+  return { runtime, internals };
+}
+
+const wiredExecutor = {
+  advertisedProjects: async () => [PROJECT],
+  execute: async (toolName: string) => {
+    assert.equal(toolName, "gsd_status");
+    return mcpResult(statusPayload());
+  },
+};
+
+async function flushAsync(): Promise<void> {
+  for (let index = 0; index < 5; index += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+test("producer starts after the hello and streams session_event frames", async (t) => {
+  const { runtime, internals } = makeWiredRuntime({}, wiredExecutor);
+  t.after(() => runtime.stop());
+  const socket = fakeSocket();
+  internals.socket = socket;
+
+  internals.handleSocketOpen(socket);
+  await flushAsync();
+
+  const frames = socket.sent.map((text) => JSON.parse(text) as Record<string, unknown>);
+  const helloIndex = frames.findIndex((frame) => frame.type === "hello");
+  const eventIndex = frames.findIndex((frame) => frame.type === "session_event");
+  assert.ok(helloIndex !== -1, "hello is sent");
+  assert.ok(eventIndex > helloIndex, "session_event frames follow the hello");
+  assert.equal((frames[eventIndex] as { event?: { kind?: string } }).event?.kind, "session_started");
+  assert.equal(frames[eventIndex]!.runtimeId, "runtime");
+});
+
+test("session_events: false produces zero session_event frames", async (t) => {
+  const { runtime, internals } = makeWiredRuntime({ session_events: false }, wiredExecutor);
+  t.after(() => runtime.stop());
+  const socket = fakeSocket();
+  internals.socket = socket;
+
+  internals.handleSocketOpen(socket);
+  await flushAsync();
+
+  assert.equal(internals.sessionEvents, undefined, "producer is never created");
+  assert.ok(socket.sent.every((text) => (JSON.parse(text) as { type: string }).type !== "session_event"));
+});
+
+test("socket close pauses polling; reconnect resumes without recreating the producer", async (t) => {
+  const { runtime, internals } = makeWiredRuntime({}, wiredExecutor);
+  t.after(() => runtime.stop());
+  const socket = fakeSocket();
+  internals.socket = socket;
+
+  internals.handleSocketOpen(socket);
+  await flushAsync();
+  const producer = internals.sessionEvents;
+  assert.ok(producer);
+  assert.ok((producer as unknown as { timer?: unknown }).timer !== undefined);
+
+  internals.handleSocketClose(socket);
+  assert.equal((producer as unknown as { timer?: unknown }).timer, undefined, "polling stops on close");
+
+  const reopened = fakeSocket();
+  internals.socket = reopened;
+  internals.handleSocketOpen(reopened);
+  await flushAsync();
+
+  assert.equal(internals.sessionEvents, producer, "same producer resumes across reconnects");
+  assert.ok(
+    reopened.sent.some((text) => (JSON.parse(text) as { type: string }).type === "session_event"),
+    "replayed/heartbeat frames flow on the new socket",
+  );
+});

--- a/packages/gsd-cloud/src/session-events.test.ts
+++ b/packages/gsd-cloud/src/session-events.test.ts
@@ -389,6 +389,11 @@ test("pathologically oversized frames are skipped without burning a seq", async 
 
   assert.deepEqual(kinds(sent), ["session_started", "turn_started"]);
   assert.deepEqual(sent.map((frame) => frame.seq), [1, 2], "no seq gap from the dropped frame");
+  assert.equal(
+    warnings.filter((data) => data.kind === "blocker_pending").length,
+    2,
+    "blocker_pending is retried when the first emit is dropped",
+  );
 });
 
 test("concurrent session bound: extra sessions are skipped and logged once", async (t) => {

--- a/packages/gsd-cloud/src/session-events.test.ts
+++ b/packages/gsd-cloud/src/session-events.test.ts
@@ -216,6 +216,39 @@ test("terminal statuses map to session_ended reasons; later repeats are ignored"
   }
 });
 
+test("a reused sessionId is revived after it ended, with a continuing seq", async (t) => {
+  let payload = statusPayload();
+  const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce(); // session_started (seq 1)
+
+  payload = statusPayload({ status: "completed" });
+  await producer.pollOnce(); // session_ended (seq 2)
+
+  // Same sessionId reported active again (resumed): re-announce immediately
+  // rather than waiting for the ~10 min TTL prune of the ended entry.
+  payload = statusPayload({ status: "running" });
+  await producer.pollOnce(); // session_started (seq 3)
+
+  // A subsequent event streams as a normal delta on the revived session.
+  payload = statusPayload({
+    status: "running",
+    progress: { eventCount: 1, toolCalls: 0 },
+    recentEvents: [{ type: "turn_start", turnIndex: 0 }],
+  });
+  await producer.pollOnce(); // turn_started (seq 4)
+
+  assert.deepEqual(kinds(sent), [
+    "session_started",
+    "session_ended",
+    "session_started",
+    "turn_started",
+  ]);
+  // seq keeps climbing across the revive so the relay's (device, session, seq)
+  // dedupe accepts the resumed stream instead of dropping it as a replay.
+  assert.deepEqual(sent.map((frame) => frame.seq), [1, 2, 3, 4]);
+  assert.equal(sent[2]!.sessionId, "s1");
+});
+
 test("error status emits an error event before session_ended", async (t) => {
   let payload = statusPayload();
   const { producer, sent } = makeProducer(t, { poll: async () => mcpResult(payload) });

--- a/packages/gsd-cloud/src/session-events.test.ts
+++ b/packages/gsd-cloud/src/session-events.test.ts
@@ -396,6 +396,47 @@ test("pathologically oversized frames are skipped without burning a seq", async 
   );
 });
 
+test("event window overflow reports the gap without re-emitting an overlapping tail", async (t) => {
+  // The server keeps only the last three events. Between the baseline and the
+  // next poll, five events elapsed, so two are unrecoverable (never in any
+  // future window). The visible tail must be emitted exactly once and the gap
+  // logged; a later poll that slides the window forward must not re-emit the
+  // events it already streamed (duplicates carry fresh seqs the relay's
+  // (device, session, seq) dedupe cannot catch).
+  let payload = statusPayload();
+  const { producer, sent, warnings } = makeProducer(t, { poll: async () => mcpResult(payload) });
+  await producer.pollOnce(); // baseline: eventCount 0
+
+  payload = statusPayload({
+    progress: { eventCount: 5, toolCalls: 0 },
+    recentEvents: [
+      { type: "tool_use", name: "e3" },
+      { type: "tool_use", name: "e4" },
+      { type: "tool_use", name: "e5" },
+    ],
+  });
+  await producer.pollOnce();
+
+  payload = statusPayload({
+    progress: { eventCount: 6, toolCalls: 0 },
+    recentEvents: [
+      { type: "tool_use", name: "e4" },
+      { type: "tool_use", name: "e5" },
+      { type: "tool_use", name: "e6" },
+    ],
+  });
+  await producer.pollOnce();
+
+  const toolNames = sent.filter((frame) => frame.event.kind === "tool_call").map((frame) => frame.event.data.name);
+  assert.deepEqual(toolNames, ["e3", "e4", "e5", "e6"], "no event is emitted twice across the gap");
+  const seqs = sent.map((frame) => frame.seq);
+  assert.deepEqual(seqs, [...new Set(seqs)], "seqs stay unique");
+  assert.ok(
+    warnings.some((data) => data.skipped === 2 && data.windowSize === 3),
+    "the unrecoverable gap is reported",
+  );
+});
+
 test("concurrent session bound: extra sessions are skipped and logged once", async (t) => {
   const payloads: Record<string, unknown> = {
     s1: statusPayload({ sessionId: "s1" }),
@@ -591,4 +632,22 @@ test("socket close pauses polling; reconnect resumes without recreating the prod
     reopened.sent.some((text) => (JSON.parse(text) as { type: string }).type === "session_event"),
     "replayed/heartbeat frames flow on the new socket",
   );
+});
+
+test("session events bypass the offline outbox; must-deliver frames are buffered", (t) => {
+  const { runtime, internals } = makeWiredRuntime({}, wiredExecutor);
+  t.after(() => runtime.stop());
+  // No open socket: a session_event is dropped (the producer's replay buffer
+  // redelivers it on reconnect) so it cannot evict a queued tool_result from
+  // the bounded offline outbox.
+  const priv = internals as unknown as {
+    sendSessionEvent: (frame: unknown, projectPath?: string) => void;
+    send: (message: unknown, projectPath?: string) => void;
+    outbox: Array<{ text: string }>;
+  };
+  priv.sendSessionEvent({ type: "session_event", seq: 1 });
+  priv.send({ type: "tool_result", requestId: "r1", result: {} });
+
+  const buffered = priv.outbox.map((frame) => (JSON.parse(frame.text) as { type: string }).type);
+  assert.deepEqual(buffered, ["tool_result"], "only the tool_result is queued while disconnected");
 });

--- a/packages/gsd-cloud/src/session-events.ts
+++ b/packages/gsd-cloud/src/session-events.ts
@@ -298,7 +298,16 @@ export class SessionEventProducer {
   private track(project: AdvertisedProject, payload: StatusPayload): TrackedSession | undefined {
     const key = sessionKey(project.path, payload.sessionId);
     const existing = this.sessions.get(key);
-    if (existing) return existing;
+    if (existing) {
+      // A reused sessionId with a non-terminal status is a new GSD session — drop
+      // the ended entry so live deltas are not suppressed until prune.
+      if (existing.ended && !TERMINAL_STATUSES.has(payload.status)) {
+        this.sessions.delete(key);
+        this.skippedBound.delete(key);
+      } else {
+        return existing;
+      }
+    }
 
     if (this.activeSessionCount() >= this.maxSessions) {
       if (!this.skippedBound.has(key)) {

--- a/packages/gsd-cloud/src/session-events.ts
+++ b/packages/gsd-cloud/src/session-events.ts
@@ -345,21 +345,25 @@ export class SessionEventProducer {
     let emitted = false;
 
     // --- event deltas (chronological order) ---
-    const counterReset = payload.eventCount < tracked.lastEventCount;
-    const events = deltaEvents(tracked, payload);
-    for (const raw of events) {
+    // When more events elapsed between polls than the server's recentEvents
+    // window holds, the overflow is unrecoverable: gsd_status only returns a
+    // bounded tail and cannot page further back. Emit the visible tail once and
+    // advance the cursor to the server count so later polls never re-emit an
+    // overlapping window (that would surface as duplicate events under fresh
+    // seqs, which the relay's (device, session, seq) dedupe cannot catch). Log
+    // the gap so the loss is observable instead of silent.
+    const gap = payload.eventCount - tracked.lastEventCount - payload.recentEvents.length;
+    if (gap > 0) {
+      this.deps.logger.warn("session events: event window overflow; older events skipped", {
+        sessionId: tracked.sessionId,
+        skipped: gap,
+        windowSize: payload.recentEvents.length,
+      });
+    }
+    for (const raw of deltaEvents(tracked, payload)) {
       emitted = this.mapRawEvent(tracked, raw) || emitted;
     }
-    if (counterReset) {
-      tracked.lastEventCount = payload.eventCount;
-    } else if (events.length > 0) {
-      // Advance only by events actually present in the bounded window — jumping
-      // straight to eventCount would skip gaps when delta > recentEvents.length.
-      tracked.lastEventCount += events.length;
-    } else if (payload.eventCount > tracked.lastEventCount) {
-      // Counter moved but the window is empty; acknowledge the gap.
-      tracked.lastEventCount = payload.eventCount;
-    }
+    tracked.lastEventCount = Math.max(tracked.lastEventCount, payload.eventCount);
 
     // --- blocker transitions ---
     const blocker = payload.pendingBlocker;

--- a/packages/gsd-cloud/src/session-events.ts
+++ b/packages/gsd-cloud/src/session-events.ts
@@ -398,7 +398,7 @@ export class SessionEventProducer {
     for (const raw of deltaEvents(tracked, payload)) {
       emitted = this.mapRawEvent(tracked, raw) || emitted;
     }
-    tracked.lastEventCount = Math.max(tracked.lastEventCount, payload.eventCount);
+    tracked.lastEventCount = payload.eventCount;
 
     // --- blocker transitions ---
     const blocker = payload.pendingBlocker;

--- a/packages/gsd-cloud/src/session-events.ts
+++ b/packages/gsd-cloud/src/session-events.ts
@@ -152,6 +152,7 @@ export class SessionEventProducer {
   private readonly now: () => number;
   private readonly sessions = new Map<string, TrackedSession>();
   private readonly skippedBound = new Set<string>();
+  private readonly reportedPollFailure = new Set<string>();
   private timer: ReturnType<typeof setInterval> | undefined;
   private polling = false;
   // Bumped on every stopPolling(); an in-flight poll cycle compares its
@@ -278,8 +279,10 @@ export class SessionEventProducer {
       const key = sessionKey(project.path, sessionId);
       try {
         const result = readStatusResult(await this.deps.poll(project, sessionId));
-        if (result.payload) payloads.push(result.payload);
-        else this.pollFailure(key, sessionId, result.errorText ?? "unexpected gsd_status result");
+        if (result.payload) {
+          payloads.push(result.payload);
+          this.reportedPollFailure.delete(key);
+        } else this.pollFailure(key, sessionId, result.errorText ?? "unexpected gsd_status result");
       } catch (err) {
         this.pollFailure(key, sessionId, err instanceof Error ? err.message : String(err));
       }
@@ -292,6 +295,8 @@ export class SessionEventProducer {
     if (message.startsWith("Session not found")) return; // vanish is handled by the diff
     const tracked = this.sessions.get(key);
     if (!tracked || tracked.ended) return;
+    if (this.reportedPollFailure.has(key)) return;
+    this.reportedPollFailure.add(key);
     this.emit(tracked, "error", { message: truncate(message, CAP_MESSAGE) });
   }
 
@@ -304,6 +309,7 @@ export class SessionEventProducer {
       if (existing.ended && !TERMINAL_STATUSES.has(payload.status)) {
         this.sessions.delete(key);
         this.skippedBound.delete(key);
+        this.reportedPollFailure.delete(key);
       } else {
         return existing;
       }
@@ -552,6 +558,7 @@ export class SessionEventProducer {
       if (tracked.ended && now - tracked.endedAt > this.endedTtlMs) {
         this.sessions.delete(key);
         this.skippedBound.delete(key);
+        this.reportedPollFailure.delete(key);
       }
     }
   }

--- a/packages/gsd-cloud/src/session-events.ts
+++ b/packages/gsd-cloud/src/session-events.ts
@@ -225,7 +225,7 @@ export class SessionEventProducer {
   private async pollProject(project: AdvertisedProject, generation: number): Promise<void> {
     let payloads: StatusPayload[];
     try {
-      payloads = await this.enumerate(project);
+      payloads = await this.enumerate(project, generation);
     } catch (err) {
       // Enumeration failed (MCP child down, timeout, …). Do not diff against a
       // missing view — sessions would look "vanished" and end spuriously.
@@ -263,7 +263,7 @@ export class SessionEventProducer {
    * gsd_status answers with an ambiguity hint that names each sessionId, so
    * parse it and poll each session explicitly.
    */
-  private async enumerate(project: AdvertisedProject): Promise<StatusPayload[]> {
+  private async enumerate(project: AdvertisedProject, generation: number): Promise<StatusPayload[]> {
     const first = readStatusResult(await this.deps.poll(project));
     if (first.payload) return [first.payload];
     const text = first.errorText ?? "";
@@ -276,22 +276,30 @@ export class SessionEventProducer {
     const sessionIds = parseTrackedSessionHints(text);
     const payloads: StatusPayload[] = [];
     for (const sessionId of sessionIds) {
+      // A multi-session enumeration awaits one poll per session; if polling was
+      // stopped mid-enumeration, abandon the rest so we do not keep probing or
+      // mutating state on behalf of a dead connection.
+      if (generation !== this.generation) break;
       const key = sessionKey(project.path, sessionId);
       try {
         const result = readStatusResult(await this.deps.poll(project, sessionId));
         if (result.payload) {
           payloads.push(result.payload);
           this.reportedPollFailure.delete(key);
-        } else this.pollFailure(key, sessionId, result.errorText ?? "unexpected gsd_status result");
+        } else this.pollFailure(key, sessionId, result.errorText ?? "unexpected gsd_status result", generation);
       } catch (err) {
-        this.pollFailure(key, sessionId, err instanceof Error ? err.message : String(err));
+        this.pollFailure(key, sessionId, err instanceof Error ? err.message : String(err), generation);
       }
     }
     return payloads;
   }
 
   /** Surface a per-session poll failure as an `error` event (session known). */
-  private pollFailure(key: string, sessionId: string, message: string): void {
+  private pollFailure(key: string, sessionId: string, message: string, generation: number): void {
+    // The poll for this session may have straddled a stopPolling(): if the
+    // generation moved on, do not emit (or mark) — a stale error frame must not
+    // land on the next connection with a fresh seq after reconnect.
+    if (generation !== this.generation) return;
     if (message.startsWith("Session not found")) return; // vanish is handled by the diff
     const tracked = this.sessions.get(key);
     if (!tracked || tracked.ended) return;

--- a/packages/gsd-cloud/src/session-events.ts
+++ b/packages/gsd-cloud/src/session-events.ts
@@ -345,10 +345,21 @@ export class SessionEventProducer {
     let emitted = false;
 
     // --- event deltas (chronological order) ---
-    for (const raw of deltaEvents(tracked, payload)) {
+    const counterReset = payload.eventCount < tracked.lastEventCount;
+    const events = deltaEvents(tracked, payload);
+    for (const raw of events) {
       emitted = this.mapRawEvent(tracked, raw) || emitted;
     }
-    tracked.lastEventCount = Math.max(tracked.lastEventCount, payload.eventCount);
+    if (counterReset) {
+      tracked.lastEventCount = payload.eventCount;
+    } else if (events.length > 0) {
+      // Advance only by events actually present in the bounded window — jumping
+      // straight to eventCount would skip gaps when delta > recentEvents.length.
+      tracked.lastEventCount += events.length;
+    } else if (payload.eventCount > tracked.lastEventCount) {
+      // Counter moved but the window is empty; acknowledge the gap.
+      tracked.lastEventCount = payload.eventCount;
+    }
 
     // --- blocker transitions ---
     const blocker = payload.pendingBlocker;
@@ -360,13 +371,16 @@ export class SessionEventProducer {
       if (blocker.options?.length) {
         data.options = blocker.options.slice(0, CAP_OPTIONS_MAX).map((option) => truncate(option, CAP_OPTION));
       }
-      this.emit(tracked, "blocker_pending", data);
-      tracked.pendingBlockerId = blocker.id;
-      emitted = true;
+      if (this.emit(tracked, "blocker_pending", data)) {
+        tracked.pendingBlockerId = blocker.id;
+        emitted = true;
+      }
     } else if (!blocker && tracked.pendingBlockerId !== null) {
-      this.emit(tracked, "blocker_resolved", { blockerId: tracked.pendingBlockerId });
-      tracked.pendingBlockerId = null;
-      emitted = true;
+      const blockerId = tracked.pendingBlockerId;
+      if (this.emit(tracked, "blocker_resolved", { blockerId })) {
+        tracked.pendingBlockerId = null;
+        emitted = true;
+      }
     }
 
     // --- terminal status transitions ---
@@ -453,7 +467,7 @@ export class SessionEventProducer {
     }
   }
 
-  private emit(tracked: TrackedSession, kind: SessionEventKind, data: Record<string, unknown>): void {
+  private emit(tracked: TrackedSession, kind: SessionEventKind, data: Record<string, unknown>): boolean {
     const frame: SessionEventFrame = {
       type: "session_event",
       runtimeId: this.deps.runtimeId,
@@ -469,7 +483,7 @@ export class SessionEventProducer {
         kind,
         maxEventBytes: this.maxEventBytes,
       });
-      return; // do not burn the seq — consumers never see a gap from us
+      return false; // do not burn the seq — consumers never see a gap from us
     }
     tracked.seq = sized.seq;
     tracked.replay.push(sized);
@@ -477,6 +491,7 @@ export class SessionEventProducer {
       tracked.replay.splice(0, tracked.replay.length - this.replayBufferSize);
     }
     this.deps.send(sized, tracked.projectPath);
+    return true;
   }
 
   /**
@@ -618,7 +633,8 @@ function deltaEvents(tracked: TrackedSession, payload: StatusPayload): Array<Rec
     // Counter reset (session object rebuilt) — treat the visible window as new.
     return payload.eventCount < tracked.lastEventCount ? payload.recentEvents : [];
   }
-  return payload.recentEvents.slice(-delta);
+  const startIndex = Math.max(0, payload.recentEvents.length - delta);
+  return payload.recentEvents.slice(startIndex);
 }
 
 function extractText(content: unknown): string {

--- a/packages/gsd-cloud/src/session-events.ts
+++ b/packages/gsd-cloud/src/session-events.ts
@@ -304,15 +304,29 @@ export class SessionEventProducer {
     const key = sessionKey(project.path, payload.sessionId);
     const existing = this.sessions.get(key);
     if (existing) {
-      // A reused sessionId with a non-terminal status is a new GSD session — drop
-      // the ended entry so live deltas are not suppressed until prune.
+      // An ended entry lingers briefly so a server that keeps returning a
+      // finished session does not cause a session_started/session_ended flap.
+      // But if the same sessionId is reported active again (reused/resumed after
+      // a new gsd_execute), revive the entry in place so a fresh session_started
+      // and its deltas flow immediately instead of being suppressed until the
+      // TTL prune. seq and the replay buffer are kept so the monotonic
+      // (device, session, seq) stream the relay dedupes on is not restarted.
       if (existing.ended && !TERMINAL_STATUSES.has(payload.status)) {
-        this.sessions.delete(key);
-        this.skippedBound.delete(key);
+        existing.ended = false;
+        existing.endedAt = 0;
+        existing.lastEventCount = payload.eventCount;
+        existing.lastStatus = "";
+        existing.pendingBlockerId = null;
+        existing.openTools.clear();
+        existing.turnCounter = 0;
+        existing.hadActivity = false;
+        existing.lastSnapshotAt = this.now();
+        // The revived session is a fresh lifetime: allow a new poll-failure
+        // error to be reported again for it.
         this.reportedPollFailure.delete(key);
-      } else {
-        return existing;
+        this.emitSessionStarted(existing, payload);
       }
+      return existing;
     }
 
     if (this.activeSessionCount() >= this.maxSessions) {
@@ -348,11 +362,17 @@ export class SessionEventProducer {
       endedAt: 0,
     };
     this.sessions.set(key, tracked);
+    this.emitSessionStarted(tracked, payload);
+    return tracked;
+  }
+
+  /** Emit the session_started frame, carrying title/model when the server
+   * reports them. Shared by first-observation tracking and session revival. */
+  private emitSessionStarted(tracked: TrackedSession, payload: StatusPayload): void {
     const data: Record<string, unknown> = {};
     if (payload.title) data.title = payload.title;
     if (payload.model) data.model = payload.model;
     this.emit(tracked, "session_started", data);
-    return tracked;
   }
 
   private applyPayload(tracked: TrackedSession, payload: StatusPayload): void {

--- a/packages/gsd-cloud/src/session-events.ts
+++ b/packages/gsd-cloud/src/session-events.ts
@@ -1,0 +1,660 @@
+// Project/App: Open GSD
+// File Purpose: Live session-event producer for the cloud runtime.
+//
+// While the runtime is connected to the gateway, poll `gsd_status` on each
+// advertised project (through the per-project MCP stdio client behind the
+// Executor seam) every 3 s and normalize the observed deltas into the
+// `session_event` wire frames pinned by the v1.6 live-sessions spec:
+//
+//   { type: "session_event", runtimeId, projectAlias, sessionId, seq,
+//     event: { kind, at, data } }
+//
+// Producer responsibilities:
+// - map status/event deltas onto the fixed kind vocabulary (session_started,
+//   turn_started, assistant_text, tool_call, tool_result, blocker_pending,
+//   blocker_resolved, session_idle, session_ended, error, snapshot)
+// - maintain a per-(runtimeId, sessionId) monotonic seq (starts at 1)
+// - keep a replay buffer of the last 500 events per session; on reconnect a
+//   bounded tail is re-sent and the relay dedupes via its unique
+//   (device, session, seq) constraint
+// - emit a `snapshot` every 30 s per active session so late-joining consumers
+//   can reconcile
+// - enforce bounds: 8 KB per serialized event (string fields are truncated to
+//   their per-field caps; frames still oversized after truncation are skipped
+//   and logged) and 20 concurrent tracked sessions per runtime (beyond that,
+//   skip and log)
+
+import type { Logger } from "./logger.js";
+import type { AdvertisedProject } from "./executors/executor.js";
+
+export type SessionEventKind =
+  | "session_started"
+  | "turn_started"
+  | "assistant_text"
+  | "tool_call"
+  | "tool_result"
+  | "blocker_pending"
+  | "blocker_resolved"
+  | "session_idle"
+  | "session_ended"
+  | "error"
+  | "snapshot";
+
+export interface SessionEventFrame {
+  type: "session_event";
+  runtimeId: string;
+  projectAlias: string | null;
+  sessionId: string;
+  seq: number;
+  event: {
+    kind: SessionEventKind;
+    at: string;
+    data: Record<string, unknown>;
+  };
+}
+
+/** Raw MCP tool result shape returned by the Executor seam. */
+interface McpToolResult {
+  isError?: boolean;
+  content?: Array<{ type?: string; text?: unknown }>;
+}
+
+/** Normalized subset of the `gsd_status` payload the producer diffs on. */
+interface StatusPayload {
+  sessionId: string;
+  status: string;
+  eventCount: number;
+  recentEvents: Array<Record<string, unknown>>;
+  pendingBlocker: { id: string; message: string; options?: string[] } | null;
+  title?: string;
+  model?: string;
+  errorMessage?: string;
+}
+
+/**
+ * Poll `gsd_status` for one advertised project and return the raw MCP tool
+ * result. When `sessionId` is given, the poll targets that session directly.
+ */
+export type SessionStatusPoll = (
+  project: AdvertisedProject,
+  sessionId?: string,
+) => Promise<unknown>;
+
+export interface SessionEventProducerOptions {
+  runtimeId: string;
+  /** Advertised projects to poll — re-read every cycle so re-hellos apply. */
+  projects: () => AdvertisedProject[];
+  poll: SessionStatusPoll;
+  /** Deliver a frame to the gateway (CloudRuntime's bounded outbox send). */
+  send: (frame: SessionEventFrame, projectPath?: string) => void;
+  logger: Logger;
+  /** Master switch — when false, start() is a no-op. Default true. */
+  enabled?: boolean;
+  pollIntervalMs?: number;
+  snapshotIntervalMs?: number;
+  maxSessions?: number;
+  replayBufferSize?: number;
+  /** Frames per session re-sent on (re)connect; bounded to stay well under the
+   * relay's per-connection session_event rate limit. */
+  replayOnConnectMax?: number;
+  maxEventBytes?: number;
+  /** How long an ended session stays tracked so a server that keeps returning
+   * it does not trigger a session_started/session_ended flap. */
+  endedTtlMs?: number;
+  now?: () => number;
+}
+
+interface TrackedSession {
+  sessionId: string;
+  projectAlias: string | null;
+  projectPath: string;
+  seq: number;
+  replay: SessionEventFrame[];
+  lastEventCount: number;
+  lastStatus: string;
+  pendingBlockerId: string | null;
+  openTools: Map<string, string>;
+  turnCounter: number;
+  hadActivity: boolean;
+  lastSnapshotAt: number;
+  ended: boolean;
+  endedAt: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 3_000;
+const DEFAULT_SNAPSHOT_INTERVAL_MS = 30_000;
+const DEFAULT_MAX_SESSIONS = 20;
+const DEFAULT_REPLAY_BUFFER_SIZE = 500;
+const DEFAULT_REPLAY_ON_CONNECT_MAX = 100;
+const DEFAULT_MAX_EVENT_BYTES = 8 * 1024;
+const DEFAULT_ENDED_TTL_MS = 10 * 60_000;
+
+// Per-field caps pinned by the spec ("max 8 KB per event after JSON
+// serialization, truncate strings").
+const CAP_ASSISTANT_TEXT = 2_000;
+const CAP_SUMMARY = 500;
+const CAP_MESSAGE = 500;
+const CAP_ID = 200;
+const CAP_OPTION = 200;
+const CAP_OPTIONS_MAX = 10;
+
+const TERMINAL_STATUSES = new Set(["completed", "cancelled", "error"]);
+
+export class SessionEventProducer {
+  private readonly enabled: boolean;
+  private readonly pollIntervalMs: number;
+  private readonly snapshotIntervalMs: number;
+  private readonly maxSessions: number;
+  private readonly replayBufferSize: number;
+  private readonly replayOnConnectMax: number;
+  private readonly maxEventBytes: number;
+  private readonly endedTtlMs: number;
+  private readonly now: () => number;
+  private readonly sessions = new Map<string, TrackedSession>();
+  private readonly skippedBound = new Set<string>();
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private polling = false;
+  // Bumped on every stopPolling(); an in-flight poll cycle compares its
+  // captured generation and abandons work (including logging) once stale, so a
+  // poll that outlives a shutdown cannot write into a closed logger or send
+  // on behalf of a dead connection.
+  private generation = 0;
+
+  constructor(private readonly deps: SessionEventProducerOptions) {
+    this.enabled = deps.enabled ?? true;
+    this.pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.snapshotIntervalMs = deps.snapshotIntervalMs ?? DEFAULT_SNAPSHOT_INTERVAL_MS;
+    this.maxSessions = deps.maxSessions ?? DEFAULT_MAX_SESSIONS;
+    this.replayBufferSize = deps.replayBufferSize ?? DEFAULT_REPLAY_BUFFER_SIZE;
+    this.replayOnConnectMax = deps.replayOnConnectMax ?? DEFAULT_REPLAY_ON_CONNECT_MAX;
+    this.maxEventBytes = deps.maxEventBytes ?? DEFAULT_MAX_EVENT_BYTES;
+    this.endedTtlMs = deps.endedTtlMs ?? DEFAULT_ENDED_TTL_MS;
+    this.now = deps.now ?? Date.now;
+  }
+
+  /**
+   * Begin producing. Idempotent. Re-sends a bounded tail of each active
+   * session's replay buffer first — after a reconnect the relay dedupes those
+   * frames via its unique (device, session, seq) constraint.
+   */
+  start(): void {
+    if (!this.enabled || this.timer) return;
+    this.replayBuffered();
+    this.timer = setInterval(() => void this.pollOnce(), this.pollIntervalMs);
+    void this.pollOnce();
+  }
+
+  /**
+   * Stop the polling loop. Session state (seq counters, replay buffers) is
+   * kept so a later start() resumes rather than restarts the stream.
+   */
+  stopPolling(): void {
+    this.generation += 1;
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  /** Run one poll cycle across all advertised projects. Overlap-safe and never
+   * rejects: a poll cycle runs unattended on a timer, so every failure is
+   * contained here (logged) instead of surfacing as an unhandled rejection. */
+  async pollOnce(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    const generation = this.generation;
+    try {
+      for (const project of this.deps.projects()) {
+        if (generation !== this.generation) return;
+        await this.pollProject(project, generation);
+      }
+      this.pruneEnded();
+    } catch (err) {
+      this.logIfCurrent(generation, "session events: poll cycle failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  private logIfCurrent(generation: number, message: string, data: Record<string, unknown>): void {
+    if (generation !== this.generation) return;
+    this.deps.logger.warn(message, data);
+  }
+
+  private async pollProject(project: AdvertisedProject, generation: number): Promise<void> {
+    let payloads: StatusPayload[];
+    try {
+      payloads = await this.enumerate(project);
+    } catch (err) {
+      // Enumeration failed (MCP child down, timeout, …). Do not diff against a
+      // missing view — sessions would look "vanished" and end spuriously.
+      this.logIfCurrent(generation, "session events: status poll failed", {
+        project: project.path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    if (generation !== this.generation) return;
+
+    const seen = new Set<string>();
+    for (const payload of payloads) {
+      if (!payload.sessionId) continue;
+      seen.add(payload.sessionId);
+      const tracked = this.track(project, payload);
+      if (!tracked) continue; // beyond the concurrent-session bound
+      this.applyPayload(tracked, payload);
+    }
+
+    // A session the server no longer returns (and never reported a terminal
+    // status for) is over — close the stream so consumers are not left waiting.
+    for (const tracked of this.sessions.values()) {
+      if (tracked.projectPath !== project.path || tracked.ended) continue;
+      if (!seen.has(tracked.sessionId)) {
+        this.emit(tracked, "session_ended", { reason: "completed" });
+        this.markEnded(tracked);
+      }
+    }
+  }
+
+  /**
+   * List the sessions a project's MCP server currently tracks. The common
+   * case is zero or one session per project; when the server tracks several,
+   * gsd_status answers with an ambiguity hint that names each sessionId, so
+   * parse it and poll each session explicitly.
+   */
+  private async enumerate(project: AdvertisedProject): Promise<StatusPayload[]> {
+    const first = readStatusResult(await this.deps.poll(project));
+    if (first.payload) return [first.payload];
+    const text = first.errorText ?? "";
+    if (text.startsWith("No tracked GSD sessions") || text.startsWith("Session not found")) {
+      return [];
+    }
+    if (!text.includes("Multiple tracked GSD sessions")) {
+      throw new Error(text || "unexpected gsd_status result");
+    }
+    const sessionIds = parseTrackedSessionHints(text);
+    const payloads: StatusPayload[] = [];
+    for (const sessionId of sessionIds) {
+      const key = sessionKey(project.path, sessionId);
+      try {
+        const result = readStatusResult(await this.deps.poll(project, sessionId));
+        if (result.payload) payloads.push(result.payload);
+        else this.pollFailure(key, sessionId, result.errorText ?? "unexpected gsd_status result");
+      } catch (err) {
+        this.pollFailure(key, sessionId, err instanceof Error ? err.message : String(err));
+      }
+    }
+    return payloads;
+  }
+
+  /** Surface a per-session poll failure as an `error` event (session known). */
+  private pollFailure(key: string, sessionId: string, message: string): void {
+    if (message.startsWith("Session not found")) return; // vanish is handled by the diff
+    const tracked = this.sessions.get(key);
+    if (!tracked || tracked.ended) return;
+    this.emit(tracked, "error", { message: truncate(message, CAP_MESSAGE) });
+  }
+
+  private track(project: AdvertisedProject, payload: StatusPayload): TrackedSession | undefined {
+    const key = sessionKey(project.path, payload.sessionId);
+    const existing = this.sessions.get(key);
+    if (existing) return existing;
+
+    if (this.activeSessionCount() >= this.maxSessions) {
+      if (!this.skippedBound.has(key)) {
+        this.skippedBound.add(key);
+        this.deps.logger.warn("session events: concurrent session bound reached; skipping session", {
+          sessionId: payload.sessionId,
+          project: project.path,
+          maxSessions: this.maxSessions,
+        });
+      }
+      return undefined;
+    }
+
+    const tracked: TrackedSession = {
+      sessionId: payload.sessionId,
+      projectAlias: project.alias,
+      projectPath: project.path,
+      seq: 0,
+      replay: [],
+      // Baseline: events that happened before the first observation are not
+      // replayed; the delta cursor starts at the current count. lastStatus
+      // stays empty so a session first observed in a terminal status still
+      // emits session_ended on its first applyPayload.
+      lastEventCount: payload.eventCount,
+      lastStatus: "",
+      pendingBlockerId: null,
+      openTools: new Map(),
+      turnCounter: 0,
+      hadActivity: false,
+      lastSnapshotAt: this.now(),
+      ended: false,
+      endedAt: 0,
+    };
+    this.sessions.set(key, tracked);
+    const data: Record<string, unknown> = {};
+    if (payload.title) data.title = payload.title;
+    if (payload.model) data.model = payload.model;
+    this.emit(tracked, "session_started", data);
+    return tracked;
+  }
+
+  private applyPayload(tracked: TrackedSession, payload: StatusPayload): void {
+    if (tracked.ended) return;
+    let emitted = false;
+
+    // --- event deltas (chronological order) ---
+    for (const raw of deltaEvents(tracked, payload)) {
+      emitted = this.mapRawEvent(tracked, raw) || emitted;
+    }
+    tracked.lastEventCount = Math.max(tracked.lastEventCount, payload.eventCount);
+
+    // --- blocker transitions ---
+    const blocker = payload.pendingBlocker;
+    if (blocker && tracked.pendingBlockerId !== blocker.id) {
+      const data: Record<string, unknown> = {
+        blockerId: truncate(blocker.id, CAP_ID),
+        question: truncate(blocker.message, CAP_MESSAGE),
+      };
+      if (blocker.options?.length) {
+        data.options = blocker.options.slice(0, CAP_OPTIONS_MAX).map((option) => truncate(option, CAP_OPTION));
+      }
+      this.emit(tracked, "blocker_pending", data);
+      tracked.pendingBlockerId = blocker.id;
+      emitted = true;
+    } else if (!blocker && tracked.pendingBlockerId !== null) {
+      this.emit(tracked, "blocker_resolved", { blockerId: tracked.pendingBlockerId });
+      tracked.pendingBlockerId = null;
+      emitted = true;
+    }
+
+    // --- terminal status transitions ---
+    if (payload.status !== tracked.lastStatus && TERMINAL_STATUSES.has(payload.status)) {
+      if (payload.status === "error") {
+        this.emit(tracked, "error", { message: truncate(payload.errorMessage ?? "session entered error state", CAP_MESSAGE) });
+      }
+      this.emit(tracked, "session_ended", { reason: payload.status });
+      this.markEnded(tracked);
+      return;
+    }
+    tracked.lastStatus = payload.status;
+
+    // --- idle edge: the session went quiet after activity ---
+    if (emitted) {
+      tracked.hadActivity = true;
+    } else if (tracked.hadActivity && payload.status === "running" && tracked.pendingBlockerId === null) {
+      this.emit(tracked, "session_idle", {});
+      tracked.hadActivity = false;
+    }
+
+    // --- periodic snapshot for late-joining consumers ---
+    if (this.now() - tracked.lastSnapshotAt >= this.snapshotIntervalMs) {
+      const data: Record<string, unknown> = {
+        status: payload.status,
+        // lastSeq is the seq this very frame will carry — the high-water mark.
+        lastSeq: tracked.seq + 1,
+      };
+      const activeTool = [...tracked.openTools.values()].pop();
+      if (activeTool) data.activeTool = activeTool;
+      if (tracked.pendingBlockerId !== null) data.pendingBlockerId = tracked.pendingBlockerId;
+      this.emit(tracked, "snapshot", data);
+      tracked.lastSnapshotAt = this.now();
+    }
+  }
+
+  /** Map one raw agent event onto the wire vocabulary. Returns true when a frame was emitted. */
+  private mapRawEvent(tracked: TrackedSession, raw: Record<string, unknown>): boolean {
+    const type = typeof raw.type === "string" ? raw.type : "";
+    switch (type) {
+      case "turn_start": {
+        const turn = typeof raw.turnIndex === "number" ? raw.turnIndex
+          : typeof raw.turn === "number" ? raw.turn
+          : tracked.turnCounter;
+        tracked.turnCounter = Math.max(tracked.turnCounter, turn + 1);
+        this.emit(tracked, "turn_started", { turn });
+        return true;
+      }
+      case "message_end": {
+        const message = raw.message as Record<string, unknown> | undefined;
+        if (!message || message.role !== "assistant") return false;
+        const text = extractText(message.content);
+        if (!text) return false;
+        this.emit(tracked, "assistant_text", { text: truncate(text, CAP_ASSISTANT_TEXT) });
+        return true;
+      }
+      case "tool_execution_start":
+      case "tool_use": {
+        const name = stringField(raw.toolName) ?? stringField(raw.name) ?? "unknown";
+        const toolCallId = stringField(raw.toolCallId);
+        if (toolCallId) tracked.openTools.set(toolCallId, name);
+        this.emit(tracked, "tool_call", {
+          name,
+          summary: truncate(summarize(raw.args), CAP_SUMMARY),
+        });
+        return true;
+      }
+      case "tool_execution_end": {
+        const name = stringField(raw.toolName) ?? stringField(raw.name) ?? "unknown";
+        const toolCallId = stringField(raw.toolCallId);
+        if (toolCallId) tracked.openTools.delete(toolCallId);
+        this.emit(tracked, "tool_result", {
+          name,
+          ok: raw.isError !== true,
+          summary: truncate(summarizeResult(raw.result), CAP_SUMMARY),
+        });
+        return true;
+      }
+      default:
+        // agent_start/agent_end, message_start/update, turn_end, cost_update,
+        // extension_ui_request (surfaced via pendingBlocker), … are not part of
+        // the wire vocabulary.
+        return false;
+    }
+  }
+
+  private emit(tracked: TrackedSession, kind: SessionEventKind, data: Record<string, unknown>): void {
+    const frame: SessionEventFrame = {
+      type: "session_event",
+      runtimeId: this.deps.runtimeId,
+      projectAlias: tracked.projectAlias,
+      sessionId: tracked.sessionId,
+      seq: tracked.seq + 1,
+      event: { kind, at: new Date(this.now()).toISOString(), data },
+    };
+    const sized = this.enforceFrameSize(frame);
+    if (!sized) {
+      this.deps.logger.warn("session events: dropping oversized frame", {
+        sessionId: tracked.sessionId,
+        kind,
+        maxEventBytes: this.maxEventBytes,
+      });
+      return; // do not burn the seq — consumers never see a gap from us
+    }
+    tracked.seq = sized.seq;
+    tracked.replay.push(sized);
+    if (tracked.replay.length > this.replayBufferSize) {
+      tracked.replay.splice(0, tracked.replay.length - this.replayBufferSize);
+    }
+    this.deps.send(sized, tracked.projectPath);
+  }
+
+  /**
+   * Enforce the 8 KB serialized-event bound. Per-field caps make this a safety
+   * net: progressively halve the longest string fields until the frame fits,
+   * or give up (returns undefined → caller skips and logs).
+   */
+  private enforceFrameSize(frame: SessionEventFrame): SessionEventFrame | undefined {
+    let current = frame;
+    for (let attempts = 0; attempts < 8; attempts += 1) {
+      if (Buffer.byteLength(JSON.stringify(current)) <= this.maxEventBytes) return current;
+      const data = current.event.data;
+      let longestKey: string | undefined;
+      let longest = 0;
+      for (const [key, value] of Object.entries(data)) {
+        if (typeof value === "string" && value.length > longest) {
+          longest = value.length;
+          longestKey = key;
+        }
+      }
+      if (!longestKey || longest === 0) return undefined;
+      current = {
+        ...current,
+        event: {
+          ...current.event,
+          data: { ...data, [longestKey]: (data[longestKey] as string).slice(0, Math.floor(longest / 2)) },
+        },
+      };
+    }
+    return undefined;
+  }
+
+  private markEnded(tracked: TrackedSession): void {
+    tracked.ended = true;
+    tracked.endedAt = this.now();
+    tracked.openTools.clear();
+  }
+
+  /** Ended sessions stay tracked briefly so a server that keeps returning
+   * them does not cause a session_started/session_ended flap; prune eventually
+   * so they cannot pile up against the concurrent-session bound. */
+  private pruneEnded(): void {
+    const now = this.now();
+    for (const [key, tracked] of this.sessions) {
+      if (tracked.ended && now - tracked.endedAt > this.endedTtlMs) {
+        this.sessions.delete(key);
+        this.skippedBound.delete(key);
+      }
+    }
+  }
+
+  private activeSessionCount(): number {
+    let count = 0;
+    for (const tracked of this.sessions.values()) {
+      if (!tracked.ended) count += 1;
+    }
+    return count;
+  }
+
+  private replayBuffered(): void {
+    for (const tracked of this.sessions.values()) {
+      if (tracked.ended || tracked.replay.length === 0) continue;
+      const tail = tracked.replay.slice(-this.replayOnConnectMax);
+      this.deps.logger.debug("session events: replaying buffered frames", {
+        sessionId: tracked.sessionId,
+        frames: tail.length,
+      });
+      for (const frame of tail) {
+        this.deps.send(frame, tracked.projectPath);
+      }
+    }
+  }
+}
+
+function sessionKey(projectPath: string, sessionId: string): string {
+  return `${projectPath}\n${sessionId}`;
+}
+
+/** Parse the sessionId hints from a gsd_status "Multiple tracked" error. */
+function parseTrackedSessionHints(text: string): string[] {
+  const marker = "Tracked sessions:";
+  const index = text.indexOf(marker);
+  if (index === -1) return [];
+  return text
+    .slice(index + marker.length)
+    .split(";")
+    .map((entry) => entry.trim().split(/\s+/)[0] ?? "")
+    .filter((id) => id !== "" && id !== "(no");
+}
+
+/** Unwrap the MCP tool result into a normalized payload or an error text. */
+function readStatusResult(result: unknown): { payload?: StatusPayload; errorText?: string } {
+  const toolResult = result as McpToolResult | undefined;
+  const text = (toolResult?.content ?? [])
+    .map((part) => (typeof part?.text === "string" ? part.text : ""))
+    .filter(Boolean)
+    .join("\n");
+  if (toolResult?.isError) return { errorText: text };
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { errorText: text || "unexpected gsd_status result" };
+  }
+  if (typeof raw.error === "string") return { errorText: raw.error };
+  return { payload: normalizePayload(raw) };
+}
+
+function normalizePayload(raw: Record<string, unknown>): StatusPayload {
+  const progress = raw.progress as Record<string, unknown> | undefined;
+  const blocker = raw.pendingBlocker as Record<string, unknown> | null | undefined;
+  return {
+    sessionId: typeof raw.sessionId === "string" ? raw.sessionId : "",
+    status: typeof raw.status === "string" ? raw.status : "running",
+    eventCount: typeof progress?.eventCount === "number" ? progress.eventCount : 0,
+    recentEvents: Array.isArray(raw.recentEvents)
+      ? raw.recentEvents.filter((event): event is Record<string, unknown> => event != null && typeof event === "object")
+      : [],
+    pendingBlocker: blocker && typeof blocker.id === "string"
+      ? {
+          id: blocker.id,
+          message: typeof blocker.message === "string" ? blocker.message : "",
+          ...(Array.isArray(blocker.options)
+            ? { options: blocker.options.filter((option): option is string => typeof option === "string") }
+            : {}),
+        }
+      : null,
+    ...(typeof raw.title === "string" ? { title: raw.title } : {}),
+    ...(typeof raw.model === "string" ? { model: raw.model } : {}),
+    ...(typeof raw.error === "string" ? { errorMessage: raw.error } : {}),
+    ...(typeof raw.errorMessage === "string" ? { errorMessage: raw.errorMessage } : {}),
+  };
+}
+
+/** Events that appeared since the last observation, oldest first. */
+function deltaEvents(tracked: TrackedSession, payload: StatusPayload): Array<Record<string, unknown>> {
+  const delta = payload.eventCount - tracked.lastEventCount;
+  if (delta <= 0) {
+    // Counter reset (session object rebuilt) — treat the visible window as new.
+    return payload.eventCount < tracked.lastEventCount ? payload.recentEvents : [];
+  }
+  return payload.recentEvents.slice(-delta);
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part != null && typeof part === "object" && typeof (part as { text?: unknown }).text === "string") {
+        return (part as { text: string }).text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function summarize(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function summarizeResult(result: unknown): string {
+  const text = extractText((result as { content?: unknown } | undefined)?.content);
+  return text || summarize(result);
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}

--- a/packages/gsd-cloud/src/types.ts
+++ b/packages/gsd-cloud/src/types.ts
@@ -37,6 +37,8 @@ export interface DaemonConfig {
     runtime_id?: string;
     runtime_name?: string;
     enabled?: boolean;
+    /** Live session-event streaming (default true; GSD_CLOUD_SESSION_EVENTS overrides). */
+    session_events?: boolean;
   };
   discord?: {
     token: string;

--- a/scripts/validate-gsd-cloud-tarball.mjs
+++ b/scripts/validate-gsd-cloud-tarball.mjs
@@ -215,7 +215,7 @@ try {
     helpOut = `${err.stdout ?? ''}${err.stderr ?? ''}${err.message}`;
   }
   check('bin/gsd-cloud.js --help exits 0 from the extracted tarball', helpOk, helpOk ? '' : helpOut.slice(0, 400));
-  for (const command of ['login', 'pair', 'status', 'connect', 'stop', 'disconnect']) {
+  for (const command of ['login', 'pair', 'status', 'connect', 'stop', 'disconnect', 'service']) {
     check(`--help lists \`${command}\``, helpOut.includes(command));
   }
   check('--help documents the cloud.opengsd.net default', helpOut.includes('cloud.opengsd.net'));

--- a/scripts/validate-gsd-cloud-tarball.mjs
+++ b/scripts/validate-gsd-cloud-tarball.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+// gsd-pi + scripts/validate-gsd-cloud-tarball.mjs
+//
+// Pre-publish tarball gate for @opengsd/gsd-cloud (CAGT-04 smoke). Runs
+// `npm pack` exactly as a publish would, then asserts the tarball:
+//   1. contains ONLY the intended files (package.json, README.md, bin/, dist/)
+//      — no src/, no tests, no tsconfig, no .env, no secrets-shaped filenames;
+//   2. ships a manifest with no `workspace:*` ranges and ONLY the runtime deps
+//      the self-contained package declares (ws + yaml — no @opengsd/* pins);
+//   3. carries no SaaS internals in file contents (only the intended
+//      cloud.opengsd.net default; no relay URLs, cloud infra, or key material);
+//   4. has a working bin — `node bin/gsd-cloud.js --help` from the EXTRACTED
+//      tarball exits 0 and lists every public command.
+//
+// The package must be built first (`pnpm --filter @opengsd/gsd-cloud run build`)
+// because the tarball ships dist/ and npm publish runs with --ignore-scripts.
+//
+// Usage:
+//   node scripts/validate-gsd-cloud-tarball.mjs
+//   pnpm --filter @opengsd/gsd-cloud run validate:tarball
+//
+// Exit 0 = the tarball is publishable. Exit 1 = a gate failed (each failure is
+// printed; the temp dirs are always cleaned up).
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const PKG_DIR = join(REPO_ROOT, 'packages', 'gsd-cloud');
+const EXPECTED_NAME = '@opengsd/gsd-cloud';
+// The self-contained runtime contract: gsd-cloud deliberately depends ONLY on
+// ws + yaml (no @opengsd/daemon — see docs/dev/gsd-cloud-publish-runbook.md).
+const EXPECTED_RUNTIME_DEPS = ['ws', 'yaml'];
+const INTENDED_GATEWAY = 'https://cloud.opengsd.net';
+
+const failures = [];
+const passes = [];
+function check(label, ok, detail = '') {
+  if (ok) {
+    passes.push(label);
+    console.log(`  ✓ ${label}`);
+  } else {
+    failures.push(detail ? `${label} — ${detail}` : label);
+    console.error(`  ✗ ${label}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+// Files the tarball is allowed to contain (paths are npm's "package/..." form).
+function isAllowedPath(path) {
+  if (path === 'package/package.json') return true;
+  if (path === 'package/README.md') return true;
+  if (/^package\/LICEN[SC]E(\..*)?$/i.test(path)) return true; // npm auto-includes it when present
+  if (path === 'package/bin/gsd-cloud.js') return true;
+  if (path.startsWith('package/dist/')) return true;
+  return false;
+}
+
+// Paths that must never ship, wherever they appear.
+const FORBIDDEN_PATH_PATTERNS = [
+  [/\.test\.[^/]*$/, 'compiled test file'],
+  [/__tests__/, 'test directory'],
+  [/\/src\//, 'TypeScript source (ship dist/ only)'],
+  [/tsconfig[^/]*\.json$/, 'tsconfig'],
+  [/(^|\/)\.env(\.|$)/i, 'env file'],
+  [/(^|\/)\.npmrc$/, 'npmrc (may carry auth tokens)'],
+  [/(^|\/)\.git(\/|$)/, 'git metadata'],
+  [/\.(pem|key|p12|pfx|jks|keystore)$/i, 'key material'],
+  [/id_(rsa|ed25519|ecdsa)(\.pub)?$/i, 'ssh key'],
+  [/(^|\/)(secrets?|credentials?)(\.|\/|$)/i, 'secrets-shaped filename'],
+  [/(^|\/)\.htpasswd$/i, 'htpasswd file'],
+];
+
+// Content that must never appear inside any packed file (SaaS internals + key
+// material). The intended public gateway default is asserted separately.
+const FORBIDDEN_CONTENT_PATTERNS = [
+  [/cloud-gateway\.opengsd\.net/i, 'relay hostname (learned from the server, never hardcoded)'],
+  [/amazonaws\.com/i, 'cloud infra reference'],
+  [/vercel\.(app|com)/i, 'hosting internals'],
+  [/neon\.tech/i, 'database internals'],
+  [/\.internal(\/|:|"|')/i, 'internal hostname'],
+  [/-----BEGIN [A-Z ]*PRIVATE KEY-----/, 'private key material'],
+  [/ghp_[A-Za-z0-9]{20,}/, 'GitHub token'],
+  [/sk-[A-Za-z0-9_-]{20,}/, 'API key'],
+  [/xox[baprs]-[A-Za-z0-9-]{10,}/, 'Slack token'],
+  [/npm_[A-Za-z0-9]{30,}/, 'npm token'],
+];
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (entry.isFile()) out.push(full);
+  }
+  return out;
+}
+
+// 1. The tarball ships dist/, so the package must be built up-front (npm
+//    publish runs --ignore-scripts and will NOT build it for us).
+const distDir = join(PKG_DIR, 'dist');
+let distBuilt = false;
+try {
+  distBuilt = statSync(distDir).isDirectory() && readdirSync(distDir).length > 0;
+} catch {
+  distBuilt = false;
+}
+if (!distBuilt) {
+  console.error('validate-gsd-cloud-tarball: packages/gsd-cloud/dist is missing or empty.');
+  console.error('Build first: pnpm --filter @opengsd/gsd-cloud run build');
+  process.exit(1);
+}
+
+const packDir = mkdtempSync(join(tmpdir(), 'gsd-cloud-pack-'));
+// Extract INSIDE the package dir so Node resolves the tarball's runtime deps
+// (ws, yaml) from the workspace node_modules during the bin smoke below.
+const extractDir = mkdtempSync(join(PKG_DIR, '.pack-smoke-'));
+
+try {
+  // 2. Pack exactly as publish does (files whitelist + bin handling).
+  const packJson = execFileSync('npm', ['pack', '--json', '--pack-destination', packDir], {
+    cwd: PKG_DIR,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  const packResult = JSON.parse(packJson)[0];
+  const tarballPath = join(packDir, packResult.filename);
+  // npm reports paths relative to the package root; the tar layout prefixes
+  // everything with "package/". Normalize to the tar form for all checks.
+  const entries = packResult.files.map((f) => `package/${f.path}`);
+  console.log(`Packed ${packResult.filename} (${entries.length} files).`);
+
+  // 3. File-list gates.
+  const outsideWhitelist = entries.filter((p) => !isAllowedPath(p));
+  check(
+    'tarball contains only package.json, README.md, bin/gsd-cloud.js, and dist/',
+    outsideWhitelist.length === 0,
+    `unexpected files: ${outsideWhitelist.join(', ')}`,
+  );
+  for (const [pattern, why] of FORBIDDEN_PATH_PATTERNS) {
+    const hits = entries.filter((p) => pattern.test(p));
+    check(`no ${why} in tarball`, hits.length === 0, hits.join(', '));
+  }
+  check(
+    'no compiled tests shipped',
+    !entries.some((p) => p.includes('.test.')),
+    entries.filter((p) => p.includes('.test.')).join(', '),
+  );
+  for (const required of ['package/package.json', 'package/README.md', 'package/bin/gsd-cloud.js', 'package/dist/cli.js', 'package/dist/index.js']) {
+    check(`tarball includes ${required}`, entries.includes(required));
+  }
+
+  // 4. Manifest gates (from the tarball, not the working tree).
+  execFileSync('tar', ['-xzf', tarballPath, '-C', extractDir], { stdio: ['ignore', 'ignore', 'inherit'] });
+  const extractedRoot = join(extractDir, 'package');
+  const packedPkg = JSON.parse(readFileSync(join(extractedRoot, 'package.json'), 'utf8'));
+  const workingPkg = JSON.parse(readFileSync(join(PKG_DIR, 'package.json'), 'utf8'));
+
+  check('manifest name is @opengsd/gsd-cloud', packedPkg.name === EXPECTED_NAME, packedPkg.name);
+  check(
+    'manifest version matches the working tree',
+    packedPkg.version === workingPkg.version,
+    `tarball=${packedPkg.version} tree=${workingPkg.version} (run the build again after a version bump)`,
+  );
+  check('bin entry gsd-cloud → ./bin/gsd-cloud.js', packedPkg.bin?.['gsd-cloud'] === './bin/gsd-cloud.js');
+  check('files whitelist present', Array.isArray(packedPkg.files) && packedPkg.files.length > 0);
+  check('license is MIT', packedPkg.license === 'MIT', packedPkg.license);
+  check('engines requires Node >= 22', typeof packedPkg.engines?.node === 'string' && packedPkg.engines.node.includes('22'));
+
+  const depFields = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+  const workspaceRanges = [];
+  for (const field of depFields) {
+    for (const [dep, range] of Object.entries(packedPkg[field] || {})) {
+      if (String(range).startsWith('workspace:')) workspaceRanges.push(`${field}.${dep}=${range}`);
+    }
+  }
+  check('no workspace:* ranges in the packed manifest', workspaceRanges.length === 0, workspaceRanges.join(', '));
+
+  const runtimeDeps = Object.keys(packedPkg.dependencies || {}).sort();
+  check(
+    'runtime deps are exactly ws + yaml (self-contained; no @opengsd/* pins)',
+    JSON.stringify(runtimeDeps) === JSON.stringify([...EXPECTED_RUNTIME_DEPS].sort()),
+    `got: ${runtimeDeps.join(', ')}`,
+  );
+
+  // 5. Content gates — scan every packed file for SaaS internals / key material.
+  const packedFiles = walk(extractedRoot);
+  for (const [pattern, why] of FORBIDDEN_CONTENT_PATTERNS) {
+    const hits = [];
+    for (const file of packedFiles) {
+      const text = readFileSync(file, 'utf8');
+      if (pattern.test(text)) hits.push(relative(extractedRoot, file));
+    }
+    check(`no ${why} in packed contents`, hits.length === 0, hits.join(', '));
+  }
+  const distText = packedFiles
+    .filter((f) => f.includes(`${join('package', 'dist')}`) || f.endsWith('gsd-cloud.js'))
+    .map((f) => readFileSync(f, 'utf8'))
+    .join('\n');
+  check('intended default gateway present (cloud.opengsd.net)', distText.includes(INTENDED_GATEWAY));
+
+  // 6. Bin smoke from the EXTRACTED tarball — proves what ships actually runs.
+  let helpOut = '';
+  let helpOk = false;
+  try {
+    helpOut = execFileSync('node', [join(extractedRoot, 'bin', 'gsd-cloud.js'), '--help'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 30_000,
+    });
+    helpOk = true;
+  } catch (err) {
+    helpOut = `${err.stdout ?? ''}${err.stderr ?? ''}${err.message}`;
+  }
+  check('bin/gsd-cloud.js --help exits 0 from the extracted tarball', helpOk, helpOk ? '' : helpOut.slice(0, 400));
+  for (const command of ['login', 'pair', 'status', 'connect', 'stop', 'disconnect']) {
+    check(`--help lists \`${command}\``, helpOut.includes(command));
+  }
+  check('--help documents the cloud.opengsd.net default', helpOut.includes('cloud.opengsd.net'));
+} finally {
+  rmSync(packDir, { recursive: true, force: true });
+  rmSync(extractDir, { recursive: true, force: true });
+}
+
+console.log('');
+if (failures.length > 0) {
+  console.error(`validate-gsd-cloud-tarball: FAILED — ${failures.length} gate(s) did not pass:`);
+  for (const failure of failures) console.error(`  - ${failure}`);
+  console.error('Do NOT publish until every gate passes.');
+  process.exit(1);
+}
+console.log(`validate-gsd-cloud-tarball: OK — ${passes.length} gates passed; tarball is publishable.`);


### PR DESCRIPTION
## TL;DR

**What:** Closes out the v1.5 Cloud Agent Distribution milestone for `@opengsd/gsd-cloud`: publish-readiness hardening, an automated end-to-end verification harness, OS service install (launchd/systemd), and live session-event streaming from the runtime.
**Why:** Phase 24 requires a publishable package with verified install→login→online behavior; the deferred background-service requirement and the v1.6 live-sessions pipeline both land in the same package.
**How:** Four reviewed feature branches merged into one integration branch and re-verified as a unit (147/147 package tests, 45/45 tarball gates, 11/11 E2E steps).

## What

Scope is strictly `@opengsd/gsd-cloud` plus two docs and one script:

- **Publish readiness (CAGT-03/04):** package.json metadata hygiene (`homepage`, `bugs`, `keywords`, `main`/`types`/`exports`); new `scripts/validate-gsd-cloud-tarball.mjs` pre-publish gate (45 assertions over file whitelist, exact `ws`+`yaml` runtime deps, no test/src/secret-shaped files, `--help` bin smoke from the extracted tarball); publish-day runbook `docs/dev/gsd-cloud-publish-runbook.md` (version sync, dispatch order, provenance, post-publish smoke, rollback).
- **E2E harness (CAGT-05):** `packages/gsd-cloud/e2e/` — boots the local gateway with a temp auth store, creates a pairing code, runs the real CLI `pair` + `connect`, asserts registry, MCP `tools/list`, `gsd_cloud_projects`, and a forwarded `gsd_query`, then tears down. Loopback-only, hard timeouts, env-gated out of the default test run. `docs/dev/cloud-live-e2e-runbook.md` documents the manual production verification for publish day.
- **Service install:** `service install|status|uninstall` — launchd LaunchAgent on macOS, systemd user unit on Linux; units run `connect --foreground` so `status`/`stop` see the service-managed runtime; zero new dependencies (package stays `ws`+`yaml` only).
- **Live session events:** the runtime streams `session_event` frames over the existing cloud WebSocket — 12 normalized event kinds from `gsd_status` polling, per-session monotonic `seq`, 500-event replay buffer (bounded re-send on reconnect), 8 KB per-event cap, 20 concurrent sessions max, `GSD_CLOUD_SESSION_EVENTS` / `cloud.session_events` opt-out (default on). Tool-call forwarding is unchanged.

## Why

- v1.5 Phase 24 (CAGT-03/04/05) is the open phase on the cloud roadmap; the publish itself stays operator-gated via `workflow_dispatch` — this PR makes the package verifiably ready for it.
- Background-service install was explicitly deferred out of v1.5 into a follow-up; this lands it (DMGN-04/05 shape: launchd + systemd user unit, reboot survival).
- The cloud product's live-session pipeline (relay + dashboard land separately) needs the runtime to emit session events; this is the producer half, frame-compatible with the relay contract.

## How

- The package stays self-contained (`ws`+`yaml` only) — the v1.5 doc's "thin wrapper over `@opengsd/daemon`" assumption does not match the shipped architecture; that contract is now enforced by the tarball gate so a future dependency addition fails loudly.
- Session-event producer rides the existing executor seam (one `gsd --mode mcp` client per advertised project) and the existing bounded WS outbox; the relay deduplicates on `(device, session, seq)`, so reconnect replays are safe.
- Service units use `connect --foreground` (not the hidden `_run`) so the existing PID/state files make service and non-service runs indistinguishable to `status`/`stop`; a clean stop exits 0 so neither supervisor resurrects it.
- Verification on this branch: `pnpm --filter @opengsd/gsd-cloud test` 147/147, `validate:tarball` 45/45, `test:e2e` 11/11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud WebSocket runtime behavior (session events, offline send paths) and OS service install invoking launchctl/systemctl; mistakes could affect reconnect semantics or supervisor-managed agents, but tool forwarding is unchanged and coverage is heavy.
> 
> **Overview**
> Prepares `@opengsd/gsd-cloud` for public release and expands the cloud agent with **publish gates**, **verification harnesses**, **OS service management**, and **live session streaming**.
> 
> **Publish & ops:** Adds `validate:tarball` (npm pack checks: file whitelist, `ws`+`yaml` only, no secrets/tests, `--help` smoke) plus publish-day and production live-E2E runbooks. Package metadata gains `exports`/`main`/`types` and new `test:e2e` script.
> 
> **Runtime features:** New `service install|status|uninstall` (launchd / systemd user units running `connect --foreground`). The runtime polls `gsd_status` and emits `session_event` WebSocket frames (seq, replay buffer, size/session caps) with `GSD_CLOUD_SESSION_EVENTS` / `cloud.session_events` opt-out. `pair` now persists project scan roots; `saveCloudConfig` preserves unrelated `cloud:` YAML keys.
> 
> **Testing:** Loopback E2E harness (`pair` → `connect` → MCP `gsd_query`) with an MCP stdio fixture; extensive unit tests for service install and session events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e874f0634e4b4552fc5c70af72bf2db6cf7fbf72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->