### PR TITLE
fix(issue): queued-shell phantom milestone promoted to active by deriveStateFromDb, no user-facing recovery path

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { cleanNumberedGsdVariants } from "./repo-identity.js";
-import { milestonesDir, gsdRoot, resolveGsdRootFile, resolveMilestonePath } from "./paths.js";
+import { milestonesDir, gsdRoot, resolveGsdRootFile, milestoneDirExists } from "./paths.js";
 import { deriveState, isGhostMilestone, isReusableGhostMilestone } from "./state.js";
 import { saveFile } from "./files.js";
 import { nativeIsRepo, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
@@ -779,12 +779,17 @@ export async function checkRuntimeHealth(
     if (isDbAvailable()) {
       for (const milestone of getAllMilestones()) {
         // Every milestone status, including `queued`, is subject to the
-        // missing-directory orphan check below. A legitimate in-flight queued
-        // milestone has a resolvable directory on disk, so resolveMilestonePath
-        // succeeds and it is not flagged. A `queued` phantom left by
-        // gsd_milestone_generate_id (no directory, no content) has no resolvable
-        // path and is correctly reported as an orphan to clean up (#1524).
-        if (!resolveMilestonePath(basePath, milestone.id)) {
+        // missing-directory orphan check below. This is a directory-PRESENCE
+        // check (milestoneDirExists), not a content-bearing one: the workflow
+        // prompts create the milestone directory early (often before any
+        // CONTEXT/ROADMAP is written), so a legitimate in-flight queued
+        // milestone with only a scaffold directory (e.g. an empty slices/)
+        // must not be flagged. resolveMilestonePath alone would return null for
+        // such a legacy scaffold dir and produce a false positive during normal
+        // planning. A `queued` phantom left by gsd_milestone_generate_id (no
+        // directory at all) is correctly reported as an orphan to clean up
+        // (#1524).
+        if (!milestoneDirExists(basePath, milestone.id)) {
           issues.push({
             severity: "warning",
             code: "orphan_milestone_db",

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { cleanNumberedGsdVariants } from "./repo-identity.js";
-import { milestonesDir, gsdRoot, resolveGsdRootFile, resolveMilestonePath, resolveMilestoneFile } from "./paths.js";
+import { milestonesDir, gsdRoot, resolveGsdRootFile, resolveMilestonePath } from "./paths.js";
 import { deriveState, isGhostMilestone, isReusableGhostMilestone } from "./state.js";
 import { saveFile } from "./files.js";
 import { nativeIsRepo, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
@@ -778,17 +778,12 @@ export async function checkRuntimeHealth(
   try {
     if (isDbAvailable()) {
       for (const milestone of getAllMilestones()) {
-        // Only skip `queued` milestones that have content files on disk
-        // (legitimate in-flight planning). A `queued` row with no CONTEXT,
-        // ROADMAP, or SUMMARY is a phantom left by gsd_milestone_generate_id
-        // that was never planned — fall through so the missing-directory check
-        // below reports it as an orphan the user can clean up (#1524).
-        if (milestone.status === "queued") {
-          const hasContent = resolveMilestoneFile(basePath, milestone.id, "CONTEXT")
-            || resolveMilestoneFile(basePath, milestone.id, "ROADMAP")
-            || resolveMilestoneFile(basePath, milestone.id, "SUMMARY");
-          if (hasContent) continue;
-        }
+        // Every milestone status, including `queued`, is subject to the
+        // missing-directory orphan check below. A legitimate in-flight queued
+        // milestone has a resolvable directory on disk, so resolveMilestonePath
+        // succeeds and it is not flagged. A `queued` phantom left by
+        // gsd_milestone_generate_id (no directory, no content) has no resolvable
+        // path and is correctly reported as an orphan to clean up (#1524).
         if (!resolveMilestonePath(basePath, milestone.id)) {
           issues.push({
             severity: "warning",

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { cleanNumberedGsdVariants } from "./repo-identity.js";
-import { milestonesDir, gsdRoot, resolveGsdRootFile, resolveMilestonePath } from "./paths.js";
+import { milestonesDir, gsdRoot, resolveGsdRootFile, resolveMilestonePath, resolveMilestoneFile } from "./paths.js";
 import { deriveState, isGhostMilestone, isReusableGhostMilestone } from "./state.js";
 import { saveFile } from "./files.js";
 import { nativeIsRepo, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
@@ -778,7 +778,17 @@ export async function checkRuntimeHealth(
   try {
     if (isDbAvailable()) {
       for (const milestone of getAllMilestones()) {
-        if (milestone.status === "queued") continue;
+        // Only skip `queued` milestones that have content files on disk
+        // (legitimate in-flight planning). A `queued` row with no CONTEXT,
+        // ROADMAP, or SUMMARY is a phantom left by gsd_milestone_generate_id
+        // that was never planned — fall through so the missing-directory check
+        // below reports it as an orphan the user can clean up (#1524).
+        if (milestone.status === "queued") {
+          const hasContent = resolveMilestoneFile(basePath, milestone.id, "CONTEXT")
+            || resolveMilestoneFile(basePath, milestone.id, "ROADMAP")
+            || resolveMilestoneFile(basePath, milestone.id, "SUMMARY");
+          if (hasContent) continue;
+        }
         if (!resolveMilestonePath(basePath, milestone.id)) {
           issues.push({
             severity: "warning",

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -859,6 +859,33 @@ export function resolveMilestonePath(basePath: string, milestoneId: string): str
 }
 
 /**
+ * Returns true iff a milestone directory physically exists on disk, regardless
+ * of whether it is content-bearing.
+ *
+ * Distinct from resolveMilestonePath, which intentionally returns null for a
+ * legacy `milestones/<MID>/` directory that holds only scaffolding (e.g. an
+ * empty `slices/` created by discuss/queue flows before any CONTEXT/ROADMAP is
+ * written). That content-bearing gate is right for artifact resolution but
+ * wrong as a "directory is missing from disk" proxy: the workflow prompts
+ * create the milestone directory early, so a queued milestone in normal
+ * in-flight planning would otherwise look like an orphan. Use this to decide
+ * whether a milestone directory is truly absent (no directory at all) vs merely
+ * empty. See doctor-runtime-checks.ts orphan_milestone_db (#1524).
+ */
+export function milestoneDirExists(basePath: string, milestoneId: string): boolean {
+  // Flat-phase dirs (and content-bearing legacy dirs) resolve directly.
+  if (resolveMilestonePath(basePath, milestoneId)) return true;
+  // Legacy layout: a scaffold-only milestones/<MID>/ directory exists on disk
+  // but is not content-bearing, so resolveMilestonePath returns null. Treat the
+  // bare directory as present.
+  const oldMilestonesDir = join(gsdProjectionRoot(basePath), "milestones");
+  if (existsSync(oldMilestonesDir) && resolveDir(oldMilestonesDir, milestoneId)) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Resolve the full path to a milestone file (e.g. ROADMAP, CONTEXT, RESEARCH).
  */
 export function resolveMilestoneFile(

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -261,11 +261,27 @@ function handleNoActiveMilestone(
     const blockerDetails = pendingEntries
       .filter(e => e.dependsOn && e.dependsOn.length > 0)
       .map(e => `${e.id} is waiting on unmet deps: ${e.dependsOn!.join(', ')}`);
-    return buildDerivedState(context, 'blocked', 'Resolve milestone dependencies before proceeding.', {
-      blockers: blockerDetails.length > 0
-        ? blockerDetails
-        : ['All remaining milestones are dep-blocked but no deps listed — check CONTEXT.md files'],
-    });
+
+    // Genuine dependency block: at least one pending milestone is waiting on an
+    // unmet dependency, so directing the user at those deps is accurate.
+    if (blockerDetails.length > 0) {
+      return buildDerivedState(context, 'blocked', 'Resolve milestone dependencies before proceeding.', {
+        blockers: blockerDetails,
+      });
+    }
+
+    // No pending milestone has unmet deps, yet none could be promoted to
+    // active. These are content-less queued shells — phantom rows left by
+    // gsd_milestone_generate_id with no CONTEXT/CONTEXT-DRAFT/slices — so the
+    // old "resolve dependencies" blocker was misleading and offered no recovery
+    // path (#1524). Point the user at the doctor (which now flags these as
+    // orphan milestone rows) or at planning a real milestone.
+    const phantomIds = pendingEntries.map(e => e.id).join(', ');
+    return buildDerivedState(
+      context,
+      'pre-planning',
+      `Found queued milestone(s) with no planning content and no dependencies (${phantomIds}) — likely orphaned rows. Run /gsd doctor fix to repair them, or /gsd to plan a milestone.`,
+    );
   }
 
   if (parkedEntries.length > 0) {

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -3,13 +3,15 @@
 
 import type { ActiveRef, GSDState, MilestoneRegistryEntry, Phase } from '../../types.js';
 import { join } from 'node:path';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { isClosedStatus, isDeferredStatus } from '../../status-guards.js';
 import {
   buildMilestoneFileName,
   resolveFile,
+  resolveGsdRootFile,
   resolveMilestonePath,
 } from '../../paths.js';
+import { parseProject } from '../../schemas/parsers.js';
 import {
   getAllMilestones,
   getPendingGateCountForTurn,
@@ -129,6 +131,26 @@ function milestoneArtifactExistsInResolvedDir(
   return existsSync(flatPath) || resolveFile(milestoneDir, milestoneId, suffix) !== null;
 }
 
+// The IDs the user actually committed to as their roadmap, read from the
+// PROJECT.md "Milestone Sequence". A content-less queued milestone that appears
+// here is a real, not-yet-planned roadmap stage (e.g. the first milestone right
+// after deep-project setup) and is safe to promote to active. A content-less
+// queued row that is NOT listed here is a phantom left by
+// gsd_milestone_generate_id that was never made part of the roadmap (#1524) and
+// must not be promoted. Returns an empty set when PROJECT.md is absent or
+// unparsable, which keeps phantom-only repos out of the promotion path.
+function loadProjectSequenceIds(basePath: string): Set<string> {
+  const projectPath = resolveGsdRootFile(basePath, 'PROJECT');
+  if (!existsSync(projectPath)) return new Set();
+  try {
+    const parsed = parseProject(readFileSync(projectPath, 'utf-8'));
+    return new Set(parsed.milestones.map((m) => m.id));
+  } catch (e) {
+    logWarning('state', `failed to parse PROJECT.md milestone sequence: ${(e as Error).message}`);
+    return new Set();
+  }
+}
+
 async function buildRegistryAndFindActive(
   basePath: string,
   milestones: MilestoneRow[],
@@ -140,7 +162,9 @@ async function buildRegistryAndFindActive(
   let activeMilestoneSlices: SliceRow[] = [];
   let activeMilestoneFound = false;
   let activeMilestoneHasDraft = false;
-  let firstDeferredQueuedShell: { id: string; title: string; deps: string[]; hasDraftContext: boolean } | null = null;
+  let firstPromotableQueuedShell: { id: string; title: string; deps: string[]; hasDraftContext: boolean } | null = null;
+
+  const projectSequenceIds = loadProjectSequenceIds(basePath);
 
   const activeMilestoneIds = milestones
     .filter((m) => !parkedMilestoneIds.has(m.id))
@@ -187,17 +211,17 @@ async function buildRegistryAndFindActive(
       }
 
       if (readiness.kind === 'queued-shell') {
-        // Track the deferred queued-shell used for the promotion guard below.
-        // Store the first shell seen, then upgrade to the first shell that
-        // carries draft context. Only draft-bearing shells are eligible for
-        // promotion (see the guard below), so this upgrade ensures an earlier
-        // phantom (no draft) can't mask a later resumable draft milestone
-        // (#1524). A stored phantom is never promoted — it stays 'pending'.
-        if (
-          !firstDeferredQueuedShell ||
-          (!firstDeferredQueuedShell.hasDraftContext && readiness.hasDraftContext)
-        ) {
-          firstDeferredQueuedShell = { id: m.id, title, deps, hasDraftContext: readiness.hasDraftContext };
+        // Only a *promotable* queued-shell may become active in the fallback
+        // below: one that carries draft context (discuss-milestone was started)
+        // or is listed in the PROJECT.md roadmap sequence (a real, not-yet-
+        // planned stage). A content-less shell that is neither is a phantom left
+        // by gsd_milestone_generate_id that was never planned; promoting it
+        // strands the user on an empty milestone (#1524), so we record it only
+        // as 'pending' and never promote it. Storing just the first promotable
+        // shell also means an earlier phantom can't mask a later resumable one.
+        const promotable = readiness.hasDraftContext || projectSequenceIds.has(m.id);
+        if (promotable && !firstPromotableQueuedShell) {
+          firstPromotableQueuedShell = { id: m.id, title, deps, hasDraftContext: readiness.hasDraftContext };
         }
         registry.push({ id: m.id, title, status: 'pending', ...(deps.length > 0 ? { dependsOn: deps } : {}) });
         continue;
@@ -223,18 +247,20 @@ async function buildRegistryAndFindActive(
     }
   }
 
-  // Only promote a deferred queued-shell to active when it has draft context
-  // (i.e. discuss-milestone was started). A phantom shell with no content and
-  // no draft is a ghost row left by gsd_milestone_generate_id that was never
-  // planned — promoting it strands the user on an empty milestone with no
-  // actionable options (#1524). Leave it as 'pending' so state falls through
-  // to handleNoActiveMilestone and the doctor can flag it as an orphan.
-  if (!activeMilestoneFound && firstDeferredQueuedShell && firstDeferredQueuedShell.hasDraftContext) {
-    const shell = firstDeferredQueuedShell;
+  // Promote the first promotable queued-shell as a fallback when no other
+  // milestone became active. "Promotable" (tracked above) means it either
+  // carries draft context or is part of the PROJECT.md roadmap sequence.
+  // Content-less phantom rows never reach here, so state falls through to
+  // handleNoActiveMilestone and the doctor can flag them as orphans (#1524).
+  // A draft-bearing shell resumes discussion (needs-discussion); an in-sequence
+  // shell with no draft goes to pre-planning, so only carry the draft flag
+  // when the shell actually has draft context.
+  if (!activeMilestoneFound && firstPromotableQueuedShell) {
+    const shell = firstPromotableQueuedShell;
     activeMilestone = { id: shell.id, title: shell.title };
     activeMilestoneSlices = [];
     activeMilestoneFound = true;
-    activeMilestoneHasDraft = true;
+    if (shell.hasDraftContext) activeMilestoneHasDraft = true;
     const entry = registry.find(e => e.id === shell.id);
     if (entry) entry.status = 'active';
   }

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -214,12 +214,18 @@ async function buildRegistryAndFindActive(
     }
   }
 
-  if (!activeMilestoneFound && firstDeferredQueuedShell) {
+  // Only promote a deferred queued-shell to active when it has draft context
+  // (i.e. discuss-milestone was started). A phantom shell with no content and
+  // no draft is a ghost row left by gsd_milestone_generate_id that was never
+  // planned — promoting it strands the user on an empty milestone with no
+  // actionable options (#1524). Leave it as 'pending' so state falls through
+  // to handleNoActiveMilestone and the doctor can flag it as an orphan.
+  if (!activeMilestoneFound && firstDeferredQueuedShell && firstDeferredQueuedShell.hasDraftContext) {
     const shell = firstDeferredQueuedShell;
     activeMilestone = { id: shell.id, title: shell.title };
     activeMilestoneSlices = [];
     activeMilestoneFound = true;
-    if (shell.hasDraftContext) activeMilestoneHasDraft = true;
+    activeMilestoneHasDraft = true;
     const entry = registry.find(e => e.id === shell.id);
     if (entry) entry.status = 'active';
   }

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -187,7 +187,16 @@ async function buildRegistryAndFindActive(
       }
 
       if (readiness.kind === 'queued-shell') {
-        if (!firstDeferredQueuedShell) {
+        // Track the deferred queued-shell used for the promotion guard below.
+        // Prefer the earliest shell WITH draft context: a phantom shell (no
+        // draft) must not mask a later resumable draft milestone (#1524).
+        // Store the first shell seen, but upgrade to a later shell once it
+        // carries draft context so a real draft isn't hidden behind an earlier
+        // phantom. Falls back to the earliest phantom when no draft exists.
+        if (
+          !firstDeferredQueuedShell ||
+          (!firstDeferredQueuedShell.hasDraftContext && readiness.hasDraftContext)
+        ) {
           firstDeferredQueuedShell = { id: m.id, title, deps, hasDraftContext: readiness.hasDraftContext };
         }
         registry.push({ id: m.id, title, status: 'pending', ...(deps.length > 0 ? { dependsOn: deps } : {}) });

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -141,13 +141,13 @@ function milestoneArtifactExistsInResolvedDir(
 // unparsable, which keeps phantom-only repos out of the promotion path.
 function loadProjectSequenceIds(basePath: string): Set<string> {
   const projectPath = resolveGsdRootFile(basePath, 'PROJECT');
-  if (!existsSync(projectPath)) return new Set();
+  if (!existsSync(projectPath)) return new Set<string>();
   try {
     const parsed = parseProject(readFileSync(projectPath, 'utf-8'));
     return new Set(parsed.milestones.map((m) => m.id));
   } catch (e) {
     logWarning('state', `failed to parse PROJECT.md milestone sequence: ${(e as Error).message}`);
-    return new Set();
+    return new Set<string>();
   }
 }
 

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -188,11 +188,11 @@ async function buildRegistryAndFindActive(
 
       if (readiness.kind === 'queued-shell') {
         // Track the deferred queued-shell used for the promotion guard below.
-        // Prefer the earliest shell WITH draft context: a phantom shell (no
-        // draft) must not mask a later resumable draft milestone (#1524).
-        // Store the first shell seen, but upgrade to a later shell once it
-        // carries draft context so a real draft isn't hidden behind an earlier
-        // phantom. Falls back to the earliest phantom when no draft exists.
+        // Store the first shell seen, then upgrade to the first shell that
+        // carries draft context. Only draft-bearing shells are eligible for
+        // promotion (see the guard below), so this upgrade ensures an earlier
+        // phantom (no draft) can't mask a later resumable draft milestone
+        // (#1524). A stored phantom is never promoted — it stays 'pending'.
         if (
           !firstDeferredQueuedShell ||
           (!firstDeferredQueuedShell.hasDraftContext && readiness.hasDraftContext)

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -1375,7 +1375,9 @@ describe('derive-state-db', async () => {
       invalidateStateCache();
       const dbState = await deriveStateFromDb(base);
 
-      assert.equal(dbState.activeMilestone?.id, 'M001', 'single-resolve: queued milestone becomes active');
+      // A content-less queued shell (no CONTEXT, no CONTEXT-DRAFT, no slices)
+      // is a phantom and must NOT be promoted to active (#1524).
+      assert.equal(dbState.activeMilestone, null, 'single-resolve: content-less queued shell is not promoted');
       assert.equal(
         phaseDirExistsChecks,
         3,

--- a/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
@@ -161,4 +161,24 @@ describe("gsd_doctor orphan milestone directory check (#4996)", () => {
     const orphan = issues.find(i => i.code === "orphan_milestone_db" && i.unitId === "M005");
     assert.ok(!orphan, "queued row with content files is legitimate in-flight planning, not an orphan");
   });
+
+  it("(h) queued DB row with an empty on-disk milestone dir is NOT reported as orphan_milestone_db (#1524)", async () => {
+    base = makeBase();
+    // Discuss/queue flows create the milestone dir (e.g. `mkdir -p
+    // .gsd/milestones/<ID>/slices`) before any CONTEXT/ROADMAP is written, so
+    // the dir exists but is not yet content-bearing. resolveMilestonePath
+    // returns null for such a legacy scaffold, so the check must use directory
+    // presence, not content, or it warns during normal in-flight planning.
+    stubDir(base, "M006");
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M006", status: "queued" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "orphan_milestone_db" && i.unitId === "M006");
+    assert.ok(!orphan, "queued row with an existing (empty) milestone dir must not be flagged as a missing-directory orphan");
+  });
 });

--- a/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
@@ -129,4 +129,36 @@ describe("gsd_doctor orphan milestone directory check (#4996)", () => {
     assert.equal(orphan?.severity, "warning");
     assert.equal(orphan?.fixable, false);
   });
+
+  it("(f) phantom queued DB row with no content files is reported as orphan_milestone_db (#1524)", async () => {
+    base = makeBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    // Phantom: queued row, no directory, no CONTEXT/ROADMAP/SUMMARY on disk.
+    insertMilestone({ id: "M015", status: "queued" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "orphan_milestone_db" && i.unitId === "M015");
+    assert.ok(orphan, "phantom queued row with no content must be reported as orphan");
+    assert.equal(orphan?.severity, "warning");
+  });
+
+  it("(g) queued DB row WITH content files is NOT reported as orphan_milestone_db (#1524)", async () => {
+    base = makeBase();
+    populateDir(base, "M005");
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    // Legitimate in-flight planning: queued row with a CONTEXT file on disk.
+    insertMilestone({ id: "M005", status: "queued" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "orphan_milestone_db" && i.unitId === "M005");
+    assert.ok(!orphan, "queued row with content files is legitimate in-flight planning, not an orphan");
+  });
 });

--- a/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
@@ -219,6 +219,71 @@ describe("stale queued milestone selection (#3470)", () => {
     assert.equal(m015Entry!.status, "pending", "Phantom queued shell should stay pending, not active");
   });
 
+  test("content-less queued shell listed in the PROJECT.md sequence is promoted to pre-planning (#1524)", async () => {
+    base = createFixtureBase();
+    openDatabase(":memory:");
+
+    // M001/M002 are the roadmap the user committed to during deep-project setup:
+    // both are still content-less queued shells, but they appear in PROJECT.md's
+    // Milestone Sequence, so the first one is a real not-yet-planned stage (not a
+    // phantom) and must be promoted to active so the user can plan it.
+    insertMilestone({ id: "M001", title: "Foundation", status: "queued" });
+    insertMilestone({ id: "M002", title: "Polish", status: "queued" });
+    writeFile(
+      base,
+      "PROJECT.md",
+      [
+        "# Project",
+        "",
+        "## Milestone Sequence",
+        "",
+        "- [ ] M001: Foundation - Establish the first runnable slice.",
+        "- [ ] M002: Polish - Follow-up experience work.",
+        "",
+      ].join("\n"),
+    );
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    assert.equal(state.activeMilestone?.id, "M001", "First in-sequence roadmap shell should be promoted to active");
+    assert.equal(state.phase, "pre-planning", "A content-less in-sequence shell should go to pre-planning, not needs-discussion");
+
+    const m001Entry = state.registry.find((e: any) => e.id === "M001");
+    assert.equal(m001Entry!.status, "active", "M001 should be active in the registry");
+    const m002Entry = state.registry.find((e: any) => e.id === "M002");
+    assert.equal(m002Entry!.status, "pending", "M002 should stay pending behind the active M001");
+  });
+
+  test("content-less queued shell NOT in the PROJECT.md sequence stays a phantom (#1524)", async () => {
+    base = createFixtureBase();
+    openDatabase(":memory:");
+
+    // PROJECT.md only commits to M001. M099 is a stray row left by
+    // gsd_milestone_generate_id that never entered the roadmap, so even though a
+    // PROJECT.md exists it must not be promoted.
+    insertMilestone({ id: "M099", title: "Stray Phantom", status: "queued" });
+    writeFile(
+      base,
+      "PROJECT.md",
+      [
+        "# Project",
+        "",
+        "## Milestone Sequence",
+        "",
+        "- [ ] M001: Foundation - Establish the first runnable slice.",
+        "",
+      ].join("\n"),
+    );
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    assert.equal(state.activeMilestone, null, "A queued shell absent from the PROJECT.md sequence must not be promoted");
+    const m099Entry = state.registry.find((e: any) => e.id === "M099");
+    assert.equal(m099Entry!.status, "pending", "Stray phantom should stay pending");
+  });
+
   test("phantom-only repo surfaces a doctor recovery path, not a misleading dep-block message (#1524)", async () => {
     base = createFixtureBase();
     openDatabase(":memory:");

--- a/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
@@ -219,6 +219,30 @@ describe("stale queued milestone selection (#3470)", () => {
     assert.equal(m015Entry!.status, "pending", "Phantom queued shell should stay pending, not active");
   });
 
+  test("phantom-only repo surfaces a doctor recovery path, not a misleading dep-block message (#1524)", async () => {
+    base = createFixtureBase();
+    openDatabase(":memory:");
+
+    // Two phantom shells, neither with content, draft, slices, or deps. With no
+    // promotable milestone, deriveStateFromDb falls into handleNoActiveMilestone.
+    insertMilestone({ id: "M015", title: "Phantom One", status: "queued" });
+    insertMilestone({ id: "M016", title: "Phantom Two", status: "queued" });
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    assert.equal(state.activeMilestone, null, "Phantom-only repo has no active milestone");
+    // Must NOT claim the milestones are dependency-blocked — they have no deps.
+    assert.notEqual(state.phase, "blocked", "Phantom-only repo must not report a dependency block");
+    assert.deepStrictEqual(state.blockers, [], "No dependency blockers should be surfaced for phantom-only repo");
+    // Must direct the user toward a recovery path (doctor / planning).
+    assert.match(
+      state.nextAction,
+      /doctor/,
+      "nextAction should direct the user to the doctor for orphaned phantom rows",
+    );
+  });
+
   test("queued milestone with CONTEXT-DRAFT becomes active with needs-discussion phase when nothing else is active", async () => {
     base = createFixtureBase();
     openDatabase(":memory:");

--- a/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
@@ -200,6 +200,25 @@ describe("stale queued milestone selection (#3470)", () => {
     assert.equal(m068Entry!.status, "pending", "M068 with stale draft should be pending, not active");
   });
 
+  test("phantom queued shell (no content, no draft, no slices) is not promoted to active (#1524)", async () => {
+    base = createFixtureBase();
+    openDatabase(":memory:");
+
+    // M015: phantom row left by gsd_milestone_generate_id — never planned,
+    // no CONTEXT/ROADMAP/SUMMARY, no draft, no slices. It is the only
+    // milestone, so the old fallback would have promoted it to active.
+    insertMilestone({ id: "M015", title: "Phantom", status: "queued" });
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    assert.equal(state.activeMilestone, null, "Phantom queued shell must not be promoted to active");
+
+    const m015Entry = state.registry.find((e: any) => e.id === "M015");
+    assert.ok(m015Entry, "M015 should still appear in registry");
+    assert.equal(m015Entry!.status, "pending", "Phantom queued shell should stay pending, not active");
+  });
+
   test("queued milestone with CONTEXT-DRAFT becomes active with needs-discussion phase when nothing else is active", async () => {
     base = createFixtureBase();
     openDatabase(":memory:");

--- a/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
@@ -233,4 +233,28 @@ describe("stale queued milestone selection (#3470)", () => {
     assert.equal(state.activeMilestone?.id, "M068", "Queued milestone with draft should become active when nothing else is");
     assert.equal(state.phase, "needs-discussion", "Should resume discussion for queued milestone with draft");
   });
+
+  test("earlier phantom queued shell does not mask a later draft-bearing queued shell (#1524)", async () => {
+    base = createFixtureBase();
+    openDatabase(":memory:");
+
+    // M010: phantom shell encountered first — no CONTEXT, no draft, no slices.
+    insertMilestone({ id: "M010", title: "Phantom First", status: "queued" });
+
+    // M020: a real resumable draft milestone encountered later.
+    insertMilestone({ id: "M020", title: "Draft Later", status: "queued" });
+    writeFile(base, "milestones/M020/M020-CONTEXT-DRAFT.md", "# M020: Draft Later\n\nPartial context from an in-progress discussion.");
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    // The earlier phantom must not permanently capture the promotion slot; the
+    // later draft-bearing shell is the resumable milestone and should win.
+    assert.equal(state.activeMilestone?.id, "M020", "Later draft-bearing shell must be promoted, not masked by the earlier phantom");
+    assert.equal(state.phase, "needs-discussion", "Promoted draft shell should resume discussion");
+
+    const m010Entry = state.registry.find((e: any) => e.id === "M010");
+    assert.ok(m010Entry, "M010 should still appear in registry");
+    assert.equal(m010Entry!.status, "pending", "Phantom M010 should stay pending, not active");
+  });
 });


### PR DESCRIPTION
## Summary
- Guarded queued-shell promotion on draft context and made the doctor flag content-less queued phantoms as orphans; verified via derive-state, stale-queued, and doctor orphan test suites.

## Bugs Addressed
- [x] **`state/derive/from-db.js:130-136` — queued-shell promoted to active without content check**
- [x] **`doctor-runtime-checks.js:732` — doctor skips queued milestones entirely**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1524
- [#1524 queued-shell phantom milestone promoted to active by deriveStateFromDb, no user-facing recovery path](https://github.com/open-gsd/gsd-pi/issues/1524)

## User
- @TerminalSausage

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1524-queued-shell-phantom-milestone-promoted--1784690023`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DB-backed milestone selection and doctor orphan detection; behavior is well-covered by tests but affects how active milestone and next-action are derived for edge-case repos.
> 
> **Overview**
> Fixes **#1524**, where empty `queued` milestone rows from `gsd_milestone_generate_id` could become the active milestone and leave users with no clear recovery path.
> 
> **State derivation** (`deriveStateFromDb`) no longer promotes a content-less queued shell to active by default. Promotion is limited to shells that have **CONTEXT-DRAFT** or appear in **PROJECT.md**’s Milestone Sequence (legitimate roadmap stages). Phantom shells stay `pending`; when nothing is promotable, the UI uses **pre-planning** with guidance to run `/gsd doctor` instead of a misleading dependency **blocked** state.
> 
> **Doctor** applies `orphan_milestone_db` to **all** milestone statuses (including `queued`) when no milestone directory exists on disk, using new **`milestoneDirExists`** (directory presence) rather than **`resolveMilestonePath`** (content-bearing), so in-flight scaffold dirs are not false positives.
> 
> Tests cover phantoms, PROJECT.md promotion, doctor orphan cases, and masking of later draft-bearing shells.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11fc160e0910202b6af1e11ac822c124d2542a90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->