### PR TITLE
ci: add explicit retention-days to artifact uploads

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -121,6 +121,7 @@ jobs:
           name: native-${{ matrix.platform }}
           path: artifacts/gsd_engine.node
           if-no-files-found: error
+          retention-days: 7
 
   publish:
     needs: build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -299,6 +299,7 @@ jobs:
           name: prod-release-metadata
           path: release-metadata/
           if-no-files-found: error
+          retention-days: 7
 
   prod-native-build:
     name: Build native ${{ matrix.platform }}
@@ -382,6 +383,7 @@ jobs:
           name: native-${{ matrix.platform }}
           path: artifacts/gsd_engine.node
           if-no-files-found: error
+          retention-days: 7
 
   prod-release:
     name: Production Release

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -110,6 +110,7 @@ jobs:
           path: |
             ${{ matrix.workspace }}/dependency-audit.json
             ${{ matrix.workspace }}/dependency-audit-summary.md
+          retention-days: 7
 
   cargo-audit:
     name: cargo audit
@@ -162,6 +163,7 @@ jobs:
           path: |
             native/cargo-audit.json
             native/cargo-audit-summary.md
+          retention-days: 7
 
   secret-scan-full:
     # Full-tree secret scan. The per-PR scan in ci-fast-gates.sh is diff-only, so


### PR DESCRIPTION
## TL;DR

**What:** Adds explicit `retention-days` to the five `actions/upload-artifact` steps that had none.
**Why:** Steps without `retention-days` keep artifacts for the 90-day default; org artifact storage hit ~204 GB and blocked all uploads org-wide, breaking CI on unrelated PRs.
**How:** Set 7-day retention on per-run audit results, release metadata, and native platform binaries after confirming no cross-run consumption exists.

## What

Adds one `retention-days` line to each upload step that was missing it (5 lines total, no other changes):

| File | Artifact | retention-days |
| --- | --- | --- |
| `.github/workflows/security-audit.yml` | `dependency-audit-*` | 7 |
| `.github/workflows/security-audit.yml` | `cargo-audit` | 7 |
| `.github/workflows/npm-publish.yml` | `prod-release-metadata` | 7 |
| `.github/workflows/npm-publish.yml` | `native-*` (5 platforms) | 7 |
| `.github/workflows/build-native.yml` | `native-*` (5 platforms) | 7 |

Upload steps that already set explicit retention are unchanged: `ci-build-artifacts` (1 day), `e2e-artifacts` (7 days), `e2e-artifacts-windows` (7 days), `coverage-report` (14 days).

## Why

The open-gsd org's artifact storage hit ~204 GB and GitHub blocked all artifact uploads org-wide ("Artifact storage quota has been hit"), which broke CI on unrelated PRs across repos. ~1,460 stale artifacts were mass-deleted to recover. The root cause was workflows uploading large per-run artifacts with the implicit 90-day default retention — in this repo, `native-*` platform binaries (~9 MB x 5 platforms per run) accumulated without bound. Every upload step should declare its retention explicitly so storage stays bounded by policy instead of by cleanup incidents.

## How

Retention values were chosen per artifact class:

- **Tiny audit/scan results** (`dependency-audit-*`, `cargo-audit` — JSON + markdown summaries): 7 days. Consumed only for inspection of the run that produced them.
- **Per-run release/build bundles** (`prod-release-metadata`, `native-*`): 7 days. Before choosing this, every workflow and `scripts/` was checked for cross-run consumption (`dawidd6/action-download-artifact`, `run_id`-scoped downloads, `gh run download`, REST artifact endpoints). None exists — all downloads (`actions/download-artifact` in `build-native.yml`, `npm-publish.yml`, and the `restore-ci-build-artifacts` composite action) are same-run, so a 7-day window cannot strand a consumer. Same-run downloads complete within the run regardless of retention.

All three edited files were validated with a YAML parser. Diff is limited to the five added lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no runtime or auth impact; 7 days matches existing e2e artifact policy and same-run download patterns.
> 
> **Overview**
> Sets **`retention-days: 7`** on five `actions/upload-artifact` steps that previously relied on GitHub’s **90-day default**, so org artifact storage stays bounded after quota incidents.
> 
> **`security-audit.yml`:** dependency audit JSON/summaries and cargo audit results.
> 
> **`npm-publish.yml`:** `prod-release-metadata` and per-platform **`native-*`** binaries from the production native build matrix.
> 
> **`build-native.yml`:** **`native-*`** binaries from the manual native build workflow.
> 
> Other upload steps in the repo already declare retention (e.g. 1, 7, or 14 days); this change only fills the gaps. Consumers use same-workflow `download-artifact`, so shortening retention does not affect in-run release or publish flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31fa012694040bb93740774c46119023ae1a5eb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->