### PR TITLE
feat(gsd-cloud): implement cloud terminal channel in the daemon runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "ignore": "^7.0.5",
     "marked": "^15.0.12",
     "minimatch": "^10.2.3",
+    "node-pty": "^1.1.0",
     "openai": "^6.26.0",
     "partial-json": "^0.1.7",
     "picomatch": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "ignore": "^7.0.5",
     "marked": "^15.0.12",
     "minimatch": "^10.2.3",
-    "node-pty": "^1.1.0",
     "openai": "^6.26.0",
     "partial-json": "^0.1.7",
     "picomatch": "^4.0.3",
@@ -222,7 +221,8 @@
     "@opengsd/engine-linux-x64-gnu": "1.11.0",
     "@opengsd/engine-win32-x64-msvc": "1.11.0",
     "fsevents": "~2.3.3",
-    "koffi": "^2.9.0"
+    "koffi": "^2.9.0",
+    "node-pty": "^1.1.0"
   },
   "overrides": {
     "uuid": "^11.1.1",

--- a/packages/gsd-cloud/README.md
+++ b/packages/gsd-cloud/README.md
@@ -3,12 +3,18 @@
 Connect a local GSD runtime to [GSD Cloud](https://cloud.opengsd.net) so you can
 monitor and control your GSD projects from any browser.
 
-This is a **self-contained** agent. It depends only on `ws` and `yaml` — no
-`@opengsd/daemon`, no `@opengsd/mcp-server`, no `@opengsd/gsd-pi`. It runs the
-RFC 8628 device-flow login, opens a persistent WebSocket to the cloud gateway,
-and forwards each requested GSD workflow tool to your locally-installed `gsd`
-CLI (via `gsd --mode mcp`). The gateway default of `https://cloud.opengsd.net`
-is injected for `login`/`pair` so you never have to type `--gateway`.
+This is a **self-contained** agent. Its required runtime dependencies are only
+`ws` and `yaml` — no `@opengsd/daemon`, no `@opengsd/mcp-server`, no
+`@opengsd/gsd-pi`. It runs the RFC 8628 device-flow login, opens a persistent
+WebSocket to the cloud gateway, and forwards each requested GSD workflow tool to
+your locally-installed `gsd` CLI (via `gsd --mode mcp`). The gateway default of
+`https://cloud.opengsd.net` is injected for `login`/`pair` so you never have to
+type `--gateway`.
+
+`node-pty` is an **optional** native dependency used only for browser terminal
+sessions. It is loaded dynamically at runtime; if it is not installed (for
+example when its prebuilt binary is unavailable for your platform), the core CLI
+still works and only the cloud terminal feature is unavailable.
 
 Requires the `gsd` CLI (from `@opengsd/gsd-pi`) to be installed and on your
 `PATH` (or set `GSD_CLI_PATH`).

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -41,6 +41,7 @@
     "test:e2e": "pnpm --filter @opengsd/cloud-mcp-gateway... run build && pnpm run build && node e2e/run-e2e.mjs"
   },
   "dependencies": {
+    "node-pty": "^1.1.0",
     "ws": "^8.21.0",
     "yaml": "^2.8.2"
   },

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -41,9 +41,11 @@
     "test:e2e": "pnpm --filter @opengsd/cloud-mcp-gateway... run build && pnpm run build && node e2e/run-e2e.mjs"
   },
   "dependencies": {
-    "node-pty": "^1.1.0",
     "ws": "^8.21.0",
     "yaml": "^2.8.2"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.0",

--- a/packages/gsd-cloud/src/binary-frame.ts
+++ b/packages/gsd-cloud/src/binary-frame.ts
@@ -16,7 +16,7 @@ export const HEADER_LENGTH_SIZE = 1;
  * @throws If channel name exceeds 255 bytes when UTF-8 encoded.
  */
 export function encodeBinaryFrame(channel: string, data: Buffer): Buffer {
-  const channelBuf = Buffer.from(channel, 'utf8');
+  const channelBuf = Buffer.from(channel, "utf8");
   if (channelBuf.length > 255) {
     throw new Error(`Channel name exceeds 255 bytes: ${channelBuf.length}`);
   }
@@ -42,7 +42,7 @@ export function decodeBinaryFrame(frame: Buffer): { channel: string; data: Buffe
       `Binary frame truncated: channel length ${headerLen} but only ${frame.length - HEADER_LENGTH_SIZE} channel byte(s) available`,
     );
   }
-  const channel = frame.subarray(HEADER_LENGTH_SIZE, HEADER_LENGTH_SIZE + headerLen).toString('utf8');
+  const channel = frame.subarray(HEADER_LENGTH_SIZE, HEADER_LENGTH_SIZE + headerLen).toString("utf8");
   const data = frame.subarray(HEADER_LENGTH_SIZE + headerLen);
   return { channel, data };
 }

--- a/packages/gsd-cloud/src/binary-frame.ts
+++ b/packages/gsd-cloud/src/binary-frame.ts
@@ -33,7 +33,15 @@ export function encodeBinaryFrame(channel: string, data: Buffer): Buffer {
  * @returns The channel name and remaining payload data.
  */
 export function decodeBinaryFrame(frame: Buffer): { channel: string; data: Buffer } {
+  if (frame.length < HEADER_LENGTH_SIZE) {
+    throw new Error(`Binary frame too short: ${frame.length} byte(s), need at least ${HEADER_LENGTH_SIZE}`);
+  }
   const headerLen = frame[0]!;
+  if (frame.length < HEADER_LENGTH_SIZE + headerLen) {
+    throw new Error(
+      `Binary frame truncated: channel length ${headerLen} but only ${frame.length - HEADER_LENGTH_SIZE} channel byte(s) available`,
+    );
+  }
   const channel = frame.subarray(HEADER_LENGTH_SIZE, HEADER_LENGTH_SIZE + headerLen).toString('utf8');
   const data = frame.subarray(HEADER_LENGTH_SIZE + headerLen);
   return { channel, data };

--- a/packages/gsd-cloud/src/binary-frame.ts
+++ b/packages/gsd-cloud/src/binary-frame.ts
@@ -1,0 +1,40 @@
+// Project/App: gsd-pi
+// File Purpose: Binary frame encode/decode for terminal I/O over WebSocket relay (D-04-09).
+// Frame layout: [1 byte: channel length][N bytes: channel UTF-8][remaining: payload]
+
+/**
+ * Size of the header-length prefix in bytes.
+ * The first byte of every binary frame stores the length of the channel name.
+ */
+export const HEADER_LENGTH_SIZE = 1;
+
+/**
+ * Encodes a binary frame with a channel header for relay multiplexing.
+ *
+ * Layout: [1 byte: channel-name length][N bytes: channel UTF-8][remaining: payload]
+ *
+ * @throws If channel name exceeds 255 bytes when UTF-8 encoded.
+ */
+export function encodeBinaryFrame(channel: string, data: Buffer): Buffer {
+  const channelBuf = Buffer.from(channel, 'utf8');
+  if (channelBuf.length > 255) {
+    throw new Error(`Channel name exceeds 255 bytes: ${channelBuf.length}`);
+  }
+  const frame = Buffer.allocUnsafe(HEADER_LENGTH_SIZE + channelBuf.length + data.length);
+  frame[0] = channelBuf.length;
+  channelBuf.copy(frame, HEADER_LENGTH_SIZE);
+  data.copy(frame, HEADER_LENGTH_SIZE + channelBuf.length);
+  return frame;
+}
+
+/**
+ * Decodes a binary frame, extracting the channel name and payload.
+ *
+ * @returns The channel name and remaining payload data.
+ */
+export function decodeBinaryFrame(frame: Buffer): { channel: string; data: Buffer } {
+  const headerLen = frame[0]!;
+  const channel = frame.subarray(HEADER_LENGTH_SIZE, HEADER_LENGTH_SIZE + headerLen).toString('utf8');
+  const data = frame.subarray(HEADER_LENGTH_SIZE + headerLen);
+  return { channel, data };
+}

--- a/packages/gsd-cloud/src/cloud-runtime.test.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.test.ts
@@ -449,3 +449,28 @@ test("binary terminal frames reach the PTY and attached replays buffered output"
     ["replay-1", "replay-2"],
   );
 });
