### PR TITLE
fix(issue): verification-gate: prose Verify fields with shell metachars (; < >) plus leading command word misclassified as unsafe, suppressing task-plan-prose fallback -> false no-host-checks pause

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -783,6 +783,18 @@ test("isLikelyCommand: known command word followed by English prose is rejected 
   assert.equal(isLikelyCommand("npm run test:unit"), true);
 });
 
+test("isLikelyCommand: prose markers exclude operand-shaped words", () => {
+  // Bare prepositions and single letters are plausible operands, so they must
+  // not flip a flagless command to prose.
+  assert.equal(isLikelyCommand("git diff on master"), true);
+  assert.equal(isLikelyCommand("git checkout at release"), true);
+  assert.equal(isLikelyCommand("make install into build"), true);
+  assert.equal(isLikelyCommand("cat a b c"), true);
+  assert.equal(isLikelyCommand("go build with tags"), true);
+  // Articles, copulas, and prose verbs still identify descriptions
+  assert.equal(isLikelyCommand("git log shows the commit on master"), false);
+});
+
 test("isLikelyCommand: non-ASCII prose descriptions are rejected", () => {
   assert.equal(isLikelyCommand("所有 命令 输出 一行 JSONL go test ./... 通过"), false);
 });

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -255,6 +255,26 @@ describe("verification-gate: discovery", () => {
     assert.deepStrictEqual(result.commands, []);
   });
 
