### PR TITLE
fix(issue): headless next counts deliberately-skipped unplanned milestones as projection drift

### DIFF
--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -94,21 +94,33 @@ function excludeUnplannedMilestonesFromDbScan(
   markdownScan: HierarchyScan,
   dbScan: HierarchyScan,
 ): void {
+  const excludedMilestoneIds = new Set<string>();
   for (const milestone of getAllMilestones()) {
     if (markdownScan.milestones.has(milestone.id)) continue;
     const slices = getMilestoneSlices(milestone.id);
     if (milestone.vision.trim() || slices.some((slice) => slice.status !== "skipped")) continue;
+    excludedMilestoneIds.add(milestone.id);
+  }
+  if (excludedMilestoneIds.size === 0) return;
 
-    if (dbScan.milestones.delete(milestone.id)) dbScan.counts.milestones--;
-    const prefix = `${milestone.id}/`;
-    for (const identity of [...dbScan.slices]) {
-      if (!identity.startsWith(prefix)) continue;
-      if (dbScan.slices.delete(identity)) dbScan.counts.slices--;
-    }
-    for (const identity of [...dbScan.tasks]) {
-      if (!identity.startsWith(prefix)) continue;
-      if (dbScan.tasks.delete(identity)) dbScan.counts.tasks--;
-    }
+  // Identities are `${milestoneId}/…`, so the milestone is the leading segment.
+  const milestoneOf = (identity: string): string => {
+    const slash = identity.indexOf("/");
+    return slash === -1 ? identity : identity.slice(0, slash);
+  };
+
+  for (const id of excludedMilestoneIds) {
+    if (dbScan.milestones.delete(id)) dbScan.counts.milestones--;
+  }
+  // Single pass over each set. Deleting the current element during Set
+  // iteration is well-defined, so no intermediate array copy is needed.
+  for (const identity of dbScan.slices) {
+    if (excludedMilestoneIds.has(milestoneOf(identity)) && dbScan.slices.delete(identity))
+      dbScan.counts.slices--;
+  }
+  for (const identity of dbScan.tasks) {
+    if (excludedMilestoneIds.has(milestoneOf(identity)) && dbScan.tasks.delete(identity))
+      dbScan.counts.tasks--;
   }
 }
 

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -103,13 +103,11 @@ function excludeUnplannedMilestonesFromDbScan(
     const prefix = `${milestone.id}/`;
     for (const identity of [...dbScan.slices]) {
       if (!identity.startsWith(prefix)) continue;
-      dbScan.slices.delete(identity);
-      dbScan.counts.slices--;
+      if (dbScan.slices.delete(identity)) dbScan.counts.slices--;
     }
     for (const identity of [...dbScan.tasks]) {
       if (!identity.startsWith(prefix)) continue;
-      dbScan.tasks.delete(identity);
-      dbScan.counts.tasks--;
+      if (dbScan.tasks.delete(identity)) dbScan.counts.tasks--;
     }
   }
 }

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -90,6 +90,30 @@ function scanHasExtraIdentities(a: HierarchyScan, b: HierarchyScan): boolean {
   );
 }
 
+function excludeUnplannedMilestonesFromDbScan(
+  markdownScan: HierarchyScan,
+  dbScan: HierarchyScan,
+): void {
+  for (const milestone of getAllMilestones()) {
+    if (markdownScan.milestones.has(milestone.id)) continue;
+    const slices = getMilestoneSlices(milestone.id);
+    if (milestone.vision.trim() || slices.some((slice) => slice.status !== "skipped")) continue;
+
+    if (dbScan.milestones.delete(milestone.id)) dbScan.counts.milestones--;
+    const prefix = `${milestone.id}/`;
+    for (const identity of [...dbScan.slices]) {
+      if (!identity.startsWith(prefix)) continue;
+      dbScan.slices.delete(identity);
+      dbScan.counts.slices--;
+    }
+    for (const identity of [...dbScan.tasks]) {
+      if (!identity.startsWith(prefix)) continue;
+      dbScan.tasks.delete(identity);
+      dbScan.counts.tasks--;
+    }
+  }
+}
+
 function paddedMilestoneId(id: string): string | null {
   return /^\d+$/.test(id) ? `M${id.padStart(3, "0")}` : null;
 }
