### PR TITLE
fix(issue): Auto-mode permanently stuck: paused_session pins active-but-superseded milestone; resume path has no active-milestone check (auto.js:2059)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -29,6 +29,7 @@ import { parseUnitId } from "./unit-id.js";
 import type { GSDState } from "./types.js";
 import {
   assessInterruptedSession,
+  getSupersedingActiveMilestoneId,
   readPausedSessionMetadata,
   PAUSED_SESSION_KV_KEY,
   type InterruptedSessionAssessment,
@@ -2680,17 +2681,20 @@ export async function startAuto(
               }
             }
           }
-          const activeMilestoneId = freshStartAssessment.state?.activeMilestone?.id;
+          const supersedingActiveMilestoneId = getSupersedingActiveMilestoneId(
+            meta,
+            freshStartAssessment.state,
+          );
           if (!mDir || summaryIsTerminal) {
             clearPausedSession("paused-session DB cleanup failed (milestone gone/complete)");
             ctx.ui.notify(
               `Paused milestone ${meta.milestoneId} is ${!mDir ? "missing" : "already complete"}. Starting fresh.`,
               "info",
             );
-          } else if (activeMilestoneId && activeMilestoneId !== meta.milestoneId) {
+          } else if (supersedingActiveMilestoneId) {
             clearPausedSession("paused-session DB cleanup failed (milestone superseded)");
             ctx.ui.notify(
-              `Paused milestone ${meta.milestoneId} was superseded by ${activeMilestoneId}. Starting fresh.`,
+              `Paused milestone ${meta.milestoneId} was superseded by ${supersedingActiveMilestoneId}. Starting fresh.`,
               "info",
             );
           } else {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2680,10 +2680,17 @@ export async function startAuto(
               }
             }
           }
+          const activeMilestoneId = freshStartAssessment.state?.activeMilestone?.id;
           if (!mDir || summaryIsTerminal) {
             clearPausedSession("paused-session DB cleanup failed (milestone gone/complete)");
             ctx.ui.notify(
               `Paused milestone ${meta.milestoneId} is ${!mDir ? "missing" : "already complete"}. Starting fresh.`,
+              "info",
+            );
+          } else if (activeMilestoneId && activeMilestoneId !== meta.milestoneId) {
+            clearPausedSession("paused-session DB cleanup failed (milestone superseded)");
+            ctx.ui.notify(
+              `Paused milestone ${meta.milestoneId} was superseded by ${activeMilestoneId}. Starting fresh.`,
               "info",
             );
           } else {

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -22,6 +22,12 @@ import {
   loadUnboundProjectionEvidence,
   previewUnboundProjectionEvidenceResolution,
 } from "./managed-projection-history.js";
+import {
+  getSupersedingActiveMilestoneId,
+  PAUSED_SESSION_KV_KEY,
+  type PausedSessionMetadata,
+} from "./interrupted-session.js";
+import { deleteRuntimeKv, getRuntimeKv } from "./db/runtime-kv.js";
 
 const MAX_UAT_ATTEMPTS = 3;
 
@@ -73,6 +79,43 @@ export async function checkRuntimeHealth(
         fixable: false,
       });
     }
+  }
+
+  // ── Stale paused session ──────────────────────────────────────────────
+  // A pause is only resumable while it targets the milestone that state
+  // derivation currently considers active. Keeping an older milestone in
+  // runtime_kv can otherwise pin every new /gsd auto invocation to work that
+  // has been superseded in the project queue (#1643).
+  try {
+    const pausedSession = getRuntimeKv<PausedSessionMetadata>(
+      "global",
+      "",
+      PAUSED_SESSION_KV_KEY,
+    );
+    if (pausedSession?.milestoneId) {
+      const state = await deriveState(basePath);
+      const activeMilestoneId = getSupersedingActiveMilestoneId(pausedSession, state);
+      if (activeMilestoneId) {
+        if (shouldFix("stale_paused_session")) {
+          deleteRuntimeKv("global", "", PAUSED_SESSION_KV_KEY);
+          fixesApplied.push(
+            `cleared stale paused session for ${pausedSession.milestoneId} (active milestone: ${activeMilestoneId})`,
+          );
+        } else {
+          issues.push({
+            severity: "error",
+            code: "stale_paused_session",
+            scope: "project",
+            unitId: "project",
+            message: `Paused auto-mode session targets ${pausedSession.milestoneId}, but the active milestone is ${activeMilestoneId}. The stale pause can pin auto-mode to the superseded milestone.`,
+            file: ".gsd/gsd.db",
+            fixable: true,
+          });
+        }
+      }
+    }
+  } catch {
+    // Non-fatal — paused-session check failed
   }
 
   // ── Stale crash lock ──────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -19,6 +19,7 @@ export type DoctorIssueCode =
   | "tracked_runtime_files"
   | "legacy_slice_branches"
   | "stale_crash_lock"
