### PR TITLE
fix(issue): v1.12.0 regression: auto-mode dispatches replan-task but no Unit manifest is registered

### DIFF
--- a/packages/native/src/__tests__/module-compat.test.mjs
+++ b/packages/native/src/__tests__/module-compat.test.mjs
@@ -62,6 +62,13 @@ describe("@gsd/native module compatibility (#2861)", () => {
     }
   });
 
+  test("package exports the file-identity subpath used by GSD workflow executors", () => {
+    assert.deepEqual(pkg.exports?.["./file-identity"], {
+      types: "./dist/file-identity/index.d.ts",
+      default: "./dist/file-identity/index.js",
+    });
+  });
+
   test(
     "compiled CJS output loads under a parent package with type: module (regression guard for #2861)",
     () => {

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -318,6 +318,7 @@ try {
     'packages/pi-coding-agent/dist/index.js',
     'packages/pi-ai/bin/pi-ai.js',
     'packages/pi-ai/dist/cli.js',
+    'packages/native/dist/file-identity/index.js',
     'packages/daemon/bin/gsd-daemon.js',
     'packages/daemon/dist/cli.js',
     'packages/rpc-client/dist/index.js',
@@ -396,6 +397,30 @@ try {
     process.exit(1);
   }
   console.log(`    All ${getLinkablePackages().length} linkable packages are resolvable.`);
+
+  // Internal extension code imports this public subpath directly. Resolving it
+  // from the installed tarball catches both a missing exports-map entry and a
+  // package-staging/linking mismatch before the release reaches users.
+  console.log('==> Verifying packaged native file-identity subpath...');
+  try {
+    execFileSync(
+      process.execPath,
+      ['-e', "require.resolve('@gsd/native/file-identity')"],
+      {
+        cwd: installedRoot,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+        maxBuffer: DEFAULT_MAX_BUFFER,
+      },
+    );
+    console.log('    @gsd/native/file-identity resolves from the installed tarball.');
+  } catch (err) {
+    console.log('ERROR: installed tarball cannot resolve @gsd/native/file-identity.');
+    if (err.stdout) console.log(err.stdout);
+    if (err.stderr) console.log(err.stderr);
+    process.exit(1);
+  }
 
   // --- Verify the packaged standalone web host resolves its runtime deps ---
   // pnpm lays top-level deps down as symlinks into a `.pnpm/` store, and

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -211,7 +211,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
  */
 export const KNOWN_UNIT_LABELS = [
   "research-milestone", "plan-milestone", "research-slice", "plan-slice", "refine-slice",
-  "execute-task", "reactive-execute", "gate-evaluate", "complete-slice", "replan-slice", "reassess-roadmap",
+  "execute-task", "replan-task", "reactive-execute", "gate-evaluate", "complete-slice", "replan-slice", "reassess-roadmap",
   "run-uat", "complete-milestone", "validate-milestone", "rewrite-docs",
   "discuss-milestone", "discuss-slice", "worktree-merge",
   // Deep planning mode (project-level) units

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -98,6 +98,17 @@ test("Tool Contract compiles known Unit prompt and tool policy", () => {
   });
 });
 
+test("Tool Contract compiles the replan-task recovery Unit", () => {
+  const result = compileUnitToolContract("replan-task");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.contract.unitType, "replan-task");
+  assert.deepEqual(result.ok && result.contract.requiredWorkflowTools, ["gsd_replan_task"]);
+  assert.equal(result.ok && result.contract.contextMode, "planning");
+  assert.equal(result.ok && result.contract.toolsPolicy.mode, "workflow-only");
+  assert.deepEqual(result.ok && result.contract.promptContext.artifacts.inline, ["task-plan"]);
+});
+
 test("Tool Contract derives dispatch readiness from Unit workflow tools", () => {
   const error = getUnitWorkflowDispatchReadinessError({
     provider: "claude-code",

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -116,6 +116,7 @@ test("Context Mode: every manifest declares the expected contextMode lane", () =
     "replan-slice": "planning",
     "reassess-roadmap": "planning",
     "execute-task": "execution",
+    "replan-task": "planning",
     "reactive-execute": "execution",
     "quick-task": "execution",
     "run-uat": "verification",

--- a/src/resources/extensions/gsd/tests/unit-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-registry.test.ts
@@ -43,6 +43,7 @@ const EXPECTED_KNOWN_UNIT_TYPES = [
   "complete-slice",
   "reassess-roadmap",
   "execute-task",
+  "replan-task",
   "reactive-execute",
   "run-uat",
   "gate-evaluate",
@@ -58,7 +59,7 @@ const EXPECTED_KNOWN_UNIT_TYPES = [
 
 // The contract table carried two keys KNOWN_UNIT_TYPES never had (variants)
 // and lacked two it did have (sidecars without contracts).
-const EXPECTED_CONTRACT_ONLY_TYPES = ["discuss-slice", "execute-task-simple", "replan-task"];
+const EXPECTED_CONTRACT_ONLY_TYPES = ["discuss-slice", "execute-task-simple"];
 const EXPECTED_CONTRACT_LESS_TYPES = ["triage-captures", "quick-task"];
 
 const EXPECTED_EXECUTE_TASK_SET = ["execute-task", "execute-task-simple", "reactive-execute"];

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -358,7 +358,7 @@ export function composeToolSurfaceInstructions(
   unitType: string,
   opts: ComposeToolSurfaceInstructionOptions,
 ): string {
-  // The manifest is optional here: three units (discuss-slice, replan-task,
+  // The manifest is optional here: two units (discuss-slice and
   // execute-task-simple) carry an enforced tool contract without one, and
   // returning early for them left their allowed set unadvertised.
   const manifest = resolveManifest(unitType);

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -564,6 +564,21 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     },
     maxSystemPromptChars: COMMON_BUDGET_LARGE,
   },
+  "replan-task": {
+    skills: { mode: "none" },
+    knowledge: "none",
+    memory: "none",
+    codebaseMap: false,
+    preferences: "none",
+    contextMode: "planning",
+    tools: { mode: "workflow-only" },
+    artifacts: {
+      inline: ["task-plan"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_SMALL,
+  },
   "reactive-execute": {
     skills: skillPolicyForUnit("reactive-execute"),
     knowledge: "scoped",

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -349,7 +349,7 @@ export const UNIT_REGISTRY = {
     },
   },
   "replan-task": {
-    kind: "variant",
+    kind: "primary",
     scopeClass: "standard",
     phaseChain: ["planning"],
     promptTemplate: "replan-task",


### PR DESCRIPTION
## Summary
- Registered replan-task and added packaged file-identity export verification, with focused checks passing.

## Bugs Addressed
- [x] **Auto-mode dispatches unregistered `replan-task` unit type**
- [x] **`@gsd/native` package exports omit './file-identity' subpath**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1614
- [#1614 v1.12.0 regression: auto-mode dispatches replan-task but no Unit manifest is registered](https://github.com/open-gsd/gsd-pi/issues/1614)

## User
- @mikenorgate

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1614-v1-12-0-regression-auto-mode-dispatches--1786154138`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->