### PR TITLE
fix(issue): v1.12.0: passing gsd_task_complete verificationEvidence is not considered before blocking project-wide verification_commands

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -20,7 +20,7 @@ import { resolveMilestoneValidationVerdict } from "./milestone-validation-verdic
 import { isMilestoneLifecycleAdopted } from "./db/milestone-closeout-readiness.js";
 import { hasPendingMilestoneSubjectiveUat } from "./milestone-subjective-uat-domain-operation.js";
 import { parseUnitId } from "./unit-id.js";
-import { isDbAvailable, getTask, getSliceTasks, getMilestoneSlices } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSliceTasks, getMilestoneSlices, getTaskVerificationEvidence } from "./gsd-db.js";
 import type { TaskRow } from "./db-task-slice-rows.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import type { GSDPreferences } from "./preferences-types.js";
@@ -33,7 +33,7 @@ import {
   captureRuntimeErrors,
   runDependencyAudit,
 } from "./verification-gate.js";
-import type { VerificationTarget } from "./verification-gate.js";
+import type { VerificationTarget, TaskVerificationEvidence } from "./verification-gate.js";
 import { writeVerificationJSON, type PostExecutionCheckJSON, type EvidenceJSON } from "./verification-evidence.js";
 import { logWarning } from "./workflow-logger.js";
 import { runPostExecutionChecks, type PostExecutionResult } from "./post-execution-checks.js";
