### PR TITLE
fix(gsd-cloud): launch workflow MCP server for cloud tools

### DIFF
--- a/docs/dev/cloud-live-e2e-runbook.md
+++ b/docs/dev/cloud-live-e2e-runbook.md
@@ -13,9 +13,9 @@ the SaaS (`/api/device/*` endpoints are not part of the standalone gateway).
 ## Prerequisites
 
 - Node.js >= 22 on the test machine.
-- The `gsd` CLI (`@opengsd/gsd-pi`) installed and on `PATH` (or exported via
-  `GSD_CLI_PATH`), with its workflow MCP server discoverable. See the
-  [`@opengsd/gsd-cloud` environment requirements](../../packages/gsd-cloud/README.md#environment).
+- The local prerequisites in the [`@opengsd/gsd-cloud` requirements](../../packages/gsd-cloud/README.md#requirements);
+  use its [environment reference](../../packages/gsd-cloud/README.md#environment)
+  for non-default discovery.
 - A local GSD project directory (contains `.gsd/`). `cd` into it — it becomes
   the advertised project.
 - A cloud.opengsd.net account you can log into in a browser.
@@ -122,7 +122,7 @@ directories you created.
 | `login` spinner never completes | Approval not given, or code expired (10 min TTL) | Re-run `login`; approve promptly. |
 | `Authorization approved!` then immediate exit | `gateway_url` returned by the server failed CLI validation | Check stderr for `ignoring invalid server-supplied relay URL`; verify the deployment's relay URL config. |
 | `connected in the background` but machine offline on dashboard | WebSocket to relay rejected (device token) or relay unreachable | Read the runtime log from `status`; check `https://cloud.opengsd.net/healthz`. |
-| `status` shows `running: false` after `login` | Background child died after ready | Read the log file path from `status`; look for executor discovery errors (`gsd` missing from `PATH` → set `GSD_CLI_PATH`; workflow server missing → follow the package environment requirements). |
+| `status` shows `running: false` after `login` | Background child died after ready | Read the log file path from `status`; for executor discovery errors, follow the package environment requirements linked above. |
 | Dashboard project view errors | Local workflow MCP server failed in the project dir | Run `gsd-mcp-server` manually in the project dir and check it initializes, or test the command configured by `GSD_WORKFLOW_MCP_COMMAND`. |
 
 ## Rollback signals

--- a/docs/dev/cloud-live-e2e-runbook.md
+++ b/docs/dev/cloud-live-e2e-runbook.md
@@ -14,7 +14,8 @@ the SaaS (`/api/device/*` endpoints are not part of the standalone gateway).
 
 - Node.js >= 22 on the test machine.
 - The `gsd` CLI (`@opengsd/gsd-pi`) installed and on `PATH` (or exported via
-  `GSD_CLI_PATH`).
+  `GSD_CLI_PATH`), with its workflow MCP server discoverable. See the
+  [`@opengsd/gsd-cloud` environment requirements](../../packages/gsd-cloud/README.md#environment).
 - A local GSD project directory (contains `.gsd/`). `cd` into it — it becomes
   the advertised project.
 - A cloud.opengsd.net account you can log into in a browser.
@@ -86,9 +87,9 @@ Expected JSON output:
 ## 5. Exercise a cloud read path
 
 From the dashboard, open the advertised project and trigger a read-only view
-that goes through the gateway → runtime → local `gsd --mode mcp` loop (project
-state/roadmap view). Expected: project state renders; the runtime log on the
-machine records the forwarded tool call and its `tool_result`.
+that goes through the gateway → runtime → local workflow MCP server loop
+(project state/roadmap view). Expected: project state renders; the runtime log
+on the machine records the forwarded tool call and its `tool_result`.
 
 This is the production equivalent of the local harness's forwarded
 `gsd_query` assertion.
@@ -121,8 +122,8 @@ directories you created.
 | `login` spinner never completes | Approval not given, or code expired (10 min TTL) | Re-run `login`; approve promptly. |
 | `Authorization approved!` then immediate exit | `gateway_url` returned by the server failed CLI validation | Check stderr for `ignoring invalid server-supplied relay URL`; verify the deployment's relay URL config. |
 | `connected in the background` but machine offline on dashboard | WebSocket to relay rejected (device token) or relay unreachable | Read the runtime log from `status`; check `https://cloud.opengsd.net/healthz`. |
-| `status` shows `running: false` after `login` | Background child died after ready | Read the log file path from `status`; look for executor spawn errors (`gsd` missing from `PATH` → set `GSD_CLI_PATH`). |
-| Dashboard project view errors | Local `gsd --mode mcp` failed in the project dir | Run `gsd --mode mcp` manually in the project dir and check it initializes. |
+| `status` shows `running: false` after `login` | Background child died after ready | Read the log file path from `status`; look for executor discovery errors (`gsd` missing from `PATH` → set `GSD_CLI_PATH`; workflow server missing → follow the package environment requirements). |
+| Dashboard project view errors | Local workflow MCP server failed in the project dir | Run `gsd-mcp-server` manually in the project dir and check it initializes, or test the command configured by `GSD_WORKFLOW_MCP_COMMAND`. |
 
 ## Rollback signals
 

--- a/docs/dev/gsd-cloud-publish-runbook.md
+++ b/docs/dev/gsd-cloud-publish-runbook.md
@@ -93,10 +93,8 @@ npm view @opengsd/gsd-cloud dependencies     # exactly: ws, yaml (nothing else)
 npx -y @opengsd/gsd-cloud@<version> --help   # lists login/pair/status/connect/stop/disconnect
 ```
 
-A deeper live smoke (the v1.5 CAGT-05 acceptance loop) is: from a GSD project
-directory, `npx @opengsd/gsd-cloud login` (no `--gateway`), approve the device
-in the browser at cloud.opengsd.net, then confirm the machine shows online on
-the dashboard and `npx @opengsd/gsd-cloud status` reports connected.
+For the deeper live smoke, follow the authoritative
+[cloud live E2E runbook](cloud-live-e2e-runbook.md).
 
 ## Rollback / the 72-hour rule
 

--- a/packages/gsd-cloud/README.md
+++ b/packages/gsd-cloud/README.md
@@ -7,9 +7,9 @@ This is a **self-contained** agent. Its only runtime dependencies are `ws` and
 `yaml` — no `@opengsd/daemon`, `@opengsd/mcp-server`, or `@opengsd/gsd-pi`. It
 runs the RFC 8628 device-flow login, opens a persistent WebSocket to the cloud
 gateway, and forwards each requested GSD workflow tool to a workflow MCP server.
-That server is resolved at runtime, in order: an explicit
-`GSD_WORKFLOW_MCP_COMMAND`, the server bundled with a locally installed
-`@opengsd/gsd-pi`, or `gsd-mcp-server` found on your `PATH`.
+That server is resolved through the configured, installed-package, and `PATH`
+routes described under [Environment](#environment). Startup fails before the
+cloud connection is opened when none of those routes resolves a server.
 The gateway default of `https://cloud.opengsd.net` is injected for `login`/`pair`
 so you never have to type `--gateway`.
 
@@ -18,8 +18,8 @@ sessions. It is loaded dynamically at runtime; if it is not installed (for
 example when its prebuilt binary is unavailable for your platform), the core CLI
 still works and only the cloud terminal feature is unavailable.
 
-Requires the `gsd` CLI (from `@opengsd/gsd-pi`) to be installed and on your
-`PATH` (or set `GSD_CLI_PATH`).
+See [Requirements](#requirements) for local prerequisites and
+[Environment](#environment) for discovery overrides.
 
 ## Usage
 
@@ -76,6 +76,9 @@ npx @opengsd/gsd-cloud service uninstall
 
 Pair with `login` first — the service runs `connect --foreground`, so `status`
 and `stop` see the service-managed runtime exactly like a `connect` session.
+`service install` copies `GSD_CLI_PATH` / `GSD_BIN_PATH`, `GSD_WORKFLOW_PATH`,
+and the `GSD_WORKFLOW_MCP_*` variables into the service definition; run it again
+after changing those values.
 On macOS the service appends stdout/stderr to the same `cloud-runtime.log`
 artifact that `connect` uses; on Linux it logs to the journal
 (`journalctl --user -u gsd-cloud`). On headless Linux servers, run
@@ -112,10 +115,14 @@ are skipped and logged). Tool-call forwarding is unchanged. Set
 
 - `GSD_CLOUD_PROJECTS` — path-delimiter separated list of project directories to
   advertise to the cloud (default: the current working directory).
-- `GSD_CLI_PATH` — path to the `gsd` binary (default: `gsd` on `PATH`).
+- `GSD_CLI_PATH` / `GSD_BIN_PATH` — path to the `gsd` binary (default: `gsd` on
+  `PATH`). `GSD_CLI_PATH` takes precedence when both ambient variables are set.
+- `GSD_WORKFLOW_PATH` — additional installed-package discovery anchor. The
+  daemon walks upward from this path looking for `packages/mcp-server/dist/cli.js`.
 - `GSD_WORKFLOW_MCP_COMMAND` — workflow MCP server command. By default the
-  daemon discovers `packages/mcp-server/dist/cli.js` beside the installed `gsd`
-  package, then falls back to `gsd-mcp-server` on `PATH`.
+  daemon discovers `packages/mcp-server/dist/cli.js` from the resolved `gsd`
+  installation or `GSD_WORKFLOW_PATH`, then falls back to `gsd-mcp-server` on
+  `PATH`.
 - `GSD_WORKFLOW_MCP_ARGS` — optional JSON array of arguments for
   `GSD_WORKFLOW_MCP_COMMAND`.
 - `GSD_WORKFLOW_MCP_ENV` — optional JSON object of environment variables for an
@@ -136,5 +143,8 @@ current terminal.
 ## Requirements
 
 - Node.js >= 22
-- The `gsd` CLI (`@opengsd/gsd-pi`) installed locally with its workflow MCP
-  server discoverable, or `GSD_WORKFLOW_MCP_COMMAND` configured explicitly
+- A workflow MCP server discoverable from a local `@opengsd/gsd-pi`
+  installation, as `gsd-mcp-server` on `PATH`, or through
+  `GSD_WORKFLOW_MCP_COMMAND`
+- The `gsd` CLI available to that server on `PATH` or through `GSD_CLI_PATH` /
+  `GSD_BIN_PATH`

--- a/packages/gsd-cloud/README.md
+++ b/packages/gsd-cloud/README.md
@@ -118,6 +118,11 @@ are skipped and logged). Tool-call forwarding is unchanged. Set
   package, then falls back to `gsd-mcp-server` on `PATH`.
 - `GSD_WORKFLOW_MCP_ARGS` — optional JSON array of arguments for
   `GSD_WORKFLOW_MCP_COMMAND`.
+- `GSD_WORKFLOW_MCP_ENV` — optional JSON object of environment variables for an
+  explicit workflow MCP server, including nested `GSD_CLI_PATH` or
+  `GSD_BIN_PATH` overrides.
+- `GSD_WORKFLOW_MCP_CWD` — optional working directory for an explicit workflow
+  MCP server.
 - `GSD_CLOUD_EXECUTOR` — backend adapter: `gsd-pi` (default). `codex` and
   `claude` adapters are stubbed for future use.
 - `GSD_CLOUD_SESSION_EVENTS` — live session-event streaming: `0` or `false`

--- a/packages/gsd-cloud/README.md
+++ b/packages/gsd-cloud/README.md
@@ -3,11 +3,13 @@
 Connect a local GSD runtime to [GSD Cloud](https://cloud.opengsd.net) so you can
 monitor and control your GSD projects from any browser.
 
-This is a **self-contained** agent. Its required linked runtime dependencies are
-only `ws` and `yaml` — no `@opengsd/daemon`, `@opengsd/mcp-server`, or
-`@opengsd/gsd-pi`. It runs the RFC 8628 device-flow login, opens a persistent
-WebSocket to the cloud gateway, and forwards each requested GSD workflow tool to
-the workflow MCP server shipped with your locally installed `@opengsd/gsd-pi`.
+This is a **self-contained** agent. Its only runtime dependencies are `ws` and
+`yaml` — no `@opengsd/daemon`, `@opengsd/mcp-server`, or `@opengsd/gsd-pi`. It
+runs the RFC 8628 device-flow login, opens a persistent WebSocket to the cloud
+gateway, and forwards each requested GSD workflow tool to a workflow MCP server.
+That server is resolved at runtime, in order: an explicit
+`GSD_WORKFLOW_MCP_COMMAND`, the server bundled with a locally installed
+`@opengsd/gsd-pi`, or `gsd-mcp-server` found on your `PATH`.
 The gateway default of `https://cloud.opengsd.net` is injected for `login`/`pair`
 so you never have to type `--gateway`.
 

--- a/packages/gsd-cloud/README.md
+++ b/packages/gsd-cloud/README.md
@@ -3,13 +3,13 @@
 Connect a local GSD runtime to [GSD Cloud](https://cloud.opengsd.net) so you can
 monitor and control your GSD projects from any browser.
 
-This is a **self-contained** agent. Its required runtime dependencies are only
-`ws` and `yaml` — no `@opengsd/daemon`, no `@opengsd/mcp-server`, no
+This is a **self-contained** agent. Its required linked runtime dependencies are
+only `ws` and `yaml` — no `@opengsd/daemon`, `@opengsd/mcp-server`, or
 `@opengsd/gsd-pi`. It runs the RFC 8628 device-flow login, opens a persistent
 WebSocket to the cloud gateway, and forwards each requested GSD workflow tool to
-your locally-installed `gsd` CLI (via `gsd --mode mcp`). The gateway default of
-`https://cloud.opengsd.net` is injected for `login`/`pair` so you never have to
-type `--gateway`.
+the workflow MCP server shipped with your locally installed `@opengsd/gsd-pi`.
+The gateway default of `https://cloud.opengsd.net` is injected for `login`/`pair`
+so you never have to type `--gateway`.
 
 `node-pty` is an **optional** native dependency used only for browser terminal
 sessions. It is loaded dynamically at runtime; if it is not installed (for
@@ -91,8 +91,8 @@ unsupported platforms (e.g. Windows) `service` exits with a clear error; use
 
 While connected, the runtime also streams `session_event` frames over the same
 WebSocket so the dashboard can render GSD sessions live. For each advertised
-project it polls `gsd_status` every 3 seconds (via that project's
-`gsd --mode mcp` client) and normalizes the deltas into a fixed event
+project it polls `gsd_status` every 3 seconds through that project's workflow
+MCP server and normalizes the deltas into a fixed event
 vocabulary: `session_started`, `turn_started`, `assistant_text`, `tool_call`,
 `tool_result`, `blocker_pending`, `blocker_resolved`, `session_idle`,
 `session_ended`, and `error`, plus a `snapshot` every 30 seconds per active
@@ -111,6 +111,11 @@ are skipped and logged). Tool-call forwarding is unchanged. Set
 - `GSD_CLOUD_PROJECTS` — path-delimiter separated list of project directories to
   advertise to the cloud (default: the current working directory).
 - `GSD_CLI_PATH` — path to the `gsd` binary (default: `gsd` on `PATH`).
+- `GSD_WORKFLOW_MCP_COMMAND` — workflow MCP server command. By default the
+  daemon discovers `packages/mcp-server/dist/cli.js` beside the installed `gsd`
+  package, then falls back to `gsd-mcp-server` on `PATH`.
+- `GSD_WORKFLOW_MCP_ARGS` — optional JSON array of arguments for
+  `GSD_WORKFLOW_MCP_COMMAND`.
 - `GSD_CLOUD_EXECUTOR` — backend adapter: `gsd-pi` (default). `codex` and
   `claude` adapters are stubbed for future use.
 - `GSD_CLOUD_SESSION_EVENTS` — live session-event streaming: `0` or `false`
@@ -124,4 +129,5 @@ current terminal.
 ## Requirements
 
 - Node.js >= 22
-- The `gsd` CLI (`@opengsd/gsd-pi`) installed locally
+- The `gsd` CLI (`@opengsd/gsd-pi`) installed locally with its workflow MCP
+  server discoverable, or `GSD_WORKFLOW_MCP_COMMAND` configured explicitly

--- a/packages/gsd-cloud/e2e/README.md
+++ b/packages/gsd-cloud/e2e/README.md
@@ -35,7 +35,8 @@ separate gate you opt into locally or in CI.
    `gsd_cloud_projects` (asserts the fixture project is listed), and a
    forwarded `gsd_query` tool call (asserts the fixture's marker response came
    back through gateway → websocket → runtime → executor → stdio MCP → and
-   return).
+   return). It also forwards `gsd_status` to prove the workflow tool surface is
+   available through the same path.
 7. SIGTERMs the runtime, asserts a clean exit code and that the registry
    detaches, then tears everything down.
 

--- a/packages/gsd-cloud/e2e/README.md
+++ b/packages/gsd-cloud/e2e/README.md
@@ -25,9 +25,9 @@ separate gate you opt into locally or in CI.
    written to the config.
 4. Runs the real CLI `gsd-cloud connect --foreground` with
    `GSD_CLOUD_PROJECTS` pointing at a fixture project (minimal `.gsd`) and
-   `GSD_CLI_PATH` pointing at `fixture-gsd-mcp.mjs`, a stand-in for
-   `gsd --mode mcp` that speaks the executor's newline-delimited MCP stdio
-   protocol.
+   `GSD_WORKFLOW_MCP_COMMAND`/`ARGS` launching `fixture-gsd-mcp.mjs`, a stand-in
+   for the workflow MCP server that speaks the executor's newline-delimited MCP
+   stdio protocol.
 5. Asserts the runtime registers in the gateway registry (alias, canonical
    path, `online: true`, `gsd` marker).
 6. Drives the `/mcp` Streamable HTTP endpoint: `initialize`, `tools/list`
@@ -45,7 +45,7 @@ separate gate you opt into locally or in CI.
 | --- | --- |
 | `GSD_CLOUD_E2E=0` / `false` | Skip the harness (exit 0) — for CI jobs that cannot build the full chain. |
 | `GSD_CLOUD_E2E_TIMEOUT_MS` | Global watchdog timeout (default `120000`). |
-| `GSD_CLOUD_E2E_GSD_CLI` | Path to a real `gsd` binary to use instead of the fixture (full-stack mode; the fixture project must then satisfy `gsd --mode mcp`). |
+| `GSD_CLOUD_E2E_GSD_CLI` | Path to a real `gsd` binary whose installed package contains the workflow MCP server (full-stack mode). |
 | `GSD_CLOUD_E2E_KEEP_TMP=1` | Keep the temp root for debugging (the path is printed in the summary). |
 
 ## CI notes

--- a/packages/gsd-cloud/e2e/fixture-gsd-mcp.mjs
+++ b/packages/gsd-cloud/e2e/fixture-gsd-mcp.mjs
@@ -54,11 +54,11 @@ rl.on("line", (line) => {
 
   if (method === "tools/list") {
     return respond(id, {
-      tools: [{
-        name: "gsd_query",
-        description: "Fixture stand-in for the gsd_query reader tool.",
+      tools: ["gsd_query", "gsd_status"].map((name) => ({
+        name,
+        description: `Fixture stand-in for the ${name} workflow tool.`,
         inputSchema: { type: "object", properties: {}, required: [] },
-      }],
+      })),
     });
   }
 
@@ -72,6 +72,15 @@ rl.on("line", (line) => {
         content: [{
           type: "text",
           text: `${FIXTURE_MARKER} gsd_query ok projectDir=${projectDir} query=${query}`,
+        }],
+      });
+    }
+    if (name === "gsd_status") {
+      const projectDir = typeof args.projectDir === "string" ? args.projectDir : "<none>";
+      return respond(id, {
+        content: [{
+          type: "text",
+          text: `${FIXTURE_MARKER} gsd_status ok projectDir=${projectDir}`,
         }],
       });
     }

--- a/packages/gsd-cloud/e2e/fixture-gsd-mcp.mjs
+++ b/packages/gsd-cloud/e2e/fixture-gsd-mcp.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 // Project/App: Open GSD
-// File Purpose: E2E fixture standing in for the `gsd` binary.
+// File Purpose: E2E fixture standing in for the workflow MCP server.
 //
-// The gsd-pi executor drives a real `gsd --mode mcp` child over newline-delimited
+// The gsd-pi executor drives the workflow MCP server over newline-delimited
 // JSON-RPC on stdio. This fixture speaks exactly that protocol subset so the E2E
 // harness can exercise the full cloud path (gateway -> WS relay -> cloud runtime
-// -> executor -> stdio MCP) without building the entire gsd CLI. It is selected
-// via GSD_CLI_PATH; set GSD_CLOUD_E2E_GSD_CLI to a real gsd binary for a
-// full-stack run instead.
+// -> executor -> stdio MCP) without starting the installed server. It is selected
+// via GSD_WORKFLOW_MCP_COMMAND/ARGS; set GSD_CLOUD_E2E_GSD_CLI to a real gsd
+// binary for a full-stack run instead.
 //
 // Protocol contract (mirrors what McpStdioClient sends/reads):
 //   <- {"jsonrpc":"2.0","id":N,"method":"initialize","params":{...}}

--- a/packages/gsd-cloud/e2e/run-e2e.mjs
+++ b/packages/gsd-cloud/e2e/run-e2e.mjs
@@ -14,7 +14,7 @@
 //      command pointing at a fixture stdio server.
 //   5. Assert the runtime registers (gateway registry lists the fixture project).
 //   6. Drive the /mcp endpoint (Streamable HTTP): initialize, tools/list,
-//      gsd_cloud_projects, and a forwarded gsd_query tool call.
+//      gsd_cloud_projects, and forwarded gsd_query + gsd_status tool calls.
 //   7. SIGTERM the runtime, assert clean exit and registry detach, tear down.
 //
 // This script is intentionally NOT part of `pnpm test` (which is unit-test only).
@@ -52,6 +52,7 @@ const CLI_DIST = join(PKG_DIR, "dist", "cli.js");
 const GATEWAY_DIST = join(REPO_ROOT, "packages", "cloud-mcp-gateway", "dist", "index.js");
 const FIXTURE_WORKFLOW_SERVER = join(E2E_DIR, "fixture-gsd-mcp.mjs");
 const FIXTURE_MARKER = "GSD_CLOUD_E2E_FIXTURE";
+const REAL_GSD_CLI = process.env.GSD_CLOUD_E2E_GSD_CLI?.trim();
 
 const HTTP_TIMEOUT_MS = 10_000;
 const PAIR_TIMEOUT_MS = 30_000;
@@ -106,6 +107,7 @@ async function runAllSteps() {
   await step("MCP initialize + tools/list over /mcp", () => assertMcpHandshake(ctx));
   await step("MCP gsd_cloud_projects returns the fixture project", () => assertCloudProjects(ctx));
   await step("MCP gsd_query is forwarded to the runtime and back", () => assertForwardedQuery(ctx));
+  await step("MCP gsd_status reaches the workflow tool surface", () => assertForwardedStatus(ctx));
   await step("runtime shuts down cleanly and detaches from the registry", () => assertShutdown(ctx));
 }
 
@@ -308,12 +310,46 @@ async function assertForwardedQuery(ctx) {
     arguments: { query: "state", projectAlias: "fixture-project" },
   });
   const text = response.result?.content?.[0]?.text;
-  if (typeof text !== "string" || !text.includes(`${FIXTURE_MARKER} gsd_query ok`)) {
-    throw new Error(`forwarded gsd_query did not reach the fixture: ${JSON.stringify(response)}`);
-  }
   const expectedPath = realpathSync(join(tmpRoot, "fixture-project"));
+  if (typeof text !== "string") {
+    throw new Error(`forwarded gsd_query returned no text: ${JSON.stringify(response)}`);
+  }
+  if (REAL_GSD_CLI) {
+    const result = JSON.parse(text);
+    if (result.projectDir !== expectedPath || result.query !== "state" || !result.state?.includes("E2E fixture project")) {
+      throw new Error(`real workflow gsd_query response was unexpected: ${text}`);
+    }
+    return;
+  }
+  if (!text.includes(`${FIXTURE_MARKER} gsd_query ok`)) {
+    throw new Error(`forwarded gsd_query did not reach the fixture: ${text}`);
+  }
   if (!text.includes(`projectDir=${expectedPath}`) || !text.includes("query=state")) {
     throw new Error(`forwarded gsd_query args were not routed as expected: ${text}`);
+  }
+}
+
+async function assertForwardedStatus(ctx) {
+  const response = await mcpRpc(ctx, 5, "tools/call", {
+    name: "gsd_status",
+    arguments: { projectAlias: "fixture-project" },
+  });
+  const text = response.result?.content?.[0]?.text;
+  const expectedPath = realpathSync(join(tmpRoot, "fixture-project"));
+  if (typeof text !== "string") {
+    throw new Error(`forwarded gsd_status returned no text: ${JSON.stringify(response)}`);
+  }
+  if (REAL_GSD_CLI) {
+    if (!response.result?.isError || text !== `Session not found for projectDir: ${expectedPath}`) {
+      throw new Error(`real workflow gsd_status response was unexpected: ${JSON.stringify(response)}`);
+    }
+    return;
+  }
+  if (!text.includes(`${FIXTURE_MARKER} gsd_status ok`)) {
+    throw new Error(`forwarded gsd_status did not reach the fixture: ${text}`);
+  }
+  if (!text.includes(`projectDir=${expectedPath}`)) {
+    throw new Error(`forwarded gsd_status args were not routed as expected: ${text}`);
   }
 }
 
@@ -351,9 +387,8 @@ function childEnv() {
     GSD_CLOUD_TOKEN_KEY: "gsd-cloud-e2e-token-key",
     GSD_CLOUD_PROJECTS: join(tmpRoot, "fixture-project"),
   };
-  const gsdCliPath = process.env.GSD_CLOUD_E2E_GSD_CLI?.trim();
-  if (gsdCliPath) {
-    env.GSD_CLI_PATH = gsdCliPath;
+  if (REAL_GSD_CLI) {
+    env.GSD_CLI_PATH = REAL_GSD_CLI;
     delete env.GSD_WORKFLOW_MCP_COMMAND;
     delete env.GSD_WORKFLOW_MCP_ARGS;
   } else {

--- a/packages/gsd-cloud/e2e/run-e2e.mjs
+++ b/packages/gsd-cloud/e2e/run-e2e.mjs
@@ -10,8 +10,8 @@
 //   2. POST /pairing-codes (user bearer token) to mint a pairing code.
 //   3. Run the real gsd-cloud CLI `pair` against it (temp HOME + temp config).
 //   4. Run the real gsd-cloud CLI `connect --foreground` with GSD_CLOUD_PROJECTS
-//      pointing at a fixture project dir (minimal .gsd) and GSD_CLI_PATH pointing
-//      at a fixture MCP stdio server standing in for `gsd --mode mcp`.
+//      pointing at a fixture project dir (minimal .gsd) and the workflow MCP
+//      command pointing at a fixture stdio server.
 //   5. Assert the runtime registers (gateway registry lists the fixture project).
 //   6. Drive the /mcp endpoint (Streamable HTTP): initialize, tools/list,
 //      gsd_cloud_projects, and a forwarded gsd_query tool call.
@@ -24,8 +24,8 @@
 // Environment:
 //   GSD_CLOUD_E2E=0|false        Skip (exit 0) — for CI jobs without a full build.
 //   GSD_CLOUD_E2E_TIMEOUT_MS     Global watchdog timeout (default 120000).
-//   GSD_CLOUD_E2E_GSD_CLI        Use a real gsd binary instead of the fixture
-//                                (fixture project must then satisfy gsd --mode mcp).
+//   GSD_CLOUD_E2E_GSD_CLI        Use a real gsd installation and its bundled
+//                                workflow MCP server instead of the fixture.
 //   GSD_CLOUD_E2E_KEEP_TMP=1     Keep the temp root for debugging (path is printed).
 
 import { randomBytes } from "node:crypto";
@@ -50,7 +50,7 @@ const REPO_ROOT = join(PKG_DIR, "..", "..");
 const CLI_BIN = join(PKG_DIR, "bin", "gsd-cloud.js");
 const CLI_DIST = join(PKG_DIR, "dist", "cli.js");
 const GATEWAY_DIST = join(REPO_ROOT, "packages", "cloud-mcp-gateway", "dist", "index.js");
-const FIXTURE_GSD_BIN = join(E2E_DIR, "fixture-gsd-mcp.mjs");
+const FIXTURE_WORKFLOW_SERVER = join(E2E_DIR, "fixture-gsd-mcp.mjs");
 const FIXTURE_MARKER = "GSD_CLOUD_E2E_FIXTURE";
 
 const HTTP_TIMEOUT_MS = 10_000;
@@ -131,7 +131,7 @@ function checkPrereqs() {
   writeFileSync(join(projectDir, ".gsd", "PROJECT.md"), "# Project\n\ngsd-cloud e2e fixture.\n");
 
   // The fixture must be executable regardless of how git materialized file modes.
-  chmodSync(FIXTURE_GSD_BIN, 0o755);
+  chmodSync(FIXTURE_WORKFLOW_SERVER, 0o755);
 }
 
 async function startGateway(ctx) {
@@ -343,15 +343,25 @@ async function assertShutdown(ctx) {
 // ---------------------------------------------------------------------------
 
 function childEnv() {
-  return {
+  const env = {
     ...process.env,
     HOME: join(tmpRoot, "home"),
     // Deterministic device-token encryption key — pair and connect run as
     // separate processes and must derive the same key.
     GSD_CLOUD_TOKEN_KEY: "gsd-cloud-e2e-token-key",
     GSD_CLOUD_PROJECTS: join(tmpRoot, "fixture-project"),
-    GSD_CLI_PATH: process.env.GSD_CLOUD_E2E_GSD_CLI ?? FIXTURE_GSD_BIN,
   };
+  const gsdCliPath = process.env.GSD_CLOUD_E2E_GSD_CLI?.trim();
+  if (gsdCliPath) {
+    env.GSD_CLI_PATH = gsdCliPath;
+    delete env.GSD_WORKFLOW_MCP_COMMAND;
+    delete env.GSD_WORKFLOW_MCP_ARGS;
+  } else {
+    delete env.GSD_CLI_PATH;
+    env.GSD_WORKFLOW_MCP_COMMAND = process.execPath;
+    env.GSD_WORKFLOW_MCP_ARGS = JSON.stringify([FIXTURE_WORKFLOW_SERVER]);
+  }
+  return env;
 }
 
 function runProcess(command, args, { env, timeoutMs }) {

--- a/packages/gsd-cloud/e2e/run-e2e.mjs
+++ b/packages/gsd-cloud/e2e/run-e2e.mjs
@@ -340,7 +340,10 @@ async function assertForwardedStatus(ctx) {
     throw new Error(`forwarded gsd_status returned no text: ${JSON.stringify(response)}`);
   }
   if (REAL_GSD_CLI) {
-    if (!response.result?.isError || text !== `Session not found for projectDir: ${expectedPath}`) {
+    // This asserts forwarding/wiring, so match the stable parts (error flag +
+    // "Session not found" prefix + routed projectDir) rather than the workflow
+    // server's exact wording, which can change harmlessly.
+    if (!response.result?.isError || !text.startsWith("Session not found") || !text.includes(expectedPath)) {
       throw new Error(`real workflow gsd_status response was unexpected: ${JSON.stringify(response)}`);
     }
     return;

--- a/packages/gsd-cloud/package.json
+++ b/packages/gsd-cloud/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false",
-    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/service-install.test.js dist/background-cli.test.js dist/session-events.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js",
+    "test": "pnpm run build && node --test dist/inject-gateway.test.js dist/cloud-gateway-lookup.test.js dist/cloud-config.test.js dist/device-flow.test.js dist/cloud-runtime.test.js dist/runtime-telemetry.test.js dist/runtime-process.test.js dist/service-install.test.js dist/background-cli.test.js dist/session-events.test.js dist/executors/mcp-stdio-client.test.js dist/executors/gsd-pi-executor.test.js dist/executors/workflow-server-launch.test.js",
     "validate:tarball": "node ../../scripts/validate-gsd-cloud-tarball.mjs",
     "test:e2e": "pnpm --filter @opengsd/cloud-mcp-gateway... run build && pnpm run build && node e2e/run-e2e.mjs"
   },

--- a/packages/gsd-cloud/src/cloud-runtime.test.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.test.ts
@@ -359,6 +359,34 @@ test("startup failures flush runtime telemetry before rejecting", async (t) => {
 
 });
 
+test("startup rejects executor initialization before connecting", async (t) => {
+  const events: string[] = [];
+  const telemetry = {
+    ...Object.fromEntries([
+      "connected", "disconnected", "received", "sent", "projectsAdvertised",
+      "requestStarted", "requestFinished", "stopped", "failed", "flush",
+    ].map((name) => [name, () => undefined])),
+    connecting: () => events.push("connecting"),
+    socketError: (message: string) => events.push(`error:${message}`),
+  } as never;
+  const runtime = new CloudRuntime(
+    { gateway_url: "not-a-url", device_token: "fixture", runtime_id: "runtime" },
+    {
+      initialize: () => {
+        throw new Error("Cannot locate the GSD workflow MCP server");
+      },
+      execute: async () => ({}),
+      advertisedProjects: async () => [],
+    },
+    noopLogger as never,
+    telemetry,
+  );
+  t.after(() => runtime.stop());
+
+  await assert.rejects(runtime.start(), /Cannot locate the GSD workflow MCP server/);
+  assert.deepEqual(events, ["error:Cannot locate the GSD workflow MCP server"]);
+});
+
 test("malformed gateway failures flush runtime telemetry before rejecting", async (t) => {
   const root = mkdtempSync(join(tmpdir(), "gsd-cloud-startup-url-error-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));

--- a/packages/gsd-cloud/src/cloud-runtime.ts
+++ b/packages/gsd-cloud/src/cloud-runtime.ts
@@ -111,6 +111,7 @@ export class CloudRuntime {
       throw error;
     });
     try {
+      this.executor.initialize?.();
       this.connect();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/gsd-cloud/src/executors/executor.ts
+++ b/packages/gsd-cloud/src/executors/executor.ts
@@ -31,6 +31,7 @@ export interface AdvertisedProject {
  *   CloudRuntime sends them in the `hello` message on every (re)connect.
  */
 export interface Executor {
+  /** Optional startup preflight. Must throw synchronously when validation fails. */
   initialize?(): void;
   execute(
     toolName: string,

--- a/packages/gsd-cloud/src/executors/executor.ts
+++ b/packages/gsd-cloud/src/executors/executor.ts
@@ -31,6 +31,7 @@ export interface AdvertisedProject {
  *   CloudRuntime sends them in the `hello` message on every (re)connect.
  */
 export interface Executor {
+  initialize?(): void;
   execute(
     toolName: string,
     rawArgs: Record<string, unknown>,

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -15,13 +15,18 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, delimiter, dirname, join, resolve } from "node:path";
-import { GsdPiExecutor } from "./gsd-pi-executor.js";
+import { GsdPiExecutor, type WorkflowClientFactory } from "./gsd-pi-executor.js";
 import type { McpStdioClient } from "./mcp-stdio-client.js";
+
+// Derive the spawn-options shape from the executor's factory signature so the
+// helper stays aligned with it (e.g. windowsVerbatimArguments) instead of
+// re-declaring a subset that drifts and hides Windows-shim wiring.
+type SpawnOptions = Parameters<WorkflowClientFactory>[3];
 
 interface SpawnRecord {
   command: string;
   args: string[];
-  options: { env?: NodeJS.ProcessEnv; cwd?: string };
+  options: SpawnOptions;
 }
 
 /** Restore an env var, deleting it when the original was unset (assigning
@@ -32,13 +37,8 @@ function restoreEnv(key: string, value: string | undefined): void {
 }
 
 /** Records how the per-project MCP client would be constructed, without spawning. */
-function recordingClientFactory(sink: SpawnRecord[]) {
-  return (
-    command: string,
-    args: string[],
-    _logger: unknown,
-    options: { env?: NodeJS.ProcessEnv; cwd?: string },
-  ): McpStdioClient => {
+function recordingClientFactory(sink: SpawnRecord[]): WorkflowClientFactory {
+  return (command, args, _logger, options) => {
     sink.push({ command, args, options });
     return {
       callTool: async () => ({ ok: true }),

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -356,6 +356,10 @@ test("createProjectEntry honors explicit workflow env and cwd", async (t) => {
   assert.equal(spawned[0]!.options.env?.CUSTOM_WORKFLOW_VALUE, "preserved");
   assert.equal(spawned[0]!.options.env?.GSD_CLI_PATH, "/opt/custom/gsd");
   assert.equal(spawned[0]!.options.env?.GSD_BIN_PATH, "/opt/custom/gsd");
+  // GSD_WORKFLOW_MCP_CWD overrides the working directory only — it must NOT leak
+  // into the workflow project root, which stays pinned to the per-project path
+  // so multi-project routing is preserved.
+  assert.equal(spawned[0]!.options.env?.GSD_WORKFLOW_PROJECT_ROOT, resolve(projectDir));
 });
 
 test("GSD_BIN_PATH wins over the executor's default gsd PATH anchor", async (t) => {

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -4,6 +4,7 @@
 // of silently routing cloud work to whichever entry comes first.
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import {
   chmodSync,
   mkdirSync,
@@ -73,6 +74,42 @@ test("advertised alias is the directory basename", async () => {
   const projects = await exec.advertisedProjects();
   assert.equal(projects.length, 1);
   assert.equal(projects[0]?.alias, "app");
+});
+
+test("missing workflow server rejects without an unhandled rejection", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-missing-server-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const projectDir = join(root, "project");
+  mkdirSync(projectDir, { recursive: true });
+
+  const childScript = `
+    import { GsdPiExecutor } from ${JSON.stringify(new URL("./gsd-pi-executor.js", import.meta.url).href)};
+    const logger = { info() {}, warn() {}, error() {}, debug() {} };
+    const executor = new GsdPiExecutor(logger, {
+      gsdBinary: ${JSON.stringify(join(root, "missing-gsd"))},
+      projectDirs: [${JSON.stringify(projectDir)}],
+    });
+    try {
+      await executor.execute("gsd_status", {});
+      process.exitCode = 2;
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes("Cannot locate")) {
+        process.exitCode = 3;
+      }
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+  `;
+  const env: NodeJS.ProcessEnv = { ...process.env, PATH: "" };
+  delete env.GSD_CLI_PATH;
+  delete env.GSD_WORKFLOW_MCP_COMMAND;
+  delete env.GSD_WORKFLOW_MCP_ARGS;
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", childScript],
+    { encoding: "utf8", env },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
 });
 
 test("configured gsd binary is passed to the workflow server", async (t) => {

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -106,7 +106,7 @@ test("advertised alias is the directory basename", async () => {
   assert.equal(projects[0]?.alias, "app");
 });
 
-test("missing workflow server rejects without an unhandled rejection", (t) => {
+test("initialization rejects a missing workflow server without an unhandled rejection", (t) => {
   const root = mkdtempSync(join(tmpdir(), "gsd-cloud-missing-server-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const projectDir = join(root, "project");
@@ -120,7 +120,7 @@ test("missing workflow server rejects without an unhandled rejection", (t) => {
       projectDirs: [${JSON.stringify(projectDir)}],
     });
     try {
-      await executor.execute("gsd_status", {});
+      executor.initialize();
       process.exitCode = 2;
     } catch (error) {
       if (!(error instanceof Error) || !error.message.includes("Cannot locate")) {
@@ -131,6 +131,8 @@ test("missing workflow server rejects without an unhandled rejection", (t) => {
   `;
   const env: NodeJS.ProcessEnv = { ...process.env, PATH: "" };
   delete env.GSD_CLI_PATH;
+  delete env.GSD_BIN_PATH;
+  delete env.GSD_WORKFLOW_PATH;
   delete env.GSD_WORKFLOW_MCP_COMMAND;
   delete env.GSD_WORKFLOW_MCP_ARGS;
   const result = spawnSync(

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -8,6 +8,36 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { GsdPiExecutor } from "./gsd-pi-executor.js";
+import type { McpStdioClient } from "./mcp-stdio-client.js";
+
+interface SpawnRecord {
+  command: string;
+  args: string[];
+  options: { env?: NodeJS.ProcessEnv; cwd?: string };
+}
+
+/** Restore an env var, deleting it when the original was unset (assigning
+ * `undefined` would otherwise coerce to the string "undefined"). */
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+/** Records how the per-project MCP client would be constructed, without spawning. */
+function recordingClientFactory(sink: SpawnRecord[]) {
+  return (
+    command: string,
+    args: string[],
+    _logger: unknown,
+    options: { env?: NodeJS.ProcessEnv; cwd?: string },
+  ): McpStdioClient => {
+    sink.push({ command, args, options });
+    return {
+      callTool: async () => ({ ok: true }),
+      close: () => undefined,
+    } as unknown as McpStdioClient;
+  };
+}
 
 const warnings: Array<{ msg: string; meta: unknown }> = [];
 const logger = {
@@ -110,4 +140,70 @@ test("Milestone lifecycle request identity becomes private MCP metadata", async 
     args: { milestoneId: "M001", projectDir: resolve(projectDir) },
     meta: { "io.opengsd/idempotency-key": `gateway-${name}` },
   })));
+});
+
+test("createProjectEntry spawns the resolved workflow server pinned to the project dir", async (t) => {
+  const projectDir = mkdtempSync(join(tmpdir(), "gsd-cloud-wiring-"));
+  t.after(() => rmSync(projectDir, { recursive: true, force: true }));
+
+  const originalCmd = process.env.GSD_WORKFLOW_MCP_COMMAND;
+  const originalArgs = process.env.GSD_WORKFLOW_MCP_ARGS;
+  // Pin discovery to an explicit command so the test does not depend on a real
+  // installed server or PATH.
+  process.env.GSD_WORKFLOW_MCP_COMMAND = "/opt/gsd/wf-server";
+  process.env.GSD_WORKFLOW_MCP_ARGS = '["--stdio"]';
+  t.after(() => {
+    restoreEnv("GSD_WORKFLOW_MCP_COMMAND", originalCmd);
+    restoreEnv("GSD_WORKFLOW_MCP_ARGS", originalArgs);
+  });
+
+  const spawned: SpawnRecord[] = [];
+  const executor = new GsdPiExecutor(logger as never, {
+    gsdBinary: "/usr/local/bin/gsd",
+    projectDirs: [projectDir],
+    clientFactory: recordingClientFactory(spawned),
+  });
+
+  await executor.execute("gsd_status", {}, basename(projectDir));
+
+  assert.equal(spawned.length, 1);
+  const call = spawned[0]!;
+  assert.equal(call.command, "/opt/gsd/wf-server");
+  assert.deepEqual(call.args, ["--stdio"]);
+  assert.equal(call.options.cwd, resolve(projectDir));
+  assert.equal(call.options.env?.GSD_PROJECT_ROOT, resolve(projectDir));
+  assert.equal(call.options.env?.GSD_WORKFLOW_PROJECT_ROOT, resolve(projectDir));
+  // gsdBinary is an absolute path, so it is propagated to the child.
+  assert.equal(call.options.env?.GSD_CLI_PATH, "/usr/local/bin/gsd");
+});
+
+test("createProjectEntry does not inject GSD_CLI_PATH for a bare gsd binary name", async (t) => {
+  const projectDir = mkdtempSync(join(tmpdir(), "gsd-cloud-wiring-bare-"));
+  t.after(() => rmSync(projectDir, { recursive: true, force: true }));
+
+  const originalCmd = process.env.GSD_WORKFLOW_MCP_COMMAND;
+  const originalArgs = process.env.GSD_WORKFLOW_MCP_ARGS;
+  const originalCliPath = process.env.GSD_CLI_PATH;
+  process.env.GSD_WORKFLOW_MCP_COMMAND = "/opt/gsd/wf-server";
+  delete process.env.GSD_WORKFLOW_MCP_ARGS;
+  // Ensure the ambient env does not carry GSD_CLI_PATH, so the assertion proves
+  // the executor did not inject the bare name.
+  delete process.env.GSD_CLI_PATH;
+  t.after(() => {
+    restoreEnv("GSD_WORKFLOW_MCP_COMMAND", originalCmd);
+    restoreEnv("GSD_WORKFLOW_MCP_ARGS", originalArgs);
+    restoreEnv("GSD_CLI_PATH", originalCliPath);
+  });
+
+  const spawned: SpawnRecord[] = [];
+  const executor = new GsdPiExecutor(logger as never, {
+    gsdBinary: "gsd",
+    projectDirs: [projectDir],
+    clientFactory: recordingClientFactory(spawned),
+  });
+
+  await executor.execute("gsd_status", {}, basename(projectDir));
+
+  assert.equal(spawned.length, 1);
+  assert.equal(spawned[0]!.options.env?.GSD_CLI_PATH, undefined);
 });

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -4,7 +4,7 @@
 // of silently routing cloud work to whichever entry comes first.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { GsdPiExecutor } from "./gsd-pi-executor.js";
@@ -49,6 +49,46 @@ test("advertised alias is the directory basename", async () => {
   const projects = await exec.advertisedProjects();
   assert.equal(projects.length, 1);
   assert.equal(projects[0]?.alias, "app");
+});
+
+test("configured gsd binary is passed to the workflow server", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-cli-path-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const projectDir = join(root, "project");
+  const serverPath = join(root, "server.mjs");
+  const gsdBinary = join(root, "custom", "gsd");
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(
+    serverPath,
+    `import { createInterface } from "node:readline";
+const lines = createInterface({ input: process.stdin });
+for await (const line of lines) {
+  const message = JSON.parse(line);
+  if (message.id === undefined) continue;
+  const result = message.method === "initialize"
+    ? { protocolVersion: "2024-11-05", capabilities: {} }
+    : { gsdCliPath: process.env.GSD_CLI_PATH };
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }) + "\\n");
+}
+`,
+  );
+
+  const previousCommand = process.env.GSD_WORKFLOW_MCP_COMMAND;
+  const previousArgs = process.env.GSD_WORKFLOW_MCP_ARGS;
+  process.env.GSD_WORKFLOW_MCP_COMMAND = process.execPath;
+  process.env.GSD_WORKFLOW_MCP_ARGS = JSON.stringify([serverPath]);
+  t.after(() => {
+    if (previousCommand === undefined) delete process.env.GSD_WORKFLOW_MCP_COMMAND;
+    else process.env.GSD_WORKFLOW_MCP_COMMAND = previousCommand;
+    if (previousArgs === undefined) delete process.env.GSD_WORKFLOW_MCP_ARGS;
+    else process.env.GSD_WORKFLOW_MCP_ARGS = previousArgs;
+  });
+
+  const executor = new GsdPiExecutor(logger as never, { gsdBinary, projectDirs: [projectDir] });
+  t.after(() => executor.close());
+  const result = await executor.execute("gsd_status", {});
+
+  assert.deepEqual(result, { gsdCliPath: gsdBinary });
 });
 
 test("Milestone lifecycle request identity becomes private MCP metadata", async (t) => {

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -316,8 +316,10 @@ test("createProjectEntry spawns the resolved workflow server pinned to the proje
   assert.equal(call.options.cwd, resolve(projectDir));
   assert.equal(call.options.env?.GSD_PROJECT_ROOT, resolve(projectDir));
   assert.equal(call.options.env?.GSD_WORKFLOW_PROJECT_ROOT, resolve(projectDir));
-  // gsdBinary is an absolute path, so it is propagated to the child.
+  // gsdBinary is an absolute path, so it is propagated to the child as both
+  // GSD_CLI_PATH and GSD_BIN_PATH (equivalent CLI-path overrides downstream).
   assert.equal(call.options.env?.GSD_CLI_PATH, "/usr/local/bin/gsd");
+  assert.equal(call.options.env?.GSD_BIN_PATH, "/usr/local/bin/gsd");
 });
 
 test("createProjectEntry does not inject GSD_CLI_PATH for a bare gsd binary name", async (t) => {
@@ -327,12 +329,16 @@ test("createProjectEntry does not inject GSD_CLI_PATH for a bare gsd binary name
   const originalCmd = process.env.GSD_WORKFLOW_MCP_COMMAND;
   const originalArgs = process.env.GSD_WORKFLOW_MCP_ARGS;
   const originalCliPath = process.env.GSD_CLI_PATH;
+  const originalBinPath = process.env.GSD_BIN_PATH;
   const originalPath = process.env.PATH;
   process.env.GSD_WORKFLOW_MCP_COMMAND = "/opt/gsd/wf-server";
   delete process.env.GSD_WORKFLOW_MCP_ARGS;
   // Ensure the ambient env does not carry GSD_CLI_PATH, so the assertion proves
   // the executor did not inject the bare name.
   delete process.env.GSD_CLI_PATH;
+  // Seed a stale GSD_BIN_PATH (an equivalent CLI-path override downstream) to
+  // prove the executor strips it rather than letting it leak into the child.
+  process.env.GSD_BIN_PATH = "/stale/daemon/gsd";
   // Point PATH at an empty dir so the bare "gsd" anchor cannot resolve to a
   // real on-disk binary — a host-installed gsd would legitimately be
   // discovered by the resolver and propagated as gsdCliPath.
@@ -343,6 +349,7 @@ test("createProjectEntry does not inject GSD_CLI_PATH for a bare gsd binary name
     restoreEnv("GSD_WORKFLOW_MCP_COMMAND", originalCmd);
     restoreEnv("GSD_WORKFLOW_MCP_ARGS", originalArgs);
     restoreEnv("GSD_CLI_PATH", originalCliPath);
+    restoreEnv("GSD_BIN_PATH", originalBinPath);
     restoreEnv("PATH", originalPath);
   });
 
@@ -357,4 +364,6 @@ test("createProjectEntry does not inject GSD_CLI_PATH for a bare gsd binary name
 
   assert.equal(spawned.length, 1);
   assert.equal(spawned[0]!.options.env?.GSD_CLI_PATH, undefined);
+  // The stale inherited GSD_BIN_PATH must be stripped alongside GSD_CLI_PATH.
+  assert.equal(spawned[0]!.options.env?.GSD_BIN_PATH, undefined);
 });

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -4,9 +4,16 @@
 // of silently routing cloud work to whichever entry comes first.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
 import { GsdPiExecutor } from "./gsd-pi-executor.js";
 
 const warnings: Array<{ msg: string; meta: unknown }> = [];
@@ -16,6 +23,23 @@ const logger = {
   error: () => undefined,
   debug: () => undefined,
 };
+
+function writeCliPathServer(serverPath: string): void {
+  writeFileSync(
+    serverPath,
+    `import { createInterface } from "node:readline";
+const lines = createInterface({ input: process.stdin });
+for await (const line of lines) {
+  const message = JSON.parse(line);
+  if (message.id === undefined) continue;
+  const result = message.method === "initialize"
+    ? { protocolVersion: "2024-11-05", capabilities: {} }
+    : { gsdCliPath: process.env.GSD_CLI_PATH };
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }) + "\\n");
+}
+`,
+  );
+}
 
 test("ambiguous alias across colliding basenames rejects instead of mis-routing", async () => {
   const exec = new GsdPiExecutor(logger as never, {
@@ -58,20 +82,9 @@ test("configured gsd binary is passed to the workflow server", async (t) => {
   const serverPath = join(root, "server.mjs");
   const gsdBinary = join(root, "custom", "gsd");
   mkdirSync(projectDir, { recursive: true });
-  writeFileSync(
-    serverPath,
-    `import { createInterface } from "node:readline";
-const lines = createInterface({ input: process.stdin });
-for await (const line of lines) {
-  const message = JSON.parse(line);
-  if (message.id === undefined) continue;
-  const result = message.method === "initialize"
-    ? { protocolVersion: "2024-11-05", capabilities: {} }
-    : { gsdCliPath: process.env.GSD_CLI_PATH };
-  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }) + "\\n");
-}
-`,
-  );
+  mkdirSync(dirname(gsdBinary), { recursive: true });
+  writeFileSync(gsdBinary, "#!/usr/bin/env node\n");
+  writeCliPathServer(serverPath);
 
   const previousCommand = process.env.GSD_WORKFLOW_MCP_COMMAND;
   const previousArgs = process.env.GSD_WORKFLOW_MCP_ARGS;
@@ -88,7 +101,46 @@ for await (const line of lines) {
   t.after(() => executor.close());
   const result = await executor.execute("gsd_status", {});
 
-  assert.deepEqual(result, { gsdCliPath: gsdBinary });
+  assert.deepEqual(result, { gsdCliPath: realpathSync(gsdBinary) });
+});
+
+test("bare gsd name is resolved before reaching the workflow server", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-bare-cli-path-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const projectDir = join(root, "project");
+  const npmBin = join(root, "npm");
+  const serverPath = join(root, "server.mjs");
+  const gsdBinary = join(npmBin, process.platform === "win32" ? "gsd.cmd" : "gsd");
+  mkdirSync(projectDir, { recursive: true });
+  mkdirSync(npmBin, { recursive: true });
+  writeFileSync(gsdBinary, process.platform === "win32" ? "@node %*\r\n" : "#!/bin/sh\n");
+  if (process.platform !== "win32") chmodSync(gsdBinary, 0o755);
+  writeCliPathServer(serverPath);
+
+  const previousCommand = process.env.GSD_WORKFLOW_MCP_COMMAND;
+  const previousArgs = process.env.GSD_WORKFLOW_MCP_ARGS;
+  const previousCliPath = process.env.GSD_CLI_PATH;
+  const previousPath = process.env.PATH;
+  process.env.GSD_WORKFLOW_MCP_COMMAND = process.execPath;
+  process.env.GSD_WORKFLOW_MCP_ARGS = JSON.stringify([serverPath]);
+  delete process.env.GSD_CLI_PATH;
+  process.env.PATH = `${npmBin}${delimiter}${previousPath ?? ""}`;
+  t.after(() => {
+    if (previousCommand === undefined) delete process.env.GSD_WORKFLOW_MCP_COMMAND;
+    else process.env.GSD_WORKFLOW_MCP_COMMAND = previousCommand;
+    if (previousArgs === undefined) delete process.env.GSD_WORKFLOW_MCP_ARGS;
+    else process.env.GSD_WORKFLOW_MCP_ARGS = previousArgs;
+    if (previousCliPath === undefined) delete process.env.GSD_CLI_PATH;
+    else process.env.GSD_CLI_PATH = previousCliPath;
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+  });
+
+  const executor = new GsdPiExecutor(logger as never, { projectDirs: [projectDir] });
+  t.after(() => executor.close());
+  const result = await executor.execute("gsd_status", {});
+
+  assert.deepEqual(result, { gsdCliPath: realpathSync(gsdBinary) });
 });
 
 test("Milestone lifecycle request identity becomes private MCP metadata", async (t) => {

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -318,10 +318,88 @@ test("createProjectEntry spawns the resolved workflow server pinned to the proje
   assert.equal(call.options.cwd, resolve(projectDir));
   assert.equal(call.options.env?.GSD_PROJECT_ROOT, resolve(projectDir));
   assert.equal(call.options.env?.GSD_WORKFLOW_PROJECT_ROOT, resolve(projectDir));
+  assert.equal(call.options.env?.GSD_MCP_CLIENT_MANAGED, "1");
   // gsdBinary is an absolute path, so it is propagated to the child as both
   // GSD_CLI_PATH and GSD_BIN_PATH (equivalent CLI-path overrides downstream).
   assert.equal(call.options.env?.GSD_CLI_PATH, "/usr/local/bin/gsd");
   assert.equal(call.options.env?.GSD_BIN_PATH, "/usr/local/bin/gsd");
+});
+
+test("createProjectEntry honors explicit workflow env and cwd", async (t) => {
+  const projectDir = mkdtempSync(join(tmpdir(), "gsd-cloud-explicit-launch-"));
+  t.after(() => rmSync(projectDir, { recursive: true, force: true }));
+
+  const previousCommand = process.env.GSD_WORKFLOW_MCP_COMMAND;
+  const previousEnv = process.env.GSD_WORKFLOW_MCP_ENV;
+  const previousCwd = process.env.GSD_WORKFLOW_MCP_CWD;
+  process.env.GSD_WORKFLOW_MCP_COMMAND = "/opt/gsd/wf-server";
+  process.env.GSD_WORKFLOW_MCP_ENV = JSON.stringify({
+    CUSTOM_WORKFLOW_VALUE: "preserved",
+    GSD_BIN_PATH: "/opt/custom/gsd",
+  });
+  process.env.GSD_WORKFLOW_MCP_CWD = "/opt/workflow-cwd";
+  t.after(() => {
+    restoreEnv("GSD_WORKFLOW_MCP_COMMAND", previousCommand);
+    restoreEnv("GSD_WORKFLOW_MCP_ENV", previousEnv);
+    restoreEnv("GSD_WORKFLOW_MCP_CWD", previousCwd);
+  });
+
+  const spawned: SpawnRecord[] = [];
+  const executor = new GsdPiExecutor(logger as never, {
+    projectDirs: [projectDir],
+    clientFactory: recordingClientFactory(spawned),
+  });
+
+  await executor.execute("gsd_status", {}, basename(projectDir));
+
+  assert.equal(spawned[0]!.options.cwd, "/opt/workflow-cwd");
+  assert.equal(spawned[0]!.options.env?.CUSTOM_WORKFLOW_VALUE, "preserved");
+  assert.equal(spawned[0]!.options.env?.GSD_CLI_PATH, "/opt/custom/gsd");
+  assert.equal(spawned[0]!.options.env?.GSD_BIN_PATH, "/opt/custom/gsd");
+});
+
+test("GSD_BIN_PATH wins over the executor's default gsd PATH anchor", async (t) => {
+  const preferred = mkdtempSync(join(tmpdir(), "gsd-cloud-preferred-gsd-"));
+  const pathInstall = mkdtempSync(join(tmpdir(), "gsd-cloud-path-gsd-"));
+  const projectDir = mkdtempSync(join(tmpdir(), "gsd-cloud-precedence-project-"));
+  t.after(() => {
+    rmSync(preferred, { recursive: true, force: true });
+    rmSync(pathInstall, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  const preferredGsd = join(preferred, "dist", "loader.js");
+  const pathGsd = join(pathInstall, "gsd");
+  mkdirSync(dirname(preferredGsd), { recursive: true });
+  writeFileSync(preferredGsd, "// preferred gsd\n");
+  writeFileSync(pathGsd, "#!/bin/sh\n");
+  chmodSync(pathGsd, 0o755);
+
+  const previousCommand = process.env.GSD_WORKFLOW_MCP_COMMAND;
+  const previousBinPath = process.env.GSD_BIN_PATH;
+  const previousCliPath = process.env.GSD_CLI_PATH;
+  const previousPath = process.env.PATH;
+  process.env.GSD_WORKFLOW_MCP_COMMAND = "/opt/gsd/wf-server";
+  process.env.GSD_BIN_PATH = preferredGsd;
+  delete process.env.GSD_CLI_PATH;
+  process.env.PATH = pathInstall;
+  t.after(() => {
+    restoreEnv("GSD_WORKFLOW_MCP_COMMAND", previousCommand);
+    restoreEnv("GSD_BIN_PATH", previousBinPath);
+    restoreEnv("GSD_CLI_PATH", previousCliPath);
+    restoreEnv("PATH", previousPath);
+  });
+
+  const spawned: SpawnRecord[] = [];
+  const executor = new GsdPiExecutor(logger as never, {
+    projectDirs: [projectDir],
+    clientFactory: recordingClientFactory(spawned),
+  });
+
+  await executor.execute("gsd_status", {}, basename(projectDir));
+
+  assert.equal(spawned[0]!.options.env?.GSD_CLI_PATH, realpathSync(preferredGsd));
+  assert.equal(spawned[0]!.options.env?.GSD_BIN_PATH, realpathSync(preferredGsd));
 });
 
 test("createProjectEntry does not inject GSD_CLI_PATH for a bare gsd binary name", async (t) => {

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.test.ts
@@ -111,10 +111,24 @@ test("bare gsd name is resolved before reaching the workflow server", async (t) 
   const npmBin = join(root, "npm");
   const serverPath = join(root, "server.mjs");
   const gsdBinary = join(npmBin, process.platform === "win32" ? "gsd.cmd" : "gsd");
+  let expectedGsdCliPath = gsdBinary;
   mkdirSync(projectDir, { recursive: true });
   mkdirSync(npmBin, { recursive: true });
   writeFileSync(gsdBinary, process.platform === "win32" ? "@node %*\r\n" : "#!/bin/sh\n");
-  if (process.platform !== "win32") chmodSync(gsdBinary, 0o755);
+  if (process.platform === "win32") {
+    expectedGsdCliPath = join(
+      npmBin,
+      "node_modules",
+      "@opengsd",
+      "gsd-pi",
+      "dist",
+      "loader.js",
+    );
+    mkdirSync(dirname(expectedGsdCliPath), { recursive: true });
+    writeFileSync(expectedGsdCliPath, "#!/usr/bin/env node\n");
+  } else {
+    chmodSync(gsdBinary, 0o755);
+  }
   writeCliPathServer(serverPath);
 
   const previousCommand = process.env.GSD_WORKFLOW_MCP_COMMAND;
@@ -140,7 +154,7 @@ test("bare gsd name is resolved before reaching the workflow server", async (t) 
   t.after(() => executor.close());
   const result = await executor.execute("gsd_status", {});
 
-  assert.deepEqual(result, { gsdCliPath: realpathSync(gsdBinary) });
+  assert.deepEqual(result, { gsdCliPath: realpathSync(expectedGsdCliPath) });
 });
 
 test("Milestone lifecycle request identity becomes private MCP metadata", async (t) => {

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -71,7 +71,7 @@ interface ProjectEntry {
 }
 
 export class GsdPiExecutor implements Executor {
-  private readonly gsdBinary: string;
+  private readonly gsdBinary?: string;
   private readonly projectDirs: string[];
   /** Lazily-created MCP clients, keyed by resolved absolute project path. */
   private readonly projects = new Map<string, ProjectEntry>();
@@ -87,9 +87,7 @@ export class GsdPiExecutor implements Executor {
   private readonly clientFactory: WorkflowClientFactory;
 
   constructor(private readonly logger: Logger, opts: GsdPiExecutorOptions = {}) {
-    this.gsdBinary = opts.gsdBinary
-      ?? process.env["GSD_CLI_PATH"]
-      ?? "gsd";
+    this.gsdBinary = opts.gsdBinary;
     this.clientFactory = opts.clientFactory
       ?? ((command, args, logger, options) => new McpStdioClient(command, args, logger, options));
     this.projectDirs = (opts.projectDirs ?? defaultProjectDirs()).map((p) => resolve(p));
@@ -184,8 +182,10 @@ export class GsdPiExecutor implements Executor {
     const launch = this.resolveWorkflowLaunch();
     const childEnv: NodeJS.ProcessEnv = {
       ...process.env,
+      ...launch.env,
       GSD_PROJECT_ROOT: path,
-      GSD_WORKFLOW_PROJECT_ROOT: path,
+      GSD_WORKFLOW_PROJECT_ROOT: launch.env?.GSD_WORKFLOW_PROJECT_ROOT ?? path,
+      GSD_MCP_CLIENT_MANAGED: "1",
     };
     // The workflow server resolves the GSD CLI via GSD_CLI_PATH / GSD_BIN_PATH
     // (else `gsd` on PATH); detectWorkflowMcpLaunchConfig treats both as
@@ -197,7 +197,7 @@ export class GsdPiExecutor implements Executor {
     // inherited from the daemon's own environment.
     const childCliPath =
       launch.gsdCliPath ??
-      (this.gsdBinary.includes("/") || this.gsdBinary.includes("\\") ? this.gsdBinary : undefined);
+      (this.gsdBinary?.includes("/") || this.gsdBinary?.includes("\\") ? this.gsdBinary : undefined);
     if (childCliPath) {
       childEnv.GSD_CLI_PATH = childCliPath;
       childEnv.GSD_BIN_PATH = childCliPath;
@@ -211,7 +211,7 @@ export class GsdPiExecutor implements Executor {
       this.logger,
       {
         env: childEnv,
-        cwd: path,
+        cwd: launch.cwd ?? path,
         windowsVerbatimArguments: launch.windowsVerbatimArguments,
       },
     );

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -41,6 +41,17 @@ import type { AdvertisedProject, Executor } from "./executor.js";
 import { McpStdioClient } from "./mcp-stdio-client.js";
 import { resolveWorkflowServerLaunch, type WorkflowServerLaunch } from "./workflow-server-launch.js";
 
+/**
+ * Factory for a per-project MCP client. Injectable so tests can observe the
+ * resolved command/args/env without spawning a real child process.
+ */
+export type WorkflowClientFactory = (
+  command: string,
+  args: string[],
+  logger: Logger,
+  options: { env?: NodeJS.ProcessEnv; cwd?: string },
+) => McpStdioClient;
+
 export interface GsdPiExecutorOptions {
   /**
    * Path to the `gsd` binary, used as the discovery anchor for the workflow
@@ -53,6 +64,11 @@ export interface GsdPiExecutorOptions {
    * GSD_CLOUD_PROJECTS (path-delimiter separated), else [cwd].
    */
   projectDirs?: string[];
+  /**
+   * Overrides how per-project MCP clients are constructed. Defaults to spawning
+   * a real McpStdioClient; injected in tests to assert the wiring.
+   */
+  clientFactory?: WorkflowClientFactory;
 }
 
 interface ProjectEntry {
@@ -75,11 +91,14 @@ export class GsdPiExecutor implements Executor {
    * "no server found". The synchronous which/where lookup runs at most once.
    */
   private workflowLaunch: WorkflowServerLaunch | null | undefined;
+  private readonly clientFactory: WorkflowClientFactory;
 
   constructor(private readonly logger: Logger, opts: GsdPiExecutorOptions = {}) {
     this.gsdBinary = opts.gsdBinary
       ?? process.env["GSD_CLI_PATH"]
       ?? "gsd";
+    this.clientFactory = opts.clientFactory
+      ?? ((command, args, logger, options) => new McpStdioClient(command, args, logger, options));
     this.projectDirs = (opts.projectDirs ?? defaultProjectDirs()).map((p) => resolve(p));
     this.warnDuplicateAliases();
   }
@@ -176,7 +195,7 @@ export class GsdPiExecutor implements Executor {
     if (this.gsdBinary.includes("/") || this.gsdBinary.includes("\\")) {
       childEnv.GSD_CLI_PATH = this.gsdBinary;
     }
-    const client = new McpStdioClient(
+    const client = this.clientFactory(
       launch.command,
       launch.args,
       this.logger,

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -48,8 +48,8 @@ export type WorkflowClientFactory = (
 export interface GsdPiExecutorOptions {
   /**
    * Path to the `gsd` binary, used as the discovery anchor for the workflow
-   * MCP server (see workflow-server-launch.ts). Defaults to GSD_CLI_PATH env,
-   * else `gsd` on PATH.
+   * MCP server (see workflow-server-launch.ts). Defaults to GSD_CLI_PATH or
+   * GSD_BIN_PATH, then `gsd` on PATH.
    */
   gsdBinary?: string;
   /**

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -103,6 +103,10 @@ export class GsdPiExecutor implements Executor {
     this.warnDuplicateAliases();
   }
 
+  initialize(): void {
+    this.resolveWorkflowLaunch();
+  }
+
   /**
    * Advertised aliases are directory basenames, so two projects that share a
    * folder name collide. Warn up front — such an alias can only be routed by an

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -167,7 +167,12 @@ export class GsdPiExecutor implements Executor {
       launch.args,
       this.logger,
       {
-        env: { ...process.env, GSD_PROJECT_ROOT: path, GSD_WORKFLOW_PROJECT_ROOT: path },
+        env: {
+          ...process.env,
+          GSD_CLI_PATH: this.gsdBinary,
+          GSD_PROJECT_ROOT: path,
+          GSD_WORKFLOW_PROJECT_ROOT: path,
+        },
         cwd: path,
       },
     );

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -39,7 +39,7 @@ import { basename, delimiter, resolve } from "node:path";
 import type { Logger } from "../logger.js";
 import type { AdvertisedProject, Executor } from "./executor.js";
 import { McpStdioClient } from "./mcp-stdio-client.js";
-import { resolveWorkflowServerLaunch } from "./workflow-server-launch.js";
+import { resolveWorkflowServerLaunch, type WorkflowServerLaunch } from "./workflow-server-launch.js";
 
 export interface GsdPiExecutorOptions {
   /**
@@ -68,6 +68,13 @@ export class GsdPiExecutor implements Executor {
   private readonly projects = new Map<string, ProjectEntry>();
   /** In-flight project client creation, keyed by resolved absolute project path. */
   private readonly projectInit = new Map<string, Promise<ProjectEntry>>();
+  /**
+   * Cached workflow-server launch config. Discovery is host-level (anchored on
+   * gsdBinary, not the project), so it is resolved once per executor rather than
+   * per advertised project. `undefined` = not yet resolved; `null` = resolved to
+   * "no server found". The synchronous which/where lookup runs at most once.
+   */
+  private workflowLaunch: WorkflowServerLaunch | null | undefined;
 
   constructor(private readonly logger: Logger, opts: GsdPiExecutorOptions = {}) {
     this.gsdBinary = opts.gsdBinary
@@ -156,14 +163,7 @@ export class GsdPiExecutor implements Executor {
     // register the workflow adapter surface (gsd_status, gsd_roadmap, …), so
     // every call against it fails with "Unknown tool" (issue #1513). Spawn in
     // the project directory and pin the workflow root explicitly.
-    const launch = resolveWorkflowServerLaunch({ gsdBinary: this.gsdBinary });
-    if (!launch) {
-      throw new Error(
-        "Cannot locate the GSD workflow MCP server. Set GSD_WORKFLOW_MCP_COMMAND, " +
-          "install @opengsd/gsd-pi (ships packages/mcp-server/dist/cli.js), " +
-          "or put gsd-mcp-server on PATH.",
-      );
-    }
+    const launch = this.resolveWorkflowLaunch();
     const childEnv: NodeJS.ProcessEnv = {
       ...process.env,
       GSD_PROJECT_ROOT: path,
@@ -185,6 +185,25 @@ export class GsdPiExecutor implements Executor {
     const entry: ProjectEntry = { alias: basename(path), path, client };
     this.projects.set(path, entry);
     return entry;
+  }
+
+  /**
+   * Resolve (and memoize) the workflow-server launch config. Discovery is
+   * host-level, so the synchronous which/where lookup runs once per executor
+   * instead of once per advertised project.
+   */
+  private resolveWorkflowLaunch(): WorkflowServerLaunch {
+    if (this.workflowLaunch === undefined) {
+      this.workflowLaunch = resolveWorkflowServerLaunch({ gsdBinary: this.gsdBinary });
+    }
+    if (!this.workflowLaunch) {
+      throw new Error(
+        "Cannot locate the GSD workflow MCP server. Set GSD_WORKFLOW_MCP_COMMAND, " +
+          "install @opengsd/gsd-pi (ships packages/mcp-server/dist/cli.js), " +
+          "or put gsd-mcp-server on PATH.",
+      );
+    }
+    return this.workflowLaunch;
   }
 
   private resolveProjectPath(aliasOrPath?: string): string {

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -11,10 +11,12 @@
 // cloud gateway forwards. No GSD package is linked; the only contract is the
 // MCP wire protocol.
 //
-// NOTE: `gsd --mode mcp` is NOT a valid child for this executor — its session
-// registry does not include the workflow adapter tools, so every call fails
-// with "Unknown tool" (issue #1513). Discovery of the correct server lives in
-// workflow-server-launch.ts.
+// NOTE: as of gsd-pi 1.11.0, `gsd --mode mcp` is NOT a valid child for this
+// executor — its session registry does not include the workflow adapter tools,
+// so every call fails with "Unknown tool" (issue #1513). This is a current
+// behavioral limitation, not a permanent contract: if `--mode mcp` is fixed to
+// register the workflow surface, it may become a viable child. Discovery of the
+// correct server lives in workflow-server-launch.ts.
 //
 // DOCUMENTED GAPS (see report):
 //  1. Project discovery. The daemon's LocalToolExecutor scanned filesystem roots
@@ -162,14 +164,23 @@ export class GsdPiExecutor implements Executor {
           "or put gsd-mcp-server on PATH.",
       );
     }
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      GSD_PROJECT_ROOT: path,
+      GSD_WORKFLOW_PROJECT_ROOT: path,
+    };
+    // The workflow server resolves the GSD CLI via GSD_CLI_PATH (else `gsd` on
+    // PATH). When this executor was configured with a concrete binary path,
+    // propagate it so tool execution still works on hosts where `gsd` is not on
+    // PATH. A bare name (e.g. "gsd") is left to normal PATH resolution.
+    if (this.gsdBinary.includes("/") || this.gsdBinary.includes("\\")) {
+      childEnv.GSD_CLI_PATH = this.gsdBinary;
+    }
     const client = new McpStdioClient(
       launch.command,
       launch.args,
       this.logger,
-      {
-        env: { ...process.env, GSD_PROJECT_ROOT: path, GSD_WORKFLOW_PROJECT_ROOT: path },
-        cwd: path,
-      },
+      { env: childEnv, cwd: path },
     );
     const entry: ProjectEntry = { alias: basename(path), path, client };
     this.projects.set(path, entry);

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -3,14 +3,18 @@
 //
 // MECHANISM
 // ---------
-// The `gsd` CLI exposes every registered workflow tool over the Model Context
-// Protocol when started with `gsd --mode mcp` (see src/cli.ts in gsd-pi: mode
-// 'mcp' flips the active tool set to the full registry and serves MCP over
-// stdin/stdout). This adapter spawns ONE long-lived `gsd --mode mcp` child per
-// project and issues `tools/call` requests for each `execute()` — the same
-// gsd_* tool names the cloud gateway forwards (gsd_execute, gsd_status,
-// gsd_graph, gsd_cancel, gsd_query, …). No GSD package is linked; the only
-// contract is the MCP wire protocol.
+// The workflow tool surface (gsd_execute, gsd_status, gsd_graph, gsd_cancel,
+// gsd_query, …) is owned by the workflow MCP server (@opengsd/mcp-server,
+// shipped inside the gsd-pi package at packages/mcp-server/dist/cli.js). This
+// adapter spawns ONE long-lived workflow-server child per project and issues
+// `tools/call` requests for each `execute()` — the same gsd_* tool names the
+// cloud gateway forwards. No GSD package is linked; the only contract is the
+// MCP wire protocol.
+//
+// NOTE: `gsd --mode mcp` is NOT a valid child for this executor — its session
+// registry does not include the workflow adapter tools, so every call fails
+// with "Unknown tool" (issue #1513). Discovery of the correct server lives in
+// workflow-server-launch.ts.
 //
 // DOCUMENTED GAPS (see report):
 //  1. Project discovery. The daemon's LocalToolExecutor scanned filesystem roots
@@ -20,11 +24,11 @@
 //     working directory. Each advertised project's `repoIdentity` is computed
 //     exactly as the daemon did (sha256 of the git origin remote, else
 //     basename:path), so gateway-side identity matching is preserved.
-//  2. One MCP server per project. `gsd --mode mcp` is project-scoped (it resolves
-//     the GSD root from its cwd). A `tool_call` carrying a `projectAlias` is
-//     routed to that project's dedicated child; the `projectDir` arg the daemon
-//     injected is not needed because cwd already scopes the server. Tool args are
-//     forwarded verbatim otherwise.
+//  2. One MCP server per project. The workflow server is project-scoped via
+//     cwd + GSD_WORKFLOW_PROJECT_ROOT, and every `tools/call` also carries the
+//     resolved `projectDir`. A `tool_call` carrying a `projectAlias` is routed
+//     to that project's dedicated child. Tool args are forwarded verbatim
+//     otherwise.
 
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
@@ -33,9 +37,14 @@ import { basename, delimiter, resolve } from "node:path";
 import type { Logger } from "../logger.js";
 import type { AdvertisedProject, Executor } from "./executor.js";
 import { McpStdioClient } from "./mcp-stdio-client.js";
+import { resolveWorkflowServerLaunch } from "./workflow-server-launch.js";
 
 export interface GsdPiExecutorOptions {
-  /** Path to the `gsd` binary. Defaults to GSD_CLI_PATH env, else `gsd` on PATH. */
+  /**
+   * Path to the `gsd` binary, used as the discovery anchor for the workflow
+   * MCP server (see workflow-server-launch.ts). Defaults to GSD_CLI_PATH env,
+   * else `gsd` on PATH.
+   */
   gsdBinary?: string;
   /**
    * Explicit list of project directories to advertise. Defaults to
@@ -141,14 +150,26 @@ export class GsdPiExecutor implements Executor {
   private async createProjectEntry(path: string): Promise<ProjectEntry> {
     const existing = this.projects.get(path);
     if (existing) return existing;
-    // `gsd --mode mcp` resolves its GSD root from cwd, so spawn the child in the
-    // project directory. GSD_PROJECT_ROOT is also set as a belt-and-suspenders
-    // hint for gsd's root resolution.
+    // The child must be the workflow MCP server — `gsd --mode mcp` does not
+    // register the workflow adapter surface (gsd_status, gsd_roadmap, …), so
+    // every call against it fails with "Unknown tool" (issue #1513). Spawn in
+    // the project directory and pin the workflow root explicitly.
+    const launch = resolveWorkflowServerLaunch({ gsdBinary: this.gsdBinary });
+    if (!launch) {
+      throw new Error(
+        "Cannot locate the GSD workflow MCP server. Set GSD_WORKFLOW_MCP_COMMAND, " +
+          "install @opengsd/gsd-pi (ships packages/mcp-server/dist/cli.js), " +
+          "or put gsd-mcp-server on PATH.",
+      );
+    }
     const client = new McpStdioClient(
-      this.gsdBinary,
-      ["--mode", "mcp"],
+      launch.command,
+      launch.args,
       this.logger,
-      { env: { ...process.env, GSD_PROJECT_ROOT: path }, cwd: path },
+      {
+        env: { ...process.env, GSD_PROJECT_ROOT: path, GSD_WORKFLOW_PROJECT_ROOT: path },
+        cwd: path,
+      },
     );
     const entry: ProjectEntry = { alias: basename(path), path, client };
     this.projects.set(path, entry);

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -142,7 +142,10 @@ export class GsdPiExecutor implements Executor {
     if (!init) {
       init = this.createProjectEntry(path);
       this.projectInit.set(path, init);
-      void init.finally(() => this.projectInit.delete(path));
+      void init.then(
+        () => this.projectInit.delete(path),
+        () => this.projectInit.delete(path),
+      );
     }
     return init;
   }

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -1,5 +1,5 @@
 // Project/App: Open GSD
-// File Purpose: Executor adapter that drives the installed `gsd` CLI headlessly.
+// File Purpose: Executor adapter that drives the installed workflow MCP server.
 //
 // MECHANISM
 // ---------
@@ -10,13 +10,6 @@
 // `tools/call` requests for each `execute()` — the same gsd_* tool names the
 // cloud gateway forwards. No GSD package is linked; the only contract is the
 // MCP wire protocol.
-//
-// NOTE: as of gsd-pi 1.11.0, `gsd --mode mcp` is NOT a valid child for this
-// executor — its session registry does not include the workflow adapter tools,
-// so every call fails with "Unknown tool" (issue #1513). This is a current
-// behavioral limitation, not a permanent contract: if `--mode mcp` is fixed to
-// register the workflow surface, it may become a viable child. Discovery of the
-// correct server lives in workflow-server-launch.ts.
 //
 // DOCUMENTED GAPS (see report):
 //  1. Project discovery. The daemon's LocalToolExecutor scanned filesystem roots
@@ -185,10 +178,9 @@ export class GsdPiExecutor implements Executor {
   private async createProjectEntry(path: string): Promise<ProjectEntry> {
     const existing = this.projects.get(path);
     if (existing) return existing;
-    // The child must be the workflow MCP server — `gsd --mode mcp` does not
-    // register the workflow adapter surface (gsd_status, gsd_roadmap, …), so
-    // every call against it fails with "Unknown tool" (issue #1513). Spawn in
-    // the project directory and pin the workflow root explicitly.
+    // Spawn the discovered workflow MCP server in the project directory and
+    // pin the workflow root explicitly. workflow-server-launch.ts owns the
+    // discovery contract and the reason `gsd --mode mcp` is not used here.
     const launch = this.resolveWorkflowLaunch();
     const childEnv: NodeJS.ProcessEnv = {
       ...process.env,

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -162,17 +162,17 @@ export class GsdPiExecutor implements Executor {
           "or put gsd-mcp-server on PATH.",
       );
     }
+    const childEnv = { ...process.env };
+    if (launch.gsdCliPath) childEnv.GSD_CLI_PATH = launch.gsdCliPath;
+    else delete childEnv.GSD_CLI_PATH;
+    childEnv.GSD_PROJECT_ROOT = path;
+    childEnv.GSD_WORKFLOW_PROJECT_ROOT = path;
     const client = new McpStdioClient(
       launch.command,
       launch.args,
       this.logger,
       {
-        env: {
-          ...process.env,
-          GSD_CLI_PATH: this.gsdBinary,
-          GSD_PROJECT_ROOT: path,
-          GSD_WORKFLOW_PROJECT_ROOT: path,
-        },
+        env: childEnv,
         cwd: path,
       },
     );

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -191,18 +191,23 @@ export class GsdPiExecutor implements Executor {
       GSD_PROJECT_ROOT: path,
       GSD_WORKFLOW_PROJECT_ROOT: path,
     };
-    // The workflow server resolves the GSD CLI via GSD_CLI_PATH (else `gsd` on
-    // PATH). Prefer the resolver's discovered CLI path; otherwise, when this
-    // executor was configured with a concrete binary path, propagate it so tool
-    // execution still works on hosts where `gsd` is not on PATH (this also
-    // covers Windows .cmd shims the resolver rejects). Never leak a stale
-    // GSD_CLI_PATH inherited from the daemon's own environment.
-    if (launch.gsdCliPath) {
-      childEnv.GSD_CLI_PATH = launch.gsdCliPath;
-    } else if (this.gsdBinary.includes("/") || this.gsdBinary.includes("\\")) {
-      childEnv.GSD_CLI_PATH = this.gsdBinary;
+    // The workflow server resolves the GSD CLI via GSD_CLI_PATH / GSD_BIN_PATH
+    // (else `gsd` on PATH); detectWorkflowMcpLaunchConfig treats both as
+    // equivalent CLI-path overrides. Prefer the resolver's discovered CLI path;
+    // otherwise, when this executor was configured with a concrete binary path,
+    // propagate it so tool execution still works on hosts where `gsd` is not on
+    // PATH (this also covers Windows .cmd shims the resolver rejects). Set both
+    // vars together so they never disagree, and never leak a stale value
+    // inherited from the daemon's own environment.
+    const childCliPath =
+      launch.gsdCliPath ??
+      (this.gsdBinary.includes("/") || this.gsdBinary.includes("\\") ? this.gsdBinary : undefined);
+    if (childCliPath) {
+      childEnv.GSD_CLI_PATH = childCliPath;
+      childEnv.GSD_BIN_PATH = childCliPath;
     } else {
       delete childEnv.GSD_CLI_PATH;
+      delete childEnv.GSD_BIN_PATH;
     }
     const client = this.clientFactory(
       launch.command,

--- a/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
+++ b/packages/gsd-cloud/src/executors/gsd-pi-executor.ts
@@ -174,6 +174,7 @@ export class GsdPiExecutor implements Executor {
       {
         env: childEnv,
         cwd: path,
+        windowsVerbatimArguments: launch.windowsVerbatimArguments,
       },
     );
     const entry: ProjectEntry = { alias: basename(path), path, client };

--- a/packages/gsd-cloud/src/executors/index.ts
+++ b/packages/gsd-cloud/src/executors/index.ts
@@ -19,8 +19,8 @@ export interface SelectExecutorOptions extends GsdPiExecutorOptions {
 
 /**
  * Resolve the execution backend. Defaults to the gsd-pi shell-out adapter, which
- * drives the installed `gsd` CLI over MCP. Selection can also be overridden with
- * the GSD_CLOUD_EXECUTOR env var.
+ * drives the installed workflow MCP server. Selection can also be overridden
+ * with the GSD_CLOUD_EXECUTOR env var.
  */
 export function selectExecutor(logger: Logger, opts: SelectExecutorOptions = {}): Executor {
   const kind = opts.kind ?? (process.env["GSD_CLOUD_EXECUTOR"] as ExecutorKind | undefined) ?? "gsd-pi";

--- a/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
+++ b/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
@@ -3,7 +3,7 @@
 //
 // Zero external deps — just enough of the Model Context Protocol to `initialize`
 // a server and issue `tools/call` requests. Used by the gsd-pi shell-out adapter
-// to drive `gsd --mode mcp` without linking any GSD package.
+// to drive the workflow MCP server without linking any GSD package.
 
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createInterface, type Interface } from "node:readline";

--- a/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
+++ b/packages/gsd-cloud/src/executors/mcp-stdio-client.ts
@@ -43,7 +43,11 @@ export class McpStdioClient {
     private readonly command: string,
     private readonly args: string[],
     private readonly logger: Logger,
-    private readonly options: { env?: NodeJS.ProcessEnv; cwd?: string } = {},
+    private readonly options: {
+      env?: NodeJS.ProcessEnv;
+      cwd?: string;
+      windowsVerbatimArguments?: boolean;
+    } = {},
   ) {}
 
   /** Ensure the server is spawned and `initialize` has completed. Idempotent. */
@@ -99,6 +103,7 @@ export class McpStdioClient {
       stdio: ["pipe", "pipe", "pipe"],
       env: this.options.env ?? process.env,
       ...(this.options.cwd ? { cwd: this.options.cwd } : {}),
+      ...(this.options.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
     }) as ChildProcessWithoutNullStreams;
     this.child = child;
 

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -79,6 +79,34 @@ test("explicit GSD_WORKFLOW_MCP_COMMAND wins over discovery", (t) => {
   });
 });
 
+test("explicit workflow server env and cwd are carried into the launch", () => {
+  const launch = resolveWorkflowServerLaunch({
+    env: {
+      GSD_WORKFLOW_MCP_COMMAND: "/custom/wf-server",
+      GSD_WORKFLOW_MCP_ENV: JSON.stringify({
+        FOO: "bar",
+        GSD_BIN_PATH: "/custom/gsd",
+        GSD_WORKFLOW_PROJECT_ROOT: "/custom/project",
+      }),
+      GSD_WORKFLOW_MCP_CWD: "/custom/cwd",
+    },
+    lookup: () => null,
+  });
+
+  assert.deepEqual(launch, {
+    command: "/custom/wf-server",
+    args: [],
+    cwd: "/custom/cwd",
+    env: {
+      FOO: "bar",
+      GSD_CLI_PATH: "/custom/gsd",
+      GSD_BIN_PATH: "/custom/gsd",
+      GSD_WORKFLOW_PROJECT_ROOT: "/custom/project",
+    },
+    gsdCliPath: "/custom/gsd",
+  });
+});
+
 test("preserves relative explicit workflow server commands for the project cwd", () => {
   const launch = resolveWorkflowServerLaunch({
     env: {

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -96,6 +96,31 @@ test("rejects malformed GSD_WORKFLOW_MCP_ARGS loudly", (t) => {
   );
 });
 
+test(
+  "resolves gsd-mcp-server via a Node PATH scan when which/where is unavailable",
+  { skip: process.platform === "win32" ? "POSIX PATH-scan fallback" : false },
+  (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "gsd-cloud-path-scan-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    writeFileSync(join(dir, "gsd-mcp-server"), "#!/bin/sh\n");
+    // PATH holds only our temp dir, so `which` itself cannot be located and
+    // execFileSync throws — forcing the default lookup's Node-side scan, which
+    // must still find the server file sitting on PATH.
+    const originalPath = process.env.PATH;
+    process.env.PATH = dir;
+    t.after(() => {
+      process.env.PATH = originalPath;
+    });
+    const launch = resolveWorkflowServerLaunch({
+      gsdBinary: join(dir, "missing", "gsd"),
+      env: {},
+    });
+    assert.ok(launch, "expected a launch config");
+    assert.equal(launch.command, join(dir, "gsd-mcp-server"));
+    assert.deepEqual(launch.args, []);
+  },
+);
+
 test("rejects invalid-JSON GSD_WORKFLOW_MCP_ARGS with a targeted error", (t) => {
   const { gsdBinary } = makeInstalledLayout(t);
   assert.throws(

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -160,6 +160,63 @@ test("resolves a Windows workflow server PATH shim to its JavaScript entrypoint"
     command: process.execPath,
     args: [realpathSync(entrypoint)],
   });
+
+  const explicitLaunch = resolveWorkflowServerLaunch({
+    gsdBinary: join(root, "missing-gsd"),
+    env: {
+      GSD_WORKFLOW_MCP_COMMAND: commandShim,
+      GSD_WORKFLOW_MCP_ARGS: '["--probe"]',
+    },
+    lookup: () => null,
+    platform: "win32",
+  });
+  assert.deepEqual(explicitLaunch, {
+    command: process.execPath,
+    args: [realpathSync(entrypoint), "--probe"],
+  });
+});
+
+test("wraps nonstandard Windows workflow server shims with native interpreters", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-windows-server-fallback-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const commandShim = join(root, "custom-server.cmd");
+  const powershellShim = join(root, "custom-server.ps1");
+  writeFileSync(commandShim, "@custom-workflow-server %*\r\n");
+  writeFileSync(powershellShim, "& custom-workflow-server @args\r\n");
+
+  const commandLaunch = resolveWorkflowServerLaunch({
+    gsdBinary: join(root, "missing-gsd"),
+    env: { COMSPEC: "C:\\Windows\\System32\\cmd.exe" },
+    lookup: (command) => (command === "gsd-mcp-server" ? commandShim : null),
+    platform: "win32",
+  });
+  assert.deepEqual(commandLaunch, {
+    command: "C:\\Windows\\System32\\cmd.exe",
+    args: ["/d", "/s", "/c", realpathSync(commandShim)],
+  });
+
+  const powershellLaunch = resolveWorkflowServerLaunch({
+    gsdBinary: join(root, "missing-gsd"),
+    env: {
+      GSD_WORKFLOW_MCP_COMMAND: powershellShim,
+      GSD_WORKFLOW_MCP_ARGS: '["--probe"]',
+    },
+    lookup: () => null,
+    platform: "win32",
+  });
+  assert.deepEqual(powershellLaunch, {
+    command: "powershell.exe",
+    args: [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      realpathSync(powershellShim),
+      "--probe",
+    ],
+  });
 });
 
 test("returns null when no workflow server can be located", (t) => {

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -6,7 +6,7 @@
 // gsd_status", hanging the SaaS app boot).
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveWorkflowServerLaunch } from "./workflow-server-launch.js";
@@ -102,7 +102,10 @@ test(
   (t) => {
     const dir = mkdtempSync(join(tmpdir(), "gsd-cloud-path-scan-"));
     t.after(() => rmSync(dir, { recursive: true, force: true }));
-    writeFileSync(join(dir, "gsd-mcp-server"), "#!/bin/sh\n");
+    const stub = join(dir, "gsd-mcp-server");
+    writeFileSync(stub, "#!/bin/sh\n");
+    // Executable bit set so the scan (which mirrors `which`'s X_OK check) accepts it.
+    chmodSync(stub, 0o755);
     // The injected env's PATH holds only our temp dir, so `which` itself cannot
     // be located and execFileSync throws — forcing the default lookup's
     // Node-side scan, which must honor options.env (not process.env) and still
@@ -112,7 +115,7 @@ test(
       env: { PATH: dir },
     });
     assert.ok(launch, "expected a launch config");
-    assert.equal(launch.command, join(dir, "gsd-mcp-server"));
+    assert.equal(launch.command, stub);
     assert.deepEqual(launch.args, []);
   },
 );

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -107,6 +107,20 @@ test("explicit workflow server env and cwd are carried into the launch", () => {
   });
 });
 
+test("GSD_WORKFLOW_MCP_CWD sets cwd only and never becomes the workflow project root", () => {
+  const launch = resolveWorkflowServerLaunch({
+    env: {
+      GSD_WORKFLOW_MCP_COMMAND: "/custom/wf-server",
+      GSD_WORKFLOW_MCP_CWD: "/custom/cwd",
+    },
+    lookup: () => null,
+  });
+  // cwd honors the override, but no project root is inferred from it — otherwise
+  // a single cwd override would pin every memoized per-project child to one root.
+  assert.equal(launch?.cwd, "/custom/cwd");
+  assert.equal(launch?.env?.GSD_WORKFLOW_PROJECT_ROOT, undefined);
+});
+
 test("preserves relative explicit workflow server commands for the project cwd", () => {
   const launch = resolveWorkflowServerLaunch({
     env: {

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -50,6 +50,20 @@ test("explicit GSD_WORKFLOW_MCP_COMMAND wins over discovery", (t) => {
   });
 });
 
+test("preserves relative explicit workflow server commands for the project cwd", () => {
+  const launch = resolveWorkflowServerLaunch({
+    env: {
+      GSD_WORKFLOW_MCP_COMMAND: "./scripts/workflow-server",
+      GSD_WORKFLOW_MCP_ARGS: '["--flag"]',
+    },
+    lookup: () => null,
+  });
+  assert.deepEqual(launch, {
+    command: "./scripts/workflow-server",
+    args: ["--flag"],
+  });
+});
+
 test("bare gsd binary name resolves through PATH lookup before walking ancestors", (t) => {
   const { gsdBinary, workflowCli } = makeInstalledLayout(t);
   const launch = resolveWorkflowServerLaunch({
@@ -192,7 +206,8 @@ test("wraps nonstandard Windows workflow server shims with native interpreters",
   });
   assert.deepEqual(commandLaunch, {
     command: "C:\\Windows\\System32\\cmd.exe",
-    args: ["/d", "/s", "/c", realpathSync(commandShim)],
+    args: ["/d", "/s", "/c", `"${realpathSync(commandShim)}"`],
+    windowsVerbatimArguments: true,
   });
 
   const powershellLaunch = resolveWorkflowServerLaunch({
@@ -216,6 +231,73 @@ test("wraps nonstandard Windows workflow server shims with native interpreters",
       realpathSync(powershellShim),
       "--probe",
     ],
+  });
+});
+
+test("does not replace an explicit custom wrapper beside the workflow package", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-custom-wrapper-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const customWrapper = join(root, "custom-wrapper.cmd");
+  const entrypoint = join(
+    root,
+    "node_modules",
+    "@opengsd",
+    "mcp-server",
+    "bin",
+    "gsd-mcp-server.js",
+  );
+  mkdirSync(dirname(entrypoint), { recursive: true });
+  writeFileSync(customWrapper, "@custom-workflow-server %*\r\n");
+  writeFileSync(entrypoint, "// workflow server entrypoint\n");
+
+  const launch = resolveWorkflowServerLaunch({
+    env: {
+      COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+      GSD_WORKFLOW_MCP_COMMAND: customWrapper,
+      GSD_WORKFLOW_MCP_ARGS: '["--probe"]',
+    },
+    lookup: () => null,
+    platform: "win32",
+  });
+
+  assert.deepEqual(launch, {
+    command: "C:\\Windows\\System32\\cmd.exe",
+    args: [
+      "/d",
+      "/s",
+      "/c",
+      `"${realpathSync(customWrapper)} ^\"--probe^\""`,
+    ],
+    windowsVerbatimArguments: true,
+  });
+});
+
+test("escapes spaced CMD shim paths and metacharacter arguments", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd cloud cmd fallback-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const commandShim = join(root, "custom server.cmd");
+  writeFileSync(commandShim, "@custom-workflow-server %*\r\n");
+
+  const launch = resolveWorkflowServerLaunch({
+    env: {
+      COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+      GSD_WORKFLOW_MCP_COMMAND: commandShim,
+      GSD_WORKFLOW_MCP_ARGS: '["left & right"]',
+    },
+    lookup: () => null,
+    platform: "win32",
+  });
+  const escapedCommand = realpathSync(commandShim).replace(/ /g, "^ ");
+
+  assert.deepEqual(launch, {
+    command: "C:\\Windows\\System32\\cmd.exe",
+    args: [
+      "/d",
+      "/s",
+      "/c",
+      `"${escapedCommand} ^\"left^ ^&^ right^\""`,
+    ],
+    windowsVerbatimArguments: true,
   });
 });
 

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -66,6 +66,7 @@ test("discovers the installed workflow server from a Windows npm command shim", 
   const root = mkdtempSync(join(tmpdir(), "gsd-cloud-windows-shim-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const npmBin = join(root, "npm");
+  const extensionlessShim = join(npmBin, "gsd");
   const gsdBinary = join(npmBin, "gsd.cmd");
   const gsdLoader = join(
     npmBin,
@@ -87,6 +88,7 @@ test("discovers the installed workflow server from a Windows npm command shim", 
   );
   mkdirSync(dirname(gsdLoader), { recursive: true });
   mkdirSync(dirname(workflowCli), { recursive: true });
+  writeFileSync(extensionlessShim, "#!/bin/sh\n");
   writeFileSync(gsdBinary, "@node node_modules/@opengsd/gsd-pi/dist/loader.js %*\r\n");
   writeFileSync(gsdLoader, "// gsd loader\n");
   writeFileSync(workflowCli, "// workflow server\n");
@@ -94,12 +96,24 @@ test("discovers the installed workflow server from a Windows npm command shim", 
   const launch = resolveWorkflowServerLaunch({
     gsdBinary: "gsd",
     env: {},
-    lookup: (command) => (command === "gsd" ? gsdBinary : null),
+    lookup: (command) =>
+      command === "gsd" ? `${extensionlessShim}\r\n${gsdBinary}\r\n` : null,
+    platform: "win32",
   });
 
   assert.ok(launch, "expected a launch config");
   assert.deepEqual(launch.args, [realpathSync(workflowCli)]);
   assert.equal(launch.gsdCliPath, realpathSync(gsdLoader));
+
+  const extensionlessLaunch = resolveWorkflowServerLaunch({
+    gsdBinary: extensionlessShim,
+    env: {},
+    lookup: () => null,
+    platform: "win32",
+  });
+  assert.ok(extensionlessLaunch, "expected a launch config from the extensionless shim");
+  assert.deepEqual(extensionlessLaunch.args, [realpathSync(workflowCli)]);
+  assert.equal(extensionlessLaunch.gsdCliPath, realpathSync(gsdLoader));
 });
 
 test("falls back to gsd-mcp-server on PATH when no installed layout matches", (t) => {

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -135,3 +135,46 @@ test("rejects invalid-JSON GSD_WORKFLOW_MCP_ARGS with a targeted error", (t) => 
     /GSD_WORKFLOW_MCP_ARGS must be valid JSON/,
   );
 });
+
+test(
+  "scans a Windows-style Path (not PATH) env var in the Node PATH fallback",
+  { skip: process.platform === "win32" ? "POSIX PATH-scan fallback" : false },
+  (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "gsd-cloud-path-casing-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    const stub = join(dir, "gsd-mcp-server");
+    writeFileSync(stub, "#!/bin/sh\n");
+    chmodSync(stub, 0o755);
+    // Only `Path` is set (no `PATH`), as Windows exposes it. With no PATH on the
+    // injected env, `which` cannot be located and execFileSync throws, forcing
+    // the Node-side scan, which must still find the server via the case-variant
+    // fallback. No lookup is injected so the real defaultLookup runs.
+    const launch = resolveWorkflowServerLaunch({
+      gsdBinary: join(dir, "missing", "gsd"),
+      env: { Path: dir },
+    });
+    assert.ok(launch, "expected a launch config");
+    assert.equal(launch.command, stub);
+    assert.deepEqual(launch.args, []);
+  },
+);
+
+test("a bare gsd name that does not resolve on PATH does not anchor discovery off cwd", (t) => {
+  const fakeCwd = mkdtempSync(join(tmpdir(), "gsd-cloud-cwd-anchor-"));
+  t.after(() => rmSync(fakeCwd, { recursive: true, force: true }));
+  // A decoy `gsd` file plus a plausible installed layout in cwd — the trap the
+  // pre-fix code would walk into via resolve("gsd") anchoring off cwd.
+  mkdirSync(join(fakeCwd, "packages", "mcp-server", "dist"), { recursive: true });
+  writeFileSync(join(fakeCwd, "gsd"), "// decoy launcher\n");
+  writeFileSync(join(fakeCwd, "packages", "mcp-server", "dist", "cli.js"), "// decoy server\n");
+  const originalCwd = process.cwd();
+  process.chdir(fakeCwd);
+  t.after(() => process.chdir(originalCwd));
+  const launch = resolveWorkflowServerLaunch({
+    gsdBinary: "gsd",
+    env: {},
+    // Neither the bare gsd name nor gsd-mcp-server resolves on PATH.
+    lookup: () => null,
+  });
+  assert.equal(launch, null);
+});

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -67,6 +67,14 @@ test("discovers the installed workflow server from a Windows npm command shim", 
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const npmBin = join(root, "npm");
   const gsdBinary = join(npmBin, "gsd.cmd");
+  const gsdLoader = join(
+    npmBin,
+    "node_modules",
+    "@opengsd",
+    "gsd-pi",
+    "dist",
+    "loader.js",
+  );
   const workflowCli = join(
     npmBin,
     "node_modules",
@@ -77,8 +85,10 @@ test("discovers the installed workflow server from a Windows npm command shim", 
     "dist",
     "cli.js",
   );
+  mkdirSync(dirname(gsdLoader), { recursive: true });
   mkdirSync(dirname(workflowCli), { recursive: true });
   writeFileSync(gsdBinary, "@node node_modules/@opengsd/gsd-pi/dist/loader.js %*\r\n");
+  writeFileSync(gsdLoader, "// gsd loader\n");
   writeFileSync(workflowCli, "// workflow server\n");
 
   const launch = resolveWorkflowServerLaunch({
@@ -89,7 +99,7 @@ test("discovers the installed workflow server from a Windows npm command shim", 
 
   assert.ok(launch, "expected a launch config");
   assert.deepEqual(launch.args, [realpathSync(workflowCli)]);
-  assert.equal(launch.gsdCliPath, realpathSync(gsdBinary));
+  assert.equal(launch.gsdCliPath, realpathSync(gsdLoader));
 });
 
 test("falls back to gsd-mcp-server on PATH when no installed layout matches", (t) => {

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -8,10 +8,10 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { resolveWorkflowServerLaunch } from "./workflow-server-launch.js";
 
-function makeInstalledLayout(t: test.TestContext): { packageRoot: string; gsdBinary: string; workflowCli: string } {
+function makeInstalledLayout(t: test.TestContext): { gsdBinary: string; workflowCli: string } {
   const root = mkdtempSync(join(tmpdir(), "gsd-cloud-workflow-launch-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const packageRoot = join(root, "lib", "node_modules", "@opengsd", "gsd-pi");
@@ -21,9 +21,7 @@ function makeInstalledLayout(t: test.TestContext): { packageRoot: string; gsdBin
   const gsdBinary = join(packageRoot, "dist", "loader.js");
   writeFileSync(gsdBinary, "// gsd loader\n");
   writeFileSync(workflowCli, "// workflow server\n");
-  // realpath: discovery resolves symlinks (macOS /var → /private/var), so
-  // expectations must compare against the resolved path.
-  return { packageRoot, gsdBinary, workflowCli: realpathSync(workflowCli) };
+  return { gsdBinary, workflowCli: realpathSync(workflowCli) };
 }
 
 test("discovers the workflow server beside an installed gsd binary", (t) => {
@@ -56,6 +54,35 @@ test("bare gsd binary name resolves through PATH lookup before walking ancestors
   });
   assert.ok(launch, "expected a launch config");
   assert.deepEqual(launch.args, [workflowCli]);
+});
+
+test("discovers the installed workflow server from a Windows npm command shim", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-windows-shim-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const npmBin = join(root, "npm");
+  const gsdBinary = join(npmBin, "gsd.cmd");
+  const workflowCli = join(
+    npmBin,
+    "node_modules",
+    "@opengsd",
+    "gsd-pi",
+    "packages",
+    "mcp-server",
+    "dist",
+    "cli.js",
+  );
+  mkdirSync(dirname(workflowCli), { recursive: true });
+  writeFileSync(gsdBinary, "@node node_modules/@opengsd/gsd-pi/dist/loader.js %*\r\n");
+  writeFileSync(workflowCli, "// workflow server\n");
+
+  const launch = resolveWorkflowServerLaunch({
+    gsdBinary: "gsd",
+    env: {},
+    lookup: (command) => (command === "gsd" ? gsdBinary : null),
+  });
+
+  assert.ok(launch, "expected a launch config");
+  assert.deepEqual(launch.args, [realpathSync(workflowCli)]);
 });
 
 test("falls back to gsd-mcp-server on PATH when no installed layout matches", (t) => {

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -127,6 +127,41 @@ test("falls back to gsd-mcp-server on PATH when no installed layout matches", (t
   assert.deepEqual(launch, { command: "/usr/local/bin/gsd-mcp-server", args: [] });
 });
 
+test("resolves a Windows workflow server PATH shim to its JavaScript entrypoint", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-windows-server-shim-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const npmBin = join(root, "npm");
+  const extensionlessShim = join(npmBin, "gsd-mcp-server");
+  const commandShim = join(npmBin, "gsd-mcp-server.cmd");
+  const entrypoint = join(
+    npmBin,
+    "node_modules",
+    "@opengsd",
+    "mcp-server",
+    "bin",
+    "gsd-mcp-server.js",
+  );
+  mkdirSync(dirname(entrypoint), { recursive: true });
+  writeFileSync(extensionlessShim, "#!/bin/sh\n");
+  writeFileSync(commandShim, "@node node_modules/@opengsd/mcp-server/bin/gsd-mcp-server.js %*\r\n");
+  writeFileSync(entrypoint, "// workflow server entrypoint\n");
+
+  const launch = resolveWorkflowServerLaunch({
+    gsdBinary: join(root, "missing-gsd"),
+    env: {},
+    lookup: (command) =>
+      command === "gsd-mcp-server"
+        ? `${extensionlessShim}\r\n${commandShim}\r\n`
+        : null,
+    platform: "win32",
+  });
+
+  assert.deepEqual(launch, {
+    command: process.execPath,
+    args: [realpathSync(entrypoint)],
+  });
+});
+
 test("returns null when no workflow server can be located", (t) => {
   const root = mkdtempSync(join(tmpdir(), "gsd-cloud-nothing-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -272,10 +272,11 @@ test("does not replace an explicit custom wrapper beside the workflow package", 
   });
 });
 
-test("escapes spaced CMD shim paths and metacharacter arguments", (t) => {
+test("double-escapes metacharacter arguments for spaced node_modules bin shims", (t) => {
   const root = mkdtempSync(join(tmpdir(), "gsd cloud cmd fallback-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
-  const commandShim = join(root, "custom server.cmd");
+  const commandShim = join(root, "node_modules", ".bin", "custom server.cmd");
+  mkdirSync(dirname(commandShim), { recursive: true });
   writeFileSync(commandShim, "@custom-workflow-server %*\r\n");
 
   const launch = resolveWorkflowServerLaunch({
@@ -295,7 +296,7 @@ test("escapes spaced CMD shim paths and metacharacter arguments", (t) => {
       "/d",
       "/s",
       "/c",
-      `"${escapedCommand} ^\"left^ ^&^ right^\""`,
+      `"${escapedCommand} ^^^\"left^^^ ^^^&^^^ right^^^\""`,
     ],
     windowsVerbatimArguments: true,
   });

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -97,23 +97,19 @@ test("rejects malformed GSD_WORKFLOW_MCP_ARGS loudly", (t) => {
 });
 
 test(
-  "resolves gsd-mcp-server via a Node PATH scan when which/where is unavailable",
+  "resolves gsd-mcp-server via a Node PATH scan on the injected env when which/where is unavailable",
   { skip: process.platform === "win32" ? "POSIX PATH-scan fallback" : false },
   (t) => {
     const dir = mkdtempSync(join(tmpdir(), "gsd-cloud-path-scan-"));
     t.after(() => rmSync(dir, { recursive: true, force: true }));
     writeFileSync(join(dir, "gsd-mcp-server"), "#!/bin/sh\n");
-    // PATH holds only our temp dir, so `which` itself cannot be located and
-    // execFileSync throws — forcing the default lookup's Node-side scan, which
-    // must still find the server file sitting on PATH.
-    const originalPath = process.env.PATH;
-    process.env.PATH = dir;
-    t.after(() => {
-      process.env.PATH = originalPath;
-    });
+    // The injected env's PATH holds only our temp dir, so `which` itself cannot
+    // be located and execFileSync throws — forcing the default lookup's
+    // Node-side scan, which must honor options.env (not process.env) and still
+    // find the server file sitting on that PATH.
     const launch = resolveWorkflowServerLaunch({
       gsdBinary: join(dir, "missing", "gsd"),
-      env: {},
+      env: { PATH: dir },
     });
     assert.ok(launch, "expected a launch config");
     assert.equal(launch.command, join(dir, "gsd-mcp-server"));

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -30,6 +30,7 @@ test("discovers the workflow server beside an installed gsd binary", (t) => {
   assert.ok(launch, "expected a launch config");
   assert.equal(launch.command, process.execPath);
   assert.deepEqual(launch.args, [workflowCli]);
+  assert.equal(launch.gsdCliPath, realpathSync(gsdBinary));
 });
 
 test("explicit GSD_WORKFLOW_MCP_COMMAND wins over discovery", (t) => {
@@ -42,7 +43,11 @@ test("explicit GSD_WORKFLOW_MCP_COMMAND wins over discovery", (t) => {
     },
     lookup: () => null,
   });
-  assert.deepEqual(launch, { command: "/custom/wf-server", args: ["--flag"] });
+  assert.deepEqual(launch, {
+    command: "/custom/wf-server",
+    args: ["--flag"],
+    gsdCliPath: realpathSync(gsdBinary),
+  });
 });
 
 test("bare gsd binary name resolves through PATH lookup before walking ancestors", (t) => {
@@ -54,6 +59,7 @@ test("bare gsd binary name resolves through PATH lookup before walking ancestors
   });
   assert.ok(launch, "expected a launch config");
   assert.deepEqual(launch.args, [workflowCli]);
+  assert.equal(launch.gsdCliPath, realpathSync(gsdBinary));
 });
 
 test("discovers the installed workflow server from a Windows npm command shim", (t) => {
@@ -83,6 +89,7 @@ test("discovers the installed workflow server from a Windows npm command shim", 
 
   assert.ok(launch, "expected a launch config");
   assert.deepEqual(launch.args, [realpathSync(workflowCli)]);
+  assert.equal(launch.gsdCliPath, realpathSync(gsdBinary));
 });
 
 test("falls back to gsd-mcp-server on PATH when no installed layout matches", (t) => {

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -1,0 +1,97 @@
+// Project/App: Open GSD
+// File Purpose: Regression tests for workflow MCP server discovery. The cloud
+// daemon must spawn the workflow MCP server (gsd_status, gsd_roadmap, …) — not
+// `gsd --mode mcp`, whose session registry never includes the workflow adapter
+// surface (issue #1513: daemon session polling failed with "Unknown tool:
+// gsd_status", hanging the SaaS app boot).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveWorkflowServerLaunch } from "./workflow-server-launch.js";
+
+function makeInstalledLayout(t: test.TestContext): { packageRoot: string; gsdBinary: string; workflowCli: string } {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-workflow-launch-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const packageRoot = join(root, "lib", "node_modules", "@opengsd", "gsd-pi");
+  const workflowCli = join(packageRoot, "packages", "mcp-server", "dist", "cli.js");
+  mkdirSync(join(packageRoot, "dist"), { recursive: true });
+  mkdirSync(join(packageRoot, "packages", "mcp-server", "dist"), { recursive: true });
+  const gsdBinary = join(packageRoot, "dist", "loader.js");
+  writeFileSync(gsdBinary, "// gsd loader\n");
+  writeFileSync(workflowCli, "// workflow server\n");
+  // realpath: discovery resolves symlinks (macOS /var → /private/var), so
+  // expectations must compare against the resolved path.
+  return { packageRoot, gsdBinary, workflowCli: realpathSync(workflowCli) };
+}
+
+test("discovers the workflow server beside an installed gsd binary", (t) => {
+  const { gsdBinary, workflowCli } = makeInstalledLayout(t);
+  const launch = resolveWorkflowServerLaunch({ gsdBinary, env: {}, lookup: () => null });
+  assert.ok(launch, "expected a launch config");
+  assert.equal(launch.command, process.execPath);
+  assert.deepEqual(launch.args, [workflowCli]);
+});
+
+test("explicit GSD_WORKFLOW_MCP_COMMAND wins over discovery", (t) => {
+  const { gsdBinary } = makeInstalledLayout(t);
+  const launch = resolveWorkflowServerLaunch({
+    gsdBinary,
+    env: {
+      GSD_WORKFLOW_MCP_COMMAND: "/custom/wf-server",
+      GSD_WORKFLOW_MCP_ARGS: '["--flag"]',
+    },
+    lookup: () => null,
+  });
+  assert.deepEqual(launch, { command: "/custom/wf-server", args: ["--flag"] });
+});
+
+test("bare gsd binary name resolves through PATH lookup before walking ancestors", (t) => {
+  const { gsdBinary, workflowCli } = makeInstalledLayout(t);
+  const launch = resolveWorkflowServerLaunch({
+    gsdBinary: "gsd",
+    env: {},
+    lookup: (cmd) => (cmd === "gsd" ? gsdBinary : null),
+  });
+  assert.ok(launch, "expected a launch config");
+  assert.deepEqual(launch.args, [workflowCli]);
+});
+
+test("falls back to gsd-mcp-server on PATH when no installed layout matches", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-no-layout-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const launch = resolveWorkflowServerLaunch({
+    gsdBinary: join(root, "gsd"),
+    env: {},
+    lookup: (cmd) => (cmd === "gsd-mcp-server" ? "/usr/local/bin/gsd-mcp-server" : null),
+  });
+  assert.deepEqual(launch, { command: "/usr/local/bin/gsd-mcp-server", args: [] });
+});
+
+test("returns null when no workflow server can be located", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cloud-nothing-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const launch = resolveWorkflowServerLaunch({
+    gsdBinary: join(root, "gsd"),
+    env: {},
+    lookup: () => null,
+  });
+  assert.equal(launch, null);
+});
+
+test("rejects malformed GSD_WORKFLOW_MCP_ARGS loudly", (t) => {
+  const { gsdBinary } = makeInstalledLayout(t);
+  assert.throws(
+    () =>
+      resolveWorkflowServerLaunch({
+        gsdBinary,
+        env: {
+          GSD_WORKFLOW_MCP_COMMAND: "/custom/wf-server",
+          GSD_WORKFLOW_MCP_ARGS: '{"not":"an array"}',
+        },
+        lookup: () => null,
+      }),
+    /GSD_WORKFLOW_MCP_ARGS/,
+  );
+});

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -329,6 +329,22 @@ test("rejects malformed GSD_WORKFLOW_MCP_ARGS loudly", (t) => {
   );
 });
 
+test("coerces non-string GSD_WORKFLOW_MCP_ARGS entries to strings instead of throwing", (t) => {
+  const { gsdBinary } = makeInstalledLayout(t);
+  // Numbers/booleans are accepted and String()-coerced, matching the extension's
+  // detectWorkflowMcpLaunchConfig contract, rather than rejected.
+  const launch = resolveWorkflowServerLaunch({
+    gsdBinary,
+    env: {
+      GSD_WORKFLOW_MCP_COMMAND: "/custom/wf-server",
+      GSD_WORKFLOW_MCP_ARGS: '["--port", 8080, true]',
+    },
+    lookup: () => null,
+  });
+  assert.ok(launch, "expected a launch config");
+  assert.deepEqual(launch.args, ["--port", "8080", "true"]);
+});
+
 test(
   "resolves gsd-mcp-server via a Node PATH scan on the injected env when which/where is unavailable",
   { skip: process.platform === "win32" ? "POSIX PATH-scan fallback" : false },

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -95,3 +95,19 @@ test("rejects malformed GSD_WORKFLOW_MCP_ARGS loudly", (t) => {
     /GSD_WORKFLOW_MCP_ARGS/,
   );
 });
+
+test("rejects invalid-JSON GSD_WORKFLOW_MCP_ARGS with a targeted error", (t) => {
+  const { gsdBinary } = makeInstalledLayout(t);
+  assert.throws(
+    () =>
+      resolveWorkflowServerLaunch({
+        gsdBinary,
+        env: {
+          GSD_WORKFLOW_MCP_COMMAND: "/custom/wf-server",
+          GSD_WORKFLOW_MCP_ARGS: "--flag --other",
+        },
+        lookup: () => null,
+      }),
+    /GSD_WORKFLOW_MCP_ARGS must be valid JSON/,
+  );
+});

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -159,6 +159,23 @@ test(
   },
 );
 
+test(
+  "ignores a same-named directory on PATH (searchable bit is not executability)",
+  { skip: process.platform === "win32" ? "POSIX directory exec-bit semantics" : false },
+  (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "gsd-cloud-dir-decoy-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    // A directory named exactly like the command carries the execute
+    // ("searchable") bit on POSIX; the scan must not mistake it for the binary.
+    mkdirSync(join(dir, "gsd-mcp-server"));
+    const launch = resolveWorkflowServerLaunch({
+      gsdBinary: join(dir, "missing", "gsd"),
+      env: { PATH: dir },
+    });
+    assert.equal(launch, null);
+  },
+);
+
 test("a bare gsd name that does not resolve on PATH does not anchor discovery off cwd", (t) => {
   const fakeCwd = mkdtempSync(join(tmpdir(), "gsd-cloud-cwd-anchor-"));
   t.after(() => rmSync(fakeCwd, { recursive: true, force: true }));

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.test.ts
@@ -33,6 +33,35 @@ test("discovers the workflow server beside an installed gsd binary", (t) => {
   assert.equal(launch.gsdCliPath, realpathSync(gsdBinary));
 });
 
+test("discovers the installed workflow server from GSD_BIN_PATH", (t) => {
+  const { gsdBinary, workflowCli } = makeInstalledLayout(t);
+  const launch = resolveWorkflowServerLaunch({
+    env: { GSD_BIN_PATH: gsdBinary },
+    lookup: () => null,
+  });
+
+  assert.deepEqual(launch, {
+    command: process.execPath,
+    args: [workflowCli],
+    gsdCliPath: realpathSync(gsdBinary),
+  });
+});
+
+test("discovers the installed workflow server from GSD_WORKFLOW_PATH", (t) => {
+  const { gsdBinary, workflowCli } = makeInstalledLayout(t);
+  const workflowPath = join(dirname(dirname(gsdBinary)), "GSD-WORKFLOW.md");
+  writeFileSync(workflowPath, "# GSD Workflow\n");
+  const launch = resolveWorkflowServerLaunch({
+    env: { GSD_WORKFLOW_PATH: workflowPath },
+    lookup: () => null,
+  });
+
+  assert.deepEqual(launch, {
+    command: process.execPath,
+    args: [workflowCli],
+  });
+});
+
 test("explicit GSD_WORKFLOW_MCP_COMMAND wins over discovery", (t) => {
   const { gsdBinary } = makeInstalledLayout(t);
   const launch = resolveWorkflowServerLaunch({

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -7,10 +7,11 @@
 // `gsd --mode mcp` instead yields a session registry without those tools, so
 // every workflow call fails with "Unknown tool" (issue #1513).
 //
-// Resolution order (daemon-specific; it does not mirror the extension's
-// detectWorkflowMcpLaunchConfig, which probes the project root for hints):
+// Resolution mirrors the extension's environment override, installed-layout,
+// and PATH stages, but uses host installation anchors instead of the project root:
 //  1. GSD_WORKFLOW_MCP_COMMAND (+ optional GSD_WORKFLOW_MCP_ARGS JSON array)
-//  2. packages/mcp-server/dist/cli.js walking up from the resolved gsd binary
+//  2. packages/mcp-server/dist/cli.js walking up from resolved gsd binaries or
+//     GSD_WORKFLOW_PATH
 //  3. `gsd-mcp-server` on PATH
 import { execFileSync } from "node:child_process";
 import { accessSync, constants, existsSync, realpathSync, statSync } from "node:fs";

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -359,11 +359,16 @@ export function resolveWorkflowServerLaunch(
   const explicitCommand = env.GSD_WORKFLOW_MCP_COMMAND?.trim();
   if (explicitCommand) {
     const args = parseArgsEnv(env.GSD_WORKFLOW_MCP_ARGS);
+    // GSD_WORKFLOW_MCP_CWD (explicitCwd) is a working-directory override for the
+    // server process only — it is deliberately NOT a project-root fallback.
+    // Discovery is memoized host-level, so folding it into GSD_WORKFLOW_PROJECT_ROOT
+    // would pin every per-project child to the same root and clobber the
+    // executor's per-project path (gsd-pi-executor uses launch.env root ?? path),
+    // breaking multi-project routing. It still lands as launch.cwd below.
     const workflowProjectRoot =
       explicitEnvironment?.GSD_WORKFLOW_PROJECT_ROOT?.trim()
       || env.GSD_WORKFLOW_PROJECT_ROOT?.trim()
-      || env.GSD_PROJECT_ROOT?.trim()
-      || explicitCwd;
+      || env.GSD_PROJECT_ROOT?.trim();
     const launchEnvironment = {
       ...explicitEnvironment,
       ...(configuredCliPath && gsdCliPath

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -9,7 +9,7 @@
 //
 // Resolution mirrors the extension's environment override, installed-layout,
 // and PATH stages, but uses host installation anchors instead of the project root:
-//  1. GSD_WORKFLOW_MCP_COMMAND (+ optional GSD_WORKFLOW_MCP_ARGS JSON array)
+//  1. GSD_WORKFLOW_MCP_COMMAND (+ optional ARGS, ENV, and CWD overrides)
 //  2. packages/mcp-server/dist/cli.js walking up from resolved gsd binaries or
 //     GSD_WORKFLOW_PATH
 //  3. `gsd-mcp-server` on PATH
@@ -20,6 +20,8 @@ import { dirname, isAbsolute, join, posix, resolve, win32 } from "node:path";
 export interface WorkflowServerLaunch {
   command: string;
   args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
   gsdCliPath?: string;
   windowsVerbatimArguments?: boolean;
 }
@@ -50,6 +52,23 @@ function parseArgsEnv(raw: string | undefined): string[] {
   // the extension's detectWorkflowMcpLaunchConfig contract (explicitArgs.map(String)),
   // so reasonable values like numbers/booleans don't cause startup failures.
   return parsed.map(String);
+}
+
+function parseEnvironmentEnv(raw: string | undefined): Record<string, string> | undefined {
+  if (!raw || !raw.trim()) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`GSD_WORKFLOW_MCP_ENV must be valid JSON: ${detail}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("GSD_WORKFLOW_MCP_ENV must be a JSON object");
+  }
+  return Object.fromEntries(
+    Object.entries(parsed).map(([key, value]) => [key, String(value)]),
+  );
 }
 
 /**
@@ -315,16 +334,43 @@ export function resolveWorkflowServerLaunch(
   const rawLookup = options.lookup ?? ((command: string) => defaultLookup(command, env, platform));
   const lookup = (command: string): string | null =>
     selectLookupPath(rawLookup(command), platform);
+  const explicitEnvironment = parseEnvironmentEnv(env.GSD_WORKFLOW_MCP_ENV);
+  const explicitCwd = env.GSD_WORKFLOW_MCP_CWD?.trim();
+  const configuredCliPath =
+    explicitEnvironment?.GSD_CLI_PATH?.trim()
+    || explicitEnvironment?.GSD_BIN_PATH?.trim()
+    || env.GSD_CLI_PATH?.trim()
+    || env.GSD_BIN_PATH?.trim();
+  const anchorCandidates = options.gsdBinary !== undefined
+    ? [options.gsdBinary, configuredCliPath]
+    : [configuredCliPath, "gsd"];
+  const resolvedConfiguredCliPath = resolveGsdBinary(configuredCliPath, lookup);
   const resolvedGsdAnchors: string[] = [];
-  for (const candidate of [options.gsdBinary, env.GSD_BIN_PATH, env.GSD_CLI_PATH]) {
-    const resolved = resolveGsdBinary(candidate, lookup);
+  for (const candidate of anchorCandidates) {
+    const resolved = candidate === configuredCliPath
+      ? resolvedConfiguredCliPath
+      : resolveGsdBinary(candidate, lookup);
     if (resolved && !resolvedGsdAnchors.includes(resolved)) resolvedGsdAnchors.push(resolved);
   }
-  const gsdCliPath = resolvedGsdAnchors[0];
+  const gsdCliPath = options.gsdBinary === undefined && configuredCliPath
+    ? resolvedConfiguredCliPath ?? configuredCliPath
+    : resolvedGsdAnchors[0];
 
   const explicitCommand = env.GSD_WORKFLOW_MCP_COMMAND?.trim();
   if (explicitCommand) {
     const args = parseArgsEnv(env.GSD_WORKFLOW_MCP_ARGS);
+    const workflowProjectRoot =
+      explicitEnvironment?.GSD_WORKFLOW_PROJECT_ROOT?.trim()
+      || env.GSD_WORKFLOW_PROJECT_ROOT?.trim()
+      || env.GSD_PROJECT_ROOT?.trim()
+      || explicitCwd;
+    const launchEnvironment = {
+      ...explicitEnvironment,
+      ...(configuredCliPath && gsdCliPath
+        ? { GSD_CLI_PATH: gsdCliPath, GSD_BIN_PATH: gsdCliPath }
+        : {}),
+      ...(workflowProjectRoot ? { GSD_WORKFLOW_PROJECT_ROOT: resolve(workflowProjectRoot) } : {}),
+    };
     const hasPath = explicitCommand.includes("/") || explicitCommand.includes("\\");
     const commandPath = hasPath ? explicitCommand : lookup(explicitCommand) ?? explicitCommand;
     let launch: WorkflowServerLaunch;
@@ -343,6 +389,8 @@ export function resolveWorkflowServerLaunch(
     }
     return {
       ...launch,
+      ...(explicitCwd ? { cwd: explicitCwd } : {}),
+      ...(Object.keys(launchEnvironment).length > 0 ? { env: launchEnvironment } : {}),
       ...(gsdCliPath ? { gsdCliPath } : {}),
     };
   }

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -136,11 +136,13 @@ function escapeWindowsCommand(command: string): string {
   return command.replace(WINDOWS_META_CHARS, "^$1");
 }
 
-function escapeWindowsArgument(argument: string): string {
-  const quoted = `"${argument
+function escapeWindowsArgument(argument: string, doubleEscapeMetaChars: boolean): string {
+  let escaped = `"${argument
     .replace(/(?=(\\+?)?)\1"/g, "$1$1\\\"")
     .replace(/(?=(\\+?)?)\1$/, "$1$1")}"`;
-  return quoted.replace(WINDOWS_META_CHARS, "^$1");
+  escaped = escaped.replace(WINDOWS_META_CHARS, "^$1");
+  if (doubleEscapeMetaChars) escaped = escaped.replace(WINDOWS_META_CHARS, "^$1");
+  return escaped;
 }
 
 function wrapWindowsServerShim(
@@ -163,9 +165,10 @@ function wrapWindowsServerShim(
       ],
     };
   }
+  const doubleEscapeMetaChars = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i.test(commandPath);
   const shellCommand = [
     escapeWindowsCommand(commandPath),
-    ...args.map(escapeWindowsArgument),
+    ...args.map((argument) => escapeWindowsArgument(argument, doubleEscapeMetaChars)),
   ].join(" ");
   return {
     command: env.COMSPEC?.trim() || "cmd.exe",

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -117,6 +117,41 @@ function findWorkflowCliFromBinary(gsdCliPath: string): string | null {
   }
 }
 
+function resolveWorkflowServerCommand(commandPath: string): WorkflowServerLaunch | null {
+  let resolvedCommand: string;
+  try {
+    resolvedCommand = realpathSync(resolve(commandPath));
+  } catch {
+    if (/\.(?:cmd|ps1)$/i.test(commandPath)) return null;
+    return { command: commandPath, args: [] };
+  }
+
+  const commandDir = dirname(resolvedCommand);
+  const entrypoint = [
+    resolve(
+      commandDir,
+      "node_modules",
+      "@opengsd",
+      "mcp-server",
+      "bin",
+      "gsd-mcp-server.js",
+    ),
+    resolve(
+      commandDir,
+      "..",
+      "@opengsd",
+      "mcp-server",
+      "bin",
+      "gsd-mcp-server.js",
+    ),
+  ].find((path) => existsSync(path));
+  if (entrypoint) {
+    return { command: process.execPath, args: [realpathSync(entrypoint)] };
+  }
+  if (/\.(?:cmd|ps1)$/i.test(resolvedCommand)) return null;
+  return { command: resolvedCommand, args: [] };
+}
+
 export function resolveWorkflowServerLaunch(
   options: ResolveWorkflowServerLaunchOptions = {},
 ): WorkflowServerLaunch | null {
@@ -143,7 +178,8 @@ export function resolveWorkflowServerLaunch(
 
   const onPath = lookup("gsd-mcp-server");
   if (onPath) {
-    return { command: onPath, args: [], ...(gsdCliPath ? { gsdCliPath } : {}) };
+    const launch = resolveWorkflowServerCommand(onPath);
+    if (launch) return { ...launch, ...(gsdCliPath ? { gsdCliPath } : {}) };
   }
 
   return null;

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -117,13 +117,50 @@ function findWorkflowCliFromBinary(gsdCliPath: string): string | null {
   }
 }
 
-function resolveWorkflowServerCommand(commandPath: string): WorkflowServerLaunch | null {
+function isWindowsShim(commandPath: string): boolean {
+  return /\.(?:cmd|ps1)$/i.test(commandPath);
+}
+
+function wrapWindowsServerShim(
+  commandPath: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): WorkflowServerLaunch {
+  if (/\.ps1$/i.test(commandPath)) {
+    return {
+      command: "powershell.exe",
+      args: [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        commandPath,
+        ...args,
+      ],
+    };
+  }
+  return {
+    command: env.COMSPEC?.trim() || "cmd.exe",
+    args: ["/d", "/s", "/c", commandPath, ...args],
+  };
+}
+
+function resolveWorkflowServerCommand(
+  commandPath: string,
+  args: string[],
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): WorkflowServerLaunch {
   let resolvedCommand: string;
   try {
     resolvedCommand = realpathSync(resolve(commandPath));
   } catch {
-    if (/\.(?:cmd|ps1)$/i.test(commandPath)) return null;
-    return { command: commandPath, args: [] };
+    if (platform === "win32" && isWindowsShim(commandPath)) {
+      return wrapWindowsServerShim(commandPath, args, env);
+    }
+    return { command: commandPath, args };
   }
 
   const commandDir = dirname(resolvedCommand);
@@ -146,10 +183,12 @@ function resolveWorkflowServerCommand(commandPath: string): WorkflowServerLaunch
     ),
   ].find((path) => existsSync(path));
   if (entrypoint) {
-    return { command: process.execPath, args: [realpathSync(entrypoint)] };
+    return { command: process.execPath, args: [realpathSync(entrypoint), ...args] };
   }
-  if (/\.(?:cmd|ps1)$/i.test(resolvedCommand)) return null;
-  return { command: resolvedCommand, args: [] };
+  if (platform === "win32" && isWindowsShim(resolvedCommand)) {
+    return wrapWindowsServerShim(resolvedCommand, args, env);
+  }
+  return { command: resolvedCommand, args };
 }
 
 export function resolveWorkflowServerLaunch(
@@ -164,9 +203,13 @@ export function resolveWorkflowServerLaunch(
 
   const explicitCommand = env.GSD_WORKFLOW_MCP_COMMAND?.trim();
   if (explicitCommand) {
+    const args = parseArgsEnv(env.GSD_WORKFLOW_MCP_ARGS);
+    const commandPath = explicitCommand.includes("/") || explicitCommand.includes("\\")
+      ? explicitCommand
+      : lookup(explicitCommand) ?? explicitCommand;
+    const launch = resolveWorkflowServerCommand(commandPath, args, platform, env);
     return {
-      command: explicitCommand,
-      args: parseArgsEnv(env.GSD_WORKFLOW_MCP_ARGS),
+      ...launch,
       ...(gsdCliPath ? { gsdCliPath } : {}),
     };
   }
@@ -178,8 +221,8 @@ export function resolveWorkflowServerLaunch(
 
   const onPath = lookup("gsd-mcp-server");
   if (onPath) {
-    const launch = resolveWorkflowServerCommand(onPath);
-    if (launch) return { ...launch, ...(gsdCliPath ? { gsdCliPath } : {}) };
+    const launch = resolveWorkflowServerCommand(onPath, [], platform, env);
+    return { ...launch, ...(gsdCliPath ? { gsdCliPath } : {}) };
   }
 
   return null;

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -13,7 +13,7 @@
 //  2. packages/mcp-server/dist/cli.js walking up from the resolved gsd binary
 //  3. `gsd-mcp-server` on PATH
 import { execFileSync } from "node:child_process";
-import { accessSync, constants, existsSync, realpathSync } from "node:fs";
+import { accessSync, constants, existsSync, realpathSync, statSync } from "node:fs";
 import { delimiter, dirname, join, resolve } from "node:path";
 
 export interface WorkflowServerLaunch {
@@ -53,6 +53,10 @@ function parseArgsEnv(raw: string | undefined): string[] {
  */
 function isExecutableFile(candidate: string): boolean {
   try {
+    // Reject directories: on POSIX they usually carry the execute ("searchable")
+    // bit, so an X_OK-only check would mistake a same-named directory for the
+    // binary. which/where only return regular files.
+    if (!statSync(candidate).isFile()) return false;
     accessSync(candidate, constants.X_OK);
     return true;
   } catch {

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -72,7 +72,9 @@ function searchPath(command: string, env: NodeJS.ProcessEnv): string | null {
     const abs = resolve(command);
     return isExecutableFile(abs) ? abs : null;
   }
-  const pathValue = env.PATH ?? "";
+  // Windows commonly exposes PATH as `Path` (or `path`); injected env objects
+  // are case-sensitive, unlike the process.env proxy, so check all casings.
+  const pathValue = env.PATH ?? env.Path ?? env.path ?? "";
   if (!pathValue) return null;
   const exts =
     process.platform === "win32"
@@ -141,7 +143,11 @@ export function resolveWorkflowServerLaunch(
 
   let anchor = options.gsdBinary?.trim();
   if (anchor && !anchor.includes("/") && !anchor.includes("\\")) {
-    anchor = lookup(anchor) ?? anchor;
+    // A bare command name is only a valid discovery anchor once resolved to an
+    // on-disk path. If PATH lookup fails, drop it rather than keeping the bare
+    // name: resolve("gsd") would otherwise anchor discovery off the daemon's
+    // cwd. Callers wanting a relative anchor can pass "./gsd" explicitly.
+    anchor = lookup(anchor) ?? undefined;
   }
   if (anchor) {
     const cli = findWorkflowCliFromBinary(anchor);

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -13,12 +13,13 @@
 //  3. `gsd-mcp-server` on PATH
 import { execFileSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, isAbsolute, resolve, win32 } from "node:path";
 
 export interface WorkflowServerLaunch {
   command: string;
   args: string[];
   gsdCliPath?: string;
+  windowsVerbatimArguments?: boolean;
 }
 
 export interface ResolveWorkflowServerLaunchOptions {
@@ -121,6 +122,27 @@ function isWindowsShim(commandPath: string): boolean {
   return /\.(?:cmd|ps1)$/i.test(commandPath);
 }
 
+function isWorkflowServerShim(commandPath: string): boolean {
+  return /^gsd-mcp-server(?:\.(?:cmd|ps1))?$/i.test(commandPath.split(/[\\/]/).pop() ?? "");
+}
+
+function isAbsoluteCommand(commandPath: string, platform: NodeJS.Platform): boolean {
+  return isAbsolute(commandPath) || (platform === "win32" && win32.isAbsolute(commandPath));
+}
+
+const WINDOWS_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
+
+function escapeWindowsCommand(command: string): string {
+  return command.replace(WINDOWS_META_CHARS, "^$1");
+}
+
+function escapeWindowsArgument(argument: string): string {
+  const quoted = `"${argument
+    .replace(/(?=(\\+?)?)\1"/g, "$1$1\\\"")
+    .replace(/(?=(\\+?)?)\1$/, "$1$1")}"`;
+  return quoted.replace(WINDOWS_META_CHARS, "^$1");
+}
+
 function wrapWindowsServerShim(
   commandPath: string,
   args: string[],
@@ -141,9 +163,14 @@ function wrapWindowsServerShim(
       ],
     };
   }
+  const shellCommand = [
+    escapeWindowsCommand(commandPath),
+    ...args.map(escapeWindowsArgument),
+  ].join(" ");
   return {
     command: env.COMSPEC?.trim() || "cmd.exe",
-    args: ["/d", "/s", "/c", commandPath, ...args],
+    args: ["/d", "/s", "/c", `"${shellCommand}"`],
+    windowsVerbatimArguments: true,
   };
 }
 
@@ -152,6 +179,7 @@ function resolveWorkflowServerCommand(
   args: string[],
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
+  inferEntrypoint: boolean,
 ): WorkflowServerLaunch {
   let resolvedCommand: string;
   try {
@@ -163,27 +191,29 @@ function resolveWorkflowServerCommand(
     return { command: commandPath, args };
   }
 
-  const commandDir = dirname(resolvedCommand);
-  const entrypoint = [
-    resolve(
-      commandDir,
-      "node_modules",
-      "@opengsd",
-      "mcp-server",
-      "bin",
-      "gsd-mcp-server.js",
-    ),
-    resolve(
-      commandDir,
-      "..",
-      "@opengsd",
-      "mcp-server",
-      "bin",
-      "gsd-mcp-server.js",
-    ),
-  ].find((path) => existsSync(path));
-  if (entrypoint) {
-    return { command: process.execPath, args: [realpathSync(entrypoint), ...args] };
+  if (inferEntrypoint) {
+    const commandDir = dirname(resolvedCommand);
+    const entrypoint = [
+      resolve(
+        commandDir,
+        "node_modules",
+        "@opengsd",
+        "mcp-server",
+        "bin",
+        "gsd-mcp-server.js",
+      ),
+      resolve(
+        commandDir,
+        "..",
+        "@opengsd",
+        "mcp-server",
+        "bin",
+        "gsd-mcp-server.js",
+      ),
+    ].find((path) => existsSync(path));
+    if (entrypoint) {
+      return { command: process.execPath, args: [realpathSync(entrypoint), ...args] };
+    }
   }
   if (platform === "win32" && isWindowsShim(resolvedCommand)) {
     return wrapWindowsServerShim(resolvedCommand, args, env);
@@ -204,10 +234,22 @@ export function resolveWorkflowServerLaunch(
   const explicitCommand = env.GSD_WORKFLOW_MCP_COMMAND?.trim();
   if (explicitCommand) {
     const args = parseArgsEnv(env.GSD_WORKFLOW_MCP_ARGS);
-    const commandPath = explicitCommand.includes("/") || explicitCommand.includes("\\")
-      ? explicitCommand
-      : lookup(explicitCommand) ?? explicitCommand;
-    const launch = resolveWorkflowServerCommand(commandPath, args, platform, env);
+    const hasPath = explicitCommand.includes("/") || explicitCommand.includes("\\");
+    const commandPath = hasPath ? explicitCommand : lookup(explicitCommand) ?? explicitCommand;
+    let launch: WorkflowServerLaunch;
+    if (hasPath && !isAbsoluteCommand(explicitCommand, platform)) {
+      launch = platform === "win32" && isWindowsShim(explicitCommand)
+        ? wrapWindowsServerShim(explicitCommand, args, env)
+        : { command: explicitCommand, args };
+    } else {
+      launch = resolveWorkflowServerCommand(
+        commandPath,
+        args,
+        platform,
+        env,
+        isWorkflowServerShim(commandPath),
+      );
+    }
     return {
       ...launch,
       ...(gsdCliPath ? { gsdCliPath } : {}),
@@ -221,7 +263,7 @@ export function resolveWorkflowServerLaunch(
 
   const onPath = lookup("gsd-mcp-server");
   if (onPath) {
-    const launch = resolveWorkflowServerCommand(onPath, [], platform, env);
+    const launch = resolveWorkflowServerCommand(onPath, [], platform, env, true);
     return { ...launch, ...(gsdCliPath ? { gsdCliPath } : {}) };
   }
 

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -18,6 +18,7 @@ import { dirname, resolve } from "node:path";
 export interface WorkflowServerLaunch {
   command: string;
   args: string[];
+  gsdCliPath?: string;
 }
 
 export interface ResolveWorkflowServerLaunchOptions {
@@ -52,15 +53,25 @@ function defaultLookup(command: string): string | null {
   }
 }
 
-function findWorkflowCliFromBinary(gsdBinary: string): string | null {
-  let current: string;
+function resolveGsdBinary(
+  gsdBinary: string | undefined,
+  lookup: (command: string) => string | null,
+): string | undefined {
+  const candidate = gsdBinary?.trim();
+  if (!candidate) return undefined;
+  const resolved = candidate.includes("/") || candidate.includes("\\")
+    ? candidate
+    : lookup(candidate);
+  if (!resolved) return undefined;
   try {
-    // realpath resolves symlinked launchers (e.g. /opt/homebrew/bin/gsd) to the
-    // installed package, whose root holds packages/mcp-server.
-    current = dirname(realpathSync(resolve(gsdBinary)));
+    return realpathSync(resolve(resolved));
   } catch {
-    return null;
+    return undefined;
   }
+}
+
+function findWorkflowCliFromBinary(gsdCliPath: string): string | null {
+  let current = dirname(gsdCliPath);
   while (true) {
     const candidates = [
       resolve(current, "packages", "mcp-server", "dist", "cli.js"),
@@ -88,23 +99,26 @@ export function resolveWorkflowServerLaunch(
 ): WorkflowServerLaunch | null {
   const env = options.env ?? process.env;
   const lookup = options.lookup ?? defaultLookup;
+  const gsdCliPath = resolveGsdBinary(options.gsdBinary, lookup);
 
   const explicitCommand = env.GSD_WORKFLOW_MCP_COMMAND?.trim();
   if (explicitCommand) {
-    return { command: explicitCommand, args: parseArgsEnv(env.GSD_WORKFLOW_MCP_ARGS) };
+    return {
+      command: explicitCommand,
+      args: parseArgsEnv(env.GSD_WORKFLOW_MCP_ARGS),
+      ...(gsdCliPath ? { gsdCliPath } : {}),
+    };
   }
 
-  let anchor = options.gsdBinary?.trim();
-  if (anchor && !anchor.includes("/") && !anchor.includes("\\")) {
-    anchor = lookup(anchor) ?? anchor;
-  }
-  if (anchor) {
-    const cli = findWorkflowCliFromBinary(anchor);
-    if (cli) return { command: process.execPath, args: [cli] };
+  if (gsdCliPath) {
+    const cli = findWorkflowCliFromBinary(gsdCliPath);
+    if (cli) return { command: process.execPath, args: [cli], gsdCliPath };
   }
 
   const onPath = lookup("gsd-mcp-server");
-  if (onPath) return { command: onPath, args: [] };
+  if (onPath) {
+    return { command: onPath, args: [], ...(gsdCliPath ? { gsdCliPath } : {}) };
+  }
 
   return null;
 }

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -173,8 +173,8 @@ function resolveGsdBinary(
   }
 }
 
-function findWorkflowCliFromBinary(gsdCliPath: string): string | null {
-  let current = dirname(gsdCliPath);
+function findWorkflowCliFromAnchor(anchor: string): string | null {
+  let current = dirname(anchor);
   while (true) {
     const candidates = [
       resolve(current, "packages", "mcp-server", "dist", "cli.js"),
@@ -311,7 +311,12 @@ export function resolveWorkflowServerLaunch(
   const rawLookup = options.lookup ?? ((command: string) => defaultLookup(command, env, platform));
   const lookup = (command: string): string | null =>
     selectLookupPath(rawLookup(command), platform);
-  const gsdCliPath = resolveGsdBinary(options.gsdBinary, lookup);
+  const resolvedGsdAnchors: string[] = [];
+  for (const candidate of [options.gsdBinary, env.GSD_BIN_PATH, env.GSD_CLI_PATH]) {
+    const resolved = resolveGsdBinary(candidate, lookup);
+    if (resolved && !resolvedGsdAnchors.includes(resolved)) resolvedGsdAnchors.push(resolved);
+  }
+  const gsdCliPath = resolvedGsdAnchors[0];
 
   const explicitCommand = env.GSD_WORKFLOW_MCP_COMMAND?.trim();
   if (explicitCommand) {
@@ -338,9 +343,19 @@ export function resolveWorkflowServerLaunch(
     };
   }
 
-  if (gsdCliPath) {
-    const cli = findWorkflowCliFromBinary(gsdCliPath);
-    if (cli) return { command: process.execPath, args: [cli], gsdCliPath };
+  const workflowPath = env.GSD_WORKFLOW_PATH?.trim();
+  const discoveryAnchors = workflowPath
+    ? [...resolvedGsdAnchors, workflowPath]
+    : resolvedGsdAnchors;
+  for (const anchor of discoveryAnchors) {
+    const cli = findWorkflowCliFromAnchor(anchor);
+    if (cli) {
+      return {
+        command: process.execPath,
+        args: [cli],
+        ...(gsdCliPath ? { gsdCliPath } : {}),
+      };
+    }
   }
 
   const onPath = lookup("gsd-mcp-server");

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -13,7 +13,7 @@
 //  2. packages/mcp-server/dist/cli.js walking up from the resolved gsd binary
 //  3. `gsd-mcp-server` on PATH
 import { execFileSync } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { accessSync, constants, existsSync, realpathSync } from "node:fs";
 import { delimiter, dirname, join, resolve } from "node:path";
 
 export interface WorkflowServerLaunch {
@@ -46,16 +46,31 @@ function parseArgsEnv(raw: string | undefined): string[] {
 }
 
 /**
+ * True when `candidate` is a runnable executable, matching `which`/`where`
+ * semantics. On POSIX this requires the execute bit (X_OK); on Windows X_OK is
+ * a no-op so this degrades to an existence check, and executability is instead
+ * governed by the PATHEXT filtering in searchPath.
+ */
+function isExecutableFile(candidate: string): boolean {
+  try {
+    accessSync(candidate, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Node-side PATH scan, used when `which`/`where` is unavailable (minimal
  * container images often ship neither) or returns nothing. Splits the supplied
  * env's PATH on the OS delimiter and, on Windows, tries each PATHEXT extension.
- * Only returns a path that actually exists.
+ * Only returns an executable file, mirroring `which`/`where`.
  */
 function searchPath(command: string, env: NodeJS.ProcessEnv): string | null {
-  // An explicit path is not a PATH lookup — just confirm it exists.
+  // An explicit path is not a PATH lookup — just confirm it is executable.
   if (command.includes("/") || command.includes("\\")) {
     const abs = resolve(command);
-    return existsSync(abs) ? abs : null;
+    return isExecutableFile(abs) ? abs : null;
   }
   const pathValue = env.PATH ?? "";
   if (!pathValue) return null;
@@ -67,7 +82,7 @@ function searchPath(command: string, env: NodeJS.ProcessEnv): string | null {
     if (!dir) continue;
     for (const ext of exts) {
       const candidate = join(dir, command + ext);
-      if (existsSync(candidate)) return candidate;
+      if (isExecutableFile(candidate)) return candidate;
     }
   }
   return null;

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -42,10 +42,13 @@ function parseArgsEnv(raw: string | undefined): string[] {
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(`GSD_WORKFLOW_MCP_ARGS must be valid JSON: ${detail}`);
   }
-  if (!Array.isArray(parsed) || parsed.some((value) => typeof value !== "string")) {
-    throw new Error("GSD_WORKFLOW_MCP_ARGS must be a JSON array of strings");
+  if (!Array.isArray(parsed)) {
+    throw new Error("GSD_WORKFLOW_MCP_ARGS must be a JSON array");
   }
-  return parsed as string[];
+  // Coerce entries with String(...) rather than rejecting non-strings, matching
+  // the extension's detectWorkflowMcpLaunchConfig contract (explicitArgs.map(String)),
+  // so reasonable values like numbers/booleans don't cause startup failures.
+  return parsed.map(String);
 }
 
 /**

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -1,0 +1,98 @@
+// Project/App: Open GSD
+// File Purpose: Resolve how to launch the GSD workflow MCP server for a project.
+//
+// The cloud daemon's per-project child must be the workflow MCP server
+// (@opengsd/mcp-server, bin `gsd-mcp-server`) — that process owns the workflow
+// adapter surface (gsd_status, gsd_roadmap, gsd_progress, …). Spawning
+// `gsd --mode mcp` instead yields a session registry without those tools, so
+// every workflow call fails with "Unknown tool" (issue #1513).
+//
+// Resolution order mirrors detectWorkflowMcpLaunchConfig in the gsd extension:
+//  1. GSD_WORKFLOW_MCP_COMMAND (+ optional GSD_WORKFLOW_MCP_ARGS JSON array)
+//  2. packages/mcp-server/dist/cli.js walking up from the resolved gsd binary
+//  3. `gsd-mcp-server` on PATH
+import { execFileSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+export interface WorkflowServerLaunch {
+  command: string;
+  args: string[];
+}
+
+export interface ResolveWorkflowServerLaunchOptions {
+  /** Path (or bare name) of the gsd binary used as the discovery anchor. */
+  gsdBinary?: string;
+  /** Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+  /** PATH lookup, injectable for tests. Defaults to which/where. */
+  lookup?: (command: string) => string | null;
+}
+
+function parseArgsEnv(raw: string | undefined): string[] {
+  if (!raw || !raw.trim()) return [];
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed) || parsed.some((value) => typeof value !== "string")) {
+    throw new Error("GSD_WORKFLOW_MCP_ARGS must be a JSON array of strings");
+  }
+  return parsed as string[];
+}
+
+function defaultLookup(command: string): string | null {
+  const tool = process.platform === "win32" ? "where" : "which";
+  try {
+    const out = execFileSync(tool, [command], {
+      timeout: 5_000,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return out.trim().split(/\r?\n/)[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Walk up from the resolved gsd binary looking for packages/mcp-server/dist/cli.js. */
+function findWorkflowCliFromBinary(gsdBinary: string): string | null {
+  let current: string;
+  try {
+    // realpath resolves symlinked launchers (e.g. /opt/homebrew/bin/gsd) to the
+    // installed package, whose root holds packages/mcp-server.
+    current = dirname(realpathSync(resolve(gsdBinary)));
+  } catch {
+    return null;
+  }
+  while (true) {
+    const candidate = resolve(current, "packages", "mcp-server", "dist", "cli.js");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+export function resolveWorkflowServerLaunch(
+  options: ResolveWorkflowServerLaunchOptions = {},
+): WorkflowServerLaunch | null {
+  const env = options.env ?? process.env;
+  const lookup = options.lookup ?? defaultLookup;
+
+  const explicitCommand = env.GSD_WORKFLOW_MCP_COMMAND?.trim();
+  if (explicitCommand) {
+    return { command: explicitCommand, args: parseArgsEnv(env.GSD_WORKFLOW_MCP_ARGS) };
+  }
+
+  let anchor = options.gsdBinary?.trim();
+  if (anchor && !anchor.includes("/") && !anchor.includes("\\")) {
+    anchor = lookup(anchor) ?? anchor;
+  }
+  if (anchor) {
+    const cli = findWorkflowCliFromBinary(anchor);
+    if (cli) return { command: process.execPath, args: [cli] };
+  }
+
+  const onPath = lookup("gsd-mcp-server");
+  if (onPath) return { command: onPath, args: [] };
+
+  return null;
+}

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -28,6 +28,7 @@ export interface ResolveWorkflowServerLaunchOptions {
   env?: NodeJS.ProcessEnv;
   /** PATH lookup, injectable for tests. Defaults to which/where. */
   lookup?: (command: string) => string | null;
+  platform?: NodeJS.Platform;
 }
 
 function parseArgsEnv(raw: string | undefined): string[] {
@@ -47,10 +48,21 @@ function defaultLookup(command: string): string | null {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });
-    return out.trim().split(/\r?\n/)[0] || null;
+    return out.trim() || null;
   } catch {
     return null;
   }
+}
+
+function selectLookupPath(output: string | null, platform: NodeJS.Platform): string | null {
+  const paths = output
+    ?.split(/\r?\n/)
+    .map((path) => path.trim())
+    .filter(Boolean) ?? [];
+  if (platform === "win32") {
+    return paths.find((path) => /\.cmd$/i.test(path)) ?? paths[0] ?? null;
+  }
+  return paths[0] ?? null;
 }
 
 function resolveGsdBinary(
@@ -65,17 +77,17 @@ function resolveGsdBinary(
   if (!resolved) return undefined;
   try {
     const cliPath = realpathSync(resolve(resolved));
-    if (!/\.(?:cmd|ps1)$/i.test(cliPath)) return cliPath;
-    return realpathSync(
-      resolve(
-        dirname(cliPath),
-        "node_modules",
-        "@opengsd",
-        "gsd-pi",
-        "dist",
-        "loader.js",
-      ),
+    const npmLoader = resolve(
+      dirname(cliPath),
+      "node_modules",
+      "@opengsd",
+      "gsd-pi",
+      "dist",
+      "loader.js",
     );
+    if (existsSync(npmLoader)) return realpathSync(npmLoader);
+    if (/\.(?:cmd|ps1)$/i.test(cliPath)) return undefined;
+    return cliPath;
   } catch {
     return undefined;
   }
@@ -109,7 +121,10 @@ export function resolveWorkflowServerLaunch(
   options: ResolveWorkflowServerLaunchOptions = {},
 ): WorkflowServerLaunch | null {
   const env = options.env ?? process.env;
-  const lookup = options.lookup ?? defaultLookup;
+  const rawLookup = options.lookup ?? defaultLookup;
+  const platform = options.platform ?? process.platform;
+  const lookup = (command: string): string | null =>
+    selectLookupPath(rawLookup(command), platform);
   const gsdCliPath = resolveGsdBinary(options.gsdBinary, lookup);
 
   const explicitCommand = env.GSD_WORKFLOW_MCP_COMMAND?.trim();

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -52,7 +52,6 @@ function defaultLookup(command: string): string | null {
   }
 }
 
-/** Walk up from the resolved gsd binary looking for packages/mcp-server/dist/cli.js. */
 function findWorkflowCliFromBinary(gsdBinary: string): string | null {
   let current: string;
   try {
@@ -63,8 +62,21 @@ function findWorkflowCliFromBinary(gsdBinary: string): string | null {
     return null;
   }
   while (true) {
-    const candidate = resolve(current, "packages", "mcp-server", "dist", "cli.js");
-    if (existsSync(candidate)) return candidate;
+    const candidates = [
+      resolve(current, "packages", "mcp-server", "dist", "cli.js"),
+      resolve(
+        current,
+        "node_modules",
+        "@opengsd",
+        "gsd-pi",
+        "packages",
+        "mcp-server",
+        "dist",
+        "cli.js",
+      ),
+    ];
+    const candidate = candidates.find((path) => existsSync(path));
+    if (candidate) return realpathSync(candidate);
     const parent = dirname(current);
     if (parent === current) return null;
     current = parent;

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -14,7 +14,7 @@
 //  3. `gsd-mcp-server` on PATH
 import { execFileSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 
 export interface WorkflowServerLaunch {
   command: string;
@@ -45,6 +45,34 @@ function parseArgsEnv(raw: string | undefined): string[] {
   return parsed as string[];
 }
 
+/**
+ * Node-side PATH scan, used when `which`/`where` is unavailable (minimal
+ * container images often ship neither) or returns nothing. Splits PATH on the
+ * OS delimiter and, on Windows, tries each PATHEXT extension. Only returns a
+ * path that actually exists.
+ */
+function searchPath(command: string): string | null {
+  // An explicit path is not a PATH lookup — just confirm it exists.
+  if (command.includes("/") || command.includes("\\")) {
+    const abs = resolve(command);
+    return existsSync(abs) ? abs : null;
+  }
+  const pathValue = process.env.PATH ?? "";
+  if (!pathValue) return null;
+  const exts =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)
+      : [""];
+  for (const dir of pathValue.split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const candidate = join(dir, command + ext);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
 function defaultLookup(command: string): string | null {
   const tool = process.platform === "win32" ? "where" : "which";
   try {
@@ -53,10 +81,14 @@ function defaultLookup(command: string): string | null {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });
-    return out.trim().split(/\r?\n/)[0] || null;
+    const resolved = out.trim().split(/\r?\n/)[0] || null;
+    // `which`/`where` can report a stale hit; confirm the target still exists.
+    if (resolved && existsSync(resolved)) return resolved;
   } catch {
-    return null;
+    // `which`/`where` missing (minimal image) or errored — fall through to the
+    // Node-side PATH scan below.
   }
+  return searchPath(command);
 }
 
 /** Walk up from the resolved gsd binary looking for packages/mcp-server/dist/cli.js. */

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -64,7 +64,18 @@ function resolveGsdBinary(
     : lookup(candidate);
   if (!resolved) return undefined;
   try {
-    return realpathSync(resolve(resolved));
+    const cliPath = realpathSync(resolve(resolved));
+    if (!/\.(?:cmd|ps1)$/i.test(cliPath)) return cliPath;
+    return realpathSync(
+      resolve(
+        dirname(cliPath),
+        "node_modules",
+        "@opengsd",
+        "gsd-pi",
+        "dist",
+        "loader.js",
+      ),
+    );
   } catch {
     return undefined;
   }

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -47,21 +47,21 @@ function parseArgsEnv(raw: string | undefined): string[] {
 
 /**
  * Node-side PATH scan, used when `which`/`where` is unavailable (minimal
- * container images often ship neither) or returns nothing. Splits PATH on the
- * OS delimiter and, on Windows, tries each PATHEXT extension. Only returns a
- * path that actually exists.
+ * container images often ship neither) or returns nothing. Splits the supplied
+ * env's PATH on the OS delimiter and, on Windows, tries each PATHEXT extension.
+ * Only returns a path that actually exists.
  */
-function searchPath(command: string): string | null {
+function searchPath(command: string, env: NodeJS.ProcessEnv): string | null {
   // An explicit path is not a PATH lookup — just confirm it exists.
   if (command.includes("/") || command.includes("\\")) {
     const abs = resolve(command);
     return existsSync(abs) ? abs : null;
   }
-  const pathValue = process.env.PATH ?? "";
+  const pathValue = env.PATH ?? "";
   if (!pathValue) return null;
   const exts =
     process.platform === "win32"
-      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)
+      ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)
       : [""];
   for (const dir of pathValue.split(delimiter)) {
     if (!dir) continue;
@@ -73,13 +73,16 @@ function searchPath(command: string): string | null {
   return null;
 }
 
-function defaultLookup(command: string): string | null {
+function defaultLookup(command: string, env: NodeJS.ProcessEnv): string | null {
   const tool = process.platform === "win32" ? "where" : "which";
   try {
     const out = execFileSync(tool, [command], {
       timeout: 5_000,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      // Honor the caller-supplied env so `which`/`where` searches the same PATH
+      // as the Node-side fallback below.
+      env,
     });
     const resolved = out.trim().split(/\r?\n/)[0] || null;
     // `which`/`where` can report a stale hit; confirm the target still exists.
@@ -88,7 +91,7 @@ function defaultLookup(command: string): string | null {
     // `which`/`where` missing (minimal image) or errored — fall through to the
     // Node-side PATH scan below.
   }
-  return searchPath(command);
+  return searchPath(command, env);
 }
 
 /** Walk up from the resolved gsd binary looking for packages/mcp-server/dist/cli.js. */
@@ -114,7 +117,7 @@ export function resolveWorkflowServerLaunch(
   options: ResolveWorkflowServerLaunchOptions = {},
 ): WorkflowServerLaunch | null {
   const env = options.env ?? process.env;
-  const lookup = options.lookup ?? defaultLookup;
+  const lookup = options.lookup ?? ((command: string) => defaultLookup(command, env));
 
   const explicitCommand = env.GSD_WORKFLOW_MCP_COMMAND?.trim();
   if (explicitCommand) {

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -7,7 +7,8 @@
 // `gsd --mode mcp` instead yields a session registry without those tools, so
 // every workflow call fails with "Unknown tool" (issue #1513).
 //
-// Resolution order mirrors detectWorkflowMcpLaunchConfig in the gsd extension:
+// Resolution order (daemon-specific; it does not mirror the extension's
+// detectWorkflowMcpLaunchConfig, which probes the project root for hints):
 //  1. GSD_WORKFLOW_MCP_COMMAND (+ optional GSD_WORKFLOW_MCP_ARGS JSON array)
 //  2. packages/mcp-server/dist/cli.js walking up from the resolved gsd binary
 //  3. `gsd-mcp-server` on PATH
@@ -31,7 +32,13 @@ export interface ResolveWorkflowServerLaunchOptions {
 
 function parseArgsEnv(raw: string | undefined): string[] {
   if (!raw || !raw.trim()) return [];
-  const parsed = JSON.parse(raw) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`GSD_WORKFLOW_MCP_ARGS must be valid JSON: ${detail}`);
+  }
   if (!Array.isArray(parsed) || parsed.some((value) => typeof value !== "string")) {
     throw new Error("GSD_WORKFLOW_MCP_ARGS must be a JSON array of strings");
   }

--- a/packages/gsd-cloud/src/executors/workflow-server-launch.ts
+++ b/packages/gsd-cloud/src/executors/workflow-server-launch.ts
@@ -14,7 +14,7 @@
 //  3. `gsd-mcp-server` on PATH
 import { execFileSync } from "node:child_process";
 import { accessSync, constants, existsSync, realpathSync, statSync } from "node:fs";
-import { delimiter, dirname, isAbsolute, join, resolve, win32 } from "node:path";
+import { dirname, isAbsolute, join, posix, resolve, win32 } from "node:path";
 
 export interface WorkflowServerLaunch {
   command: string;
@@ -73,7 +73,7 @@ function isExecutableFile(candidate: string): boolean {
  * env's PATH on the OS delimiter and, on Windows, tries each PATHEXT extension.
  * Only returns an executable file, mirroring `which`/`where`.
  */
-function searchPath(command: string, env: NodeJS.ProcessEnv): string | null {
+function searchPath(command: string, env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string | null {
   // An explicit path is not a PATH lookup — just confirm it is executable.
   if (command.includes("/") || command.includes("\\")) {
     const abs = resolve(command);
@@ -83,11 +83,14 @@ function searchPath(command: string, env: NodeJS.ProcessEnv): string | null {
   // are case-sensitive, unlike the process.env proxy, so check all casings.
   const pathValue = env.PATH ?? env.Path ?? env.path ?? "";
   if (!pathValue) return null;
-  const exts =
-    process.platform === "win32"
-      ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)
-      : [""];
-  for (const dir of pathValue.split(delimiter)) {
+  const isWindows = platform === "win32";
+  const exts = isWindows
+    ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)
+    : [""];
+  // Split PATH with the delimiter of the injected platform, not the host's, so
+  // Windows-style (`;`) values resolve when tests simulate win32 on POSIX.
+  const pathDelimiter = isWindows ? win32.delimiter : posix.delimiter;
+  for (const dir of pathValue.split(pathDelimiter)) {
     if (!dir) continue;
     for (const ext of exts) {
       const candidate = join(dir, command + ext);
@@ -97,8 +100,12 @@ function searchPath(command: string, env: NodeJS.ProcessEnv): string | null {
   return null;
 }
 
-function defaultLookup(command: string, env: NodeJS.ProcessEnv): string | null {
-  const tool = process.platform === "win32" ? "where" : "which";
+function defaultLookup(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string | null {
+  const tool = platform === "win32" ? "where" : "which";
   try {
     const out = execFileSync(tool, [command], {
       timeout: 5_000,
@@ -120,7 +127,7 @@ function defaultLookup(command: string, env: NodeJS.ProcessEnv): string | null {
     // `which`/`where` missing (minimal image) or errored — fall through to the
     // Node-side PATH scan below.
   }
-  return searchPath(command, env);
+  return searchPath(command, env, platform);
 }
 
 function selectLookupPath(output: string | null, platform: NodeJS.Platform): string | null {
@@ -300,8 +307,8 @@ export function resolveWorkflowServerLaunch(
   options: ResolveWorkflowServerLaunchOptions = {},
 ): WorkflowServerLaunch | null {
   const env = options.env ?? process.env;
-  const rawLookup = options.lookup ?? ((command: string) => defaultLookup(command, env));
   const platform = options.platform ?? process.platform;
+  const rawLookup = options.lookup ?? ((command: string) => defaultLookup(command, env, platform));
   const lookup = (command: string): string | null =>
     selectLookupPath(rawLookup(command), platform);
   const gsdCliPath = resolveGsdBinary(options.gsdBinary, lookup);

--- a/packages/gsd-cloud/src/service-install.test.ts
+++ b/packages/gsd-cloud/src/service-install.test.ts
@@ -158,6 +158,25 @@ test("systemd unit quotes arguments containing spaces", (t) => {
   assert.ok(!unit.includes(`--config ${configPath}\n`));
 });
 
+test("service unit PATH appends the install-time PATH so interactive-only commands resolve", (t) => {
+  const home = tmpHome(t);
+  const opts = baseInstallOpts(home, {
+    nodePath: "/opt/node/bin/node",
+    environment: { PATH: `/home/user/.local/bin:/usr/bin:${join(home, "bin")}` },
+  });
+  // Node bin dir + system dirs stay first; interactive-only dirs are appended,
+  // and dirs already in the base (e.g. /usr/bin) are not duplicated. This lets a
+  // bare GSD_WORKFLOW_MCP_COMMAND on ~/.local/bin resolve under the service.
+  const expected =
+    `/opt/node/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/user/.local/bin:${join(home, "bin")}`;
+
+  const xml = generateLaunchdPlist(opts);
+  assert.ok(xml.includes(`<key>PATH</key>\n\t\t<string>${expected}</string>`));
+
+  const unit = generateSystemdUnit(opts);
+  assert.ok(unit.includes(`Environment="PATH=${expected}"`));
+});
+
 test("service units preserve workflow MCP discovery overrides", (t) => {
   const home = tmpHome(t);
   const environment = {
@@ -198,6 +217,13 @@ test("service units preserve workflow MCP discovery overrides", (t) => {
     }
   });
 
+  // installService with environment:undefined captures process.env at install
+  // time, and buildEnvPath now folds that env's PATH into the unit PATH. Render
+  // the expectation from the same process.env so the equality reflects the
+  // fallback path rather than the PATH-free opts used for the key assertions.
+  const expectedPlist = generateLaunchdPlist({ ...opts, environment: process.env });
+  const expectedUnit = generateSystemdUnit({ ...opts, environment: process.env });
+
   for (const platform of ["darwin", "linux"] as const) {
     const unitPath = join(home, `${platform}.service`);
     installService(
@@ -206,7 +232,7 @@ test("service units preserve workflow MCP discovery overrides", (t) => {
     );
     assert.equal(
       readFileSync(unitPath, "utf8"),
-      platform === "darwin" ? plist : unit,
+      platform === "darwin" ? expectedPlist : expectedUnit,
     );
   }
 });

--- a/packages/gsd-cloud/src/service-install.test.ts
+++ b/packages/gsd-cloud/src/service-install.test.ts
@@ -35,6 +35,7 @@ function baseInstallOpts(home: string, overrides?: Partial<ServiceInstallOptions
     binaryPath: "/usr/local/lib/node_modules/@opengsd/gsd-cloud/bin/gsd-cloud.js",
     configPath: join(home, ".gsd", "daemon.yaml"),
     homeDir: home,
+    environment: {},
     ...overrides,
   };
 }
@@ -155,6 +156,59 @@ test("systemd unit quotes arguments containing spaces", (t) => {
   const unit = generateSystemdUnit(baseInstallOpts(home, { configPath }));
   assert.ok(unit.includes(`--config "${configPath}"`));
   assert.ok(!unit.includes(`--config ${configPath}\n`));
+});
+
+test("service units preserve workflow MCP discovery overrides", (t) => {
+  const home = tmpHome(t);
+  const environment = {
+    GSD_BIN_PATH: "/opt/gsd/bin/gsd",
+    GSD_WORKFLOW_MCP_COMMAND: "/opt/workflow/bin/server",
+    GSD_WORKFLOW_MCP_ARGS: '["--label","one & two"]',
+    GSD_WORKFLOW_MCP_ENV: '{"TOKEN":"quote\\\" & percent%"}',
+    GSD_WORKFLOW_MCP_CWD: "/srv/workflow & projects",
+  };
+  const opts = baseInstallOpts(home, {
+    environment,
+  });
+
+  const plist = generateLaunchdPlist(opts);
+  const unit = generateSystemdUnit(opts);
+
+  for (const [key, value] of Object.entries(environment)) {
+    assert.ok(plist.includes(`<key>${key}</key>`), `launchd missing ${key}`);
+    assert.ok(plist.includes(`<string>${escapeXml(value)}</string>`), `launchd missing ${key} value`);
+    const escapedForSystemd = value
+      .replace(/%/g, "%%")
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"');
+    assert.ok(
+      unit.includes(`Environment="${key}=${escapedForSystemd}"`),
+      `systemd missing ${key}`,
+    );
+  }
+
+  const previousEnvironment = Object.fromEntries(
+    Object.keys(environment).map((key) => [key, process.env[key]]),
+  );
+  Object.assign(process.env, environment);
+  t.after(() => {
+    for (const [key, value] of Object.entries(previousEnvironment)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  for (const platform of ["darwin", "linux"] as const) {
+    const unitPath = join(home, `${platform}.service`);
+    installService(
+      { ...opts, platform, unitPath, environment: undefined },
+      mockRunCommand().run,
+    );
+    assert.equal(
+      readFileSync(unitPath, "utf8"),
+      platform === "darwin" ? plist : unit,
+    );
+  }
 });
 
 // --------------- install ---------------

--- a/packages/gsd-cloud/src/service-install.test.ts
+++ b/packages/gsd-cloud/src/service-install.test.ts
@@ -1,6 +1,6 @@
 // Project/App: Open GSD
 // File Purpose: Unit coverage for OS service unit rendering, platform dispatch, and failure paths.
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test, type TestContext } from "node:test";
@@ -326,6 +326,21 @@ test("installService surfaces systemctl failures with user-session guidance", (t
     () => installService(opts, run),
     /Failed to connect to bus: No medium found.*loginctl enable-linger/s,
   );
+});
+
+test("installService writes unit files owner-only so persisted secrets stay private", (t) => {
+  const home = tmpHome(t);
+  // The unit files can embed GSD_WORKFLOW_MCP_ENV credentials, so they must not
+  // be readable by other local users.
+  const secretEnv = { GSD_WORKFLOW_MCP_ENV: '{"TOKEN":"s3cret"}' };
+
+  const darwin = baseInstallOpts(home, { platform: "darwin", environment: secretEnv });
+  installService(darwin, mockRunCommand().run);
+  assert.equal(statSync(launchdPlistPath(home)).mode & 0o777, 0o600);
+
+  const linux = baseInstallOpts(home, { platform: "linux", environment: secretEnv });
+  installService(linux, mockRunCommand().run);
+  assert.equal(statSync(systemdUnitPath(home)).mode & 0o777, 0o600);
 });
 
 // --------------- uninstall ---------------

--- a/packages/gsd-cloud/src/service-install.test.ts
+++ b/packages/gsd-cloud/src/service-install.test.ts
@@ -211,6 +211,27 @@ test("service units preserve workflow MCP discovery overrides", (t) => {
   }
 });
 
+test("gsdCliPath pins GSD_CLI_PATH and GSD_BIN_PATH together, overriding a stale GSD_BIN_PATH", (t) => {
+  const home = tmpHome(t);
+  // A mismatched GSD_BIN_PATH in the captured environment must not survive: the
+  // two vars are equivalent CLI-path overrides downstream, so both must resolve
+  // to the freshly resolved binary rather than disagreeing.
+  const opts = baseInstallOpts(home, {
+    gsdCliPath: "/opt/homebrew/bin/gsd",
+    environment: { GSD_BIN_PATH: "/stale/daemon/gsd" },
+  });
+
+  const plist = generateLaunchdPlist(opts);
+  assert.ok(plist.includes("<key>GSD_CLI_PATH</key>\n\t\t<string>/opt/homebrew/bin/gsd</string>"));
+  assert.ok(plist.includes("<key>GSD_BIN_PATH</key>\n\t\t<string>/opt/homebrew/bin/gsd</string>"));
+  assert.ok(!plist.includes("/stale/daemon/gsd"));
+
+  const unit = generateSystemdUnit(opts);
+  assert.ok(unit.includes(`Environment="GSD_CLI_PATH=/opt/homebrew/bin/gsd"`));
+  assert.ok(unit.includes(`Environment="GSD_BIN_PATH=/opt/homebrew/bin/gsd"`));
+  assert.ok(!unit.includes("/stale/daemon/gsd"));
+});
+
 // --------------- install ---------------
 
 test("installService writes the launchd plist, loads it, and verifies registration", (t) => {

--- a/packages/gsd-cloud/src/service-install.ts
+++ b/packages/gsd-cloud/src/service-install.ts
@@ -138,7 +138,14 @@ function serviceEnvironment(opts: ServiceInstallOptions): Array<[string, string]
     const value = opts.environment?.[key];
     if (value !== undefined) values.set(key, value);
   }
-  if (opts.gsdCliPath) values.set("GSD_CLI_PATH", opts.gsdCliPath);
+  if (opts.gsdCliPath) {
+    // GSD_CLI_PATH and GSD_BIN_PATH are equivalent CLI-path overrides
+    // downstream, so pin both to the resolved binary. Setting only GSD_CLI_PATH
+    // would leave a mismatched GSD_BIN_PATH from opts.environment intact, and a
+    // consumer reading GSD_BIN_PATH would then see a stale, disagreeing path.
+    values.set("GSD_CLI_PATH", opts.gsdCliPath);
+    values.set("GSD_BIN_PATH", opts.gsdCliPath);
+  }
   return [...values];
 }
 

--- a/packages/gsd-cloud/src/service-install.ts
+++ b/packages/gsd-cloud/src/service-install.ts
@@ -35,6 +35,7 @@ export interface ServiceInstallOptions extends ServiceTargetOptions {
   logPath?: string;
   /** Path to the `gsd` binary for the executor (from GSD_CLI_PATH at install time). */
   gsdCliPath?: string;
+  /** Workflow discovery environment to persist in the generated service definition. */
   environment?: NodeJS.ProcessEnv;
 }
 

--- a/packages/gsd-cloud/src/service-install.ts
+++ b/packages/gsd-cloud/src/service-install.ts
@@ -126,10 +126,22 @@ export function escapeXml(value: string): string {
  * Build the NVM-aware PATH string. Includes the directory containing the Node
  * binary so the service can find node (and a PATH-local `gsd`) even when
  * launched outside a shell session where NVM isn't sourced.
+ *
+ * The install-time PATH (`inheritedPath`) is appended after the fixed base so a
+ * bare `GSD_WORKFLOW_MCP_COMMAND` / `gsd` that was only discoverable via the
+ * user's interactive PATH (e.g. ~/.local/bin) still resolves under the service.
+ * The Node bin dir and system dirs stay first, so they keep priority; only
+ * additional interactive dirs are appended, de-duplicated.
  */
-function buildEnvPath(nodePath: string): string {
+function buildEnvPath(nodePath: string, inheritedPath?: string): string {
   const nodeBinDir = dirname(nodePath);
-  return `${nodeBinDir}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`;
+  const base = `${nodeBinDir}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`;
+  const baseDirs = new Set(base.split(":"));
+  const extra = (inheritedPath ?? "")
+    .split(":")
+    .map((dir) => dir.trim())
+    .filter((dir) => dir.length > 0 && !baseDirs.has(dir));
+  return extra.length > 0 ? `${base}:${extra.join(":")}` : base;
 }
 
 function serviceEnvironment(opts: ServiceInstallOptions): Array<[string, string]> {
@@ -164,7 +176,7 @@ function systemdArg(value: string): string {
 export function generateLaunchdPlist(opts: ServiceInstallOptions): string {
   const home = opts.homeDir ?? homedir();
   const logPath = opts.logPath ?? runtimeLogPath(opts.configPath);
-  const envPath = buildEnvPath(opts.nodePath);
+  const envPath = buildEnvPath(opts.nodePath, opts.environment?.PATH);
   const workflowEnvironment = serviceEnvironment(opts)
     .map(([key, value]) => `
 \t\t<key>${escapeXml(key)}</key>
@@ -221,7 +233,7 @@ export function generateLaunchdPlist(opts: ServiceInstallOptions): string {
 /** Generate the systemd user unit for the gsd-cloud runtime. */
 export function generateSystemdUnit(opts: ServiceInstallOptions): string {
   const home = opts.homeDir ?? homedir();
-  const envPath = buildEnvPath(opts.nodePath);
+  const envPath = buildEnvPath(opts.nodePath, opts.environment?.PATH);
   const workflowEnvironment = serviceEnvironment(opts)
     .map(([key, value]) => `Environment=${systemdArg(`${key}=${value}`)}`)
     .join("\n");

--- a/packages/gsd-cloud/src/service-install.ts
+++ b/packages/gsd-cloud/src/service-install.ts
@@ -291,7 +291,9 @@ export function installService(
     }
     mkdirSync(dirname(logPath!), { recursive: true });
     writeFileSync(unitPath, generateLaunchdPlist(renderOptions), "utf8");
-    chmodSync(unitPath, 0o644);
+    // Owner-only: the plist can embed GSD_WORKFLOW_MCP_ENV secrets, so it must
+    // not be world-readable. It is a per-user LaunchAgent read by the same user.
+    chmodSync(unitPath, 0o600);
     try {
       runCommand(["launchctl", "load", unitPath]);
     } catch (error) {
@@ -307,7 +309,9 @@ export function installService(
     }
   } else {
     writeFileSync(unitPath, generateSystemdUnit(renderOptions), "utf8");
-    chmodSync(unitPath, 0o644);
+    // Owner-only: the unit can embed GSD_WORKFLOW_MCP_ENV secrets, so it must
+    // not be world-readable. It is a per-user systemd unit read by the same user.
+    chmodSync(unitPath, 0o600);
     try {
       runCommand(["systemctl", "--user", "daemon-reload"]);
       runCommand(["systemctl", "--user", "enable", "--now", SYSTEMD_UNIT_NAME]);

--- a/packages/gsd-cloud/src/service-install.ts
+++ b/packages/gsd-cloud/src/service-install.ts
@@ -35,6 +35,7 @@ export interface ServiceInstallOptions extends ServiceTargetOptions {
   logPath?: string;
   /** Path to the `gsd` binary for the executor (from GSD_CLI_PATH at install time). */
   gsdCliPath?: string;
+  environment?: NodeJS.ProcessEnv;
 }
 
 export interface InstalledService {
@@ -70,6 +71,15 @@ export const LAUNCHD_LABEL = "net.opengsd.gsd-cloud";
 const LAUNCHD_PLIST_FILENAME = `${LAUNCHD_LABEL}.plist`;
 export const SYSTEMD_UNIT_NAME = "gsd-cloud.service";
 const SYSTEMD_RESTART_DELAY_SECONDS = 5;
+const SERVICE_ENVIRONMENT_KEYS = [
+  "GSD_CLI_PATH",
+  "GSD_BIN_PATH",
+  "GSD_WORKFLOW_PATH",
+  "GSD_WORKFLOW_MCP_COMMAND",
+  "GSD_WORKFLOW_MCP_ARGS",
+  "GSD_WORKFLOW_MCP_ENV",
+  "GSD_WORKFLOW_MCP_CWD",
+] as const;
 
 // --------------- platform dispatch ---------------
 
@@ -121,9 +131,25 @@ function buildEnvPath(nodePath: string): string {
   return `${nodeBinDir}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`;
 }
 
+function serviceEnvironment(opts: ServiceInstallOptions): Array<[string, string]> {
+  const values = new Map<string, string>();
+  for (const key of SERVICE_ENVIRONMENT_KEYS) {
+    const value = opts.environment?.[key];
+    if (value !== undefined) values.set(key, value);
+  }
+  if (opts.gsdCliPath) values.set("GSD_CLI_PATH", opts.gsdCliPath);
+  return [...values];
+}
+
 /** Quote one argument for a systemd unit line (no shell is involved). */
 function systemdArg(value: string): string {
-  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"")}"`;
+  return `"${value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, "\\\"")
+    .replace(/%/g, "%%")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t")}"`;
 }
 
 /** Generate the launchd plist XML for the gsd-cloud runtime. */
@@ -131,6 +157,11 @@ export function generateLaunchdPlist(opts: ServiceInstallOptions): string {
   const home = opts.homeDir ?? homedir();
   const logPath = opts.logPath ?? runtimeLogPath(opts.configPath);
   const envPath = buildEnvPath(opts.nodePath);
+  const workflowEnvironment = serviceEnvironment(opts)
+    .map(([key, value]) => `
+\t\t<key>${escapeXml(key)}</key>
+\t\t<string>${escapeXml(value)}</string>`)
+    .join("");
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -163,9 +194,7 @@ export function generateLaunchdPlist(opts: ServiceInstallOptions): string {
 \t\t<key>PATH</key>
 \t\t<string>${escapeXml(envPath)}</string>
 \t\t<key>HOME</key>
-\t\t<string>${escapeXml(home)}</string>${opts.gsdCliPath ? `
-\t\t<key>GSD_CLI_PATH</key>
-\t\t<string>${escapeXml(opts.gsdCliPath)}</string>` : ""}
+\t\t<string>${escapeXml(home)}</string>${workflowEnvironment}
 \t</dict>
 
 \t<key>WorkingDirectory</key>
@@ -185,6 +214,9 @@ export function generateLaunchdPlist(opts: ServiceInstallOptions): string {
 export function generateSystemdUnit(opts: ServiceInstallOptions): string {
   const home = opts.homeDir ?? homedir();
   const envPath = buildEnvPath(opts.nodePath);
+  const workflowEnvironment = serviceEnvironment(opts)
+    .map(([key, value]) => `Environment=${systemdArg(`${key}=${value}`)}`)
+    .join("\n");
 
   return `[Unit]
 Description=GSD Cloud runtime agent (gsd-cloud)
@@ -196,8 +228,8 @@ ExecStart=${systemdArg(opts.nodePath)} ${systemdArg(opts.binaryPath)} connect --
 Restart=on-failure
 RestartSec=${SYSTEMD_RESTART_DELAY_SECONDS}
 Environment=${systemdArg(`HOME=${home}`)}
-Environment=${systemdArg(`PATH=${envPath}`)}${opts.gsdCliPath ? `
-Environment=${systemdArg(`GSD_CLI_PATH=${opts.gsdCliPath}`)}` : ""}
+Environment=${systemdArg(`PATH=${envPath}`)}${workflowEnvironment ? `
+${workflowEnvironment}` : ""}
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=gsd-cloud
@@ -233,6 +265,9 @@ export function installService(
   opts: ServiceInstallOptions,
   runCommand: RunServiceCommandFn = defaultRunServiceCommand,
 ): InstalledService {
+  const renderOptions = opts.environment === undefined
+    ? { ...opts, environment: process.env }
+    : opts;
   const manager = serviceManagerForPlatform(opts.platform);
   const unitPath = resolveUnitPath(manager, opts);
   const logPath = manager === "launchd" ? (opts.logPath ?? runtimeLogPath(opts.configPath)) : null;
@@ -247,7 +282,7 @@ export function installService(
       }
     }
     mkdirSync(dirname(logPath!), { recursive: true });
-    writeFileSync(unitPath, generateLaunchdPlist(opts), "utf8");
+    writeFileSync(unitPath, generateLaunchdPlist(renderOptions), "utf8");
     chmodSync(unitPath, 0o644);
     try {
       runCommand(["launchctl", "load", unitPath]);
@@ -263,7 +298,7 @@ export function installService(
       );
     }
   } else {
-    writeFileSync(unitPath, generateSystemdUnit(opts), "utf8");
+    writeFileSync(unitPath, generateSystemdUnit(renderOptions), "utf8");
     chmodSync(unitPath, 0o644);
     try {
       runCommand(["systemctl", "--user", "daemon-reload"]);

--- a/packages/mcp-server/src/cli-runner.test.ts
+++ b/packages/mcp-server/src/cli-runner.test.ts
@@ -427,6 +427,69 @@ describe('runMcpServerCli', () => {
     }
   });
 
+  test('client-managed servers do not mutate the singleton PID registry', async () => {
+    const calls: string[] = [];
+    const stderr = new Writable({ write(_chunk, _encoding, callback) { callback(); } });
+
+    await assert.rejects(
+      runMcpServerCli({
+        cwd: () => '/workspace/project',
+        env: { GSD_MCP_CLIENT_MANAGED: '1' },
+        exit(code) {
+          throw new ExitError(code);
+        },
+        loadStoredCredentialEnvKeys() {
+          calls.push('load-env');
+        },
+        registerMcpInstance() {
+          calls.push('register');
+        },
+        sweepProjectOrphanMcpServers() {
+          calls.push('sweep');
+        },
+        unregisterMcpInstance() {
+          calls.push('unregister');
+        },
+        createSessionManager() {
+          calls.push('create-session-manager');
+          return {
+            async cleanup() {
+              calls.push('cleanup-session-manager');
+            },
+          };
+        },
+        async createMcpServer() {
+          calls.push('create-server');
+          throw new Error('create failed');
+        },
+        async importStdioServerTransport() {
+          throw new Error('should not import transport');
+        },
+        warmWorkflowToolBridges() {
+          throw new Error('should not warm bridges');
+        },
+        stdin: new PassThrough(),
+        stdout: new PassThrough(),
+        stderr,
+        onSignal() {},
+        now: () => 0,
+        setInterval() {
+          throw new Error('should not start interval');
+        },
+        clearInterval() {},
+        isOrphaned: () => false,
+      }),
+      (error) => error instanceof ExitError && error.code === 1,
+    );
+
+    assert.deepEqual(calls, [
+      'load-env',
+      'create-session-manager',
+      'create-server',
+      'cleanup-session-manager',
+    ]);
+  });
+
   test('fails before PID mutation when observation-token authority is unavailable', async () => {
     const calls: string[] = [];
     const stderr = new Writable({ write(_chunk, _encoding, callback) { callback(); } });

--- a/packages/mcp-server/src/cli-runner.ts
+++ b/packages/mcp-server/src/cli-runner.ts
@@ -231,6 +231,9 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
 
   const projectDir = env.GSD_WORKFLOW_PROJECT_ROOT || cwd();
   const probeSession = isMcpProbeSession(env);
+  // A parent MCP client owns these children's lifetimes and may intentionally
+  // run more than one for the same project. Keep them out of the singleton PID
+  // registry so one child cannot sweep or unregister another.
   const clientManagedSession = env.GSD_MCP_CLIENT_MANAGED?.trim() === '1';
   const observationToken = env.GSD_MILESTONE_STATUS_OBSERVATION_TOKEN?.trim();
   let pumpScopedObservationSession = false;

--- a/packages/mcp-server/src/cli-runner.ts
+++ b/packages/mcp-server/src/cli-runner.ts
@@ -231,6 +231,7 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
 
   const projectDir = env.GSD_WORKFLOW_PROJECT_ROOT || cwd();
   const probeSession = isMcpProbeSession(env);
+  const clientManagedSession = env.GSD_MCP_CLIENT_MANAGED?.trim() === '1';
   const observationToken = env.GSD_MILESTONE_STATUS_OBSERVATION_TOKEN?.trim();
   let pumpScopedObservationSession = false;
   let registered = false;
@@ -298,7 +299,7 @@ export async function runMcpServerCli(options: RunMcpServerCliOptions = {}): Pro
     }
     if (cleaningUp) return;
 
-    if (!probeSession && !pumpScopedObservationSession) {
+    if (!probeSession && !pumpScopedObservationSession && !clientManagedSession) {
       sweepOrphans(projectDir);
       if (registerInstance(projectDir) === false) {
         throw new Error('refusing to start: existing MCP server PID could not be verified');


### PR DESCRIPTION
## Intent

Fix the cloud daemon boot hang (issue #1513): the SaaS app at /devices/<id>/app hangs on 'Establishing the live bridge session' because the daemon spawned 'gsd --mode mcp' per project, whose session registry lacks the workflow adapter tools (gsd_status etc.), so every poll failed with 'Unknown tool'. Deliberate decision: fix on the daemon side (packages/gsd-cloud executor) by spawning the workflow MCP server (@opengsd/mcp-server) — the canonical owner of that tool surface — instead of changing 'gsd --mode mcp', since the daemon only ever calls workflow tools. Discovery mirrors the gsd extension's detectWorkflowMcpLaunchConfig (env override, installed package layout, PATH). Fail loudly when no server found rather than silently falling back. Regression tests cover the discovery contract.

## What Changed

- Replace per-project `gsd --mode mcp` processes with the canonical workflow MCP server, preflight discovery before connecting, and fail clearly when no server is available.
- Add discovery through explicit command, arguments, environment, and working-directory overrides, installed package layouts, GSD anchors, `PATH`, and Windows shims; isolate client-managed children from the singleton PID registry.
- Persist workflow discovery overrides for launchd/systemd services and update regression coverage, E2E fixtures, and documentation for the new launch contract.

## Risk Assessment

🚨 High: The remediation exposes potentially sensitive workflow environment values and still breaks a required environment-override configuration in service mode.

## Testing

A clean target checkout was inspected, focused daemon and MCP-server tests passed, fixture-backed and installed-GSD loopback E2E flows demonstrated successful cloud `gsd_status` routing, the isolated no-server CLI check demonstrated fail-loud startup, transcripts were preserved, and generated build outputs were cleaned.

<details>
<summary>Evidence: Fixture-backed cloud E2E transcript</summary>

<code>PASS MCP gsd_query is forwarded to the runtime and back&#10;PASS MCP gsd_status reaches the workflow tool surface&#10;PASS runtime shuts down cleanly and detaches from the registry</code>

```text

> @opengsd/gsd-cloud@1.11.0 test:e2e /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KY1E5GS0V0FF3MY7X34775DC/packages/gsd-cloud
> pnpm --filter @opengsd/cloud-mcp-gateway... run build && pnpm run build && node e2e/run-e2e.mjs

Scope: 5 of 16 workspace projects
../pi-ai build$ pnpm run clean && tsc -p tsconfig.json --incremental false
../contracts build$ node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false
../pi-ai build: > @gsd/pi-ai@1.11.0 clean /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KY1E5GS0V0FF3MY7X34775DC/packages/pi-ai
../pi-ai build: > node ../../scripts/clean-package-dist.cjs
../contracts build: Done
../pi-ai build: Done
../rpc-client build$ node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false
../rpc-client build: Done
../mcp-server build$ node ../../scripts/clean-package-dist.cjs && tsc --incremental false
../mcp-server build: Done
../cloud-mcp-gateway build$ node ../../scripts/clean-package-dist.cjs && tsc
../cloud-mcp-gateway build: Done

> @opengsd/gsd-cloud@1.11.0 build /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KY1E5GS0V0FF3MY7X34775DC/packages/gsd-cloud
> node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false

PASS prerequisites: gsd-cloud + gateway build outputs present (1ms)
PASS gateway listening on ephemeral port with temp auth store (27ms)
PASS GET /healthz responds ok (8ms)
PASS POST /pairing-codes mints a code for the user token (44ms)
PASS CLI `pair` exchanges the code and writes temp config (138ms)
PASS CLI `connect --foreground` establishes the runtime websocket (121ms)
PASS gateway registry lists the advertised fixture project (0ms)
PASS MCP initialize + tools/list over /mcp (58ms)
PASS MCP gsd_cloud_projects returns the fixture project (24ms)
PASS MCP gsd_query is forwarded to the runtime and back (23ms)
PASS MCP gsd_status reaches the workflow tool surface (23ms)
PASS runtime shuts down cleanly and detaches from the registry (4ms)

E2E SUMMARY: PASS — 12/12 steps passed in 0.5s
```
</details>
<details>
<summary>Evidence: Installed workflow-server cloud E2E transcript</summary>

<code>PASS MCP gsd_query is forwarded to the runtime and back&#10;PASS MCP gsd_status reaches the workflow tool surface&#10;PASS runtime shuts down cleanly and detaches from the registry</code>

```text

> @opengsd/gsd-cloud@1.11.0 test:e2e /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KY1E5GS0V0FF3MY7X34775DC/packages/gsd-cloud
> pnpm --filter @opengsd/cloud-mcp-gateway... run build && pnpm run build && node e2e/run-e2e.mjs

Scope: 5 of 16 workspace projects
../pi-ai build$ pnpm run clean && tsc -p tsconfig.json --incremental false
../contracts build$ node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false
../pi-ai build: > @gsd/pi-ai@1.11.0 clean /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KY1E5GS0V0FF3MY7X34775DC/packages/pi-ai
../pi-ai build: > node ../../scripts/clean-package-dist.cjs
../contracts build: Done
../pi-ai build: Done
../rpc-client build$ node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false
../rpc-client build: Done
../mcp-server build$ node ../../scripts/clean-package-dist.cjs && tsc --incremental false
../mcp-server build: Done
../cloud-mcp-gateway build$ node ../../scripts/clean-package-dist.cjs && tsc
../cloud-mcp-gateway build: Done

> @opengsd/gsd-cloud@1.11.0 build /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01KY1E5GS0V0FF3MY7X34775DC/packages/gsd-cloud
> node ../../scripts/clean-package-dist.cjs && tsc -p tsconfig.json --incremental false

PASS prerequisites: gsd-cloud + gateway build outputs present (1ms)
PASS gateway listening on ephemeral port with temp auth store (26ms)
PASS GET /healthz responds ok (8ms)
PASS POST /pairing-codes mints a code for the user token (44ms)
PASS CLI `pair` exchanges the code and writes temp config (139ms)
PASS CLI `connect --foreground` establishes the runtime websocket (121ms)
PASS gateway registry lists the advertised fixture project (0ms)
PASS MCP initialize + tools/list over /mcp (57ms)
PASS MCP gsd_cloud_projects returns the fixture project (25ms)
PASS MCP gsd_query is forwarded to the runtime and back (786ms)
PASS MCP gsd_status reaches the workflow tool surface (23ms)
PASS runtime shuts down cleanly and detaches from the registry (9ms)

E2E SUMMARY: PASS — 12/12 steps passed in 1.2s
```
</details>
<details>
<summary>Evidence: Fail-loud missing-server CLI transcript</summary>

<code>gsd-cloud: fatal: Cannot locate the GSD workflow MCP server. Set GSD_WORKFLOW_MCP_COMMAND, install @opengsd/gsd-pi (ships packages/mcp-server/dist/cli.js), or put gsd-mcp-server on PATH.&#10;EXPECTED RESULT: process exited 1 before gateway connection because no workflow MCP server was discoverable.</code>

```text
gsd-cloud: fatal: Cannot locate the GSD workflow MCP server. Set GSD_WORKFLOW_MCP_COMMAND, install @opengsd/gsd-pi (ships packages/mcp-server/dist/cli.js), or put gsd-mcp-server on PATH.
EXPECTED RESULT: process exited 1 before gateway connection because no workflow MCP server was discoverable.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 errors</summary>

- 🚨 `packages/gsd-cloud/src/executors/gsd-pi-executor.ts:208` - The new long-lived per-project workflow child conflicts with the canonical server’s singleton invariant: `cli-runner.ts` registers each server by project, and `pid-registry.ts` terminates an existing same-project server. A cloud child and an IDE/extension child can therefore repeatedly kill and restart each other, dropping calls and potentially recreating the live-session hang. Define a multi-client/registry policy before using this server concurrently.
- 🚨 `packages/gsd-cloud/src/executors/workflow-server-launch.ts:325` - Required criterion: “Discovery mirrors the gsd extension&#39;s detectWorkflowMcpLaunchConfig (env override, installed package layout, PATH).” The explicit branch only reads `GSD_WORKFLOW_MCP_COMMAND/ARGS`; unlike the canonical function, it ignores `GSD_WORKFLOW_MCP_ENV` and `GSD_WORKFLOW_MCP_CWD`, including nested CLI-path overrides. Existing canonical configurations can consequently launch without required environment or from the wrong directory. Either carry these fields through or explicitly approve a narrower daemon contract.
- 🚨 `packages/gsd-cloud/src/executors/workflow-server-launch.ts:319` - Required criterion: discovery must mirror the canonical environment override behavior. The executor always supplies default `gsdBinary: &#34;gsd&#34;`, and this loop resolves that PATH command before `GSD_BIN_PATH`. When both exist, the explicit `GSD_BIN_PATH` override is ignored and its CLI/package layout is not used. Give the explicit environment path precedence unless `gsdBinary` was actually supplied by the caller.
- 🚨 `packages/gsd-cloud/src/executors/workflow-server-launch.ts:325` - The required environment-override route is lost in service mode. This resolver supports `GSD_WORKFLOW_MCP_COMMAND/ARGS`, but service installation persists only `HOME`, generated `PATH`, and optional `GSD_CLI_PATH`. A configuration that works interactively can therefore fail discovery and restart-loop immediately under launchd/systemd. Decide whether to persist and safely escape these values in both service formats or document service mode as unsupported for explicit overrides.

🔧 Fix: Honor workflow overrides and isolate client-managed MCP servers
2 errors still open:
- 🚨 `packages/gsd-cloud/src/service-install.ts:137` - `GSD_WORKFLOW_MCP_ENV` is copied verbatim into service definitions and may contain credentials—the added fixture itself uses `TOKEN`—but both generated files are chmodded `0644`. On multi-user hosts this exposes workflow-server secrets. Create/retain the unit as `0600`, or move sensitive values to an owner-only environment file.
- 🚨 `packages/gsd-cloud/src/service-install.ts:74` - Required criterion: “Discovery mirrors … env override.” The new allowlist persists `GSD_WORKFLOW_MCP_COMMAND` but not the install-time `PATH`; service generation replaces PATH with a fixed set of directories. A valid bare override found through a custom path such as `~/.local/bin` therefore works interactively but fails after service installation. Preserve the relevant PATH or resolve the command to an absolute path when installing.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Baseline: `git rev-parse HEAD`, `git merge-base --is-ancestor 7ae15a8 HEAD`, `git branch --contains HEAD`, and `git status --short`</code>
- `pnpm --filter @opengsd/gsd-cloud test`
- `pnpm --filter @opengsd/mcp-server run build:test && node --test packages/mcp-server/dist/cli-runner.test.js`
- `pnpm --filter @opengsd/gsd-cloud run test:e2e`
- `GSD_CLOUD_E2E_GSD_CLI=/opt/homebrew/bin/gsd pnpm --filter @opengsd/gsd-cloud run test:e2e`
- <code>Isolated `gsd-cloud connect --foreground` under `env -i` with an empty `PATH`; asserted exit 1 and the workflow-server discovery error</code>
- <code>Removed generated package `dist` directories and confirmed the working tree remained clean and evidence files remained present</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core cloud runtime wiring, process spawning, and service definitions that may embed workflow secrets; incorrect discovery or concurrent MCP registry behavior could break production cloud sessions or leak credentials on multi-user hosts.
> 
> **Overview**
> Fixes the cloud live-bridge hang (**#1513**) by routing forwarded workflow tools through the **workflow MCP server** (`gsd-mcp-server` / bundled `packages/mcp-server/dist/cli.js`) instead of **`gsd --mode mcp`**, whose tool surface lacks workflow adapters such as **`gsd_status`**.
> 
> **Runtime behavior:** `GsdPiExecutor` resolves launch via new **`workflow-server-launch`** (explicit `GSD_WORKFLOW_MCP_*`, installed layout, `GSD_BIN_PATH` / `GSD_WORKFLOW_PATH`, PATH, Windows shims). **`CloudRuntime.start()`** calls **`executor.initialize()`** before opening the gateway so missing servers fail loudly. Per-project children set **`GSD_MCP_CLIENT_MANAGED=1`**; **`mcp-server`** skips singleton PID registration for those processes so cloud and IDE servers do not fight.
> 
> **Services & tests:** **`service install`** copies workflow discovery env, appends install-time PATH for bare commands, pins **`GSD_CLI_PATH`/`GSD_BIN_PATH`**, and writes launchd/systemd units **`0600`** when secrets may be embedded. E2E uses **`GSD_WORKFLOW_MCP_COMMAND`** and asserts forwarded **`gsd_status`**; docs/runbooks describe the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef95b86c38d85d2e0446f5032793a59e944c968e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->