### PR TITLE
fix(issue): [Bug]: [drift-check] /gsd auto enters a two-state drift loop: disk-slice-id-divergence fix triggers roadmap-divergence

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -12,7 +12,7 @@
 import { readFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { createProjectionDirectorySync, removeProjectionFileSync } from "./atomic-write.js";
 import { logWarning } from "./workflow-logger.js";
-import { isClosedStatus, toStatus } from "./status-guards.js";
+import { isClosedStatus, isHiddenFromRoadmap, toStatus } from "./status-guards.js";
 import { dirname, join } from "node:path";
 import {
   getAllMilestones,
@@ -568,7 +568,11 @@ export async function renderRoadmapFromDb(
     throw new Error(`milestone ${milestoneId} not found`);
   }
 
-  const slices = getMilestoneSlices(milestoneId).filter((slice) => slice.status !== "skipped");
+  // Shared with roadmap-divergence detection (#1623) so the projection and the
+  // drift check agree on which slices ROADMAP.md is expected to contain.
+  const slices = getMilestoneSlices(milestoneId).filter(
+    (slice) => !isHiddenFromRoadmap(slice.status),
+  );
 
   // Refuse to render a stub ROADMAP for an unplanned milestone (#852).
   // A milestone row created by gsd_milestone_generate_id / ensureMilestoneDbRow

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -320,6 +320,26 @@ function milestoneIdAliases(
   return aliases;
 }
 
+/**
+ * Slice ids that a bare, PLAN-filename-derived id may legitimately resolve to.
+ *
+ * #1623: a flat-phase plan file only encodes a numeric index (`NN-MM-PLAN.md`),
+ * so the derived id is always bare (`S01`). DB rows, however, routinely carry a
+ * suffix — `S01-replan`, `S02-db-repair`, `S00-blocker` — and exact-equality
+ * membership flagged every one of them as `disk-slice-id-divergence`, pausing
+ * `/gsd auto` with no repair path short of hand-creating a bare placeholder
+ * slice. Accept the bare id itself or any id that extends it with a `-<suffix>`;
+ * the `-` separator keeps `S1` from matching `S10`.
+ */
+function knownSliceIdMatches(knownSliceIds: ReadonlySet<string>, sliceId: string): boolean {
+  if (knownSliceIds.has(sliceId)) return true;
+  const prefix = `${sliceId}-`;
+  for (const known of knownSliceIds) {
+    if (known.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
 function detectDiskSliceIdDivergenceForMilestone(
   milestoneId: string,
   filesystemIds: string[],
@@ -343,7 +363,7 @@ function detectDiskSliceIdDivergenceForMilestone(
       if (!planMatch) continue;
       const planNum = parseInt(planMatch[1]!, 10);
       const sliceId = `S${String(planNum).padStart(2, "0")}`;
-      if (knownSliceIds.has(sliceId)) continue;
+      if (knownSliceIdMatches(knownSliceIds, sliceId)) continue;
       drifts.push({
         kind: "disk-slice-id-divergence",
         milestoneId,

--- a/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
@@ -16,7 +16,11 @@ import { renderRoadmapFromDb } from "../../markdown-renderer.js";
 import { findMilestoneIds } from "../../milestone-ids.js";
 import { parseRoadmap } from "../../parsers-legacy.js";
 import { resolveMilestoneFile } from "../../paths.js";
-import { isClosedStatus, isSkippedForDispatch } from "../../status-guards.js";
+import {
+  isClosedStatus,
+  isHiddenFromRoadmap,
+  isSkippedForDispatch,
+} from "../../status-guards.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
@@ -37,6 +41,11 @@ function getSlicesReadyForDivergenceCheck(
 ): Set<string> {
   const ready = new Set<string>();
   for (const slice of dbSlices) {
+    // #1623: a skipped slice is never rendered into ROADMAP.md, so it can
+    // never satisfy the "ready slice must appear in the roadmap" rule. Treating
+    // it as ready made the drift unrepairable — re-rendering reproduced the
+    // same omission and /gsd auto paused after the reconciliation cap.
+    if (isHiddenFromRoadmap(slice.status)) continue;
     if (isClosedStatus(slice.status) || getSliceTasks(milestoneId, slice.id).length > 0) {
       ready.add(slice.id);
     }
@@ -60,7 +69,11 @@ function milestoneHasDivergence(
 
   const dbSlices = getMilestoneSlices(milestoneId);
   const dbSliceMap = new Map(dbSlices.map((s) => [s.id, s]));
-  const dbSliceOrder = new Map(dbSlices.map((s, index) => [s.id, index]));
+  // Sequence positions are compared against the *rendered* slice list, which
+  // omits skipped slices (#1623) — indexing the raw DB list would report a
+  // permanent off-by-N whenever a milestone contains a skipped slice.
+  const renderedSlices = dbSlices.filter((s) => !isHiddenFromRoadmap(s.status));
+  const dbSliceOrder = new Map(renderedSlices.map((s, index) => [s.id, index]));
   const readySliceIds = getSlicesReadyForDivergenceCheck(milestoneId, dbSlices);
   if (dbSlices.length > 0 && readySliceIds.size === 0) {
     return false;
@@ -72,6 +85,9 @@ function milestoneHasDivergence(
     roadmapSliceIds.add(roadmapSlice.id);
     const dbSlice = dbSliceMap.get(roadmapSlice.id);
     if (!dbSlice) return true; // Roadmap has a slice the DB doesn't.
+    // A stale roadmap row for a now-skipped slice: re-rendering removes it, so
+    // flagging this converges rather than looping.
+    if (isHiddenFromRoadmap(dbSlice.status)) return true;
     if (!readySliceIds.has(dbSlice.id)) continue;
     if (dbSliceOrder.get(dbSlice.id) !== i) return true;
     if (!arraysEqual(dbSlice.depends, roadmapSlice.depends)) return true;

--- a/src/resources/extensions/gsd/status-guards.ts
+++ b/src/resources/extensions/gsd/status-guards.ts
@@ -65,6 +65,20 @@ export function isClosedStatus(status: string): boolean {
   return RAW_CLOSED_SET.has(status);
 }
 
+/**
+ * Returns true when a slice is omitted from the rendered ROADMAP projection.
+ *
+ * #1623: `renderRoadmapFromDb` drops skipped slices, but roadmap-divergence
+ * detection treated them as "ready" (because `isClosedStatus("skipped")` is
+ * true) and therefore expected them to appear in ROADMAP.md. A skipped slice
+ * then produced permanent drift: re-rendering could never add a row the
+ * renderer deliberately omits, so `/gsd auto` paused with "drift persisted
+ * after cap=2 passes". Both sides now share this single predicate.
+ */
+export function isHiddenFromRoadmap(status: string): boolean {
+  return status === "skipped";
+}
+
 /** Returns true when a slice status indicates it was deferred by a decision. */
 export function isDeferredStatus(status: string): boolean {
   return status === "deferred";

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -2077,6 +2077,147 @@ test("#1565: unique-suffix DB milestone id resolves slices planned under the fil
   );
 });
 
+test("#1623: suffixed DB slice id satisfies the bare PLAN-filename slice id", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-suffixed-slice-drift-"));
+  t.after(() => cleanup(base));
+
+  const phaseDir = join(base, ".gsd", "phases", "01-test");
+  mkdirSync(phaseDir, { recursive: true });
+  writeFileSync(join(phaseDir, "01-01-PLAN.md"), "# Plan S01\n");
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  // Replanning stored the slice with a suffix; the plan filename can only ever
+  // encode the bare numeric index, so exact-id matching flagged false drift.
+  insertSlice({ id: "S01-replan", milestoneId: "M001", title: "Slice", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.blockers.join("\n").includes("references unknown S01"),
+    false,
+    "suffixed slice id must satisfy the bare id derived from the plan filename",
+  );
+});
+
+test("#1623: bare plan slice id does not match a longer numeric slice id", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-bare-slice-prefix-drift-"));
+  t.after(() => cleanup(base));
+
+  const phaseDir = join(base, ".gsd", "phases", "01-test");
+  mkdirSync(phaseDir, { recursive: true });
+  writeFileSync(join(phaseDir, "01-01-PLAN.md"), "# Plan S01\n");
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S010", milestoneId: "M001", title: "Slice", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(
+    result.blockers.join("\n").includes("references unknown S01"),
+    true,
+    "S010 is a different slice, not a suffixed alias of S01",
+  );
+});
+
+test("#1623: skipped slice does not produce unrepairable roadmap-divergence", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-skipped-roadmap-drift-"));
+  t.after(() => cleanup(base));
+
+  const phaseDir = join(base, ".gsd", "phases", "01-test");
+  mkdirSync(phaseDir, { recursive: true });
+  const roadmapPath = join(phaseDir, "01-ROADMAP.md");
+  // The rendered projection omits skipped slices, so S01 is absent by design.
+  writeFileSync(
+    roadmapPath,
+    [
+      "# M001: Test",
+      "",
+      "**Vision:** Verify skipped slices stay out of the divergence check",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S02: Feature** `risk:medium` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({
+    id: "M001",
+    title: "Test",
+    status: "active",
+    planning: { vision: "Verify skipped slices stay out of the divergence check" },
+  });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Placeholder", status: "skipped", risk: "medium", depends: [], demo: "", sequence: 1 });
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Feature", status: "pending", risk: "medium", depends: [], demo: "", sequence: 2 });
+  insertTask({ id: "T01", sliceId: "S02", milestoneId: "M001", title: "Plan S02", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true, result.ok ? "" : result.blockers.join("\n"));
+  assert.equal(
+    result.repaired.some((d) => d.kind === "roadmap-divergence"),
+    false,
+    "a skipped slice missing from ROADMAP.md is the rendered contract, not drift",
+  );
+});
+
+test("#1623: stale roadmap row for a now-skipped slice is re-rendered away", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-skipped-roadmap-stale-"));
+  t.after(() => cleanup(base));
+
+  const phaseDir = join(base, ".gsd", "phases", "01-test");
+  mkdirSync(phaseDir, { recursive: true });
+  const roadmapPath = join(phaseDir, "01-ROADMAP.md");
+  writeFileSync(
+    roadmapPath,
+    [
+      "# M001: Test",
+      "",
+      "**Vision:** Verify skipped slices are dropped from a stale projection",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Placeholder** `risk:medium` `depends:[]`",
+      "- [ ] **S02: Feature** `risk:medium` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({
+    id: "M001",
+    title: "Test",
+    status: "active",
+    planning: { vision: "Verify skipped slices are dropped from a stale projection" },
+  });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Placeholder", status: "skipped", risk: "medium", depends: [], demo: "", sequence: 1 });
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Feature", status: "pending", risk: "medium", depends: [], demo: "", sequence: 2 });
+  insertTask({ id: "T01", sliceId: "S02", milestoneId: "M001", title: "Plan S02", status: "pending" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true, result.ok ? "" : result.blockers.join("\n"));
+  const roadmap = readFileSync(roadmapPath, "utf-8");
+  assert.equal(roadmap.includes("S01: Placeholder"), false, "skipped slice is dropped");
+  assert.match(roadmap, /S02: Feature/);
+});
+
 // ─── #5707: caller closure (reconcileBeforeSpawn) ────────────────────────────
 
 test("ADR-017 (#5707): reconcileBeforeSpawn returns ok=true on clean reconciliation", async () => {


### PR DESCRIPTION
## Summary
- Fixed the two-state drift loop by prefix-matching suffixed slice ids against bare PLAN-filename ids and by sharing one skipped-slice predicate between the roadmap renderer and the divergence check; verified with 4 new regression tests plus the drift, renderer, and status-guard suites and verify:fast.

## Bugs Addressed
- [x] **disk-slice-id-divergence requires exact bare slice id from PLAN filename**
- [x] **skipped slices are 'ready' for roadmap divergence but filtered from rendered ROADMAP.md**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1623
- [#1623 [Bug]: [drift-check] /gsd auto enters a two-state drift loop: disk-slice-id-divergence fix triggers roadmap-divergence](https://github.com/open-gsd/gsd-pi/issues/1623)

## User
- @efrembaraldo

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1623-bug-drift-check-gsd-auto-enters-a-two-st-1786113581`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->