### PR TITLE
fix(issue): [Bug]: phase dir name divergence causes un-retryable stuck loop — S04-T02-SUMMARY.md written to stale 09-obg27g-… dir, verification checks 09-m009-obg27g-… dir

### DIFF
--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -26,10 +26,11 @@ import {
   resolveMilestoneFile,
   clearPathCache,
   resolveGsdRootFile,
+  phaseDirMatchesMilestoneId,
 } from "./paths.js";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { LAYOUT_SEGMENTS, milestoneIdToPhaseNum } from "./layout-policy.js";
+import { LAYOUT_SEGMENTS, milestoneIdToPhaseNum, milestoneIdUniqueSuffix } from "./layout-policy.js";
 import { basename, dirname, join, resolve } from "node:path";
 import {
   resolveExpectedArtifactPath,
@@ -162,7 +163,11 @@ function hasLegacyCheckedTaskCompletion(base: string, mid: string, sid: string, 
   return cbRe.test(planContent);
 }
 
-function findExistingSiblingPhaseArtifact(absPath: string, unitId: string): string | null {
+function findExistingSiblingPhaseArtifact(
+  absPath: string,
+  unitId: string,
+  allowTeamSuffixProjections = false,
+): string | null {
   const { milestone } = parseUnitId(unitId);
   if (!MILESTONE_ID_RE.test(milestone)) return null;
 
@@ -172,14 +177,19 @@ function findExistingSiblingPhaseArtifact(absPath: string, unitId: string): stri
 
   const expectedFile = basename(absPath);
   const expectedDirName = basename(expectedDir);
-  const phasePrefix = `${String(milestoneIdToPhaseNum(milestone)).padStart(2, "0")}-`;
+  const phaseNum = milestoneIdToPhaseNum(milestone);
+  const phasePrefix = `${String(phaseNum).padStart(2, "0")}-`;
   if (!expectedDirName.startsWith(phasePrefix)) return null;
 
   try {
     for (const entry of readdirSync(phasesDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) continue;
       if (entry.name === expectedDirName) continue;
-      if (!entry.name.startsWith(phasePrefix)) continue;
+      const matchesPrimary = phaseDirMatchesMilestoneId(entry.name, milestone, phaseNum);
+      const matchesFallback = allowTeamSuffixProjections
+        && !milestoneIdUniqueSuffix(milestone)
+        && phaseDirMatchesMilestoneId(entry.name, milestone, phaseNum, true);
+      if (!matchesPrimary && !matchesFallback) continue;
       const candidate = join(phasesDir, entry.name, expectedFile);
       if (existsSync(candidate)) return candidate;
     }
@@ -371,6 +381,7 @@ export function verifyExpectedArtifact(
   }
 
   const artifactBase = resolveArtifactVerificationBase(unitId, base);
+  const allowSiblingTeamSuffixProjections = unitType === "execute-task";
   let absPath = resolveExpectedArtifactPath(unitType, unitId, artifactBase);
   if (!absPath || !existsSync(absPath)) {
     const projectRoot = resolve(resolveWorktreeProjectRoot(artifactBase));
@@ -379,7 +390,11 @@ export function verifyExpectedArtifact(
       if (projectPath && existsSync(projectPath)) {
         absPath = projectPath;
       } else if (projectPath) {
-        const siblingPath = findExistingSiblingPhaseArtifact(projectPath, unitId);
+        const siblingPath = findExistingSiblingPhaseArtifact(
+          projectPath,
+          unitId,
+          allowSiblingTeamSuffixProjections,
+        );
         if (siblingPath) absPath = siblingPath;
       }
     }
@@ -389,7 +404,11 @@ export function verifyExpectedArtifact(
     return false;
   }
   if (!existsSync(absPath)) {
-    const siblingPath = findExistingSiblingPhaseArtifact(absPath, unitId);
+    const siblingPath = findExistingSiblingPhaseArtifact(
+      absPath,
+      unitId,
+      allowSiblingTeamSuffixProjections,
+    );
     if (siblingPath) absPath = siblingPath;
   }
   if (!existsSync(absPath)) {

--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -27,10 +27,10 @@ import {
   clearPathCache,
   resolveGsdRootFile,
 } from "./paths.js";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { LAYOUT_SEGMENTS } from "./layout-policy.js";
-import { dirname, join, resolve } from "node:path";
+import { LAYOUT_SEGMENTS, milestoneIdToPhaseNum } from "./layout-policy.js";
+import { basename, dirname, join, resolve } from "node:path";
 import {
   resolveExpectedArtifactPath,
   resolveExistingSliceResearchPath,
@@ -160,6 +160,34 @@ function hasLegacyCheckedTaskCompletion(base: string, mid: string, sid: string, 
   const planContent = readFileSync(planAbs, "utf-8");
   const cbRe = new RegExp(`^\\s*-\\s+\\[[xX]\\]\\s+\\*\\*${escapeRegExp(tid)}(?:\\*\\*)?:`, "m");
   return cbRe.test(planContent);
+}
+
+function findExistingSiblingPhaseArtifact(absPath: string, unitId: string): string | null {
+  const { milestone } = parseUnitId(unitId);
+  if (!MILESTONE_ID_RE.test(milestone)) return null;
+
+  const expectedDir = dirname(absPath);
+  const phasesDir = dirname(expectedDir);
+  if (basename(phasesDir) !== LAYOUT_SEGMENTS.level1) return null;
+
+  const expectedFile = basename(absPath);
+  const expectedDirName = basename(expectedDir);
+  const phasePrefix = `${String(milestoneIdToPhaseNum(milestone)).padStart(2, "0")}-`;
+  if (!expectedDirName.startsWith(phasePrefix)) return null;
+
+  try {
+    for (const entry of readdirSync(phasesDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === expectedDirName) continue;
+      if (!entry.name.startsWith(phasePrefix)) continue;
+      const candidate = join(phasesDir, entry.name, expectedFile);
+      if (existsSync(candidate)) return candidate;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 }
 
 /**
@@ -350,12 +378,19 @@ export function verifyExpectedArtifact(
       const projectPath = resolveExpectedArtifactPath(unitType, unitId, projectRoot);
       if (projectPath && existsSync(projectPath)) {
         absPath = projectPath;
+      } else if (projectPath) {
+        const siblingPath = findExistingSiblingPhaseArtifact(projectPath, unitId);
+        if (siblingPath) absPath = siblingPath;
       }
     }
   }
   if (!absPath) {
     logWarning("recovery", `verify-fail ${unitType} ${unitId}: resolveExpectedArtifactPath returned null (no artifact contract registered for this unit type)`);
     return false;
+  }
+  if (!existsSync(absPath)) {
+    const siblingPath = findExistingSiblingPhaseArtifact(absPath, unitId);
+    if (siblingPath) absPath = siblingPath;
   }
   if (!existsSync(absPath)) {
     const worktreeFailure = diagnoseWorktreeIntegrityFailure(artifactBase);

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -735,7 +735,7 @@ function slugLooksLikeTeamSuffixProjection(slugPart: string): boolean {
   return /^[a-z0-9]{6}(-|$)/.test(slugPart);
 }
 
-function phaseDirMatchesMilestoneId(
+export function phaseDirMatchesMilestoneId(
   dirName: string,
   milestoneId: string,
   phaseNum: number,

--- a/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
+++ b/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
@@ -244,6 +244,71 @@ test("#1500: execute-task accepts SUMMARY in stale sibling flat-phase dir", (t) 
   );
 });
 
+test("#1500: plan-milestone does NOT borrow a roadmap from a team-suffix sibling projection", (t) => {
+  closeDatabase();
+  const base = mkdtempSync(join(tmpdir(), "gsd-sibling-plan-milestone-"));
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const phasesDir = join(base, ".gsd", "phases");
+  // Canonical (non-team-suffix) phase dir the resolver picks lacks the roadmap;
+  // only a deprioritized team-suffix projection dir carries a valid roadmap.
+  const canonicalDir = join(phasesDir, "09-web-api");
+  const teamSuffixDir = join(phasesDir, "09-obg27g-web-api");
+  mkdirSync(canonicalDir, { recursive: true });
+  mkdirSync(teamSuffixDir, { recursive: true });
+
+  writeFileSync(
+    join(teamSuffixDir, "09-ROADMAP.md"),
+    [
+      "# M009: Roadmap",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: First slice** `risk:low` `depends:[]`",
+      "  > After this: a real slice exists.",
+      "",
+    ].join("\n"),
+  );
+
+  // The team-suffix fallback is reserved for execute-task recovery; plan-milestone
+  // must not pass verification off a stale team-suffix projection's roadmap.
+  assert.equal(
+    verifyExpectedArtifact("plan-milestone", "M009", base),
+    false,
+    "plan-milestone must not accept a roadmap from a team-suffix sibling projection",
+  );
+});
+
+test("#1500: execute-task does NOT borrow a summary from a different-milestone same-phase dir", (t) => {
+  closeDatabase();
+  const base = mkdtempSync(join(tmpdir(), "gsd-sibling-foreign-milestone-"));
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const phasesDir = join(base, ".gsd", "phases");
+  // M009-abc123's own phase dir has the checked plan but no summary; only a
+  // DIFFERENT milestone (M009-def456) that merely shares the padded phase number
+  // carries the summary.
+  const ownDir = join(phasesDir, "09-abc123-web-api");
+  const foreignDir = join(phasesDir, "09-def456-web-api");
+  mkdirSync(ownDir, { recursive: true });
+  mkdirSync(foreignDir, { recursive: true });
+
+  writeFileSync(join(ownDir, "09-04-PLAN.md"), "# S04 plan\n\n- [x] **T02: Build endpoint**\n");
+  writeFileSync(join(foreignDir, "S04-T02-SUMMARY.md"), "# T02 summary\n");
+
+  assert.equal(
+    verifyExpectedArtifact("execute-task", "M009-abc123/S04/T02", base),
+    false,
+    "verification must not borrow a summary from a different team-suffix milestone sharing the phase number",
+  );
+});
+
 // ── #852 follow-up: worktree→project-root artifact fallback ──────────────────
 //
 // A milestone running in a worktree may not have its CONTEXT projected into the

--- a/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
+++ b/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
@@ -220,6 +220,30 @@ test("execute-task DB lag branch — summary without checked plan still fails", 
   );
 });
 
+test("#1500: execute-task accepts SUMMARY in stale sibling flat-phase dir", (t) => {
+  closeDatabase();
+  const base = mkdtempSync(join(tmpdir(), "gsd-stale-sibling-phase-"));
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const phasesDir = join(base, ".gsd", "phases");
+  const staleDir = join(phasesDir, "09-obg27g-m009-obg27g-web-api");
+  const activeDir = join(phasesDir, "09-m009-obg27g-m009-obg27g-web-api");
+  mkdirSync(staleDir, { recursive: true });
+  mkdirSync(activeDir, { recursive: true });
+
+  writeFileSync(join(activeDir, "09-04-PLAN.md"), "# S04 plan\n\n- [x] **T02: Build endpoint**\n");
+  writeFileSync(join(staleDir, "S04-T02-SUMMARY.md"), "# T02 summary\n");
+
+  assert.equal(
+    verifyExpectedArtifact("execute-task", "M009/S04/T02", base),
+    true,
+    "verification must accept the summary from a same-number sibling phase dir",
+  );
+});
+
 // ── #852 follow-up: worktree→project-root artifact fallback ──────────────────
 //
 // A milestone running in a worktree may not have its CONTEXT projected into the


### PR DESCRIPTION
## Summary
- Added sibling phase artifact fallback for stale phase-dir summaries and verified syntax/diff checks, with runtime tests blocked by unavailable dependencies.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1500
- [#1500 [Bug]: phase dir name divergence causes un-retryable stuck loop — S04-T02-SUMMARY.md written to stale 09-obg27g-… dir, verification checks 09-m009-obg27g-… dir](https://github.com/open-gsd/gsd-pi/issues/1500)

## User
- @birdypme

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1500-bug-phase-dir-name-divergence-causes-un--1784467374`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow recovery and artifact verification paths; behavior is guarded by milestone matching and unit-type flags, with targeted regression tests, but incorrect matching could still mask or accept wrong artifacts.
> 
> **Overview**
> Fixes **stuck execute-task retry loops** when task summaries land in a **stale sibling flat-phase directory** (e.g. `09-obg27g-…`) while verification resolves the **active** phase dir (e.g. `09-m009-obg27g-…`).
> 
> `verifyExpectedArtifact` now scans other `phases/` dirs with the same padded phase number and matching milestone via `phaseDirMatchesMilestoneId`, and accepts the expected filename there when the primary path is missing. This runs after the existing worktree→project-root fallback.
> 
> **Scope is intentionally narrow:** only **`execute-task`** may use the extra **team-suffix projection** sibling match; **`plan-milestone`** and other unit types cannot “borrow” roadmaps or artifacts from deprioritized team-suffix dirs, and summaries are **not** taken from a **different milestone** that merely shares the phase number.
> 
> `phaseDirMatchesMilestoneId` is **exported** from `paths.ts` for this lookup. Regression tests cover the happy path, plan-milestone rejection, and foreign-milestone rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a0d07ab5316de738c85460d8705d1ee9309c5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->