### PR TITLE
fix(issue): bug: gsd_milestone_status does not return persisted dependsOn / milestone dependencies

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -3257,7 +3257,7 @@ export function registerWorkflowTools(
 
   server.tool(
     "gsd_milestone_status",
-    "Read the current status of a milestone and all its slices from the GSD database.",
+    "Read the current status of a milestone and all its slices from the GSD database. Includes `dependsOn`, the persisted milestone dependencies.",
     milestoneStatusParams,
     async (args: Record<string, unknown>) => {
       // gsd_milestone_status is a read-only query. In-process (query-tools.ts)

--- a/src/resources/extensions/gsd/bootstrap/query-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/query-tools.ts
@@ -131,7 +131,8 @@ export function registerQueryTools(
     label: "Milestone Status",
     description:
       "Read the current status of a milestone and all its slices from the GSD database. " +
-      "Returns milestone metadata, per-slice status, and task counts per slice. " +
+      "Returns milestone metadata (including `dependsOn`, the persisted milestone dependencies), " +
+      "per-slice status, and task counts per slice. " +
       "Use this instead of querying .gsd/gsd.db directly via sqlite3 or better-sqlite3.",
     promptSnippet: "Get milestone status, slice statuses, and task counts for a given milestoneId",
     promptGuidelines: [

--- a/src/resources/extensions/gsd/tests/milestone-status-shadow-observation.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-status-shadow-observation.test.ts
@@ -141,6 +141,7 @@ test("milestone status observes all five shadow classes from its read snapshot w
     status: "pending",
     createdAt: "2026-07-14T10:00:00.000Z",
     completedAt: null,
+    dependsOn: [],
     sliceCount: 2,
     slices: [
       { id: "S01", status: "active", taskCounts: { total: 1, done: 1, pending: 0 } },

--- a/src/resources/extensions/gsd/tests/milestone-status-tool.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-status-tool.test.ts
@@ -120,6 +120,7 @@ test("gsd_milestone_status returns milestone metadata and slice statuses", async
       status: "active",
       createdAt: _getAdapter()!.prepare("SELECT created_at FROM milestones WHERE id = 'M001'").get()!["created_at"],
       completedAt: null,
+      dependsOn: [],
       sliceCount: 2,
       slices: [
         { id: "S01", status: "complete", taskCounts: { total: 2, done: 2, pending: 0 } },

--- a/src/resources/extensions/gsd/tests/semantic-shadow-capstone-harness.ts
+++ b/src/resources/extensions/gsd/tests/semantic-shadow-capstone-harness.ts
@@ -222,6 +222,7 @@ function expectedResponse() {
     status: "pending",
     createdAt: "2026-07-15T00:00:00.000Z",
     completedAt: null,
+    dependsOn: [],
     sliceCount: 2,
     slices: [
       { id: "S01", status: "active", taskCounts: { total: 1, done: 1, pending: 0 } },

--- a/src/resources/extensions/gsd/tests/semantic-shadow-contract.test.ts
+++ b/src/resources/extensions/gsd/tests/semantic-shadow-contract.test.ts
@@ -323,6 +323,7 @@ test("keeps milestone status byte/deep-equal across native Pi and the shared wor
     status: "active",
     createdAt: "2026-07-14T00:00:00.000Z",
     completedAt: null,
+    dependsOn: [],
     sliceCount: 1,
     slices: [{
       id: "S01",

--- a/src/resources/extensions/gsd/tests/semantic-shadow-mode-matrix.test.ts
+++ b/src/resources/extensions/gsd/tests/semantic-shadow-mode-matrix.test.ts
@@ -219,6 +219,7 @@ function expectedFoundResponse() {
     status: "pending",
     createdAt: "2026-07-15T00:00:00.000Z",
     completedAt: null,
+    dependsOn: [],
     sliceCount: 2,
     slices: [
       { id: "S01", status: "active", taskCounts: { total: 1, done: 1, pending: 0 } },

--- a/src/resources/extensions/gsd/tests/semantic-shadow-no-cutover.test.ts
+++ b/src/resources/extensions/gsd/tests/semantic-shadow-no-cutover.test.ts
@@ -175,6 +175,7 @@ test("legacy milestone status remains public when canonical lifecycle disagrees"
     status: "active",
     createdAt: "2026-07-15T00:00:00.000Z",
     completedAt: null,
+    dependsOn: [],
     sliceCount: 1,
     slices: [{
       id: "S01",

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -990,11 +990,33 @@ test("executeMilestoneStatus returns milestone metadata and slice counts", async
     assert.equal(parsed.milestoneId, "M001");
     assert.equal(parsed.title, "Milestone One");
     assert.equal(parsed.sliceCount, 1);
+    assert.deepEqual(parsed.dependsOn, []);
     assert.equal(parsed.slices[0].id, "S01");
     assert.equal(parsed.slices[0].taskCounts.pending, 1);
     assert.equal(result.details.status, "active");
     assert.equal(result.details.title, "Milestone One");
+    assert.deepEqual(result.details.dependsOn, []);
     assert.deepEqual(result.details.slices, parsed.slices);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeMilestoneStatus returns persisted milestone dependencies", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M009", "Milestone Nine");
+    seedMilestone("M010", "Milestone Ten");
+    _getAdapter()!.prepare("UPDATE milestones SET depends_on = ? WHERE id = ?")
+      .run(JSON.stringify(["M009"]), "M010");
+
+    const result = await inProjectDir(base, () => executeMilestoneStatus({ milestoneId: "M010" }, base));
+    const parsed = JSON.parse(result.content[0].text);
+
+    assert.deepEqual(parsed.dependsOn, ["M009"]);
+    assert.deepEqual(result.details.dependsOn, ["M009"]);
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -2186,6 +2186,7 @@ export async function executeMilestoneStatus(
         status: milestone.status,
         createdAt: milestone.created_at,
         completedAt: milestone.completed_at,
+        dependsOn: milestone.depends_on ?? [],
         sliceCount: slices.length,
         slices,
       };


### PR DESCRIPTION
## Summary
- Added `dependsOn` to the `gsd_milestone_status` result (and both tool descriptions), verified by a new unit test plus the executor, shadow-parity, and mcp-server workflow-tool suites and an extensions typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1601
- [#1601 bug: gsd_milestone_status does not return persisted dependsOn / milestone dependencies](https://github.com/open-gsd/gsd-pi/issues/1601)

## User
- @pimmink

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1601-bug-gsd-milestone-status-does-not-return-1785847818`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->