### PR TITLE
fix(issue): [Bug]: SOURCE_PATHSPEC hardcodes literal ".gsd/**", never excludes tracked GSD bookkeeping files when .gsd is a symlink (always true) — causes stuck-loop on first execute-task verdict replay

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-source-integrity.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-source-integrity.test.ts
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, test } from "node:test";
 
 import {
@@ -206,4 +206,17 @@ test("tracked bookkeeping under a symlinked .gsd does not change the tested sour
   const after = capture([{ id: "root", cwd }]);
 
   assert.equal(after.aggregateRevision, before.aggregateRevision);
+});
+
+test("a .gsd symlink resolving to the repository parent still produces a source proof", () => {
+  const cwd = createRepository("parent-symlinked-state");
+  // `relative()` yields exactly ".." here — without treating that as outside-repo
+  // the pathspec would become `:(exclude)..` and git would reject the command.
+  symlinkSync(dirname(cwd), join(cwd, ".gsd"), "dir");
+
+  const before = capture([{ id: "root", cwd }]);
+  writeFileSync(join(cwd, "tracked.txt"), "changed\n");
+  const after = capture([{ id: "root", cwd }]);
+
+  assert.notEqual(after.aggregateRevision, before.aggregateRevision);
 });

--- a/src/resources/extensions/gsd/tests/verification-source-integrity.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-source-integrity.test.ts
@@ -3,7 +3,7 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
@@ -186,6 +186,23 @@ test("workflow state under .gsd does not change the tested source revision", () 
 
   writeFileSync(join(cwd, ".gsd", "state.json"), "{\"revision\":2}\n");
   writeFileSync(join(cwd, ".gsd", "projection.md"), "generated\n");
+  const after = capture([{ id: "root", cwd }]);
+
+  assert.equal(after.aggregateRevision, before.aggregateRevision);
+});
+
+test("tracked bookkeeping under a symlinked .gsd does not change the tested source revision", () => {
+  const cwd = createRepository("symlinked-state");
+  const stateDir = join(cwd, ".gsd-state", "projects", "abc123");
+  mkdirSync(stateDir, { recursive: true });
+  symlinkSync(stateDir, join(cwd, ".gsd"), "dir");
+  writeFileSync(join(stateDir, "CODEBASE.md"), "# codebase\n");
+  git(cwd, ["add", "-f", ".gsd-state/projects/abc123/CODEBASE.md"]);
+  git(cwd, ["commit", "-qm", "durable bookkeeping"]);
+  const before = capture([{ id: "root", cwd }]);
+
+  writeFileSync(join(cwd, ".gsd", "CODEBASE.md"), "# codebase (regenerated)\n");
+  writeFileSync(join(cwd, ".gsd", "S01-T01-VERIFY.json"), "{\"verdict\":\"pass\"}\n");
   const after = capture([{ id: "root", cwd }]);
 
   assert.equal(after.aggregateRevision, before.aggregateRevision);

--- a/src/resources/extensions/gsd/verification-source-integrity.ts
+++ b/src/resources/extensions/gsd/verification-source-integrity.ts
@@ -68,7 +68,7 @@ function gsdBookkeepingExclusions(cwd: string): string[] {
     return [];
   }
   const rel = relative(repoRoot, gsdTarget).replaceAll("\\", "/");
-  if (!rel || rel === ".gsd" || rel.startsWith("../") || isAbsolute(rel)) return [];
+  if (!rel || rel === ".gsd" || rel === ".." || rel.startsWith("../") || isAbsolute(rel)) return [];
   return [`:(exclude)${rel}`, `:(exclude)${rel}/**`];
 }
 

--- a/src/resources/extensions/gsd/verification-source-integrity.ts
+++ b/src/resources/extensions/gsd/verification-source-integrity.ts
@@ -3,8 +3,8 @@
 
 import { createHash, type Hash } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { closeSync, lstatSync, openSync, readSync, readlinkSync } from "node:fs";
-import { join } from "node:path";
+import { closeSync, lstatSync, openSync, readSync, readlinkSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
 import type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 import type { GSDPreferences } from "./preferences-types.js";
 import {
@@ -47,6 +47,30 @@ export interface VerificationSourceSnapshotOptions {
 }
 
 const SOURCE_PATHSPEC = ["--", ".", ":(exclude).gsd/**"];
+
+/**
+ * Git pathspecs match tracked path names, not symlink targets. In a GSD-managed
+ * project `.gsd` is always a symlink to the real per-project state directory, so
+ * the literal `:(exclude).gsd/**` above never matches the bookkeeping files —
+ * git indexes them under the symlink's real path. When that real path lives
+ * inside the repository (the documented layout for committing durable audit
+ * artifacts), GSD rewriting its own SUMMARY/VERIFY/CODEBASE files would
+ * otherwise change the source hash and invalidate a just-recorded pass verdict
+ * on replay, producing a stuck retry loop (#1590).
+ */
+function gsdBookkeepingExclusions(cwd: string): string[] {
+  let repoRoot: string;
+  let gsdTarget: string;
+  try {
+    repoRoot = realpathSync(cwd);
+    gsdTarget = realpathSync(join(cwd, ".gsd"));
+  } catch {
+    return [];
+  }
+  const rel = relative(repoRoot, gsdTarget).replaceAll("\\", "/");
+  if (!rel || rel === ".gsd" || rel.startsWith("../") || isAbsolute(rel)) return [];
+  return [`:(exclude)${rel}`, `:(exclude)${rel}/**`];
+}
 
 export function resolveVerificationRepositoryTargets(
   basePath: string,
@@ -133,6 +157,7 @@ function sourcePaths(cwd: string, options: VerificationSourceSnapshotOptions): s
     "--exclude-standard",
     "-z",
     ...SOURCE_PATHSPEC,
+    ...gsdBookkeepingExclusions(cwd),
     ...exclusions,
   ])
     .toString("utf8")
@@ -170,6 +195,7 @@ function addSubmoduleRevision(hash: Hash, cwd: string, path: string): void {
     "--",
     ".",
     ":(exclude).gsd/**",
+    ...gsdBookkeepingExclusions(absolutePath),
   ]).length > 0;
   if (dirty) throw new Error(`verification source submodule has unpublished changes: ${path}`);
   addHashField(hash, "source-repository", entry.objectId);


### PR DESCRIPTION
## Summary
- Resolved the `.gsd` symlink to its real path when building the verification-source git pathspec so tracked GSD bookkeeping files are actually excluded; verified with a new regression test that fails before the fix and passes after.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1590
- [#1590 [Bug]: SOURCE_PATHSPEC hardcodes literal ".gsd/**", never excludes tracked GSD bookkeeping files when .gsd is a symlink (always true) — causes stuck-loop on first execute-task verdict replay](https://github.com/open-gsd/gsd-pi/issues/1590)

## User
- @efrembaraldo

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1590-bug-source-pathspec-hardcodes-literal-gs-1785808699`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->