### PR TITLE
fix(issue): Auto-mode leaks SDK tasks in status:running on unit abort/re-dispatch (status bar shows ever-growing 'N running', e.g. 82)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -338,6 +338,7 @@ import {
   isBlockedStopReason,
   stopNoticeDisplayReason,
 } from "./stop-notice.js";
+import { abortActiveUnitTurn } from "./auto/unit-turn-abort.js";
 
 // ── ENCAPSULATION INVARIANT ─────────────────────────────────────────────────
 // ALL mutable auto-mode state lives in the AutoSession class (auto/session.ts).
@@ -723,6 +724,8 @@ export {
 function closeOutSignalInterruptedUnit(currentBasePath: string): void {
   const currentUnit = s.currentUnit;
   if (!currentUnit) return;
+
+  abortActiveUnitTurn(s.cmdCtx);
 
   const reason = "Auto-mode process received a termination signal";
   const errorContext: ErrorContext = {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -82,6 +82,7 @@ import {
   settleDispatchFailed,
   settleDispatchIfNeeded,
 } from "./workflow-dispatch-ledger.js";
+import { abortActiveUnitTurn } from "./unit-turn-abort.js";
 import { emitOpenUnitEndForUnit } from "../crash-recovery.js";
 import { writeUnitRuntimeRecord } from "../unit-runtime.js";
 import { ensureDispatchLease, openDispatchClaim } from "./workflow-dispatch-claim.js";
@@ -436,6 +437,7 @@ async function closeOutCrashedUnit(
   err: unknown,
 ): Promise<void> {
   const summary = formatDispatchExceptionSummary({ error: err });
+  abortActiveUnitTurn(ctx);
   try {
     emitOpenUnitEndForUnit(
       s.basePath,
@@ -1713,6 +1715,7 @@ export async function autoLoop(
         break;
       }
       if (finalizeDecision.action === "retry") {
+        abortActiveUnitTurn(ctx);
         dispatchSettled = settleDispatchIfNeeded(dispatchSettled, () =>
           settleDispatchFailed(dispatchId, finalizeDecision.ledgerErrorSummary, {
             markFailed: markDispatchFailed,

--- a/src/resources/extensions/gsd/auto/unit-turn-abort.ts
+++ b/src/resources/extensions/gsd/auto/unit-turn-abort.ts
@@ -1,0 +1,18 @@
+// Project/App: gsd-pi
+// File Purpose: Best-effort auto-mode unit turn cancellation.
+
+import type { ExtensionContext } from "@gsd/pi-coding-agent";
+
+type AbortableContext = Pick<ExtensionContext, "abort"> | { abort?: unknown };
+
+export function abortActiveUnitTurn(ctx: AbortableContext | null | undefined): boolean {
+  const abort = ctx && typeof ctx.abort === "function" ? ctx.abort : null;
+  if (!abort) return false;
+
+  try {
+    abort.call(ctx);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/resources/extensions/gsd/auto/unit-turn-abort.ts
+++ b/src/resources/extensions/gsd/auto/unit-turn-abort.ts
@@ -3,11 +3,31 @@
 
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 
-type AbortableContext = Pick<ExtensionContext, "abort"> | { abort?: unknown };
+type AbortableContext =
+  | Pick<ExtensionContext, "abort" | "isIdle">
+  | { abort?: unknown; isIdle?: unknown };
 
 export function abortActiveUnitTurn(ctx: AbortableContext | null | undefined): boolean {
   const abort = ctx && typeof ctx.abort === "function" ? ctx.abort : null;
   if (!abort) return false;
+
+  // Mirror pauseAuto's `!ctx.isIdle()` guard (auto.ts): when the context can
+  // report idleness and says it is idle, there is no active turn to abort, so
+  // skip. This keeps cleanup callers (signal interrupt, crash close-out,
+  // finalize retry) from accidentally aborting a future/idle turn. `isIdle` is
+  // an opt-in, best-effort guard: when it is unavailable or throws, fall back
+  // to the unconditional best-effort abort.
+  const isIdle =
+    ctx && typeof (ctx as { isIdle?: unknown }).isIdle === "function"
+      ? (ctx as { isIdle: () => unknown }).isIdle
+      : null;
+  if (isIdle) {
+    try {
+      if (isIdle.call(ctx)) return false;
+    } catch {
+      // Idleness could not be determined; fall through to best-effort abort.
+    }
+  }
 
   try {
     abort.call(ctx);

--- a/src/resources/extensions/gsd/auto/unit-turn-abort.ts
+++ b/src/resources/extensions/gsd/auto/unit-turn-abort.ts
@@ -3,6 +3,8 @@
 
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 
+import { logWarning } from "../workflow-logger.js";
+
 type AbortableContext =
   | Pick<ExtensionContext, "abort" | "isIdle">
   | { abort?: unknown; isIdle?: unknown };
@@ -24,8 +26,14 @@ export function abortActiveUnitTurn(ctx: AbortableContext | null | undefined): b
   if (isIdle) {
     try {
       if (isIdle.call(ctx)) return false;
-    } catch {
+    } catch (err) {
       // Idleness could not be determined; fall through to best-effort abort.
+      logWarning(
+        "recovery",
+        `abortActiveUnitTurn: isIdle() check failed, falling back to abort: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
   }
 

--- a/src/resources/extensions/gsd/auto/workflow-dispatch-ledger.ts
+++ b/src/resources/extensions/gsd/auto/workflow-dispatch-ledger.ts
@@ -10,7 +10,7 @@ interface DispatchLedgerFailDeps extends DispatchLedgerWriteDeps {
 }
 
 interface DispatchLedgerCompleteDeps extends DispatchLedgerWriteDeps {
-  markCompleted: (dispatchId: number) => void;
+  markCompleted: (dispatchId: number) => boolean;
 }
 
 export function settleDispatchIfNeeded(
@@ -42,8 +42,7 @@ export function settleDispatchCompleted(
   if (dispatchId === null) return false;
 
   try {
-    deps.markCompleted(dispatchId);
-    return true;
+    return deps.markCompleted(dispatchId);
   } catch (err) {
     deps.logWriteFailure(err);
     return false;

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -287,8 +287,8 @@ export interface CompleteOpts {
 }
 
 /** Transition a dispatch into `completed`. */
-export function markCompleted(dispatchId: number, opts?: CompleteOpts): void {
-  if (!isDbAvailable()) return;
+export function markCompleted(dispatchId: number, opts?: CompleteOpts): boolean {
+  if (!isDbAvailable()) return false;
   const now = new Date().toISOString();
   const db = _getAdapter()!;
   let changes = 0;
@@ -311,7 +311,7 @@ export function markCompleted(dispatchId: number, opts?: CompleteOpts): void {
         ? (result as { changes: number }).changes
         : 0;
   });
-  if (changes < 1) return;
+  if (changes < 1) return false;
   insertAuditEvent({
     eventId: randomUUID(),
     traceId: dispatchId.toString(),
@@ -320,6 +320,7 @@ export function markCompleted(dispatchId: number, opts?: CompleteOpts): void {
     ts: now,
     payload: { dispatchId },
   });
+  return true;
 }
 
 export interface FailureOpts {
@@ -377,8 +378,8 @@ export function markFailed(dispatchId: number, opts: FailureOpts): boolean {
 }
 
 /** Transition a dispatch into `stuck`. */
-export function markStuck(dispatchId: number, reason: string): void {
-  if (!isDbAvailable()) return;
+export function markStuck(dispatchId: number, reason: string): boolean {
+  if (!isDbAvailable()) return false;
   const now = new Date().toISOString();
   const db = _getAdapter()!;
   const result = transaction(() => {
@@ -393,7 +394,7 @@ export function markStuck(dispatchId: number, reason: string): void {
     typeof (result as { changes?: unknown }).changes === "number"
       ? (result as { changes: number }).changes
       : 0;
-  if (changes <= 0) return;
+  if (changes <= 0) return false;
   insertAuditEvent({
     eventId: randomUUID(),
     traceId: dispatchId.toString(),
@@ -402,34 +403,45 @@ export function markStuck(dispatchId: number, reason: string): void {
     ts: now,
     payload: { dispatchId, reason },
   });
+  return true;
 }
 
 /** Transition a dispatch into `paused`. */
-export function markPaused(dispatchId: number): void {
-  if (!isDbAvailable()) return;
+export function markPaused(dispatchId: number): boolean {
+  if (!isDbAvailable()) return false;
   const now = new Date().toISOString();
   const db = _getAdapter()!;
-  transaction(() => {
-    db.prepare(
+  const result = transaction(() => {
+    return db.prepare(
       `UPDATE unit_dispatches
        SET status = 'paused', ended_at = :ended_at
        WHERE id = :id AND status IN ('claimed','running')`,
     ).run({ ":id": dispatchId, ":ended_at": now });
   });
+  const changes =
+    typeof (result as { changes?: unknown }).changes === "number"
+      ? (result as { changes: number }).changes
+      : 0;
+  return changes > 0;
 }
 
 /** Transition a dispatch into `canceled`. */
-export function markCanceled(dispatchId: number, reason: string): void {
-  if (!isDbAvailable()) return;
+export function markCanceled(dispatchId: number, reason: string): boolean {
+  if (!isDbAvailable()) return false;
   const now = new Date().toISOString();
   const db = _getAdapter()!;
-  transaction(() => {
-    db.prepare(
+  const result = transaction(() => {
+    return db.prepare(
       `UPDATE unit_dispatches
        SET status = 'canceled', ended_at = :ended_at, exit_reason = :reason
        WHERE id = :id AND status IN ('pending','claimed','running')`,
     ).run({ ":id": dispatchId, ":ended_at": now, ":reason": reason });
   });
+  const changes =
+    typeof (result as { changes?: unknown }).changes === "number"
+      ? (result as { changes: number }).changes
+      : 0;
+  return changes > 0;
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1637,6 +1637,32 @@ test("autoLoop exits when s.active is set to false", async (t) => {
   );
 });
 
+test("autoLoop aborts the active unit turn when dispatch crashes", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  let abortCalls = 0;
+  ctx.abort = () => {
+    abortCalls += 1;
+  };
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+
+  const deps = makeMockDeps({
+    taskExecutionBoundary: async () => {
+      throw new Error("dispatch crashed");
+    },
+    stopAuto: async () => {
+      s.active = false;
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.ok(abortCalls > 0, "crashed unit closeout must abort the active SDK turn");
+});
+
 test("autoLoop stops before dispatch when command context lacks newSession", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
@@ -170,7 +170,7 @@ test("after markCompleted, a fresh claim for the same unit succeeds", (t) => {
   assert.equal(first.ok, true);
   if (!first.ok) return;
   markRunning(first.dispatchId);
-  markCompleted(first.dispatchId);
+  assert.equal(markCompleted(first.dispatchId), true);
 
   // Re-dispatch
   const second = recordDispatchClaim({
@@ -208,11 +208,11 @@ test("markFailed records error_summary and retry metadata", (t) => {
   assert.equal(claim.ok, true);
   if (!claim.ok) return;
   markRunning(claim.dispatchId);
-  markFailed(claim.dispatchId, {
+  assert.equal(markFailed(claim.dispatchId, {
     errorSummary: "boom",
     errorCode: "test-fail",
     retryAfterMs: 5000,
-  });
+  }), true);
 
   const row = getLatestForUnit("M001/S01")!;
   assert.equal(row.status, "failed");
@@ -233,7 +233,7 @@ test("markStuck and markCanceled set their respective statuses", (t) => {
   });
   assert.equal(a.ok, true);
   if (!a.ok) return;
-  markStuck(a.dispatchId, "test-stuck");
+  assert.equal(markStuck(a.dispatchId, "test-stuck"), true);
   assert.equal(getLatestForUnit("M001/S01")!.status, "stuck");
 
   const b = recordDispatchClaim({
@@ -242,7 +242,7 @@ test("markStuck and markCanceled set their respective statuses", (t) => {
   });
   assert.equal(b.ok, true);
   if (!b.ok) return;
-  markCanceled(b.dispatchId, "user-cancel");
+  assert.equal(markCanceled(b.dispatchId, "user-cancel"), true);
   assert.equal(getLatestForUnit("M001/S01/T01")!.status, "canceled");
 });
 
@@ -292,9 +292,10 @@ test("terminal transitions do not overwrite an already terminal dispatch", (t) =
   if (!claim.ok) return;
 
   markRunning(claim.dispatchId);
-  markCompleted(claim.dispatchId, { exitReason: "done" });
-  markFailed(claim.dispatchId, { errorSummary: "late-failure" });
-  markStuck(claim.dispatchId, "late-stuck");
+  assert.equal(markCompleted(claim.dispatchId, { exitReason: "done" }), true);
+  assert.equal(markFailed(claim.dispatchId, { errorSummary: "late-failure" }), false);
+  assert.equal(markStuck(claim.dispatchId, "late-stuck"), false);
+  assert.equal(markCanceled(claim.dispatchId, "late-cancel"), false);
 
   const row = getLatestForUnit("M001/S09")!;
   assert.equal(row.status, "completed");

--- a/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
@@ -20,6 +20,7 @@ import {
   markCompleted,
   markFailed,
   markStuck,
+  markPaused,
   markCanceled,
   markLatestActiveForWorkerCanceled,
   getRecentForUnit,
@@ -295,12 +296,27 @@ test("terminal transitions do not overwrite an already terminal dispatch", (t) =
   assert.equal(markCompleted(claim.dispatchId, { exitReason: "done" }), true);
   assert.equal(markFailed(claim.dispatchId, { errorSummary: "late-failure" }), false);
   assert.equal(markStuck(claim.dispatchId, "late-stuck"), false);
+  assert.equal(markPaused(claim.dispatchId), false);
   assert.equal(markCanceled(claim.dispatchId, "late-cancel"), false);
 
   const row = getLatestForUnit("M001/S09")!;
   assert.equal(row.status, "completed");
   assert.equal(row.exit_reason, "done");
   assert.equal(row.error_summary, null);
+});
+
+test("terminal helpers report missing dispatch ids as no-op writes", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  setup(base);
+
+  const missingDispatchId = 999_999;
+
+  assert.equal(markCompleted(missingDispatchId), false);
+  assert.equal(markFailed(missingDispatchId, { errorSummary: "missing-failure" }), false);
+  assert.equal(markStuck(missingDispatchId, "missing-stuck"), false);
+  assert.equal(markPaused(missingDispatchId), false);
+  assert.equal(markCanceled(missingDispatchId, "missing-cancel"), false);
 });
 
 test("recordDispatchClaim rejects claims for missing leases before insert", (t) => {

--- a/src/resources/extensions/gsd/tests/unit-turn-abort.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-turn-abort.test.ts
@@ -1,0 +1,33 @@
+// Project/App: gsd-pi
+// File Purpose: Unit turn abort cleanup regression tests.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { abortActiveUnitTurn } from "../auto/unit-turn-abort.ts";
+
+test("abortActiveUnitTurn aborts the provided context", () => {
+  let abortCalls = 0;
+
+  const aborted = abortActiveUnitTurn({
+    abort: () => {
+      abortCalls += 1;
+    },
+  });
+
+  assert.equal(aborted, true);
+  assert.equal(abortCalls, 1);
+});
+
+test("abortActiveUnitTurn is best-effort when context lacks abort or abort throws", () => {
+  assert.equal(abortActiveUnitTurn({}), false);
+  assert.equal(abortActiveUnitTurn(null), false);
+
+  const aborted = abortActiveUnitTurn({
+    abort: () => {
+      throw new Error("abort failed");
+    },
+  });
+
+  assert.equal(aborted, false);
+});

--- a/src/resources/extensions/gsd/tests/unit-turn-abort.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-turn-abort.test.ts
@@ -31,3 +31,47 @@ test("abortActiveUnitTurn is best-effort when context lacks abort or abort throw
 
   assert.equal(aborted, false);
 });
+
+test("abortActiveUnitTurn skips abort when the context reports idle", () => {
+  let abortCalls = 0;
+
+  const aborted = abortActiveUnitTurn({
+    isIdle: () => true,
+    abort: () => {
+      abortCalls += 1;
+    },
+  });
+
+  assert.equal(aborted, false);
+  assert.equal(abortCalls, 0);
+});
+
+test("abortActiveUnitTurn aborts when the context reports non-idle", () => {
+  let abortCalls = 0;
+
+  const aborted = abortActiveUnitTurn({
+    isIdle: () => false,
+    abort: () => {
+      abortCalls += 1;
+    },
+  });
+
+  assert.equal(aborted, true);
+  assert.equal(abortCalls, 1);
+});
+
+test("abortActiveUnitTurn falls back to abort when isIdle throws", () => {
+  let abortCalls = 0;
+
+  const aborted = abortActiveUnitTurn({
+    isIdle: () => {
+      throw new Error("isIdle failed");
+    },
+    abort: () => {
+      abortCalls += 1;
+    },
+  });
+
+  assert.equal(aborted, true);
+  assert.equal(abortCalls, 1);
+});

--- a/src/resources/extensions/gsd/tests/workflow-dispatch-ledger.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-dispatch-ledger.test.ts
@@ -77,12 +77,24 @@ test("settleDispatchCompleted writes completion and reports settled state", () =
   const calls: number[] = [];
 
   const settled = settleDispatchCompleted(42, {
-    markCompleted: dispatchId => calls.push(dispatchId),
+    markCompleted: dispatchId => {
+      calls.push(dispatchId);
+      return true;
+    },
     logWriteFailure: () => assert.fail("logWriteFailure should not be called"),
   });
 
   assert.equal(settled, true);
   assert.deepEqual(calls, [42]);
+});
+
+test("settleDispatchCompleted reports a no-op completion write as unsettled", () => {
+  const settled = settleDispatchCompleted(42, {
+    markCompleted: () => false,
+    logWriteFailure: () => assert.fail("logWriteFailure should not be called"),
+  });
+
+  assert.equal(settled, false);
 });
 
 test("settleDispatchCompleted skips null dispatch ids", () => {


### PR DESCRIPTION
## Summary
- Fixed auto-mode unit-boundary abort cleanup and truthful dispatch settlement reporting with focused tests passing where dependencies were available.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1485
- [#1485 Auto-mode leaks SDK tasks in status:running on unit abort/re-dispatch (status bar shows ever-growing 'N running', e.g. 82)](https://github.com/open-gsd/gsd-pi/issues/1485)

## User
- @DragonSigh

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1485-auto-mode-leaks-sdk-tasks-in-status-runn-1784553939`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-loop orchestration, signal handling, and dispatch terminalization semantics; behavior is well-tested but affects coordination and status reporting paths.
> 
> **Overview**
> Fixes auto-mode **SDK task leaks** (growing `status:running` counts) by cancelling the active coding-agent turn whenever a unit is torn down or re-dispatched without a normal turn completion.
> 
> Adds **`abortActiveUnitTurn`**, a shared helper that calls `ctx.abort()` with the same **`isIdle()` guard** as `pauseAuto`, so signal/crash/finalize-retry cleanup does not abort an idle or future turn. It is invoked on **SIGTERM unit close-out**, **dispatch crash close-out**, and **finalize retry** before `retryActiveUnit`.
> 
> **Dispatch ledger settlement** is tightened: terminal `mark*` helpers (`markCompleted`, `markStuck`, `markPaused`, `markCanceled`) now return whether the UPDATE actually changed a row, and **`settleDispatchCompleted`** treats a no-op write as unsettled instead of always reporting success.
> 
> Regression tests cover abort behavior, crash close-out, missing dispatch IDs, and ledger no-op completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3292626b71ab315476887dc841dc77abe9a34e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->