### PR TITLE
fix(issue): gsd_task_complete: parallel duplicate calls each trip fail-closed verification guard

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -403,6 +403,44 @@ test("executeTaskComplete derives missing verification from evidence", async () 
   }
 });
 
+test("executeTaskComplete treats a malformed duplicate for an already-complete task as idempotent", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    const planDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "S01-PLAN.md"), "# S01\n\n- [ ] **T01: Demo** `est:5m`\n");
+
+    const first = await inProjectDir(base, () => executeTaskComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      oneLiner: "Completed task",
+      narrative: "Did the work",
+      verification: "npm test",
+    }, base));
+    assert.ok(!first.isError, "the well-formed call should complete the task");
+
+    // Parallel duplicate from the same turn: no verification, no evidence, no
+    // blocker. Must not trip the fail-closed guard now that the task is closed.
+    const duplicate = await inProjectDir(base, () => executeTaskComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      oneLiner: "Completed task",
+      narrative: "Did the work",
+    } as Parameters<typeof executeTaskComplete>[0], base));
+
+    assert.ok(!duplicate.isError, "duplicate completion should not be an error");
+    assert.equal(duplicate.details.error, undefined);
+    assert.equal(duplicate.details.duplicate, true);
+    assert.equal(duplicate.details.summaryPath, first.details.summaryPath);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeTaskComplete creates the legacy escalation directory and surfaces its metadata", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -127,6 +127,28 @@ function taskSummaryPath(
   );
 }
 
+/**
+ * Resolve the on-disk SUMMARY.md path for a task without writing anything.
+ *
+ * Used by callers that need to reference an already-completed task's summary
+ * (e.g. the idempotent duplicate short-circuit in `executeTaskComplete`), which
+ * must apply the same canonical-milestone-root resolution `handleCompleteTask`
+ * uses so the reported path matches the one the real completion wrote.
+ */
+export function resolveTaskSummaryPath(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+): string {
+  return taskSummaryPath(
+    resolveCanonicalMilestoneRoot(basePath, milestoneId),
+    milestoneId,
+    sliceId,
+    taskId,
+  );
+}
+
 async function repairMissingTaskSummaryProjection(
   artifactBasePath: string,
   taskRow: TaskRow,

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -11,6 +11,7 @@ import {
   getMilestoneLifecycleShadowSnapshot,
   getSliceStatusSummary,
   getSliceTaskCounts,
+  getTask,
   insertMilestone,
   insertAssessment,
   insertGateRun,
@@ -43,7 +44,7 @@ import { hostname } from "node:os";
 import { join } from "node:path";
 import type { CompleteMilestoneParams } from "./complete-milestone.js";
 import { handleCompleteMilestone } from "./complete-milestone.js";
-import { handleCompleteTask } from "./complete-task.js";
+import { handleCompleteTask, resolveTaskSummaryPath } from "./complete-task.js";
 import {
   resolveTaskCompletionAuthority,
   stageTaskCompletion,
@@ -853,6 +854,35 @@ export async function executeTaskComplete(
       } else if (params.blockerDiscovered === true) {
         coerced.verification = "Not run: blocker discovered before verification.";
       } else {
+        // A model that fires several parallel gsd_task_complete calls for the
+        // same task in one turn typically sends one well-formed call plus
+        // malformed duplicates. Failing those closed produces spurious
+        // error-trace anomalies for a task that actually completed, so when the
+        // task is already closed in current DB state, unwind the duplicate as an
+        // idempotent success pointing at the existing summary instead (#1569).
+        const existingTask = getTask(params.milestoneId, params.sliceId, params.taskId);
+        if (existingTask && isClosedStatus(existingTask.status)) {
+          const summaryPath = resolveTaskSummaryPath(
+            basePath,
+            params.milestoneId,
+            params.sliceId,
+            params.taskId,
+          );
+          return {
+            content: [{
+              type: "text",
+              text: `Task ${params.taskId} (${params.sliceId}/${params.milestoneId}) is already complete; ignoring duplicate completion call. Summary: ${summaryPath}`,
+            }],
+            details: {
+              operation: "complete_task",
+              taskId: params.taskId,
+              sliceId: params.sliceId,
+              milestoneId: params.milestoneId,
+              summaryPath,
+              duplicate: true,
+            },
+          };
+        }
         return {
           content: [{
             type: "text",


### PR DESCRIPTION
## Summary
- Made executeTaskComplete short-circuit malformed duplicate calls as idempotent successes when the task is already closed in DB state, verified by a new passing regression test plus a stashed baseline run confirming the 3 remaining suite failures are pre-existing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1569
- [#1569 gsd_task_complete: parallel duplicate calls each trip fail-closed verification guard](https://github.com/open-gsd/gsd-pi/issues/1569)

## User
- @Kile-Thomson

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1569-gsd-task-complete-parallel-duplicate-cal-1785224515`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->