### PR TITLE
fix(issue): Bug: session.currentMilestoneId stuck on parked milestone — dispatch mismatch guard fires permanently (shouldAdoptActiveMilestone ignores parked status)

### DIFF
--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -163,7 +163,7 @@ function shouldAdoptActiveMilestone(
   }
 
   const currentMilestone = state.registry.find((milestone) => milestone.id === currentMilestoneId);
-  return !!currentMilestone && isClosedStatus(currentMilestone.status);
+  return !!currentMilestone && (isClosedStatus(currentMilestone.status) || currentMilestone.status === "parked");
 }
 
 /**

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -55,7 +55,7 @@ import { createWorkspace, scopeMilestone } from "../workspace.js";
 import { supportsStructuredQuestions } from "../workflow-mcp.js";
 import { getRegisteredToolSnapshot, getToolBaselineSnapshot } from "../auto-model-selection.js";
 import { deriveState } from "../state.js";
-import { isClosedStatus } from "../status-guards.js";
+import { isSkippedForDispatch } from "../status-guards.js";
 import { getErrorMessage } from "../error-utils.js";
 import { logWarning } from "../workflow-logger.js";
 import { normalizeRealPath } from "../paths.js";
@@ -162,8 +162,13 @@ function shouldAdoptActiveMilestone(
     return false;
   }
 
+  // Adopt the active milestone whenever the session's current milestone is no
+  // longer a valid dispatch target (closed, parked, or deferred). Using the
+  // canonical isSkippedForDispatch predicate (not just isClosedStatus) is the
+  // root-cause fix for the permanent dispatch-mismatch guard: a parked or
+  // deferred current milestone previously left currentMilestoneId stuck.
   const currentMilestone = state.registry.find((milestone) => milestone.id === currentMilestoneId);
-  return !!currentMilestone && (isClosedStatus(currentMilestone.status) || currentMilestone.status === "parked");
+  return !!currentMilestone && isSkippedForDispatch(currentMilestone.status);
 }
 
 /**

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -163,10 +163,12 @@ function shouldAdoptActiveMilestone(
   }
 
   // Adopt the active milestone whenever the session's current milestone is no
-  // longer a valid dispatch target (closed, parked, or deferred). Using the
-  // canonical isSkippedForDispatch predicate (not just isClosedStatus) is the
-  // root-cause fix for the permanent dispatch-mismatch guard: a parked or
-  // deferred current milestone previously left currentMilestoneId stuck.
+  // longer a valid dispatch target per the canonical isSkippedForDispatch
+  // predicate (a derived milestone status is only complete/active/pending/parked,
+  // so in practice "closed or parked"), rather than the narrower isClosedStatus.
+  // This is the root-cause fix for the permanent dispatch-mismatch guard: a
+  // parked current milestone previously left currentMilestoneId stuck because
+  // isClosedStatus ignored it.
   const currentMilestone = state.registry.find((milestone) => milestone.id === currentMilestoneId);
   return !!currentMilestone && isSkippedForDispatch(currentMilestone.status);
 }

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1449,7 +1449,7 @@ test("decideOrchestratorDispatch does not replay milestone-scoped verification r
   assert.equal(sess.pendingVerificationRetryDispatch, stalePendingRetry);
 });
 
-test("decideOrchestratorDispatch adopts next active milestone after the session milestone is closed or parked", async (t) => {
+test("decideOrchestratorDispatch adopts next active milestone after the session milestone is closed, parked, or deferred", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-milestone-adopt-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));
 
@@ -1472,7 +1472,7 @@ test("decideOrchestratorDispatch adopts next active milestone after the session 
   setRegistry(new RuleRegistry([captureRule]));
 
   try {
-    for (const status of ["complete", "parked"] as const) {
+    for (const status of ["complete", "parked", "deferred"] as const) {
       openDispatchDecisionDatabase(t, [
         { id: "M001", title: "First", status },
         { id: "M002", title: "Next", status: "active" },

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1449,22 +1449,10 @@ test("decideOrchestratorDispatch does not replay milestone-scoped verification r
   assert.equal(sess.pendingVerificationRetryDispatch, stalePendingRetry);
 });
 
-test("decideOrchestratorDispatch adopts next active milestone after the session milestone is closed", async (t) => {
+test("decideOrchestratorDispatch adopts next active milestone after the session milestone is closed or parked", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-milestone-adopt-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));
-  openDispatchDecisionDatabase(t, [
-    { id: "M001", title: "First", status: "complete" },
-    { id: "M002", title: "Next", status: "active" },
-  ]);
 
-  const stateSnapshot: GSDState = {
-    ...makeState(),
-    activeMilestone: { id: "M002", title: "Next" },
-    registry: [
-      { id: "M001", title: "First", status: "complete" },
-      { id: "M002", title: "Next", status: "active" },
-    ],
-  };
   const captured: DispatchContext[] = [];
   const captureRule: UnifiedRule = {
     name: "test-milestone-adoption",
@@ -1484,21 +1472,36 @@ test("decideOrchestratorDispatch adopts next active milestone after the session 
   setRegistry(new RuleRegistry([captureRule]));
 
   try {
-    const ctx = { model: {}, modelRegistry: { getAll: () => [], getAvailable: () => [] } } as never;
-    const pi = { getActiveTools: () => [] } as never;
-    const session = {
-      basePath: base,
-      originalBasePath: base,
-      currentMilestoneId: "M001",
-    } as never;
+    for (const status of ["complete", "parked"] as const) {
+      openDispatchDecisionDatabase(t, [
+        { id: "M001", title: "First", status },
+        { id: "M002", title: "Next", status: "active" },
+      ]);
 
-    const result = await decideOrchestratorDispatch(ctx, pi, base, session, { stateSnapshot });
+      const stateSnapshot: GSDState = {
+        ...makeState(),
+        activeMilestone: { id: "M002", title: "Next" },
+        registry: [
+          { id: "M001", title: "First", status },
+          { id: "M002", title: "Next", status: "active" },
+        ],
+      };
+      const ctx = { model: {}, modelRegistry: { getAll: () => [], getAvailable: () => [] } } as never;
+      const pi = { getActiveTools: () => [] } as never;
+      const session = {
+        basePath: base,
+        originalBasePath: base,
+        currentMilestoneId: "M001",
+      } as never;
 
-    assert.ok(result);
-    if (!result || !("unitType" in result)) assert.fail(`expected dispatch decision, got ${JSON.stringify(result)}`);
-    assert.equal(result.unitId, "M002/S01/T01");
-    assert.equal((session as { currentMilestoneId: string }).currentMilestoneId, "M002");
-    assert.equal(captured[0]?.session?.currentMilestoneId, "M002");
+      const result = await decideOrchestratorDispatch(ctx, pi, base, session, { stateSnapshot });
+
+      assert.ok(result);
+      if (!result || !("unitType" in result)) assert.fail(`expected dispatch decision, got ${JSON.stringify(result)}`);
+      assert.equal(result.unitId, "M002/S01/T01");
+      assert.equal((session as { currentMilestoneId: string }).currentMilestoneId, "M002", status);
+      assert.equal(captured[captured.length - 1]?.session?.currentMilestoneId, "M002", status);
+    }
   } finally {
     resetRegistry();
   }

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1473,6 +1473,10 @@ test("decideOrchestratorDispatch adopts next active milestone after the session 
 
   try {
     for (const status of ["complete", "parked", "deferred"] as const) {
+      // Reset per iteration so the assertion below cannot pass by reading a
+      // captured context from an earlier status when this iteration failed to
+      // invoke the dispatch rule.
+      captured.length = 0;
       openDispatchDecisionDatabase(t, [
         { id: "M001", title: "First", status },
         { id: "M002", title: "Next", status: "active" },
@@ -1500,7 +1504,8 @@ test("decideOrchestratorDispatch adopts next active milestone after the session 
       if (!result || !("unitType" in result)) assert.fail(`expected dispatch decision, got ${JSON.stringify(result)}`);
       assert.equal(result.unitId, "M002/S01/T01");
       assert.equal((session as { currentMilestoneId: string }).currentMilestoneId, "M002", status);
-      assert.equal(captured[captured.length - 1]?.session?.currentMilestoneId, "M002", status);
+      assert.equal(captured.length, 1, status);
+      assert.equal(captured[0]?.session?.currentMilestoneId, "M002", status);
     }
   } finally {
     resetRegistry();

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1486,7 +1486,11 @@ test("decideOrchestratorDispatch adopts next active milestone after the session 
         ...makeState(),
         activeMilestone: { id: "M002", title: "Next" },
         registry: [
-          { id: "M001", title: "First", status },
+          // "deferred" is a valid isSkippedForDispatch input but not a status
+          // deriveState emits for a milestone, so the narrow registry union
+          // omits it; cast at this boundary to exercise the predicate's
+          // deferred branch without widening the production type.
+          { id: "M001", title: "First", status: status as GSDState["registry"][number]["status"] },
           { id: "M002", title: "Next", status: "active" },
         ],
       };


### PR DESCRIPTION
## Summary
- Fixed parked stale milestone adoption in the auto orchestrator and added focused regression coverage; whitespace verification passed, but the focused test was blocked by missing dependencies and disabled registry access.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1494
- [#1494 Bug: session.currentMilestoneId stuck on parked milestone — dispatch mismatch guard fires permanently (shouldAdoptActiveMilestone ignores parked status)](https://github.com/open-gsd/gsd-pi/issues/1494)

## User
- @TerminalSausage

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1494-bug-session-currentmilestoneid-stuck-on--1784473478`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-orchestrator dispatch/session milestone adoption logic; behavior change is narrow but affects when auto-mode advances past parked milestones.
> 
> **Overview**
> Fixes **#1494** by changing **`shouldAdoptActiveMilestone`** in the auto orchestrator so the session moves off a stale **`currentMilestoneId`** when that milestone is no longer dispatchable—not only when it is **closed**, but also when it is **parked** or **deferred**.
> 
> The adoption check now uses **`isSkippedForDispatch`** instead of **`isClosedStatus`**, aligning with the same predicate used elsewhere for “skip this milestone for dispatch.” When the active milestone differs from the session’s current one and the current milestone is skipped, dispatch updates **`session.currentMilestoneId`** (and clears the milestone lease token) before resolving the next unit, which stops the permanent **dispatch milestone mismatch** guard when work moved on but the session still pointed at a parked milestone.
> 
> Regression tests loop **`complete`**, **`parked`**, and **`deferred`** and assert adoption to **M002** with per-iteration capture reset so failures cannot mask each other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa575165a37fc281a3d450a538911924e3ca4f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->