### PR TITLE
fix(issue): bug: dispatch-guard.js blocks research-slice/parallel-research sentinel — missing DB exemption

### DIFF
--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -107,6 +107,12 @@ export function getPriorSliceCompletionBlocker(
       continue;
     }
 
+    // #4414: Sentinel unitId "{mid}/parallel-research" orchestrates research
+    // across multiple real slices and is never inserted into the slices table,
+    // so the per-slice identity/dependency checks below cannot apply to it.
+    // Earlier-milestone gating above still runs.
+    if (targetSid === "parallel-research") continue;
+
     const targetSlice = slices.find((slice) => slice.id === targetSid);
     if (!targetSlice) {
       return `Cannot dispatch ${unitType} ${unitId}: slice ${targetMid}/${targetSid} is missing from the workflow DB.`;

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -167,6 +167,58 @@ test("dispatch guard allows dispatch when all earlier slices complete", (t) => {
   assert.equal(getPriorSliceCompletionBlocker(repo, "main", "plan-milestone", "M003"), null);
 });
 
+test("dispatch guard exempts the parallel-research sentinel from slice DB presence (#1616)", (t) => {
+  const repo = setupRepo();
+  t.after(() => teardownRepo(repo));
+
+  mkdirSync(join(repo, ".gsd", "milestones", "M042"), { recursive: true });
+  mkdirSync(join(repo, ".gsd", "milestones", "M043"), { recursive: true });
+
+  insertMilestone({ id: "M042", title: "Previous" });
+  insertSlice({ id: "S01", milestoneId: "M042", title: "Done", status: "complete", depends: [], sequence: 1 });
+
+  // M043 has real slices S01-S02; "parallel-research" is never inserted by design.
+  insertMilestone({ id: "M043", title: "Current" });
+  insertSlice({ id: "S01", milestoneId: "M043", title: "First", status: "pending", depends: [], sequence: 1 });
+  insertSlice({ id: "S02", milestoneId: "M043", title: "Second", status: "pending", depends: [], sequence: 2 });
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M042", "M042-ROADMAP.md"), "# M042\n");
+  writeFileSync(join(repo, ".gsd", "milestones", "M043", "M043-ROADMAP.md"), "# M043\n");
+
+  assert.equal(
+    getPriorSliceCompletionBlocker(repo, "main", "research-slice", "M043/parallel-research"),
+    null,
+  );
+
+  // Real slice ids are still checked against the DB.
+  assert.match(
+    getPriorSliceCompletionBlocker(repo, "main", "research-slice", "M043/S99") ?? "",
+    /slice M043\/S99 is missing from the workflow DB/i,
+  );
+});
+
+test("dispatch guard still blocks parallel-research when an earlier milestone is incomplete (#1616)", (t) => {
+  const repo = setupRepo();
+  t.after(() => teardownRepo(repo));
+
+  mkdirSync(join(repo, ".gsd", "milestones", "M042"), { recursive: true });
+  mkdirSync(join(repo, ".gsd", "milestones", "M043"), { recursive: true });
+
+  insertMilestone({ id: "M042", title: "Previous" });
+  insertSlice({ id: "S01", milestoneId: "M042", title: "Pending", status: "pending", depends: [], sequence: 1 });
+
+  insertMilestone({ id: "M043", title: "Current" });
+  insertSlice({ id: "S01", milestoneId: "M043", title: "First", status: "pending", depends: [], sequence: 1 });
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M042", "M042-ROADMAP.md"), "# M042\n");
+  writeFileSync(join(repo, ".gsd", "milestones", "M043", "M043-ROADMAP.md"), "# M043\n");
+
+  assert.equal(
+    getPriorSliceCompletionBlocker(repo, "main", "research-slice", "M043/parallel-research"),
+    "Cannot dispatch research-slice M043/parallel-research: earlier slice M042/S01 is not complete.",
+  );
+});
+
 test("dispatch guard unblocks slice when positionally-earlier slice depends on it (#1638)", (t) => {
   // S05 depends on S06, but S05 appears first positionally.
   // Old behavior: S06 blocked because S05 (positionally earlier) is incomplete.


### PR DESCRIPTION
## Summary
- Exempted the synthetic `parallel-research` sentinel from dispatch-guard's slice DB presence/dependency checks (keeping earlier-milestone gating), with two new regression tests; dispatch-guard suites pass 141/141.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1616
- [#1616 bug: dispatch-guard.js blocks research-slice/parallel-research sentinel — missing DB exemption](https://github.com/open-gsd/gsd-pi/issues/1616)

## User
- @splichy

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1616-bug-dispatch-guard-js-blocks-research-sl-1786039942`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->