### PR TITLE
fix(build): drop vestigial sharp paths mapping that breaks build:core

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,7 @@
     "declaration": true,
     "incremental": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "sharp": ["./node_modules/sharp/lib/index.d.ts"]
-    }
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["src/resources/extensions", "src/resources/skills", "src/resources/agents", "src/tests", "src/web"]


### PR DESCRIPTION
Closes #1558.

## Problem

`pnpm run build:core` fails on `main` (`bb1a5a10`) with:

```
src/resources/extensions/browser-tools/screenshot-constraints.ts(12,46): error TS2339: Property 'default' does not exist on type 'typeof sharp'.
```

Root `tsconfig.json` maps `sharp` to `node_modules/sharp/lib/index.d.ts` (added in `87e42e00`). That file is the CommonJS declaration — it ends in `export = sharp;` and has no `default`. `screenshot-constraints.ts` types the cached factory as `(typeof import("sharp"))["default"]` (added in `3c750888`). The two are incompatible.

The error surfaces from the **`copy-resources`** step, which compiles `tsconfig.resources.json` — that config inherits the mapping via `extends`. Root `tsc` passes clean because root `tsconfig.json` excludes `src/resources/extensions`.

Only the *type* query fails; the value sites (`(await import("sharp")).default` in `zoom.ts`, `visual-diff.ts`) compile fine, since `esModuleInterop` synthesizes a value-level default for an `export =` module.

## Fix

Remove the `paths` block. It is vestigial: `296de662` bumped sharp to `^0.35.2` "to restore missing types export" — the same gap `87e42e00`'s mapping was working around. sharp 0.35.3's `package.json` points `types` at `dist/index.d.mts`, which ends in `export default sharp;`, so ordinary NodeNext resolution now finds exactly what the code expects.

No source changes; one config block removed.

## Verification

Node 24.18.0, pnpm 10.12.1 (corepack, per `packageManager`), TypeScript 5.9.3, sharp 0.35.3 as pinned by the committed lockfile:

| command | before | after |
|---|---|---|
| `pnpm run build:core` | exit 2 | **exit 0** |
| `pnpm run typecheck:extensions` | exit 0 | exit 0 |
| `pnpm run test:unit` | — | **14374 passed, 0 failed, 30 skipped** |

Unit suite run with the native addon built from source (`build:native:test`) and `GSD_NATIVE_PREFER_LOCAL=1`, mirroring the `build` job.

## Note

CI is green on the tip today, so this may be install-shape dependent — a `paths` substitution whose target is missing is silently ignored and resolution falls back to the working path. Details and a hypothesis about which CI run covered what are in #1558. Either way the mapping is no longer load-bearing, so removing it should be safe in both shapes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787704620&installation_model_id=22188&pr_number=1559&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1559&signature=937e4caf5c06aaff710b2ab5e57e7bbbfeb3b2b86539e460cde553ba5feb4651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->