### PR TITLE
fix(issue): fix: forensics redactForGitHub misses OS username, workspace repo IDs, and doctor issue paths

### DIFF
--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -40,7 +40,7 @@ import {
 } from "./command-feedback.js";
 import { ensurePreferencesFile, serializePreferencesToFrontmatter } from "./commands-prefs-wizard.js";
 import { summarizeWorktreeTelemetry, percentile, type WorktreeTelemetrySummary } from "./worktree-telemetry.js";
-import { homedir } from "node:os";
+import { homedir, userInfo } from "node:os";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -1041,7 +1041,10 @@ function saveForensicReport(basePath: string, report: ForensicReport, problemDes
   const ts = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "-").slice(0, 19);
   const filePath = join(dir, `report-${ts}.md`);
 
-  const redact = (s: string) => redactForGitHub(s, basePath);
+  const workspaceRepoIds = Object.keys(
+    loadEffectiveGSDPreferences(basePath)?.preferences?.workspace?.repositories ?? {},
+  );
+  const redact = (s: string) => redactForGitHub(s, basePath, workspaceRepoIds);
 
   const sections: string[] = [
     `# GSD Forensic Report`,
@@ -1062,7 +1065,7 @@ function saveForensicReport(basePath: string, report: ForensicReport, problemDes
   if (report.anomalies.length > 0) {
     sections.push(`## Anomalies Detected (${report.anomalies.length})`, ``);
     for (const a of report.anomalies) {
-      sections.push(`### [${a.severity.toUpperCase()}] ${a.type}: ${a.summary}`);
+      sections.push(`### [${a.severity.toUpperCase()}] ${a.type}: ${redact(a.summary)}`);
       if (a.unitType) sections.push(`- Unit: ${a.unitType}/${a.unitId ?? ""}`);
       sections.push(`- ${redact(a.details)}`, ``);
     }
@@ -1099,7 +1102,7 @@ function saveForensicReport(basePath: string, report: ForensicReport, problemDes
   // Doctor issues
   if (report.doctorIssues.length > 0) {
     sections.push(`## Doctor Issues`, ``);
-    sections.push(formatDoctorIssuesForPrompt(report.doctorIssues), ``);
+    sections.push(redact(formatDoctorIssuesForPrompt(report.doctorIssues)), ``);
   }
 
   // Crash lock
@@ -1384,7 +1387,24 @@ function formatReportForPrompt(report: ForensicReport): string {
 
 // ─── Redaction ────────────────────────────────────────────────────────────────
 
-function redactForGitHub(text: string, basePath: string): string {
+/**
+ * Usernames that identify nobody in particular. Redacting these would mangle
+ * unrelated prose ("root cause", "admin panel") for no privacy gain.
+ */
+const GENERIC_USERNAMES = new Set(["root", "admin", "administrator", "user", "ubuntu", "runner", "node"]);
+
+/** Current OS username, or null when the platform can't resolve one. */
+function currentUsername(): string | null {
+  try {
+    const name = userInfo().username?.trim();
+    if (!name || name.length < 3) return null;
+    return GENERIC_USERNAMES.has(name.toLowerCase()) ? null : name;
+  } catch {
+    return null;
+  }
+}
+
+export function redactForGitHub(text: string, basePath: string, repoIds: readonly string[] = []): string {
   let result = text;
 
   // Build regex that matches both / and \ separator variants (Windows)
@@ -1402,6 +1422,23 @@ function redactForGitHub(text: string, basePath: string): string {
     result = result.replace(pathRe(gsdHomePath), "~/.gsd");
   }
   result = result.replace(pathRe(homedir()), "~");
+
+  // Workspace-declared repository IDs leak project structure (VERIFY.json command
+  // entries prefix each check with `[<repo-id>]`). The bare-word replacement also
+  // covers the bracketed form. "project" is the implicit self repo — replacing it
+  // would mangle unrelated prose, and it identifies nothing.
+  repoIds
+    .filter((id) => id && id !== "project")
+    .forEach((id, i) => {
+      result = result.replace(new RegExp(`\\b${esc(id)}\\b`, "gi"), `child-repo-${i + 1}`);
+    });
+
+  // Bare OS username occurrences (e.g. the owner/group columns of `ls -la` output
+  // captured in error traces) survive the homedir path replacement above.
+  const username = currentUsername();
+  if (username) {
+    result = result.replace(new RegExp(`\\b${esc(username)}\\b`, "gi"), "<user>");
+  }
 
   // Strip API key patterns
   result = result.replace(/sk-[a-zA-Z0-9]{20,}/g, "sk-***");

--- a/src/resources/extensions/gsd/tests/forensics-redaction.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-redaction.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Forensics redactForGitHub tests — #1632
+ *
+ * Verifies that report redaction strips bare OS usernames (not just homedir
+ * path prefixes) and workspace-declared repository IDs, so neither leaks into
+ * a filed GitHub issue.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { userInfo } from "node:os";
+import { redactForGitHub } from "../forensics.js";
+
+const GENERIC = new Set(["root", "admin", "administrator", "user", "ubuntu", "runner", "node"]);
+const username = (() => {
+  try {
+    const name = userInfo().username?.trim();
+    if (!name || name.length < 3 || GENERIC.has(name.toLowerCase())) return null;
+    return name;
+  } catch {
+    return null;
+  }
+})();
+
+test("#1632 bare OS username occurrences are redacted", { skip: username ? false : "no identifying OS username" }, () => {
+  const line = `drwxrwxr-x 1 ${username} ${username} 726 Jul  3 13:34 .`;
+  const out = redactForGitHub(line, "/tmp/project");
+
+  assert.equal(out.includes(username!), false, "username should not survive redaction");
+  assert.match(out, /drwxrwxr-x 1 <user> <user> 726/);
+});
+
+test("#1632 workspace repository IDs are redacted in both bracket and bare form", () => {
+  const text = [
+    "[child-repo-name] test -f some/path/file.hcl && echo ok",
+    "verification failed in child-repo-name",
+  ].join("\n");
+
+  const out = redactForGitHub(text, "/tmp/project", ["project", "child-repo-name", "other-service"]);
+
+  assert.equal(out.includes("child-repo-name"), false, "repo id should not survive redaction");
+  assert.match(out, /^\[child-repo-1\] test -f/m);
+  assert.match(out, /verification failed in child-repo-1$/m);
+});
+
+test("#1632 the implicit 'project' repo id is left alone", () => {
+  const out = redactForGitHub("project state is stale", "/tmp/base", ["project"]);
+  assert.equal(out, "project state is stale");
+});
+
+test("#1632 redaction is a no-op when no repo ids are declared", () => {
+  const out = redactForGitHub("nothing sensitive here", "/tmp/base");
+  assert.equal(out, "nothing sensitive here");
+});


### PR DESCRIPTION
## Summary
- Extended forensics redactForGitHub to strip bare OS usernames and workspace repo IDs and routed anomaly summaries plus doctor-issue output through redact(); verified with a new 4-case redaction test, 31 passing forensics tests, and verify:fast.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1632
- [#1632 fix: forensics redactForGitHub misses OS username, workspace repo IDs, and doctor issue paths](https://github.com/open-gsd/gsd-pi/issues/1632)

## User
- @splichy

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1632-fix-forensics-redactforgithub-misses-os--1786129662`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->