### PR TITLE
fix(issue): renderRoadmapMarkdown emits trailing whitespace on empty Vision/After-this fields, causing doctor↔sync infinite loop

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -231,7 +231,7 @@ function renderRoadmapMarkdown(milestone: MilestoneRow, slices: SliceRow[]): str
 
   lines.push(`# ${milestone.id}: ${milestone.title || milestone.id}`);
   lines.push("");
-  lines.push(`**Vision:** ${milestone.vision}`);
+  lines.push(milestone.vision ? `**Vision:** ${milestone.vision}` : "**Vision:**");
   lines.push("");
 
   if (milestone.success_criteria.length > 0) {
@@ -257,7 +257,7 @@ function renderRoadmapMarkdown(milestone: MilestoneRow, slices: SliceRow[]): str
     // truncate the line.
     const sketchBadge = slice.is_sketch === 1 ? "`[sketch]` " : "";
     lines.push(`- [${done}] **${slice.id}: ${safeTitle}** ${sketchBadge}\`risk:${safeRisk}\` \`depends:${depends}\``);
-    lines.push(`  > After this: ${slice.demo}`);
+    lines.push(slice.demo ? `  > After this: ${slice.demo}` : "  > After this:");
     lines.push("");
   }
 

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -1732,6 +1732,9 @@ test('── markdown-renderer: renderRoadmapFromDb renders a planned milestone 
       'content' in result && result.content.includes('S01'),
       'content includes the planned slice',
     );
+    assert.ok('content' in result && result.content.includes('**Vision:**\n'), 'empty vision has no trailing space');
+    assert.ok('content' in result && result.content.includes('  > After this:\n'), 'empty demo has no trailing space');
+    assert.ok('content' in result && !/[ \t]$/m.test(result.content), 'roadmap content has no trailing whitespace');
   } finally {
     closeDatabase();
     cleanupDir(tmpDir);


### PR DESCRIPTION
## Summary
- Fixed empty ROADMAP Vision/After-this rendering and verified the diff has no trailing whitespace.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1509
- [#1509 renderRoadmapMarkdown emits trailing whitespace on empty Vision/After-this fields, causing doctor↔sync infinite loop](https://github.com/open-gsd/gsd-pi/issues/1509)

## User
- @birdypme

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1509-renderroadmapmarkdown-emits-trailing-whi-1784567034`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small rendering change in markdown projection with targeted tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **ROADMAP** projection so empty `vision` and slice `demo` no longer add a trailing space after the label (`**Vision:**` and `> After this:`).
> 
> That whitespace made rendered markdown differ from what doctor/sync expected, which could trigger a **doctor↔sync** loop (#1509). Tests on `renderRoadmapFromDb` now assert those lines have no trailing space and that the full roadmap has no line-ending whitespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b052d75787b018f803d5caaa5dc46d4eda21b856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->