### PR TITLE
feat(pi-ai): refresh MiniMax-M3 video input and adaptive thinking

### DIFF
--- a/packages/pi-ai/scripts/generate-models.ts
+++ b/packages/pi-ai/scripts/generate-models.ts
@@ -268,6 +268,15 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	) {
 		mergeAnthropicMessagesCompat(model, { forceAdaptiveThinking: true });
 	}
+	if (
+		(model.provider === "minimax" || model.provider === "minimax-cn") &&
+		model.api === "anthropic-messages" &&
+		model.id === "MiniMax-M3"
+	) {
+		// M3 exposes adaptive and disabled thinking modes over the Anthropic-compatible
+		// endpoint, so force adaptive thinking instead of the budget-based default.
+		mergeAnthropicMessagesCompat(model, { forceAdaptiveThinking: true });
+	}
 	if (model.api === "openai-completions" && model.id.includes("deepseek-v4")) {
 		mergeThinkingLevelMap(model, DEEPSEEK_V4_THINKING_LEVEL_MAP);
 	}
@@ -1786,12 +1795,16 @@ async function generateModels() {
 		}
 	}
 
-	const minimaxDirectModelOverrides = new Map([
+	const minimaxDirectModelOverrides = new Map<
+		string,
+		{ contextWindow: number; maxTokens: number; input?: ("text" | "image" | "video")[] }
+	>([
 		["MiniMax-M2.7", { contextWindow: 204800, maxTokens: 131072 }],
 		["MiniMax-M2.7-highspeed", { contextWindow: 204800, maxTokens: 131072 }],
 		// MiniMax's API overview advertises a 1M context window for M3; models.dev
-		// currently reports the documented guaranteed 512K floor.
-		["MiniMax-M3", { contextWindow: 1000000, maxTokens: 131072 }],
+		// currently reports the documented guaranteed 512K floor. M3 also accepts
+		// video inputs alongside text and image, which models.dev does not report.
+		["MiniMax-M3", { contextWindow: 1000000, maxTokens: 131072, input: ["text", "image", "video"] }],
 	]);
 	const minimaxDirectSupportedIds = new Set(minimaxDirectModelOverrides.keys());
 
@@ -1804,6 +1817,9 @@ async function generateModels() {
 			if (override) {
 				candidate.contextWindow = override.contextWindow;
 				candidate.maxTokens = override.maxTokens;
+				if (override.input) {
+					candidate.input = override.input;
+				}
 			}
 		}
 	}

--- a/packages/pi-ai/src/model-catalog.ts
+++ b/packages/pi-ai/src/model-catalog.ts
@@ -111,7 +111,7 @@ const ModelCatalogEntrySchema = Type.Object({
 	baseUrl: Type.String(),
 	reasoning: Type.Boolean(),
 	thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
-	input: Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]), { minItems: 1 }),
+	input: Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image"), Type.Literal("video")]), { minItems: 1 }),
 	cost: Type.Object({
 		input: Type.Number(),
 		output: Type.Number(),

--- a/packages/pi-ai/src/models.generated.json
+++ b/packages/pi-ai/src/models.generated.json
@@ -7694,10 +7694,14 @@
       "api": "anthropic-messages",
       "provider": "minimax",
       "baseUrl": "https://api.minimax.io/anthropic",
+      "compat": {
+        "forceAdaptiveThinking": true
+      },
       "reasoning": true,
       "input": [
         "text",
-        "image"
+        "image",
+        "video"
       ],
       "cost": {
         "input": 0.6,
@@ -7754,10 +7758,14 @@
       "api": "anthropic-messages",
       "provider": "minimax-cn",
       "baseUrl": "https://api.minimaxi.com/anthropic",
+      "compat": {
+        "forceAdaptiveThinking": true
+      },
       "reasoning": true,
       "input": [
         "text",
-        "image"
+        "image",
+        "video"
       ],
       "cost": {
         "input": 0.6,

--- a/packages/pi-ai/src/models.generated.ts
+++ b/packages/pi-ai/src/models.generated.ts
@@ -6132,8 +6132,9 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "minimax",
 			baseUrl: "https://api.minimax.io/anthropic",
+			compat: {"forceAdaptiveThinking":true},
 			reasoning: true,
-			input: ["text", "image"],
+			input: ["text", "image", "video"],
 			cost: {
 				input: 0.6,
 				output: 2.4,
@@ -6185,8 +6186,9 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "minimax-cn",
 			baseUrl: "https://api.minimaxi.com/anthropic",
+			compat: {"forceAdaptiveThinking":true},
 			reasoning: true,
-			input: ["text", "image"],
+			input: ["text", "image", "video"],
 			cost: {
 				input: 0.6,
 				output: 2.4,

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -609,7 +609,7 @@ export interface Model<TApi extends Api> {
 	 * Missing keys use provider defaults. null marks a level as unsupported.
 	 */
 	thinkingLevelMap?: ThinkingLevelMap;
-	input: ("text" | "image")[];
+	input: ("text" | "image" | "video")[];
 	cost: {
 		input: number; // $/million tokens
 		output: number; // $/million tokens

--- a/packages/pi-ai/test/generated-models.test.ts
+++ b/packages/pi-ai/test/generated-models.test.ts
@@ -180,7 +180,8 @@ describe("models.generated.ts", () => {
 				provider,
 				baseUrl,
 				reasoning: true,
-				input: ["text", "image"],
+				input: ["text", "image", "video"],
+				compat: { forceAdaptiveThinking: true },
 				cost: {
 					input: 0.6,
 					output: 2.4,

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -1167,7 +1167,7 @@ export class ModelRegistry {
 	private getDiscoveryProviderDefaults(provider: string): {
 		api: Api;
 		baseUrl: string;
-		input: ("text" | "image")[];
+		input: Model<Api>["input"];
 		contextWindow: number;
 		maxTokens: number;
 	} {


### PR DESCRIPTION
Reason: MiniMax-M3 accepts video input and supports adaptive and disabled thinking modes, but the generated catalog capped its input at text and image and left it on the budget-based thinking default.

## What changed

- Add `video` to the `Model.input` modality union and to the catalog validation schema, so a model can declare video input support.
- Update the model generator so MiniMax-M3 is emitted with `["text", "image", "video"]` input and with `forceAdaptiveThinking` enabled to match its adaptive and disabled thinking modes.
- Refresh the generated catalog (`models.generated.ts` and `models.generated.json`) for MiniMax-M3 on both the global and China providers.
- Update the MiniMax-M3 regression test to assert the video input modality and the thinking compatibility flag.

MiniMax-M2.7 is intentionally left unchanged, as its parameters already match.

## Checks

- `pnpm --filter @gsd/pi-ai exec vitest --run test/generated-models.test.ts` — 14 passed (includes the catalog mirror and validation tests).
- `pnpm --filter @gsd/pi-ai exec tsc -p tsconfig.json --noEmit` — clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787980796&installation_model_id=22188&pr_number=1573&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1573&signature=693729105eb2bae35e4ba17afdd3842163ef07e617ac6ae9c5d0b7e3327a04b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->