### PR TITLE
fix(issue): roadmap-divergence reconciliation never converges when a slice is skipped (detector includes skipped slices, renderer omits them)

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
@@ -58,7 +58,13 @@ function milestoneHasDivergence(
     return false;
   }
 
-  const dbSlices = getMilestoneSlices(milestoneId);
+  // Mirror renderRoadmapFromDb's filter (#1619): the ROADMAP projection omits
+  // skipped slices, so the detector must compare against the same view.
+  // Without this, a skipped slice counts as "ready" (skipped ∈
+  // RAW_CLOSED_STATUSES) but never appears in the rendered markdown, so the
+  // absence/order checks below report a divergence that re-rendering can never
+  // repair — reconcileBeforeDispatch then throws on every dispatch.
+  const dbSlices = getMilestoneSlices(milestoneId).filter((s) => s.status !== "skipped");
   const dbSliceMap = new Map(dbSlices.map((s) => [s.id, s]));
   const dbSliceOrder = new Map(dbSlices.map((s, index) => [s.id, index]));
   const readySliceIds = getSlicesReadyForDivergenceCheck(milestoneId, dbSlices);

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1384,6 +1384,61 @@ test("ADR-017 (#870): roadmap-divergence accepts recovered S00 blocker sequence"
   assert.equal(readFileSync(roadmapPath, "utf-8"), originalRoadmap);
 });
 
+test("ADR-017 (#1619): skipped slices are excluded from the divergence view", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-skipped-"));
+  const milestoneId = "M017";
+  const milestoneDir = join(base, ".gsd", "milestones", milestoneId);
+  const roadmapPath = join(milestoneDir, `${milestoneId}-ROADMAP.md`);
+  mkdirSync(milestoneDir, { recursive: true });
+  // The projection omits the skipped S00-blocker, so S01 renders first.
+  const originalRoadmap = [
+    `# ${milestoneId}: Blocker Skipped Milestone`,
+    "",
+    "**Vision:** Skipped blocker slice must not wedge reconciliation.",
+    "",
+    "## Slices",
+    "",
+    "- [ ] **S01: Source of truth contract** `risk:medium` `depends:[]`",
+    "  > After this: ",
+    "",
+    "- [ ] **S02: Policy implementation** `risk:medium` `depends:[]`",
+    "  > After this: ",
+    "",
+  ].join("\n");
+  writeFileSync(roadmapPath, originalRoadmap);
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({
+    id: milestoneId,
+    title: "Blocker Skipped Milestone",
+    status: "queued",
+    planning: { vision: "Skipped blocker slice must not wedge reconciliation." },
+  });
+  insertSlice({ id: "S00-blocker", milestoneId, title: "Blocker placeholder", status: "skipped", risk: "medium", depends: [], demo: "", sequence: 0 });
+  insertSlice({ id: "S01", milestoneId, title: "Source of truth contract", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
+  insertSlice({ id: "S02", milestoneId, title: "Policy implementation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 2 });
+  // S01 is planned, so it counts as "ready" — without excluding the skipped
+  // S00-blocker its DB index (1) would never match its roadmap index (0).
+  insertTask({ id: "T01", sliceId: "S01", milestoneId, title: "Map policy inputs", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: milestoneId, title: "Blocker Skipped Milestone" } }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.repaired.some((d) => d.kind === "roadmap-divergence"),
+    false,
+    "a skipped slice omitted by the renderer must not report roadmap-divergence",
+  );
+  assert.equal(readFileSync(roadmapPath, "utf-8"), originalRoadmap);
+});
+
 test("ADR-017 (#5705): roadmap-divergence re-renders projection without syncing depends into DB", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-"));
   const milestoneDir = join(base, ".gsd", "phases", "01-test");


### PR DESCRIPTION
## Summary
- Filtered skipped slices out of the roadmap-divergence detector to match the renderer's projection, with a regression test verified to fail without the fix.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1619
- [#1619 roadmap-divergence reconciliation never converges when a slice is skipped (detector includes skipped slices, renderer omits them)](https://github.com/open-gsd/gsd-pi/issues/1619)

## User
- @afkayla

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1619-roadmap-divergence-reconciliation-never--1786063701`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->