### PR TITLE
fix(issue): Safety harness: false-positive "unexpected file change" on auto-generated files in .gsd/ or .gsd-state/ when GSD_STATE_DIR is set

### DIFF
--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -13,6 +13,7 @@
 
 import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
+import { isAbsolute, relative, resolve } from "node:path";
 import { normalizePlannedFileReference } from "../files.js";
 import { logWarning } from "../workflow-logger.js";
 
@@ -76,13 +77,24 @@ export function validateFileChanges(
   const actualFiles = getChangedFilesFromLastCommit(basePath);
   if (!actualFiles) return null;
 
+  const configuredProjectsDir = process.env.GSD_STATE_DIR
+    ? relative(resolve(basePath), resolve(process.env.GSD_STATE_DIR, "projects")).replaceAll("\\", "/")
+    : null;
+  const configuredProjectsPrefix = configuredProjectsDir
+    && configuredProjectsDir !== ".."
+    && !configuredProjectsDir.startsWith("../")
+    && !isAbsolute(configuredProjectsDir)
+    ? `${configuredProjectsDir.replace(/\/$/, "")}/`
+    : null;
+
   // Filter out GSD-internal paths — only validate project source files.
   const projectFiles = actualFiles.filter(
     (f) =>
       !f.startsWith(".gsd/") &&
       !f.startsWith(".gsd\\") &&
       !f.startsWith(".gsd-backups/") &&
-      !f.startsWith(".gsd-backups\\"),
+      !f.startsWith(".gsd-backups\\") &&
+      !(configuredProjectsPrefix && f.replaceAll("\\", "/").startsWith(configuredProjectsPrefix)),
   );
 
   // Normalize expected paths (strip leading ./ or /)

--- a/src/resources/extensions/gsd/tests/file-change-validator.test.ts
+++ b/src/resources/extensions/gsd/tests/file-change-validator.test.ts
@@ -156,6 +156,48 @@ test("validateFileChanges excludes .gsd-backups/ migration snapshots from unexpe
   );
 });
 
+test("validateFileChanges excludes the configured in-repo GSD state directory", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
+  const originalStateDir = process.env.GSD_STATE_DIR;
+  process.env.GSD_STATE_DIR = join(base, ".gsd-state");
+  t.after(() => {
+    if (originalStateDir === undefined) delete process.env.GSD_STATE_DIR;
+    else process.env.GSD_STATE_DIR = originalStateDir;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const managedFile = join(
+    base,
+    ".gsd-state",
+    "projects",
+    "abc123",
+    "phases",
+    "02-new-milestone",
+    "S01-replan-T02-VERIFY.json",
+  );
+  mkdirSync(join(base, "src"), { recursive: true });
+  mkdirSync(join(managedFile, ".."), { recursive: true });
+
+  git(base, "init");
+  git(base, "config", "user.email", "test@example.com");
+  git(base, "config", "user.name", "Test User");
+
+  writeFileSync(join(base, "src", "app.ts"), "initial\n");
+  writeFileSync(managedFile, "{}\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "initial");
+
+  writeFileSync(join(base, "src", "app.ts"), "updated\n");
+  writeFileSync(managedFile, '{"updated":true}\n');
+  git(base, "add", ".");
+  git(base, "commit", "-m", "task commit");
+
+  const audit = validateFileChanges(base, ["src/app.ts"], []);
+  assert.ok(audit, "audit should be produced");
+  assert.deepEqual(audit.unexpectedFiles, [], "configured GSD state must not trigger warnings");
+  assert.deepEqual(audit.actualFiles, ["src/app.ts"]);
+});
+
 test("GSD-managed .gitignore edit swept into a task commit is not flagged", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary
- Excluded configured GSD state artifacts from safety audits and verified the fix with focused tests and fast gates.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1629
- [#1629 Safety harness: false-positive "unexpected file change" on auto-generated files in .gsd/ or .gsd-state/ when GSD_STATE_DIR is set](https://github.com/open-gsd/gsd-pi/issues/1629)

## User
- @efrembaraldo

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1629-safety-harness-false-positive-unexpected-1786151762`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->