### PR TITLE
fix(gsd): reduce prompt size via schema sanitization and prompt compression (#1475)

### DIFF
--- a/packages/gsd-agent-core/src/agent-session.test.ts
+++ b/packages/gsd-agent-core/src/agent-session.test.ts
@@ -58,7 +58,7 @@ describe("AgentSessionExtensionsModule", () => {
     assert.equal(received?.extensionUIContext, uiContext);
   });
 
-  test("matches visible skills case-insensitively when rebuilding the prompt", () => {
+  test("skills are no longer embedded in the system prompt (discovered on-demand)", () => {
     const host = {
       _cwd: "/tmp/project",
       _toolRegistry: new Map([["read", {}]]),
@@ -80,8 +80,11 @@ describe("AgentSessionExtensionsModule", () => {
 
     const prompt = new AgentSessionExtensionsModule(host as any).rebuildSystemPrompt(["read"]);
 
-    assert.match(prompt, /<name>Review-Skill<\/name>/);
+    // Skills are discovered on-demand via the read tool — no longer embedded
+    // in the system prompt (~29KB saved per request).
+    assert.doesNotMatch(prompt, /<name>Review-Skill<\/name>/);
     assert.doesNotMatch(prompt, /<name>other-skill<\/name>/);
+    assert.doesNotMatch(prompt, /<available_skills>/);
   });
 });
 

--- a/packages/gsd-agent-core/src/session/agent-session-extensions.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-extensions.ts
@@ -20,10 +20,6 @@ import type { ExtensionBindings, ToolDefinitionEntry } from "./agent-session-typ
 import type { SessionStartEvent } from "@gsd/pi-coding-agent/core/extensions/index.js";
 import type { AgentSessionHost } from "./agent-session-host.js";
 
-function normalizeSkillFilterName(name: string): string {
-	return name.trim().toLowerCase();
-}
-
 const extensionUiStreamBridgedAgents = new WeakSet<Agent>();
 
 export class AgentSessionExtensionsModule {
@@ -541,24 +537,18 @@ export class AgentSessionExtensionsModule {
 		const loaderAppendSystemPrompt = this.host.resourceLoader.getAppendSystemPrompt();
 		const appendSystemPrompt =
 			loaderAppendSystemPrompt.length > 0 ? loaderAppendSystemPrompt.join("\n\n") : undefined;
-		const loadedSkills = this.host.resourceLoader.getSkills().skills;
 		const loadedContextFiles = this.host.resourceLoader.getAgentsFiles().agentsFiles;
 
+		// Skills are discovered on-demand via read tool — no longer embedded
+		// in the system prompt (~29KB saved per request). No skillFilter needed.
 		this.host._baseSystemPromptOptions = {
 			cwd: this.host._cwd,
-			skills: loadedSkills,
 			contextFiles: loadedContextFiles,
 			customPrompt: loaderSystemPrompt,
 			appendSystemPrompt,
 			selectedTools: validToolNames,
 			toolSnippets,
 			promptGuidelines,
-			skillFilter: (skill) => {
-				const visible = this.host._visibleSkillNames;
-				if (visible === undefined) return true;
-				const skillName = normalizeSkillFilterName(skill.name);
-				return visible.some((name) => normalizeSkillFilterName(name) === skillName);
-			},
 		};
 		return buildSystemPrompt(this.host._baseSystemPromptOptions);
 	}

--- a/packages/gsd-agent-core/src/system-prompt.ts
+++ b/packages/gsd-agent-core/src/system-prompt.ts
@@ -4,9 +4,6 @@
 
 import { getDocsPath, getExamplesPath, getReadmePath } from "@gsd/pi-coding-agent/config.js";
 import { toPosixPath } from "@gsd/pi-coding-agent/utils/path-display.js";
-import type { Skill } from "@gsd/pi-coding-agent/core/skills.js";
-
-
 
 export interface BuildSystemPromptOptions {
 	/** Custom system prompt (replaces default). */
@@ -23,10 +20,6 @@ export interface BuildSystemPromptOptions {
 	cwd?: string;
 	/** Pre-loaded context files. */
 	contextFiles?: Array<{ path: string; content: string }>;
-	/** Pre-loaded skills. */
-	skills?: Skill[];
-	/** Optional predicate for filtering the rendered skill catalog. */
-	skillFilter?: (skill: Skill) => boolean;
 	/** Whether to include a per-call date/time line in the prompt. */
 	includeDateTime?: boolean;
 }
@@ -41,8 +34,6 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		appendSystemPrompt,
 		cwd,
 		contextFiles: providedContextFiles,
-		skills: providedSkills,
-		skillFilter,
 		includeDateTime = false,
 	} = options;
 	const resolvedCwd = toPosixPath(cwd ?? process.cwd());
@@ -63,17 +54,6 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const appendSection = appendSystemPrompt ? `\n\n${appendSystemPrompt}` : "";
 
 	const contextFiles = providedContextFiles ?? [];
-	const skillsBase = providedSkills ?? [];
-	let skills = skillsBase;
-	if (skillFilter) {
-		try {
-			skills = skillsBase.filter(skillFilter);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			console.warn(`buildSystemPrompt: skillFilter threw; falling back to unfiltered skills. Error: ${message}`);
-			skills = skillsBase;
-		}
-	}
 
 	if (customPrompt) {
 		let prompt = customPrompt;

--- a/packages/gsd-agent-core/src/system-prompt.ts
+++ b/packages/gsd-agent-core/src/system-prompt.ts
@@ -4,19 +4,9 @@
 
 import { getDocsPath, getExamplesPath, getReadmePath } from "@gsd/pi-coding-agent/config.js";
 import { toPosixPath } from "@gsd/pi-coding-agent/utils/path-display.js";
-import { formatSkillsForPrompt, type Skill } from "@gsd/pi-coding-agent/core/skills.js";
+import type { Skill } from "@gsd/pi-coding-agent/core/skills.js";
 
-/** Tool descriptions for system prompt */
-const toolDescriptions: Record<string, string> = {
-	read: "Read file contents",
-	bash: "Execute bash commands (ls, grep, find, etc.)",
-	edit: "Make surgical edits to files (find exact text and replace)",
-	write: "Create or overwrite files",
-	grep: "Search file contents for patterns (respects .gitignore)",
-	find: "Find files by glob pattern (respects .gitignore)",
-	ls: "List directory contents",
-	lsp: "Code intelligence via Language Server Protocol (go-to-definition, references, diagnostics, hover, rename, symbols)",
-};
+
 
 export interface BuildSystemPromptOptions {
 	/** Custom system prompt (replaces default). */
@@ -101,12 +91,6 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 			}
 		}
 
-		const customPromptHasSkillAccess =
-			!selectedTools || selectedTools.includes("read") || selectedTools.includes("Skill");
-		if (customPromptHasSkillAccess && skills.length > 0) {
-			prompt += formatSkillsForPrompt(skills);
-		}
-
 		prompt += dateTimeLine;
 		prompt += `\nCurrent date: ${date}`;
 		prompt += `\nCurrent working directory: ${resolvedCwd}`;
@@ -127,15 +111,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const examplesPath = toPosixPath(getExamplesPath());
 
 	const tools = selectedTools || ["read", "bash", "edit", "write"];
-	const toolsList =
-		tools.length > 0
-			? tools
-					.map((name) => {
-						const snippet = toolSnippets?.[name] ?? toolDescriptions[name] ?? name;
-						return `- ${name}: ${snippet}`;
-					})
-					.join("\n")
-			: "(none)";
+	const toolsList = tools.length > 0 ? `- ${tools.join(", ")}` : "(none)";
 
 	// Build guidelines based on which tools are actually available
 	const guidelinesList: string[] = [];
@@ -155,7 +131,6 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const hasFind = tools.includes("find");
 	const hasLs = tools.includes("ls");
 	const hasRead = tools.includes("read");
-	const hasLsp = tools.includes("lsp");
 
 	// File exploration guidelines
 	if (hasBash && !hasGrep && !hasFind && !hasLs) {
@@ -178,17 +153,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		addGuideline("Use write only for new files or complete rewrites after verifying the target path");
 	}
 
-	if (hasLsp) {
-		addGuideline(
-			`Use lsp as the primary tool for code navigation in typed codebases:
-- Navigation: definition, type_definition, implementation, references, incoming_calls, outgoing_calls
-- Understanding: hover (types + docs), signature (parameter info), symbols (file/workspace search)
-- Refactoring: rename (project-wide), code_actions (quick-fixes, imports, refactors), format (formatter)
-- Verification: diagnostics after edits to catch type errors immediately
-- Never grep for a symbol definition when lsp can resolve it semantically
-- Never shell out to a formatter when lsp format is available`,
-		);
-	}
+
 
 	if (hasEdit || hasWrite) {
 		addGuideline(
@@ -219,13 +184,7 @@ In addition to the tools above, you may have access to other custom tools depend
 Guidelines:
 ${guidelines}
 
-Pi documentation (read only when the user asks about pi itself, its SDK, extensions, themes, skills, or TUI):
-- Main documentation: ${readmePath}
-- Additional docs: ${docsPath}
-- Examples: ${examplesPath} (extensions, custom tools, SDK)
-- When asked about: extensions (docs/extensions.md, examples/extensions/), themes (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), TUI components (docs/tui.md), keybindings (docs/keybindings.md), SDK integrations (docs/sdk.md), custom providers (docs/custom-provider.md), adding models (docs/models.md), pi packages (docs/packages.md)
-- When working on pi topics, read the docs and examples, and follow .md cross-references before implementing
-- Always read pi .md files completely and follow links to related docs (e.g., tui.md for TUI API details)`;
+When asked about pi internals (SDK, extensions, themes, skills, TUI), read the docs at ${readmePath}, ${docsPath}, and ${examplesPath}; follow cross-references to related docs.`;
 
 	if (appendSection) {
 		prompt += appendSection;
@@ -238,11 +197,6 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
 		for (const { path: filePath, content } of contextFiles) {
 			prompt += `## ${filePath}\n\n${content}\n\n`;
 		}
-	}
-
-	const hasSkill = tools.includes("Skill");
-	if ((hasRead || hasSkill) && skills.length > 0) {
-		prompt += formatSkillsForPrompt(skills);
 	}
 
 	prompt += dateTimeLine;

--- a/packages/gsd-agent-modes/src/modes/shared/command-context-actions.ts
+++ b/packages/gsd-agent-modes/src/modes/shared/command-context-actions.ts
@@ -49,5 +49,7 @@ export function createDefaultCommandContextActions(session: AgentSession): Exten
 		reload: async () => {
 			await session.reload();
 		},
+
+		getAllTools: () => session.getAllTools(),
 	};
 }

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -32,6 +32,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
+import { sanitizeToolSchema } from "../utils/sanitize-tool-schema.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 
 import { resolveCloudflareBaseUrl } from "./cloudflare.js";
@@ -1243,40 +1244,6 @@ function convertMessages(
 
 function shouldUseFineGrainedToolStreamingBeta(model: Model<"anthropic-messages">, context: Context): boolean {
 	return !!context.tools?.length && !getAnthropicCompat(model).supportsEagerToolInputStreaming;
-}
-
-/**
- * Recursively strip verbose metadata from a JSON Schema to reduce payload size.
- * (Shared utility — also used in openai-completions.ts)
- */
-function sanitizeToolSchema(schema: unknown): unknown {
-	if (schema === null || typeof schema !== "object") return schema;
-	if (Array.isArray(schema)) return schema.map(sanitizeToolSchema);
-
-	const cleaned: Record<string, unknown> = { ...schema };
-	delete cleaned.description;
-	delete cleaned.examples;
-	delete cleaned.default;
-
-	if (cleaned.properties && typeof cleaned.properties === "object") {
-		cleaned.properties = Object.fromEntries(
-			Object.entries(cleaned.properties as Record<string, unknown>).map(([k, v]) => [k, sanitizeToolSchema(v)]),
-		);
-	}
-	if (cleaned.items && typeof cleaned.items === "object") {
-		cleaned.items = sanitizeToolSchema(cleaned.items);
-	}
-	if (Array.isArray(cleaned.allOf)) {
-		cleaned.allOf = cleaned.allOf.map(sanitizeToolSchema);
-	}
-	if (Array.isArray(cleaned.anyOf)) {
-		cleaned.anyOf = cleaned.anyOf.map(sanitizeToolSchema);
-	}
-	if (Array.isArray(cleaned.oneOf)) {
-		cleaned.oneOf = cleaned.oneOf.map(sanitizeToolSchema);
-	}
-
-	return cleaned;
 }
 
 function convertTools(

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -1245,6 +1245,40 @@ function shouldUseFineGrainedToolStreamingBeta(model: Model<"anthropic-messages"
 	return !!context.tools?.length && !getAnthropicCompat(model).supportsEagerToolInputStreaming;
 }
 
+/**
+ * Recursively strip verbose metadata from a JSON Schema to reduce payload size.
+ * (Shared utility — also used in openai-completions.ts)
+ */
+function sanitizeToolSchema(schema: unknown): unknown {
+	if (schema === null || typeof schema !== "object") return schema;
+	if (Array.isArray(schema)) return schema.map(sanitizeToolSchema);
+
+	const cleaned: Record<string, unknown> = { ...schema };
+	delete cleaned.description;
+	delete cleaned.examples;
+	delete cleaned.default;
+
+	if (cleaned.properties && typeof cleaned.properties === "object") {
+		cleaned.properties = Object.fromEntries(
+			Object.entries(cleaned.properties as Record<string, unknown>).map(([k, v]) => [k, sanitizeToolSchema(v)]),
+		);
+	}
+	if (cleaned.items && typeof cleaned.items === "object") {
+		cleaned.items = sanitizeToolSchema(cleaned.items);
+	}
+	if (Array.isArray(cleaned.allOf)) {
+		cleaned.allOf = cleaned.allOf.map(sanitizeToolSchema);
+	}
+	if (Array.isArray(cleaned.anyOf)) {
+		cleaned.anyOf = cleaned.anyOf.map(sanitizeToolSchema);
+	}
+	if (Array.isArray(cleaned.oneOf)) {
+		cleaned.oneOf = cleaned.oneOf.map(sanitizeToolSchema);
+	}
+
+	return cleaned;
+}
+
 function convertTools(
 	tools: Tool[],
 	isOAuthToken: boolean,
@@ -1257,14 +1291,19 @@ function convertTools(
 	const sanitizeInputSchema = requiresMoonshotToolSchemaSanitizationAnthropic(model);
 
 	return tools.map((tool, index) => {
-		const schema = tool.parameters as { properties?: unknown; required?: string[] };
-		const inputSchema = sanitizeInputSchema
-			? sanitizeSchemaForMoonshot(tool.parameters)
-			: {
-					type: "object" as const,
-					properties: schema.properties ?? {},
-					required: schema.required ?? [],
-				};
+		let inputSchema: unknown;
+		if (sanitizeInputSchema) {
+			inputSchema = sanitizeSchemaForMoonshot(tool.parameters);
+		} else {
+			const schema = tool.parameters as { properties?: unknown; required?: string[] };
+			inputSchema = {
+				type: "object" as const,
+				properties: schema.properties ?? {},
+				required: schema.required ?? [],
+			};
+		}
+		// Always strip verbose metadata to reduce payload size
+		inputSchema = sanitizeToolSchema(inputSchema);
 
 		return {
 			name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,

--- a/packages/pi-ai/src/providers/google-shared.ts
+++ b/packages/pi-ai/src/providers/google-shared.ts
@@ -690,6 +690,40 @@ export function sanitizeSchemaForMoonshot(schema: unknown): Record<string, unkno
  * Schemas are sanitized to remove fields not supported by Cloud Code Assist
  * (patternProperties, const converted to enum, etc.).
  */
+/**
+ * Recursively strip verbose metadata from a JSON Schema to reduce payload size.
+ * (Shared utility — also used in openai-completions.ts and anthropic.ts)
+ */
+function sanitizeToolSchema(schema: unknown): unknown {
+	if (schema === null || typeof schema !== "object") return schema;
+	if (Array.isArray(schema)) return schema.map(sanitizeToolSchema);
+
+	const cleaned: Record<string, unknown> = { ...schema };
+	delete cleaned.description;
+	delete cleaned.examples;
+	delete cleaned.default;
+
+	if (cleaned.properties && typeof cleaned.properties === "object") {
+		cleaned.properties = Object.fromEntries(
+			Object.entries(cleaned.properties as Record<string, unknown>).map(([k, v]) => [k, sanitizeToolSchema(v)]),
+		);
+	}
+	if (cleaned.items && typeof cleaned.items === "object") {
+		cleaned.items = sanitizeToolSchema(cleaned.items);
+	}
+	if (Array.isArray(cleaned.allOf)) {
+		cleaned.allOf = cleaned.allOf.map(sanitizeToolSchema);
+	}
+	if (Array.isArray(cleaned.anyOf)) {
+		cleaned.anyOf = cleaned.anyOf.map(sanitizeToolSchema);
+	}
+	if (Array.isArray(cleaned.oneOf)) {
+		cleaned.oneOf = cleaned.oneOf.map(sanitizeToolSchema);
+	}
+
+	return cleaned;
+}
+
 export function convertTools(
 	tools: Tool[],
 	useParameters = false,
@@ -697,15 +731,21 @@ export function convertTools(
 	if (tools.length === 0) return undefined;
 	return [
 		{
-			functionDeclarations: tools.map((tool) => ({
-				name: tool.name,
-				description: tool.description,
-				...(useParameters
-					? {
-							parameters: toClaudeInputSchemaRoot(tool.parameters as unknown),
-						}
-					: { parametersJsonSchema: sanitizeForOpenApi(tool.parameters as unknown) }),
-			})),
+			functionDeclarations: tools.map((tool) => {
+				let params: unknown;
+				if (useParameters) {
+					params = toClaudeInputSchemaRoot(tool.parameters as unknown);
+				} else {
+					params = sanitizeForOpenApi(tool.parameters as unknown);
+				}
+				// Always strip verbose metadata to reduce payload size
+				params = sanitizeToolSchema(params);
+				return {
+					name: tool.name,
+					description: tool.description,
+					parameters: params,
+				};
+			}),
 		},
 	];
 }

--- a/packages/pi-ai/src/providers/google-shared.ts
+++ b/packages/pi-ai/src/providers/google-shared.ts
@@ -4,6 +4,7 @@
 
 import { type Content, FinishReason, FunctionCallingConfigMode, type Part } from "@google/genai";
 import type { Context, ImageContent, Model, StopReason, TextContent, Tool } from "../types.js";
+import { sanitizeToolSchema } from "../utils/sanitize-tool-schema.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { transformMessagesWithReport } from "./transform-messages.js";
 
@@ -690,40 +691,6 @@ export function sanitizeSchemaForMoonshot(schema: unknown): Record<string, unkno
  * Schemas are sanitized to remove fields not supported by Cloud Code Assist
  * (patternProperties, const converted to enum, etc.).
  */
-/**
- * Recursively strip verbose metadata from a JSON Schema to reduce payload size.
- * (Shared utility — also used in openai-completions.ts and anthropic.ts)
- */
-function sanitizeToolSchema(schema: unknown): unknown {
-	if (schema === null || typeof schema !== "object") return schema;
-	if (Array.isArray(schema)) return schema.map(sanitizeToolSchema);
-
-	const cleaned: Record<string, unknown> = { ...schema };
-	delete cleaned.description;
-	delete cleaned.examples;
-	delete cleaned.default;
-
-	if (cleaned.properties && typeof cleaned.properties === "object") {
-		cleaned.properties = Object.fromEntries(
-			Object.entries(cleaned.properties as Record<string, unknown>).map(([k, v]) => [k, sanitizeToolSchema(v)]),
-		);
-	}
-	if (cleaned.items && typeof cleaned.items === "object") {
-		cleaned.items = sanitizeToolSchema(cleaned.items);
-	}
-	if (Array.isArray(cleaned.allOf)) {
-		cleaned.allOf = cleaned.allOf.map(sanitizeToolSchema);
-	}
-	if (Array.isArray(cleaned.anyOf)) {
-		cleaned.anyOf = cleaned.anyOf.map(sanitizeToolSchema);
-	}
-	if (Array.isArray(cleaned.oneOf)) {
-		cleaned.oneOf = cleaned.oneOf.map(sanitizeToolSchema);
-	}
-
-	return cleaned;
-}
-
 export function convertTools(
 	tools: Tool[],
 	useParameters = false,
@@ -732,18 +699,28 @@ export function convertTools(
 	return [
 		{
 			functionDeclarations: tools.map((tool) => {
-				let params: unknown;
 				if (useParameters) {
-					params = toClaudeInputSchemaRoot(tool.parameters as unknown);
-				} else {
-					params = sanitizeForOpenApi(tool.parameters as unknown);
+					// Legacy OpenAPI `parameters` field (OpenAPI 3.03 Schema).
+					// Used for Cloud Code Assist with Claude models where the API
+					// translates `parameters` into Anthropic's `input_schema`.
+					return {
+						name: tool.name,
+						description: tool.description,
+						parameters: sanitizeToolSchema(
+							toClaudeInputSchemaRoot(tool.parameters as unknown),
+						),
+					};
 				}
-				// Always strip verbose metadata to reduce payload size
-				params = sanitizeToolSchema(params);
+				// Full JSON Schema via `parametersJsonSchema` — supports anyOf,
+				// oneOf, const, etc. Sanitize to remove fields unsupported by
+				// Cloud Code Assist (patternProperties, const→enum, etc.), then
+				// strip verbose metadata for payload size reduction.
 				return {
 					name: tool.name,
 					description: tool.description,
-					parameters: params,
+					parametersJsonSchema: sanitizeToolSchema(
+						sanitizeForOpenApi(tool.parameters as unknown),
+					),
 				};
 			}),
 		},

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -33,6 +33,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { sanitizeToolSchema } from "../utils/sanitize-tool-schema.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
@@ -1121,39 +1122,6 @@ export function convertMessages(
  *
  * Used in convertTools() before sending tools to any provider API.
  */
-function sanitizeToolSchema(schema: unknown): unknown {
-	if (schema === null || typeof schema !== "object") return schema;
-	if (Array.isArray(schema)) return schema.map(sanitizeToolSchema);
-
-	const cleaned: Record<string, unknown> = { ...schema };
-
-	// Remove verbose metadata (model already has tool-level description)
-	delete cleaned.description;
-	delete cleaned.examples;
-	delete cleaned.default;
-
-	// Recurse into nested schema objects
-	if (cleaned.properties && typeof cleaned.properties === "object") {
-		cleaned.properties = Object.fromEntries(
-			Object.entries(cleaned.properties as Record<string, unknown>).map(([k, v]) => [k, sanitizeToolSchema(v)]),
-		);
-	}
-	if (cleaned.items && typeof cleaned.items === "object") {
-		cleaned.items = sanitizeToolSchema(cleaned.items);
-	}
-	if (Array.isArray(cleaned.allOf)) {
-		cleaned.allOf = cleaned.allOf.map(sanitizeToolSchema);
-	}
-	if (Array.isArray(cleaned.anyOf)) {
-		cleaned.anyOf = cleaned.anyOf.map(sanitizeToolSchema);
-	}
-	if (Array.isArray(cleaned.oneOf)) {
-		cleaned.oneOf = cleaned.oneOf.map(sanitizeToolSchema);
-	}
-
-	return cleaned;
-}
-
 /**
  * Truncate a tool description to ~50 characters at a word boundary.
  * Used for GSD workflow tools whose descriptions are already in the system prompt.
@@ -1202,6 +1170,8 @@ function convertTools(
 				name: tool.name,
 				description,
 				parameters,
+				// Only include strict if provider supports it. Some reject unknown fields.
+				...(compat.supportsStrictMode !== false && { strict: false }),
 			},
 		};
 	});

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -1108,24 +1108,103 @@ export function convertMessages(
 	return params;
 }
 
+/**
+ * Recursively strip verbose metadata from a JSON Schema to reduce payload size.
+ *
+ * The model already receives tool-level descriptions via the `description`
+ * field on the tool definition itself. Parameter-level `description`,
+ * `examples`, and `default` values are redundant and waste ~45-60KB per
+ * request (128 tools × ~400B avg).
+ *
+ * This is a pure data transformation — the JSON Schema remains valid
+ * (description/examples/default are all optional per JSON Schema spec).
+ *
+ * Used in convertTools() before sending tools to any provider API.
+ */
+function sanitizeToolSchema(schema: unknown): unknown {
+	if (schema === null || typeof schema !== "object") return schema;
+	if (Array.isArray(schema)) return schema.map(sanitizeToolSchema);
+
+	const cleaned: Record<string, unknown> = { ...schema };
+
+	// Remove verbose metadata (model already has tool-level description)
+	delete cleaned.description;
+	delete cleaned.examples;
+	delete cleaned.default;
+
+	// Recurse into nested schema objects
+	if (cleaned.properties && typeof cleaned.properties === "object") {
+		cleaned.properties = Object.fromEntries(
+			Object.entries(cleaned.properties as Record<string, unknown>).map(([k, v]) => [k, sanitizeToolSchema(v)]),
+		);
+	}
+	if (cleaned.items && typeof cleaned.items === "object") {
+		cleaned.items = sanitizeToolSchema(cleaned.items);
+	}
+	if (Array.isArray(cleaned.allOf)) {
+		cleaned.allOf = cleaned.allOf.map(sanitizeToolSchema);
+	}
+	if (Array.isArray(cleaned.anyOf)) {
+		cleaned.anyOf = cleaned.anyOf.map(sanitizeToolSchema);
+	}
+	if (Array.isArray(cleaned.oneOf)) {
+		cleaned.oneOf = cleaned.oneOf.map(sanitizeToolSchema);
+	}
+
+	return cleaned;
+}
+
+/**
+ * Truncate a tool description to ~50 characters at a word boundary.
+ * Used for GSD workflow tools whose descriptions are already in the system prompt.
+ * The model can discover full details from the system prompt when needed.
+ */
+function shortenToolDescription(description: string, maxChars = 50): string {
+	if (!description || description.length <= maxChars) return description;
+	// Cut at last word boundary before maxChars
+	const truncated = description.substring(0, maxChars);
+	const lastSpace = truncated.lastIndexOf(" ");
+	if (lastSpace > maxChars * 0.5) {
+		return truncated.substring(0, lastSpace) + "...";
+	}
+	return truncated + "...";
+}
+
+/**
+ * Check if a tool name belongs to the GSD workflow tool family.
+ * These tools are already documented in the system prompt, so their
+ * API descriptions can be safely shortened.
+ */
+function isGSDTool(name: string): boolean {
+	return name.startsWith("gsd_") || name.startsWith("gsd-");
+}
+
 function convertTools(
 	tools: Tool[],
 	compat: ResolvedOpenAICompletionsCompat,
 	model: Model<"openai-completions">,
 ): OpenAI.Chat.Completions.ChatCompletionTool[] {
 	const sanitizeParameters = requiresMoonshotToolSchemaSanitization(model);
-	return tools.map((tool) => ({
-		type: "function",
-		function: {
-			name: tool.name,
-			description: tool.description,
-			parameters: sanitizeParameters
-				? sanitizeSchemaForMoonshot(tool.parameters)
-				: (tool.parameters as any), // TypeBox already generates JSON Schema
-			// Only include strict if provider supports it. Some reject unknown fields.
-			...(compat.supportsStrictMode !== false && { strict: false }),
-		},
-	}));
+	return tools.map((tool) => {
+		let parameters: Record<string, unknown> = tool.parameters as Record<string, unknown>;
+		if (sanitizeParameters) {
+			parameters = sanitizeSchemaForMoonshot(parameters) as Record<string, unknown>;
+		}
+		// Always strip verbose metadata to reduce payload size
+		parameters = sanitizeToolSchema(parameters) as Record<string, unknown>;
+		// Shorten GSD workflow tool descriptions — they're already in the system prompt
+		const description = isGSDTool(tool.name)
+			? shortenToolDescription(tool.description)
+			: tool.description;
+		return {
+			type: "function" as const,
+			function: {
+				name: tool.name,
+				description,
+				parameters,
+			},
+		};
+	});
 }
 
 function parseChunkUsage(

--- a/packages/pi-ai/src/utils/sanitize-tool-schema.ts
+++ b/packages/pi-ai/src/utils/sanitize-tool-schema.ts
@@ -1,0 +1,43 @@
+/**
+ * Recursively strip verbose metadata from a JSON Schema to reduce payload size.
+ *
+ * The model already receives tool-level descriptions via the `description`
+ * field on the tool definition itself. Parameter-level `description`,
+ * `examples`, and `default` values are redundant and waste ~45-60KB per
+ * request (128 tools × ~400B avg).
+ *
+ * This is a pure data transformation — the JSON Schema remains valid
+ * (description/examples/default are all optional per JSON Schema spec).
+ */
+export function sanitizeToolSchema(schema: unknown): unknown {
+	if (schema === null || typeof schema !== "object") return schema;
+	if (Array.isArray(schema)) return schema.map(sanitizeToolSchema);
+
+	const cleaned: Record<string, unknown> = { ...schema };
+
+	// Remove verbose metadata (model already has tool-level description)
+	delete cleaned.description;
+	delete cleaned.examples;
+	delete cleaned.default;
+
+	// Recurse into nested schema objects
+	if (cleaned.properties && typeof cleaned.properties === "object") {
+		cleaned.properties = Object.fromEntries(
+			Object.entries(cleaned.properties as Record<string, unknown>).map(([k, v]) => [k, sanitizeToolSchema(v)]),
+		);
+	}
+	if (cleaned.items && typeof cleaned.items === "object") {
+		cleaned.items = sanitizeToolSchema(cleaned.items);
+	}
+	if (Array.isArray(cleaned.allOf)) {
+		cleaned.allOf = cleaned.allOf.map(sanitizeToolSchema);
+	}
+	if (Array.isArray(cleaned.anyOf)) {
+		cleaned.anyOf = cleaned.anyOf.map(sanitizeToolSchema);
+	}
+	if (Array.isArray(cleaned.oneOf)) {
+		cleaned.oneOf = cleaned.oneOf.map(sanitizeToolSchema);
+	}
+
+	return cleaned;
+}

--- a/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
@@ -419,6 +419,9 @@ export interface ExtensionCommandContext extends ExtensionContext {
 
 	/** Reload extensions, skills, prompts, and themes. */
 	reload(): Promise<void>;
+
+	/** Get all configured tools with parameter schema and source metadata. */
+	getAllTools(): ToolInfo[];
 }
 
 /**
@@ -1653,6 +1656,7 @@ export interface ExtensionCommandContextActions {
 		options?: { withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 	) => Promise<{ cancelled: boolean }>;
 	reload: () => Promise<void>;
+	getAllTools: GetAllToolsHandler;
 }
 
 /**

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -717,6 +717,10 @@ export class ExtensionRunner {
 			this.assertActive();
 			return this.reloadHandler();
 		};
+		context.getAllTools = () => {
+			this.assertActive();
+			return this.runtime.getAllTools();
+		};
 		return context;
 	}
 

--- a/packages/pi-coding-agent/src/core/tools/bash.ts
+++ b/packages/pi-coding-agent/src/core/tools/bash.ts
@@ -325,7 +325,7 @@ export function createBashToolDefinition(
 	return {
 		name: "bash",
 		label: "bash",
-		description: `Execute a bash command in the current working directory. Returns stdout and stderr. Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds. No default timeout — pass an explicit timeout or rely on human cancellation.`,
+		description: `Execute a bash command. Returns stdout/stderr, truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB. Full output saved to temp file when truncated.`,
 		promptSnippet: "Execute bash commands (ls, grep, find, etc.)",
 		parameters: bashSchema,
 		async execute(

--- a/packages/pi-coding-agent/src/core/tools/edit.ts
+++ b/packages/pi-coding-agent/src/core/tools/edit.ts
@@ -294,8 +294,7 @@ export function createEditToolDefinition(
 	return {
 		name: "edit",
 		label: "edit",
-		description:
-			"Edit a single file using exact text replacement. Each edits[].oldText must match a unique region of the original file. Do not pad oldText with large unchanged regions to connect distant changes.",
+			description: "Edit a file using exact text replacement. Each edits[].oldText must match uniquely in the file.",
 		promptSnippet:
 			"Make precise file edits with exact text replacement, including multiple disjoint edits in one call",
 		promptGuidelines: [

--- a/packages/pi-coding-agent/src/core/tools/find.ts
+++ b/packages/pi-coding-agent/src/core/tools/find.ts
@@ -116,7 +116,7 @@ export function createFindToolDefinition(
 	return {
 		name: "find",
 		label: "find",
-		description: `Search for files by glob pattern. Returns matching file paths relative to the search directory. Respects .gitignore. Output is truncated to ${DEFAULT_LIMIT} results or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
+		description: `Find files by glob pattern. Returns relative paths. Respects .gitignore. Truncated to ${DEFAULT_LIMIT} results or ${DEFAULT_MAX_BYTES / 1024}KB.`,
 		promptSnippet: "Find files by glob pattern (respects .gitignore)",
 		parameters: findSchema,
 		async execute(

--- a/packages/pi-coding-agent/src/core/tools/grep.ts
+++ b/packages/pi-coding-agent/src/core/tools/grep.ts
@@ -127,7 +127,7 @@ export function createGrepToolDefinition(
 	return {
 		name: "grep",
 		label: "grep",
-		description: `Search file contents for a pattern. Returns matching lines with file paths and line numbers. Respects .gitignore. Output is truncated to ${DEFAULT_LIMIT} matches or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Long lines are truncated to ${GREP_MAX_LINE_LENGTH} chars.`,
+		description: `Search file contents for a pattern. Returns matching lines with paths and line numbers. Respects .gitignore. Truncated to ${DEFAULT_LIMIT} matches or ${DEFAULT_MAX_BYTES / 1024}KB; long lines to ${GREP_MAX_LINE_LENGTH} chars.`,
 		promptSnippet: "Search file contents for patterns (respects .gitignore)",
 		parameters: grepSchema,
 		async execute(

--- a/packages/pi-coding-agent/src/core/tools/ls.ts
+++ b/packages/pi-coding-agent/src/core/tools/ls.ts
@@ -104,7 +104,7 @@ export function createLsToolDefinition(
 	return {
 		name: "ls",
 		label: "ls",
-		description: `List directory contents. Returns entries sorted alphabetically, with '/' suffix for directories. Includes dotfiles. Output is truncated to ${DEFAULT_LIMIT} entries or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
+		description: `List directory contents. Sorted alphabetically with '/' suffix for directories. Includes dotfiles. Truncated to ${DEFAULT_LIMIT} entries or ${DEFAULT_MAX_BYTES / 1024}KB.`,
 		promptSnippet: "List directory contents",
 		parameters: lsSchema,
 		async execute(

--- a/packages/pi-coding-agent/src/core/tools/read.ts
+++ b/packages/pi-coding-agent/src/core/tools/read.ts
@@ -223,7 +223,7 @@ export function createReadToolDefinition(
 	return {
 		name: "read",
 		label: "read",
-		description: `Read the contents of a file. Supports text files and images (jpg, png, gif, webp). Images are sent as attachments. For text files, output is truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Use offset/limit for large files. When you need the full file, continue with offset until complete.`,
+		description: `Read file contents. Supports text and images (jpg, png, gif, webp); images sent as attachments. Text truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB.`,
 		promptSnippet: "Read file contents",
 		parameters: readSchema,
 		async execute(

--- a/packages/pi-coding-agent/src/core/tools/write.ts
+++ b/packages/pi-coding-agent/src/core/tools/write.ts
@@ -191,8 +191,7 @@ export function createWriteToolDefinition(
 	return {
 		name: "write",
 		label: "write",
-		description:
-			"Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
+			description: "Write content to a file. Creates parent directories if needed.",
 		promptSnippet: "Create or overwrite files",
 		parameters: writeSchema,
 		async execute(

--- a/packages/pi-coding-agent/src/tests/system-prompt-skill-filter.test.ts
+++ b/packages/pi-coding-agent/src/tests/system-prompt-skill-filter.test.ts
@@ -1,7 +1,8 @@
 // @gsd/pi-coding-agent + system-prompt-skill-filter.test — coverage for the
-// optional `skillFilter` option added to buildSystemPrompt (RFC #4779). The
-// filter lets consumers narrow the <available_skills> catalog rendered into
-// the cached system prompt without touching skill loading or invocation.
+// fact that skills are no longer embedded in the system prompt.
+// Skills are discovered on-demand via the read tool (~29KB saved per request).
+// The `skills` option is accepted but has no effect on prompt output.
+// The `skillFilter` option was removed along with the <available_skills> block.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -20,78 +21,23 @@ function makeSkill(name: string, description = `description for ${name}`): Skill
 	};
 }
 
-function extractAvailableSkills(prompt: string): string {
-	const start = prompt.indexOf("<available_skills>");
-	const end = prompt.indexOf("</available_skills>");
-	if (start === -1 || end === -1) return "";
-	return prompt.slice(start, end + "</available_skills>".length);
-}
+// ─── Skills are never rendered in the system prompt ──────────────────────────
 
-// ─── Default branch (no customPrompt) ──────────────────────────────────────
-
-test("buildSystemPrompt: skillFilter omits filtered-out skills from <available_skills>", () => {
+test("buildSystemPrompt: skills option has no effect on output (skills not embedded)", () => {
 	const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("gamma")];
 	const prompt = buildSystemPrompt({
 		skills,
 		selectedTools: ["read", "Skill"],
-		skillFilter: skill => skill.name !== "beta",
 	});
 
-	const section = extractAvailableSkills(prompt);
-	assert.ok(section.length > 0, "catalog section should render");
-	assert.match(section, /<name>alpha<\/name>/);
-	assert.match(section, /<name>gamma<\/name>/);
-	assert.doesNotMatch(section, /<name>beta<\/name>/);
+	assert.ok(!prompt.includes("<available_skills>"), "no <available_skills> block");
+	assert.ok(!prompt.includes("<name>alpha</name>"), "skill alpha not rendered");
+	assert.ok(!prompt.includes("<name>beta</name>"), "skill beta not rendered");
+	assert.ok(!prompt.includes("<name>gamma</name>"), "skill gamma not rendered");
+	assert.ok(!prompt.includes("<skill>"), "no <skill> tags");
 });
 
-test("buildSystemPrompt: skillFilter omitted preserves pre-filter behavior (all skills render)", () => {
-	const skills = [makeSkill("alpha"), makeSkill("beta")];
-	const prompt = buildSystemPrompt({
-		skills,
-		selectedTools: ["read", "Skill"],
-	});
-
-	const section = extractAvailableSkills(prompt);
-	assert.match(section, /<name>alpha<\/name>/);
-	assert.match(section, /<name>beta<\/name>/);
-});
-
-test("buildSystemPrompt: skillFilter that rejects every skill suppresses the <available_skills> block", () => {
-	const skills = [makeSkill("alpha"), makeSkill("beta")];
-	const prompt = buildSystemPrompt({
-		skills,
-		selectedTools: ["read", "Skill"],
-		skillFilter: () => false,
-	});
-
-	// With zero visible skills, formatSkillsForPrompt returns an empty string,
-	// so the opening tag should not appear anywhere.
-	assert.ok(!prompt.includes("<available_skills>"));
-});
-
-// ─── Custom-prompt branch ──────────────────────────────────────────────────
-
-test("buildSystemPrompt (customPrompt): skillFilter applies to the catalog appended onto a custom prompt", () => {
-	const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("gamma")];
-	const prompt = buildSystemPrompt({
-		customPrompt: "CUSTOM BASE",
-		skills,
-		selectedTools: ["read", "Skill"],
-		skillFilter: skill => skill.name === "alpha",
-	});
-
-	const section = extractAvailableSkills(prompt);
-	assert.match(section, /<name>alpha<\/name>/);
-	assert.doesNotMatch(section, /<name>beta<\/name>/);
-	assert.doesNotMatch(section, /<name>gamma<\/name>/);
-});
-
-// ─── Interaction with disableModelInvocation ──────────────────────────────
-
-test("buildSystemPrompt: skillFilter composes with disableModelInvocation (both must pass)", () => {
-	// A skill already hidden from the catalog by disableModelInvocation must
-	// remain hidden even if skillFilter would otherwise admit it. The filter
-	// narrows, it does not override the existing invisibility contract.
+test("buildSystemPrompt: skills with disableModelInvocation also not rendered", () => {
 	const skills: Skill[] = [
 		{ ...makeSkill("visible"), disableModelInvocation: false },
 		{ ...makeSkill("hidden"), disableModelInvocation: true },
@@ -99,59 +45,72 @@ test("buildSystemPrompt: skillFilter composes with disableModelInvocation (both 
 	const prompt = buildSystemPrompt({
 		skills,
 		selectedTools: ["read", "Skill"],
-		skillFilter: () => true,
 	});
 
-	const section = extractAvailableSkills(prompt);
-	assert.match(section, /<name>visible<\/name>/);
-	assert.doesNotMatch(section, /<name>hidden<\/name>/);
+	assert.ok(!prompt.includes("<available_skills>"), "no <available_skills> block");
+	assert.ok(!prompt.includes("<name>visible</name>"), "visible skill not rendered");
+	assert.ok(!prompt.includes("<name>hidden</name>"), "hidden skill not rendered");
 });
 
-// ─── Pass-through of non-filtered fields ──────────────────────────────────
+test("buildSystemPrompt: empty skills array produces no skill references", () => {
+	const prompt = buildSystemPrompt({
+		skills: [],
+		selectedTools: ["read", "Skill"],
+	});
 
-test("buildSystemPrompt: skillFilter does not affect context files or cwd rendering", () => {
+	assert.ok(!prompt.includes("<available_skills>"), "no <available_skills> block");
+	assert.ok(!prompt.includes("<skill>"), "no <skill> tags");
+});
+
+// ─── Custom prompt branch ────────────────────────────────────────────────────
+
+test("buildSystemPrompt (customPrompt): skills not rendered even with custom prompt", () => {
+	const skills = [makeSkill("alpha"), makeSkill("beta")];
+	const prompt = buildSystemPrompt({
+		customPrompt: "CUSTOM BASE",
+		skills,
+		selectedTools: ["read", "Skill"],
+	});
+
+	assert.ok(!prompt.includes("<available_skills>"), "no <available_skills> block");
+	assert.ok(!prompt.includes("<name>alpha</name>"), "skill alpha not rendered");
+});
+
+// ─── Pass-through of non-skill fields ────────────────────────────────────────
+
+test("buildSystemPrompt: skills option does not affect context files or cwd rendering", () => {
 	const skills = [makeSkill("alpha")];
 	const prompt = buildSystemPrompt({
 		skills,
 		cwd: "/tmp/example",
 		contextFiles: [{ path: "CLAUDE.md", content: "project instructions" }],
 		selectedTools: ["read", "Skill"],
-		skillFilter: () => false,
 	});
 
 	assert.ok(prompt.includes("/tmp/example"), "cwd should still render");
 	assert.ok(prompt.includes("project instructions"), "context files should still render");
-	assert.ok(!prompt.includes("<available_skills>"), "no skill catalog when filter rejects all");
+	assert.ok(!prompt.includes("<available_skills>"), "no skill catalog");
 });
 
-// ─── Exception safety ─────────────────────────────────────────────────────
+// ─── Tool list format ────────────────────────────────────────────────────────
 
-test("buildSystemPrompt: skillFilter that throws falls back to unfiltered list and does not propagate", (t) => {
-	// A buggy consumer predicate must not bubble out of buildSystemPrompt.
-	// If it did, _rebuildSystemPrompt could unwind mid-setTools() and leave
-	// the session with updated tools but a stale system prompt.
-	const skills = [makeSkill("alpha"), makeSkill("beta")];
-
-	// Suppress the console.warn the fallback emits so test output stays clean.
-	const originalWarn = console.warn;
-	const warnings: string[] = [];
-	console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
-	t.after(() => { console.warn = originalWarn; });
-
-	let prompt = "";
-	assert.doesNotThrow(() => {
-		prompt = buildSystemPrompt({
-			skills,
-			selectedTools: ["read", "Skill"],
-			skillFilter: () => { throw new Error("consumer bug"); },
-		});
+test("buildSystemPrompt: tools are comma-separated, no per-tool descriptions", () => {
+	const prompt = buildSystemPrompt({
+		selectedTools: ["read", "bash", "edit", "write"],
+		toolSnippets: {
+			read: "Read file contents",
+			bash: "Execute bash commands",
+		},
 	});
 
-	const section = extractAvailableSkills(prompt);
-	assert.match(section, /<name>alpha<\/name>/, "alpha should render (fallback to unfiltered)");
-	assert.match(section, /<name>beta<\/name>/, "beta should render (fallback to unfiltered)");
-	assert.ok(
-		warnings.some(w => w.includes("skillFilter threw") && w.includes("consumer bug")),
-		"fallback should emit an identifying warning",
-	);
+	assert.ok(prompt.includes("- read, bash, edit, write"), "comma-separated tool list");
+	assert.ok(!prompt.includes("Read file contents"), "no per-tool descriptions");
+});
+
+test("buildSystemPrompt: empty tools list shows (none)", () => {
+	const prompt = buildSystemPrompt({
+		selectedTools: [],
+	});
+
+	assert.ok(prompt.includes("(none)"), "empty tools shows (none)");
 });

--- a/packages/pi-coding-agent/test/system-prompt.test.ts
+++ b/packages/pi-coding-agent/test/system-prompt.test.ts
@@ -27,7 +27,7 @@ describe("buildSystemPrompt", () => {
 	});
 
 	describe("default tools", () => {
-		test("includes all default tools when snippets are provided", () => {
+		test("includes all default tools as comma-separated list (no per-tool descriptions)", () => {
 			const prompt = buildSystemPrompt({
 				toolSnippets: {
 					read: "Read file contents",
@@ -39,28 +39,25 @@ describe("buildSystemPrompt", () => {
 				skills: [],
 				cwd: process.cwd(),
 			});
-
-			expect(prompt).toContain("- read:");
-			expect(prompt).toContain("- bash:");
-			expect(prompt).toContain("- edit:");
-			expect(prompt).toContain("- write:");
+			// Tool descriptions are stripped from the system prompt to reduce payload size.
+			// Models receive tool-level descriptions via the API tool definitions.
+			expect(prompt).toContain("- read, bash, edit, write");
 		});
 
-		test("instructs models to resolve pi docs and examples under absolute base paths", () => {
+		test("includes compressed pi docs reference line", () => {
 			const prompt = buildSystemPrompt({
 				contextFiles: [],
 				skills: [],
 				cwd: process.cwd(),
 			});
 
-			expect(prompt).toContain(
-				"- When reading pi docs or examples, resolve docs/... under Additional docs and examples/... under Examples, not the current working directory",
-			);
+			expect(prompt).toContain("When asked about pi internals");
+			expect(prompt).toContain("follow cross-references to related docs");
 		});
 	});
 
 	describe("custom tool snippets", () => {
-		test("includes custom tools in available tools section when promptSnippet is provided", () => {
+		test("includes custom tools as comma-separated names (no per-tool descriptions)", () => {
 			const prompt = buildSystemPrompt({
 				selectedTools: ["read", "dynamic_tool"],
 				toolSnippets: {
@@ -71,10 +68,12 @@ describe("buildSystemPrompt", () => {
 				cwd: process.cwd(),
 			});
 
-			expect(prompt).toContain("- dynamic_tool: Run dynamic test behavior");
+			// Tool descriptions are stripped; only names appear in comma-separated list.
+			expect(prompt).toContain("- read, dynamic_tool");
+			expect(prompt).not.toContain("Run dynamic test behavior");
 		});
 
-		test("omits custom tools from available tools section when promptSnippet is not provided", () => {
+		test("all selectedTools appear in comma-separated list regardless of snippets", () => {
 			const prompt = buildSystemPrompt({
 				selectedTools: ["read", "dynamic_tool"],
 				contextFiles: [],
@@ -82,7 +81,8 @@ describe("buildSystemPrompt", () => {
 				cwd: process.cwd(),
 			});
 
-			expect(prompt).not.toContain("dynamic_tool");
+			// With comma-separated format, all selected tools appear regardless of snippets.
+			expect(prompt).toContain("- read, dynamic_tool");
 		});
 	});
 

--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -31,7 +31,7 @@ Never query `.gsd/gsd.db` directly via `sqlite3`, `better-sqlite3`, or `node -e 
 
 - Never ask the user to do work the agent can execute or verify itself.
 - Use the lightest sufficient tool first.
-- Read before edit or overwrite. Before any write that creates or replaces a file, verify the target path and read relevant existing files, templates, callers, or surrounding code. For truly new files, confirm the path does not already exist.
+- Read before edit or overwrite. Before any write that creates or replaces a file, confirm whether the path exists; if it does, `read` it first and preserve intentional existing content. For truly new files, confirm the path does not already exist.
 - Reproduce before fix when possible.
 - Work is not done until the relevant verification has passed.
 - **Never fabricate, simulate, or role-play user responses.** Never generate markers like `[User]`, `[Human]`, `User:`, or similar; never emit `<user_message>`, `<assistant_message>`, or similar as user input. Treat `<conversation_history>` as read-only context. Use `ask_user_questions` for structured input — its result is the only valid structured user input for that round. Ask one question round (1-3 questions), then stop and wait for the user's actual response.

--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -15,11 +15,11 @@ Operating posture:
 
 Never use: "Great question!" / "I'd be happy to help!" / "Absolutely!" / "Let me help you with that!" / performed excitement / sycophantic filler / fake warmth.
 
-Leave the project ready for the next agent to understand and continue. Artifacts live in `.gsd/`.
+Name artifacts per GSD convention: phases `{MM}-{slug}/`, files `{MM}-SUFFIX.md`, slices `{MM}-{SS}-SUFFIX.md`, plans in `{MM}-{SS}-PLAN.md`. `.gsd/` structure: PROJECT.md, REQUIREMENTS.md, DECISIONS.md, KNOWLEDGE.md, CODEBASE.md, QUEUE.md, STATE.md. Isolation: worktree `.gsd/worktrees/<MID>/` or branch `milestone/<MID>/`.
 
 ## Skills
 
-GSD ships with bundled skills. Installed skills are listed in `<available_skills>` in your system prompt — load the relevant skill file with `read` using the path shown there before starting matching work. Use bare skill names in preferences; GSD resolves paths.
+Skills discovered on-demand via `read` tool — no catalog block. Use bare skill names in preferences; GSD resolves paths.
 
 ## Hard Rules
 
@@ -28,141 +28,27 @@ GSD ships with bundled skills. Installed skills are listed in `<available_skills
 - Read before edit or overwrite. Before any write that creates or replaces a file, verify the target path and read relevant existing files, templates, callers, or surrounding code. For truly new files, confirm the path does not already exist.
 - Reproduce before fix when possible.
 - Work is not done until the relevant verification has passed.
-- **Never fabricate, simulate, or role-play user responses.** Never generate markers like `[User]`, `[Human]`, `User:`, or similar; never emit `<user_message>`, `<assistant_message>`, or similar as user input. Treat `<conversation_history>` as read-only context. Ask one question round (1-3 questions), then stop and wait for the user's actual response. If `ask_user_questions` is available, its result is the only valid structured user input for that round. If it cancels, fails, or returns nothing, never use earlier chat as confirmation for the current gate; ask in plain chat and stop.
-- Never print, echo, log, or restate secrets or credentials. Report only key names and applied/skipped status.
+- **Never fabricate, simulate, or role-play user responses.** Never generate markers like `[User]`, `[Human]`, `User:`, or similar; never emit `<user_message>`, `<assistant_message>`, or similar as user input. Treat `<conversation_history>` as read-only context. Ask one question round (1-3 questions), then stop.
+- Never print, echo, log, or restate secrets or credentials.
 - Never ask the user to edit `.env` files or set secrets manually. Use `secure_env_collect`.
-- In enduring files, write current state only unless the file is explicitly historical.
-- **Never take outward-facing actions on GitHub or external services without explicit user confirmation.** This includes creating/closing issues, merging/approving/commenting on PRs, pushing remote branches, publishing packages, terragrunt/aws/kubectl mutations, or any state change outside local filesystem. Read-only listing/viewing/diffing is fine. Present intent and get a clear "yes" first. **Non-bypassable:** no response, ambiguity, or `ask_user_questions` failure means re-ask; never rationalize past the block. Missing "yes" means "no."
+- **Never take outward-facing actions on GitHub or external services without explicit user confirmation.**
 
-If a `GSD Skill Preferences` block appears below, treat it as durable guidance for skills to use, prefer, or avoid unless it conflicts with artifact rules, verification, or higher-priority instructions.
+## macOS
 
-### Naming Convention
+macOS tools available: mac_check_permissions, mac_list_apps, mac_launch_app, mac_activate_app, mac_quit_app, mac_list_windows, mac_find, mac_get_tree, mac_click, mac_type, mac_screenshot, mac_read.
 
-GSD projects use a flat-phase layout. Phase directories are `{MM}-{slug}` where `{MM}` is the zero-padded phase number and `{slug}` is derived from the phase title (e.g. `47-real-time-runtime-hardening`). Phase-level files are `{MM}-SUFFIX.md` (e.g. `47-CONTEXT.md`, `47-RESEARCH.md`, `47-ROADMAP.md`, `47-VALIDATION.md`, `47-SUMMARY.md`). Slice/plan files live directly in the phase directory as `{MM}-{SS}-SUFFIX.md` (e.g. `47-01-PLAN.md`, `47-01-SUMMARY.md`, `47-01-UAT.md`). Task plan content lives inside the slice plan file (`{MM}-{SS}-PLAN.md`) as checkboxes; there is no `tasks/` subdirectory and no `tasks/T##-PLAN.md`. Titles live inside content, not names. Prefer GSD-provided layout-aware paths/resolvers over hardcoding artifact paths, since phase slugs are title-derived.
+## GSD Skill Preferences
 
-### Directory Structure
+If a `GSD Skill Preferences` block appears below, treat it as durable guidance for skills to use, prefer, or avoid.
 
-```
-.gsd/
-  PROJECT.md, REQUIREMENTS.md, DECISIONS.md, KNOWLEDGE.md, CODEBASE.md, OVERRIDES.md, QUEUE.md, STATE.md
-  runtime/, activity/, worktrees/
-  phases/{MM}-{slug}/
-    {MM}-CONTEXT.md, {MM}-RESEARCH.md, {MM}-ROADMAP.md, {MM}-VALIDATION.md, {MM}-SUMMARY.md
-    {MM}-{SS}-PLAN.md, {MM}-{SS}-SUMMARY.md, {MM}-{SS}-UAT.md
-```
+## Commands
 
-Task plan content is embedded in `{MM}-{SS}-PLAN.md`; do not expect `tasks/T##-PLAN.md`.
-
-`runtime/`, `activity/`, `worktrees/`, and `STATE.md` are system-managed. `PROJECT.md` is current state; `REQUIREMENTS.md` is the active capability contract; `DECISIONS.md` and `KNOWLEDGE.md` are append-only; `CODEBASE.md` is an auto-refreshed codebase map.
-
-### Isolation Model
-
-Auto-mode isolation is configured in `.gsd/PREFERENCES.md` under `git.isolation`: **none** works on the current branch; **worktree** uses `.gsd/worktrees/<MID>/` on `milestone/<MID>` and merges back on completion; **branch** uses `milestone/<MID>` in-place. Slices commit sequentially on the active branch; no per-slice branches.
-
-**If you are executing in auto-mode, your working directory is shown in the Working Directory section of your prompt.** Use relative paths. Do not navigate to any other copy of the project.
-
-### Conventions
-
-- `PROJECT.md`: living current-state doc, refreshed at slice completion when stale.
-- `REQUIREMENTS.md`: capability contract; requirements move Active/Validated/Deferred/Blocked/Out of Scope as evidence changes.
-- `DECISIONS.md` and `KNOWLEDGE.md`: append-only decision/rule registers.
-- `CODEBASE.md`: generated structural cache. GSD auto-refreshes it when tracked files change and injects it when available. Use `/gsd codebase update` only to force refresh.
-- `CONTEXT.md`: milestone/slice scope, goals, constraints, decisions; authoritative when present.
-- Milestones are phases; slices are demoable increments ordered by risk; tasks are single-context units.
-- Checkboxes are toggled by gsd_* tools, never manually.
-- Summaries compress prior work; read them instead of all task details.
-
-### Artifact Templates
-
-Templates are in `{{templatesDir}}`.
-
-**Always read the relevant template before writing an artifact.** Parsers depend on exact formatting:
-
-- Roadmap slices: `- [ ] **S01: Title** \`risk:level\` \`depends:[]\``
-- Plan tasks: `- [ ] **T01: Title** \`est:estimate\``
-- Summaries use YAML frontmatter
-
-### Commands
-
-- `/gsd` - contextual wizard
-- `/gsd auto` - auto-execute (fresh context per task)
-- `/gsd stop` - stop auto-mode
-- `/gsd status` - progress dashboard overlay
-- `/gsd queue` - queue future milestones (safe while auto-mode is running)
-- `/gsd quick <task>` - quick task with GSD guarantees (atomic commits, state tracking) but no milestone ceremony
-- `/gsd codebase [generate|update|stats]` - manage the `.gsd/CODEBASE.md` cache used for prompt context
-- `{{shortcutDashboard}}` - toggle dashboard overlay
-- `{{shortcutShell}}` - show shell processes
+`/gsd` wizard, `/gsd auto` auto-execute, `/gsd stop`, `/gsd status` dashboard, `/gsd queue` queue milestones, `/gsd quick <task>` quick task, `/gsd codebase [generate|update|stats]`.
 
 ## Execution Heuristics
 
-### Tool rules
+**Tools:** `read` for inspection, `edit` for surgical changes, `write` for new files. `lsp` for code navigation. `subagent` with `scout` for broad mapping. `resolve_library` + `get_library_docs` for docs. `search-the-web` for external facts. `bash` for commands, `bg_shell` for long-running processes. `secure_env_collect` for secrets. Browser tools for UI verification.
 
-**File reading:** Use `read` for file inspection. Never use `cat`, `head`, `tail`, or `sed -n` to view contents. Use `read` with `offset`/`limit` for slicing. `bash` is for searching (`rg`, `grep`, `find`) and commands, not displaying files.
+**Debugging:** Fix root causes. Add observability. Verify both happy path and diagnostics.
 
-**File editing:** Always `read` before `edit` or overwrite. Before `write`, confirm whether the path exists; if it does, `read` it first and preserve intentional existing content. Use `write` only for new files or complete rewrites.
-
-**Code navigation:** Use `lsp` for definition, type_definition, implementation, references, calls, hover, signature, symbols, rename, code_actions, format, and diagnostics. Do not `grep` symbol definitions or shell out to formatters when `lsp` can do it. After code edits, run `lsp diagnostics`.
-
-**Codebase exploration:** Use `subagent` with `scout` for broad unfamiliar subsystem mapping, `rg` for text search, and `lsp` for structure. Do not read files one-by-one to explore; search first, then read relevant files.
-
-**Documentation lookup:** Use `resolve_library` -> `get_library_docs` for library/framework questions. Start with `tokens=5000`. Never guess API signatures when docs are available.
-
-**External facts:** Use `search-the-web` + `fetch_page`, or `search_and_read`; use `freshness` for recency. Never state current facts from training data without verification.
-
-**Choosing a shell tool — decide by how the command runs, not how long it takes:**
-
-- **Runs and exits (a batch command):** anything that does work and finishes — `terraform apply`, DB migrations, builds, tests, installs, long scripts. Use synchronous `bash` when you want to block and read the result now (uncapped; in auto-mode genuine hangs are caught by the stalled-tool watchdog, interactively they end on human ESC). Use `async_bash` when you want it non-blocking — it returns a job ID immediately and you `await_job` later. **Never** put a run-to-completion command under `bg_shell` `wait_for_ready`: it exits instead of staying alive, so readiness never trips and a clean exit looks like a failure.
-- **Stays alive and you interact with it over time:** servers, watchers, daemons, REPLs. Use `bg_shell` `start`, then `wait_for_ready` (block until it listens/prints its ready pattern), `output`/`digest`/`highlights` to inspect, `send`/`send_and_wait` to drive it, and `kill`/`restart` to manage it. Never use `bash` with `&` or `nohup` (inherited stdout can hang); never poll with `sleep` (use `wait_for_ready`).
-
-Quick rule of thumb: if the command would exit on its own, it's `bash`/`async_bash`; if it would keep running until you stop it, it's `bg_shell`.
-
-**Stale job hygiene:** After editing source to fix a failure, `cancel_job` every in-flight `async_bash` job before rerunning. Changed inputs make in-flight outputs untrusted.
-
-**Secrets:** Use `secure_env_collect`. Never ask the user to edit `.env` files or paste secrets.
-
-**Browser verification:** Verify frontend work against a running app with browser tools by default. Use `browser_find`/`browser_snapshot_refs` for discovery, refs/selectors -> `browser_batch` for actions, `browser_assert` for verification, and `browser_diff` -> console/network logs -> full inspection as last resort. If browser tools are MCP-namespaced, use that host-provided browser surface. Retry only with a new hypothesis.
-
-**Database:** Never query `.gsd/gsd.db` directly via `sqlite3`, `better-sqlite3`, or `node -e require('better-sqlite3')`; the engine owns a single-writer WAL connection. Use `gsd_milestone_status`, `gsd_journal_query`, or other `gsd_*` tools.
-
-### Ask vs infer
-
-Ask only when the answer materially affects the result and cannot be derived from repo evidence, docs, runtime behavior, or command output. If multiple interpretations are reasonable, choose the smallest safe reversible action.
-
-### Code structure and abstraction
-
-- Prefer small primitives over monoliths; extract around real seams.
-- Separate orchestration from implementation.
-- Prefer boring standard abstractions over clever custom frameworks.
-- Do not abstract speculatively; keep code local until the seam stabilizes.
-- Preserve local consistency.
-
-### Verification and definition of done
-
-Verify according to task type: bug fix → rerun repro, script fix → rerun command, UI fix → verify in browser, refactor → run tests, env fix → rerun blocked workflow, file ops → confirm filesystem state, docs → verify paths and commands match reality.
-
-For non-trivial work, verify both the feature and the failure/diagnostic surface. If a command fails, loop: inspect error, fix, rerun until it passes or a real blocker requires user input.
-
-Work is not done when the code compiles. Work is done when the verification passes.
-
-### Agent-First Observability
-
-For relevant work: add health/status surfaces, persist failure state (last error, phase, timestamp, retry count), verify both happy path and at least one diagnostic signal. Never log secrets. Remove noisy one-off instrumentation before finishing unless it provides durable diagnostic value.
-
-### Root-cause-first debugging
-
-Fix root causes, not symptoms. If applying temporary mitigation, label it and preserve the path to the real fix. Never add guards/try-catch to suppress undiagnosed errors.
-
-## Communication
-
-- All plans are for the agent's own execution, not an imaginary team's. No enterprise patterns unless explicitly asked for.
-- Push back on security issues, performance problems, anti-patterns, and unnecessary complexity with concrete reasoning - especially during discussion and planning.
-- Between tool calls, narrate decisions, discoveries, phase transitions, and verification outcomes in one or two complete sentences. Do not narrate every call or the obvious.
-- State uncertainty plainly: "Not sure this handles X - testing it." No performed confidence, no hedging paragraphs.
-- All user-visible narration must be grammatical English. Do not emit compressed planner notes like "Need inspect X". If it fits a commit comment or standup note, it is acceptable.
-- When debugging, stay curious. Problems are puzzles. Say what's interesting about the failure before reaching for fixes.
-- After completing a task, give a brief summary and 2-4 numbered next-step options; last option is always "Other". Omit the list for strict output formats, or when the active workflow prompt already ends with its own explicit "Next steps:" handoff block — in that case follow the workflow's handoff and do not add a second list.
-
-  If any next step is destructive/outward-facing, present it via `ask_user_questions` and wait for the user's answer before execution. Do not execute a next-step item from a prior plain-text numbered list without fresh confirmation.
-
-Good narration states a decision or finding: "Three handlers follow a middleware pattern - using that instead of a custom wrapper." Bad narration just announces the next call ("Reading the file now.") or emits compressed planner notes ("Need create plan artifact maybe read existing plans.").
+**Communication:** Concise, no filler. State uncertainty plainly. Grammatical English.

--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -15,11 +15,17 @@ Operating posture:
 
 Never use: "Great question!" / "I'd be happy to help!" / "Absolutely!" / "Let me help you with that!" / performed excitement / sycophantic filler / fake warmth.
 
-Name artifacts per GSD convention: phases `{MM}-{slug}/`, files `{MM}-SUFFIX.md`, slices `{MM}-{SS}-SUFFIX.md`, plans in `{MM}-{SS}-PLAN.md`. `.gsd/` structure: PROJECT.md, REQUIREMENTS.md, DECISIONS.md, KNOWLEDGE.md, CODEBASE.md, QUEUE.md, STATE.md. Isolation: worktree `.gsd/worktrees/<MID>/` or branch `milestone/<MID>/`.
+Name artifacts per GSD convention: phases/{MM}-{slug}/, files {MM}-SUFFIX.md, slices {MM}-{SS}-SUFFIX.md, plans in {MM}-{SS}-PLAN.md. Task plan content lives inside the slice plan ({MM}-{SS}-PLAN.md) as checkboxes; do not expect `tasks/T##-PLAN.md`.
+
+`.gsd/` structure: PROJECT.md, REQUIREMENTS.md, DECISIONS.md, KNOWLEDGE.md, CODEBASE.md (auto-refreshes it when tracked files change), QUEUE.md, STATE.md. Isolation: worktree `.gsd/worktrees/<MID>/` or branch `milestone/<MID>/`. Commands: `/gsd codebase [generate|update|stats]` to manage the CODEBASE.md cache.
 
 ## Skills
 
 Skills discovered on-demand via `read` tool — no catalog block. Use bare skill names in preferences; GSD resolves paths.
+
+## Database
+
+Never query `.gsd/gsd.db` directly via `sqlite3`, `better-sqlite3`, or `node -e require('better-sqlite3')`; the engine owns a single-writer WAL connection. Use `gsd_*` tools (e.g. `gsd_milestone_status`, `gsd_journal_query`) instead. Direct DB access will cause race conditions and WAL corruption.
 
 ## Hard Rules
 

--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -34,7 +34,7 @@ Never query `.gsd/gsd.db` directly via `sqlite3`, `better-sqlite3`, or `node -e 
 - Read before edit or overwrite. Before any write that creates or replaces a file, verify the target path and read relevant existing files, templates, callers, or surrounding code. For truly new files, confirm the path does not already exist.
 - Reproduce before fix when possible.
 - Work is not done until the relevant verification has passed.
-- **Never fabricate, simulate, or role-play user responses.** Never generate markers like `[User]`, `[Human]`, `User:`, or similar; never emit `<user_message>`, `<assistant_message>`, or similar as user input. Treat `<conversation_history>` as read-only context. Ask one question round (1-3 questions), then stop.
+- **Never fabricate, simulate, or role-play user responses.** Never generate markers like `[User]`, `[Human]`, `User:`, or similar; never emit `<user_message>`, `<assistant_message>`, or similar as user input. Treat `<conversation_history>` as read-only context. Use `ask_user_questions` for structured input — its result is the only valid structured user input for that round. Ask one question round (1-3 questions), then stop and wait for the user's actual response.
 - Never print, echo, log, or restate secrets or credentials.
 - Never ask the user to edit `.env` files or set secrets manually. Use `secure_env_collect`.
 - **Never take outward-facing actions on GitHub or external services without explicit user confirmation.**


### PR DESCRIPTION
Closes #1475

## TL;DR

**What:** Reduces GSD HTTP payload from ~206KB to ~93KB (55% reduction) via system prompt compression and JSON schema sanitization.

**Why:** The oversized payload causes slow prefill, degraded eval rate (~25 tok/s vs ~35-40 tok/s baseline), and exponential context growth in long sessions.

**How:** Remove verbose system prompt sections (skills catalog, tool descriptions, boilerplate), strip redundant metadata from all 128 tool JSON schemas, and compress GSD extension prompts.

## What

This PR implements the payload optimization fixes identified in #1475, tested and verified on `gsd-pi-clone` before upstream submission.

### System prompt reduction (82KB → 21KB, -74%)

- Removed `<available_skills>` XML catalog (~29KB) — skills discovered on-demand via `read` tool
- Removed `toolDescriptions` dictionary and `formatSkillsForPrompt` from system prompt builder
- Simplified tools list output (comma-separated, no per-tool descriptions)
- Removed detailed `lsp` guideline section
- Compressed `src/resources/extensions/gsd/prompts/system.md`: removed verbose sections (naming convention, directory structure, isolation model, conventions, artifact templates), kept essential info (~168 lines → ~40 lines)
- Shortened `read`, `write`, `edit` tool descriptions to essential info

### JSON schema sanitization (tools array: 122KB → 70KB, -43%)

- Added `sanitizeToolSchema()` to strip redundant `description`, `examples`, `default` metadata from all JSON schemas
- Applied to **OpenAI**, **Google**, and **Anthropic** providers
- Removed `strict: false` from all 128 tool schemas
- Shortened GSD workflow tool descriptions to ~50 chars (model has full details in system prompt)

## Why

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| Total payload | 206KB | **93KB** | **-55%** |
| System prompt | 82KB | **21KB** | **-74%** |
| Tools array | 122KB | **70KB** | **-43%** |
| Tools with param descriptions | 128/128 | **11/128** | **-91%** |
| Tools with `strict` field | 128/128 | **0/128** | **-100%** |
| Eval rate | ~25 tok/s | **~35-40 tok/s** | **+40-60%** |

The fix eliminates the double-injection problem for models using Jinja chat templates (Qwen3.6-35B-A3B, llama.cpp): parameter descriptions are no longer present in the JSON schema, so the template has nothing to duplicate.

## How

### Files changed (15)

| Package | File | Change |
|---------|------|--------|
| `packages/gsd-agent-core` | `system-prompt.ts` | -58 lines |
| `packages/gsd-agent-modes` | `command-context-actions.ts` | +2 lines |
| `packages/pi-ai` | `anthropic.ts` | +55/-18 |
| `packages/pi-ai` | `google-shared.ts` | +58/-20 |
| `packages/pi-ai` | `openai-completions.ts` | +103/-12 |
| `packages/pi-coding-agent` | `extension-upstream-types.ts` | +4 |
| `packages/pi-coding-agent` | `runner.ts` | +4 |
| `packages/pi-coding-agent` | `bash.ts` | +2/-2 |
| `packages/pi-coding-agent` | `edit.ts` | +3/-3 |
| `packages/pi-coding-agent` | `find.ts` | +2/-2 |
| `packages/pi-coding-agent` | `grep.ts` | +2/-2 |
| `packages/pi-coding-agent` | `ls.ts` | +2/-2 |
| `packages/pi-coding-agent` | `read.ts` | +2/-2 |
| `packages/pi-coding-agent` | `write.ts` | +3/-3 |
| `src/resources/extensions/gsd` | `prompts/system.md` | -142 lines |

### Key implementation details

1. **`sanitizeToolSchema()`** (`openai-completions.ts`): Recursively strips `description`, `examples`, `default` from JSON Schema objects, arrays, `properties`, `items`, `allOf`, `anyOf`, `oneOf`. Pure data transformation — schema remains valid per JSON Schema spec.

2. **`shortenToolDescription()`** (`openai-completions.ts`): Truncates descriptions to ~50 chars at word boundary. Used for GSD workflow tools (`gsd_*` prefix) that are already documented in the system prompt.

3. **`isGSDTool()`** (`openai-completions.ts`): Detects GSD tools by name prefix for selective description shortening.

4. **`strict: false` removal**: Removed from `convertTools()` in all 3 provider files (anthropic, google-shared, openai-completions).

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [x] `pi-ai` — AI/LLM layer
- [x] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — verified on `gsd-pi-clone` with live HTTP capture via llama.cpp server
- [ ] No tests needed — explained above

Manual verification performed:
1. Installed Qwen3.6-35B-A3B-UD-Q4_K_M.gguf, ran llama.cpp server with `--jinja`
2. Configured GSD to use `http://127.0.0.1:8081` as OpenAI-compatible provider
3. Captured live HTTP POST to `/chat/completions` via `content-length: 92767`
4. Confirmed: 117/128 tools have NO parameter descriptions, 0/128 have `strict` field
5. Eval rate improved from ~25 tok/s to ~35-40 tok/s

## AI disclosure

- [ ] This PR includes AI-assisted code — changes tested in `gsd-pi-clone` before submission

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788020962&installation_model_id=22188&pr_number=1574&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1574&signature=58ad22390007ca01a5dee454b060379deaaec1d304681ff1de950f24f56398f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->