### PR TITLE
fix(issue): evidence-xref blocking mismatch pauses without settling the Attempt, then pre-verification-dispatched routes into the publication boundary — unrecoverable execute-task re-dispatch loop

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -110,6 +110,8 @@ import {
   isTaskAttemptAwaitingVerification,
   readLatestTaskAttempt,
 } from "./task-execution-domain-operation.js";
+import { recordTaskTechnicalVerdict } from "./task-verification-domain-operation.js";
+import { recordFailureAndSelectRecovery } from "./task-recovery-domain-operation.js";
 import { isTaskExecutionReadyForHostVerification } from "./auto/task-execution-cutover.js";
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
@@ -1011,6 +1013,12 @@ export interface PreVerificationOpts {
   agentEndMessages?: unknown[];
 }
 
+export type PreVerificationResult =
+  | "dispatched"
+  | "continue"
+  | "retry"
+  | "evidence-xref-blocked";
+
 export interface PostUnitContext {
   s: AutoSession;
   ctx: ExtensionContext;
@@ -1431,8 +1439,9 @@ async function runCloseoutGitAction(
  * - "dispatched" — a signal caused stop/pause
  * - "continue" — proceed normally
  * - "retry" — artifact verification failed, s.pendingVerificationRetry set for loop re-iteration
+ * - "evidence-xref-blocked" — claimed evidence failed safety verification and was routed to recovery
  */
-export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreVerificationOpts): Promise<"dispatched" | "continue" | "retry"> {
+export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreVerificationOpts): Promise<PreVerificationResult> {
   const { s, ctx, pi, stopAuto, pauseAuto } = pctx;
 
   // ── Parallel worker signal check ──
@@ -1871,12 +1880,71 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
                     `Safety: task ${sTid} claimed passing verification that failed in recorded execution`,
                     "error",
                   );
+                  if (!attempt.resultId) {
+                    logError("safety", "evidence-xref: settled Task Attempt Result identity is missing");
+                    await pauseAuto(ctx, pi);
+                    return "evidence-xref-blocked";
+                  }
+                  try {
+                    const actualMismatch = blockingMismatch.actual;
+                    const observedAt = new Date(actualMismatch?.timestamp ?? Date.now()).toISOString();
+                    const verdict = recordTaskTechnicalVerdict({
+                      invocation: internalExecutionInvocation(
+                        `internal:auto:attempt.verify:${attempt.attemptId}`,
+                      ),
+                      attemptId: attempt.attemptId,
+                      testedSourceRevision: "unavailable",
+                      verdict: "fail",
+                      rationale: blockingMismatch.reason,
+                      evidence: {
+                        evidenceClass: "command",
+                        commandOrTool: blockingMismatch.claimed.command,
+                        workingDirectory: s.basePath,
+                        startedAt: observedAt,
+                        endedAt: observedAt,
+                        exitCode: actualMismatch?.exitCode ?? 1,
+                        observation: "failed",
+                        durableOutputRef: `db://evidence-xref/${attempt.attemptId}`,
+                        environment: {
+                          verificationPolicy: "evidence-cross-reference",
+                          claimedExitCode: blockingMismatch.claimed.exitCode,
+                          actualExitCode: actualMismatch?.exitCode ?? null,
+                          toolCallId: actualMismatch?.toolCallId ?? null,
+                        },
+                      },
+                    });
+                    recordFailureAndSelectRecovery({
+                      invocation: internalExecutionInvocation(
+                        `internal:auto:attempt.route:${attempt.resultId}`,
+                      ),
+                      attemptId: attempt.attemptId,
+                      resultId: attempt.resultId,
+                      owner: "agent",
+                      classification: { failureKind: "verification-failed" },
+                      summary: "Claimed passing verification failed in recorded execution",
+                      evidence: {
+                        verdictId: verdict.verdictId,
+                        evidenceId: verdict.evidenceId,
+                        mismatch: blockingMismatch.reason,
+                      },
+                      rationale: "Route the blocking evidence cross-reference mismatch through durable Task recovery",
+                    });
+                    clearEvidenceFromDisk(s.basePath, sMid, sSid, sTid);
+                  } catch (e) {
+                    logError("safety", `evidence-xref recovery routing failed: ${String(e)}`);
+                    ctx.ui.notify(
+                      `Safety: task ${sTid} evidence mismatch could not be routed; auto-mode remains paused`,
+                      "error",
+                    );
+                    await pauseAuto(ctx, pi);
+                    return "evidence-xref-blocked";
+                  }
                   const gitActionResult = await runCloseoutGitAction(pctx, s.currentUnit);
                   if (gitActionResult === "dispatched") {
-                    return "dispatched";
+                    return "evidence-xref-blocked";
                   }
                   await pauseAuto(ctx, pi);
-                  return "dispatched";
+                  return "evidence-xref-blocked";
                 }
               }
             }

--- a/src/resources/extensions/gsd/auto/finalize.ts
+++ b/src/resources/extensions/gsd/auto/finalize.ts
@@ -166,6 +166,11 @@ export async function runFinalize(
   }
 
   const preResult = preResultGuard.value;
