### PR TITLE
fix(issue): [Bug]: workflow adapter tools (gsd_status, gsd_roadmap, ...) not registered in gsd --mode mcp — cloud daemon session polling fails, /devices/<id>/app hangs on boot

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -534,6 +534,14 @@ gsd --mode mcp
 
 The server registers all tools from the agent session and maps MCP `tools/list` and `tools/call` requests to GSD tool definitions. It runs until the transport closes.
 
+MCP mode also exposes the GSD workflow adapter tools used by headless and cloud runtimes:
+
+- Session control tools: `gsd_execute`, `gsd_status`, `gsd_result`, `gsd_cancel`, `gsd_resolve_blocker`
+- Project state and read-only tools: `gsd_query`, `gsd_progress`, `gsd_roadmap`, `gsd_history`, `gsd_doctor`, `gsd_captures`, `gsd_knowledge`, `gsd_graph`
+- Interactive form tool: `ask_user_questions`
+
+For an auto-mode run, call `gsd_execute` first with an absolute `projectDir`. It returns a `sessionId`; poll `gsd_status` with that `sessionId` until the run finishes, then call `gsd_result` for accumulated output or `gsd_cancel` to stop it. If a client loses the `sessionId`, `gsd_status` can fall back to `projectDir`, or omit both fields only when this MCP server tracks exactly one session. The read-only project tools read `.gsd/` directly and do not require an active session.
+
 ## Cloud MCP Gateway Runtime
 
 `gsd-cloud-mcp-gateway` starts an HTTP gateway for remote MCP clients. `gsd-daemon cloud` pairs and connects a local runtime to that gateway.

--- a/docs/zh-CN/user-docs/commands.md
+++ b/docs/zh-CN/user-docs/commands.md
@@ -367,6 +367,14 @@ gsd --mode mcp
 
 服务会注册 agent 会话中的全部工具，并把 MCP 的 `tools/list` 与 `tools/call` 请求映射到 GSD 的工具定义上。连接会一直保持，直到底层 transport 关闭。
 
+MCP 模式也会暴露 headless 和 cloud runtime 使用的 GSD workflow adapter 工具：
+
+- 会话控制工具：`gsd_execute`、`gsd_status`、`gsd_result`、`gsd_cancel`、`gsd_resolve_blocker`
+- 项目状态和只读工具：`gsd_query`、`gsd_progress`、`gsd_roadmap`、`gsd_history`、`gsd_doctor`、`gsd_captures`、`gsd_knowledge`、`gsd_graph`
+- 交互式表单工具：`ask_user_questions`
+
+运行自动模式时，先用绝对路径 `projectDir` 调用 `gsd_execute`。它会返回 `sessionId`；之后用这个 `sessionId` 轮询 `gsd_status`，直到运行结束，再调用 `gsd_result` 获取累积输出，或调用 `gsd_cancel` 停止运行。如果客户端丢失了 `sessionId`，`gsd_status` 可以回退到 `projectDir`；只有当这个 MCP server 只跟踪一个会话时，才可以同时省略这两个字段。项目只读工具会直接读取 `.gsd/`，不需要活跃会话。
+
 ## 会话内更新
 
 `/gsd update` 会检查 npm 上是否有更新版本，并在不离开当前会话的情况下完成安装。

--- a/gitbook/features/headless.md
+++ b/gitbook/features/headless.md
@@ -85,6 +85,14 @@ gsd --mode mcp
 
 Compatible with Claude Desktop, VS Code Copilot, and any MCP host.
 
+MCP mode also exposes the workflow adapter tools used by headless and cloud runtimes:
+
+- Session control tools: `gsd_execute`, `gsd_status`, `gsd_result`, `gsd_cancel`, `gsd_resolve_blocker`
+- Project state and read-only tools: `gsd_query`, `gsd_progress`, `gsd_roadmap`, `gsd_history`, `gsd_doctor`, `gsd_captures`, `gsd_knowledge`, `gsd_graph`
+- Interactive form tool: `ask_user_questions`
+
+Start auto-mode work with `gsd_execute`; it returns a `sessionId` that clients should pass to `gsd_status`, `gsd_result`, and `gsd_cancel`. If the client loses the `sessionId`, `gsd_status` can use `projectDir` as a fallback, or omit both fields only when this MCP server tracks exactly one session. The read-only project tools read `.gsd/` directly and do not need a running session.
+
 ## Auto-Restart
 
 In headless mode, crashes trigger automatic restart with exponential backoff (5s → 10s → 30s cap, default 3 attempts). SIGINT/SIGTERM bypasses restart. Combined with crash recovery, this enables true overnight unattended execution.

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,6 +4,11 @@
 
 export { SessionManager } from './session-manager.js';
 export { createMcpServer } from './server.js';
