### PR TITLE
fix(cli): headless --bare kills the RPC child at startup — parseCliArgs rejects the forwarded flag

### DIFF
--- a/src/cli-web-branch.ts
+++ b/src/cli-web-branch.ts
@@ -20,6 +20,8 @@ export interface CliFlags {
   extensions: string[]
   appendSystemPrompt?: string
   tools?: string[]
+  /** --bare: minimal context — suppress CLAUDE.md/AGENTS.md, user skills, prompt templates, themes */
+  bare?: boolean
   messages: string[]
   web?: boolean
   /** Optional project path for web mode: `gsd --web <path>` or `gsd web start <path>` */
@@ -136,6 +138,10 @@ export function parseCliArgs(argv: string[]): CliFlags {
       flags.appendSystemPrompt = args[++i]
     } else if (arg === '--tools' && i + 1 < args.length) {
       flags.tools = args[++i].split(',')
+    } else if (arg === '--bare') {
+      // Forwarded by the headless orchestrator / MCP session manager to the
+      // spawned RPC child (`--mode rpc ... --bare`); must parse at top level.
+      flags.bare = true
     } else if (arg === '--list-models') {
       flags.listModels = (i + 1 < args.length && !args[i + 1].startsWith('-')) ? args[++i] : true
     } else if (!arg.startsWith('--') && !arg.startsWith('-')) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import type {
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { agentDir, sessionsDir, authFilePath } from './app-paths.js'
-import { initResources, buildResourceLoader, getNewerManagedResourceVersion } from './resource-loader.js'
+import { initResources, buildResourceLoader, bareResourceLoaderOptions, getNewerManagedResourceVersion } from './resource-loader.js'
 import { ensureManagedTools } from './tool-bootstrap.js'
 import { loadStoredEnvKeys } from './wizard.js'
 import { migratePiCredentials } from './pi-migration.js'
@@ -720,6 +720,8 @@ if (isPrintMode) {
     cwd: process.cwd(),
     additionalExtensionPaths: cliFlags.extensions.length > 0 ? cliFlags.extensions : undefined,
     appendSystemPrompt: appendSystemPrompt ? [appendSystemPrompt] : undefined,
+    // --bare (forwarded by headless/MCP to this RPC child): minimal context.
+    ...bareResourceLoaderOptions(cliFlags.bare),
   })
   await resourceLoader.reload()
   markStartup('resourceLoader.reload')
@@ -854,6 +856,7 @@ markStartup('initResources')
 // starting it early shaves ~50-200ms off interactive startup.
 const resourceLoader = await buildResourceLoader(agentDir, {
   additionalExtensionPaths: cliFlags.extensions.length > 0 ? cliFlags.extensions : undefined,
+  bare: cliFlags.bare,
 })
 const resourceLoadPromise = resourceLoader.reload()
 

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -870,8 +870,21 @@ function getBundledExtensionKeys(): Set<string> {
   return _bundledExtensionKeys
 }
 
+/**
+ * Resource-loader options for --bare mode: skip user skills, prompt templates,
+ * themes, and the CLAUDE.md/AGENTS.md ancestor walk. Single source of truth so
+ * the print-mode and interactive loader construction sites cannot drift.
+ */
+export function bareResourceLoaderOptions(bare: boolean | undefined): Record<string, unknown> {
+  return bare
+    ? { noSkills: true, noPromptTemplates: true, noThemes: true, noContextFiles: true }
+    : {}
+}
+
 interface BuildResourceLoaderOptions {
   additionalExtensionPaths?: string[]
+  /** --bare: minimal context (see bareResourceLoaderOptions) */
+  bare?: boolean
 }
 
 export async function buildResourceLoader(
@@ -891,6 +904,7 @@ export async function buildResourceLoader(
     cwd: process.cwd(),
     additionalExtensionPaths,
     bundledExtensionKeys: bundledKeys,
+    ...bareResourceLoaderOptions(options.bare),
     extensionPathsTransform: (paths: string[]) => {
       // 1. Filter community extensions through the GSD registry
       const filteredPaths = paths.filter((entryPath) => {

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -871,11 +871,23 @@ function getBundledExtensionKeys(): Set<string> {
 }
 
 /**
+ * The suppression subset of the loader's constructor options that --bare sets.
+ * Derived from the real option type so a key typo (or an upstream rename) fails
+ * typecheck instead of silently degrading --bare to a no-op.
+ */
+type BareResourceLoaderOptions = Partial<
+  Pick<
+    ConstructorParameters<typeof DefaultResourceLoaderType>[0],
+    'noSkills' | 'noPromptTemplates' | 'noThemes' | 'noContextFiles'
+  >
+>
+
+/**
  * Resource-loader options for --bare mode: skip user skills, prompt templates,
  * themes, and the CLAUDE.md/AGENTS.md ancestor walk. Single source of truth so
  * the print-mode and interactive loader construction sites cannot drift.
  */
-export function bareResourceLoaderOptions(bare: boolean | undefined): Record<string, unknown> {
+export function bareResourceLoaderOptions(bare: boolean | undefined): BareResourceLoaderOptions {
   return bare
     ? { noSkills: true, noPromptTemplates: true, noThemes: true, noContextFiles: true }
     : {}

--- a/src/tests/bare-resource-loader-options.test.ts
+++ b/src/tests/bare-resource-loader-options.test.ts
@@ -1,0 +1,23 @@
+// gsd-pi — Regression test: --bare maps to the resource-loader suppression options
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { bareResourceLoaderOptions } from '../resource-loader.ts'
+
+test('--bare suppresses skills, prompt templates, themes, and CLAUDE.md/AGENTS.md context files', () => {
+  // The RPC child spawned by `gsd headless --bare` builds its resource loader
+  // from these options. If this mapping is dropped, --bare degrades to a
+  // silent no-op (full context loaded) — worse than the startup crash it fixed.
+  assert.deepEqual(bareResourceLoaderOptions(true), {
+    noSkills: true,
+    noPromptTemplates: true,
+    noThemes: true,
+    noContextFiles: true,
+  })
+})
+
+test('without --bare the options are untouched', () => {
+  assert.deepEqual(bareResourceLoaderOptions(undefined), {})
+  assert.deepEqual(bareResourceLoaderOptions(false), {})
+})

--- a/src/tests/integration/e2e-smoke.test.ts
+++ b/src/tests/integration/e2e-smoke.test.ts
@@ -483,17 +483,21 @@ test("gsd --mode rpc --bare is not rejected at startup (headless --bare forwardi
   // top-level parseCliArgs rejected --bare, so every `gsd headless --bare ...`
   // child died at startup with "Unknown option: --bare" before RPC mode began.
   //
-  // A healthy RPC child serves stdin JSONL forever (it never exits on EOF), so
-  // timing out here means the child got past argument parsing and is starting
-  // or serving — that's the success case, and this test always spends its full
-  // budget. The regression exits within ~2s with the "Unknown option" marker,
-  // so the budget only needs to comfortably exceed cold parse-error startup.
+  // runGsd closes stdin immediately, so a child that accepted --bare either
+  // keeps serving until the budget expires (timedOut) or shuts down cleanly on
+  // EOF (exit 0). The regression instead threw out of parseCliArgs and exited
+  // nonzero within ~2s, so requiring "timed out or exit 0" pins that the child
+  // survived startup rather than merely failing for some other reason.
   const result = await runGsd(["--mode", "rpc", "--bare"], 15_000);
 
   const combined = stripAnsi(result.stdout + result.stderr);
   assert.ok(
     !combined.includes("Unknown option: --bare"),
     `RPC child rejected --bare at startup:\n${combined.slice(0, 500)}`,
+  );
+  assert.ok(
+    result.timedOut || result.code === 0,
+    `RPC child died at startup (exit ${result.code}):\n${combined.slice(0, 500)}`,
   );
 });
 

--- a/src/tests/integration/e2e-smoke.test.ts
+++ b/src/tests/integration/e2e-smoke.test.ts
@@ -477,6 +477,26 @@ test("gsd headless query returns JSON from the built CLI", async (t) => {
   assert.equal(typeof snapshot.state?.phase, "string", "query output should include state.phase");
 });
 
+test("gsd --mode rpc --bare is not rejected at startup (headless --bare forwarding argv)", async () => {
+  // headless.ts and the MCP/daemon session managers forward --bare to the
+  // spawned RPC child (`node cli.js --mode rpc ... --bare`). Regression: the
+  // top-level parseCliArgs rejected --bare, so every `gsd headless --bare ...`
+  // child died at startup with "Unknown option: --bare" before RPC mode began.
+  //
+  // A healthy RPC child serves stdin JSONL forever (it never exits on EOF), so
+  // timing out here means the child got past argument parsing and is starting
+  // or serving — that's the success case, and this test always spends its full
+  // budget. The regression exits within ~2s with the "Unknown option" marker,
+  // so the budget only needs to comfortably exceed cold parse-error startup.
+  const result = await runGsd(["--mode", "rpc", "--bare"], 15_000);
+
+  const combined = stripAnsi(result.stdout + result.stderr);
+  assert.ok(
+    !combined.includes("Unknown option: --bare"),
+    `RPC child rejected --bare at startup:\n${combined.slice(0, 500)}`,
+  );
+});
+
 test("gsd worktree list loads the built worktree CLI without module errors", async (t) => {
   const tmpDir = createTempGitRepo("gsd-e2e-worktree-");
 

--- a/src/tests/parse-cli-args.test.ts
+++ b/src/tests/parse-cli-args.test.ts
@@ -128,6 +128,18 @@ describe('parseCliArgs — short flags and basic options', () => {
     assert.deepEqual(flags.messages, ['headless', '--bare', 'auto'])
   })
 
+  test('--bare is accepted at top level (the RPC child argv from headless/MCP forwarding)', () => {
+    // headless.ts and the MCP/daemon session managers spawn the RPC child as
+    // `node cli.js --mode rpc ... --bare`; that argv hits this parser directly.
+    const flags = parse('--mode', 'rpc', '--thinking', 'medium', '--bare')
+    assert.equal(flags.bare, true)
+    assert.equal(flags.mode, 'rpc')
+  })
+
+  test('bare is undefined when --bare not passed', () => {
+    assert.equal(parse('-p').bare, undefined)
+  })
+
   test('`auto` does not pass through: --model/--thinking are parsed so buildHeadlessAutoArgs can reorder them', () => {
     const flags = parse('auto', '--model', 'test-model', '--thinking', 'medium')
     assert.deepEqual(flags.messages, ['auto'])


### PR DESCRIPTION
## Linked issue

Closes #1576

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Accept `--bare` in the top-level CLI parser and wire it to the resource-loader suppressions.
**Why:** `gsd headless --bare ...` spawns an RPC child with `--mode rpc ... --bare`, and `parseCliArgs` rejected the flag — every bare child died at startup with `Unknown option: --bare`.
**How:** `bare?: boolean` on `CliFlags` + a shared `bareResourceLoaderOptions()` helper applied at both loader construction sites in `src/cli.ts`.

## What

- `src/cli-web-branch.ts`: `parseCliArgs` accepts `--bare` (`bare?: boolean` on `CliFlags`).
- `src/resource-loader.ts`: new exported `bareResourceLoaderOptions()` — `noSkills`, `noPromptTemplates`, `noThemes`, `noContextFiles` — single source of truth for bare semantics; `buildResourceLoader` gains a `bare` option.
- `src/cli.ts`: spreads the helper into the print/RPC-mode `DefaultResourceLoader` (the path the headless/MCP child takes) and passes `bare` through `buildResourceLoader` on the interactive path, so `gsd --bare` is not accepted-and-silently-ignored.
- Tests: parser unit tests (exact forwarded child argv), a unit test pinning the bare→loader option mapping, and an e2e smoke test asserting the RPC child is not rejected at startup.

## Why

The headless orchestrator (`src/headless.ts:469`) and the MCP/daemon session managers forward `--bare` to the spawned RPC child; `RpcClient.start()` spawns `node <cliPath> --mode rpc ...args`. The top-level parser had no `--bare` case, so the child exited 1 immediately — the documented `gsd headless --bare` flow (`src/help-text.ts:183`) was fully broken.

## How

The child argv is a real CLI contract (`--model`/`--thinking` already travel the same channel), so the fix is at the parser, not the spawn site. For the loader wiring I used the loader's built-in `noContextFiles` rather than mirroring `agentsFilesOverride: () => ({ agentsFiles: [] })` from `@gsd/agent-modes` `main.ts`: the override runs after `loadProjectContextFiles()`, so it would still pay the full CLAUDE.md/AGENTS.md ancestor walk and discard the result; `noContextFiles` skips the I/O entirely with identical output. Latent note: `RpcClient` can also emit `--provider`, which `parseCliArgs` would likewise reject, but no in-repo caller sets `provider` today — left out of scope.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

Manual verification: `node dist/cli.js --mode rpc --bare </dev/null` previously printed `[gsd] Error: Unknown option: --bare` and exited 1; after the fix the child proceeds into startup (and unknown flags like `--bogusflag` still fail loudly). Unit suites: 47/47 pass compiled; e2e smoke test passes in ~17s.

## AI disclosure

- [ ] This PR includes AI-assisted code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->