@@ -226,9 +250,15 @@ export async function checkMarkdownHierarchyAgainstDb(
   refreshWorkflowDatabaseFromDisk();
 
   const dbScan = scanDbHierarchy();
-  const beforeDb = dbScan.counts;
   alignNumericMarkdownIdsWithDb(markdownScan, dbScan);
   alignBareMarkdownIdsWithSuffixedDb(markdownScan, dbScan);
+
+  // renderRoadmapFromDb deliberately skips milestones with no non-skipped
+  // slices and no vision, refusing to create a misleading stub ROADMAP (#852).
+  // Exclude the same hierarchy branches from projection parity so a newly
+  // admitted, not-yet-planned milestone is not reported as repairable drift.
+  excludeUnplannedMilestonesFromDbScan(markdownScan, dbScan);
+  const beforeDb = dbScan.counts;
 
   // Discussion-phase scratch: a milestone dir with no ROADMAP and no DB row is
   // a pre-registration discussion artifact (CONTEXT/CONTEXT-DRAFT only — the

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -151,6 +151,33 @@ test("migration auto-check leaves matching DB hierarchy alone", async () => {
   }
 });
 
+test("migration auto-check ignores unplanned DB milestones deliberately omitted from markdown (#1549)", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  await writeGSDDirectory(projectFixture(), base);
+  assert.equal(await ensureDbOpen(base), true);
+  insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Legacy Slice", status: "pending", risk: "medium", depends: [], demo: "Legacy slice demo", sequence: 1 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Legacy Task", status: "pending" });
+
+  // A newly admitted milestone has no vision or slices. The renderer
+  // deliberately refuses to create a stub ROADMAP for it, so that expected
+  // absence must not count as projection drift.
+  insertMilestone({ id: "M002", title: "Next Milestone", status: "queued" });
+
+  // The renderer applies the same guard when every existing slice is skipped.
+  // Ensure those hidden descendants do not keep the DB scan out of parity.
+  insertMilestone({ id: "M003", title: "Skipped Milestone", status: "queued" });
+  insertSlice({ id: "S01", milestoneId: "M003", title: "Skipped Slice", status: "skipped", risk: "low", depends: [], demo: "", sequence: 1 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M003", title: "Skipped Task", status: "skipped" });
+
+  const result = await checkMarkdownHierarchyAgainstDb(base);
+  assert.equal(result.action, "none");
+  assert.equal(result.reason, "in-sync");
+  assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
+  assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 1 });
+});
+
 test("migration auto-check flags a populated DB with missing markdown and points at rebuild (not recover)", async () => {
   const base = makeBase();
   try {


### PR DESCRIPTION
## Summary
- Excluded deliberately skipped unplanned milestones from projection parity so `headless next` no longer reports a newly admitted, not-yet-planned milestone as repairable projection drift (#1549). `renderRoadmapFromDb` already skips milestones with no non-skipped slices and no vision (#852); this mirrors that skip in the parity check.
- Guarded the slice/task/milestone count decrements on the `delete()` result so counts only drop when an identity is actually removed.

## Rebased onto main
- This PR previously carried CI-unblocking lockfile/sharp fixes. Those latent `main` breakages were fixed independently and merged via #1547, so the commits here were fully redundant and have been dropped during a rebase onto the updated `main`. The PR is now scoped to just the `migration-auto-check.ts` fix and its guard refactor; the overlapping files (`package.json`, `pnpm-lock.yaml`, `screenshot-constraints.ts`) now match `main`.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1549
- [#1549 headless next counts deliberately-skipped unplanned milestones as projection drift](https://github.com/open-gsd/gsd-pi/issues/1549)

## User
- @proofoftom

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1549-headless-next-counts-deliberately-skippe-1785024825`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
