### PR TITLE
fix(gsd): stop missing-task-plan recovery when the worktree projection is stale

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -423,6 +423,22 @@ function missingSliceStop(mid: string, phase: string): DispatchAction {
   };
 }
 
+/**
+ * True when the slice's tasks live inside the slice plan file itself —
+ * flat-phase phases/ layout with task checkboxes, or a renderPlanFromDb
+ * `<tasks>` block — rather than as per-task PLAN files under tasks/.
+ */
+function slicePlanHasEmbeddedTasks(basePath: string, mid: string, sid: string): boolean {
+  const slicePlanPath = resolveSliceFile(basePath, mid, sid, "PLAN");
+  if (!slicePlanPath || !existsSync(slicePlanPath)) return false;
+  const content = readFileSync(slicePlanPath, "utf-8");
+  const phasesRoot = join(gsdProjectionRoot(basePath), "phases");
+  const isPhasesSlicePlan =
+    slicePlanPath === phasesRoot || slicePlanPath.startsWith(`${phasesRoot}${sep}`);
+  const hasTaskCheckboxes = /^-\s+\[[ xX]\]\s+\*\*[\w.]+/m.test(content);
+  return content.includes("<tasks>") || (isPhasesSlicePlan && hasTaskCheckboxes);
+}
+
 function isRegistryMilestoneComplete(state: GSDState, mid: string): boolean {
   return state.registry.some((milestone) =>
     milestone.id === mid && milestone.status === "complete"
@@ -1724,22 +1740,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // issue #909. Flat-phase layout embeds tasks in the slice plan file, so
       // skip recovery when tasks are embedded (<tasks> block or task checkboxes in phases/ plan).
       const taskPlanPath = resolveTaskFile(artifactBasePath, mid, sid, tid, "PLAN");
-      const slicePlanPath = resolveSliceFile(artifactBasePath, mid, sid, "PLAN");
-      const phasesRoot = join(gsdProjectionRoot(artifactBasePath), "phases");
-      const slicePlanContent = slicePlanPath && existsSync(slicePlanPath)
-        ? readFileSync(slicePlanPath, "utf-8")
-        : "";
-      const isPhasesSlicePlan =
-        slicePlanPath !== null &&
-        (slicePlanPath === phasesRoot || slicePlanPath.startsWith(`${phasesRoot}${sep}`));
-      const hasTaskCheckboxes = /^-\s+\[[ xX]\]\s+\*\*[\w.]+/m.test(slicePlanContent);
-      const tasksEmbeddedInSlicePlan = Boolean(
-        slicePlanPath &&
-        existsSync(slicePlanPath) &&
-        (slicePlanContent.includes("<tasks>") || (isPhasesSlicePlan && hasTaskCheckboxes)),
-      );
       // tasksEmbeddedInSlicePlan is true when tasks live inside the slice plan
       // (flat-phase phases/ layout with task checkboxes or renderPlanFromDb <tasks> block).
+      const tasksEmbeddedInSlicePlan = slicePlanHasEmbeddedTasks(artifactBasePath, mid, sid);
       const projectionTaskPlanPath = join(
         gsdProjectionRoot(artifactBasePath),
         "milestones",
@@ -1754,6 +1757,26 @@ export const DISPATCH_RULES: DispatchRule[] = [
         !existsSync(projectionTaskPlanPath) &&
         !tasksEmbeddedInSlicePlan
       ) {
+        // #1520: if the slice plan with embedded tasks exists at the original
+        // project root but not in the active worktree, the root→worktree state
+        // projection is broken or stale. Re-planning the slice cannot repair a
+        // projection gap — it would burn both retries and then misreport the
+        // failure as "missing task plans". Stop immediately with an accurate
+        // diagnosis instead. When the root plan is also absent or carries no
+        // embedded tasks, the #909 replan recovery below still applies.
+        const originalRoot = session?.originalBasePath;
+        if (
+          originalRoot &&
+          originalRoot !== artifactBasePath &&
+          slicePlanHasEmbeddedTasks(originalRoot, mid, sid)
+        ) {
+          session?.missingTaskPlanRetryCount?.delete(unitId);
+          return {
+            action: "stop",
+            reason: `${unitId}: the slice plan with embedded tasks exists at the project root but is missing from the active worktree — the root→worktree state projection is broken or stale, and re-planning cannot fix that. Run /gsd doctor to repair the projection, then run /gsd auto to resume.`,
+            level: "error",
+          };
+        }
         const MAX_MISSING_TASK_PLAN_RETRIES = 2;
         const retryCount = session?.missingTaskPlanRetryCount?.get(unitId) ?? 0;
         if (retryCount >= MAX_MISSING_TASK_PLAN_RETRIES) {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -433,8 +433,7 @@ function slicePlanHasEmbeddedTasks(basePath: string, mid: string, sid: string): 
   if (!slicePlanPath || !existsSync(slicePlanPath)) return false;
   const content = readFileSync(slicePlanPath, "utf-8");
   const phasesRoot = join(gsdProjectionRoot(basePath), "phases");
-  const isPhasesSlicePlan =
-    slicePlanPath === phasesRoot || slicePlanPath.startsWith(`${phasesRoot}${sep}`);
+  const isPhasesSlicePlan = slicePlanPath.startsWith(`${phasesRoot}${sep}`);
   const hasTaskCheckboxes = /^-\s+\[[ xX]\]\s+\*\*[\w.]+/m.test(content);
   return content.includes("<tasks>") || (isPhasesSlicePlan && hasTaskCheckboxes);
 }

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -553,3 +553,73 @@ test("dispatch: missing task plan recovery logs root/worktree diagnostic when de
     "should dispatch without crashing in debug mode");
   // Flat-phase: no recovery diagnostic entry expected (tasks in slice plan)
 });
+
+test("dispatch: unprojected worktree stops with a projection diagnosis instead of plan-slice recovery — issue #1520", async (t) => {
+  // Incident shape: flat-phase slice plan with embedded tasks exists at the
+  // project root, but the active worktree's projection is incomplete — the
+  // milestone CONTEXT landed, the slice plan did not. Re-planning cannot fix
+  // a projection gap, so the rule must stop with an accurate diagnosis rather
+  // than burn plan-slice retries and blame "missing" task plans.
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-1520-unprojected-"));
+  t.after(() => removeWorkflowTestDirectory(tmp));
+  scaffoldWorkflowDatabase(tmp, "M004", "S02", "T01");
+
+  scaffoldMilestoneContext(tmp, "M004");
+  scaffoldSlicePlan(tmp, "M004", "S02");
+
+  // Active worktree is partially projected: CONTEXT present, slice plan missing.
+  const worktreeRoot = join(tmp, ".gsd", "worktrees", "M004");
+  mkdirSync(worktreeRoot, { recursive: true });
+  scaffoldMilestoneContext(worktreeRoot, "M004");
+
+  const session = {
+    basePath: worktreeRoot,
+    originalBasePath: tmp,
+    currentMilestoneId: "M004",
+    missingTaskPlanRetryCount: new Map<string, number>(),
+  };
+  const result = await resolveDispatch(makeContextFor(tmp, "M004", "S02", "T01", session));
+
+  assert.equal(result.action, "stop",
+    `expected stop, got ${result.action}${result.action === "dispatch" ? `/${result.unitType}` : ""}`);
+  assert.ok(result.action === "stop");
+  assert.equal(result.level, "error");
+  assert.match(result.reason, /projection/i);
+  assert.match(result.reason, /M004\/S02/);
+  assert.doesNotMatch(result.reason, /Fix the task-plan files manually/);
+  // No plan-slice retry budget was spent on an unfixable-by-replan condition.
+  assert.equal(session.missingTaskPlanRetryCount.has("M004/S02"), false);
+});
+
+test("dispatch: worktree recovery still replans when the root slice plan lacks embedded tasks — #909 preserved", async (t) => {
+  // Boundary case: the slice plan exists in legacy form (no embedded tasks)
+  // at both the project root and the active worktree, and the per-task plan
+  // is genuinely absent. The #909 plan-slice recovery still applies — the
+  // projection-diagnosis stop must not swallow it. (A legacy worktree with
+  // no slice plan at all never reaches the recovery rule: the missing-context
+  // guard dispatches discuss-milestone first.)
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-1520-legacy-replan-"));
+  t.after(() => removeWorkflowTestDirectory(tmp));
+  scaffoldWorkflowDatabase(tmp, "M004", "S02", "T01");
+
+  scaffoldLegacyMilestoneContext(tmp, "M004");
+  scaffoldLegacySlicePlan(tmp, "M004", "S02");
+
+  const worktreeRoot = join(tmp, ".gsd", "worktrees", "M004");
+  mkdirSync(worktreeRoot, { recursive: true });
+  scaffoldLegacyMilestoneContext(worktreeRoot, "M004");
+  scaffoldLegacySlicePlan(worktreeRoot, "M004", "S02");
+
+  const session = {
+    basePath: worktreeRoot,
+    originalBasePath: tmp,
+    currentMilestoneId: "M004",
+    missingTaskPlanRetryCount: new Map<string, number>(),
+  };
+  const result = await resolveDispatch(makeContextFor(tmp, "M004", "S02", "T01", session));
+
+  assert.equal(result.action, "dispatch");
+  assert.ok(result.action === "dispatch" && result.unitType === "plan-slice",
+    `unitType should be plan-slice, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
+  assert.equal(session.missingTaskPlanRetryCount.get("M004/S02"), 1);
+});


### PR DESCRIPTION
## TL;DR

**What:** The missing-task-plan recovery rule in auto-dispatch now checks the original project root before spending plan-slice retries. If the root has a slice plan with embedded tasks but the active worktree does not, it stops immediately with a projection diagnosis instead of re-planning.
**Why:** When the root→worktree state projection is broken or stale (e.g. native projection unavailable), the recovery rule misread the empty worktree as a planning failure, burned both retries, and hard-stopped with "Fix the task-plan files manually" — a diagnosis no manual edit could resolve. Closes #1520.
**How:** Extract the embedded-tasks check into `slicePlanHasEmbeddedTasks()` and, inside the recovery branch, compare root vs. worktree before incrementing the retry counter. Projection gap → immediate stop pointing at `/gsd doctor`; otherwise the #909 replan behavior is byte-for-byte unchanged.

## Verification

- [x] New test: unprojected worktree stops with a projection diagnosis (fails pre-fix, passes post-fix)
- [x] New test: #909 replan preserved when the root slice plan lacks embedded tasks
- [x] `dispatch-missing-task-plans.test.ts` 18/18
- [x] `state-machine-edge-cases` + `state-machine-runtime-failures` 105/105
- [x] `pnpm run typecheck:extensions` clean
- [x] `pnpm run test:changed:src` green

---
_AI-assisted PR (Kimi Work agent); reviewed and verified by the maintainers' CI gates._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-dispatch recovery logic on the executing path for milestone worktrees; wrong detection could block auto or skip needed replan, but behavior is narrowly scoped and covered by regression tests.
> 
> **Overview**
> **Auto-dispatch** now distinguishes a **broken root→worktree projection** from a real missing-task-plan planning gap (#1520).
> 
> The embedded-tasks check is centralized in **`slicePlanHasEmbeddedTasks()`**. In the executing-phase **missing task plan → plan-slice** recovery path, if per-task plans are absent in the active worktree but the **original project root** still has a slice plan with embedded tasks, dispatch **stops immediately** with an error that points at **`/gsd doctor`** to repair projection—instead of burning **plan-slice** retries and ending on “fix task-plan files manually.”
> 
> When the root plan is missing or has no embedded tasks, **#909** behavior is unchanged: **plan-slice** recovery and the retry counter still apply.
> 
> Tests cover the unprojected-worktree stop and that legacy layouts without embedded tasks still trigger **plan-slice** recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 275b1d248ea8eefcd28c1d22c5c5c6d2e05108e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->