### PR TITLE
fix(issue): [Bug]: prompt-golden-fixtures Phase 2 reduction gate fails on macOS — prompt size is fixture-path-length sensitive

### DIFF
--- a/src/tests/prompt-golden-fixtures.test.ts
+++ b/src/tests/prompt-golden-fixtures.test.ts
@@ -3,7 +3,7 @@
 
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -49,7 +49,7 @@ test("prompt golden fixtures meet Phase 2 reduction gate", async (t) => {
   let baselineChars = 0;
   let currentChars = 0;
   for (const fixture of promptGoldenUnits) {
-    const chars = prompts[fixture.unitType].length;
+    const chars = normalizeFixtureRoot(prompts[fixture.unitType], base).length;
     baselineChars += fixture.phase2StartChars;
     currentChars += chars;
     assert.ok(
@@ -80,6 +80,20 @@ function promptMetric(prompt: string): { chars: number; bytes: number; lines: nu
     lines: prompt.length === 0 ? 0 : prompt.split(/\r\n|\r|\n/).length,
     sha256: createHash("sha256").update(prompt).digest("hex"),
   };
+}
+
+// The rendered prompts embed the fixture root's absolute path, whose length is
+// platform-dependent (Linux `/tmp/...` vs macOS `/var/folders/<hash>/T/...`).
+// Collapse it to a fixed token so the size gate measures prompt content only.
+const FIXTURE_ROOT_TOKEN = "/gsd-fixture-root";
+
+function normalizeFixtureRoot(prompt: string, base: string): string {
+  const roots = new Set([base, realpathSync(base)]);
+  let normalized = prompt;
+  for (const root of roots) {
+    normalized = normalized.split(root).join(FIXTURE_ROOT_TOKEN);
+  }
+  return normalized;
 }
 
 async function loadPromptBuilders(base: string): Promise<{

--- a/src/tests/prompt-golden-fixtures.test.ts
+++ b/src/tests/prompt-golden-fixtures.test.ts
@@ -84,14 +84,14 @@ function promptMetric(prompt: string): { chars: number; bytes: number; lines: nu
 
 // The rendered prompts embed the fixture root's absolute path, whose length is
 // platform-dependent (Linux `/tmp/...` vs macOS `/var/folders/<hash>/T/...`).
-// Collapse it to a fixed token so the size gate measures prompt content only.
-const FIXTURE_ROOT_TOKEN = "/gsd-fixture-root";
+// Collapse it to a fixed placeholder so the size gate measures prompt content only.
+const FIXTURE_ROOT_PLACEHOLDER = "/gsd-fixture-root";
 
 function normalizeFixtureRoot(prompt: string, base: string): string {
   const roots = new Set([base, realpathSync(base)]);
   let normalized = prompt;
   for (const root of roots) {
-    normalized = normalized.split(root).join(FIXTURE_ROOT_TOKEN);
+    normalized = normalized.split(root).join(FIXTURE_ROOT_PLACEHOLDER);
   }
   return normalized;
 }


### PR DESCRIPTION
## Summary
- Normalized the temp fixture root path out of the measured prompt in prompt-golden-fixtures.test.ts so the Phase 2 size gate is path-length independent; verified it fails before and passes after on macOS.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1583
- [#1583 [Bug]: prompt-golden-fixtures Phase 2 reduction gate fails on macOS — prompt size is fixture-path-length sensitive](https://github.com/open-gsd/gsd-pi/issues/1583)

## User
- @jeremymcs

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1583-bug-prompt-golden-fixtures-phase-2-reduc-1785807613`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->