### PR TITLE
fix(migrate): slice completion guard + decision field extraction (fixes #1606, #1607)

### DIFF
--- a/src/resources/extensions/gsd/migrate/transformer.ts
+++ b/src/resources/extensions/gsd/migrate/transformer.ts
@@ -176,7 +176,11 @@ function mapSlice(
     tasks = planNumbers.map((pn, i) => mapTask(phase.plans[pn], i, phase.summaries));
   }
 
-  const done = entry.done;
+  // #1606: a ROADMAP checkbox alone is insufficient — verify every child task is
+  // also done. A slice with pending tasks must remain open to avoid phantom
+  // completion that causes auto-mode to skip unfinished work.
+  const allTasksDone = tasks.length === 0 || tasks.every((t) => t.done);
+  const done = entry.done && allTasksDone;
   const sliceSummary = done && phase ? buildSliceSummary(phase) : null;
 
   return {
@@ -342,18 +346,25 @@ function deriveVision(parsed: PlanningProject): string {
 
 function deriveDecisions(parsed: PlanningProject): string {
   // Extract key decisions from phase summaries if available
-  const decisions: string[] = [];
+  // #1607: use extractDecisionFields for file-sourced decisions to preserve semantics.
+  interface RowEntry { decision: string; choice: string; rationale: string; scope: string }
+  const rows: RowEntry[] = [];
+
   const decisionFiles = [...parsed.decisions].sort((a, b) => a.fileName.localeCompare(b.fileName));
-  for (const decision of decisionFiles) {
-    decisions.push(extractDecisionTitle(decision.fileName, decision.content));
+  for (const df of decisionFiles) {
+    rows.push(extractDecisionFields(df.fileName, df.content));
   }
+
   for (const phase of Object.values(parsed.phases)) {
     for (const summary of Object.values(phase.summaries)) {
       const kd = summary.frontmatter['key-decisions'] ?? [];
-      decisions.push(...kd);
+      for (const entry of kd) {
+        rows.push({ decision: entry, choice: '(from summary)', rationale: '(from summary key-decisions)', scope: 'migration' });
+      }
     }
   }
-  if (decisions.length === 0) return '';
+
+  if (rows.length === 0) return '';
   const lines = [
     '# Decisions Register',
     '',
@@ -362,22 +373,57 @@ function deriveDecisions(parsed: PlanningProject): string {
     '     Read this file at the start of any planning or research phase. -->',
     '',
     '| # | When | Scope | Decision | Choice | Rationale | Revisable? | Made By |',
-    '|---|------|-------|----------|--------|-----------|------------|---------|',
+    '| --- | --- | --- | --- | --- | --- | --- | --- |',
   ];
 
-  decisions.forEach((decision, index) => {
+  rows.forEach((row, index) => {
     const id = padId('D', index + 1, 3);
-    const escaped = decision.replace(/\|/g, '\\|');
-    lines.push(`| ${id} | migration | legacy-import | ${escaped} | ${escaped} | Migrated from legacy summary key-decisions | Yes | human |`);
+    const esc = (v: string) => v.replace(/\|/g, '\\|');
+    lines.push(`| ${id} | migration | ${esc(row.scope)} | ${esc(row.decision)} | ${esc(row.choice)} | ${esc(row.rationale)} | Yes | human |`);
   });
 
   return lines.join('\n') + '\n';
 }
 
-function extractDecisionTitle(fileName: string, content: string): string {
+interface MigrationDecisionFields {
+  decision: string;
+  choice: string;
+  rationale: string;
+  scope: string;
+}
+
+/** #1607: extract structured fields from a legacy decision file.
+ * Tries ## Choice / ## Rationale / ## Scope sections first; falls back to
+ * preserving body content in Rationale rather than fabricating values.
+ */
+function extractDecisionFields(fileName: string, content: string): MigrationDecisionFields {
   const heading = content.split('\n').find((line) => /^#\s+/.test(line.trim()));
-  if (heading) return heading.replace(/^#\s+/, '').trim();
-  return fileName.replace(/\.md$/i, '').replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/-/g, ' ');
+  const decision = heading
+    ? heading.replace(/^#\s+/, '').trim()
+    : fileName.replace(/\.md$/i, '').replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/-/g, ' ');
+
+  const sectionMatch = (label: string) => {
+    const m = content.match(new RegExp(`^##\\s+${label}\\s*\n([\\s\\S]*?)(?=^##\\s|\$)`, 'm'));
+    return m ? m[1].trim() : null;
+  };
+
+  const choiceSection = sectionMatch('Choice');
+  const rationaleSection = sectionMatch('Rationale');
+  const scopeSection = sectionMatch('Scope');
+
+  // Preserve as much signal as possible; never fabricate structured fields.
+  const choice = choiceSection
+    ? choiceSection.split('\n')[0]!.trim()
+    : '(not parsed -- see migration source)';
+
+  const rationale = rationaleSection
+    ? rationaleSection.replace(/\n+/g, ' ').trim().slice(0, 300)
+    : content.replace(/^#[^\n]*\n/, '').trim().replace(/\n+/g, ' ').slice(0, 300) ||
+      '(not parsed -- see migration source)';
+
+  const scope = scopeSection ? scopeSection.split('\n')[0]!.trim() : 'migration';
+
+  return { decision, choice, rationale, scope };
 }
 
 function buildMilestoneFromLegacyMilestone(source: PlanningMilestone, index: number): GSDMilestone {
@@ -392,7 +438,9 @@ function buildMilestoneFromLegacyMilestone(source: PlanningMilestone, index: num
       entries.push({
         number: phase.number,
         title: phase.slug,
-        done: Object.keys(phase.summaries).length > 0,
+        // #1606: require ALL plans to have summaries, not just any summary.
+        done: Object.keys(phase.plans).length > 0 &&
+              Object.keys(phase.plans).every((pn) => phase.summaries[pn] !== undefined),
         raw: '',
       });
     }

--- a/src/resources/extensions/gsd/tests/migrate-transformer.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-transformer.test.ts
@@ -355,7 +355,8 @@ test('Scenario 4: Completion state mapping', () => {
   const doneSlice = result.milestones[0]?.slices[0];
   const activeSlice = result.milestones[0]?.slices[1];
 
-  assert.ok(doneSlice?.done === true, 'completion: done phase → done slice');
+  // #1606 fix: done-phase has plan 02 without a summary → slice must NOT be marked done.
+  assert.ok(doneSlice?.done === false, 'completion: #1606: done phase with pending task → slice NOT done');
   assert.ok(activeSlice?.done === false, 'completion: active phase → not-done slice');
   assert.ok(doneSlice?.tasks[0]?.done === true, 'completion: plan with summary → done task');
   assert.ok(doneSlice?.tasks[1]?.done === false, 'completion: plan without summary → not-done task');
@@ -366,7 +367,8 @@ test('Scenario 4: Completion state mapping', () => {
   assert.deepStrictEqual(doneSlice?.tasks[0]?.summary?.provides, ['feature-01'], 'completion: summary provides from frontmatter');
   assert.deepStrictEqual(doneSlice?.tasks[0]?.summary?.keyFiles, ['file-01.ts'], 'completion: summary keyFiles from frontmatter');
   assert.ok(doneSlice?.tasks[0]?.summary?.whatHappened?.includes('Summary body') ?? false, 'completion: summary whatHappened from body');
-  assert.ok(doneSlice?.summary !== null, 'completion: done slice has slice summary');
+  // #1606: since doneSlice is now done=false, no slice summary is generated.
+  assert.ok(doneSlice?.summary === null, 'completion: #1606: partially-done slice has null summary');
   assert.ok(activeSlice?.summary === null, 'completion: active slice has null summary');
   assert.deepStrictEqual(doneSlice?.tasks[0]?.estimate, '2h', 'completion: task estimate from summary duration');
 });
@@ -708,3 +710,76 @@ test('Scenario 15: Empty research', () => {
 });
 
 // ─── Results ───────────────────────────────────────────────────────────────
+
+
+// ─── Scenario 4b: #1606 regression — fully-done slice ───────────────────────
+
+test('Scenario 4b: #1606 — slice with all tasks done IS marked done', () => {
+  const project = emptyProject({
+    roadmap: flatRoadmap([roadmapEntry(1, 'all-done-phase', true)]),
+    phases: {
+      '1-all-done-phase': makePhase('1-all-done-phase', 1, 'all-done-phase', {
+        plans: { '01': makePlan('01'), '02': makePlan('02') },
+        summaries: {
+          '01': makeSummary('01'),
+          '02': makeSummary('02'),  // both plans have summaries
+        },
+      }),
+    },
+  });
+
+  const result = transformToGSD(project);
+  const slice = result.milestones[0]?.slices[0];
+
+  assert.ok(slice?.done === true, '#1606: slice with all tasks done must be marked done');
+  assert.ok(slice?.tasks[0]?.done === true, '#1606: task with summary → done');
+  assert.ok(slice?.tasks[1]?.done === true, '#1606: task with summary → done');
+  assert.ok(slice?.summary !== null, '#1606: fully-done slice has slice summary');
+});
+
+// ─── Scenario 4c: #1607 regression — decision file field extraction ──────────
+
+test('Scenario 4c: #1607 — decision file with structured sections extracts fields', () => {
+  const structuredDecision = `# Choose Postgres as primary datastore
+
+## Choice
+Postgres with Prisma ORM
+
+## Rationale
+Postgres provides strong ACID guarantees and Prisma offers type-safe migrations.
+The team has existing Postgres expertise.
+
+## Scope
+Infrastructure and data layer decisions
+`;
+
+  const project = emptyProject({
+    roadmap: flatRoadmap([]),
+    decisions: [{ fileName: '001-choose-database.md', content: structuredDecision }],
+  });
+
+  const result = transformToGSD(project);
+  assert.ok(result.decisionsContent.length > 0, '#1607: decision content should be generated');
+  assert.ok(result.decisionsContent.includes('Postgres with Prisma ORM'), '#1607: Choice section extracted');
+  assert.ok(result.decisionsContent.includes('Postgres provides strong ACID'), '#1607: Rationale section extracted');
+  assert.ok(!result.decisionsContent.includes('Migrated from legacy summary key-decisions'), '#1607: fabricated rationale must not appear');
+  assert.ok(!result.decisionsContent.includes('Choose Postgres as primary datastore | Choose Postgres'), '#1607: decision title must not appear in Choice column');
+});
+
+test('Scenario 4d: #1607 — decision file without structured sections preserves body', () => {
+  const unstructuredDecision = `# Use TypeScript strict mode
+
+We decided to enable strict mode in all packages because it catches a large class
+of bugs at compile time and improves long-term maintainability.
+`;
+
+  const project = emptyProject({
+    roadmap: flatRoadmap([]),
+    decisions: [{ fileName: '002-typescript-strict.md', content: unstructuredDecision }],
+  });
+
+  const result = transformToGSD(project);
+  assert.ok(result.decisionsContent.includes('decided to enable strict mode'), '#1607: body preserved in rationale when no sections found');
+  assert.ok(result.decisionsContent.includes('(not parsed -- see migration source)'), '#1607: choice falls back gracefully');
+  assert.ok(!result.decisionsContent.includes('Migrated from legacy summary key-decisions'), '#1607: fabricated rationale must not appear');
+});


### PR DESCRIPTION
### Problem

Fixes #1606 and #1607: Two consistency bugs in the legacy migration transformer.

**#1606 — Slice completion guard uses only ROADMAP checkbox, ignores task state**

`buildSliceFromLegacyPhase` marks a slice as `done` when the ROADMAP checkbox is checked, even when individual tasks are not. A slice should only be `done` when both the ROADMAP entry is checked AND all its tasks are done.

`buildMilestoneFromLegacyMilestone` also used `Object.keys(phase.summaries).length > 0` (has any summary) instead of verifying that every plan has a matching summary.

**#1607 — Decision field extraction fabricates rationale from title**

`extractDecisionTitle()` returned the title string for all three fields (title, choice, rationale). The `choice` and `rationale` fields should be parsed from the decision document body (`## Choice`, `## Rationale` sections), not copied from the title.

### Changes

**`migrate/transformer.ts`**
```typescript
// #1606 slice fix:
const allTasksDone = tasks.length === 0 || tasks.every((t) => t.done);
const done = entry.done && allTasksDone;

// #1606 milestone fix:
done: Object.keys(phase.plans).length > 0 &&
      Object.keys(phase.plans).every((pn) => phase.summaries[pn] !== undefined),
```

New `extractDecisionFields()` function replaces `extractDecisionTitle()`:
- Parses `## Choice` / `## Rationale` / `## Scope` sections from body
- Falls back to body content in Rationale (never fabricates)
- Choice falls back to `"(not parsed -- see migration source)"` instead of repeating the title

**`tests/migrate-transformer.test.ts`**
- Scenario 4b: fully-done slice is still done (regression guard)
- Scenario 4c: structured decision file → all fields extracted, no fabricated rationale
- Scenario 4d: unstructured file → body preserved in Rationale

### Non-breaking

Migration is import-time only. No runtime schema or API changes.

Fixes #1606
Fixes #1607

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788611716&installation_model_id=22188&pr_number=1611&repository=open-gsd%2Fgsd-pi&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-pi%2Fpull%2F1611&signature=91c1bd14ace2cc94bc7e8723b8895f36cc05b2bec67707692ddedc8356542843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->