+  test("prose with shell metachars and a leading command word → task-plan-prose (issue #1567)", () => {
+    const result = discoverCommands({
+      taskPlanVerify:
+        "git log shows the scaffold commit authored by Name <user@example.com> on branch x; " +
+        "git ls-files piped to grep for .gsd/ returns nothing; platformio.ini is at repo root.",
+      cwd: tmp,
+    });
+    assert.equal(result.source, "task-plan-prose");
+    assert.deepStrictEqual(result.commands, []);
+  });
+
+  test("genuinely unsafe command still suppresses the prose fallback", () => {
+    const result = discoverCommands({
+      taskPlanVerify: "npm run test > results.txt",
+      cwd: tmp,
+    });
+    assert.equal(result.source, "none");
+    assert.deepStrictEqual(result.commands, []);
+  });
+
   test("valid command in taskPlanVerify still works", () => {
     const result = discoverCommands({
       taskPlanVerify: "npm run lint && npm run test",
@@ -751,6 +771,16 @@ test("isLikelyCommand: prose descriptions are rejected", () => {
   assert.equal(isLikelyCommand("All tests pass and coverage is above 80%"), false);
   assert.equal(isLikelyCommand("File should exist in the output directory"), false);
   assert.equal(isLikelyCommand("Build succeeds without errors or warnings"), false);
+});
+
+test("isLikelyCommand: known command word followed by English prose is rejected (issue #1567)", () => {
+  assert.equal(isLikelyCommand("git log shows the scaffold commit on branch x"), false);
+  assert.equal(isLikelyCommand("make builds the firmware without errors at repo root"), false);
+  // Real commands starting with the same words stay command-like
+  assert.equal(isLikelyCommand("git log --oneline -5"), true);
+  assert.equal(isLikelyCommand("git ls-files packages/core/src"), true);
+  assert.equal(isLikelyCommand("cargo build --release"), true);
+  assert.equal(isLikelyCommand("npm run test:unit"), true);
 });
 
 test("isLikelyCommand: non-ASCII prose descriptions are rejected", () => {

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -70,6 +70,10 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
         commands.push(normalized);
       } else if (validation.reason === "does not look like a runnable command") {
         hasTaskPlanProse = true;
+      } else if (splitUnquotedStatements(normalized).some(s => !isLikelyCommand(s))) {
+        // Rejected for unsafe syntax, but at least one `;`-separated clause reads
+        // as prose — treat the whole candidate as a description, not a command.
+        hasTaskPlanProse = true;
       } else {
         hasUnsafeTaskPlanCommand = true;
       }
@@ -305,6 +309,52 @@ function hasUnsafeShellSyntax(cmd: string): boolean {
   return false;
 }
 
+/**
+ * Split a candidate string on unquoted `;` into individual statements.
+ * Used to re-classify prose-vs-command for candidates rejected as unsafe.
+ */
+function splitUnquotedStatements(cmd: string): string[] {
+  const statements: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+
+  for (let i = 0; i < cmd.length; i += 1) {
+    const ch = cmd[i];
+
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && !inSingle) {
+      current += ch;
+      escaped = true;
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      current += ch;
+      continue;
+    }
+    if (ch === "\"" && !inSingle) {
+      inDouble = !inDouble;
+      current += ch;
+      continue;
+    }
+    if (ch === ";" && !inSingle && !inDouble) {
+      statements.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+
+  statements.push(current);
+  return statements.map(s => s.trim()).filter(Boolean);
+}
+
 function splitLeadingShellWords(cmd: string): string[] {
   const words: string[] = [];
   let current = "";
@@ -410,6 +460,31 @@ const KNOWN_COMMAND_PREFIXES = new Set([
 ]);
 
 /**
+ * English words that never appear as a shell sub-command or operand but are
+ * common in descriptive prose. Deliberately excludes words that double as
+ * sub-commands (`build`, `test`, `show`, `run`, ...).
+ */
+const PROSE_MARKER_WORDS = new Set([
+  "a", "an", "the", "is", "are", "was", "were", "should", "shows", "showing",
+  "returns", "contains", "confirms", "exists", "piped", "authored",
+  "that", "which", "whether", "there", "its", "their",
+  "by", "with", "without", "at", "on", "into", "onto",
+]);
+
+/**
+ * Does a known-command-prefixed string read as prose rather than a command?
+ * True when there is no flag/sub-command structure but there are English
+ * function words — e.g. "git log shows the scaffold commit authored by ...".
+ */
+function readsAsProseAfterCommandWord(tokens: string[]): boolean {
+  if (tokens.length < 4) return false;
+  if (tokens.some(t => t.startsWith("-"))) return false;
+  return tokens
+    .slice(1)
+    .some(t => PROSE_MARKER_WORDS.has(t.toLowerCase().replace(/[.,;:!?]+$/, "")));
+}
+
+/**
  * Heuristic check: does this string look like an executable shell command
  * rather than a prose description?
  *
@@ -438,8 +513,10 @@ export function isLikelyCommand(cmd: string): boolean {
   const effectiveTokens = firstToken === "!" ? tokens.slice(1) : tokens;
   if (firstToken === "!" && effectiveTokens.length === 0) return false;
 
-  // Known command prefix → definitely a command
-  if (KNOWN_COMMAND_PREFIXES.has(effectiveFirstToken)) return true;
+  // Known command prefix → command, unless the rest reads as English prose
+  if (KNOWN_COMMAND_PREFIXES.has(effectiveFirstToken)) {
+    return !readsAsProseAfterCommandWord(effectiveTokens);
+  }
 
   // Path-like first token → command
   if (effectiveFirstToken.startsWith("/") || effectiveFirstToken.startsWith("./") || effectiveFirstToken.startsWith("../")) return true;

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -461,14 +461,15 @@ const KNOWN_COMMAND_PREFIXES = new Set([
 
 /**
  * English words that never appear as a shell sub-command or operand but are
- * common in descriptive prose. Deliberately excludes words that double as
- * sub-commands (`build`, `test`, `show`, `run`, ...).
+ * common in descriptive prose. Deliberately excludes:
+ *   - words that double as sub-commands (`build`, `test`, `show`, `run`, ...)
+ *   - bare prepositions and single letters, which are plausible operands —
+ *     `git diff on master` and `cat a b c` must stay commands
  */
 const PROSE_MARKER_WORDS = new Set([
-  "a", "an", "the", "is", "are", "was", "were", "should", "shows", "showing",
+  "an", "the", "is", "are", "was", "were", "should", "shows", "showing",
   "returns", "contains", "confirms", "exists", "piped", "authored",
   "that", "which", "whether", "there", "its", "their",
-  "by", "with", "without", "at", "on", "into", "onto",
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Reclassified `;`-separated prose Verify fields as task-plan-prose instead of unsafe commands and hardened `isLikelyCommand` against leading command words followed by English prose; verified with the verification-gate suite (109 pass) plus six adjacent verification suites (67 pass).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1567
- [#1567 verification-gate: prose Verify fields with shell metachars (; < >) plus leading command word misclassified as unsafe, suppressing task-plan-prose fallback -> false no-host-checks pause](https://github.com/open-gsd/gsd-pi/issues/1567)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1567-verification-gate-prose-verify-fields-wi-1785221635`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->