### PR TITLE
fix(issue): bug: `gsd extensions` throws ESYNC — lockSync called with unsupported `retries` option (v1.12.0)

### DIFF
--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -11,20 +11,8 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, 
 import { dirname, join, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
-import { createRequire } from "node:module";
 import { gsdHome } from "./gsd-home.js";
-
-const _require = createRequire(import.meta.url);
-const { lockSync, unlockSync } = _require("proper-lockfile") as {
-  lockSync: (
-    path: string,
-    options?: {
-      retries?: number | { retries?: number; minTimeout?: number; maxTimeout?: number; factor?: number };
-      stale?: number;
-    },
-  ) => () => void;
-  unlockSync: (path: string) => void;
-};
+import { withFileLockSync } from "./file-lock.js";
 
 /**
  * Strict numeric comparison of two npm-style version strings.
@@ -145,25 +133,24 @@ function saveRegistry(registry: ExtensionRegistry): void {
  * Prevents two concurrent `gsd extensions install/uninstall/update` invocations
  * from trampling each other's registry mutations.
  *
- * Uses proper-lockfile.lockSync against the registry path. Directory is created
+ * Uses withFileLockSync against the registry path, which wraps proper-lockfile's
+ * sync API in a manual retry loop — `lockSync` throws ESYNC if given a `retries`
+ * option, so retries must be driven by the caller (#1598). Directory is created
  * first so locking works on fresh installs. Lock is always released via finally.
  */
 function withRegistryLock<T>(mutate: (registry: ExtensionRegistry) => T): T {
   const filePath = getRegistryPath();
   mkdirSync(dirname(filePath), { recursive: true });
-  // lockSync requires the file to exist — ensure it does before acquiring.
+  // The lock target must exist — ensure it does before acquiring.
   if (!existsSync(filePath)) {
     writeFileSync(filePath, JSON.stringify({ version: 1, entries: {} }, null, 2), "utf-8");
   }
-  lockSync(filePath, { retries: { retries: 5, minTimeout: 50, maxTimeout: 500 } });
-  try {
+  return withFileLockSync(filePath, () => {
     const registry = loadRegistry();
     const result = mutate(registry);
     saveRegistry(registry);
     return result;
-  } finally {
-    try { unlockSync(filePath); } catch { /* lock may already be gone */ }
-  }
+  });
 }
 
 function isEnabled(registry: ExtensionRegistry, id: string): boolean {

--- a/src/resources/extensions/gsd/tests/commands-extensions-registry-lock.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-extensions-registry-lock.test.ts
@@ -1,0 +1,53 @@
+// gsd-pi — Regression test for Issue #1598 registry lock (commands-extensions.ts)
+//
+// `withRegistryLock` used to call proper-lockfile's `lockSync` with a `retries`
+// option. proper-lockfile deliberately throws ESYNC ("Cannot use retries with the
+// sync api") for that — retries are only supported by the async `lock()` API — so
+// every `gsd extensions enable/disable/install/uninstall` failed. The fix routes
+// the transaction through `withFileLockSync`, which drives retries manually.
+
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleExtensions } from "../commands-extensions.ts";
+
+function setupHome(): string {
+	const home = mkdtempSync(join(tmpdir(), "gsd-ext-lock-"));
+	const extDir = join(home, "extensions", "demo-ext");
+	mkdirSync(extDir, { recursive: true });
+	writeFileSync(
+		join(extDir, "extension-manifest.json"),
+		JSON.stringify({ id: "demo-ext", name: "Demo", tier: "optional" }),
+	);
+	return home;
+}
+
+describe("extensions registry lock (#1598)", () => {
+	test("disable then enable mutate the registry without throwing ESYNC", async () => {
+		const previous = process.env.GSD_HOME;
+		const home = setupHome();
+		process.env.GSD_HOME = home;
+		const notices: string[] = [];
+		const ctx = { ui: { notify: (msg: string) => notices.push(msg) } };
+
+		try {
+			await handleExtensions("disable demo-ext", ctx as never);
+			const disabled = JSON.parse(readFileSync(join(home, "extensions", "registry.json"), "utf-8"));
+			assert.equal(disabled.entries["demo-ext"].enabled, false);
+
+			await handleExtensions("enable demo-ext", ctx as never);
+			const enabled = JSON.parse(readFileSync(join(home, "extensions", "registry.json"), "utf-8"));
+			assert.equal(enabled.entries["demo-ext"].enabled, true);
+		} finally {
+			if (previous === undefined) delete process.env.GSD_HOME;
+			else process.env.GSD_HOME = previous;
+		}
+
+		assert.deepEqual(notices, [
+			'Disabled "demo-ext". Restart GSD to deactivate.',
+			'Enabled "demo-ext". Restart GSD to activate.',
+		]);
+	});
+});

--- a/src/resources/extensions/gsd/tests/commands-extensions-registry-lock.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-extensions-registry-lock.test.ts
@@ -8,9 +8,10 @@
 
 import test, { describe } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { handleExtensions } from "../commands-extensions.ts";
 
 function setupHome(): string {
@@ -19,9 +20,19 @@ function setupHome(): string {
 	mkdirSync(extDir, { recursive: true });
 	writeFileSync(
 		join(extDir, "extension-manifest.json"),
-		JSON.stringify({ id: "demo-ext", name: "Demo", tier: "optional" }),
+		JSON.stringify({ id: "demo-ext", name: "Demo", tier: "community" }),
 	);
 	return home;
+}
+
+function makeCtx(notices: string[]): ExtensionCommandContext {
+	return {
+		ui: {
+			notify: (message: string, _type?: "info" | "warning" | "error" | "success") => {
+				notices.push(message);
+			},
+		},
+	} as unknown as ExtensionCommandContext;
 }
 
 describe("extensions registry lock (#1598)", () => {
@@ -30,19 +41,20 @@ describe("extensions registry lock (#1598)", () => {
 		const home = setupHome();
 		process.env.GSD_HOME = home;
 		const notices: string[] = [];
-		const ctx = { ui: { notify: (msg: string) => notices.push(msg) } };
+		const ctx = makeCtx(notices);
 
 		try {
-			await handleExtensions("disable demo-ext", ctx as never);
+			await handleExtensions("disable demo-ext", ctx);
 			const disabled = JSON.parse(readFileSync(join(home, "extensions", "registry.json"), "utf-8"));
 			assert.equal(disabled.entries["demo-ext"].enabled, false);
 
-			await handleExtensions("enable demo-ext", ctx as never);
+			await handleExtensions("enable demo-ext", ctx);
 			const enabled = JSON.parse(readFileSync(join(home, "extensions", "registry.json"), "utf-8"));
 			assert.equal(enabled.entries["demo-ext"].enabled, true);
 		} finally {
 			if (previous === undefined) delete process.env.GSD_HOME;
 			else process.env.GSD_HOME = previous;
+			rmSync(home, { recursive: true, force: true });
 		}
 
 		assert.deepEqual(notices, [


### PR DESCRIPTION
## Summary
- Routed the extension registry transaction through withFileLockSync instead of lockSync with an unsupported retries option, verified by reproducing the ESYNC failure pre-fix and passing a new regression test plus the existing gsd extension tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1598
- [#1598 bug: `gsd extensions` throws ESYNC — lockSync called with unsupported `retries` option (v1.12.0)](https://github.com/open-gsd/gsd-pi/issues/1598)

## User
- @pimmink

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1598-bug-gsd-extensions-throws-esync-locksync-1785844699`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->