### PR TITLE
fix(cursor-cli): exclude prompt echoes and thinking from assistant output

### DIFF
--- a/src/resources/extensions/cursor-cli/stream-adapter.ts
+++ b/src/resources/extensions/cursor-cli/stream-adapter.ts
@@ -258,8 +258,9 @@ export function parseCursorAgentLine(line: string): ParsedCursorAgentLine {
 	// cursor-agent echoes the composed prompt back as a `user` event and streams
 	// reasoning as top-level `thinking` events; neither is assistant text, but both
 	// carry text reachable by the generic fallback below.
-	// ponytail: thinking deltas dropped; surfacing real thinking_delta events would require
-	// reworking this adapter's content-index state machine (text is pinned to contentIndex 0)
+	// Thinking is dropped rather than re-emitted as `thinking_*` events: this adapter pins all
+	// text to contentIndex 0, so emitting reasoning as its own content block would require
+	// reworking the content-index state machine. Dropping keeps assistant text correct today.
 	if (type === "user" || type === "thinking") return { type: "ignore" };
 	const message = objectValue(event.message);
 	const role = stringValue(message?.role);

--- a/src/resources/extensions/cursor-cli/stream-adapter.ts
+++ b/src/resources/extensions/cursor-cli/stream-adapter.ts
@@ -255,6 +255,16 @@ export function parseCursorAgentLine(line: string): ParsedCursorAgentLine {
 		return { type: "error", message: stringValue(event.message, event.error) ?? "cursor_agent_error" };
 	}
 
+	// cursor-agent echoes the composed prompt back as a `user` event and streams
+	// reasoning as top-level `thinking` events; neither is assistant text, but both
+	// carry text reachable by the generic fallback below.
+	// ponytail: thinking deltas dropped; surfacing real thinking_delta events would require
+	// reworking this adapter's content-index state machine (text is pinned to contentIndex 0)
+	if (type === "user" || type === "thinking") return { type: "ignore" };
+	const message = objectValue(event.message);
+	const role = stringValue(message?.role);
+	if (role && role !== "assistant") return { type: "ignore" };
+
 	if (type === "tool_call") {
 		if (event.call_id || event.subtype || event.tool_call) return { type: "ignore" };
 
@@ -279,7 +289,7 @@ export function parseCursorAgentLine(line: string): ParsedCursorAgentLine {
 		return usage ? { type: "usage", usage: mapUsage(usage) } : { type: "ignore" };
 	}
 
-	const text = extractText(event.delta ?? event.text ?? event.content ?? objectValue(event.message)?.content ?? event.message);
+	const text = extractText(event.delta ?? event.text ?? event.content ?? message?.content ?? event.message);
 	if (text) return { type: "text", text };
 
 	const usage = objectValue(event.usage);

--- a/src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts
@@ -69,6 +69,53 @@ test("parseCursorAgentLine maps text, legacy tool, result, usage, and errors", (
 	assert.deepEqual(parseCursorAgentLine('{"type":"error","message":"boom"}'), { type: "error", message: "boom" });
 });
 
+test("parseCursorAgentLine ignores the echoed prompt and thinking events (not assistant text)", () => {
+	// Real shapes captured from cursor-agent 2026.07.23 stream-json output.
+	const promptEcho =
+		'{"type":"user","message":{"role":"user","content":[{"type":"text","text":"System instructions:\\nYou are an expert coding assistant."}]},"session_id":"s1"}';
+	assert.deepEqual(parseCursorAgentLine(promptEcho), { type: "ignore" });
+
+	assert.deepEqual(
+		parseCursorAgentLine('{"type":"thinking","subtype":"delta","text":"The user requested","session_id":"s1"}'),
+		{ type: "ignore" },
+	);
+	assert.deepEqual(
+		parseCursorAgentLine('{"type":"thinking","subtype":"completed","session_id":"s1"}'),
+		{ type: "ignore" },
+	);
+
+	// Role-tagged non-assistant message events must not leak either, whatever the type label.
+	assert.deepEqual(
+		parseCursorAgentLine('{"type":"message","message":{"role":"user","content":[{"type":"text","text":"echo"}]}}'),
+		{ type: "ignore" },
+	);
+});
+
+test("streamViaCursorAgent does not prepend the prompt echo to assistant text", async () => {
+	const lines = [
+		'{"type":"system","subtype":"init","session_id":"s1","model":"Composer 2.5"}',
+		'{"type":"user","message":{"role":"user","content":[{"type":"text","text":"System instructions:\\nYou are an expert coding assistant.\\n\\nUser:\\nSay hi."}]},"session_id":"s1"}',
+		'{"type":"thinking","subtype":"delta","text":"The user requested a reply.","session_id":"s1"}',
+		'{"type":"thinking","subtype":"completed","session_id":"s1"}',
+		'{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"session_id":"s1"}',
+		'{"type":"result","subtype":"success","is_error":false,"result":"hi","session_id":"s1","usage":{"inputTokens":3,"outputTokens":4}}',
+	];
+	const stream = streamViaCursorAgent(model, context, {
+		_cursorAgentRunnerForTest: async () => ({ stdout: `${lines.join("\n")}\n`, stderr: "", code: 0, signal: null }),
+	});
+
+	const events = [];
+	for await (const event of stream) events.push(event);
+
+	const deltas = events.filter((event) => event.type === "text_delta").map((event) => event.delta);
+	assert.deepEqual(deltas, ["hi"], "only assistant text may stream as text_delta");
+
+	const done = events.find((event) => event.type === "done");
+	assert.ok(done && done.type === "done");
+	assert.equal(done.message.content[0].type, "text");
+	assert.equal(done.message.content[0].text, "hi");
+});
+
 test("parseCursorAgentLine ignores Cursor-owned nested tool events so GSD does not redispatch them", () => {
 	const started = parseCursorAgentLine(
 		'{"type":"tool_call","subtype":"started","call_id":"tool_1","tool_call":{"readToolCall":{"args":{"path":"a.ts"}}}}',

--- a/src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import type { Context, Model } from "@gsd/pi-ai";
+import type { Context, Message, Model } from "@gsd/pi-ai";
+import { agentLoop } from "@gsd/pi-agent-core";
+import type { AgentEvent, AgentMessage } from "@gsd/pi-agent-core";
 import {
 	buildCursorAgentRunPlan,
 	buildCursorPrompt,
@@ -114,6 +116,65 @@ test("streamViaCursorAgent does not prepend the prompt echo to assistant text", 
 	assert.ok(done && done.type === "done");
 	assert.equal(done.message.content[0].type, "text");
 	assert.equal(done.message.content[0].text, "hi");
+});
+
+test("RPC v2 message_update/message_end expose only assistant text from cursor-agent", async () => {
+	// Drives the real agent loop, which is the producer of the RPC v2 protocol events the
+	// bug report observed: streamed `message_update.assistantMessageEvent.text_delta` and the
+	// final `message_end.message.content`.
+	const lines = [
+		'{"type":"system","subtype":"init","session_id":"s1","model":"Composer 2.5"}',
+		'{"type":"user","message":{"role":"user","content":[{"type":"text","text":"System instructions:\\nBe concise.\\n\\nUser:\\nSay hi."}]},"session_id":"s1"}',
+		'{"type":"thinking","subtype":"delta","text":"The user requested a reply.","session_id":"s1"}',
+		'{"type":"thinking","subtype":"completed","session_id":"s1"}',
+		'{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"session_id":"s1"}',
+		'{"type":"result","subtype":"success","is_error":false,"result":"hi","session_id":"s1","usage":{"input_tokens":3,"output_tokens":4}}',
+	];
+	const prompt: AgentMessage = { role: "user", content: "Say hi.", timestamp: Date.now() };
+	const stream = agentLoop(
+		[prompt],
+		{ systemPrompt: "Be concise.", messages: [] },
+		{ model, convertToLlm: (messages) => messages as Message[] },
+		undefined,
+		(_model, llmContext) =>
+			streamViaCursorAgent(model, llmContext, {
+				_cursorAgentRunnerForTest: async () => ({
+					stdout: `${lines.join("\n")}\n`,
+					stderr: "",
+					code: 0,
+					signal: null,
+				}),
+			}),
+	);
+
+	const events: AgentEvent[] = [];
+	for await (const event of stream) events.push(event);
+
+	const updates = events.filter(
+		(event): event is Extract<AgentEvent, { type: "message_update" }> => event.type === "message_update",
+	);
+	const deltas = updates
+		.map((event) => event.assistantMessageEvent)
+		.filter((ame) => ame.type === "text_delta")
+		.map((ame) => (ame as { delta: string }).delta);
+	assert.deepEqual(deltas, ["hi"], "message_update text_delta must carry only assistant text");
+	assert.ok(
+		!updates.some((event) => event.assistantMessageEvent.type.startsWith("thinking")),
+		"cursor-agent thinking events must not surface as RPC v2 reasoning deltas",
+	);
+
+	const assistantEnd = events
+		.filter((event): event is Extract<AgentEvent, { type: "message_end" }> => event.type === "message_end")
+		.find((event) => event.message.role === "assistant");
+	assert.ok(assistantEnd, "expected a final assistant message_end");
+	const finalMessage = assistantEnd.message;
+	const finalText = finalMessage.role !== "assistant"
+		? ""
+		: finalMessage.content
+			.filter((block) => block.type === "text")
+			.map((block) => (block as { text: string }).text)
+			.join("");
+	assert.equal(finalText, "hi", "message_end content must carry only assistant text");
 });
 
 test("parseCursorAgentLine ignores Cursor-owned nested tool events so GSD does not redispatch them", () => {


### PR DESCRIPTION
## Intent

The developer wanted the cursor-agent stream-json adapter in gsd-pi fixed so echoed composed prompts and reasoning events are not misclassified as assistant output in RPC protocol v2. They required reproducing the issue, locating the bridge under packages, correcting event classification, and adding regression coverage that verifies both text_delta and final message_end contain only the actual assistant reply. They then asked to push all completed work, including following the repository’s contribution and validation process through review, tests, PR creation, and green CI. The change should remain focused on text classification; the separately noticed camelCase token-usage mapping issue was out of scope.

## What Changed

- Ignore Cursor prompt echoes, thinking events, and role-tagged non-assistant messages before generic text extraction.
- Add regression coverage confirming streamed deltas and the final response contain only actual assistant text.

## Risk Assessment

⚠️ Medium: The implementation is focused and appears correct, but the requested RPC v2 protocol-boundary regression coverage is missing, leaving the observed end-to-end behavior unprotected.

## Testing

No external baseline results were supplied. After repairing fresh-worktree dependency and build prerequisites, the focused regression and complete Cursor extension tests passed; a real RPC v2 CLI run demonstrated that echoed composed prompts and thinking events are omitted while both streaming and final assistant output contain only the actual reply. Reviewer-visible JSON evidence was captured and transient worktree artifacts were removed.

<details>
<summary>Evidence: Focused RPC v2 assistant evidence</summary>

<code>Protocol v2 evidence showing the injected prompt echo and thinking events were excluded; `text_delta` and assistant `message_end` contain only “Hello from Cursor”.</code>

```text
{
  "protocolVersion": 2,
  "runId": "ed46cd9b-599a-4f37-84a1-cf07bb31ab2b",
  "injectedCursorEventTypes": [
    "system",
    "user (composed prompt echo)",
    "thinking delta",
    "thinking completed",
    "assistant",
    "result"
  ],
  "observedRpcAssistantEvents": [
    {
      "type": "message_update",
      "assistantMessageEvent": {
        "type": "text_delta",
        "delta": "Hello from Cursor"
      }
    },
    {
      "type": "message_end",
      "message": {
        "role": "assistant",
        "content": [
          {
            "type": "text",
            "text": "Hello from Cursor"
          }
        ]
      }
    }
  ],
  "excludedFromRpcOutput": [
    "composed prompt echo",
    "thinking delta"
  ]
}
```
</details>
<details>
<summary>Evidence: Full CLI RPC v2 JSONL transcript</summary>

```text
{"type":"extensions_ready"}
{"id":"init-1","type":"response","command":"init","success":true,"data":{"protocolVersion":2,"sessionId":"019fb53b-7264-755b-900f-c5e19c57918a","capabilities":{"events":["execution_complete","cost_update"],"commands":["init","shutdown","subscribe"]}}}
{"id":"prompt-1","type":"response","command":"prompt","success":true,"runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"agent_start","runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"turn_start","runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"Say hello."}],"timestamp":1785452011505},"runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"Say hello."}],"timestamp":1785452011505},"runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"message_start","message":{"role":"assistant","content":[],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011566},"runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"message_update","assistantMessageEvent":{"type":"text_start","contentIndex":0,"partial":{"role":"assistant","content":[],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011566}},"message":{"role":"assistant","content":[],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011566},"runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Hello from Cursor","partial":{"role":"assistant","content":[{"type":"text","text":"Hello from Cursor"}],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011566}},"message":{"role":"assistant","content":[{"type":"text","text":"Hello from Cursor"}],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011566},"runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":0,"content":"Hello from Cursor","partial":{"role":"assistant","content":[{"type":"text","text":"Hello from Cursor"}],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0,"totalTokens":7,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011569}},"message":{"role":"assistant","content":[{"type":"text","text":"Hello from Cursor"}],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0,"totalTokens":7,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011569},"runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"cost_update","runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b","turnCost":0,"cumulativeCost":0,"tokens":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0}}
{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"Hello from Cursor"}],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0,"totalTokens":7,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011569},"runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"Hello from Cursor"}],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0,"totalTokens":7,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011569},"toolResults":[],"runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b"}
{"type":"execution_complete","runId":"ed46cd9b-599a-4f37-84a1-cf07bb31ab2b","status":"completed","stats":{"sessionId":"019fb53b-7264-755b-900f-c5e19c57918a","userMessages":1,"assistantMessages":1,"toolCalls":0,"toolResults":0,"totalMessages":2,"tokens":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0,"total":7},"cost":0,"contextUsage":{"tokens":3,"contextWindow":1000000,"percent":0.00030000000000000003}}}
{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"Say hello."}],"timestamp":1785452011505},{"role":"assistant","content":[{"type":"text","text":"Hello from Cursor"}],"api":"cursor-stream-json","provider":"cursor-agent","model":"composer-2.5","usage":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0,"totalTokens":7,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785452011569}],"willRetry":false}
{"id":"shutdown-1","type":"response","command":"shutdown","success":true}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts:113` - The regression test verifies the provider-level `done` event, not the RPC v2 `message_end` where the bug was observed. Add a narrow agent-loop/RPC v2 assertion covering both `message_update.assistantMessageEvent.delta` and `message_end.message.content`.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --frozen-lockfile --ignore-scripts` (remediated the initially missing TypeScript test dependency)</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts`
- <code>`node scripts/ensure-workspace-builds.cjs` and `pnpm --filter @gsd/pi-coding-agent run build` (prepared the fresh worktree for CLI execution)</code>
- <code>Real CLI RPC v2 exchange using `src/loader.ts --mode rpc --model cursor-agent/composer-2.5 --no-session` with a deterministic Cursor fixture emitting system, composed-prompt echo, thinking, assistant, and result events</code>
- <code>Evidence assertion over `rpc-v2-full.jsonl` verifying protocol v2, matching run IDs, only `Hello from Cursor` in assistant `text_delta` and `message_end`, and no prompt/reasoning leakage</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/cursor-cli/tests/*.test.ts`
- <code>`git status --short --untracked-files=all` after removing generated `node_modules` and package `dist` directories</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->