### PR TITLE
fix(issue): gsd_task_complete: canonical completion path rejects escalation param, forcing reopen/replan handoff

### DIFF
--- a/src/resources/extensions/gsd/tests/task-completion-executor-identity.test.ts
+++ b/src/resources/extensions/gsd/tests/task-completion-executor-identity.test.ts
@@ -472,3 +472,30 @@ test("canonical escalation fails closed until the durable adapter can persist it
   assert.equal(row("SELECT COUNT(*) AS count FROM workflow_attempt_results").count, 0);
   assert.equal(row("SELECT status FROM tasks WHERE id = 'T01'").status, "in_progress");
 });
+
+test("canonical soft escalation is dropped and staged instead of dead-ending closeout", async () => {
+  const basePath = createBase();
+  const attemptId = claimCanonicalAttempt(basePath);
+
+  // With phases.mid_execution_escalation disabled (the default) a soft
+  // escalation (continueWithDefault !== false) is ignored on the legacy path,
+  // so the canonical path must stage the completion rather than throwing.
+  const result = await executeTaskComplete({
+    ...completionParams(),
+    escalation: {
+      question: "Files changed outside the task plan — proceed?",
+      options: [
+        { id: "A", label: "Continue", tradeoffs: "Accept the incidental changes." },
+        { id: "B", label: "Pause", tradeoffs: "Wait for direction." },
+      ],
+      recommendation: "A",
+      recommendationRationale: "The changes are incidental to the verified work.",
+      continueWithDefault: true,
+    },
+  } as never, basePath, invocation("pi:gsd_task_complete:soft-escalation-call"));
+
+  assert.notEqual(result.isError, true);
+  assert.match(String(result.content[0]?.text), /awaiting host verification/i);
+  assert.equal((result.details as Record<string, unknown>).attemptId, attemptId);
+  assert.equal(row("SELECT outcome FROM workflow_attempt_results").outcome, "succeeded");
+});

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -875,7 +875,26 @@ export async function executeTaskComplete(
         throw new Error("Canonical Task completion requires private invocation identity");
       }
       if (params.escalation) {
-        throw new Error("Canonical Task completion escalation is not yet supported by the durable completion adapter");
+        // The durable completion adapter cannot yet record escalation
+        // artifacts. Rather than dead-ending the closeout, mirror the legacy
+        // escalation gating (see handleCompleteTask): escalation is only
+        // honored when phases.mid_execution_escalation is enabled. When it is
+        // disabled (the default), the legacy path drops a soft escalation
+        // (continueWithDefault !== false) with a warning and completes the
+        // task — so do the same here instead of throwing. Only cases the
+        // legacy path would actually honor (escalation enabled) or reject (a
+        // hard blocker with escalation disabled) have no canonical equivalent
+        // yet, so those still surface the unsupported error.
+        const escalationEnabled =
+          loadEffectiveGSDPreferences()?.preferences?.phases?.mid_execution_escalation === true;
+        const hardBlocker = params.escalation.continueWithDefault === false;
+        if (escalationEnabled || hardBlocker) {
+          throw new Error("Canonical Task completion escalation is not yet supported by the durable completion adapter");
+        }
+        logWarning(
+          "tool",
+          `complete_task received escalation payload but phases.mid_execution_escalation is not enabled; ignoring on the canonical completion path (${params.milestoneId}/${params.sliceId}/${params.taskId})`,
+        );
       }
       const staged = await stageTaskCompletion({
         invocation,

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -886,7 +886,7 @@ export async function executeTaskComplete(
         // hard blocker with escalation disabled) have no canonical equivalent
         // yet, so those still surface the unsupported error.
         const escalationEnabled =
-          loadEffectiveGSDPreferences()?.preferences?.phases?.mid_execution_escalation === true;
+          loadEffectiveGSDPreferences(basePath)?.preferences?.phases?.mid_execution_escalation === true;
         const hardBlocker = params.escalation.continueWithDefault === false;
         if (escalationEnabled || hardBlocker) {
           throw new Error("Canonical Task completion escalation is not yet supported by the durable completion adapter");


### PR DESCRIPTION
## Summary
- Canonical `gsd_task_complete` path now drops soft escalations gracefully (mirroring legacy `mid_execution_escalation` gating) instead of throwing, verified by the focused executor-identity test suite (10/10 pass).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1527
- [#1527 gsd_task_complete: canonical completion path rejects escalation param, forcing reopen/replan handoff](https://github.com/open-gsd/gsd-pi/issues/1527)

## User
- @jeremymcs

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1527-gsd-task-complete-canonical-completion-p-1784760228`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->