### PR TITLE
fix(gsd): classify request-time 'No API key' failures as fallback-eligible

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -85,6 +85,14 @@ const TOOL_SURFACE_NOT_READY_RE = new RegExp(TOOL_SURFACE_NOT_READY, "i");
 // Context-window 400s stay in SERVER_RE (checked earlier).
 const MODEL_ERROR_RE =
   /\b400\b.*\binvalid argument\b|\binvalid argument\b.*\b400\b|grammar is too complex|\b400\b.*\binvalid params\b(?!.*context)|invalid json payload.*unknown name ["'](?:const|patternProperties)["']|input_schema: JSON schema is invalid/i;
+// Provider adapters throw "No API key for provider: X" at request time when a
+// stored credential is expired or unrefreshable — selection-time hasAuth()
+// passed, but no usable key materialized. This is exactly the condition
+// fallback chains exist for, so route it through the model-error (fallback-
+// attempting) branch instead of the terminal unknown pause (#1533).
+// Genuine auth rejections (401 unauthorized, forbidden, …) still classify as
+// permanent earlier and keep precedence.
+const NO_API_KEY_RE = /no api key (?:available )?(?:for|found)(?: provider)?:?/i;
 
 // Provider-side model entitlement rejection: the SDK accepted the model switch,
 // but the provider refused at request time because the current account/plan/tier
@@ -197,8 +205,10 @@ export function classifyError(errorMsg: string, retryAfterMs?: number): ErrorCla
     return { kind: "connection", retryAfterMs: retryAfterMs ?? 15_000 };
   }
 
-  // 7. Model/payload errors — wrong model or incompatible request for provider
-  if (MODEL_ERROR_RE.test(errorMsg)) {
+  // 7. Model/payload errors — wrong model or incompatible request for provider,
+  //    or a credential that failed to materialize at request time (#1533).
+  //    Both are fallback-eligible, not same-model transient.
+  if (MODEL_ERROR_RE.test(errorMsg) || NO_API_KEY_RE.test(errorMsg)) {
     return { kind: "model-error" };
   }
 

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -9,7 +9,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { classifyError, isTransient, isTransientNetworkError } from "../error-classifier.ts";
 import { pauseAutoForProviderError } from "../provider-error-pause.ts";
 import { resumeAutoAfterProviderDelay } from "../bootstrap/provider-error-resume.ts";
@@ -1238,5 +1239,61 @@ test("exhausted retry errors are not deferred back to core retry handling", () =
       "Retry failed after 3 attempts: 500 empty_stream: upstream stream closed before first payload",
     ),
     false,
+  );
+});
+
+// ── no-api-key: request-time auth failure is fallback-eligible (#1533) ──────
+
+test("classifyError treats 'No API key for provider' as fallback-eligible model-error (#1533)", () => {
+  // Provider adapters throw this at request time when a stored credential is
+  // expired/unrefreshable — selection-time hasAuth() passed, but no usable key
+  // materialized. This must NOT classify as unknown (which bypasses the
+  // configured fallback chain and pauses indefinitely); model-error routes
+  // through the fallback-attempting branch in agent-end-recovery.ts.
+  const messages = [
+    "No API key for provider: openai-codex",
+    "No API key for provider: anthropic",
+    "No API key for provider: google",
+    "No API key available for provider: openrouter",
+    "No API key found for openai",
+    "No API key for openai-codex/gpt-5.4",
+  ];
+  for (const message of messages) {
+    const result = classifyError(message);
+    assert.equal(result.kind, "model-error", `${message} should classify as model-error`);
+    assert.ok(!isTransient(result), `${message} should not be same-model transient`);
+  }
+});
+
+test("classifyError keeps explicit auth failures permanent even with API-key phrasing (#1533)", () => {
+  // Genuine auth rejections must not become fallback-eligible just because the
+  // message also mentions an API key.
+  const result = classifyError("401 unauthorized: No API key for provider: openai-codex");
+  assert.equal(result.kind, "permanent");
+});
+
+test("model-error branch in agent-end-recovery attempts fallback before any terminal pause (#1533)", () => {
+  // Structural: the model-error handler must exist, must try fallbacks via
+  // pauseForProviderModelRejection without persistently blocking the model,
+  // and must precede the terminal unknown/permanent pause that bypasses
+  // fallback (pauseAutoForProviderError with isTransient: false).
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "bootstrap", "agent-end-recovery.ts"),
+    "utf-8",
+  );
+  const modelErrorIdx = src.indexOf('cls.kind === "model-error"');
+  assert.ok(modelErrorIdx > 0, "agent-end-recovery.ts must handle cls.kind model-error");
+  const rejectionCallIdx = src.indexOf("pauseForProviderModelRejection", modelErrorIdx);
+  assert.ok(rejectionCallIdx > 0, "model-error branch must call pauseForProviderModelRejection");
+  const terminalPauseIdx = src.indexOf("pauseAutoForProviderError", modelErrorIdx);
+  assert.ok(terminalPauseIdx > 0, "terminal provider-error pause must exist after the model-error branch");
+  assert.ok(
+    rejectionCallIdx < terminalPauseIdx,
+    "model-error fallback branch must precede the terminal provider-error pause (#1533)",
+  );
+  const branch = src.slice(modelErrorIdx, rejectionCallIdx + 2000);
+  assert.ok(
+    branch.includes("shouldBlockModel: false"),
+    "model-error fallback must not persistently block the model (#1533)",
   );
 });

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -1281,12 +1281,22 @@ test("model-error branch in agent-end-recovery attempts fallback before any term
     join(dirname(fileURLToPath(import.meta.url)), "..", "bootstrap", "agent-end-recovery.ts"),
     "utf-8",
   );
