### PR TITLE
fix(gsd): fall back to plain-fs projection copies when native identity locks are unavailable

### DIFF
--- a/src/resources/extensions/gsd/atomic-write.ts
+++ b/src/resources/extensions/gsd/atomic-write.ts
@@ -471,7 +471,7 @@ function transferProjectionTreeFallbackSync(
       const entryStat = lstatSync(sourceEntry);
       if (entryStat.isDirectory()) transferDirectory(sourceEntry, targetEntry);
       else if (!entryStat.isFile()) {
-        throw new Error("projection copy source entry is neither a regular file nor a directory");
+        throw new Error(`projection copy source entry is neither a regular file nor a directory: ${sourceEntry}`);
       } else if (overwrite || !existsSync(targetEntry)) {
         atomicWriteBufferSync(targetEntry, readStableProjectionSourceFallback(sourceEntry));
       }

--- a/src/resources/extensions/gsd/atomic-write.ts
+++ b/src/resources/extensions/gsd/atomic-write.ts
@@ -1,4 +1,4 @@
-import { closeSync, constants as fsConstants, existsSync, fsyncSync, lstatSync, openSync, readdirSync, readFileSync, realpathSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fs } from "node:fs";
+import { closeSync, constants as fsConstants, existsSync, fstatSync, fsyncSync, lstatSync, openSync, readdirSync, readFileSync, realpathSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fs } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { acquireProjectionRootIdentityLock, isProjectionRootIdentityLockAvailable, type ProjectionRootIdentityLock } from "@gsd/native/file-identity";
@@ -420,24 +420,41 @@ function readStableProjectionSource(handle: ProjectionRootIdentityLock, logicalP
 // Plain-fs source proof used when the native identity lock is unavailable
 // (pinned engine binary predates ProjectionRootIdentityLock, or the addon
 // failed to load). Mirrors readStableProjectionSource: double-read with a
-// content hash plus a dev:ino identity comparison.
+// content hash plus a dev:ino identity comparison. Each read opens with
+// O_NOFOLLOW (where the platform defines it) and both proves identity (via
+// fstat on the resulting fd) and reads through that same fd, so a regular
+// file to symlink swap racing the proof fails the open with ELOOP instead of
+// following the link out of the source root, the plain-fs analogue of the
+// native lock's AT_SYMLINK_NOFOLLOW reads.
 function readStableProjectionSourceFallback(sourcePath: string): Buffer {
   const statIdentity = (stat: { dev: bigint; ino: bigint }) => `${stat.dev}:${stat.ino}`;
-  const before = lstatSync(sourcePath, { bigint: true });
-  const first = readFileSync(sourcePath);
+  const readNoFollow = (): { identity: string; content: Buffer } => {
+    const fd = openSync(sourcePath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+    try {
+      return { identity: statIdentity(fstatSync(fd, { bigint: true })), content: readFileSync(fd) };
+    } finally {
+      closeSync(fd);
+    }
+  };
+  const first = readNoFollow();
   projectionCopyBoundaryForTest?.();
-  const second = readFileSync(sourcePath);
-  if (statIdentity(before) !== statIdentity(lstatSync(sourcePath, { bigint: true }))
-    || createHash("sha256").update(first).digest("hex") !== createHash("sha256").update(second).digest("hex")) {
+  const second = readNoFollow();
+  if (first.identity !== second.identity
+    || createHash("sha256").update(first.content).digest("hex") !== createHash("sha256").update(second.content).digest("hex")) {
     throw new Error("projection copy source changed during identity proof");
   }
-  return first;
+  return first.content;
 }
 
 // Plain-fs tree transfer used when the native identity lock is unavailable.
 // Preserves transferProjectionTreeSync semantics: existing non-directory
-// targets are kept unless overwrite, and symlink entries are skipped so the
-// copy cannot escape the source root.
+// targets are kept unless overwrite. Entry types are resolved with lstat (no
+// symlink follow) so the decision is accurate even on filesystems whose
+// readdir returns DT_UNKNOWN, and symlinks / other non-regular nodes are
+// rejected rather than skipped, matching the native lock's pathKind, which
+// throws on them. Failing loud avoids producing a silent partial projection
+// that leaves worktree state subtly inconsistent, and a rejected symlink
+// still cannot escape the source root.
 function transferProjectionTreeFallbackSync(
   sourcePath: string,
   directoryPath: string,
@@ -447,13 +464,15 @@ function transferProjectionTreeFallbackSync(
   function transferDirectory(sourceDir: string, target: string): void {
     if (!overwrite && existsSync(target) && !lstatSync(target).isDirectory()) return;
     createProjectionDirectorySync(target);
-    for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
-      const sourceEntry = join(sourceDir, entry.name);
+    for (const name of readdirSync(sourceDir)) {
+      const sourceEntry = join(sourceDir, name);
       if (!include(sourceEntry)) continue;
-      const targetEntry = join(target, entry.name);
-      if (entry.isDirectory()) transferDirectory(sourceEntry, targetEntry);
-      else if (entry.isSymbolicLink()) continue;
-      else if (overwrite || !existsSync(targetEntry)) {
+      const targetEntry = join(target, name);
+      const entryStat = lstatSync(sourceEntry);
+      if (entryStat.isDirectory()) transferDirectory(sourceEntry, targetEntry);
+      else if (!entryStat.isFile()) {
+        throw new Error("projection copy source entry is neither a regular file nor a directory");
+      } else if (overwrite || !existsSync(targetEntry)) {
         atomicWriteBufferSync(targetEntry, readStableProjectionSourceFallback(sourceEntry));
       }
     }

--- a/src/resources/extensions/gsd/atomic-write.ts
+++ b/src/resources/extensions/gsd/atomic-write.ts
@@ -431,7 +431,18 @@ function readStableProjectionSourceFallback(sourcePath: string): Buffer {
   const readNoFollow = (): { identity: string; content: Buffer } => {
     const fd = openSync(sourcePath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
     try {
-      return { identity: statIdentity(fstatSync(fd, { bigint: true })), content: readFileSync(fd) };
+      const opened = fstatSync(fd, { bigint: true });
+      // Defense for platforms/filesystems where O_NOFOLLOW is unavailable or a
+      // no-op (constant 0, e.g. Windows): if the open silently followed a
+      // symlink, the fd resolves to the link target while an lstat of the path
+      // (which never follows) reports the link itself. Reject on any identity
+      // mismatch, or on a non-regular opened node, so a regular file to symlink
+      // swap cannot escape the source root even without O_NOFOLLOW enforcement.
+      const onDisk = lstatSync(sourcePath, { bigint: true });
+      if (!opened.isFile() || statIdentity(opened) !== statIdentity(onDisk)) {
+        throw new Error(`projection copy source is not a regular file: ${sourcePath}`);
+      }
+      return { identity: statIdentity(opened), content: readFileSync(fd) };
     } finally {
       closeSync(fd);
     }

--- a/src/resources/extensions/gsd/atomic-write.ts
+++ b/src/resources/extensions/gsd/atomic-write.ts
@@ -405,6 +405,8 @@ export function mergeProjectionTreeSync(
   transferProjectionTreeSync(sourcePath, directoryPath, overwrite, () => true);
 }
 
+const projectionStatIdentity = (stat: { dev: bigint; ino: bigint }): string => `${stat.dev}:${stat.ino}`;
+
 function readStableProjectionSource(handle: ProjectionRootIdentityLock, logicalPath: string): Buffer {
   const identity = handle.pathIdentity(logicalPath);
   const first = handle.readFile(logicalPath);
@@ -426,9 +428,25 @@ function readStableProjectionSource(handle: ProjectionRootIdentityLock, logicalP
 // file to symlink swap racing the proof fails the open with ELOOP instead of
 // following the link out of the source root, the plain-fs analogue of the
 // native lock's AT_SYMLINK_NOFOLLOW reads.
-function readStableProjectionSourceFallback(sourcePath: string): Buffer {
-  const statIdentity = (stat: { dev: bigint; ino: bigint }) => `${stat.dev}:${stat.ino}`;
+//
+// expectedParentIdentity is the dev:ino the caller already validated for the
+// source's parent directory. The native lock pins the parent by dev:ino and
+// reads relative to that fd, so a rename/symlink swap of the parent cannot
+// redirect the read. Node has no openat, so the plain-fs analogue re-proves
+// the parent's dev:ino (and that it is still a non-symlink directory) before
+// every open: a parent swapped between the caller's check and this read then
+// fails the proof instead of redirecting the open outside the source root.
+function readStableProjectionSourceFallback(sourcePath: string, expectedParentIdentity: string): Buffer {
+  const parentPath = dirname(sourcePath);
+  const proveParent = (): void => {
+    const parentStat = lstatSync(parentPath, { bigint: true });
+    if (!parentStat.isDirectory() || parentStat.isSymbolicLink()
+      || projectionStatIdentity(parentStat) !== expectedParentIdentity) {
+      throw new Error(`projection copy source parent identity changed during proof: ${sourcePath}`);
+    }
+  };
   const readNoFollow = (): { identity: string; content: Buffer } => {
+    proveParent();
     const fd = openSync(sourcePath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
     try {
       const opened = fstatSync(fd, { bigint: true });
@@ -439,10 +457,10 @@ function readStableProjectionSourceFallback(sourcePath: string): Buffer {
       // mismatch, or on a non-regular opened node, so a regular file to symlink
       // swap cannot escape the source root even without O_NOFOLLOW enforcement.
       const onDisk = lstatSync(sourcePath, { bigint: true });
-      if (!opened.isFile() || statIdentity(opened) !== statIdentity(onDisk)) {
+      if (!opened.isFile() || projectionStatIdentity(opened) !== projectionStatIdentity(onDisk)) {
         throw new Error(`projection copy source is not a regular file: ${sourcePath}`);
       }
-      return { identity: statIdentity(opened), content: readFileSync(fd) };
+      return { identity: projectionStatIdentity(opened), content: readFileSync(fd) };
     } finally {
       closeSync(fd);
     }
@@ -475,6 +493,15 @@ function transferProjectionTreeFallbackSync(
   function transferDirectory(sourceDir: string, target: string): void {
     if (!overwrite && existsSync(target) && !lstatSync(target).isDirectory()) return;
     createProjectionDirectorySync(target);
+    // Pin this directory's identity so each per-entry read can re-prove its
+    // parent (see readStableProjectionSourceFallback): a rename/symlink swap of
+    // sourceDir between the readdir and a file read then fails the proof rather
+    // than redirecting the read outside the source root.
+    const sourceDirStat = lstatSync(sourceDir, { bigint: true });
+    if (!sourceDirStat.isDirectory() || sourceDirStat.isSymbolicLink()) {
+      throw new Error(`projection copy source directory is not identity-stable: ${sourceDir}`);
+    }
+    const sourceDirIdentity = projectionStatIdentity(sourceDirStat);
     for (const name of readdirSync(sourceDir)) {
       const sourceEntry = join(sourceDir, name);
       if (!include(sourceEntry)) continue;
@@ -484,7 +511,7 @@ function transferProjectionTreeFallbackSync(
       else if (!entryStat.isFile()) {
         throw new Error(`projection copy source entry is neither a regular file nor a directory: ${sourceEntry}`);
       } else if (overwrite || !existsSync(targetEntry)) {
-        atomicWriteBufferSync(targetEntry, readStableProjectionSourceFallback(sourceEntry));
+        atomicWriteBufferSync(targetEntry, readStableProjectionSourceFallback(sourceEntry, sourceDirIdentity));
       }
     }
   }
@@ -541,7 +568,7 @@ export function copyProjectionFileSync(sourcePath: string, filePath: string, ove
     if (!fallbackStat.isFile() || fallbackStat.isSymbolicLink()) {
       throw new Error("projection copy source is not a regular file");
     }
-    atomicWriteBufferSync(filePath, readStableProjectionSourceFallback(sourcePath));
+    atomicWriteBufferSync(filePath, readStableProjectionSourceFallback(sourcePath, projectionStatIdentity(parentStat)));
     return;
   }
   const handle = acquireProjectionRootIdentityLock(realpathSync(parent), parentStat.dev.toString(), parentStat.ino.toString());

--- a/src/resources/extensions/gsd/atomic-write.ts
+++ b/src/resources/extensions/gsd/atomic-write.ts
@@ -1,7 +1,7 @@
-import { closeSync, constants as fsConstants, existsSync, fsyncSync, lstatSync, openSync, realpathSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fs } from "node:fs";
+import { closeSync, constants as fsConstants, existsSync, fsyncSync, lstatSync, openSync, readdirSync, readFileSync, realpathSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fs } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
-import { acquireProjectionRootIdentityLock, type ProjectionRootIdentityLock } from "@gsd/native/file-identity";
+import { acquireProjectionRootIdentityLock, isProjectionRootIdentityLockAvailable, type ProjectionRootIdentityLock } from "@gsd/native/file-identity";
 import { syncDirectoryEntry } from "@gsd/native/directory-sync";
 import { withProjectionMutation, withProjectionMutationSync } from "./database-maintenance-fence.js";
 import {
@@ -417,6 +417,50 @@ function readStableProjectionSource(handle: ProjectionRootIdentityLock, logicalP
   return first;
 }
 
+// Plain-fs source proof used when the native identity lock is unavailable
+// (pinned engine binary predates ProjectionRootIdentityLock, or the addon
+// failed to load). Mirrors readStableProjectionSource: double-read with a
+// content hash plus a dev:ino identity comparison.
+function readStableProjectionSourceFallback(sourcePath: string): Buffer {
+  const statIdentity = (stat: { dev: bigint; ino: bigint }) => `${stat.dev}:${stat.ino}`;
+  const before = lstatSync(sourcePath, { bigint: true });
+  const first = readFileSync(sourcePath);
+  projectionCopyBoundaryForTest?.();
+  const second = readFileSync(sourcePath);
+  if (statIdentity(before) !== statIdentity(lstatSync(sourcePath, { bigint: true }))
+    || createHash("sha256").update(first).digest("hex") !== createHash("sha256").update(second).digest("hex")) {
+    throw new Error("projection copy source changed during identity proof");
+  }
+  return first;
+}
+
+// Plain-fs tree transfer used when the native identity lock is unavailable.
+// Preserves transferProjectionTreeSync semantics: existing non-directory
+// targets are kept unless overwrite, and symlink entries are skipped so the
+// copy cannot escape the source root.
+function transferProjectionTreeFallbackSync(
+  sourcePath: string,
+  directoryPath: string,
+  overwrite: boolean,
+  include: (sourcePath: string) => boolean,
+): void {
+  function transferDirectory(sourceDir: string, target: string): void {
+    if (!overwrite && existsSync(target) && !lstatSync(target).isDirectory()) return;
+    createProjectionDirectorySync(target);
+    for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+      const sourceEntry = join(sourceDir, entry.name);
+      if (!include(sourceEntry)) continue;
+      const targetEntry = join(target, entry.name);
+      if (entry.isDirectory()) transferDirectory(sourceEntry, targetEntry);
+      else if (entry.isSymbolicLink()) continue;
+      else if (overwrite || !existsSync(targetEntry)) {
+        atomicWriteBufferSync(targetEntry, readStableProjectionSourceFallback(sourceEntry));
+      }
+    }
+  }
+  transferDirectory(sourcePath, directoryPath);
+}
+
 function transferProjectionTreeSync(
   sourcePath: string,
   directoryPath: string,
@@ -426,6 +470,10 @@ function transferProjectionTreeSync(
   const stat = lstatSync(sourcePath, { bigint: true });
   if (!stat.isDirectory() || stat.isSymbolicLink()) {
     throw new Error("projection copy source is not an identity-stable directory");
+  }
+  if (!isProjectionRootIdentityLockAvailable()) {
+    transferProjectionTreeFallbackSync(sourcePath, directoryPath, overwrite, include);
+    return;
   }
   const handle = acquireProjectionRootIdentityLock(realpathSync(sourcePath), stat.dev.toString(), stat.ino.toString());
   function transferDirectory(logicalDirectory: string, target: string): void {
@@ -457,6 +505,14 @@ export function copyProjectionFileSync(sourcePath: string, filePath: string, ove
   const parentStat = lstatSync(parent, { bigint: true });
   if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
     throw new Error("projection copy source parent is not identity-stable");
+  }
+  if (!isProjectionRootIdentityLockAvailable()) {
+    const fallbackStat = lstatSync(sourcePath);
+    if (!fallbackStat.isFile() || fallbackStat.isSymbolicLink()) {
+      throw new Error("projection copy source is not a regular file");
+    }
+    atomicWriteBufferSync(filePath, readStableProjectionSourceFallback(sourcePath));
+    return;
   }
   const handle = acquireProjectionRootIdentityLock(realpathSync(parent), parentStat.dev.toString(), parentStat.ino.toString());
   const logicalPath = basename(sourcePath);

--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -2186,14 +2186,17 @@ function createInitialProjectionDirectory(directoryPath: string): boolean {
     projectionRoot = dirname(projectionRoot);
   }
   if (basename(projectionRoot).toLocaleLowerCase("en-US") !== ".gsd") return false;
-  if (!isProjectionRootIdentityLockAvailable()) {
-    mkdirSync(directoryPath, { recursive: true });
-    return true;
-  }
   const targetRoot = dirname(projectionRoot);
   const rootStat = lstatSync(targetRoot, { bigint: true });
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
     throw new Error("managed projection project root is not identity-stable");
+  }
+  // Validate the project root is an identity-stable, non-symlink directory in
+  // both paths before branching, so the plain-fs fallback cannot mkdir under a
+  // symlinked or non-directory root that the native lock would have rejected.
+  if (!isProjectionRootIdentityLockAvailable()) {
+    mkdirSync(directoryPath, { recursive: true });
+    return true;
   }
   const handle = acquireProjectionRootIdentityLock(
     realpathSync(targetRoot),

--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -2198,6 +2198,18 @@ function createInitialProjectionDirectory(directoryPath: string): boolean {
         throw new Error("managed projection project root is not identity-stable");
       }
     }
+    // Reject a pre-existing .gsd projection root that is a symlink (or a
+    // non-directory) before mkdir-ing under it. mkdirSync(..., { recursive:
+    // true }) follows a symlinked .gsd and would create projection directories
+    // outside the project root; the native identity-lock path traverses from
+    // the pinned root without following symlink components, so it rejects this.
+    // A missing .gsd is fine: it is created below.
+    if (existsSync(projectionRoot)) {
+      const projectionRootStat = lstatSync(projectionRoot, { bigint: true });
+      if (!projectionRootStat.isDirectory() || projectionRootStat.isSymbolicLink()) {
+        throw new Error("managed projection root is not identity-stable");
+      }
+    }
     mkdirSync(directoryPath, { recursive: true });
     return true;
   }

--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -2187,16 +2187,23 @@ function createInitialProjectionDirectory(directoryPath: string): boolean {
   }
   if (basename(projectionRoot).toLocaleLowerCase("en-US") !== ".gsd") return false;
   const targetRoot = dirname(projectionRoot);
+  if (!isProjectionRootIdentityLockAvailable()) {
+    // Validate the project root before mkdir-ing under it, mirroring the
+    // native lock's identity-stable, non-symlink root guard. A missing root
+    // is not an error here: the recursive mkdir creates it (fresh worktrees
+    // have no .gsd ancestor on disk yet).
+    if (existsSync(targetRoot)) {
+      const rootStat = lstatSync(targetRoot, { bigint: true });
+      if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+        throw new Error("managed projection project root is not identity-stable");
+      }
+    }
+    mkdirSync(directoryPath, { recursive: true });
+    return true;
+  }
   const rootStat = lstatSync(targetRoot, { bigint: true });
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
     throw new Error("managed projection project root is not identity-stable");
-  }
-  // Validate the project root is an identity-stable, non-symlink directory in
-  // both paths before branching, so the plain-fs fallback cannot mkdir under a
-  // symlinked or non-directory root that the native lock would have rejected.
-  if (!isProjectionRootIdentityLockAvailable()) {
-    mkdirSync(directoryPath, { recursive: true });
-    return true;
   }
   const handle = acquireProjectionRootIdentityLock(
     realpathSync(targetRoot),

--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -2186,6 +2186,10 @@ function createInitialProjectionDirectory(directoryPath: string): boolean {
     projectionRoot = dirname(projectionRoot);
   }
   if (basename(projectionRoot).toLocaleLowerCase("en-US") !== ".gsd") return false;
+  if (!isProjectionRootIdentityLockAvailable()) {
+    mkdirSync(directoryPath, { recursive: true });
+    return true;
+  }
   const targetRoot = dirname(projectionRoot);
   const rootStat = lstatSync(targetRoot, { bigint: true });
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -254,6 +254,50 @@ test("mergeProjectionTreeSync falls back when the pinned native engine lacks ide
     readFileSync(join(targetTree, "22-CONTEXT.md"), "utf8"),
     "worktree-local-content",
   );
+});
+
+test("projection tree fallback rejects symlink entries instead of silently skipping them", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-merge-symlink-reject-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const gsd = join(base, ".gsd");
+  mkdirSync(gsd);
+  writeFileSync(join(gsd, "gsd.db"), "database-present");
+  const sourceTree = join(gsd, "phases", "22-m022");
+  const targetTree = join(base, "worktree", ".gsd", "phases", "22-m022");
+  const outsideSecret = join(base, "outside-secret.md");
+  const moduleUrl = new URL("../atomic-write.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { mergeProjectionTreeSync } = await import(${JSON.stringify(moduleUrl)});
+    const { mkdirSync, writeFileSync, symlinkSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    mkdirSync(process.argv[1], { recursive: true });
+    writeFileSync(join(process.argv[1], "22-CONTEXT.md"), "context-content");
+    // A symlink pointing outside the source root: the native identity lock's
+    // pathKind rejects it, so the plain-fs fallback must throw too rather than
+    // skip it and leave a partial projection.
+    writeFileSync(process.argv[3], "secret-outside-root");
+    symlinkSync(process.argv[3], join(process.argv[1], "escape.md"));
+    mergeProjectionTreeSync(process.argv[1], process.argv[2], false);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    sourceTree,
+    targetTree,
+    outsideSecret,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.notEqual(result.status, 0, "expected the symlink entry to be rejected");
+  assert.match(result.stderr, /neither a regular file nor a directory/);
+  // The symlink target's content must never reach the projection target.
+  assert.equal(existsSync(join(targetTree, "escape.md")), false);
 });
 
 // ─── Durability: fsync ordering in the fallback WithOps paths ────────────────

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -300,6 +300,94 @@ test("projection tree fallback rejects symlink entries instead of silently skipp
   assert.equal(existsSync(join(targetTree, "escape.md")), false);
 });
 
+test("projection directory fallback rejects a symlinked .gsd projection root", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-dir-symlink-reject-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  // .gsd is a pre-existing symlink pointing outside the project root. mkdirSync
+  // recursive would follow it and create projection dirs in `outside`; the
+  // native identity-lock path traverses without following symlink components,
+  // so the fallback must reject it too.
+  const gsdLink = join(base, ".gsd");
+  const outside = join(base, "outside");
+  const moduleUrl = new URL("../managed-projection-history.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { createManagedProjectionDirectorySync } = await import(${JSON.stringify(moduleUrl)});
+    const { mkdirSync, symlinkSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    mkdirSync(process.argv[2], { recursive: true });
+    symlinkSync(process.argv[2], process.argv[1]);
+    createManagedProjectionDirectorySync(join(process.argv[1], "phases", "22-m022"));
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    gsdLink,
+    outside,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.notEqual(result.status, 0, "expected the symlinked .gsd root to be rejected");
+  assert.match(result.stderr, /managed projection root is not identity-stable/);
+  // No projection directory may be created through the symlink, outside the root.
+  assert.equal(existsSync(join(outside, "phases")), false);
+});
+
+test("copyProjectionFileSync fallback rejects a source-parent swap during the proof", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-copy-parent-swap-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const source = join(base, "source-dir", "DECISIONS.md");
+  const output = join(base, "worktree", ".gsd", "DECISIONS.md");
+  const outside = join(base, "outside");
+  const moduleUrl = new URL("../atomic-write.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  // The copy boundary hook fires between the two identity-proof reads. Swapping
+  // the source's parent directory for a symlink pointing outside the source
+  // root at that moment must be caught by the per-read parent-identity proof,
+  // the plain-fs analogue of the native lock reading relative to a pinned fd.
+  const script = `
+    const { copyProjectionFileSync, _setProjectionCopyBoundaryForTest } = await import(${JSON.stringify(moduleUrl)});
+    const { mkdirSync, writeFileSync, renameSync, symlinkSync } = await import("node:fs");
+    const { dirname, join } = await import("node:path");
+    const sourcePath = process.argv[1];
+    const outsideDir = process.argv[3];
+    const parent = dirname(sourcePath);
+    mkdirSync(parent, { recursive: true });
+    writeFileSync(sourcePath, "decisions-content");
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, "DECISIONS.md"), "evil-outside-content");
+    _setProjectionCopyBoundaryForTest(() => {
+      _setProjectionCopyBoundaryForTest(null);
+      renameSync(parent, parent + ".real");
+      symlinkSync(outsideDir, parent);
+    });
+    copyProjectionFileSync(sourcePath, process.argv[2], false);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    source,
+    output,
+    outside,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.notEqual(result.status, 0, "expected the parent swap to be rejected");
+  assert.match(result.stderr, /projection copy source parent identity changed during proof/);
+  // The redirected (outside) content must never reach the projection target.
+  assert.equal(existsSync(output), false);
+});
+
 // ─── Durability: fsync ordering in the fallback WithOps paths ────────────────
 
 function createFsyncSyncHarness(plan: Array<Error | null> = []) {

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -176,6 +176,86 @@ test("managed projection writes fall back when the pinned native engine lacks id
   assert.equal(readFileSync(output, "utf8"), "fallback-content");
 });
 
+test("copyProjectionFileSync falls back when the pinned native engine lacks identity locks", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-copy-native-fallback-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const gsd = join(base, ".gsd");
+  mkdirSync(gsd);
+  writeFileSync(join(gsd, "gsd.db"), "database-present");
+  const source = join(gsd, "DECISIONS.md");
+  const output = join(base, "worktree", ".gsd", "DECISIONS.md");
+  const moduleUrl = new URL("../atomic-write.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { copyProjectionFileSync } = await import(${JSON.stringify(moduleUrl)});
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(process.argv[1], "decisions-content");
+    copyProjectionFileSync(process.argv[1], process.argv[2], false);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    source,
+    output,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(readFileSync(output, "utf8"), "decisions-content");
+});
+
+test("mergeProjectionTreeSync falls back when the pinned native engine lacks identity locks", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-merge-native-fallback-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const gsd = join(base, ".gsd");
+  mkdirSync(gsd);
+  writeFileSync(join(gsd, "gsd.db"), "database-present");
+  const sourceTree = join(gsd, "phases", "22-m022");
+  const targetTree = join(base, "worktree", ".gsd", "phases", "22-m022");
+  const moduleUrl = new URL("../atomic-write.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { mergeProjectionTreeSync } = await import(${JSON.stringify(moduleUrl)});
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    mkdirSync(join(process.argv[1], "slices", "S01"), { recursive: true });
+    writeFileSync(join(process.argv[1], "22-CONTEXT.md"), "context-content");
+    writeFileSync(join(process.argv[1], "slices", "S01", "S01-PLAN.md"), "plan-content");
+    mkdirSync(process.argv[2], { recursive: true });
+    writeFileSync(join(process.argv[2], "22-CONTEXT.md"), "worktree-local-content");
+    mergeProjectionTreeSync(process.argv[1], process.argv[2], false);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    sourceTree,
+    targetTree,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  // Additive semantics preserved: nested files are copied, existing
+  // worktree-local files are not clobbered by the merge (#1886).
+  assert.equal(
+    readFileSync(join(targetTree, "slices", "S01", "S01-PLAN.md"), "utf8"),
+    "plan-content",
+  );
+  assert.equal(
+    readFileSync(join(targetTree, "22-CONTEXT.md"), "utf8"),
+    "worktree-local-content",
+  );
+});
+
 // ─── Durability: fsync ordering in the fallback WithOps paths ────────────────
 
 function createFsyncSyncHarness(plan: Array<Error | null> = []) {


### PR DESCRIPTION
## TL;DR

**What:** Adds plain-fs fallbacks to the projection copy path (`copyProjectionFileSync`, `transferProjectionTreeSync`, `createInitialProjectionDirectory`) for when the native addon is unavailable.
**Why:** When the native engine doesn't load, auto-mode's root→worktree state projection throws `native projection root identity locking is unavailable`, leaving the worktree `.gsd` empty; the missing-task-plan recovery rule then misdiagnoses this as a planning failure, burns both plan-slice retries, and hard-stops auto-mode.
**How:** Branch on `isProjectionRootIdentityLockAvailable()` and degrade to plain fs operations that preserve the existing semantics, matching the fallback policy the rest of the write path already implements (#1223).

## What

- `src/resources/extensions/gsd/atomic-write.ts`
  - `copyProjectionFileSync` / `transferProjectionTreeSync`: when the native identity lock is unavailable, fall back to plain-fs copies instead of throwing.
  - New `readStableProjectionSourceFallback`: keeps the source-stability proof (double-read + sha256) using a dev:ino identity comparison in place of the native lock identity. Each read opens with `O_NOFOLLOW` and proves identity via `fstat` on the resulting fd, so a regular-file-to-symlink swap racing the proof fails the open with `ELOOP` instead of following the link out of the source root (the plain-fs analogue of the native lock's `AT_SYMLINK_NOFOLLOW` reads).
  - New `transferProjectionTreeFallbackSync`: preserves merge semantics (existing non-directory targets kept unless `overwrite`) and resolves entry types with `lstat` (no symlink follow). Symlinks and other non-regular nodes are rejected with a thrown error rather than silently skipped, matching the native lock's `pathKind`, which throws on them; this fails loud instead of producing a partial projection, and a rejected symlink still cannot escape the source root. Writes still go through `atomicWriteBufferSync` (which already has its own fallback).
- `src/resources/extensions/gsd/managed-projection-history.ts`
  - `createInitialProjectionDirectory`: same availability guard → recursive `mkdirSync`, matching the already-guarded branch in `createManagedProjectionDirectorySync`. Previously-registered directories fell back; new ones (e.g. a fresh worktree's `.gsd/phases/NN-*`) still threw. The fallback validates an existing project root / `.gsd` root (rejecting symlinked or non-directory roots) and re-proves parent identity around source reads.
- `src/resources/extensions/gsd/tests/atomic-write.test.ts`: two regression tests that spawn a `GSD_NATIVE_DISABLE=1` subprocess and exercise `copyProjectionFileSync` and `mergeProjectionTreeSync` end to end, including additive-merge behavior (worktree-local file not clobbered).

## Why

Observed incident: auto-mode executing M022/S01 (flat-phase project, worktree isolation). The session ran under Node v26 with the native addon unavailable (`nativeParser: false` in the debug log). Projection-on-enter failed at the first `copyProjectionFileSync`, so the worktree `.gsd` stayed empty (`.gsd` is git-ignored, so the branch provides nothing). The `executing → execute-task (recover missing task plan → plan-slice)` rule then saw no slice plan on the worktree disk, could not see that tasks are embedded checkboxes in the flat-phase slice plan (which exists in the project root and DB), dispatched plan-slice twice, and hard-stopped with `Missing task-plan recovery failed 2 times`. The recovery could never succeed because the artifact it checks for can only reach the worktree via the broken projection.

The fallback design follows the loader's documented contract: when the addon is missing, consumers with JS fallbacks degrade gracefully rather than crashing (#1223).

## How

- Test-first: both regression tests fail before the fix with the exact production error and pass after.
- The merge fallback test additionally asserts additive semantics (#1886): a pre-existing worktree-local file is preserved while nested source files are copied.
- Alternatives considered: (a) fixing the auto-dispatch recovery rule to consult the project root/DB — real but a separate, larger concern (dispatch policy, RFC-adjacent); (b) surfacing projection-on-enter failure as a blocker — also separate. This PR is scoped to the root cause in the copy path.

## Verification

- `atomic-write.test.ts`: 12/12 pass (was 10/12 with the 2 new tests failing pre-fix).
- `worktree-state-projection.test.ts`: 11/11 pass.
- `migrate-safety-audit.test.ts`: zero newly failing tests vs. clean-main baseline (109 pre-existing local-env failures identical before/after; one test newly passes).
- `pnpm run typecheck:extensions`: clean.
- `pnpm run test:changed:src`: 12/12 pass.
- `pnpm run verify:fast`: all change-relevant gates pass (secret-scan, base64, docs-injection, skill-refs, require-tests, source-grep, tier map, script policy, projection-mutations). The final `test gap strict (unwired)` gate fails locally on both main and this branch because it scans stale local `.worktrees/` and `.claude/worktrees/` directories — environmental, unrelated to this change.

## Notes

- AI-assisted PR (developed with an AI coding agent); tests written and verified as described above.
- No version surfaces touched; no N-API export changes.
- Residual related gaps deliberately left out of scope: `removeProjectionTreeWithoutDatabaseSync` still requires the native lock on its plain-fs path, and the auto-dispatch missing-task-plan recovery rule still can't distinguish an unprojected worktree from a genuinely missing task plan. Happy to follow up in separate PRs if wanted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worktree projection and filesystem identity checks on a security-sensitive copy path; behavior is heavily tested but TOCTOU races differ from the native lock on edge cases.
> 
> **Overview**
> When the native **ProjectionRootIdentityLock** is unavailable (addon missing or disabled), projection copy and directory setup no longer throw; they use **plain-fs fallbacks** aligned with existing write-path degradation (#1223).
> 
> **`atomic-write.ts`:** `copyProjectionFileSync` and `transferProjectionTreeSync` (used by `mergeProjectionTreeSync`) branch on `isProjectionRootIdentityLockAvailable()`. New helpers **`readStableProjectionSourceFallback`** (double-read + SHA-256, `O_NOFOLLOW`, parent `dev:ino` re-proof) and **`transferProjectionTreeFallbackSync`** (recursive copy via `lstat`, merge/overwrite semantics, **reject** symlinks and non-regular entries instead of skipping).
> 
> **`managed-projection-history.ts`:** **`createInitialProjectionDirectory`** gets the same guard: without the lock it validates identity-stable project and `.gsd` roots (no symlinked `.gsd`) then `mkdirSync` recursive, fixing fresh worktree paths that still required the native lock.
> 
> **Tests:** Subprocess tests with `GSD_NATIVE_DISABLE=1` cover successful copy/merge, additive merge, symlink rejection, symlinked `.gsd` rejection, and parent-directory swap during identity proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3740b3e2e17747e27805696907eb9e84b4cf2884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

