### PR TITLE
fix(issue): task-recovery-abort loop after verify timeout: gsd_task_recovery_resume requires a recoveryActionId that is never surfaced anywhere

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -239,6 +239,10 @@ function routeHostTechnicalFailure(
   attempt: VerificationAttemptSnapshot,
   verdict: FailedVerdictIdentity,
   failureKind: "verification-failed" | "verification-drift" = "verification-failed",
+  // A terminal abort is resumable by design via `gsd_task_recovery_resume`, but that
+  // tool needs the exact recoveryActionId. Hand it back so the caller can surface it
+  // on the finalize break reason instead of discarding it here (#1593).
+  recordAbort?: (recoveryActionId: string) => void,
 ): "retry" | "abort" {
   if (!attempt.resultId) throw new Error("Host verification Attempt Result is missing");
   const routeInput = {
@@ -273,8 +277,11 @@ function routeHostTechnicalFailure(
     case "remediate":
     case "replan":
       return "retry";
-    case "abort":
-      return recovery.status === "replayed" && recovery.resumeAuthorized ? "retry" : "abort";
+    case "abort": {
+      if (recovery.status === "replayed" && recovery.resumeAuthorized) return "retry";
+      recordAbort?.(recovery.recoveryActionId);
+      return "abort";
+    }
     default:
       throw new Error(`Unsupported agent recovery action ${recovery.action}`);
   }
@@ -639,6 +646,14 @@ export async function runPostUnitVerification(
     return "continue";
   }
 
+  // Capture the recoveryActionId of a terminal abort so the finalize break reason can
+  // print it — it is the only key `gsd_task_recovery_resume` accepts (#1593). Reset per
+  // verification pass so a stale id from an earlier unit can never be reported.
+  s.lastTaskRecoveryAbortId = null;
+  const recordAbort = (recoveryActionId: string) => {
+    s.lastTaskRecoveryAbortId = recoveryActionId;
+  };
+
   let recoverableAttempt: VerificationAttemptSnapshot | null = null;
   let recoverableAuthority: TaskVerificationAuthority | null = null;
   let canonicalVerdictWriteStarted = false;
@@ -664,7 +679,7 @@ export async function runPostUnitVerification(
         verdictId: replayedVerdict.verdictId,
         evidenceId: replayedVerdict.evidenceId,
         verdict: replayedVerdict.verdict,
-      }, replayedVerdict.supersedesVerdictId ? "verification-drift" : "verification-failed")
+      }, replayedVerdict.supersedesVerdictId ? "verification-drift" : "verification-failed", recordAbort)
       : null;
     if (!replayedRecovery && !isTaskAttemptAwaitingVerification(latestAttempt)) {
       throw new Error("Host verification requires the latest succeeded canonical Attempt at the verify stage");
@@ -743,7 +758,7 @@ export async function runPostUnitVerification(
         verdictId: invalidated.verdictId,
         evidenceId: invalidated.evidenceId,
         verdict: "inconclusive",
-      }, "verification-drift");
+      }, "verification-drift", recordAbort);
       if (recovery === "abort") return "abort";
       return recordDurableVerificationRetry(s, retryKey, failureContext);
     }
@@ -1106,7 +1121,7 @@ export async function runPostUnitVerification(
           verdictId: recordedVerdict.verdictId,
           evidenceId: recordedVerdict.evidenceId,
           verdict: hostTechnicalVerdict,
-        });
+        }, "verification-failed", recordAbort);
       }
 
       try {
@@ -1243,7 +1258,7 @@ export async function runPostUnitVerification(
         verdictId: storedVerdict.verdictId,
         evidenceId: storedVerdict.evidenceId,
         verdict: storedVerdict.verdict,
-      }, storedVerdict.supersedesVerdictId ? "verification-drift" : "verification-failed");
+      }, storedVerdict.supersedesVerdictId ? "verification-drift" : "verification-failed", recordAbort);
       if (recovery === "abort") return "abort";
       const retryKey = verificationRetryKey(s.currentUnit.type, s.currentUnit.id);
       return recordDurableVerificationRetry(s, retryKey, message);
@@ -1271,7 +1286,7 @@ export async function runPostUnitVerification(
       verdictId: recorded.verdictId,
       evidenceId: recorded.evidenceId,
       verdict: "inconclusive",
-    });
+    }, "verification-failed", recordAbort);
     if (recovery === "abort") return "abort";
     const retryKey = verificationRetryKey(s.currentUnit.type, s.currentUnit.id);
     return recordDurableVerificationRetry(s, retryKey, message);

