### PR TITLE
fix(issue): bug: parent-workspace host verification fans out to all child repos when task targets orchestration root

### DIFF
--- a/src/resources/extensions/gsd/tests/plan-task.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-task.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, getSlice, getTask, getSliceTasks, getGateResults } from '../gsd-db.ts';
 import { handlePlanTask as handlePlanTaskWithInvocation, type PlanTaskParams } from '../tools/plan-task.ts';
 import { parsePlan } from '../parsers-legacy.ts';
+import { resolveVerificationRepositoryTargets } from '../verification-source-integrity.ts';
 
 let invocationSequence = 0;
 
@@ -341,6 +342,35 @@ test('handlePlanTask persists targetRepositories for parent-workspace tasks', as
     const planned = tasks.find((t) => t.id === 'T02');
     assert.ok(planned, 'planned task should exist');
     assert.deepEqual(planned?.target_repositories, ['project']);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handlePlanTask leaves implicit parent-workspace targets unset for root verification', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParent();
+    writeParentWorkspacePreferences(base);
+    const result = await handlePlanTask(validParams(), base);
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+    const task = getTask('M001', 'S02', 'T02');
+    const slice = getSlice('M001', 'S02');
+    assert.deepEqual(task?.target_repositories, []);
+
+    const resolved = resolveVerificationRepositoryTargets(base, {
+      workspace: {
+        mode: 'parent',
+        repositories: {
+          frontend: { path: 'frontend' },
+          backend: { path: 'backend' },
+        },
+      },
+    }, task, slice);
+    assert.deepEqual(resolved.repositories.map((repository) => repository.id), ['project']);
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/verification-source-integrity.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-source-integrity.test.ts
@@ -11,6 +11,7 @@ import { afterEach, test } from "node:test";
 import {
   captureVerificationSourceSnapshot,
   confirmVerificationSourceSnapshot,
+  resolveVerificationRepositoryTargets,
   verificationSourceChanged,
 } from "../verification-source-integrity.js";
 
@@ -44,6 +45,27 @@ function capture(
 afterEach(() => {
   for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
   tempDirs.clear();
+});
+
+test("parent-workspace verification defaults to the orchestration root", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-source-parent-workspace-"));
+  tempDirs.add(base);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  mkdirSync(join(base, "frontend"));
+  mkdirSync(join(base, "backend"));
+
+  const resolved = resolveVerificationRepositoryTargets(base, {
+    workspace: {
+      mode: "parent",
+      repositories: {
+        frontend: { path: "frontend" },
+        backend: { path: "backend" },
+      },
+    },
+  }, null, null);
+
+  assert.deepEqual(resolved.repositories.map((repository) => repository.id), ["project"]);
+  assert.equal(resolved.explicitTargetsRequested, false);
 });
 
 test("source revision changes for staged, unstaged, and untracked content", () => {

--- a/src/resources/extensions/gsd/tools/plan-task.ts
+++ b/src/resources/extensions/gsd/tools/plan-task.ts
@@ -259,6 +259,11 @@ export async function handlePlanTask(
           parentSlice.target_repositories,
           defaultTargets,
         );
+        let persistedTargetRepositories = repositoryRegistry.mode === "parent"
+          && params.targetRepositories === undefined
+          && !parentSlice.target_repositories?.length
+          ? []
+          : effectiveTargetRepositories;
         const repoValidationError = validateReferencedRepositories(effectiveTargetRepositories, repositoryRegistry);
         if (repoValidationError) {
           throw new PlanningGuardError(`validation failed: ${repoValidationError}`);
@@ -280,6 +285,7 @@ export async function handlePlanTask(
             : validatePathScopeForTargetRepositories(params, basePath, repositoryRegistry, storedTaskTargets);
           if (!storedPathScopeError) {
             effectiveTargetRepositories = storedTaskTargets;
+            persistedTargetRepositories = storedTaskTargets;
             pathScopeError = null;
           }
         }
@@ -306,7 +312,7 @@ export async function handlePlanTask(
           expectedOutput: params.expectedOutput,
           observabilityImpact: params.observabilityImpact ?? "",
           fullPlanMd: params.fullPlanMd,
-          targetRepositories: effectiveTargetRepositories,
+          targetRepositories: persistedTargetRepositories,
         });
         for (const gid of taskGates) {
           insertGateRow({ milestoneId: params.milestoneId, sliceId: params.sliceId, gateId: gid, scope: "task", taskId: params.taskId });

--- a/src/resources/extensions/gsd/verification-source-integrity.ts
+++ b/src/resources/extensions/gsd/verification-source-integrity.ts
@@ -82,7 +82,11 @@ export function resolveVerificationRepositoryTargets(
   const taskTargets = task?.target_repositories?.length ? task.target_repositories : null;
   const sliceTargets = slice?.target_repositories?.length ? slice.target_repositories : null;
   const explicitIds = taskTargets ?? sliceTargets;
-  const requestedIds = explicitIds ?? defaultRepositoryTargets(registry);
+  const requestedIds = explicitIds ?? (
+    registry.mode === "parent" && registry.byId.has("project")
+      ? ["project"]
+      : defaultRepositoryTargets(registry)
+  );
   const repositories: RegisteredRepository[] = [];
   const missingRepositoryIds: string[] = [];
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary
- Fixed parent-workspace root verification targeting with focused tests and passing fast gates.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1630
- [#1630 bug: parent-workspace host verification fans out to all child repos when task targets orchestration root](https://github.com/open-gsd/gsd-pi/issues/1630)

## User
- @splichy

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1630-bug-parent-workspace-host-verification-f-1786203101`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->