### PR TITLE
fix(issue): Stuck-loop false positive: auto-loop hardcodes 'unit-break' in dispatch ledger, tripping Rule 1

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -888,8 +888,9 @@ export async function autoLoop(
           unitId: iterData.unitId,
         });
         if (unitPhaseResult.action === "break") {
+          const breakReason = unitPhaseResult.reason ?? "unit-break";
           customDispatchSettled = settleDispatchIfNeeded(customDispatchSettled, () =>
-            settleDispatchFailed(customDispatchId, "unit-break", {
+            settleDispatchFailed(customDispatchId, breakReason, {
               markFailed: markDispatchFailed,
               logWriteFailure: logDispatchLedgerWriteFailure,
             }));
@@ -898,12 +899,12 @@ export async function autoLoop(
           }
           finishIncompleteIteration({
             status: "stopped",
-            reason: unitPhaseResult.reason ?? "unit-break",
+            reason: breakReason,
             unitType: iterData.unitType,
             unitId: iterData.unitId,
             failureClass: "execution",
           });
-          finishTurn("stopped", "execution", "unit-break");
+          finishTurn("stopped", "execution", breakReason);
           break;
         }
         if (unitPhaseResult.action === "retry") {
@@ -1599,19 +1600,20 @@ export async function autoLoop(
         restoreTaskHostVerificationContext(ic, iterData.unitType, iterData.unitId);
       }
       if (unitPhaseResult.action === "break") {
+        const breakReason = unitPhaseResult.reason ?? "unit-break";
         dispatchSettled = settleDispatchIfNeeded(dispatchSettled, () =>
-          settleDispatchFailed(dispatchId, "unit-break", {
+          settleDispatchFailed(dispatchId, breakReason, {
             markFailed: markDispatchFailed,
             logWriteFailure: logDispatchLedgerWriteFailure,
           }));
         finishIncompleteIteration({
           status: "stopped",
-          reason: unitPhaseResult.reason ?? "unit-break",
+          reason: breakReason,
           unitType: iterData.unitType,
           unitId: iterData.unitId,
           failureClass: "execution",
         });
-        finishTurn("stopped", "execution", "unit-break");
+        finishTurn("stopped", "execution", breakReason);
         break;
       }
       if (unitPhaseResult.action === "retry") {

--- a/src/resources/extensions/gsd/tests/auto-loop-break-reason-ledger.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop-break-reason-ledger.test.ts
@@ -1,0 +1,26 @@
+// Project/App: gsd-pi
+// File Purpose: Guard that auto-loop break branches record the real break reason (not a hardcoded "unit-break") in the dispatch ledger.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const LOOP_SOURCE = readFileSync(fileURLToPath(new URL("../auto/loop.ts", import.meta.url)), "utf8");
+
+test("loop break branches settle the ledger with the resolved break reason", () => {
+  const branches = LOOP_SOURCE.split('unitPhaseResult.action === "break"').slice(1);
+  assert.equal(branches.length, 2, "expected both the legacy and custom-engine break branches");
+
+  for (const branch of branches) {
+    const body = branch.slice(0, branch.search(/\n\s*break;/));
+    assert.match(body, /const breakReason = unitPhaseResult\.reason \?\? "unit-break";/);
+    assert.match(body, /settleDispatchFailed\([^,]+, breakReason,/);
+    assert.match(body, /finishTurn\("stopped", "execution", breakReason\)/);
+    assert.doesNotMatch(
+      body.replace(/const breakReason = unitPhaseResult\.reason \?\? "unit-break";/, ""),
+      /"unit-break"/,
+      "break reason must not be hardcoded — distinct reasons must stay distinct for stuck-loop detection",
+    );
+  }
+});

--- a/src/resources/extensions/gsd/tests/auto-loop-break-reason-ledger.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop-break-reason-ledger.test.ts
@@ -10,10 +10,12 @@ const LOOP_SOURCE = readFileSync(fileURLToPath(new URL("../auto/loop.ts", import
 
 test("loop break branches settle the ledger with the resolved break reason", () => {
   const branches = LOOP_SOURCE.split('unitPhaseResult.action === "break"').slice(1);
-  assert.equal(branches.length, 2, "expected both the legacy and custom-engine break branches");
+  assert.ok(branches.length >= 2, "expected at least the legacy and custom-engine break branches");
 
   for (const branch of branches) {
-    const body = branch.slice(0, branch.search(/\n\s*break;/));
+    const sentinel = branch.search(/\n\s*break;/);
+    assert.notEqual(sentinel, -1, "expected a `break;` sentinel to terminate the break branch body");
+    const body = branch.slice(0, sentinel);
     assert.match(body, /const breakReason = unitPhaseResult\.reason \?\? "unit-break";/);
     assert.match(body, /settleDispatchFailed\([^,]+, breakReason,/);
     assert.match(body, /finishTurn\("stopped", "execution", breakReason\)/);


### PR DESCRIPTION
## Summary
- Auto-loop break branches now record the actual break reason in the dispatch ledger and turn telemetry instead of a hardcoded "unit-break", verified by typecheck plus 188 focused unit tests including a new regression guard.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1563
- [#1563 Stuck-loop false positive: auto-loop hardcodes 'unit-break' in dispatch ledger, tripping Rule 1](https://github.com/open-gsd/gsd-pi/issues/1563)

## User
- @organized-thot

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1563-stuck-loop-false-positive-auto-loop-hard-1785139196`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->