--- a/src/resources/extensions/gsd/auto/finalize.ts
+++ b/src/resources/extensions/gsd/auto/finalize.ts
@@ -248,9 +248,17 @@ export async function runFinalize(
     );
 
     if (verificationResult === "abort") {
-      debugLog("autoLoop", { phase: "exit", reason: "verification-abort" });
+      // The abort is terminal but resumable via `gsd_task_recovery_resume`, which needs
+      // the exact recoveryActionId. Carry it in the break reason so it reaches the
+      // journal, the dispatch ledger, and the operator rather than being discarded —
+      // otherwise every later dispatch loops on an opaque `task-recovery-abort` (#1593).
+      const abortId = s.lastTaskRecoveryAbortId;
+      const abortReason = abortId
+        ? `verification-abort (recoveryActionId: ${abortId}; resume with gsd_task_recovery_resume)`
+        : "verification-abort";
+      debugLog("autoLoop", { phase: "exit", reason: abortReason });
       clearFinalizingUnit();
-      return { action: "break", reason: "verification-abort" };
+      return { action: "break", reason: abortReason };
     }
 
     if (verificationResult === "pause") {

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -181,6 +181,12 @@ export class AutoSession {
   // ── Recovery ─────────────────────────────────────────────────────────────
   pendingCrashRecovery: string | null = null;
   pendingVerificationRetry: PendingVerificationRetry | null = null;
+  /**
+   * recoveryActionId of the terminal agent-owned abort minted by the last host
+   * verification pass. It is the only key `gsd_task_recovery_resume` accepts, so
+   * finalize prints it in the `verification-abort` break reason (#1593).
+   */
+  lastTaskRecoveryAbortId: string | null = null;
   readonly verificationRetryCount = new Map<string, number>();
   readonly verificationRetryFailureHashes = new Map<string, string>();
   readonly exhaustedVerificationUnits = new Set<string>();
@@ -399,6 +405,7 @@ export class AutoSession {
     // Recovery
     this.pendingCrashRecovery = null;
     this.pendingVerificationRetry = null;
+    this.lastTaskRecoveryAbortId = null;
     this.verificationRetryCount.clear();
     this.verificationRetryFailureHashes.clear();
     this.exhaustedVerificationUnits.clear();

--- a/src/resources/extensions/gsd/auto/task-execution-cutover.ts
+++ b/src/resources/extensions/gsd/auto/task-execution-cutover.ts
@@ -39,7 +39,7 @@ export interface TaskExecutionCutoverDeps {
   readTaskAttempt(attemptId: string): TaskExecutionAttemptSnapshot | null;
   readTaskRecoveryRoute(attemptId: string): Pick<
     TaskRecoveryRouteSnapshot,
-    "action" | "recoveryOwner" | "resumeAuthorized"
+    "recoveryActionId" | "action" | "recoveryOwner" | "resumeAuthorized"
   > | null;
   claimTaskAttempt(input: ClaimTaskAttemptInput): ClaimTaskAttemptReceipt;
   settleTaskAttempt(input: SettleTaskAttemptInput): SettleTaskAttemptReceipt;
@@ -300,6 +300,17 @@ function routeTaskFailure(
   });
 }
 
+// The terminal abort is resumable by design via `gsd_task_recovery_resume`, but that
+// tool requires the exact recoveryActionId. Carry the id in the break reason so it
+// reaches the journal, the dispatch ledger, and the operator instead of being discarded.
+function taskRecoveryAbortResult(recoveryActionId: string): UnitPhaseResult {
+  return {
+    action: "break",
+    reason:
+      `task-recovery-abort (recoveryActionId: ${recoveryActionId}; resume with gsd_task_recovery_resume)`,
+  };
+}
+
 function applyRecoveryDecision(
   recovery: TaskRecoveryReceipt,
 ): UnitPhaseResult {
@@ -313,7 +324,7 @@ function applyRecoveryDecision(
       if (recovery.status === "replayed" && recovery.resumeAuthorized) {
         return { action: "retry", reason: "task-recovery-resumed" };
       }
-      return { action: "break", reason: "task-recovery-abort" };
+      return taskRecoveryAbortResult(recovery.recoveryActionId);
     case "clarify":
     case "pause":
       throw new Error("Agent-owned Task recovery cannot return a human-owned action");
@@ -393,7 +404,7 @@ export async function runWithTaskExecutionAttempt(
           return { action: "next", data: {} };
         }
         if (recovery.action === "abort" && !recovery.resumeAuthorized) {
-          return { action: "break", reason: "task-recovery-abort" };
+          return taskRecoveryAbortResult(recovery.recoveryActionId);
         }
       } else {
         if (!predecessor.resultId) {

--- a/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
@@ -35,6 +35,11 @@ import { recordTaskTechnicalVerdict } from "../task-verification-domain-operatio
 import { publishVerifiedTaskCompletion } from "../task-completion-compatibility-adapter.js";
 import { captureVerificationSourceSnapshot } from "../verification-source-integrity.js";
 
+// The stuck-state resume key must ride along with every terminal abort break so an
+// operator can call gsd_task_recovery_resume without querying the database by hand.
+const TASK_RECOVERY_ABORT_REASON =
+  "task-recovery-abort (recoveryActionId: recovery-action-1; resume with gsd_task_recovery_resume)";
+
 type UnitPhaseResult =
   | { action: "break"; reason: string }
   | { action: "retry"; reason: string }
@@ -76,6 +81,7 @@ interface CutoverDeps {
   readLatestTaskAttempt(task: TaskIdentity): AttemptSnapshot | null;
   readTaskAttempt(attemptId: string): AttemptSnapshot | null;
   readTaskRecoveryRoute(attemptId: string): {
+    recoveryActionId: string;
     recoveryOwner: "agent" | "user" | "external";
     action: "retry" | "repair" | "remediate" | "replan" | "abort" | "clarify" | "pause";
     resumeAuthorized?: boolean;
@@ -128,6 +134,7 @@ interface CutoverDeps {
   }): {
     status: "committed" | "replayed";
     action: "retry" | "repair" | "remediate" | "replan" | "abort";
+    recoveryActionId: string;
   };
 }
 
@@ -242,7 +249,7 @@ function fakeDomain() {
     },
     readTaskRecoveryRoute(attemptId) {
       calls.push({ name: "read-recovery", value: attemptId });
-      return { recoveryOwner: "agent", action: "retry" };
+      return { recoveryActionId: "recovery-action-1", recoveryOwner: "agent", action: "retry" };
     },
     claimTaskAttempt(claim) {
       calls.push({ name: "claim", value: claim });
@@ -288,7 +295,7 @@ function fakeDomain() {
     routeTaskFailure(route) {
       calls.push({ name: "route", value: route });
       routes.push(route);
-      return { status: "replayed", action: "retry" };
+      return { status: "replayed", action: "retry", recoveryActionId: "recovery-action-1" };
     },
   };
 
@@ -846,7 +853,11 @@ for (const phaseResult of [
       dispatchId: secondDispatchId,
     }), async () => ({ action: "break", reason: "unit-hard-timeout" }), canonicalDeps());
 
-    assert.deepEqual(terminalResult, { action: "break", reason: "task-recovery-abort" });
+    assert.equal(terminalResult.action, "break");
+    assert.match(
+      (terminalResult as { reason: string }).reason,
+      /^task-recovery-abort \(recoveryActionId: [0-9a-f-]{36}; resume with gsd_task_recovery_resume\)$/,
+    );
     const firstAttempt = database().prepare(`
       SELECT attempt_id FROM workflow_execution_attempts WHERE attempt_number = 1
     `).get() as { attempt_id: string };
@@ -886,11 +897,14 @@ test("a durable abort overrides an executor retry", async () => {
     ...domain.deps,
     routeTaskFailure(route) {
       domain.routes.push(route);
-      return { status: "committed", action: "abort" };
+      return { status: "committed", action: "abort", recoveryActionId: "recovery-action-1" };
     },
   });
 
-  assert.deepEqual(result, { action: "break", reason: "task-recovery-abort" });
+  assert.deepEqual(result, {
+    action: "break",
+    reason: TASK_RECOVERY_ABORT_REASON,
+  });
   assert.equal(domain.routes.length, 1);
 });
 
@@ -922,6 +936,7 @@ test("an explicitly resumed durable abort claims one later Attempt", async () =>
         status: "replayed",
         action: "abort",
         resumeAuthorized: true,
+        recoveryActionId: "recovery-action-1",
       };
     },
   });
