### PR TITLE
fix(gsd): plain-fs fallbacks for projection tree removal and managed-output history

### DIFF
--- a/src/resources/extensions/gsd/atomic-write.ts
+++ b/src/resources/extensions/gsd/atomic-write.ts
@@ -379,8 +379,12 @@ function removeProjectionTreeWithoutDatabaseSync(directoryPath: string): void {
     let targetStat;
     try {
       targetStat = lstatSync(absolutePath, { bigint: true });
-    } catch {
-      return;
+    } catch (error) {
+      // Only a genuinely missing target is a no-op, matching the native path
+      // (which returns early on `!handle.pathExists(name)`). Real errors like
+      // EACCES/EPERM/ENOTDIR must surface rather than be masked.
+      if (normalizeErrnoCode(error) === "ENOENT") return;
+      throw error;
     }
     if (!targetStat.isDirectory() || targetStat.isSymbolicLink()) {
       throw new Error("projection removal target is not a directory");

--- a/src/resources/extensions/gsd/atomic-write.ts
+++ b/src/resources/extensions/gsd/atomic-write.ts
@@ -1,4 +1,4 @@
-import { closeSync, constants as fsConstants, existsSync, fstatSync, fsyncSync, lstatSync, openSync, readdirSync, readFileSync, realpathSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fs } from "node:fs";
+import { closeSync, constants as fsConstants, existsSync, fstatSync, fsyncSync, lstatSync, openSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fs } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { acquireProjectionRootIdentityLock, isProjectionRootIdentityLockAvailable, type ProjectionRootIdentityLock } from "@gsd/native/file-identity";
@@ -371,6 +371,22 @@ function removeProjectionTreeWithoutDatabaseSync(directoryPath: string): void {
   const parentStat = lstatSync(parentPath, { bigint: true });
   if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
     throw new Error("projection removal parent is not an identity-stable directory");
+  }
+  if (!isProjectionRootIdentityLockAvailable()) {
+    // Plain-fs fallback: mirror the native path's contract — a missing target
+    // is a no-op, non-directory or symlink targets are rejected, removal is
+    // recursive for directory trees.
+    let targetStat;
+    try {
+      targetStat = lstatSync(absolutePath, { bigint: true });
+    } catch {
+      return;
+    }
+    if (!targetStat.isDirectory() || targetStat.isSymbolicLink()) {
+      throw new Error("projection removal target is not a directory");
+    }
+    rmSync(absolutePath, { recursive: true, force: true });
+    return;
   }
   const handle = acquireProjectionRootIdentityLock(
     realpathSync(parentPath),

--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -227,6 +227,27 @@ function parseManagedProjectionPaths(value: unknown): string[] {
   return [...new Set(value)].sort();
 }
 
+// Plain-fs counterpart of the native history read. The native
+// ProjectionRootIdentityLock reads with AT_SYMLINK_NOFOLLOW, so a symlinked (or
+// otherwise non-regular) managed-outputs.json is never followed: doing so could
+// read from outside the projection root, or mask the history as "missing" when
+// a symlink's target is absent. Mirror that here with an lstat-based check that
+// treats only a genuinely absent file as empty and rejects symlinks/non-files
+// before reading.
+function readFallbackManagedProjectionPaths(path: string): string[] {
+  let stat;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error("managed projection history is not a regular file");
+  }
+  return parseManagedProjectionPaths(JSON.parse(readFileSync(path, "utf8")) as unknown);
+}
+
 function readManagedProjectionPaths(handle: ProjectionRootIdentityLock): string[] {
   if (!handle.pathExists(HISTORY_LOGICAL_PATH)) return [];
   return parseManagedProjectionPaths(JSON.parse(handle.readFile(HISTORY_LOGICAL_PATH).toString("utf8")) as unknown);
@@ -1536,10 +1557,7 @@ export function loadManagedProjectionPaths(targetRoot: string): string[] {
     const path = historyPath(targetRoot);
     // Run the read under the write fence so it does not bypass maintenance/
     // replacement intents, matching the native path and loadUnboundProjectionEvidence.
-    return withProjectionMutationSync(path, () => {
-      if (!existsSync(path)) return [];
-      return parseManagedProjectionPaths(JSON.parse(readFileSync(path, "utf8")) as unknown);
-    });
+    return withProjectionMutationSync(path, () => readFallbackManagedProjectionPaths(path));
   }
   const path = historyPath(targetRoot);
   return withProjectionMutationSync(path, () => withManagedProjectionRoot(targetRoot, (handle) => {

--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -1534,8 +1534,12 @@ export function loadManagedProjectionPaths(targetRoot: string): string[] {
       throw new Error("native projection root identity locking is unavailable");
     }
     const path = historyPath(targetRoot);
-    if (!existsSync(path)) return [];
-    return parseManagedProjectionPaths(JSON.parse(readFileSync(path, "utf8")) as unknown);
+    // Run the read under the write fence so it does not bypass maintenance/
+    // replacement intents, matching the native path and loadUnboundProjectionEvidence.
+    return withProjectionMutationSync(path, () => {
+      if (!existsSync(path)) return [];
+      return parseManagedProjectionPaths(JSON.parse(readFileSync(path, "utf8")) as unknown);
+    });
   }
   const path = historyPath(targetRoot);
   return withProjectionMutationSync(path, () => withManagedProjectionRoot(targetRoot, (handle) => {

--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -220,13 +220,16 @@ function withManagedProjectionRoot<T>(
   }
 }
 
-function readManagedProjectionPaths(handle: ProjectionRootIdentityLock): string[] {
-  if (!handle.pathExists(HISTORY_LOGICAL_PATH)) return [];
-  const value = JSON.parse(handle.readFile(HISTORY_LOGICAL_PATH).toString("utf8")) as unknown;
+function parseManagedProjectionPaths(value: unknown): string[] {
   if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
     throw new Error("managed projection history is invalid");
   }
   return [...new Set(value)].sort();
+}
+
+function readManagedProjectionPaths(handle: ProjectionRootIdentityLock): string[] {
+  if (!handle.pathExists(HISTORY_LOGICAL_PATH)) return [];
+  return parseManagedProjectionPaths(JSON.parse(handle.readFile(HISTORY_LOGICAL_PATH).toString("utf8")) as unknown);
 }
 
 function recordManagedProjectionLogicalPath(handle: ProjectionRootIdentityLock, logicalPath: string): void {
@@ -1523,6 +1526,17 @@ function recoverManagedProjectionMutations(
 }
 
 export function loadManagedProjectionPaths(targetRoot: string): string[] {
+  if (!isProjectionRootIdentityLockAvailable()) {
+    // Mutation journals can only be recovered through the native identity
+    // lock; fail closed when recovery state exists, otherwise read the
+    // history file directly (same policy as loadUnboundProjectionEvidence).
+    if (existsSync(journalRoot(targetRoot))) {
+      throw new Error("native projection root identity locking is unavailable");
+    }
+    const path = historyPath(targetRoot);
+    if (!existsSync(path)) return [];
+    return parseManagedProjectionPaths(JSON.parse(readFileSync(path, "utf8")) as unknown);
+  }
   const path = historyPath(targetRoot);
   return withProjectionMutationSync(path, () => withManagedProjectionRoot(targetRoot, (handle) => {
     recoverManagedProjectionMutations(targetRoot, handle);

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -593,6 +593,56 @@ test("removeProjectionTreeSync fallback rejects a non-directory target", (t) => 
   assert.notEqual(result.status, 0, "expected the file target to be rejected");
   assert.match(result.stderr, /projection removal target is not a directory/);
   assert.equal(readFileSync(target, "utf8"), "state-content");
+});
+
+// The fallback rejects symlink targets to mirror the native path. This guards
+// against a regression to an rmSync-only implementation, which would silently
+// unlink the symlink instead of failing closed. Scoped to POSIX because
+// creating a directory symlink on Windows needs elevated privileges.
+test("removeProjectionTreeSync fallback rejects and preserves a symlink target", {
+  skip: process.platform === "win32"
+    ? "POSIX-only: directory symlink creation needs elevated privileges on Windows"
+    : false,
+}, (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-remove-fallback-symlink-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const gsd = join(base, ".gsd");
+  mkdirSync(gsd);
+  writeFileSync(join(gsd, "gsd.db"), "database-present");
+  const link = join(gsd, "phases");
+  // Kept inside .gsd so the symlink's realpath stays within the projection root.
+  const realDir = join(gsd, "real-target-dir");
+  const moduleUrl = new URL("../atomic-write.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { removeProjectionTreeSync } = await import(${JSON.stringify(moduleUrl)});
+    const { mkdirSync, writeFileSync, symlinkSync } = await import("node:fs");
+    const { dirname, join } = await import("node:path");
+    const link = process.argv[1];
+    const realDir = join(dirname(link), "real-target-dir");
+    mkdirSync(realDir);
+    writeFileSync(join(realDir, "keep.txt"), "keep-me");
+    symlinkSync(realDir, link, "dir");
+    removeProjectionTreeSync(link);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    link,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.notEqual(result.status, 0, "expected the symlink target to be rejected");
+  assert.match(result.stderr, /projection removal target is not a directory/);
+  // The symlink must be left intact (fail closed), not silently unlinked, and
+  // its real target and contents must be untouched.
+  assert.equal(lstatSync(link).isSymbolicLink(), true);
+  assert.equal(readFileSync(join(realDir, "keep.txt"), "utf8"), "keep-me");
 });
 
 // A non-ENOENT lstat error at the removal target must surface rather than be

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -595,6 +595,39 @@ test("removeProjectionTreeSync fallback rejects a non-directory target", (t) => 
   assert.equal(readFileSync(target, "utf8"), "state-content");
 });
 
+test("removeProjectionTreeSync fallback surfaces non-ENOENT lstat errors", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-remove-fallback-lstat-error-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const gsd = join(base, ".gsd");
+  mkdirSync(gsd);
+  writeFileSync(join(gsd, "gsd.db"), "database-present");
+  const parent = join(gsd, "phases");
+  mkdirSync(parent);
+  // An over-length basename makes lstat fail with ENAMETOOLONG (not ENOENT).
+  // The fallback must surface this rather than treating it as a missing target.
+  const target = join(parent, "x".repeat(300));
+  const moduleUrl = new URL("../atomic-write.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { removeProjectionTreeSync } = await import(${JSON.stringify(moduleUrl)});
+    removeProjectionTreeSync(process.argv[1]);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    target,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.notEqual(result.status, 0, "expected the lstat error to surface");
+  assert.match(result.stderr, /ENAMETOOLONG/);
+});
+
 test("loadManagedProjectionPaths falls back to a plain-fs read when the native engine is unavailable", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-history-native-fallback-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -529,3 +529,128 @@ test("atomicWriteAsync aborts before any rename when the temp fsync fails", asyn
   assert.equal(harness.calls.some((call) => call.startsWith("rename:")), false);
   assert.equal(harness.files.has("/data/output.txt"), false);
 });
+
+test("removeProjectionTreeSync falls back when the pinned native engine lacks identity locks", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-remove-native-fallback-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const gsd = join(base, ".gsd");
+  mkdirSync(gsd);
+  writeFileSync(join(gsd, "gsd.db"), "database-present");
+  const tree = join(gsd, "phases", "22-m022");
+  const moduleUrl = new URL("../atomic-write.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { removeProjectionTreeSync } = await import(${JSON.stringify(moduleUrl)});
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    mkdirSync(join(process.argv[1], "slices", "S01"), { recursive: true });
+    writeFileSync(join(process.argv[1], "slices", "S01", "S01-PLAN.md"), "plan-content");
+    removeProjectionTreeSync(process.argv[1]);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    tree,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(existsSync(tree), false);
+});
+
+test("removeProjectionTreeSync fallback rejects a non-directory target", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-remove-fallback-file-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const gsd = join(base, ".gsd");
+  mkdirSync(gsd);
+  writeFileSync(join(gsd, "gsd.db"), "database-present");
+  const target = join(gsd, "STATE.md");
+  const moduleUrl = new URL("../atomic-write.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { removeProjectionTreeSync } = await import(${JSON.stringify(moduleUrl)});
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(process.argv[1], "state-content");
+    removeProjectionTreeSync(process.argv[1]);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    target,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.notEqual(result.status, 0, "expected the file target to be rejected");
+  assert.match(result.stderr, /projection removal target is not a directory/);
+  assert.equal(readFileSync(target, "utf8"), "state-content");
+});
+
+test("loadManagedProjectionPaths falls back to a plain-fs read when the native engine is unavailable", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-history-native-fallback-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const migration = join(base, ".gsd", "migration");
+  mkdirSync(migration, { recursive: true });
+  writeFileSync(
+    join(migration, "managed-outputs.json"),
+    `${JSON.stringify(["phases/01-a/01-PLAN.md", "phases/01-a/01-CONTEXT.md", "phases/01-a/01-PLAN.md"])}\n`,
+  );
+  const moduleUrl = new URL("../managed-projection-history.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { loadManagedProjectionPaths } = await import(${JSON.stringify(moduleUrl)});
+    process.stdout.write(JSON.stringify(loadManagedProjectionPaths(process.argv[1])));
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    base,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    "phases/01-a/01-CONTEXT.md",
+    "phases/01-a/01-PLAN.md",
+  ]);
+});
+
+test("loadManagedProjectionPaths returns empty without a history file when the native engine is unavailable", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-history-empty-fallback-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  mkdirSync(join(base, ".gsd"));
+  const moduleUrl = new URL("../managed-projection-history.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { loadManagedProjectionPaths } = await import(${JSON.stringify(moduleUrl)});
+    process.stdout.write(JSON.stringify(loadManagedProjectionPaths(process.argv[1])));
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    base,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), []);
+});

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -747,3 +747,89 @@ test("loadManagedProjectionPaths returns empty without a history file when the n
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), []);
 });
+
+// The no-native fallback must fail closed when a managed projection mutation
+// journal directory exists: journals can only be recovered through the native
+// identity lock, so reading the history file directly could silently drop
+// pending recovery state. This guards against accidental relaxation of that
+// safety policy back to a plain read.
+test("loadManagedProjectionPaths fails closed with a mutation journal when the native engine is unavailable", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-history-journal-fail-closed-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const migration = join(base, ".gsd", "migration");
+  mkdirSync(migration, { recursive: true });
+  writeFileSync(
+    join(migration, "managed-outputs.json"),
+    `${JSON.stringify(["phases/01-a/01-PLAN.md"])}\n`,
+  );
+  // The presence of the journal directory alone must force fail-closed.
+  mkdirSync(join(migration, "projection-mutations"));
+  const moduleUrl = new URL("../managed-projection-history.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { loadManagedProjectionPaths } = await import(${JSON.stringify(moduleUrl)});
+    loadManagedProjectionPaths(process.argv[1]);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    base,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.notEqual(result.status, 0, "expected the mutation journal to force fail-closed");
+  assert.match(result.stderr, /native projection root identity locking is unavailable/);
+});
+
+// The native history read opens with AT_SYMLINK_NOFOLLOW, so the plain-fs
+// fallback must reject a symlinked managed-outputs.json rather than follow it
+// (which could read from outside the projection root, or mask the history as
+// missing when the link target is absent). Scoped to POSIX because creating a
+// symlink on Windows needs elevated privileges.
+test("loadManagedProjectionPaths fallback rejects a symlinked history file", {
+  skip: process.platform === "win32"
+    ? "POSIX-only: symlink creation needs elevated privileges on Windows"
+    : false,
+}, (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-history-symlink-fallback-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const migration = join(base, ".gsd", "migration");
+  mkdirSync(migration, { recursive: true });
+  const historyPath = join(migration, "managed-outputs.json");
+  const moduleUrl = new URL("../managed-projection-history.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { loadManagedProjectionPaths } = await import(${JSON.stringify(moduleUrl)});
+    const { writeFileSync, symlinkSync } = await import("node:fs");
+    const { dirname, join } = await import("node:path");
+    const base = process.argv[1];
+    const historyPath = process.argv[2];
+    // Real target kept inside .gsd so the link's realpath stays in the root.
+    const realTarget = join(dirname(historyPath), "real-managed-outputs.json");
+    writeFileSync(realTarget, JSON.stringify(["phases/01-a/01-PLAN.md"]) + "\\n");
+    symlinkSync(realTarget, historyPath);
+    loadManagedProjectionPaths(base);
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+    base,
+    historyPath,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
+  });
+
+  assert.notEqual(result.status, 0, "expected the symlinked history file to be rejected");
+  assert.match(result.stderr, /managed projection history is not a regular file/);
+  // The symlink must be left intact (fail closed), not followed or unlinked.
+  assert.equal(lstatSync(historyPath).isSymbolicLink(), true);
+});

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -595,7 +595,19 @@ test("removeProjectionTreeSync fallback rejects a non-directory target", (t) => 
   assert.equal(readFileSync(target, "utf8"), "state-content");
 });
 
-test("removeProjectionTreeSync fallback surfaces non-ENOENT lstat errors", (t) => {
+// A non-ENOENT lstat error at the removal target must surface rather than be
+// treated as a missing target (a no-op). The only trigger that reaches the
+// fallback's leaf-lstat through the public API with a deterministic code is an
+// over-length basename: on POSIX (NAME_MAX == 255) it reliably yields
+// ENAMETOOLONG. A null byte would seem cleaner but is rejected upstream by
+// logicalProjectionPath before the fallback runs, and Windows returns
+// platform-dependent codes for over-length components, so this assertion is
+// scoped to POSIX where the code is stable.
+test("removeProjectionTreeSync fallback surfaces non-ENOENT lstat errors", {
+  skip: process.platform === "win32"
+    ? "POSIX-only: relies on NAME_MAX yielding a stable ENAMETOOLONG code"
+    : false,
+}, (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-remove-fallback-lstat-error-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));
   const gsd = join(base, ".gsd");
@@ -603,8 +615,6 @@ test("removeProjectionTreeSync fallback surfaces non-ENOENT lstat errors", (t) =
   writeFileSync(join(gsd, "gsd.db"), "database-present");
   const parent = join(gsd, "phases");
   mkdirSync(parent);
-  // An over-length basename makes lstat fail with ENAMETOOLONG (not ENOENT).
-  // The fallback must surface this rather than treating it as a missing target.
   const target = join(parent, "x".repeat(300));
   const moduleUrl = new URL("../atomic-write.ts", import.meta.url).href;
   const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;


### PR DESCRIPTION
## TL;DR

**What:** Adds plain-fs fallbacks to `removeProjectionTreeWithoutDatabaseSync` and `loadManagedProjectionPaths` for when the native identity lock is unavailable.
**Why:** These two paths still threw `native projection root identity locking is unavailable` in no-native environments, breaking flat-phase migration/restore and worktree cleanup even after the copy-path fallbacks.
**How:** Branch on `isProjectionRootIdentityLockAvailable()` and mirror the native contracts with plain fs; fail closed only where journals require the lock to recover.

Closes #1521

## What

- `atomic-write.ts` — `removeProjectionTreeWithoutDatabaseSync`: guarded plain-fs branch. Missing target is a no-op; symlink or non-directory targets are rejected with the same error as the native path; directories are removed recursively. This unblocks `copyProjectionTreeSync` (removes the target before re-transfer) and the flat-phase migration backup/restore paths.
- `managed-projection-history.ts` — `loadManagedProjectionPaths`: plain-fs read of `migration/managed-outputs.json` when the lock is unavailable, failing closed when a mutation journal exists (journals require the lock to recover — same policy as `loadUnboundProjectionEvidence`). History shape validation is extracted into `parseManagedProjectionPaths` so the native and fallback reads enforce identical checks.
- `tests/atomic-write.test.ts` — four regression tests using the `GSD_NATIVE_DISABLE=1` subprocess pattern: tree removal fallback, non-directory rejection, history read (dedup + sort), empty history.

## Why

Same trigger class as #1519's incident: when the native addon fails to load (unsupported Node version, stale pinned engine binary), the loader installs a throw-on-call proxy and expects consumers to degrade gracefully (#1223). #1519 covered the copy path; these are the remaining reachable acquisitions that have a safe plain-fs equivalent.

**Audit of the remaining `withManagedProjectionRoot` callers** (deliberately unchanged): `shelterManagedProjectionTreeSync` / `restoreManagedProjectionTreeSync` (auto-worktree milestone shelter) and `removeLegacyProjectionTreeSync` (legacy cleanup channel) stay fail-closed — their identity-bound quarantine and evidence-retention semantics have no safe plain-fs equivalent, and silently degrading them would weaken the migration safety contract. `recordManagedProjectionPath` is only reachable through the already-guarded `recordManagedProjectionFile`.

## How

- Test-first: all four new tests fail with the production error before the fix and pass after.
- The fallback contracts mirror the native paths exactly (no-op on missing target, same rejection messages), verified by subprocess tests rather than source inspection.

## Verification

- `atomic-write.test.ts`: 14/14 pass standalone and via the compiled `test:changed:src` runner.
- `pnpm run typecheck:extensions`: clean.

## Notes

- AI-assisted PR (developed with an AI coding agent); tests written and verified as described above.
- No version surfaces touched; no N-API export changes.
- Stacking note: this branches from `main` and touches the same import line as #1519 in `atomic-write.ts`; whichever merges second gets a one-line import conflict.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem deletion and migration allowlist reads on degraded-native paths; contracts are intentionally strict (symlink rejection, journal fail-closed) but incorrect edge handling could affect migration cleanup or deletion safety.
> 
> **Overview**
> When the native projection identity lock is unavailable (`GSD_NATIVE_DISABLE` / failed addon load), **projection tree removal** and **managed-output history reads** no longer hard-fail on lock acquisition.
> 
> **`removeProjectionTreeWithoutDatabaseSync`** gains a plain-fs branch that matches the native contract: missing targets are a no-op, non-directory or symlink targets throw the same errors, and real directories are removed with `rmSync` recursively. That unblocks `copyProjectionTreeSync` pre-delete and migration backup/restore paths that still depended on this removal.
> 
> **`loadManagedProjectionPaths`** reads `migration/managed-outputs.json` directly under the maintenance fence when the lock is missing, with the same fail-closed rule as `loadUnboundProjectionEvidence` if a mutation journal directory exists (journals need the lock to recover). History parsing is centralized in **`parseManagedProjectionPaths`** so native and fallback paths share validation, dedup, and sort.
> 
> Subprocess tests with `GSD_NATIVE_DISABLE=1` cover tree removal, file/symlink rejection, `ENAMETOOLONG` surfacing, and history read (including empty file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d8b26490b5efeed1e51d90c1ac0b5fe7503bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->