+  | "stale_paused_session"
   | "stale_parallel_session"
   | "orphaned_completed_units"
   | "stale_hook_state"

--- a/src/resources/extensions/gsd/guidance.ts
+++ b/src/resources/extensions/gsd/guidance.ts
@@ -217,6 +217,7 @@ const DOCTOR_FIX_HINTS: Partial<Record<DoctorIssueCode, string>> = {
   db_unavailable:
     "The workflow database could not be opened — state derivation is degraded. Restart the session; if it persists, run `/gsd doctor` from the project root.",
   stale_crash_lock: "Run `/gsd doctor fix` to clear the stale lock, then `/gsd auto` to resume.",
+  stale_paused_session: "Run `/gsd doctor fix` to clear the stale pause, then `/gsd auto` to resume the active milestone.",
   stale_parallel_session: "Run `/gsd doctor fix` to clear the stale session registration.",
   unresolved_git_conflicts:
     "Resolve the conflict markers, commit, then re-run `/gsd auto`.",

--- a/src/resources/extensions/gsd/interrupted-session.ts
+++ b/src/resources/extensions/gsd/interrupted-session.ts
@@ -93,6 +93,23 @@ function isStalePseudoMilestonePause(meta: PausedSessionMetadata): boolean {
  */
 export const PAUSED_SESSION_KV_KEY = "paused_session";
 
+/**
+ * Return the current active milestone when a standard auto-mode pause points
+ * at a different milestone. Such metadata is stale: replaying it would pin
+ * auto-mode to work that has already been superseded in the project queue.
+ */
+export function getSupersedingActiveMilestoneId(
+  meta: PausedSessionMetadata | null,
+  state: GSDState | null,
+): string | null {
+  if (meta?.activeEngineId && meta.activeEngineId !== "dev") return null;
+  const pausedMilestoneId = meta?.milestoneId;
+  const activeMilestoneId = state?.activeMilestone?.id;
+  return pausedMilestoneId && activeMilestoneId && pausedMilestoneId !== activeMilestoneId
+    ? activeMilestoneId
+    : null;
+}
+
 export function readPausedSessionMetadata(
   basePath: string,
 ): PausedSessionMetadata | null {

--- a/src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts
@@ -6,6 +6,20 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { runGSDDoctor } from "../doctor.ts";
+import { checkRuntimeHealth } from "../doctor-runtime-checks.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  openDatabase,
+  setMilestoneQueueOrder,
+} from "../gsd-db.ts";
+import { getRuntimeKv, setRuntimeKv } from "../db/runtime-kv.ts";
+import {
+  PAUSED_SESSION_KV_KEY,
+  type PausedSessionMetadata,
+} from "../interrupted-session.ts";
+import type { DoctorIssue } from "../doctor-types.ts";
 
 function runGit(cwd: string, args: string[]): void {
   execFileSync("git", args, { cwd, stdio: "ignore" });
@@ -71,6 +85,81 @@ test("doctor fix resets run-uat counters at the dispatch cap", async (t) => {
     "doctor --fix resets the blocked counter even when the current displayed scope has advanced",
   );
   assert.equal(existsSync(counterPath), false);
+});
+
+test("doctor reports and repairs a paused session superseded by the active milestone", async (t) => {
+  const dir = createGitProject();
+  t.after(() => {
+    closeDatabase();
+    invalidateAllCaches();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const pausedMilestoneId = "M016-5b17xo";
+  const activeMilestoneId = "M018-6b0xxe";
+  for (const milestoneId of [pausedMilestoneId, activeMilestoneId]) {
+    const milestoneDir = join(dir, ".gsd", "milestones", milestoneId);
+    mkdirSync(milestoneDir, { recursive: true });
+    writeFileSync(join(milestoneDir, `${milestoneId}-CONTEXT.md`), `# ${milestoneId}\n`);
+  }
+
+  openDatabase(join(dir, ".gsd", "gsd.db"));
+  insertMilestone({ id: pausedMilestoneId, title: "Superseded milestone", status: "active" });
+  insertMilestone({ id: activeMilestoneId, title: "Current milestone", status: "active" });
+  setMilestoneQueueOrder([activeMilestoneId, pausedMilestoneId]);
+  setRuntimeKv("global", "", PAUSED_SESSION_KV_KEY, {
+    milestoneId: pausedMilestoneId,
+    originalBasePath: dir,
+  } satisfies PausedSessionMetadata);
+  invalidateAllCaches();
+
+  const issues: DoctorIssue[] = [];
+  const fixesApplied: string[] = [];
+  await checkRuntimeHealth(dir, issues, fixesApplied, () => false);
+
+  const issue = issues.find((candidate) => candidate.code === "stale_paused_session");
+  assert.ok(issue, "doctor reports the stale paused-session row");
+  assert.equal(issue.severity, "error");
+  assert.equal(issue.fixable, true);
+  assert.match(issue.message, new RegExp(pausedMilestoneId));
+  assert.match(issue.message, new RegExp(activeMilestoneId));
+  assert.ok(
+    getRuntimeKv("global", "", PAUSED_SESSION_KV_KEY),
+    "read-only doctor preserves paused-session metadata",
+  );
+
+  const fixIssues: DoctorIssue[] = [];
+  await checkRuntimeHealth(
+    dir,
+    fixIssues,
+    fixesApplied,
+    (code) => code === "stale_paused_session",
+  );
+
+  assert.equal(getRuntimeKv("global", "", PAUSED_SESSION_KV_KEY), null);
+  assert.ok(
+    fixesApplied.some((fix) => fix.includes(`cleared stale paused session for ${pausedMilestoneId}`)),
+  );
+  assert.equal(fixIssues.some((candidate) => candidate.code === "stale_paused_session"), false);
+
+  setRuntimeKv("global", "", PAUSED_SESSION_KV_KEY, {
+    activeEngineId: "custom-workflow",
+    milestoneId: pausedMilestoneId,
+    originalBasePath: dir,
+  } satisfies PausedSessionMetadata);
+  const customWorkflowIssues: DoctorIssue[] = [];
+  await checkRuntimeHealth(
+    dir,
+    customWorkflowIssues,
+    fixesApplied,
+    (code) => code === "stale_paused_session",
+  );
+  assert.equal(
+    customWorkflowIssues.some((candidate) => candidate.code === "stale_paused_session"),
+    false,
+    "doctor leaves custom-workflow pause metadata to its dedicated resume path",
+  );
+  assert.ok(getRuntimeKv("global", "", PAUSED_SESSION_KV_KEY));
 });
 
 test("doctor surfaces unresolved projection evidence with recovery instructions", async (t) => {

--- a/src/resources/extensions/gsd/tests/guidance.test.ts
+++ b/src/resources/extensions/gsd/tests/guidance.test.ts
@@ -159,6 +159,7 @@ describe("doctor fix hints", () => {
   test("fixable issue codes instruct /gsd doctor fix, not bare /gsd doctor", () => {
     const fixableCodes = [
       "stale_crash_lock",
+      "stale_paused_session",
       "stale_parallel_session",
       "orphaned_auto_worktree",
       "gitignore_missing_patterns",

--- a/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
@@ -5,7 +5,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { _handlePausedSessionResumeRecoveryForTest } from "../auto.ts";
+import { _handlePausedSessionResumeRecoveryForTest, startAuto } from "../auto.ts";
+import { autoSession } from "../auto-runtime-state.ts";
 import { assessInterruptedSession } from "../interrupted-session.ts";
 import {
   openDatabase,
@@ -16,9 +17,10 @@ import {
 import { registerAutoWorker } from "../db/auto-workers.ts";
 import { claimMilestoneLease } from "../db/milestone-leases.ts";
 import { recordDispatchClaim } from "../db/unit-dispatches.ts";
-import { setRuntimeKv } from "../db/runtime-kv.ts";
+import { getRuntimeKv, setRuntimeKv } from "../db/runtime-kv.ts";
 import {
   PAUSED_SESSION_KV_KEY,
+  type InterruptedSessionAssessment,
   type PausedSessionMetadata,
 } from "../interrupted-session.ts";
 import { normalizeRealPath } from "../paths.ts";
@@ -173,6 +175,73 @@ test("direct /gsd auto stale paused-session metadata is treated as stale when no
   } finally {
     cleanup(base);
   }
+});
+
+test("direct /gsd auto discards a paused milestone superseded by the active milestone", async (t) => {
+  const base = makeTmpBase();
+  const priorProjectId = process.env.GSD_PROJECT_ID;
+  process.env.GSD_PROJECT_ID = "invalid project id";
+  t.after(() => {
+    if (priorProjectId === undefined) delete process.env.GSD_PROJECT_ID;
+    else process.env.GSD_PROJECT_ID = priorProjectId;
+    autoSession.reset();
+    cleanup(base);
+  });
+
+  const pausedMilestoneId = "M016-5b17xo";
+  const activeMilestoneId = "M018-6b0xxe";
+  const milestoneDir = join(base, ".gsd", "milestones", pausedMilestoneId);
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(join(milestoneDir, `${pausedMilestoneId}-CONTEXT.md`), "# Paused milestone\n");
+  openFixtureDb(base);
+  insertMilestone({ id: pausedMilestoneId, title: "Paused milestone", status: "active" });
+  writePausedSession(base, pausedMilestoneId);
+
+  const interrupted: InterruptedSessionAssessment = {
+    classification: "recoverable",
+    lock: null,
+    pausedSession: {
+      milestoneId: pausedMilestoneId,
+      originalBasePath: base,
+    },
+    state: {
+      activeMilestone: { id: activeMilestoneId, title: "Current milestone" },
+      phase: "pre-planning",
+    } as InterruptedSessionAssessment["state"],
+    recovery: null,
+    recoveryPrompt: null,
+    recoveryToolCallCount: 0,
+    artifactSatisfied: false,
+    hasResumableDiskState: true,
+    isBootstrapCrash: false,
+  };
+  const notifications: string[] = [];
+  const ctx = {
+    ui: {
+      notify: (message: string) => notifications.push(message),
+    },
+    sessionManager: {
+      getSessionId: () => "superseded-paused-session-test",
+    },
+    modelRegistry: {
+      getAvailable: () => [],
+      isProviderRequestReady: () => false,
+    },
+    model: undefined,
+  } as unknown as Parameters<typeof startAuto>[0];
+  const pi = {
+    getThinkingLevel: () => "off",
+  } as unknown as Parameters<typeof startAuto>[1];
+
+  await startAuto(ctx, pi, base, false, { interrupted });
+
+  assert.equal(getRuntimeKv("global", "", PAUSED_SESSION_KV_KEY), null);
+  assert.equal(autoSession.currentMilestoneId, null, "superseded milestone must not be pinned");
+  assert.ok(notifications.some((message) =>
+    message.includes(`Paused milestone ${pausedMilestoneId} was superseded by ${activeMilestoneId}`)
+  ));
+  assert.ok(notifications.some((message) => message.includes("GSD_PROJECT_ID must contain only")),
+    "clearing the stale pause should continue through fresh bootstrap");
 });
 
 test("direct /gsd auto source only resumes paused-session metadata for recoverable state with real recovery signals", async () => {


### PR DESCRIPTION
## Summary
- Fixed superseded paused-milestone recovery and verified it with 16 focused passing tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1643
- [#1643 Auto-mode permanently stuck: paused_session pins active-but-superseded milestone; resume path has no active-milestone check (auto.js:2059)](https://github.com/open-gsd/gsd-pi/issues/1643)

## User
- @stentotre

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1643-auto-mode-permanently-stuck-paused-sessi-1786196383`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->