+
+test("attached replay follows the active PTY session, not the sessionId the browser claims", async (t) => {
+  const runtime = makeRuntime();
+  const internals = runtime as unknown as RuntimeInternals;
+  t.after(() => runtime.stop());
+  const socket = fakeSocket();
+  internals.socket = socket;
+
+  internals.terminalManager = {
+    write: () => undefined,
+    onBrowserReconnect: () => ({ replayData: [Buffer.from("replay")] }),
+    getActiveSessionId: () => "active",
+    dispose: () => undefined,
+  };
+
+  // The attach names a stale/incorrect session, but a different PTY is live.
+  // Replay must be addressed to the active session's channel so output is not
+  // mis-multiplexed onto a channel chosen by untrusted input.
+  await internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.attached", sessionId: "stale" }));
+  const sentBuffers = socket.sent as unknown as Buffer[];
+  assert.deepEqual(
+    sentBuffers.map((f) => decodeBinaryFrame(f).channel),
+    ["terminal:active"],
+  );
+});

--- a/packages/gsd-cloud/src/cloud-runtime.test.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.test.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import WebSocket from "ws";
 import { CloudRuntime } from "./cloud-runtime.js";
 import { RuntimeTelemetryStore } from "./runtime-telemetry.js";
+import { decodeBinaryFrame, encodeBinaryFrame } from "./binary-frame.js";
 
 const noopLogger = { info: () => undefined, warn: () => undefined, error: () => undefined, debug: () => undefined };
 const noopExecutor = { execute: async () => ({}), advertisedProjects: async () => [] };
@@ -33,9 +34,11 @@ type RuntimeInternals = {
   firstConnectDeferred: PromiseWithResolvers<void> | undefined;
   initialConnectAttempts: number;
   reconnect: ReturnType<typeof setTimeout> | undefined;
+  terminalManager: unknown;
   handleSocketOpen: (socket: unknown) => void;
   handleSocketClose: (socket: unknown) => void;
   handleSocketMessage: (socket: unknown, text: string) => Promise<void>;
+  handleBinaryInput: (socket: unknown, frame: Buffer) => void;
   connect: () => void;
 };
 
@@ -378,4 +381,71 @@ test("malformed gateway failures flush runtime telemetry before rejecting", asyn
     assert.equal(status.state, "error");
     assert.match(status.last_error ?? "", /absolute HTTP\(S\) URL/);
 
+});
+
+
+test("terminal control messages route to the terminal manager", async (t) => {
+  const runtime = makeRuntime();
+  const internals = runtime as unknown as RuntimeInternals;
+  t.after(() => runtime.stop());
+  const socket = fakeSocket();
+  internals.socket = socket;
+
+  const calls: unknown[][] = [];
+  internals.terminalManager = {
+    startSession: (...a: unknown[]) => calls.push(["startSession", ...a]),
+    resize: (...a: unknown[]) => calls.push(["resize", ...a]),
+    stopSession: () => calls.push(["stopSession"]),
+    onBrowserDisconnect: () => calls.push(["onBrowserDisconnect"]),
+    onBrowserReconnect: () => null,
+    getActiveSessionId: () => null,
+    dispose: () => undefined,
+  };
+
+  await internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.start", sessionId: "s1", cols: 100, rows: 40 }));
+  await internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.resize", cols: 120, rows: 50 }));
+  await internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.detached" }));
+  await internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.stop" }));
+
+  assert.deepEqual(calls, [
+    ["startSession", "s1", 100, 40],
+    ["resize", 120, 50],
+    ["onBrowserDisconnect"],
+    ["stopSession"],
+  ]);
+  // Terminal messages must never fall through to the tool_call path.
+  assert.equal(socket.sent.length, 0);
+});
+
+test("binary terminal frames reach the PTY and attached replays buffered output", async (t) => {
+  const runtime = makeRuntime();
+  const internals = runtime as unknown as RuntimeInternals;
+  t.after(() => runtime.stop());
+  const socket = fakeSocket();
+  internals.socket = socket;
+
+  const writes: string[] = [];
+  internals.terminalManager = {
+    write: (data: Buffer) => writes.push(data.toString("utf8")),
+    onBrowserReconnect: () => ({ replayData: [Buffer.from("replay-1"), Buffer.from("replay-2")] }),
+    getActiveSessionId: () => "s1",
+    dispose: () => undefined,
+  };
+
+  internals.handleBinaryInput(socket, encodeBinaryFrame("terminal:s1", Buffer.from("ls -la\n")));
+  internals.handleBinaryInput(socket, encodeBinaryFrame("other-channel", Buffer.from("ignored")));
+  assert.deepEqual(writes, ["ls -la\n"]);
+
+  await internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.attached" }));
+  assert.equal(socket.sent.length, 2);
+  // The fake socket captures the raw Buffers the runtime passes to send().
+  const sentBuffers = socket.sent as unknown as Buffer[];
+  assert.deepEqual(
+    sentBuffers.map((f) => decodeBinaryFrame(f).channel),
+    ["terminal:s1", "terminal:s1"],
+  );
+  assert.deepEqual(
+    sentBuffers.map((f) => decodeBinaryFrame(f).data.toString("utf8")),
+    ["replay-1", "replay-2"],
+  );
 });