-  const modelErrorIdx = src.indexOf('cls.kind === "model-error"');
-  assert.ok(modelErrorIdx > 0, "agent-end-recovery.ts must handle cls.kind model-error");
+  const modelErrorMatch = /cls\.kind\s*===\s*["']model-error["']/.exec(src);
+  assert.ok(modelErrorMatch, "agent-end-recovery.ts must handle cls.kind model-error");
+  const modelErrorIdx = modelErrorMatch.index;
   const rejectionCallIdx = src.indexOf("pauseForProviderModelRejection", modelErrorIdx);
   assert.ok(rejectionCallIdx > 0, "model-error branch must call pauseForProviderModelRejection");
-  const terminalPauseIdx = src.indexOf("pauseAutoForProviderError", modelErrorIdx);
-  assert.ok(terminalPauseIdx > 0, "terminal provider-error pause must exist after the model-error branch");
+  // Anchor on the terminal permanent/unknown pause section, not the first
+  // pauseAutoForProviderError after the model-error branch — that would match
+  // the intervening tool-schema pause and let the test pass even if the real
+  // terminal pause were reordered ahead of the model-error branch.
+  const terminalSectionIdx = src.search(/Permanent\s*\/\s*unknown/i);
+  assert.ok(terminalSectionIdx > 0, "terminal permanent/unknown pause section must exist");
+  const terminalPauseIdx = src.indexOf("pauseAutoForProviderError", terminalSectionIdx);
+  assert.ok(
+    terminalPauseIdx > 0,
+    "terminal provider-error pause must exist in the permanent/unknown section",
+  );
   assert.ok(
     rejectionCallIdx < terminalPauseIdx,
     "model-error fallback branch must precede the terminal provider-error pause (#1533)",


### PR DESCRIPTION
## TL;DR

**What:** `classifyError` now maps provider `No API key for provider: X` request-time failures to `model-error` instead of `unknown`.
**Why:** Selection-time `hasAuth()` counts any stored OAuth credential as usable regardless of expiry, so a dead provider can be selected from a fallback chain and then fail at request time. As `unknown`, the error bypassed the fallback-attempting recovery branch and paused auto-mode indefinitely — discarding the rest of the user's configured fallback chain. Closes #1533.
**How:** One new regex (`NO_API_KEY_RE`) folded into the existing `model-error` classification branch. The `model-error` handler in agent-end-recovery already advances through remaining fallbacks (`pauseForProviderModelRejection`, `shouldBlockModel: false`) and only pauses with prefs guidance when all are exhausted. Genuine auth rejections (401/unauthorized/forbidden) still classify `permanent` earlier and keep precedence.

Observed in the wild: `validate-milestone` resolved planning fallbacks `claude-code → openai-codex → kimi-coding`; `openai-codex` was selected on a stale OAuth entry, threw `No API key for provider: openai-codex` on first prompt, and auto-mode paused without ever trying `kimi-coding`.

## Verification

- [x] New test: all `No API key` phrasings across provider adapters classify as `model-error` (fails pre-fix, passes post-fix)
- [x] New test: explicit auth failures with API-key phrasing stay `permanent`
- [x] New structural test: model-error fallback branch precedes the terminal pause in agent-end-recovery
- [x] `provider-errors.test.ts` 90/90
- [x] Adjacent classifier-consumer suites (rate-limit, tool-schema, terminated-transient, tool-surface, guidance) 68/68
- [x] `pnpm run typecheck:extensions` clean
- [x] `pnpm run test:changed:src` green

---
_AI-assisted PR (Kimi Work agent); reviewed and verified by the maintainers' CI gates._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->