+export {
+  createWorkflowMcpAdapterToolDefs,
+  GSD_MODE_MCP_WORKFLOW_ADAPTER_TOOL_NAMES,
+} from './mcp-adapter-tools.js';
+export type { GenericMcpToolDef } from './mcp-adapter-tools.js';
 export { registerWorkflowTools, WORKFLOW_TOOL_NAMES } from './workflow-tools.js';
 export type {
   SessionStatus,

--- a/packages/mcp-server/src/mcp-adapter-tools.ts
+++ b/packages/mcp-server/src/mcp-adapter-tools.ts
@@ -1,0 +1,118 @@
+import { SessionManager } from "./session-manager.js";
+import { createMcpServer } from "./server.js";
+import { toMoonshotCompatibleInputSchema } from "./moonshot-tool-schema.js";
+
+export const GSD_MODE_MCP_WORKFLOW_ADAPTER_TOOL_NAMES = [
+	"gsd_execute",
+	"gsd_status",
+	"gsd_result",
+	"gsd_cancel",
+	"gsd_query",
+	"gsd_resolve_blocker",
+	"gsd_progress",
+	"gsd_roadmap",
+	"gsd_history",
+	"gsd_doctor",
+	"gsd_captures",
+	"gsd_knowledge",
+	"gsd_graph",
+] as const;
+
+export interface GenericMcpToolDef {
+	name: string;
+	label: string;
+	description: string;
+	parameters: Record<string, unknown>;
+	execute(
+		toolCallId: string,
+		params: Record<string, unknown>,
+		signal?: AbortSignal,
+		onUpdate?: unknown,
+	): Promise<{
+		content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+		details?: Record<string, unknown>;
+		isError?: boolean;
+	}>;
+}
+
+interface RegisteredMcpTool {
+	enabled?: boolean;
+	title?: string;
+	description?: string;
+	inputSchema?: unknown;
+	handler?: (args: Record<string, unknown>, extra?: Record<string, unknown>) => Promise<unknown>;
+	callback?: (args: Record<string, unknown>, extra?: Record<string, unknown>) => Promise<unknown>;
+}
+
+interface McpServerWithRegisteredTools {
+	_registeredTools?: Record<string, RegisteredMcpTool>;
+}
+
+const ADAPTER_TOOL_NAME_SET = new Set<string>(GSD_MODE_MCP_WORKFLOW_ADAPTER_TOOL_NAMES);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asText(value: unknown): string {
+	return typeof value === "string" ? value : JSON.stringify(value, null, 2) ?? String(value);
+}
+
+function normalizeContentBlock(block: unknown): { type: string; text?: string; data?: string; mimeType?: string } {
+	if (!isRecord(block) || typeof block.type !== "string") {
+		return { type: "text", text: asText(block) };
+	}
+
+	const normalized: { type: string; text?: string; data?: string; mimeType?: string } = { type: block.type };
+	if (typeof block.text === "string") normalized.text = block.text;
+	if (typeof block.data === "string") normalized.data = block.data;
+	if (typeof block.mimeType === "string") normalized.mimeType = block.mimeType;
+	return normalized;
+}
+
+function normalizeMcpToolResult(result: unknown): Awaited<ReturnType<GenericMcpToolDef["execute"]>> {
+	if (!isRecord(result)) {
+		return { content: [{ type: "text", text: asText(result) }] };
+	}
+
+	const content = Array.isArray(result.content)
+		? result.content.map(normalizeContentBlock)
+		: [{ type: "text", text: asText(result) }];
+	const normalized: Awaited<ReturnType<GenericMcpToolDef["execute"]>> = { content };
+	if (isRecord(result.structuredContent)) normalized.details = result.structuredContent;
+	if (result.isError === true) normalized.isError = true;
+	return normalized;
+}
+
+function registeredToolHandler(tool: RegisteredMcpTool) {
+	return typeof tool.handler === "function" ? tool.handler : tool.callback;
+}
+
+export async function createWorkflowMcpAdapterToolDefs(
+	sessionManager: SessionManager = new SessionManager(),
+): Promise<GenericMcpToolDef[]> {
+	const { server } = await createMcpServer(sessionManager);
+	const registeredTools = (server as unknown as McpServerWithRegisteredTools)._registeredTools ?? {};
+
+	const tools: GenericMcpToolDef[] = [];
+	for (const name of GSD_MODE_MCP_WORKFLOW_ADAPTER_TOOL_NAMES) {
+		const registered = registeredTools[name];
+		const handler = registered ? registeredToolHandler(registered) : undefined;
+		if (!registered || registered.enabled === false || !handler) continue;
+
+		tools.push({
+			name,
+			label: registered.title ?? name,
+			description: registered.description ?? `GSD workflow adapter tool: ${name}`,
+			parameters: toMoonshotCompatibleInputSchema(registered.inputSchema),
+			execute: async (toolCallId, params, signal) => normalizeMcpToolResult(
+				await handler(params, {
+					requestId: toolCallId,
+					...(signal ? { signal } : {}),
+				}),
+			),
+		});
+	}
+
+	return tools.filter((tool) => ADAPTER_TOOL_NAME_SET.has(tool.name));
+}

--- a/packages/mcp-server/src/mcp-adapter-tools.ts
+++ b/packages/mcp-server/src/mcp-adapter-tools.ts
@@ -16,6 +16,7 @@ export const GSD_MODE_MCP_WORKFLOW_ADAPTER_TOOL_NAMES = [
 	"gsd_captures",
 	"gsd_knowledge",
 	"gsd_graph",
+	"ask_user_questions",
 ] as const;
 
 export interface GenericMcpToolDef {

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -28,6 +28,10 @@ import {
   isLocalElicitTimeoutError,
   withElicitTimeout,
 } from './server.js';
+import {
+  createWorkflowMcpAdapterToolDefs,
+  GSD_MODE_MCP_WORKFLOW_ADAPTER_TOOL_NAMES,
+} from './mcp-adapter-tools.js';
 import { MAX_EVENTS } from './types.js';
 import type { ManagedSession, CostAccumulator, PendingBlocker } from './types.js';
 import { WORKFLOW_TOOL_ALIAS_NAMES } from '@opengsd/contracts';
@@ -974,6 +978,26 @@ describe('createMcpServer tool registration', () => {
     assert.equal(payload.sessionId, sessionId);
     assert.equal(payload.projectDir, resolve('/tmp/tool-status-infer'));
     assert.equal(payload.status, 'running');
+  });
+
+  it('creates gsd --mode mcp workflow adapter tools from the workflow MCP surface', async () => {
+    const tools = await createWorkflowMcpAdapterToolDefs(sm);
+    const toolNames = new Set(tools.map((tool) => tool.name));
+
+    for (const expected of GSD_MODE_MCP_WORKFLOW_ADAPTER_TOOL_NAMES) {
+      assert.ok(toolNames.has(expected), `adapter surface missing ${expected}`);
+    }
+
+    const statusTool = tools.find((tool) => tool.name === 'gsd_status');
+    assert.ok(statusTool, 'gsd_status should be adapted');
+    assert.equal(statusTool.parameters.type, 'object');
+
+    const result = await statusTool.execute('mcp-mode-status-test', { projectDir: '/tmp/no-tracked-session' });
+    assert.equal(result.isError, true);
+    assert.match(
+      result.content.map((block) => block.text ?? '').join('\n'),
+      /No tracked GSD sessions/,
+    );
   });
 
   it('gsd_resolve_blocker flow returns error when no blocker', async () => {

--- a/packages/mcp-server/src/moonshot-tool-schema.ts
+++ b/packages/mcp-server/src/moonshot-tool-schema.ts
@@ -30,6 +30,17 @@ type McpServerWithRegisteredTools = {
 	_registeredTools: Record<string, RegisteredTool>;
 };
 
+export function toMoonshotCompatibleInputSchema(inputSchema: unknown): Record<string, unknown> {
+	const inputObj = normalizeObjectSchema(inputSchema as Parameters<typeof normalizeObjectSchema>[0]);
+	const rawInputSchema = inputObj
+		? toJsonSchemaCompat(inputObj, {
+				strictUnions: true,
+				pipeStrategy: "input",
+			})
+		: EMPTY_OBJECT_JSON_SCHEMA;
+	return sanitizeSchemaForMoonshot(rawInputSchema);
+}
+
 /**
  * Replace the MCP SDK ListTools handler so every advertised inputSchema is
  * flattened for Moonshot/Kimi grammar. Call after all tools are registered.
@@ -39,19 +50,11 @@ export function installMoonshotCompatibleToolSchemas(mcpServer: McpServerWithReg
 		tools: Object.entries(mcpServer._registeredTools)
 			.filter(([, tool]) => tool.enabled)
 			.map(([name, tool]) => {
-				const inputObj = normalizeObjectSchema(tool.inputSchema as Parameters<typeof normalizeObjectSchema>[0]);
-				const rawInputSchema = inputObj
-					? toJsonSchemaCompat(inputObj, {
-							strictUnions: true,
-							pipeStrategy: "input",
-						})
-					: EMPTY_OBJECT_JSON_SCHEMA;
-
 				const toolDefinition: Record<string, unknown> = {
 					name,
 					title: tool.title,
 					description: tool.description,
-					inputSchema: sanitizeSchemaForMoonshot(rawInputSchema),
+					inputSchema: toMoonshotCompatibleInputSchema(tool.inputSchema),
 					annotations: tool.annotations,
 					execution: tool.execution,
 					_meta: tool._meta,

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -210,7 +210,13 @@ function resolveStatusSession(
 
   if (projectDir) {
     const session = sessionManager.getSessionByDir(projectDir);
-    return session ? { session } : { error: `Session not found for projectDir: ${projectDir}` };
+    if (session) return { session };
+    if (sessionManager.listSessions().length === 0) {
+      return {
+        error: 'No tracked GSD sessions. Call gsd_execute first, or pass projectDir for a session tracked by this server.',
+      };
+    }
+    return { error: `Session not found for projectDir: ${projectDir}` };
   }
 
   const only = sessionManager.getOnlySession();

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -213,7 +213,7 @@ function resolveStatusSession(
     if (session) return { session };
     if (sessionManager.listSessions().length === 0) {
       return {
-        error: 'No tracked GSD sessions. Call gsd_execute first, or pass projectDir for a session tracked by this server.',
+        error: 'No tracked GSD sessions. Call gsd_execute first to start a session.',
       };
     }
     return { error: `Session not found for projectDir: ${projectDir}` };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -769,6 +769,7 @@ if (isPrintMode) {
   if (mode === 'mcp') {
     printStartupTimings()
     const { startMcpServer } = await import('./mcp-server.js')
+    const { buildMcpModeTools } = await import('./mcp-mode-tools.js')
 
     // Activate every registered tool before starting the MCP transport.
     // `session.agent.state.tools` is the *active* subset, not the full
@@ -779,9 +780,10 @@ if (isPrintMode) {
     // this MCP session, which is what an external client expects.
     const allToolNames = session.getAllTools().map((t) => t.name)
     session.setActiveToolsByName(allToolNames)
+    const tools = await buildMcpModeTools(session.agent.state.tools ?? [])
 
     await startMcpServer({
-      tools: session.agent.state.tools ?? [],
+      tools,
       version: process.env.GSD_VERSION || '0.0.0',
     })
     // MCP server runs until the transport closes; keep alive

--- a/src/mcp-mode-tools.ts
+++ b/src/mcp-mode-tools.ts
@@ -1,0 +1,29 @@
+import type { McpToolDef } from "./mcp-server.js";
+
+export type WorkflowMcpAdapterToolLoader = () => Promise<McpToolDef[]>;
+
+export async function loadWorkflowMcpAdapterTools(): Promise<McpToolDef[]> {
+	const { createWorkflowMcpAdapterToolDefs } = await import("@opengsd/mcp-server");
+	return createWorkflowMcpAdapterToolDefs();
+}
+
+export function mergeMcpModeTools(
+	baseTools: readonly McpToolDef[],
+	adapterTools: readonly McpToolDef[],
+): McpToolDef[] {
+	const merged = [...baseTools];
+	const seen = new Set(merged.map((tool) => tool.name));
+	for (const tool of adapterTools) {
+		if (seen.has(tool.name)) continue;
+		seen.add(tool.name);
+		merged.push(tool);
+	}
+	return merged;
+}
+
+export async function buildMcpModeTools(
+	baseTools: readonly McpToolDef[],
+	loadAdapterTools: WorkflowMcpAdapterToolLoader = loadWorkflowMcpAdapterTools,
+): Promise<McpToolDef[]> {
+	return mergeMcpModeTools(baseTools, await loadAdapterTools());
+}

--- a/src/tests/mcp-mode-tools.test.ts
+++ b/src/tests/mcp-mode-tools.test.ts
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildMcpModeTools, mergeMcpModeTools } from "../mcp-mode-tools.ts";
+import type { McpToolDef } from "../mcp-server.ts";
+
+function tool(name: string): McpToolDef {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: name }] };
+    },
+  };
+}
+
+test("mergeMcpModeTools appends workflow adapter tools without duplicating existing tools", () => {
+  const base = [tool("read"), tool("gsd_status")];
+  const adapter = [tool("gsd_status"), tool("gsd_roadmap"), tool("gsd_progress")];
+
+  const merged = mergeMcpModeTools(base, adapter);
+
+  assert.deepEqual(merged.map((entry) => entry.name), [
+    "read",
+    "gsd_status",
+    "gsd_roadmap",
+    "gsd_progress",
+  ]);
+  assert.equal(merged.find((entry) => entry.name === "gsd_status"), base[1]);
+});
+
+test("buildMcpModeTools loads missing workflow adapter tools for gsd --mode mcp", async () => {
+  const merged = await buildMcpModeTools(
+    [tool("read")],
+    async () => [tool("gsd_status"), tool("gsd_roadmap")],
+  );
+
+  assert.deepEqual(merged.map((entry) => entry.name), [
+    "read",
+    "gsd_status",
+    "gsd_roadmap",
+  ]);
+});

--- a/src/types/opengsd-mcp-server.d.ts
+++ b/src/types/opengsd-mcp-server.d.ts
@@ -48,4 +48,24 @@ declare module "@opengsd/mcp-server" {
   export function graphStatus(projectDir: string): Promise<GraphStatusResult>;
   export function graphQuery(projectDir: string, term: string): Promise<GraphQueryResult>;
   export function graphDiff(projectDir: string): Promise<GraphDiffResult>;
+
+  export interface GenericMcpToolDef {
+    name: string;
+    label: string;
+    description: string;
+    parameters: Record<string, unknown>;
+    execute(
+      toolCallId: string,
+      params: Record<string, unknown>,
+      signal?: AbortSignal,
+      onUpdate?: unknown,
+    ): Promise<{
+      content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+      details?: Record<string, unknown>;
+      isError?: boolean;
+    }>;
+  }
+
+  export const GSD_MODE_MCP_WORKFLOW_ADAPTER_TOOL_NAMES: readonly string[];
+  export function createWorkflowMcpAdapterToolDefs(): Promise<GenericMcpToolDef[]>;
 }


### PR DESCRIPTION
## Summary
- Registered workflow adapter tools in gsd --mode mcp, added regression coverage, and verified focused helper/syntax checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1513
- [#1513 [Bug]: workflow adapter tools (gsd_status, gsd_roadmap, ...) not registered in gsd --mode mcp — cloud daemon session polling fails, /devices/<id>/app hangs on boot](https://github.com/open-gsd/gsd-pi/issues/1513)

## User
- @jeremymcs

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1513-bug-workflow-adapter-tools-gsd-status-gs-1784595229`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the MCP tool surface used by cloud daemons and external clients; behavior is covered by new tests but affects session polling and orchestration integrations.
> 
> **Overview**
> **`gsd --mode mcp` now advertises the same workflow adapter tools** (`gsd_execute`, `gsd_status`, `gsd_result`, read-only `gsd_*` tools, `ask_user_questions`, etc.) that headless and cloud runtimes rely on, fixing cloud daemon session polling when those names were missing from `tools/list`.
> 
> The CLI builds the MCP tool list via **`buildMcpModeTools`**, which merges the full active agent tool registry with definitions adapted from `@opengsd/mcp-server`’s workflow MCP surface (`createWorkflowMcpAdapterToolDefs`), without duplicating names already present. Adapter schemas reuse **`toMoonshotCompatibleInputSchema`** for Moonshot/Kimi hosts.
> 
> **`gsd_status` resolution** returns a clearer error when `projectDir` is used but this server has no tracked sessions. User docs (EN/ZH) and GitBook describe the adapter tools and the execute → status → result flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2ec29134ede1d7f0292d9186c3e564e4157bea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->