### PR TITLE
fix(issue): Auto-mode silent re-dispatch loop: execute-task refreshRecoveryDbForArtifact is a read-only no-op, projection-drift stuck-recovery never advances state

### DIFF
--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -47,7 +47,10 @@ import { hasImplementationArtifacts } from "./milestone-implementation-evidence.
 import { loadAllCaptures, loadPendingCaptures } from "./captures.js";
 import { proveMilestoneCloseout } from "./milestone-closeout-proof.js";
 import { readLatestTaskAttempt } from "./task-execution-domain-operation.js";
-import { readPendingTaskRecoveryContext } from "./task-recovery-domain-operation.js";
+import {
+  readPendingTaskRecoveryContext,
+  readTaskRecoveryRoute,
+} from "./task-recovery-domain-operation.js";
 import { readMilestoneValidationVerdict } from "./milestone-validation-verdict.js";
 
 export type ExecuteTaskArtifactReadiness = "verify" | "route";
@@ -64,6 +67,31 @@ export function readExecuteTaskArtifactReadiness(
   if (attempt.nextStage === "route") return "route";
   return null;
 }
+
+/**
+ * The recovery action id when the latest Task Attempt already settled on an
+ * agent-owned `abort` that is not resume-authorized.
+ *
+ * `readExecuteTaskArtifactReadiness` reports "route" for *any* settled Attempt
+ * parked at the route stage — including one whose agent-owned recovery already
+ * aborted. Re-dispatching that unit is a guaranteed dead end:
+ * `runWithTaskExecutionAttempt` sees the same predecessor route and breaks with
+ * `task-recovery-abort` before any work starts (#1622). Stuck recovery must
+ * refuse instead of clearing the dispatch ring and re-dispatching.
+ */
+export function readTerminalTaskRecoveryAbort(
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+): { recoveryActionId: string } | null {
+  const attempt = readLatestTaskAttempt({ milestoneId, sliceId, taskId });
+  if (!attempt) return null;
+  const route = readTaskRecoveryRoute(attempt.attemptId);
+  if (!route || route.recoveryOwner !== "agent") return null;
+  if (route.action !== "abort" || route.resumeAuthorized) return null;
+  return { recoveryActionId: route.recoveryActionId };
+}
+
 /**
  * Optional override for the legacy roadmap parser used by verifyExpectedArtifact.
  * Production leaves this null so the real parseLegacyRoadmap runs; tests inject

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -69,6 +69,7 @@ import { hasImplementationArtifacts } from "./milestone-implementation-evidence.
 import { loadAllCaptures, loadPendingCaptures } from "./captures.js";
 import {
   readExecuteTaskArtifactReadiness,
+  readTerminalTaskRecoveryAbort,
   resolveArtifactVerificationBase,
 } from "./artifact-verification.js";
 import {
@@ -219,6 +220,32 @@ export function refreshRecoveryDbForArtifact(
         reason: "execute-task-attempt-not-actionable",
         message: `Stuck recovery found execute-task ${unitId} artifacts, but its latest canonical Task Attempt has no actionable verify or route Result.`,
       };
+    }
+    // #1622: a route-stage Attempt whose agent-owned recovery already aborted is
+    // NOT recoverable by re-dispatch — the next dispatch breaks instantly with
+    // `task-recovery-abort`, orphaning a worktree and leaving auto-mode to
+    // silently re-dispatch forever. Fail closed with the operator-actionable
+    // recovery path instead of reporting success.
+    if (readiness === "route") {
+      let terminalAbort: ReturnType<typeof readTerminalTaskRecoveryAbort>;
+      try {
+        terminalAbort = readTerminalTaskRecoveryAbort(mid, sid, tid);
+      } catch (err) {
+        return {
+          ok: false,
+          fatal: true,
+          reason: "execute-task-recovery-route-read-failed",
+          message: `Stuck recovery could not read the canonical Task recovery route for execute-task ${unitId}: ${getErrorMessage(err)}`,
+        };
+      }
+      if (terminalAbort) {
+        return {
+          ok: false,
+          fatal: true,
+          reason: "execute-task-recovery-aborted",
+          message: `Stuck recovery found execute-task ${unitId} artifacts, but its canonical Task Attempt recovery already aborted (recoveryActionId: ${terminalAbort.recoveryActionId}); re-dispatching would break immediately with task-recovery-abort. Resume it with \`gsd_task_recovery_resume\` using recoveryActionId ${terminalAbort.recoveryActionId}, or reconcile the projection drift with \`gsd rebuild markdown\` then \`gsd recover\`.`,
+        };
+      }
     }
     return { ok: true };
   }

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -114,8 +114,15 @@ export function _setGithubFinalizeFnForTests(
 
 // ─── Recovery DB refresh ──────────────────────────────────────────────────────
 
+/**
+ * The success arm carries `advanced: false` when the branch only *observed*
+ * canonical state and wrote nothing (#1622). Callers must not describe such a
+ * result as a DB refresh, and must not treat it as evidence that a re-dispatch
+ * will find different state than the one that got the unit stuck. `advanced`
+ * absent means the branch either reconciled the DB or had no DB work to do.
+ */
 export type ArtifactRecoveryDbRefreshResult =