@@ -997,11 +1012,14 @@ test("a durable abort for stale-worker takeover stops before replacement claim o
     ...domain.deps,
     routeTaskFailure(route) {
       domain.routes.push(route);
-      return { status: "committed", action: "abort" };
+      return { status: "committed", action: "abort", recoveryActionId: "recovery-action-1" };
     },
   });
 
-  assert.deepEqual(result, { action: "break", reason: "task-recovery-abort" });
+  assert.deepEqual(result, {
+    action: "break",
+    reason: TASK_RECOVERY_ABORT_REASON,
+  });
   assert.equal(ran, false);
   assert.equal(domain.claims.length, 0);
   assert.equal(domain.routes.length, 1);
@@ -1029,7 +1047,7 @@ test("a newly routed failed predecessor redispatches before its lineage-linked r
     routeTaskFailure(route: Parameters<CutoverDeps["routeTaskFailure"]>[0]) {
       domain.calls.push({ name: "route", value: route });
       domain.routes.push(route);
-      return { status: routeStatus, action: "repair" as const };
+      return { status: routeStatus, action: "repair" as const, recoveryActionId: "recovery-action-1" };
     },
   };
 
@@ -1104,11 +1122,14 @@ test("an unresumed verification abort stops before a replacement claim", async (
   }, {
     ...domain.deps,
     readTaskRecoveryRoute() {
-      return { recoveryOwner: "agent", action: "abort" };
+      return { recoveryActionId: "recovery-action-1", recoveryOwner: "agent", action: "abort" };
     },
   });
 
