### PR TITLE
fix(issue): [Bug] flat-phase PLAN drift detector uses DB milestone ID instead of filesystem-canonical ID, causing permanent guard-block when unique-suffix ID enabled

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -499,7 +499,7 @@ export function setSliceSketchFlag(milestoneId: string, sliceId: string, isSketc
 
 export function upsertSlicePlanning(milestoneId: string, sliceId: string, planning: Partial<SlicePlanningRecord>): void {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-  transaction(() => getDbOrNull()!.prepare(
+  const result = transaction(() => getDbOrNull()!.prepare(
     `UPDATE slices SET
       goal = COALESCE(:goal, goal),
       success_criteria = COALESCE(:success_criteria, success_criteria),
@@ -517,7 +517,19 @@ export function upsertSlicePlanning(milestoneId: string, sliceId: string, planni
     ":integration_closure": planning.integrationClosure ?? null,
     ":observability_impact": planning.observabilityImpact ?? null,
     ":target_repositories": planning.targetRepositories ? JSON.stringify(planning.targetRepositories) : null,
-  }));
+  })) as { changes?: number };
+
+  // #1565: an UPDATE that matches no row is not a successful upsert. Without
+  // this check gsd_plan_slice reports "Planned slice S04 (M004)" and writes the
+  // PLAN file even though no slice row exists for that milestone id — planning
+  // state then silently diverges from the DB (and the drift detector later
+  // blocks on the orphaned plan file). Fail loudly instead.
+  if ((result.changes ?? 0) === 0) {
+    throw new GSDError(
+      GSD_STALE_STATE,
+      `gsd-db: no slice row for ${milestoneId}/${sliceId} — slice planning update affected 0 rows`,
+    );
+  }
 }
 
 export function insertTask(t: {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -26,6 +26,7 @@ import {
   resolveTaskFile,
 } from "../../paths.js";
 import { isClosedStatus } from "../../status-guards.js";
+import { findMilestoneIds } from "../../milestone-ids.js";
 import { removeProjectionTreeSync } from "../../atomic-write.js";
 import { invalidateStateCache } from "../../state.js";
 import type { GSDState } from "../../types.js";
@@ -295,14 +296,43 @@ function classifyDiskOnlySliceDir(
   return sawScaffold ? "quarantine-scaffold" : "delete-empty";
 }
 
+/**
+ * Milestone ids that all resolve to the same directory on disk.
+ *
+ * #1565: with unique-suffix ids enabled, `gsd_plan_milestone` stores the DB row
+ * as `M004-t76mxm` while `findMilestoneIds()` derives `M004` from the flat-phase
+ * directory name — later units then plan slices under `M004`. Both ids resolve
+ * to the same phase dir, so slices for this milestone can live under either id.
+ * Looking up only `milestone.id` yields an empty slice set and flags every
+ * `NN-MM-PLAN.md` as unknown, which blocks auto-mode permanently.
+ */
+function milestoneIdAliases(
+  basePath: string,
+  milestoneId: string,
+  milestonePath: string,
+  filesystemIds: string[],
+): string[] {
+  const aliases = [milestoneId];
+  for (const fsId of filesystemIds) {
+    if (aliases.includes(fsId)) continue;
+    if (resolveMilestonePath(basePath, fsId) === milestonePath) aliases.push(fsId);
+  }
+  return aliases;
+}
+
 function detectDiskSliceIdDivergenceForMilestone(
   basePath: string,
   milestoneId: string,
+  filesystemIds: string[],
 ): DiskSliceIdDivergenceDrift[] {
   const milestonePath = resolveMilestonePath(basePath, milestoneId);
   if (!milestonePath) return [];
 
-  const knownSliceIds = new Set(getMilestoneSlices(milestoneId).map((slice) => slice.id));
+  const knownSliceIds = new Set(
+    milestoneIdAliases(basePath, milestoneId, milestonePath, filesystemIds).flatMap((id) =>
+      getMilestoneSlices(id).map((slice) => slice.id),
+    ),
+  );
   const drifts: DiskSliceIdDivergenceDrift[] = [];
 
   // Flat-phase: scan phase dir for plan files (NN-MM-PLAN.md) where MM
@@ -394,6 +424,13 @@ function computeArtifactDbDrift(
   if (!isDbAvailable()) return [];
 
   const drifts: ArtifactDbDrift[] = [];
+  // Scanned once per pass: the disk layout is immutable while detection runs.
+  let filesystemIds: string[] = [];
+  try {
+    filesystemIds = findMilestoneIds(ctx.basePath);
+  } catch {
+    // unreadable projection root — fall back to DB ids only
+  }
 
   for (const milestone of getAllMilestones()) {
     if (isClosedStatus(milestone.status)) continue;
@@ -413,7 +450,9 @@ function computeArtifactDbDrift(
     }
 
     drifts.push(...detectArtifactDbStatusDriftForMilestone(ctx.basePath, milestone.id));
-    drifts.push(...detectDiskSliceIdDivergenceForMilestone(ctx.basePath, milestone.id));
+    drifts.push(
+      ...detectDiskSliceIdDivergenceForMilestone(ctx.basePath, milestone.id, filesystemIds),
+    );
   }
 
   return drifts;

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -310,28 +310,27 @@ function milestoneIdAliases(
   milestoneId: string,
   milestonePath: string,
   filesystemIds: string[],
-  resolvedPathByFsId: Map<string, string | null>,
+  resolvePath: (id: string) => string | null,
 ): string[] {
   const aliases = [milestoneId];
   for (const fsId of filesystemIds) {
     if (aliases.includes(fsId)) continue;
-    if (resolvedPathByFsId.get(fsId) === milestonePath) aliases.push(fsId);
+    if (resolvePath(fsId) === milestonePath) aliases.push(fsId);
   }
   return aliases;
 }
 
 function detectDiskSliceIdDivergenceForMilestone(
-  basePath: string,
   milestoneId: string,
   filesystemIds: string[],
-  resolvedPathByFsId: Map<string, string | null>,
+  resolvePath: (id: string) => string | null,
 ): DiskSliceIdDivergenceDrift[] {
-  const milestonePath = resolveMilestonePath(basePath, milestoneId);
+  const milestonePath = resolvePath(milestoneId);
   if (!milestonePath) return [];
 
   const knownSliceIds = new Set(
-    milestoneIdAliases(milestoneId, milestonePath, filesystemIds, resolvedPathByFsId).flatMap(
-      (id) => getMilestoneSlices(id).map((slice) => slice.id),
+    milestoneIdAliases(milestoneId, milestonePath, filesystemIds, resolvePath).flatMap((id) =>
+      getMilestoneSlices(id).map((slice) => slice.id),
     ),
   );
   const drifts: DiskSliceIdDivergenceDrift[] = [];
@@ -434,14 +433,18 @@ function computeArtifactDbDrift(
   }
 
   // #1565 follow-up: resolveMilestonePath scans the whole phases dir on most
-  // calls, so resolve each filesystem id to its disk path exactly once per pass
+  // calls, so resolve each milestone id to its disk path at most once per pass
   // instead of re-resolving every id inside milestoneIdAliases for every DB
-  // milestone (which was O(#milestones × #filesystemIds × #phaseDirs)).
-  const resolvedPathByFsId = new Map<string, string | null>();
-  for (const fsId of filesystemIds) {
-    if (resolvedPathByFsId.has(fsId)) continue;
-    resolvedPathByFsId.set(fsId, resolveMilestonePath(ctx.basePath, fsId));
-  }
+  // milestone (which was O(#milestones × #filesystemIds × #phaseDirs)). Safe to
+  // cache for the whole pass: the disk layout is immutable while detection runs.
+  const resolvedPathById = new Map<string, string | null>();
+  const resolvePath = (id: string): string | null => {
+    const cached = resolvedPathById.get(id);
+    if (cached !== undefined) return cached;
+    const resolved = resolveMilestonePath(ctx.basePath, id);
+    resolvedPathById.set(id, resolved);
+    return resolved;
+  };
 
   for (const milestone of getAllMilestones()) {
     if (isClosedStatus(milestone.status)) continue;
@@ -462,12 +465,7 @@ function computeArtifactDbDrift(
 
     drifts.push(...detectArtifactDbStatusDriftForMilestone(ctx.basePath, milestone.id));
     drifts.push(
-      ...detectDiskSliceIdDivergenceForMilestone(
-        ctx.basePath,
-        milestone.id,
-        filesystemIds,
-        resolvedPathByFsId,
-      ),
+      ...detectDiskSliceIdDivergenceForMilestone(milestone.id, filesystemIds, resolvePath),
     );
   }
 

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -307,15 +307,15 @@ function classifyDiskOnlySliceDir(
  * `NN-MM-PLAN.md` as unknown, which blocks auto-mode permanently.
  */
 function milestoneIdAliases(
-  basePath: string,
   milestoneId: string,
   milestonePath: string,
   filesystemIds: string[],
+  resolvedPathByFsId: Map<string, string | null>,
 ): string[] {
   const aliases = [milestoneId];
   for (const fsId of filesystemIds) {
     if (aliases.includes(fsId)) continue;
-    if (resolveMilestonePath(basePath, fsId) === milestonePath) aliases.push(fsId);
+    if (resolvedPathByFsId.get(fsId) === milestonePath) aliases.push(fsId);
   }
   return aliases;
 }
@@ -324,13 +324,14 @@ function detectDiskSliceIdDivergenceForMilestone(
   basePath: string,
   milestoneId: string,
   filesystemIds: string[],
+  resolvedPathByFsId: Map<string, string | null>,
 ): DiskSliceIdDivergenceDrift[] {
   const milestonePath = resolveMilestonePath(basePath, milestoneId);
   if (!milestonePath) return [];
 
   const knownSliceIds = new Set(
-    milestoneIdAliases(basePath, milestoneId, milestonePath, filesystemIds).flatMap((id) =>
-      getMilestoneSlices(id).map((slice) => slice.id),
+    milestoneIdAliases(milestoneId, milestonePath, filesystemIds, resolvedPathByFsId).flatMap(
+      (id) => getMilestoneSlices(id).map((slice) => slice.id),
     ),
   );
   const drifts: DiskSliceIdDivergenceDrift[] = [];
@@ -432,6 +433,16 @@ function computeArtifactDbDrift(
     // unreadable projection root — fall back to DB ids only
   }
 
+  // #1565 follow-up: resolveMilestonePath scans the whole phases dir on most
+  // calls, so resolve each filesystem id to its disk path exactly once per pass
+  // instead of re-resolving every id inside milestoneIdAliases for every DB
+  // milestone (which was O(#milestones × #filesystemIds × #phaseDirs)).
+  const resolvedPathByFsId = new Map<string, string | null>();
+  for (const fsId of filesystemIds) {
+    if (resolvedPathByFsId.has(fsId)) continue;
+    resolvedPathByFsId.set(fsId, resolveMilestonePath(ctx.basePath, fsId));
+  }
+
   for (const milestone of getAllMilestones()) {
     if (isClosedStatus(milestone.status)) continue;
 
@@ -451,7 +462,12 @@ function computeArtifactDbDrift(
 
     drifts.push(...detectArtifactDbStatusDriftForMilestone(ctx.basePath, milestone.id));
     drifts.push(
-      ...detectDiskSliceIdDivergenceForMilestone(ctx.basePath, milestone.id, filesystemIds),
+      ...detectDiskSliceIdDivergenceForMilestone(
+        ctx.basePath,
+        milestone.id,
+        filesystemIds,
+        resolvedPathByFsId,
+      ),
     );
   }
 

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -53,6 +53,7 @@ import {
   getSlice,
   setSliceSketchFlag,
   deleteDecisionById,
+  upsertSlicePlanning,
 } from '../gsd-db.ts';
 import { MigrationBackupError } from '../db-migration-backup.ts';
 import { _resetLogs, peekLogs, setStderrLoggingEnabled } from '../workflow-logger.ts';
@@ -1398,6 +1399,36 @@ describe('gsd-db', () => {
       assert.strictEqual(status.lastPhase, null, 'lastPhase cleared on successful open');
       closeDatabase();
       try { fs.unlinkSync(corruptPath); } catch { /* best effort */ }
+    });
+  });
+
+  // ─── #1565: upsertSlicePlanning zero-row guard ─────────────────────────────
+
+  describe('#1565: upsertSlicePlanning affected-row assertion', () => {
+    test('throws when no slice row matches the milestone/slice id', () => {
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M004-t76mxm', title: 'Milestone', status: 'active' });
+      insertMilestone({ id: 'M004', title: 'Milestone', status: 'active' });
+      insertSlice({ id: 'S04', milestoneId: 'M004', title: 'Slice', status: 'pending' });
+
+      assert.throws(
+        () => upsertSlicePlanning('M004-t76mxm', 'S04', { goal: 'ship it' }),
+        /no slice row for M004-t76mxm\/S04/,
+      );
+      closeDatabase();
+    });
+
+    test('succeeds when the slice row exists', () => {
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M004', title: 'Milestone', status: 'active' });
+      insertSlice({ id: 'S04', milestoneId: 'M004', title: 'Slice', status: 'pending' });
+
+      upsertSlicePlanning('M004', 'S04', { goal: 'ship it' });
+      const row = _getAdapter()!
+        .prepare('SELECT goal FROM slices WHERE milestone_id = :mid AND id = :sid')
+        .get({ ':mid': 'M004', ':sid': 'S04' }) as { goal: string };
+      assert.strictEqual(row.goal, 'ship it');
+      closeDatabase();
     });
   });
 

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -2047,6 +2047,36 @@ test("ADR-017: synthetic parallel-research slice directory is ignored", async (t
   assert.equal(result.repaired.some((record) => record.kind === "disk-slice-id-divergence"), false);
 });
 
+test("#1565: unique-suffix DB milestone id resolves slices planned under the filesystem id", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-suffix-id-drift-"));
+  t.after(() => cleanup(base));
+
+  const phaseDir = join(base, ".gsd", "phases", "04-t76mxm-new-milestone-m004-t76mxm");
+  mkdirSync(phaseDir, { recursive: true });
+  writeFileSync(join(phaseDir, "04-04-PLAN.md"), "# Plan S04\n");
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  // gsd_plan_milestone stored the unique-suffix row; later units planned slices
+  // under the short filesystem-derived id that findMilestoneIds() returns for
+  // this phase dir, which reconciliation had imported as its own milestone row.
+  insertMilestone({ id: "M004-t76mxm", title: "Milestone", status: "active" });
+  insertMilestone({ id: "M004", title: "Milestone", status: "active" });
+  insertSlice({ id: "S04", milestoneId: "M004", title: "Slice", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () =>
+      makeState({ activeMilestone: { id: "M004-t76mxm", title: "Milestone" } }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.blockers.join("\n").includes("references unknown S04"),
+    false,
+    "plan file for a slice stored under the filesystem id must not be flagged as unknown",
+  );
+});
+
 // ─── #5707: caller closure (reconcileBeforeSpawn) ────────────────────────────
 
 test("ADR-017 (#5707): reconcileBeforeSpawn returns ok=true on clean reconciliation", async () => {


### PR DESCRIPTION
## Summary
- Fixed the flat-phase PLAN drift detector to resolve slices across filesystem-canonical milestone id aliases and made upsertSlicePlanning fail on zero-row updates, verified by new regression tests plus the drift/planning suites and extension typecheck.

## Bugs Addressed
- [x] **Milestone drift detector queries slices with DB ID instead of filesystem-canonical ID**
- [x] **upsertSlicePlanning silently succeeds when UPDATE affects zero rows**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1565
- [#1565 [Bug] flat-phase PLAN drift detector uses DB milestone ID instead of filesystem-canonical ID, causing permanent guard-block when unique-suffix ID enabled](https://github.com/open-gsd/gsd-pi/issues/1565)

## User
- @itozapata

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1565-bug-flat-phase-plan-drift-detector-uses--1785192021`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->