-  | { ok: true }
+  | { ok: true; advanced?: boolean; reason?: string; message?: string }
   | { ok: false; fatal: boolean; message: string; reason: string };
 
 function closeoutProofRecoveryReason(reason: CloseoutProofFailureReason): string {
@@ -247,7 +254,19 @@ export function refreshRecoveryDbForArtifact(
         };
       }
     }
-    return { ok: true };
+    // #1622: unlike the plan-slice/complete-milestone branches below, nothing
+    // above writes the Task row — this branch only *reads* canonical Attempt
+    // readiness. Reconciling the row here would silently import a completion
+    // artifact the runtime deliberately refuses to trust (the doctor
+    // `artifact_db_status_divergence` check exists precisely to keep that an
+    // operator-invoked decision), so report the read-only outcome instead of an
+    // unqualified success and let callers describe what actually happened.
+    return {
+      ok: true,
+      advanced: false,
+      reason: "execute-task-attempt-read-only-verified",
+      message: `canonical Task Attempt verified at the ${readiness} stage (no DB write)`,
+    };
   }
 
   if (!refreshWorkflowDatabaseFromDisk()) {

--- a/src/resources/extensions/gsd/auto/dispatch.ts
+++ b/src/resources/extensions/gsd/auto/dispatch.ts
@@ -374,7 +374,9 @@ export async function runDispatch(
             return { action: "continue" };
           }
           ctx.ui.notify(
-            `Stuck recovery: artifact for ${unitType} ${unitId} found on disk. Invalidating caches.`,
+            `Stuck recovery: artifact for ${unitType} ${unitId} found on disk${
+              recoveryDb.message ? ` (${recoveryDb.message})` : ""
+            }. Invalidating caches.`,
             "info",
           );
           deps.invalidateAllCaches();
@@ -403,7 +405,9 @@ export async function runDispatch(
           const recoveryDb = refreshRecoveryDbForArtifact(unitType, unitId, s.basePath);
           if (recoveryDb.ok) {
             ctx.ui.notify(
-              `Stuck recovery: artifact for ${unitType} ${unitId} found on disk after cache invalidation. Continuing.`,
+              `Stuck recovery: artifact for ${unitType} ${unitId} found on disk after cache invalidation${
+                recoveryDb.message ? ` (${recoveryDb.message})` : ""
+              }. Continuing.`,
               "info",
             );
             loopState.recentUnits.length = 0;

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -883,35 +883,48 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
    * unbounded recover→re-saturate→recover loop — mirrors the legacy
    * Level-1-recover-then-Level-2-hard-stop escalation.
    *
-   * Returns true when recovery succeeded; the caller should re-loop (return a
-   * skipped result) instead of stopping.
+   * Returns `recovered: true` when recovery succeeded; the caller should re-loop
+   * (return a skipped result) instead of stopping. A fatal refusal carries its
+   * operator-actionable `blockedReason` so the hard-stop tells the user how to
+   * recover instead of only naming the dead end (#1622).
    */
-  private tryStuckArtifactRecovery(unitType: string, unitId: string): boolean {
+  private tryStuckArtifactRecovery(
+    unitType: string,
+    unitId: string,
+  ): { recovered: boolean; blockedReason?: string } {
     const key = buildDispatchKey(unitType, unitId);
-    if (this.lastStuckRecoveryKey === key) return false; // already tried this episode
+    if (this.lastStuckRecoveryKey === key) return { recovered: false }; // already tried this episode
     const basePath = this.getLiveDispatchBasePath();
-    if (!verifyExpectedArtifact(unitType, unitId, basePath)) return false;
+    if (!verifyExpectedArtifact(unitType, unitId, basePath)) return { recovered: false };
     const refreshed = refreshRecoveryDbForArtifact(unitType, unitId, basePath);
     // Fatal failures cannot be recovered — hard-stop. Non-fatal (e.g. plan-slice
     // DB refresh hiccup) still fall through: invalidating caches and resetting
     // the ring gives the next advance a clean slate to pick up the correct state,
     // mirroring the legacy Level-1 "continue" escalation path.
-    if (!refreshed.ok && refreshed.fatal) return false;
+    if (!refreshed.ok && refreshed.fatal) {
+      return { recovered: false, blockedReason: refreshed.message };
+    }
     this.lastStuckRecoveryKey = key;
     invalidateAllCaches();
     this.dispatchHistory.clearOnRecovery();
     this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
-    return true;
+    return { recovered: true };
   }
 
   private stuckRecovered(
     decision: { unitType: string; unitId: string },
     stateSnapshot: GSDState,
   ): AutoAdvanceResult {
+    // execute-task recovery only *reads* the canonical Task Attempt — it never
+    // writes the task row — so claiming "DB refreshed" here misreported what
+    // happened and hid the projection drift behind a success line (#1622).
+    const outcome = decision.unitType === "execute-task"
+      ? "canonical Task Attempt state verified (no DB write)"
+      : "DB refreshed";
     const recovered: AutoAdvanceResult = {
       kind: "skipped",
-      reason: `stuck-recovery: ${decision.unitType} ${decision.unitId} artifact found on disk; DB refreshed`,
+      reason: `stuck-recovery: ${decision.unitType} ${decision.unitId} artifact found on disk; ${outcome}`,
       stateSnapshot,
     };
     this.status.phase = "running";
@@ -1157,14 +1170,18 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         // #442: the unit re-dispatched immediately after finalizing may have
         // actually completed on disk with a stale DB. Verify + recover before
         // hard-stopping (legacy graduated stuck-recovery parity).
-        if (this.tryStuckArtifactRecovery(decision.unitType, decision.unitId)) {
+        const finalizedRecovery = this.tryStuckArtifactRecovery(decision.unitType, decision.unitId);
+        if (finalizedRecovery.recovered) {
           this.clearPendingDispatch();
           return this.stuckRecovered(decision, reconciliation.stateSnapshot);
         }
         this.clearPendingDispatch();
+        const finalizedReason = `state did not advance after finalized ${decision.unitType} ${decision.unitId}`;
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
-          reason: `state did not advance after finalized ${decision.unitType} ${decision.unitId}`,
+          reason: finalizedRecovery.blockedReason
+            ? `${finalizedReason} — ${finalizedRecovery.blockedReason}`
+            : finalizedReason,
           action: "stop",
           stateSnapshot: reconciliation.stateSnapshot,
         };
@@ -1220,14 +1237,17 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         // #442: before declaring a stuck loop, verify the unit didn't actually
         // complete on disk (stale DB) and recover if so — legacy graduated
         // stuck-recovery parity. Otherwise hard-stop with a diagnosable reason.
-        if (this.tryStuckArtifactRecovery(decision.unitType, decision.unitId)) {
+        const stuckRecovery = this.tryStuckArtifactRecovery(decision.unitType, decision.unitId);
+        if (stuckRecovery.recovered) {
           this.clearPendingDispatch();
           return this.stuckRecovered(decision, reconciliation.stateSnapshot);
         }
         this.clearPendingDispatch();
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
-          reason: `stuck-loop: ${stuckVerdict.reason}`,
+          reason: stuckRecovery.blockedReason
+            ? `stuck-loop: ${stuckVerdict.reason} — ${stuckRecovery.blockedReason}`
+            : `stuck-loop: ${stuckVerdict.reason}`,
           action: "stop",
         };
         this.journalTransition({

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -382,6 +382,12 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   // recovery to one attempt per stuck episode per run (reset on start/resume/
   // stop), mirroring the legacy Level-1-then-Level-2 escalation in phases.ts.
   private lastStuckRecoveryKey: string | null = null;
+  // #1622: the unit key whose last stuck recovery only *verified* canonical
+  // state without advancing its DB row. The re-dispatch such a recovery unblocks
+  // can land on exactly the state that got the unit stuck, so the next hard stop
+  // for this key must carry the operator recovery path instead of a bare
+  // stuck-loop reason the user can only answer by restarting auto-mode.
+  private lastReadOnlyRecoveryKey: string | null = null;
 
   public constructor(context: OrchestratorContext) {
     this.ctx = context.ctx;
@@ -886,12 +892,14 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
    * Returns `recovered: true` when recovery succeeded; the caller should re-loop
    * (return a skipped result) instead of stopping. A fatal refusal carries its
    * operator-actionable `blockedReason` so the hard-stop tells the user how to
-   * recover instead of only naming the dead end (#1622).
+   * recover instead of only naming the dead end (#1622). `outcome` carries what
+   * the refresh actually did so the journal cannot claim a DB write that never
+   * happened.
    */
   private tryStuckArtifactRecovery(
     unitType: string,
     unitId: string,
-  ): { recovered: boolean; blockedReason?: string } {
+  ): { recovered: boolean; outcome?: string; blockedReason?: string } {
     const key = buildDispatchKey(unitType, unitId);
     if (this.lastStuckRecoveryKey === key) return { recovered: false }; // already tried this episode
     const basePath = this.getLiveDispatchBasePath();
@@ -909,19 +917,53 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     this.dispatchHistory.clearOnRecovery();
     this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
-    return { recovered: true };
+    // #1622: a read-only refresh (execute-task: canonical Attempt verified, task
+    // row untouched) still earns one re-dispatch — the verify/route stages it
+    // unblocks do real work — but it is not proof the DB moved. Remember the key
+    // so the hard stop that follows a second failure names the recovery path.
+    const advanced = !refreshed.ok || refreshed.advanced !== false;
+    this.lastReadOnlyRecoveryKey = advanced ? null : key;
+    return {
+      recovered: true,
+      ...(refreshed.ok && refreshed.message ? { outcome: refreshed.message } : {}),
+    };
+  }
+
+  /**
+   * #1622: guidance appended to a hard stop for a unit whose last stuck recovery
+   * only verified canonical state. Without it the operator sees a bare
+   * `stuck-loop:` / finalized-repeat reason, restarts `gsd auto` — which clears
+   * the ring and the recovery key — and the whole verify→recover→re-dispatch
+   * round trip repeats invisibly.
+   */
+  private readOnlyRecoveryGuidance(unitType: string, unitId: string): string | null {
+    if (this.lastReadOnlyRecoveryKey !== buildDispatchKey(unitType, unitId)) return null;
+    return `stuck recovery for ${unitType} ${unitId} only verified canonical state on disk and did not advance its DB row, so re-running \`gsd auto\` will repeat this loop; reconcile the projection with \`gsd rebuild markdown\` then \`gsd recover\` (or resume the pending Task recovery action) before retrying.`;
+  }
+
+  /**
+   * Compose a hard-stop reason with whatever the stuck-recovery attempt learned:
+   * a fatal refusal's own message, else the read-only-recovery guidance (#1622).
+   */
+  private hardStopReason(
+    base: string,
+    recovery: { blockedReason?: string },
+    unitType: string,
+    unitId: string,
+  ): string {
+    const detail = recovery.blockedReason ?? this.readOnlyRecoveryGuidance(unitType, unitId);
+    return detail ? `${base} — ${detail}` : base;
   }
 
   private stuckRecovered(
     decision: { unitType: string; unitId: string },
     stateSnapshot: GSDState,
+    outcome: string,
   ): AutoAdvanceResult {
-    // execute-task recovery only *reads* the canonical Task Attempt — it never
-    // writes the task row — so claiming "DB refreshed" here misreported what
-    // happened and hid the projection drift behind a success line (#1622).
-    const outcome = decision.unitType === "execute-task"
-      ? "canonical Task Attempt state verified (no DB write)"
-      : "DB refreshed";
+    // The outcome comes from the refresh itself: execute-task recovery only
+    // *reads* the canonical Task Attempt, so claiming "DB refreshed" for it
+    // misreported what happened and hid the projection drift behind a success
+    // line (#1622).
     const recovered: AutoAdvanceResult = {
       kind: "skipped",
       reason: `stuck-recovery: ${decision.unitType} ${decision.unitId} artifact found on disk; ${outcome}`,
@@ -955,6 +997,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     // after a crash should see the dispatch history it had been accumulating.
     this.dispatchHistory.clearOnRecovery();
     this.lastStuckRecoveryKey = null;
+    this.lastReadOnlyRecoveryKey = null;
     this.lastDerivedPhase = null;
     this.status.phase = "running";
     this.bumpTransition();
@@ -1173,15 +1216,21 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         const finalizedRecovery = this.tryStuckArtifactRecovery(decision.unitType, decision.unitId);
         if (finalizedRecovery.recovered) {
           this.clearPendingDispatch();
-          return this.stuckRecovered(decision, reconciliation.stateSnapshot);
+          return this.stuckRecovered(
+            decision,
+            reconciliation.stateSnapshot,
+            finalizedRecovery.outcome ?? "DB refreshed",
+          );
         }
         this.clearPendingDispatch();
-        const finalizedReason = `state did not advance after finalized ${decision.unitType} ${decision.unitId}`;
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
-          reason: finalizedRecovery.blockedReason
-            ? `${finalizedReason} — ${finalizedRecovery.blockedReason}`
-            : finalizedReason,
+          reason: this.hardStopReason(
+            `state did not advance after finalized ${decision.unitType} ${decision.unitId}`,
+            finalizedRecovery,
+            decision.unitType,
+            decision.unitId,
+          ),
           action: "stop",
           stateSnapshot: reconciliation.stateSnapshot,
         };
@@ -1240,14 +1289,21 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         const stuckRecovery = this.tryStuckArtifactRecovery(decision.unitType, decision.unitId);
         if (stuckRecovery.recovered) {
           this.clearPendingDispatch();
-          return this.stuckRecovered(decision, reconciliation.stateSnapshot);
+          return this.stuckRecovered(
+            decision,
+            reconciliation.stateSnapshot,
+            stuckRecovery.outcome ?? "DB refreshed",
+          );
         }
         this.clearPendingDispatch();
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
-          reason: stuckRecovery.blockedReason
-            ? `stuck-loop: ${stuckVerdict.reason} — ${stuckRecovery.blockedReason}`
-            : `stuck-loop: ${stuckVerdict.reason}`,
+          reason: this.hardStopReason(
+            `stuck-loop: ${stuckVerdict.reason}`,
+            stuckRecovery,
+            decision.unitType,
+            decision.unitId,
+          ),
           action: "stop",
         };
         this.journalTransition({
@@ -1379,6 +1435,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       this.dispatchHistory.rehydrate();
     }
     this.lastStuckRecoveryKey = null;
+    this.lastReadOnlyRecoveryKey = null;
     // ADR-030: drop the prior "from" — the first advance after resume has no
     // edge to assert (avoids a false illegal-edge across the pause boundary).
     this.lastDerivedPhase = null;
@@ -1405,6 +1462,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       this.dispatchHistory.clearOnRecovery();
     }
     this.lastStuckRecoveryKey = null;
+    this.lastReadOnlyRecoveryKey = null;
     this.bumpTransition();
     this.journalTransition({ name: "stop", reason });
     this.notifyLifecycle({ name: "stop", detail: reason });

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -44,6 +44,8 @@ import { AutoSession } from "../auto/session.js";
 import { registerAutoWorker } from "../db/auto-workers.js";
 import { claimMilestoneLease, getMilestoneLease, releaseMilestoneLease } from "../db/milestone-leases.js";
 import { recordDispatchClaim, markFailed } from "../db/unit-dispatches.js";
+import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.js";
+import { internalExecutionInvocation } from "../execution-invocation.js";
 import { normalizeRealPath } from "../paths.js";
 import { acquireSessionLock, releaseSessionLock } from "../session-lock.js";
 import { queryJournal } from "../journal.js";
@@ -202,6 +204,46 @@ function makeFixture(opts: FixtureOptions = {}): Fixture {
       try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
     },
   };
+}
+
+/**
+ * Seed the canonical Task Attempt that makes `verifyExpectedArtifact` report the
+ * fixture task as complete on disk while its DB row stays open — the #1622
+ * projection-drift shape that drives stuck recovery down the execute-task
+ * (read-only) branch.
+ */
+function seedSucceededTaskAttempt(base: string): void {
+  const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
+  const lease = claimMilestoneLease(workerId, "M001");
+  assert.equal(lease.ok, true);
+  if (!lease.ok) throw new Error("fixture lease claim failed");
+  const claim = recordDispatchClaim({
+    traceId: "read-only-recovery",
+    workerId,
+    milestoneLeaseToken: lease.token,
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T01",
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+  });
+  assert.equal(claim.ok, true);
+  if (!claim.ok) throw new Error("fixture dispatch claim failed");
+  const attempt = claimTaskAttempt({
+    invocation: internalExecutionInvocation("test:orchestrator:read-only-recovery:claim"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId,
+    milestoneLeaseToken: lease.token,
+    coordinationDispatchId: claim.dispatchId,
+  });
+  settleTaskAttempt({
+    invocation: internalExecutionInvocation("test:orchestrator:read-only-recovery:settle"),
+    attemptId: attempt.attemptId,
+    outcome: "succeeded",
+    failureClass: "none",
+    summary: "executor succeeded",
+    output: {},
+  });
 }
 
 function makeState(): GSDState {
@@ -1069,6 +1111,45 @@ test("stuck-loop: journal records the stuck-loop reason on advance-blocked", asy
   );
   assert.ok(stuckEntry, "journal must record an advance-blocked entry with the stuck-loop reason");
   assert.ok(f.journalNames().includes("advance-blocked"));
+});
+
+test("#1622: execute-task stuck recovery reports the read-only outcome and names the recovery path on the next hard stop", async (t) => {
+  const f = makeFixture();
+  t.after(() => f.cleanup());
+  seedSucceededTaskAttempt(f.base);
+
+  // Round 1: the ring saturates, but the canonical Attempt makes the artifact
+  // verify — stuck recovery takes the unit instead of hard-stopping.
+  const first: Awaited<ReturnType<typeof f.orchestrator.advance>>[] = [];
+  for (let i = 0; i < STUCK_WINDOW_SIZE; i++) first.push(await f.orchestrator.advance());
+  const recovered = first[STUCK_WINDOW_SIZE - 1];
+  assert.equal(recovered.kind, "skipped", JSON.stringify(recovered));
+  if (recovered.kind !== "skipped") return;
+  assert.equal(
+    recovered.reason,
+    "stuck-recovery: execute-task M001/S01/T01 artifact found on disk; " +
+      "canonical Task Attempt verified at the verify stage (no DB write)",
+    "the journal must not claim a DB refresh the execute-task branch never performed",
+  );
+
+  // Round 2: the recovery cleared the ring but wrote nothing, so the unit
+  // saturates it again. This time recovery is spent, and the hard stop must
+  // carry the operator recovery path instead of a bare stuck-loop verdict.
+  let blocked: Awaited<ReturnType<typeof f.orchestrator.advance>> | null = null;
+  for (let i = 0; i < STUCK_WINDOW_SIZE; i++) {
+    const result = await f.orchestrator.advance();
+    if (result.kind === "blocked") {
+      blocked = result;
+      break;
+    }
+  }
+  assert.ok(blocked, "the second saturation must hard-stop rather than recover again");
+  if (!blocked || blocked.kind !== "blocked") return;
+  assert.equal(blocked.action, "stop");
+  assert.ok(blocked.reason.startsWith("stuck-loop:"), `expected stuck-loop reason, got: ${blocked.reason}`);
+  assert.match(blocked.reason, /did not advance its DB row/);
+  assert.match(blocked.reason, /gsd rebuild markdown/);
+  assert.match(blocked.reason, /gsd recover/);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -12,6 +12,7 @@ import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArti
 import { resolveMilestoneFile } from "../paths.ts";
 import { _getAdapter, openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, insertAssessment, getMilestone, getMilestoneCommitAttributionShas, getTask, getSlice, saveGateResult, updateMilestoneStatus } from "../gsd-db.ts";
 import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.ts";
+import { recordFailureAndSelectRecovery } from "../task-recovery-domain-operation.ts";
 import { internalExecutionInvocation } from "../execution-invocation.ts";
 import { readEvents } from "../workflow-events.ts";
 import { executeDomainOperation } from "../db/domain-operation.ts";
@@ -69,7 +70,9 @@ function makeTmpProject(): string {
   return dir;
 }
 
-function seedCanonicalTaskAttempt(outcome?: "succeeded" | "failed"): void {
+function seedCanonicalTaskAttempt(
+  outcome?: "succeeded" | "failed",
+): { attemptId: string; resultId: string | undefined } {
   const db = _getAdapter();
   assert.ok(db);
   db.exec(`
@@ -104,16 +107,18 @@ function seedCanonicalTaskAttempt(outcome?: "succeeded" | "failed"): void {
     milestoneLeaseToken: 7,
     coordinationDispatchId: Number(dispatch?.["id"]),
   });
+  let resultId: string | undefined;
   if (outcome) {
-    settleTaskAttempt({
+    resultId = settleTaskAttempt({
       invocation: internalExecutionInvocation(`test:artifact-recovery:settle:${outcome}`),
       attemptId: claim.attemptId,
       outcome,
       failureClass: outcome === "succeeded" ? "none" : "executor-failed",
       summary: `executor ${outcome}`,
       output: {},
-    });
+    }).resultId;
   }
+  return { attemptId: claim.attemptId, resultId };
 }
 
 function runGit(base: string, args: string[]): void {
@@ -585,6 +590,39 @@ test("refreshRecoveryDbForArtifact accepts canonical verify and route Result hea
     refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01", second),
     { ok: true },
   );
+});
+
+test("refreshRecoveryDbForArtifact refuses execute-task recovery after a terminal agent abort (#1622)", () => {
+  const dir = makeTmpProject();
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", title: "Task", status: "pending" });
+  const attempt = seedCanonicalTaskAttempt("failed");
+  assert.ok(attempt.resultId);
+  const route = recordFailureAndSelectRecovery({
+    invocation: internalExecutionInvocation("test:artifact-recovery:route:abort"),
+    attemptId: attempt.attemptId,
+    resultId: attempt.resultId!,
+    owner: "agent",
+    classification: { failureKind: "fatal" },
+    summary: "host verification never committed",
+    evidence: { unitType: "execute-task", unitId: "M001/S01/T01" },
+    rationale: "Terminal agent-owned abort",
+  });
+  assert.equal(route.action, "abort");
+
+  // The artifact still verifies (the Attempt is parked at the route stage), so
+  // without the guard stuck recovery reports success and re-dispatches into an
+  // instant `task-recovery-abort` break.
+  assert.equal(verifyExpectedArtifact("execute-task", "M001/S01/T01", dir), true);
+
+  const result = refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01", dir);
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.fatal, true);
+  assert.equal(result.reason, "execute-task-recovery-aborted");
+  assert.ok(result.message.includes(route.recoveryActionId));
+  assert.ok(result.message.includes("gsd_task_recovery_resume"));
+  assert.ok(result.message.includes("gsd recover"));
 });
 
 test("refreshRecoveryDbForArtifact closes complete-milestone DB row when artifacts exist but DB is stale (#5568)", async () => {

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -572,10 +572,18 @@ test("refreshRecoveryDbForArtifact accepts canonical verify and route Result hea
     true,
     "a succeeded Result at verify is sufficient without SUMMARY or PLAN projections",
   );
+  // #1622: acceptance is read-only — the task row is never written here, so the
+  // result must say so instead of passing for a DB refresh.
   assert.deepEqual(
     refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01", first),
-    { ok: true },
+    {
+      ok: true,
+      advanced: false,
+      reason: "execute-task-attempt-read-only-verified",
+      message: "canonical Task Attempt verified at the verify stage (no DB write)",
+    },
   );
+  assert.equal(getTask("M001", "S01", "T01")?.status, "pending", "recovery must not advance the task row");
 
   closeDatabase();
   const second = makeTmpProject();
@@ -588,7 +596,12 @@ test("refreshRecoveryDbForArtifact accepts canonical verify and route Result hea
   );
   assert.deepEqual(
     refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01", second),
-    { ok: true },
+    {
+      ok: true,
+      advanced: false,
+      reason: "execute-task-attempt-read-only-verified",
+      message: "canonical Task Attempt verified at the route stage (no DB write)",
+    },
   );
 });
 


### PR DESCRIPTION
## Summary
- Made execute-task stuck recovery fail closed with the recoveryActionId/`gsd recover` guidance when the canonical Task Attempt already holds a terminal agent-owned abort, instead of falsely reporting "DB refreshed" and re-dispatching; verified with a new regression test plus the orchestrator/auto-loop suites, build, and typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1622
- [#1622 Auto-mode silent re-dispatch loop: execute-task refreshRecoveryDbForArtifact is a read-only no-op, projection-drift stuck-recovery never advances state](https://github.com/open-gsd/gsd-pi/issues/1622)

## User
- @DragonSigh

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1622-auto-mode-silent-re-dispatch-loop-execut-1786112737`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->