--- a/packages/gsd-cloud/src/cloud-runtime.test.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.test.ts
@@ -474,3 +474,59 @@ test("attached replay follows the active PTY session, not the sessionId the brow
     ["terminal:active"],
   );
 });
+
+test("terminal.resize clamps malformed dimensions and never throws into the message loop", async (t) => {
+  const runtime = makeRuntime();
+  const internals = runtime as unknown as RuntimeInternals;
+  t.after(() => runtime.stop());
+  const socket = fakeSocket();
+  internals.socket = socket;
+
+  const resizes: Array<[number, number]> = [];
+  let throwNext = false;
+  internals.terminalManager = {
+    resize: (cols: number, rows: number) => {
+      resizes.push([cols, rows]);
+      if (throwNext) throw new Error("pty resize boom");
+    },
+    dispose: () => undefined,
+  };
+
+  // Hostile/malformed dimensions coerce to the clamped fallbacks instead of
+  // reaching node-pty as strings/NaN/0/negatives (which would throw).
+  await internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.resize", cols: "abc", rows: 0 }));
+  await internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.resize", cols: -5, rows: 999999 }));
+  assert.deepEqual(resizes, [[80, 24], [80, 1000]]);
+
+  // A resize that throws (node-pty rejecting a value) is swallowed with a
+  // warning rather than surfacing as an unhandled rejection.
+  throwNext = true;
+  await assert.doesNotReject(
+    internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.resize", cols: 100, rows: 40 })),
+  );
+});
+
+test("terminal.attached skips replay when the channel name would exceed 255 bytes", async (t) => {
+  const runtime = makeRuntime();
+  const internals = runtime as unknown as RuntimeInternals;
+  t.after(() => runtime.stop());
+  const socket = fakeSocket();
+  internals.socket = socket;
+
+  let reconnectCalls = 0;
+  internals.terminalManager = {
+    onBrowserReconnect: () => { reconnectCalls += 1; return { replayData: [Buffer.from("x")] }; },
+    getActiveSessionId: () => null,
+    dispose: () => undefined,
+  };
+
+  // No active PTY, so the untrusted sessionId forms the channel; an over-long
+  // id would make encodeBinaryFrame throw. The guard skips replay (before even
+  // touching the reconnect buffer) instead of crashing the message loop.
+  const hugeSessionId = "s".repeat(300);
+  await assert.doesNotReject(
+    internals.handleSocketMessage(socket, JSON.stringify({ type: "terminal.attached", sessionId: hugeSessionId })),
+  );
+  assert.equal(socket.sent.length, 0);
+  assert.equal(reconnectCalls, 0);
+});

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -2,6 +2,8 @@ import WebSocket from "ws";
 import type { Logger } from "./logger.js";
 import type { DaemonConfig } from "./types.js";
 import type { AdvertisedProject, Executor } from "./executors/executor.js";