-  assert.deepEqual(result, { action: "break", reason: "task-recovery-abort" });
+  assert.deepEqual(result, {
+    action: "break",
+    reason: TASK_RECOVERY_ABORT_REASON,
+  });
   assert.equal(ran, false);
   assert.equal(domain.claims.length, 0);
 });
@@ -1136,7 +1157,7 @@ test("an explicitly resumed verification abort claims one lineage-linked Attempt
   }, {
     ...domain.deps,
     readTaskRecoveryRoute() {
-      return { recoveryOwner: "agent", action: "abort", resumeAuthorized: true };
+      return { recoveryActionId: "recovery-action-1", recoveryOwner: "agent", action: "abort", resumeAuthorized: true };
     },
   });
 
@@ -1147,7 +1168,11 @@ test("an explicitly resumed verification abort claims one lineage-linked Attempt
 });
 
 for (const [label, recovery] of [
-  ["a user-owned verification route", { recoveryOwner: "user" as const, action: "clarify" as const }],
+  ["a user-owned verification route", {
+    recoveryActionId: "recovery-action-1",
+    recoveryOwner: "user" as const,
+    action: "clarify" as const,
+  }],
   ["a missing verification route", null],
 ] as const) {
   test(`${label} resumes verification without executing again`, async () => {
@@ -1222,7 +1247,7 @@ test("a replacement lease routes a stale running Attempt and redispatches before
     routeTaskFailure(route: Parameters<CutoverDeps["routeTaskFailure"]>[0]) {
       domain.calls.push({ name: "route", value: route });
       domain.routes.push(route);
-      return { status: routeStatus, action: "repair" as const };
+      return { status: routeStatus, action: "repair" as const, recoveryActionId: "recovery-action-1" };
     },
   };
 

--- a/src/resources/extensions/gsd/tests/auto-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-verification.test.ts
@@ -56,3 +56,47 @@ test("built-in verification retries a replayed authorized abort", () => {
 
 	assert.equal(outcome, "retry");
 });
+
+test("terminal abort surfaces its recoveryActionId to the caller (#1593)", () => {
+	const surfaced: string[] = [];
+	const outcome = _routeHostTechnicalFailureForTest({
+		routeTaskFailure: () => ({
+			action: "abort",
+			status: "applied",
+			resumeAuthorized: false,
+			recoveryActionId: "8f1d0c2e-6a44-4b19-9e77-2c3d5f0a1b62",
+		}),
+	} as never, {
+		attemptId: "attempt-1",
+		resultId: "result-1",
+	} as never, {
+		verdictId: "verdict-1",
+		evidenceId: "evidence-1",
+		verdict: "fail",
+	}, "verification-failed", (id) => surfaced.push(id));
+
+	assert.equal(outcome, "abort");
+	assert.deepEqual(surfaced, ["8f1d0c2e-6a44-4b19-9e77-2c3d5f0a1b62"]);
+});
+
+test("a replayed authorized abort does not surface a recoveryActionId (#1593)", () => {
+	const surfaced: string[] = [];
+	const outcome = _routeHostTechnicalFailureForTest({
+		routeTaskFailure: () => ({
+			action: "abort",
+			status: "replayed",
+			resumeAuthorized: true,
+			recoveryActionId: "8f1d0c2e-6a44-4b19-9e77-2c3d5f0a1b62",
+		}),
+	} as never, {
+		attemptId: "attempt-1",
+		resultId: "result-1",
+	} as never, {
+		verdictId: "verdict-1",
+		evidenceId: "evidence-1",
+		verdict: "fail",
+	}, "verification-failed", (id) => surfaced.push(id));
+
+	assert.equal(outcome, "retry");
+	assert.deepEqual(surfaced, []);
+});


### PR DESCRIPTION
## Summary
- Surfaced the abort's recoveryActionId in the task-recovery-abort break reason so it reaches the journal/ledger, verified with typecheck and 216 passing recovery/cutover/loop tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1593
- [#1593 task-recovery-abort loop after verify timeout: gsd_task_recovery_resume requires a recoveryActionId that is never surfaced anywhere](https://github.com/open-gsd/gsd-pi/issues/1593)

## User
- @jcisc0

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1593-task-recovery-abort-loop-after-verify-ti-1785811096`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->