+  if (preResult === "evidence-xref-blocked") {
+    debugLog("autoLoop", { phase: "exit", reason: preResult });
+    clearFinalizingUnit();
+    return { action: "break", reason: preResult };
+  }
   if (preResult === "dispatched") {
     const dispatchedReason = s.lastGitActionFailure
       ? "git-closeout-failure"

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -13,7 +13,11 @@ import type { GSDPreferences } from "../preferences.js";
 import type { GSDState } from "../types.js";
 import type { SessionLockStatus } from "../session-lock.js";
 import type { CloseoutOptions } from "../auto-unit-closeout.js";
-import type { PostUnitContext, PreVerificationOpts } from "../auto-post-unit.js";
+import type {
+  PostUnitContext,
+  PreVerificationOpts,
+  PreVerificationResult,
+} from "../auto-post-unit.js";
 import type {
   VerificationContext,
   VerificationResult,
@@ -324,7 +328,7 @@ export interface LoopDeps {
   postUnitPreVerification: (
     pctx: PostUnitContext,
     opts?: PreVerificationOpts,
-  ) => Promise<"dispatched" | "continue" | "retry">;
+  ) => Promise<PreVerificationResult>;
   runPostUnitVerification: (
     vctx: VerificationContext,
     pauseAuto: PauseAutoFn,

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -4162,6 +4162,38 @@ test("autoLoop stops machine-terminal verification abort without pausing or publ
   }
 });
 
+test("autoLoop stops an evidence-xref block before host verification or publication", async (t) => {
+  _resetPendingResolve();
+  mock.timers.enable({ apis: ["Date", "setTimeout"], now: 10_000 });
+  t.after(() => mock.timers.reset());
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+  let verificationCalls = 0;
+  let publicationCalls = 0;
+
+  const deps = makeMockDeps({
+    postUnitPreVerification: async () => "evidence-xref-blocked" as const,
+    runPostUnitVerification: async () => {
+      verificationCalls++;
+      return "continue" as const;
+    },
+    taskPublicationBoundary: async () => { publicationCalls++; },
+  });
+
+  const loopPromise = autoLoop(ctx, pi, s, deps);
+  await waitForMicrotasks(() => pi.calls.length === 1, "evidence-xref dispatch");
+  resolveAgentEnd(makeEvent());
+  await drainMicrotasks(100);
+  mock.timers.tick(30_000);
+  await loopPromise;
+
+  assert.equal(verificationCalls, 0);
+  assert.equal(publicationCalls, 0);
+});
+
 test("autoLoop pauses a predecessor task-recovery abort before any agent turn", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts
+++ b/src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts
@@ -3,7 +3,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { postUnitPreVerification, shouldDeferCloseoutGitAction, type PostUnitContext } from "../auto-post-unit.ts";
@@ -17,8 +17,18 @@ import {
   insertVerificationEvidence,
   openDatabase,
 } from "../gsd-db.ts";
-import { recordToolCall, recordToolResult, resetEvidence } from "../safety/evidence-collector.ts";
-import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.ts";
+import {
+  recordToolCall,
+  recordToolResult,
+  resetEvidence,
+  saveEvidenceToDisk,
+} from "../safety/evidence-collector.ts";
+import {
+  claimTaskAttempt,
+  readLatestTaskAttempt,
+  settleTaskAttempt,
+} from "../task-execution-domain-operation.ts";
+import { readTaskRecoveryRoute } from "../task-recovery-domain-operation.ts";
 import { cleanup, git, makeTempRepo } from "./test-utils.ts";
 
 function settleCanonicalTaskForHostVerification(basePath: string): void {
@@ -83,7 +93,7 @@ test("non execute-task units keep pre-verification closeout git action", () => {
   assert.equal(shouldDeferCloseoutGitAction("complete-slice"), false);
 });
 
-test("blocking evidence-xref commits deferred execute-task work before pausing", async () => {
+test("blocking evidence-xref routes recovery and clears evidence before pausing", async () => {
   const base = makeTempRepo("gsd-evidence-xref-commit-before-pause-");
 
   try {
@@ -127,6 +137,7 @@ test("blocking evidence-xref commits deferred execute-task work before pausing",
     resetEvidence();
     recordToolCall("call-1", "bash", { command: "npm test" });
     recordToolResult("call-1", "bash", "Command exited with code 1\nfailed\n", true);
+    saveEvidenceToDisk(base, "M001", "S01", "T01");
 
     const s = new AutoSession();
     s.active = true;
@@ -156,7 +167,7 @@ test("blocking evidence-xref commits deferred execute-task work before pausing",
       skipWorktreeSync: true,
     });
 
-    assert.equal(result, "dispatched");
+    assert.equal(result, "evidence-xref-blocked");
     assert.equal(pauseCalled, true);
     assert.ok(
       notifications.some((message) => message.includes("claimed passing verification")),
@@ -166,6 +177,21 @@ test("blocking evidence-xref commits deferred execute-task work before pausing",
     const commitMessage = git(base, "log", "-1", "--pretty=%B");
     assert.match(commitMessage, /^feat: Added app entrypoint/m);
     assert.match(commitMessage, /GSD-Task: S01\/T01/);
+
+    const attempt = readLatestTaskAttempt({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+    });
+    assert.equal(attempt?.nextStage, "route");
+    const recovery = attempt ? readTaskRecoveryRoute(attempt.attemptId) : null;
+    assert.equal(recovery?.action, "remediate");
+    assert.ok(recovery?.recoveryActionId, "blocking mismatch must mint a recovery action");
+    assert.equal(
+      existsSync(join(base, ".gsd", "safety", "evidence-M001-S01-T01.json")),
+      false,
+      "blocking mismatch must clear persisted evidence before pausing",
+    );
   } finally {
     resetEvidence();
     closeDatabase();


### PR DESCRIPTION
## Summary
- Routed blocking evidence mismatches into durable recovery and verified they cannot reach task publication.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1641
- [#1641 evidence-xref blocking mismatch pauses without settling the Attempt, then pre-verification-dispatched routes into the publication boundary — unrecoverable execute-task re-dispatch loop](https://github.com/open-gsd/gsd-pi/issues/1641)

## User
- @splichy

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1641-evidence-xref-blocking-mismatch-pauses-w-1786182102`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->