@@ -697,11 +697,14 @@ export async function runPostUnitVerification(
     let taskPlanVerify: string | undefined;
     let taskRow: TaskRow | null = null;
     let sliceRow: SliceRow | null = null;
+    // Structured evidence staged by gsd_task_complete for this Task (#1591).
+    let taskEvidence: TaskVerificationEvidence[] = [];
     if (mid && sid && tid) {
       if (isDbAvailable()) {
         taskRow = getTask(mid, sid, tid);
         sliceRow = getSlice(mid, sid);
         taskPlanVerify = taskRow?.verify;
+        taskEvidence = getTaskVerificationEvidence(mid, sid, tid);
       }
       // When DB unavailable, taskPlanVerify stays undefined — gate runs without task-specific checks
     }
@@ -779,12 +782,14 @@ export async function runPostUnitVerification(
         cwd: verificationTargets[0]?.cwd ?? s.basePath,
         preferenceCommands: prefs?.verification_commands ?? verificationTargets[0]?.preferenceCommands,
         taskPlanVerify,
+        taskEvidence,
       });
     } else {
       result = runVerificationGateForTargets({
         targets: verificationTargets,
         preferenceCommands: prefs?.verification_commands,
         taskPlanVerify,
+        taskEvidence,
       });
     }
 

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1135,15 +1135,32 @@ export function saveReworkBrief(entry: {
 }
 
 /**
+ * Exit code substituted when a `verification_evidence` row carries a NULL or
+ * non-numeric `exit_code`. Non-zero so unknown exit codes can never be read as
+ * a success by the verification gate (#1591).
+ */
+const UNKNOWN_VERIFICATION_EXIT_CODE = 1;
+
+/** Coerce a raw SQLite column value to a finite number, else `undefined`. */
+function toFiniteNumber(raw: unknown): number | undefined {
+  if (raw === null || raw === undefined || raw === "") return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+/**
  * Read the structured verification evidence staged for a Task by
- * `gsd_task_complete` (#1591). Used by host verification to decide whether
- * task-specific evidence already satisfies an artifact-only Task.
+ * `gsd_task_complete` (#1591). Host verification consumes this for any Task:
+ * the gate only lets it short-circuit command discovery when the Task's plan
+ * `verify` is prose and every evidence record reports a passing verdict with a
+ * zero exit code. Rows with a NULL or non-numeric `exit_code` are reported as
+ * `UNKNOWN_VERIFICATION_EXIT_CODE` so they cannot qualify as passing.
  */
 export function getTaskVerificationEvidence(
   milestoneId: string,
   sliceId: string,
   taskId: string,
-): Array<{ command: string; exitCode: number; verdict: string; durationMs: number }> {
+): Array<{ command: string; exitCode: number; verdict: string; durationMs?: number }> {
   if (!getDbOrNull()!) return [];
   const rows = getDbOrNull()!.prepare(
     `SELECT command, exit_code, verdict, duration_ms
@@ -1151,12 +1168,15 @@ export function getTaskVerificationEvidence(
      WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid
      ORDER BY id`,
   ).all({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId }) as Array<Record<string, unknown>>;
-  return rows.map((row) => ({
-    command: String(row.command ?? ""),
-    exitCode: Number(row.exit_code ?? 0),
-    verdict: String(row.verdict ?? ""),
-    durationMs: Number(row.duration_ms ?? 0),
-  }));
+  return rows.map((row) => {
+    const durationMs = toFiniteNumber(row.duration_ms);
+    return {
+      command: String(row.command ?? ""),
+      exitCode: toFiniteNumber(row.exit_code) ?? UNKNOWN_VERIFICATION_EXIT_CODE,
+      verdict: String(row.verdict ?? ""),
+      ...(durationMs !== undefined ? { durationMs } : {}),
+    };
+  });
 }
 
 export function getBlockingReworkFindingsForTask(

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1134,6 +1134,31 @@ export function saveReworkBrief(entry: {
   return { briefId };
 }
 
+/**
+ * Read the structured verification evidence staged for a Task by
+ * `gsd_task_complete` (#1591). Used by host verification to decide whether
+ * task-specific evidence already satisfies an artifact-only Task.
+ */
+export function getTaskVerificationEvidence(
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+): Array<{ command: string; exitCode: number; verdict: string; durationMs: number }> {
+  if (!getDbOrNull()!) return [];
+  const rows = getDbOrNull()!.prepare(
+    `SELECT command, exit_code, verdict, duration_ms
+     FROM verification_evidence
+     WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid
+     ORDER BY id`,
+  ).all({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId }) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    command: String(row.command ?? ""),
+    exitCode: Number(row.exit_code ?? 0),
+    verdict: String(row.verdict ?? ""),
+    durationMs: Number(row.duration_ms ?? 0),
+  }));
+}
+
 export function getBlockingReworkFindingsForTask(
   milestoneId: string,
   sliceId: string,

--- a/src/resources/extensions/gsd/tests/task-verification-evidence-exit-code.test.ts
+++ b/src/resources/extensions/gsd/tests/task-verification-evidence-exit-code.test.ts
@@ -1,0 +1,131 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests that getTaskVerificationEvidence never reports an
+// unknown (NULL / non-numeric) exit_code as a passing zero (#1591).
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  openDatabase,
+  closeDatabase,
+  isDbAvailable,
+  transaction,
+  _getAdapter,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  insertVerificationEvidence,
+  getTaskVerificationEvidence,
+} from "../gsd-db.ts";
+import { hasQualifyingTaskEvidence } from "../verification-gate.ts";
+
+const MID = "m1";
+const SID = "s1";
+const TID = "t1";
+
+/** Insert an evidence row with raw column values the typed API cannot express. */
+function insertRawEvidence(values: {
+  command: string;
+  exitCode: unknown;
+  verdict: string;
+  durationMs: unknown;
+}): void {
+  transaction(() =>
+    _getAdapter()!.prepare(
+      `INSERT INTO verification_evidence
+         (task_id, slice_id, milestone_id, command, exit_code, verdict, duration_ms, created_at)
+       VALUES (:task_id, :slice_id, :milestone_id, :command, :exit_code, :verdict, :duration_ms, :created_at)`,
+    ).run({
+      ":task_id": TID,
+      ":slice_id": SID,
+      ":milestone_id": MID,
+      ":command": values.command,
+      ":exit_code": values.exitCode,
+      ":verdict": values.verdict,
+      ":duration_ms": values.durationMs,
+      ":created_at": new Date().toISOString(),
+    }),
+  );
+}
+
+describe("getTaskVerificationEvidence: unknown exit codes", () => {
+  beforeEach(() => {
+    openDatabase(":memory:");
+    if (!isDbAvailable()) return;
+    // verification_evidence carries foreign keys onto the engine hierarchy.
+    insertMilestone({ id: MID });
+    insertSlice({ id: SID, milestoneId: MID });
+    insertTask({ id: TID, sliceId: SID, milestoneId: MID });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("a NULL exit_code is reported as non-zero, not as a passing 0", () => {
+    if (!isDbAvailable()) return; // no native driver on this host
+    insertRawEvidence({ command: "pnpm test", exitCode: null, verdict: "pass", durationMs: null });
+
+    const [evidence] = getTaskVerificationEvidence(MID, SID, TID);
+
+    assert.notEqual(evidence.exitCode, 0);
+    assert.equal(evidence.command, "pnpm test");
+    // A NULL duration must be omitted rather than coerced to 0.
+    assert.equal(evidence.durationMs, undefined);
+  });
+
+  test("a non-numeric exit_code is reported as non-zero", () => {
+    if (!isDbAvailable()) return;
+    insertRawEvidence({ command: "pnpm lint", exitCode: "unknown", verdict: "pass", durationMs: "n/a" });
+
+    const [evidence] = getTaskVerificationEvidence(MID, SID, TID);
+
+    assert.notEqual(evidence.exitCode, 0);
+    assert.equal(evidence.durationMs, undefined);
+  });
+
+  test("evidence with an unknown exit_code does not qualify as passing", () => {
+    if (!isDbAvailable()) return;
+    insertRawEvidence({ command: "pnpm test", exitCode: null, verdict: "pass", durationMs: null });
+
+    assert.equal(hasQualifyingTaskEvidence(getTaskVerificationEvidence(MID, SID, TID)), false);
+  });
+
+  test("a genuinely passing row still qualifies", () => {
+    if (!isDbAvailable()) return;
+    insertVerificationEvidence({
+      taskId: TID,
+      sliceId: SID,
+      milestoneId: MID,
+      command: "pnpm test",
+      exitCode: 0,
+      verdict: "pass",
+      durationMs: 1200,
+    });
+
+    const [evidence] = getTaskVerificationEvidence(MID, SID, TID);
+
+    assert.equal(evidence.exitCode, 0);
+    assert.equal(evidence.durationMs, 1200);
+    assert.equal(hasQualifyingTaskEvidence(getTaskVerificationEvidence(MID, SID, TID)), true);
+  });
+
+  test("one unknown exit_code disqualifies an otherwise passing evidence set", () => {
+    if (!isDbAvailable()) return;
+    insertVerificationEvidence({
+      taskId: TID,
+      sliceId: SID,
+      milestoneId: MID,
+      command: "pnpm test",
+      exitCode: 0,
+      verdict: "pass",
+      durationMs: 10,
+    });
+    insertRawEvidence({ command: "pnpm lint", exitCode: null, verdict: "pass", durationMs: null });
+
+    const evidence = getTaskVerificationEvidence(MID, SID, TID);
+
+    assert.equal(evidence.length, 2);
+    assert.equal(hasQualifyingTaskEvidence(evidence), false);
+  });
+});

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -266,6 +266,54 @@ describe("verification-gate: discovery", () => {
     assert.deepStrictEqual(result.commands, []);
   });
 
+  test("prose taskPlanVerify with passing task evidence beats preference commands (issue #1591)", () => {
+    const result = discoverCommands({
+      taskPlanVerify: "Planning artifacts exist and contain all required sections",
+      preferenceCommands: ["cargo test", "cargo clippy"],
+      taskEvidence: [
+        { command: "gsd_exec node: artifact check", exitCode: 0, verdict: "passed", durationMs: 12 },
+        { command: "gsd_exec node: consolidated artifact verification", exitCode: 0, verdict: "pass", durationMs: 8 },
+      ],
+      cwd: tmp,
+    });
+    assert.equal(result.source, "task-plan-prose");
+    assert.deepStrictEqual(result.commands, []);
+  });
+
+  test("failing task evidence still falls through to preference commands (issue #1591)", () => {
+    const result = discoverCommands({
+      taskPlanVerify: "Planning artifacts exist and contain all required sections",
+      preferenceCommands: ["cargo test"],
+      taskEvidence: [
+        { command: "gsd_exec node: artifact check", exitCode: 1, verdict: "fail", durationMs: 3 },
+      ],
+      cwd: tmp,
+    });
+    assert.equal(result.source, "preference");
+    assert.deepStrictEqual(result.commands, ["cargo test"]);
+  });
+
+  test("task evidence does not override a runnable task-plan command (issue #1591)", () => {
+    const result = discoverCommands({
+      taskPlanVerify: "npm run test",
+      preferenceCommands: ["cargo test"],
+      taskEvidence: [{ command: "node check.js", exitCode: 0, verdict: "pass", durationMs: 1 }],
+      cwd: tmp,
+    });
+    assert.equal(result.source, "task-plan");
+    assert.deepStrictEqual(result.commands, ["npm run test"]);
+  });
+
+  test("task evidence does not bypass preferences without prose task verify (issue #1591)", () => {
+    const result = discoverCommands({
+      preferenceCommands: ["cargo test"],
+      taskEvidence: [{ command: "node check.js", exitCode: 0, verdict: "pass", durationMs: 1 }],
+      cwd: tmp,
+    });
+    assert.equal(result.source, "preference");
+    assert.deepStrictEqual(result.commands, ["cargo test"]);
+  });
+
   test("genuinely unsafe command still suppresses the prose fallback", () => {
     const result = discoverCommands({
       taskPlanVerify: "npm run test > results.txt",

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -25,10 +25,33 @@ function truncate(value: string | null | undefined, maxBytes: number): string {
 
 // ─── Command Discovery ──────────────────────────────────────────────────────
 
+/** Structured evidence staged by `gsd_task_complete` for the current Task. */
+export interface TaskVerificationEvidence {
+  command: string;
+  exitCode: number;
+  verdict: string;
+  durationMs?: number;
+}
+
 export interface DiscoverCommandsOptions {
   preferenceCommands?: string[];
   taskPlanVerify?: string;
+  /** Structured task-specific evidence supplied at completion (#1591). */
+  taskEvidence?: TaskVerificationEvidence[];
   cwd: string;
+}
+
+/**
+ * Task-specific evidence qualifies when at least one record exists and every
+ * record reports a passing verdict with a zero exit code (#1591).
+ */
+export function hasQualifyingTaskEvidence(
+  evidence: TaskVerificationEvidence[] | undefined,
+): boolean {
+  if (!evidence || evidence.length === 0) return false;
+  return evidence.every((record) =>
+    record.exitCode === 0 && /^(pass|passed)$/i.test((record.verdict ?? "").trim())
+  );
 }
 
 export interface DiscoveredCommands {
@@ -81,6 +104,17 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
     if (commands.length > 0) {
       return { commands, source: "task-plan" };
     }
+  }
+
+  // 1b. Prose task verify backed by passing structured task evidence (#1591).
+  // Task-specific evidence must not be silently replaced by unrelated
+  // project-wide preference commands.
+  if (
+    hasTaskPlanProse &&
+    !hasUnsafeTaskPlanCommand &&
+    hasQualifyingTaskEvidence(options.taskEvidence)
+  ) {
+    return { commands: [], source: "task-plan-prose" };
   }
 
   // 2. Preference commands
@@ -558,6 +592,8 @@ export interface RunVerificationGateOptions {
   cwd: string;
   preferenceCommands?: string[];
   taskPlanVerify?: string;
+  /** Structured task-specific evidence supplied at completion (#1591). */
+  taskEvidence?: TaskVerificationEvidence[];
   /** Per-command timeout in ms. Defaults to 120 000 (2 minutes). */
   commandTimeoutMs?: number;
 }
@@ -620,6 +656,7 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
   const { commands, source } = discoverCommands({
     preferenceCommands: options.preferenceCommands,
     taskPlanVerify: options.taskPlanVerify,
+    ...(options.taskEvidence ? { taskEvidence: options.taskEvidence } : {}),
     cwd: options.cwd,
   });
 
@@ -696,6 +733,8 @@ export function runVerificationGateForTargets(options: {
   targets: VerificationTarget[];
   preferenceCommands?: string[];
   taskPlanVerify?: string;
+  /** Structured task-specific evidence supplied at completion (#1591). */
+  taskEvidence?: TaskVerificationEvidence[];
   commandTimeoutMs?: number;
 }): VerificationResult {
   const timestamp = Date.now();
@@ -717,6 +756,7 @@ export function runVerificationGateForTargets(options: {
       cwd: target.cwd,
       preferenceCommands: options.preferenceCommands ?? target.preferenceCommands,
       taskPlanVerify: options.taskPlanVerify,
+      ...(options.taskEvidence ? { taskEvidence: options.taskEvidence } : {}),
       commandTimeoutMs: options.commandTimeoutMs,
     });
     passed = passed && result.passed;


### PR DESCRIPTION
## Summary
- Passing structured gsd_task_complete evidence now short-circuits prose-Verify tasks to the task-plan-prose source instead of falling through to project-wide verification_commands; verified via build:core and the verification gate/verdict unit tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1591
- [#1591 v1.12.0: passing gsd_task_complete verificationEvidence is not considered before blocking project-wide verification_commands](https://github.com/open-gsd/gsd-pi/issues/1591)

## User
- @mik888em

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1591-v1-12-0-passing-gsd-task-complete-verifi-1785809298`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->