+import { decodeBinaryFrame, encodeBinaryFrame } from "./binary-frame.js";
+import { TerminalManager } from "./terminal-manager.js";
 import { createGatewayLookup, parseCloudGatewayUrl, validateGatewayNetworkTarget } from "./cloud-config.js";
 import { SessionEventProducer } from "./session-events.js";
 import {
@@ -23,6 +25,9 @@ interface GatewayMessage {
   toolName?: string;
   args?: Record<string, unknown>;
   projectAlias?: string;
+  sessionId?: string;
+  cols?: number;
+  rows?: number;
 }
 
 interface QueuedFrame {
@@ -54,6 +59,8 @@ export class CloudRuntime {
   // Kept across reconnects so per-session seq counters and replay buffers
   // survive; polling pauses while the socket is down.
   private sessionEvents: SessionEventProducer | undefined;
+  // Created per connection so the send closures bind to the live socket.
+  private terminalManager: TerminalManager | undefined;
 
   constructor(
     private readonly cloud: NonNullable<DaemonConfig["cloud"]>,
@@ -93,6 +100,9 @@ export class CloudRuntime {
     this.sessionEvents?.stopPolling();
     this.inFlight.clear();
     this.outbox = [];
+    // Kill any active PTY session before closing the socket.
+    this.terminalManager?.dispose();
+    this.terminalManager = undefined;
     const socket = this.socket;
     this.socket = undefined;
     socket?.close();
@@ -138,11 +148,26 @@ export class CloudRuntime {
       }
     }
 
+    // Per-connection terminal subsystem; its send closures bind to this socket.
+    this.terminalManager?.dispose();
+    this.terminalManager = new TerminalManager(
+      (frame: Buffer) => {
+        if (socket.readyState === WebSocket.OPEN) {
+          socket.send(frame, { binary: true });
+        }
+      },
+      (message: object) => this.send(message),
+    );
+
     socket.on("open", () => {
       this.handleSocketOpen(socket);
     });
-    socket.on("message", (data) => {
-      void this.handleSocketMessage(socket, data.toString("utf8"));
+    socket.on("message", (data, isBinary) => {
+      if (isBinary) {
+        this.handleBinaryInput(socket, data as Buffer);
+      } else {
+        void this.handleSocketMessage(socket, data.toString("utf8"));
+      }
     });
     socket.on("close", () => {
       this.handleSocketClose(socket);
@@ -259,6 +284,24 @@ export class CloudRuntime {
     this.sessionEvents.start();
   }
 
+  /**
+   * Handles incoming binary frames from the gateway (browser terminal input).
+   * Decodes the channel header and writes the payload to the PTY.
+   */
+  private handleBinaryInput(socket: WebSocket, frame: Buffer): void {
+    if (socket !== this.socket) return;
+    try {
+      const { channel, data } = decodeBinaryFrame(frame);
+      if (channel.startsWith("terminal:") && this.terminalManager) {
+        this.terminalManager.write(data);
+      }
+    } catch (err) {
+      this.logger.warn("binary frame decode error", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   private async handleMessage(text: string): Promise<void> {
     let message: GatewayMessage;
     try {
@@ -270,6 +313,45 @@ export class CloudRuntime {
       void this.cancelInFlight(message.requestId);
       return;
     }
+
+    // Terminal control messages (D-04-01, D-04-02, D-04-12)
+    if (message.type === "terminal.start" && message.sessionId && this.terminalManager) {
+      void this.terminalManager.startSession(
+        message.sessionId,
+        message.cols ?? 80,
+        message.rows ?? 24,
+      );
+      return;
+    }
+    if (message.type === "terminal.resize" && this.terminalManager) {
+      this.terminalManager.resize(message.cols ?? 80, message.rows ?? 24);
+      return;
+    }
+    if (message.type === "terminal.stop" && this.terminalManager) {
+      this.terminalManager.stopSession();
+      return;
+    }
+
+    // Browser attach/detach notifications for 5-minute persistence (D-04-02)
+    if (message.type === "terminal.detached" && this.terminalManager) {
+      this.terminalManager.onBrowserDisconnect();
+      return;
+    }
+    if (message.type === "terminal.attached" && this.terminalManager) {
+      const replay = this.terminalManager.onBrowserReconnect();
+      if (replay) {
+        const sessionId = this.terminalManager.getActiveSessionId();
+        const channel: `terminal:${string}` = `terminal:${sessionId ?? "unknown"}`;
+        for (const buf of replay.replayData) {
+          const frame = encodeBinaryFrame(channel, buf);
+          if (this.socket?.readyState === WebSocket.OPEN) {
+            this.socket.send(frame, { binary: true });
+          }
+        }
+      }
+      return;
+    }
+
     if (message.type !== "tool_call" || !message.requestId || !message.toolName) return;
     const routingKey = this.resolveRoutingKey(message);
     const project = this.resolveProject(routingKey);

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -292,9 +292,13 @@ export class CloudRuntime {
     if (socket !== this.socket) return;
     try {
       const { channel, data } = decodeBinaryFrame(frame);
-      if (channel.startsWith("terminal:") && this.terminalManager) {
-        this.terminalManager.write(data);
-      }
+      if (!channel.startsWith("terminal:") || !this.terminalManager) return;
+      // Only route input to the PTY when the frame's channel names the currently
+      // active session. A stale or incorrect sessionId (e.g. a frame that raced a
+      // reconnect) must not inject keystrokes into a different session's PTY.
+      const sessionId = channel.slice("terminal:".length);
+      if (sessionId !== this.terminalManager.getActiveSessionId()) return;
+      this.terminalManager.write(data);
     } catch (err) {
       this.logger.warn("binary frame decode error", {
         error: err instanceof Error ? err.message : String(err),
@@ -338,10 +342,14 @@ export class CloudRuntime {
       return;
     }
     if (message.type === "terminal.attached" && this.terminalManager) {
+      // Address replay to the session the attach names, falling back to the live
+      // PTY session. Without either we cannot form a real channel, so skip replay
+      // rather than emit frames on "terminal:unknown" that nothing multiplexes.
+      const sessionId = message.sessionId ?? this.terminalManager.getActiveSessionId();
+      if (!sessionId) return;
       const replay = this.terminalManager.onBrowserReconnect();
       if (replay) {
-        const sessionId = this.terminalManager.getActiveSessionId();
-        const channel: `terminal:${string}` = `terminal:${sessionId ?? "unknown"}`;
+        const channel: `terminal:${string}` = `terminal:${sessionId}`;
         for (const buf of replay.replayData) {
           const frame = encodeBinaryFrame(channel, buf);
           if (this.socket?.readyState === WebSocket.OPEN) {

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -40,6 +40,18 @@ interface InFlightRequest {
   routingKey?: string;
 }
 
+/**
+ * Normalizes a `ws` binary payload to a single Buffer. Per the `RawData` type,
+ * `ws` may deliver a binary message as a Buffer, an ArrayBuffer, or a Buffer[]
+ * (fragmented frames); casting straight to Buffer silently drops the latter two
+ * shapes, so decode fails and terminal input routing breaks.
+ */
+function toFrameBuffer(data: Buffer | ArrayBuffer | Buffer[]): Buffer {
+  if (Buffer.isBuffer(data)) return data;
+  if (Array.isArray(data)) return Buffer.concat(data);
+  return Buffer.from(data);
+}
+
 export class CloudRuntime {
   private static readonly MAX_OUTBOX = 200;
   // How many times to retry the initial connect before rejecting start(). A
@@ -164,7 +176,7 @@ export class CloudRuntime {
     });
     socket.on("message", (data, isBinary) => {
       if (isBinary) {
-        this.handleBinaryInput(socket, data as Buffer);
+        this.handleBinaryInput(socket, toFrameBuffer(data));
       } else {
         void this.handleSocketMessage(socket, data.toString("utf8"));
       }
@@ -342,10 +354,12 @@ export class CloudRuntime {
       return;
     }
     if (message.type === "terminal.attached" && this.terminalManager) {
-      // Address replay to the session the attach names, falling back to the live
-      // PTY session. Without either we cannot form a real channel, so skip replay
-      // rather than emit frames on "terminal:unknown" that nothing multiplexes.
-      const sessionId = message.sessionId ?? this.terminalManager.getActiveSessionId();
+      // Address replay to the active PTY session's channel, not the sessionId the
+      // browser claims: output-channel selection must follow the real session so
+      // replay cannot be mis-multiplexed onto a different session by untrusted
+      // input. Fall back to message.sessionId only when no PTY is active, and
+      // skip replay entirely when neither yields a channel.
+      const sessionId = this.terminalManager.getActiveSessionId() ?? message.sessionId;
       if (!sessionId) return;
       const replay = this.terminalManager.onBrowserReconnect();
       if (replay) {

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -52,6 +52,25 @@ function toFrameBuffer(data: Buffer | ArrayBuffer | Buffer[]): Buffer {
   return Buffer.from(data);
 }
 
+/** Upper bound for terminal cols/rows; guards against absurd allocations. */
+const MAX_TERMINAL_DIMENSION = 1000;
+
+/**
+ * Clamps an untrusted terminal dimension (cols/rows arrive over the network) to
+ * a sane positive integer. node-pty throws synchronously on non-finite, zero,
+ * negative, or non-integer sizes, which would otherwise crash the runtime.
+ */
+function toTerminalDimension(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  const int = Math.floor(n);
+  if (int < 1) return fallback;
+  return Math.min(int, MAX_TERMINAL_DIMENSION);
+}
+
+/** Max UTF-8 byte length of a binary-frame channel name (1-byte length prefix). */
+const MAX_CHANNEL_BYTES = 255;
+
 export class CloudRuntime {
   private static readonly MAX_OUTBOX = 200;
   // How many times to retry the initial connect before rejecting start(). A
@@ -334,13 +353,23 @@ export class CloudRuntime {
     if (message.type === "terminal.start" && message.sessionId && this.terminalManager) {
       void this.terminalManager.startSession(
         message.sessionId,
-        message.cols ?? 80,
-        message.rows ?? 24,
+        toTerminalDimension(message.cols, 80),
+        toTerminalDimension(message.rows, 24),
       );
       return;
     }
     if (message.type === "terminal.resize" && this.terminalManager) {
-      this.terminalManager.resize(message.cols ?? 80, message.rows ?? 24);
+      // cols/rows are untrusted; clamp them and guard the resize so a malformed
+      // size (string/NaN/0) cannot make node-pty throw and crash the runtime.
+      const cols = toTerminalDimension(message.cols, 80);
+      const rows = toTerminalDimension(message.rows, 24);
+      try {
+        this.terminalManager.resize(cols, rows);
+      } catch (err) {
+        this.logger.warn("terminal resize failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       return;
     }
     if (message.type === "terminal.stop" && this.terminalManager) {
@@ -361,9 +390,18 @@ export class CloudRuntime {
       // skip replay entirely when neither yields a channel.
       const sessionId = this.terminalManager.getActiveSessionId() ?? message.sessionId;
       if (!sessionId) return;
+      const channel: `terminal:${string}` = `terminal:${sessionId}`;
+      // encodeBinaryFrame throws when the channel name exceeds 255 UTF-8 bytes.
+      // The fallback sessionId is untrusted, and handleMessage() rejections are
+      // not caught upstream, so guard here rather than risk crashing the runtime.
+      if (Buffer.byteLength(channel, "utf8") > MAX_CHANNEL_BYTES) {
+        this.logger.warn("terminal.attached channel name too long; skipping replay", {
+          bytes: Buffer.byteLength(channel, "utf8"),
+        });
+        return;
+      }
       const replay = this.terminalManager.onBrowserReconnect();
       if (replay) {
-        const channel: `terminal:${string}` = `terminal:${sessionId}`;
         for (const buf of replay.replayData) {
           const frame = encodeBinaryFrame(channel, buf);
           if (this.socket?.readyState === WebSocket.OPEN) {

--- a/packages/gsd-cloud/src/terminal-manager.test.ts
+++ b/packages/gsd-cloud/src/terminal-manager.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { ensureNodePtySpawnHelperExecutable } from "./terminal-manager.js";
+
+test("terminal manager repairs non-executable node-pty spawn helper", {
+  skip: process.platform === "win32",
+}, () => {
+  const packageRoot = mkdtempSync(join(tmpdir(), "gsd-node-pty-"));
+  const prebuildRoot = join(packageRoot, "prebuilds", `${process.platform}-${process.arch}`);
+  const helperPath = join(prebuildRoot, "spawn-helper");
+
+  try {
+    mkdirSync(prebuildRoot, { recursive: true });
+    writeFileSync(helperPath, "helper", { mode: 0o644 });
+    chmodSync(helperPath, 0o644);
+
+    ensureNodePtySpawnHelperExecutable(packageRoot);
+
+    assert.notEqual(
+      statSync(helperPath).mode & 0o111,
+      0,
+      "spawn-helper must be executable before node-pty tries to launch it",
+    );
+  } finally {
+    rmSync(packageRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/gsd-cloud/src/terminal-manager.ts
+++ b/packages/gsd-cloud/src/terminal-manager.ts
@@ -114,6 +114,19 @@ export class TerminalManager {
       : process.env.SHELL || "/bin/sh";
     const channel: `terminal:${string}` = `terminal:${sessionId}`;
 
+    // sessionId is gateway-supplied and forms the binary channel name. If it
+    // exceeds 255 UTF-8 bytes, encodeBinaryFrame would throw on the first PTY
+    // output and crash the runtime, so reject up front before spawning.
+    if (Buffer.byteLength(channel, "utf8") > 255) {
+      this.sendJson({
+        channel: "control",
+        type: "terminal.error",
+        sessionId,
+        error: "Terminal session id is too long (channel name exceeds 255 bytes)",
+      });
+      return;
+    }
+
     try {
       ensureNodePtySpawnHelperExecutable();
     } catch (err) {

--- a/packages/gsd-cloud/src/terminal-manager.ts
+++ b/packages/gsd-cloud/src/terminal-manager.ts
@@ -1,0 +1,331 @@
+// Project/App: gsd-pi
+// File Purpose: PTY lifecycle manager for cloud terminal sessions (D-04-01, D-04-02, D-04-03, D-04-09, D-04-12).
+
+import { encodeBinaryFrame } from "./binary-frame.js";
+import { chmodSync, existsSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+const nodeRequire = createRequire(import.meta.url);
+
+/** 5 minutes before an unattached PTY is killed (D-04-02). */
+const DISCONNECT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Maximum ring buffer size for replay on reconnect (256 KB per RESEARCH.md). */
+const MAX_BUFFER_BYTES = 256 * 1024;
+
+/** Grace period after PTY exits before session object is cleared (allows brief replay). */
+const EXIT_CLEANUP_MS = 30_000;
+
+/**
+ * Minimal interface for the node-pty IPty object.
+ * Using a structural type avoids importing node-pty at the module level
+ * (it is a native addon, loaded dynamically).
+ */
+interface IPty {
+  pid: number;
+  onData: (callback: (data: string) => void) => { dispose(): void };
+  onExit: (callback: (e: { exitCode: number; signal?: number }) => void) => { dispose(): void };
+  write(data: string): void;
+  resize(columns: number, rows: number): void;
+  kill(signal?: string): void;
+}
+
+interface TerminalSession {
+  pty: IPty;
+  sessionId: string;
+  /** Channel for binary PTY I/O: "terminal:{sessionId}". */
+  channel: `terminal:${string}`;
+  disconnectTimer: ReturnType<typeof setTimeout> | null;
+  exitCleanupTimer: ReturnType<typeof setTimeout> | null;
+  outputBuffer: Buffer[];
+  bufferBytes: number;
+  alive: boolean;
+  /** Disposables returned by pty.onData / pty.onExit. */
+  disposables: Array<{ dispose(): void }>;
+}
+
+/** Callback to send a binary WebSocket frame (PTY output). */
+export type SendBinaryFn = (frame: Buffer) => void;
+
+/** Callback to send a JSON control message. */
+export type SendJsonFn = (message: object) => void;
+
+export function ensureNodePtySpawnHelperExecutable(
+  packageRoot = dirname(nodeRequire.resolve("node-pty/package.json")),
+): void {
+  if (process.platform === "win32") return;
+
+  const helperPaths = [
+    join(packageRoot, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper"),
+    join(packageRoot, "build", "Release", "spawn-helper"),
+  ];
+
+  for (const helperPath of helperPaths) {
+    if (!existsSync(helperPath)) continue;
+    const mode = statSync(helperPath).mode;
+    if ((mode & 0o111) === 0) chmodSync(helperPath, mode | 0o111);
+  }
+}
+
+/**
+ * Manages a single PTY terminal session per device (D-04-03).
+ *
+ * Responsibilities:
+ * - Spawn user's login shell via node-pty (D-04-01)
+ * - Send PTY output as binary frames with channel header (D-04-09)
+ * - Handle resize propagation (D-04-12)
+ * - Persist PTY for 5 minutes on browser disconnect with ring-buffer replay (D-04-02)
+ * - Enforce 1 session per device limit (D-04-03)
+ */
+export class TerminalManager {
+  private session: TerminalSession | null = null;
+
+  constructor(
+    private readonly sendBinary: SendBinaryFn,
+    private readonly sendJson: SendJsonFn,
+  ) {}
+
+  /**
+   * Starts a new PTY terminal session. Rejects if an active session already exists (D-04-03).
+   * Uses dynamic import for node-pty since it is a native addon.
+   */
+  async startSession(sessionId: string, cols: number, rows: number): Promise<void> {
+    if (this.session?.alive) {
+      this.sendJson({
+        channel: "control",
+        type: "terminal.error",
+        sessionId,
+        error: "A terminal session is already active on this device (limit: 1 per device)",
+      });
+      return;
+    }
+
+    // Clean up any leftover stopped session before starting a new one.
+    if (this.session) {
+      this.cleanupSession();
+    }
+
+    const shell = process.env.SHELL || "/bin/sh";
+    const channel: `terminal:${string}` = `terminal:${sessionId}`;
+
+    try {
+      ensureNodePtySpawnHelperExecutable();
+    } catch (err) {
+      this.sendJson({
+        channel: "control",
+        type: "terminal.error",
+        sessionId,
+        error: `Failed to prepare node-pty: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return;
+    }
+
+    let ptyModule: { spawn: (file: string, args: string[], options: Record<string, unknown>) => IPty };
+    try {
+      ptyModule = await import("node-pty") as typeof ptyModule;
+    } catch (err) {
+      this.sendJson({
+        channel: "control",
+        type: "terminal.error",
+        sessionId,
+        error: `Failed to load node-pty: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return;
+    }
+
+    let pty: IPty;
+    try {
+      pty = ptyModule.spawn(shell, [], {
+        name: "xterm-256color",
+        cols,
+        rows,
+        cwd: process.env.HOME || "/",
+        env: process.env as Record<string, string>,
+      });
+    } catch (err) {
+      this.sendJson({
+        channel: "control",
+        type: "terminal.error",
+        sessionId,
+        error: `Failed to spawn shell: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return;
+    }
+
+    const session: TerminalSession = {
+      pty,
+      sessionId,
+      channel,
+      disconnectTimer: null,
+      exitCleanupTimer: null,
+      outputBuffer: [],
+      bufferBytes: 0,
+      alive: true,
+      disposables: [],
+    };
+    this.session = session;
+
+    // PTY data -> binary frame -> WebSocket + ring buffer
+    const dataDisposable = pty.onData((data: string) => {
+      const buf = Buffer.from(data, "utf8");
+      const frame = encodeBinaryFrame(channel, buf);
+      this.sendBinary(frame);
+
+      // Append to ring buffer for reconnect replay
+      session.outputBuffer.push(buf);
+      session.bufferBytes += buf.length;
+      while (session.bufferBytes > MAX_BUFFER_BYTES && session.outputBuffer.length > 0) {
+        const evicted = session.outputBuffer.shift()!;
+        session.bufferBytes -= evicted.length;
+      }
+    });
+    session.disposables.push(dataDisposable);
+
+    // PTY exit -> send stopped message, mark dead, schedule cleanup
+    const exitDisposable = pty.onExit(({ exitCode }) => {
+      session.alive = false;
+
+      if (session.disconnectTimer) {
+        clearTimeout(session.disconnectTimer);
+        session.disconnectTimer = null;
+      }
+
+      this.sendJson({
+        channel: "control",
+        type: "terminal.stopped",
+        sessionId: session.sessionId,
+        exitCode: exitCode ?? null,
+      });
+
+      // Allow a brief window for replay before clearing the session object.
+      session.exitCleanupTimer = setTimeout(() => {
+        if (this.session === session) {
+          this.session = null;
+        }
+      }, EXIT_CLEANUP_MS);
+    });
+    session.disposables.push(exitDisposable);
+
+    this.sendJson({
+      channel: "control",
+      type: "terminal.started",
+      sessionId,
+      pid: pty.pid,
+    });
+  }
+
+  /**
+   * Writes input data from the browser to the PTY stdin.
+   */
+  write(data: Buffer): void {
+    if (this.session?.alive) {
+      this.session.pty.write(data.toString("utf8"));
+    }
+  }
+
+  /**
+   * Resizes the PTY (D-04-12). No-op if no active session.
+   */
+  resize(cols: number, rows: number): void {
+    if (this.session?.alive) {
+      this.session.pty.resize(cols, rows);
+    }
+  }
+
+  /**
+   * Called when the browser disconnects. Starts the 5-minute persistence timer (D-04-02).
+   */
+  onBrowserDisconnect(): void {
+    if (!this.session?.alive) return;
+    this.session.disconnectTimer = setTimeout(() => {
+      this.destroySession();
+    }, DISCONNECT_TIMEOUT_MS);
+  }
+
+  /**
+   * Called when the browser reconnects within the 5-minute window.
+   * Clears the disconnect timer and returns buffered output for replay.
+   */
+  onBrowserReconnect(): { replayData: Buffer[] } | null {
+    if (!this.session) return null;
+
+    if (this.session.disconnectTimer) {
+      clearTimeout(this.session.disconnectTimer);
+      this.session.disconnectTimer = null;
+    }
+
+    return { replayData: [...this.session.outputBuffer] };
+  }
+
+  /**
+   * Stops (kills) the active terminal session. The onExit handler sends terminal.stopped.
+   */
+  stopSession(): void {
+    if (!this.session) return;
+    if (this.session.alive) {
+      this.session.pty.kill();
+    }
+  }
+
+  /**
+   * Returns the active session ID, or null if no session is alive.
+   */
+  getActiveSessionId(): string | null {
+    return this.session?.alive ? this.session.sessionId : null;
+  }
+
+  /**
+   * Disposes of all resources. Called on daemon shutdown.
+   */
+  dispose(): void {
+    this.destroySession();
+  }
+
+  /**
+   * Force-kills the PTY, clears all timers, and nulls the session.
+   */
+  private destroySession(): void {
+    if (!this.session) return;
+    const session = this.session;
+    this.session = null;
+
+    if (session.disconnectTimer) {
+      clearTimeout(session.disconnectTimer);
+      session.disconnectTimer = null;
+    }
+    if (session.exitCleanupTimer) {
+      clearTimeout(session.exitCleanupTimer);
+      session.exitCleanupTimer = null;
+    }
+
+    for (const d of session.disposables) {
+      try { d.dispose(); } catch { /* best-effort cleanup */ }
+    }
+
+    if (session.alive) {
+      try { session.pty.kill(); } catch { /* best-effort cleanup */ }
+      session.alive = false;
+    }
+  }
+
+  /**
+   * Cleans up a stopped (non-alive) session without killing the PTY.
+   */
+  private cleanupSession(): void {
+    if (!this.session) return;
+    const session = this.session;
+    this.session = null;
+
+    if (session.disconnectTimer) {
+      clearTimeout(session.disconnectTimer);
+    }
+    if (session.exitCleanupTimer) {
+      clearTimeout(session.exitCleanupTimer);
+    }
+
+    for (const d of session.disposables) {
+      try { d.dispose(); } catch { /* best-effort cleanup */ }
+    }
+  }
+}

--- a/packages/gsd-cloud/src/terminal-manager.ts
+++ b/packages/gsd-cloud/src/terminal-manager.ts
@@ -323,7 +323,9 @@ export class TerminalManager {
   }
 
   /**
-   * Force-kills the PTY, clears all timers, and nulls the session.
+   * Force-kills the PTY, clears all timers, and nulls the session. Emits
+   * terminal.stopped when the session was still alive, because the onExit
+   * handler that normally sends it has been disposed by this point.
    */
   private destroySession(): void {
     if (!this.session) return;
@@ -346,6 +348,16 @@ export class TerminalManager {
     if (session.alive) {
       try { session.pty.kill(); } catch { /* best-effort cleanup */ }
       session.alive = false;
+      // The onExit handler is disposed above, so a force-destroy (e.g. the
+      // 5-minute detach timer firing or daemon shutdown) would otherwise never
+      // tell the gateway the session ended, leaving the relay holding the
+      // device's single session slot. Notify explicitly here.
+      this.sendJson({
+        channel: "control",
+        type: "terminal.stopped",
+        sessionId: session.sessionId,
+        exitCode: null,
+      });
     }
   }
 

--- a/packages/gsd-cloud/src/terminal-manager.ts
+++ b/packages/gsd-cloud/src/terminal-manager.ts
@@ -106,7 +106,12 @@ export class TerminalManager {
       this.cleanupSession();
     }
 
-    const shell = process.env.SHELL || "/bin/sh";
+    // Pick a platform-appropriate login shell: SHELL is unset on Windows and
+    // "/bin/sh" does not exist there, so a win32 spawn would fail with ENOENT.
+    const isWindows = process.platform === "win32";
+    const shell = isWindows
+      ? process.env.COMSPEC || "powershell.exe"
+      : process.env.SHELL || "/bin/sh";
     const channel: `terminal:${string}` = `terminal:${sessionId}`;
 
     try {
@@ -140,7 +145,10 @@ export class TerminalManager {
         name: "xterm-256color",
         cols,
         rows,
-        cwd: process.env.HOME || "/",
+        // HOME is typically unset on Windows and "/" is not a valid win32 cwd,
+        // so prefer USERPROFILE there and fall back to the process cwd on both
+        // platforms rather than a hardcoded root that can fail PTY spawn.
+        cwd: (isWindows ? process.env.USERPROFILE : process.env.HOME) || process.cwd(),
         env: process.env as Record<string, string>,
       });
     } catch (err) {

--- a/packages/gsd-cloud/src/terminal-manager.ts
+++ b/packages/gsd-cloud/src/terminal-manager.ts
@@ -51,14 +51,26 @@ export type SendBinaryFn = (frame: Buffer) => void;
 /** Callback to send a JSON control message. */
 export type SendJsonFn = (message: object) => void;
 
-export function ensureNodePtySpawnHelperExecutable(
-  packageRoot = dirname(nodeRequire.resolve("node-pty/package.json")),
-): void {
+export function ensureNodePtySpawnHelperExecutable(packageRoot?: string): void {
   if (process.platform === "win32") return;
 
+  // Resolve node-pty lazily, after the win32 early-return, so a missing addon
+  // never throws during default-argument evaluation. On Windows this function
+  // no-ops without touching node-pty; elsewhere, if node-pty is not installed
+  // there is no helper to repair and the dynamic import in startSession()
+  // surfaces the actionable "not installed" error instead.
+  let root = packageRoot;
+  if (root === undefined) {
+    try {
+      root = dirname(nodeRequire.resolve("node-pty/package.json"));
+    } catch {
+      return;
+    }
+  }
+
   const helperPaths = [
-    join(packageRoot, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper"),
-    join(packageRoot, "build", "Release", "spawn-helper"),
+    join(root, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper"),
+    join(root, "build", "Release", "spawn-helper"),
   ];
 
   for (const helperPath of helperPaths) {

--- a/packages/gsd-cloud/src/terminal-manager.ts
+++ b/packages/gsd-cloud/src/terminal-manager.ts
@@ -238,6 +238,13 @@ export class TerminalManager {
    */
   onBrowserDisconnect(): void {
     if (!this.session?.alive) return;
+    // Clear any timer from a prior detach so duplicate/repeated terminal.detached
+    // events restart the full 5-minute window instead of letting a stale earlier
+    // timer destroy the PTY before the most recent detach's window elapses.
+    if (this.session.disconnectTimer) {
+      clearTimeout(this.session.disconnectTimer);
+      this.session.disconnectTimer = null;
+    }
     this.session.disconnectTimer = setTimeout(() => {
       this.destroySession();
     }, DISCONNECT_TIMEOUT_MS);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,6 @@ importers:
       minimatch:
         specifier: ^10.2.3
         version: 10.2.5
-      node-pty:
-        specifier: ^1.1.0
-        version: 1.1.0
       openai:
         specifier: ^6.26.0
         version: 6.26.0(ws@8.21.0)(zod@4.4.3)
@@ -222,6 +219,9 @@ importers:
       koffi:
         specifier: ^2.9.0
         version: 2.16.2
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
 
   extensions/google-search:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       minimatch:
         specifier: ^10.2.3
         version: 10.2.5
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       openai:
         specifier: ^6.26.0
         version: 6.26.0(ws@8.21.0)(zod@4.4.3)
@@ -419,16 +422,16 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: 0.91.1
-        version: 0.91.1(zod@4.4.3)
+        version: 0.91.1(zod@3.25.76)
       '@anthropic-ai/vertex-sdk':
         specifier: 0.14.4
-        version: 0.14.4(zod@4.4.3)
+        version: 0.14.4(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime':
         specifier: 3.1048.0
         version: 3.1048.0
       '@google/genai':
         specifier: 1.52.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
       '@mistralai/mistralai':
         specifier: 2.2.1
         version: 2.2.1
@@ -443,7 +446,7 @@ importers:
         version: 7.0.6
       openai:
         specifier: 6.26.0
-        version: 6.26.0(ws@8.21.0)(zod@4.4.3)
+        version: 6.26.0(ws@8.21.0)(zod@3.25.76)
       partial-json:
         specifier: 0.1.7
         version: 0.1.7
@@ -6324,6 +6327,14 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
+  '@anthropic-ai/vertex-sdk@0.14.4(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
+      google-auth-library: 9.15.1
+    transitivePeerDependencies:
+      - supports-color
+      - zod
+
   '@anthropic-ai/vertex-sdk@0.14.4(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
@@ -7202,6 +7213,19 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.6.4
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
@@ -7517,6 +7541,29 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.28)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.28
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -11331,6 +11378,11 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  openai@6.26.0(ws@8.21.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 3.25.76
 
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
 
   packages/gsd-cloud:
     dependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -416,16 +419,16 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: 0.91.1
-        version: 0.91.1(zod@3.25.76)
+        version: 0.91.1(zod@4.4.3)
       '@anthropic-ai/vertex-sdk':
         specifier: 0.14.4
-        version: 0.14.4(zod@3.25.76)
+        version: 0.14.4(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime':
         specifier: 3.1048.0
         version: 3.1048.0
       '@google/genai':
         specifier: 1.52.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
+        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@mistralai/mistralai':
         specifier: 2.2.1
         version: 2.2.1
@@ -440,7 +443,7 @@ importers:
         version: 7.0.6
       openai:
         specifier: 6.26.0
-        version: 6.26.0(ws@8.21.0)(zod@3.25.76)
+        version: 6.26.0(ws@8.21.0)(zod@4.4.3)
       partial-json:
         specifier: 0.1.7
         version: 0.1.7
@@ -6321,14 +6324,6 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
-  '@anthropic-ai/vertex-sdk@0.14.4(zod@3.25.76)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
-      google-auth-library: 9.15.1
-    transitivePeerDependencies:
-      - supports-color
-      - zod
-
   '@anthropic-ai/vertex-sdk@0.14.4(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
@@ -7207,19 +7202,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
-    dependencies:
-      google-auth-library: 10.6.2
-      p-retry: 4.6.2
-      protobufjs: 7.6.4
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
@@ -7535,29 +7517,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.28)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.28
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -11372,11 +11331,6 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
-
-  openai@6.26.0(ws@8.21.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.21.0
-      zod: 3.25.76
 
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,9 +343,6 @@ importers:
 
   packages/gsd-cloud:
     dependencies:
-      node-pty:
-        specifier: ^1.1.0
-        version: 1.1.0
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -362,6 +359,10 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
 
   packages/mcp-server:
     dependencies:


### PR DESCRIPTION
## Problem

Browser terminals on the SaaS (cloud.opengsd.net) sat at **Connecting...** forever against daemons running the gsd-pi `@opengsd/gsd-cloud` build, while every other leg — token mint, relay `/terminal/connect` ws — was healthy.

Root cause: the relay forwards browser terminal traffic to the daemon as **binary frames** on the `terminal:<sessionId>` channel (1-byte channel-len prefix) plus `terminal.start/resize/stop/attached/detached` JSON control messages. This runtime dropped all of it:

- binary frames were coerced with `data.toString("utf8")` and discarded by the `JSON.parse` guard
- terminal control types fell through the `tool_call` gate and were silently ignored

Stacked on #1499 (the branch the shipping daemon is built from).

## Change

Ports the reference implementation from the cloud daemon package into `packages/gsd-cloud`:

- **`binary-frame.ts`** — `encodeBinaryFrame`/`decodeBinaryFrame` codec
- **`terminal-manager.ts`** — node-pty spawn, 256 KB ring-buffer replay, 5-min detach persistence (D-04-02), 1-session-per-device limit (D-04-03), resize propagation (D-04-12)
- **`cloud-runtime.ts`** — per-connection `TerminalManager`, `isBinary` branch in the socket handler, terminal control routing ahead of the `tool_call` gate, PTY disposal on stop
- **`package.json`** — adds `node-pty` (native, dynamically imported like the reference)

## Tests

- Ported the spawn-helper permission test
- New regression tests pin the exact routing intent that was broken: terminal control messages reach the manager (and never fall through to `tool_call`), binary frames reach `PTY.write`, and `terminal.attached` replays buffered output as framed binary sends
- `@opengsd/gsd-cloud` package suite: 151/151 green

## Live verification

Ran a full end-to-end probe from inside the relay machine (mint token → `/terminal/connect` → `terminal.start`) against the production daemon on a real Mac: `terminal.started` returned with a live PTY pid and a binary echo round-trip (`echo GSD_E2E_OK`) completed.

Note: a terminal session leaked pre-fix (browser detached, old daemon never answered, relay kept the 1-per-device slot) blocked new sessions until the relay was restarted. Follow-up hardening for the relay (reap sessions that never reach `terminal.started`) will come as a separate PR on gsd-cloud.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces remote shell access via PTY and native `node-pty`, but input/replay routing and dimension/channel guards reduce misuse risk; missing `node-pty` only disables terminals.
> 
> **Overview**
> Fixes cloud browser terminals stuck on **Connecting...** by handling the relay protocol the runtime previously dropped: **binary** `terminal:<sessionId>` frames and JSON **`terminal.*`** control messages no longer get lost to `toString`/`tool_call` filtering.
> 
> Adds **`binary-frame`** encode/decode and a per-connection **`TerminalManager`** that dynamically loads optional **`node-pty`**, spawns the login shell, streams PTY I/O as framed binary, supports resize, enforces one session per device, keeps the PTY for five minutes after browser detach with a 256 KB replay buffer, and tears down on runtime stop. **`CloudRuntime`** branches on `isBinary`, routes control types ahead of tool calls, clamps untrusted cols/rows, ties keystrokes and replay to the **active** session id (not stale browser claims), and skips replay when channel names would exceed 255 bytes.
> 
> Docs and **`package.json`** declare **`node-pty`** as optional so core cloud CLI still works when the native addon is missing; regression tests cover routing, binary input, attach replay, and resize hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 467c0196db8d6aabbcee672060cab7d9202a7207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->