### PR TITLE
feat(gsd): add state contract v1 projection

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -1930,6 +1930,14 @@ not part of this legacy manifest surface. Restore and hierarchy-replacement
 paths now refuse to run when adopted lifecycle rows exist, preventing the
 legacy snapshot from deleting canonical history.
 
+`.gsd/state.json` is the GSD state contract v1 projection for external readers
+such as GSD Workbench. Its schema is owned by `gsd-workbench`'s
+`docs/state-contract/v1.md`; this repository writes contract `1.0.0` with flavor
+`pi` whenever it writes the legacy state manifest. The projection describes the
+active milestone and its slices and includes a deliberately approximate,
+stale-tolerant next-command hint. It is a local runtime projection, not a restore
+or worktree-merge input.
+
 `reconcileWorktreeDb` merges hidden-worktree legacy correctness rows back into the main
 DB, including hierarchy, requirements, artifacts, memories, replan history,
 assessments, quality gates, slice dependencies, verification evidence, gate

--- a/docs/user-docs/getting-started.md
+++ b/docs/user-docs/getting-started.md
@@ -208,7 +208,7 @@ Start from a clean worktree when possible. GSD can create task worktrees for iso
 
 GSD stores project state in `.gsd/`. Depending on your workflow, some generated markdown files may be useful to commit and review, while runtime/cache files should stay local.
 
-Local runtime/cache paths include `.gsd/gsd.db*`, `.gsd/runtime/`, `.gsd-worktrees/`, and `.gsd-backups/`. GSD manages `.gitignore` for these paths by default. `.gsd-backups/` stores migration snapshots, and stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration.
+Local runtime/cache paths include `.gsd/gsd.db*`, `.gsd/state.json`, `.gsd/runtime/`, `.gsd-worktrees/`, and `.gsd-backups/`. GSD manages `.gitignore` for these paths by default. `.gsd/state.json` is the state contract projection used by external readers such as GSD Workbench; do not edit or commit it. `.gsd-backups/` stores migration snapshots, and stale `.gsd-backups/migrate-*` snapshots are pruned after 30 days once the project has completed the flat-phase `.gsd/phases/` migration.
 
 When in doubt:
 

--- a/docs/user-docs/working-in-teams.md
+++ b/docs/user-docs/working-in-teams.md
@@ -29,6 +29,8 @@ Share planning artifacts (milestones, roadmaps, decisions) while keeping runtime
 .gsd/completed-units.json
 .gsd/STATE.md
 .gsd/gsd.db*
+.gsd/state-manifest.json
+.gsd/state.json
 .gsd/metrics.json
 .gsd/activity/
 .gsd/runtime/

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -378,6 +378,7 @@ export const RUNTIME_EXCLUSION_PATHS: readonly string[] = [
   ".gsd/metrics.json",
   ".gsd/completed-units*.json", // covers completed-units.json and archived completed-units-{MID}.json
   ".gsd/state-manifest.json",
+  ".gsd/state.json",
   ".gsd/STATE.md",
   ".gsd/gsd.db*",
   ".gsd/journal/",

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -42,6 +42,7 @@ export const GSD_RUNTIME_PATTERNS = [
   ".gsd/metrics.json",
   ".gsd/completed-units*.json", // covers completed-units.json and archived completed-units-{MID}.json
   ".gsd/state-manifest.json",
+  ".gsd/state.json",
   ".gsd/STATE.md",
   ".gsd/gsd.db*",
   ".gsd/journal/",

--- a/src/resources/extensions/gsd/state-contract.ts
+++ b/src/resources/extensions/gsd/state-contract.ts
@@ -3,10 +3,13 @@
 //
 // The contract (gsd-workbench docs/state-contract/v1.md) is a small, stable
 // JSON surface: readers accept any 1.x and ignore unknown fields. The skills
-// own the file; readers never write it. It is refreshed alongside every
-// state-manifest write, so it tracks the same mutation boundaries. `next` is
-// an approximate hint (stale-tolerant per the contract), not the dependency-
-// aware dispatch decision — that stays in state/derive/from-db.ts.
+// own the file; readers never write it. It deliberately tracks the state-
+// manifest write boundary: every skill step boundary funnels through
+// writeManifest/writeManifestAndFlush. Placeholder milestone inserts, queue-
+// order reconciliation, and out-of-band edits that bypass that boundary
+// refresh on the next skill run, as tolerated by contract v1 rule 2 and
+// ADR-0004. `next` is an approximate hint, not the dependency-aware dispatch
+// decision — that stays in state/derive/from-db.ts.
 
 import type { MilestoneRow } from "./db-milestone-artifact-rows.js";
 import type { SliceRow } from "./db-task-slice-rows.js";
@@ -68,8 +71,9 @@ function routeNext(active: MilestoneRow | null, phases: StateContractPhase[]): S
  * Pure — callers pass the already-snapshotted milestones/slices so the
  * contract file is always consistent with the manifest written beside it.
  * Rows must be ordered (snapshotState orders both by sequence).
- * Active milestone follows the canonical getActiveMilestoneFromDb rule:
- * first milestone that is not closed, parked, or deferred.
+ * Active milestone follows dispatch ordering: the first milestone in queue
+ * order for which isSkippedForDispatch returns false. This is the rule
+ * reflected by the contract's phases and next hint.
  */
 export function buildStateContract(
   milestones: MilestoneRow[],

--- a/src/resources/extensions/gsd/state-contract.ts
+++ b/src/resources/extensions/gsd/state-contract.ts
@@ -1,0 +1,100 @@
+// Project/App: gsd-pi
+// File Purpose: GSD state contract v1 projection (.gsd/state.json) for external readers like GSD Workbench.
+//
+// The contract (gsd-workbench docs/state-contract/v1.md) is a small, stable
+// JSON surface: readers accept any 1.x and ignore unknown fields. The skills
+// own the file; readers never write it. It is refreshed alongside every
+// state-manifest write, so it tracks the same mutation boundaries. `next` is
+// an approximate hint (stale-tolerant per the contract), not the dependency-
+// aware dispatch decision — that stays in state/derive/from-db.ts.
+
+import type { MilestoneRow } from "./db-milestone-artifact-rows.js";
+import type { SliceRow } from "./db-task-slice-rows.js";
+import { isSkippedForDispatch, toStatus } from "./status-guards.js";
+
+export interface StateContractPhase {
+  number: number;
+  name: string;
+  status: "complete" | "in_progress" | "pending";
+}
+
+export interface StateContractNext {
+  command: string;
+  label: string;
+  reason: string;
+}
+
+export interface StateContractV1 {
+  contract: "1.0.0";
+  flavor: "pi";
+  milestone: string | null;
+  phases: StateContractPhase[];
+  next: StateContractNext;
+  updated_at: string;
+}
+
+function phaseStatus(raw: string): StateContractPhase["status"] {
+  const status = toStatus(raw);
+  if (status === "complete" || status === "skipped") return "complete";
+  return status === "active" || status === "in_progress" ? "in_progress" : "pending";
+}
+
+// Same rule as workflow-projections.stripIdPrefix — duplicated here because
+// importing it would cycle (workflow-projections → workflow-manifest → here).
+function stripIdPrefix(title: string, id: string): string {
+  const prefix = `${id}: `;
+  let result = title;
+  while (result.startsWith(prefix)) result = result.slice(prefix.length);
+  return result.trim() || title;
+}
+
+function routeNext(active: MilestoneRow | null, phases: StateContractPhase[]): StateContractNext {
+  const auto = (label: string, reason: string): StateContractNext => ({ command: "/gsd auto", label, reason });
+  if (!active) {
+    return { command: "/gsd", label: "Start next milestone", reason: "No active milestone" };
+  }
+  if (phases.length === 0) {
+    return auto(`Plan ${active.id}`, "Active milestone has no slices yet");
+  }
+  const inProgress = phases.find((p) => p.status === "in_progress");
+  if (inProgress) return auto(`Continue ${inProgress.name}`, `Slice ${inProgress.number} in progress`);
+  const pending = phases.find((p) => p.status === "pending");
+  if (pending) return auto(`Start ${pending.name}`, `Slice ${pending.number} is next`);
+  return auto(`Complete ${active.id}`, "All slices closed");
+}
+
+/**
+ * Build the state contract document from manifest snapshot rows.
+ * Pure — callers pass the already-snapshotted milestones/slices so the
+ * contract file is always consistent with the manifest written beside it.
+ * Rows must be ordered (snapshotState orders both by sequence).
+ * Active milestone follows the canonical getActiveMilestoneFromDb rule:
+ * first milestone that is not closed, parked, or deferred.
+ */
+export function buildStateContract(
+  milestones: MilestoneRow[],
+  slices: SliceRow[],
+  updatedAt: string,
+): StateContractV1 {
+  const active = milestones.find((m) => !isSkippedForDispatch(m.status)) ?? null;
+
+  const phases: StateContractPhase[] = active
+    ? slices
+        .filter((s) => s.milestone_id === active.id)
+        .map((s, i) => ({
+          number: s.sequence > 0 ? s.sequence : i + 1,
+          name: stripIdPrefix(s.title, s.id),
+          status: phaseStatus(s.status),
+        }))
+    : [];
+
+  const title = active ? stripIdPrefix(active.title, active.id) : "";
+  return {
+    contract: "1.0.0",
+    flavor: "pi",
+    milestone: active ? (title ? `${active.id} — ${title}` : active.id) : null,
+    phases,
+    next: routeNext(active, phases),
+    updated_at: updatedAt,
+  };
+}

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -295,8 +295,8 @@ describe('git-service', async () => {
 
   assert.deepStrictEqual(
     RUNTIME_EXCLUSION_PATHS.length,
-    22,
-    "exactly 22 runtime exclusion paths"
+    23,
+    "exactly 23 runtime exclusion paths"
   );
 
   const expectedPaths = [
@@ -316,6 +316,7 @@ describe('git-service', async () => {
     ".gsd/metrics.json",
     ".gsd/completed-units*.json",
     ".gsd/state-manifest.json",
+    ".gsd/state.json",
     ".gsd/STATE.md",
     ".gsd/gsd.db*",
     ".gsd/journal/",

--- a/src/resources/extensions/gsd/tests/state-contract.test.ts
+++ b/src/resources/extensions/gsd/tests/state-contract.test.ts
@@ -1,0 +1,145 @@
+// GSD Extension — state contract v1 tests
+// Tests buildStateContract routing and the .gsd/state.json write alongside the manifest.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { openDatabase, closeDatabase, insertMilestone, insertSlice } from '../gsd-db.ts';
+import { writeManifest, flushManifest } from '../workflow-manifest.ts';
+import { buildStateContract } from '../state-contract.ts';
+import type { MilestoneRow } from '../db-milestone-artifact-rows.ts';
+import type { SliceRow } from '../db-task-slice-rows.ts';
+
+const NOW = '2026-08-08T00:00:00.000Z';
+
+function milestone(overrides: Partial<MilestoneRow>): MilestoneRow {
+  return {
+    id: 'M001',
+    title: 'Hardening',
+    status: 'active',
+    depends_on: [],
+    created_at: NOW,
+    completed_at: null,
+    vision: '',
+    success_criteria: [],
+    key_risks: [],
+    proof_strategy: [],
+    verification_contract: '',
+    verification_integration: '',
+    verification_operational: '',
+    verification_uat: '',
+    definition_of_done: [],
+    requirement_coverage: '',
+    boundary_map_markdown: '',
+    sequence: 1,
+    ...overrides,
+  };
+}
+
+function slice(overrides: Partial<SliceRow>): SliceRow {
+  return {
+    milestone_id: 'M001',
+    id: 'S1',
+    title: 'Slice one',
+    status: 'pending',
+    risk: '',
+    depends: [],
+    demo: '',
+    created_at: NOW,
+    completed_at: null,
+    full_summary_md: '',
+    full_uat_md: '',
+    goal: '',
+    success_criteria: '',
+    proof_level: '',
+    integration_closure: '',
+    observability_impact: '',
+    target_repositories: [],
+    sequence: 1,
+    replan_triggered_at: null,
+    is_sketch: 0,
+    sketch_scope: '',
+    ...overrides,
+  };
+}
+
+test('state-contract: no active milestone routes to start', () => {
+  const doc = buildStateContract([milestone({ status: 'complete' })], [], NOW);
+  assert.equal(doc.contract, '1.0.0');
+  assert.equal(doc.flavor, 'pi');
+  assert.equal(doc.milestone, null);
+  assert.deepEqual(doc.phases, []);
+  assert.equal(doc.next.command, '/gsd');
+  assert.equal(doc.updated_at, NOW);
+});
+
+test('state-contract: queued milestone counts as active (canonical non-terminal rule)', () => {
+  const doc = buildStateContract([milestone({ status: 'complete' }), milestone({ id: 'M002', title: 'Next', status: 'queued' })], [], NOW);
+  assert.equal(doc.milestone, 'M002 — Next');
+  assert.equal(doc.next.label, 'Plan M002');
+});
+
+test('state-contract: active milestone maps slices to phases with status vocabulary', () => {
+  const doc = buildStateContract(
+    [milestone({ id: 'M002', title: 'M002: Reservations', status: 'active' })],
+    [
+      slice({ milestone_id: 'M002', id: 'S1', title: 'Schema', status: 'done', sequence: 1 }),
+      slice({ milestone_id: 'M002', id: 'S2', title: 'Reader', status: 'in-progress', sequence: 2 }),
+      slice({ milestone_id: 'M002', id: 'S3', title: 'Upstream', status: 'planned', sequence: 3 }),
+      slice({ milestone_id: 'OTHER', id: 'S9', title: 'Elsewhere', status: 'pending', sequence: 1 }),
+    ],
+    NOW,
+  );
+  assert.equal(doc.milestone, 'M002 — Reservations');
+  assert.deepEqual(doc.phases, [
+    { number: 1, name: 'Schema', status: 'complete' },
+    { number: 2, name: 'Reader', status: 'in_progress' },
+    { number: 3, name: 'Upstream', status: 'pending' },
+  ]);
+  assert.deepEqual(doc.next, {
+    command: '/gsd auto',
+    label: 'Continue Reader',
+    reason: 'Slice 2 in progress',
+  });
+});
+
+test('state-contract: all slices closed routes to complete milestone', () => {
+  const doc = buildStateContract(
+    [milestone({ status: 'active' })],
+    [slice({ status: 'complete' }), slice({ id: 'S2', status: 'skipped', sequence: 2 })],
+    NOW,
+  );
+  assert.equal(doc.next.label, 'Complete M001');
+});
+
+test('state-contract: pending slice with none in progress routes to start slice', () => {
+  const doc = buildStateContract(
+    [milestone({ status: 'active' })],
+    [slice({ status: 'complete' }), slice({ id: 'S2', title: 'Next up', status: 'pending', sequence: 2 })],
+    NOW,
+  );
+  assert.deepEqual(doc.next, { command: '/gsd auto', label: 'Start Next up', reason: 'Slice 2 is next' });
+});
+
+test('state-contract: writeManifest also writes .gsd/state.json', async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-state-contract-'));
+  openDatabase(path.join(base, 'test.db'));
+  try {
+    insertMilestone({ id: 'M001', title: 'Hardening', status: 'active' });
+    insertSlice({ id: 'S1', milestoneId: 'M001', title: 'Schema', status: 'in_progress', sequence: 1 });
+    writeManifest(base);
+    await flushManifest(base);
+    const doc = JSON.parse(fs.readFileSync(path.join(base, '.gsd', 'state.json'), 'utf-8'));
+    assert.equal(doc.contract, '1.0.0');
+    assert.equal(doc.flavor, 'pi');
+    assert.equal(doc.milestone, 'M001 — Hardening');
+    assert.deepEqual(doc.phases, [{ number: 1, name: 'Schema', status: 'in_progress' }]);
+    assert.equal(doc.next.command, '/gsd auto');
+    assert.ok(typeof doc.updated_at === 'string' && doc.updated_at.length > 0);
+  } finally {
+    closeDatabase();
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/state-contract.test.ts
+++ b/src/resources/extensions/gsd/tests/state-contract.test.ts
@@ -123,23 +123,74 @@ test('state-contract: pending slice with none in progress routes to start slice'
   assert.deepEqual(doc.next, { command: '/gsd auto', label: 'Start Next up', reason: 'Slice 2 is next' });
 });
 
-test('state-contract: writeManifest also writes .gsd/state.json', async () => {
+test('state-contract: writeManifest also writes .gsd/state.json', async (t) => {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-state-contract-'));
-  openDatabase(path.join(base, 'test.db'));
-  try {
-    insertMilestone({ id: 'M001', title: 'Hardening', status: 'active' });
-    insertSlice({ id: 'S1', milestoneId: 'M001', title: 'Schema', status: 'in_progress', sequence: 1 });
-    writeManifest(base);
-    await flushManifest(base);
-    const doc = JSON.parse(fs.readFileSync(path.join(base, '.gsd', 'state.json'), 'utf-8'));
-    assert.equal(doc.contract, '1.0.0');
-    assert.equal(doc.flavor, 'pi');
-    assert.equal(doc.milestone, 'M001 — Hardening');
-    assert.deepEqual(doc.phases, [{ number: 1, name: 'Schema', status: 'in_progress' }]);
-    assert.equal(doc.next.command, '/gsd auto');
-    assert.ok(typeof doc.updated_at === 'string' && doc.updated_at.length > 0);
-  } finally {
+  t.after(() => {
     closeDatabase();
     fs.rmSync(base, { recursive: true, force: true });
-  }
+  });
+  openDatabase(path.join(base, 'test.db'));
+
+  insertMilestone({ id: 'M001', title: 'Hardening', status: 'active' });
+  insertSlice({ id: 'S1', milestoneId: 'M001', title: 'Schema', status: 'in_progress', sequence: 1 });
+  writeManifest(base);
+  await flushManifest(base);
+  const doc = JSON.parse(fs.readFileSync(path.join(base, '.gsd', 'state.json'), 'utf-8'));
+  assert.equal(doc.contract, '1.0.0');
+  assert.equal(doc.flavor, 'pi');
+  assert.equal(doc.milestone, 'M001 — Hardening');
+  assert.deepEqual(doc.phases, [{ number: 1, name: 'Schema', status: 'in_progress' }]);
+  assert.equal(doc.next.command, '/gsd auto');
+  assert.ok(typeof doc.updated_at === 'string' && doc.updated_at.length > 0);
+});
+
+test('state-contract: flushManifest drains all writes before reporting a failure', async (t) => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-state-contract-flush-'));
+  let releaseContractWrite: (() => void) | undefined;
+  t.after(async () => {
+    releaseContractWrite?.();
+    await flushManifest(base).catch(() => {});
+    closeDatabase();
+    fs.rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(path.join(base, 'test.db'));
+
+  const originalWriteFile = fs.promises.writeFile.bind(fs.promises);
+  let markContractWriteStarted: (() => void) | undefined;
+  const contractWriteStarted = new Promise<void>((resolve) => {
+    markContractWriteStarted = resolve;
+  });
+  const contractWriteBlocked = new Promise<void>((resolve) => {
+    releaseContractWrite = resolve;
+  });
+  let contractWriteCompleted = false;
+  t.mock.method(fs.promises, 'writeFile', async (filePath, data, options) => {
+    const target = String(filePath);
+    if (target.includes('state-manifest.json.tmp.')) {
+      throw new Error('manifest write failed');
+    }
+    if (target.includes('state.json.tmp.')) {
+      markContractWriteStarted?.();
+      await contractWriteBlocked;
+      contractWriteCompleted = true;
+    }
+    return originalWriteFile(filePath, data, options);
+  });
+
+  writeManifest(base);
+  const flush = flushManifest(base);
+  const flushOutcome = flush.then(
+    () => 'resolved' as const,
+    () => 'rejected' as const,
+  );
+  await contractWriteStarted;
+  const outcomeBeforeRelease = await Promise.race([
+    flushOutcome,
+    new Promise<'pending'>((resolve) => setImmediate(() => resolve('pending'))),
+  ]);
+  releaseContractWrite();
+
+  assert.equal(outcomeBeforeRelease, 'pending');
+  await assert.rejects(flush, /manifest write failed/);
+  assert.equal(contractWriteCompleted, true);
 });

--- a/src/resources/extensions/gsd/tests/state-contract.test.ts
+++ b/src/resources/extensions/gsd/tests/state-contract.test.ts
@@ -164,18 +164,23 @@ test('state-contract: flushManifest drains all writes before reporting a failure
     releaseContractWrite = resolve;
   });
   let contractWriteCompleted = false;
-  t.mock.method(fs.promises, 'writeFile', async (filePath, data, options) => {
-    const target = String(filePath);
-    if (target.includes('state-manifest.json.tmp.')) {
-      throw new Error('manifest write failed');
-    }
-    if (target.includes('state.json.tmp.')) {
-      markContractWriteStarted?.();
-      await contractWriteBlocked;
-      contractWriteCompleted = true;
-    }
-    return originalWriteFile(filePath, data, options);
-  });
+  type WriteFileArgs = Parameters<typeof fs.promises.writeFile>;
+  t.mock.method(
+    fs.promises,
+    'writeFile',
+    async (filePath: WriteFileArgs[0], data: WriteFileArgs[1], options: WriteFileArgs[2]) => {
+      const target = String(filePath);
+      if (target.includes('state-manifest.json.tmp.')) {
+        throw new Error('manifest write failed');
+      }
+      if (target.includes('state.json.tmp.')) {
+        markContractWriteStarted?.();
+        await contractWriteBlocked;
+        contractWriteCompleted = true;
+      }
+      return originalWriteFile(filePath, data, options);
+    },
+  );
 
   writeManifest(base);
   const flush = flushManifest(base);
@@ -188,7 +193,7 @@ test('state-contract: flushManifest drains all writes before reporting a failure
     flushOutcome,
     new Promise<'pending'>((resolve) => setImmediate(() => resolve('pending'))),
   ]);
-  releaseContractWrite();
+  releaseContractWrite?.();
 
   assert.equal(outcomeBeforeRelease, 'pending');
   await assert.rejects(flush, /manifest write failed/);

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -446,8 +446,12 @@ function enqueueManifestWrite(filePath: string, json: string): void {
 /**
  * Queue current DB state for an async atomic write to .gsd/state-manifest.json,
  * plus the state contract v1 projection to .gsd/state.json (read by external
- * tools like GSD Workbench). Uses JSON.stringify with 2-space indent for git
- * three-way merge friendliness.
+ * tools like GSD Workbench). The contract deliberately tracks this write
+ * boundary: every skill step boundary uses writeManifest/writeManifestAndFlush,
+ * while placeholder milestone inserts, queue-order reconciliation, and out-of-
+ * band edits refresh on the next skill run as allowed by contract v1 rule 2 and
+ * ADR-0004. Uses JSON.stringify with 2-space indent for git three-way merge
+ * friendliness.
  */
 export function writeManifest(basePath: string): void {
   const manifest = snapshotState();
@@ -475,9 +479,14 @@ async function flushManifestByKey(key: string): Promise<void> {
  */
 export async function flushManifest(basePath: string): Promise<void> {
   const prefix = join(resolve(basePath), ".gsd") + sep;
-  await Promise.all(
-    Array.from(manifestWrites.keys(), (key) => (key.startsWith(prefix) ? flushManifestByKey(key) : null)),
+  const results = await Promise.allSettled(
+    Array.from(manifestWrites.keys())
+      .filter((key) => key.startsWith(prefix))
+      .map((key) => flushManifestByKey(key)),
   );
+  for (const result of results) {
+    if (result.status === "rejected") throw result.reason;
+  }
 }
 
 export async function flushAllManifests(): Promise<void> {

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -11,6 +11,7 @@ import type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 import type { VerificationEvidenceRow } from "./db-verification-evidence-rows.js";
 import type { Decision, GateRow, Requirement } from "./types.js";
 import { atomicWriteAsync, atomicWriteSync } from "./atomic-write.js";
+import { buildStateContract } from "./state-contract.js";
 import {
   getAllDecisionsFromMemories,
   getDeletedDecisionIdsFromMemories,
@@ -19,7 +20,7 @@ import { backfillDecisionsToMemories } from "./memory-backfill.js";
 import { invalidateAllCaches } from "./cache.js";
 import { logWarning } from "./workflow-logger.js";
 import { readFileSync, existsSync } from "node:fs";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 // ─── Manifest Types ──────────────────────────────────────────────────────
 
@@ -362,7 +363,6 @@ export function snapshotState(): StateManifest {
 // ─── writeManifest ───────────────────────────────────────────────────────
 
 interface ManifestWriteState {
-  filePath: string;
   latestJson: string | null;
   inFlightJson: string | null;
   /** Set by sync exit flush so an in-flight async write cannot leave stale data on disk. */
@@ -374,12 +374,12 @@ const manifestWrites = new Map<string, ManifestWriteState>();
 let processTeardownFlushInstalled = false;
 let beforeExitFlushStarted = false;
 
-function manifestWriteKey(basePath: string): string {
-  return resolve(basePath);
-}
-
 function manifestFilePath(basePath: string): string {
   return join(resolve(basePath), ".gsd", "state-manifest.json");
+}
+
+function stateContractFilePath(basePath: string): string {
+  return join(resolve(basePath), ".gsd", "state.json");
 }
 
 function describeError(err: unknown): string {
@@ -398,15 +398,15 @@ async function drainManifestWrites(key: string, state: ManifestWriteState): Prom
       state.latestJson = null;
       state.inFlightJson = json;
       try {
-        await atomicWriteAsync(state.filePath, json);
+        await atomicWriteAsync(key, json);
         if (state.syncFlushJson !== null) {
-          atomicWriteSync(state.filePath, state.syncFlushJson);
+          atomicWriteSync(key, state.syncFlushJson);
           break;
         }
         lastWriteError = null;
       } catch (err) {
         lastWriteError = err;
-        logManifestWriteFailure(state.filePath, err);
+        logManifestWriteFailure(key, err);
       } finally {
         state.inFlightJson = null;
       }
@@ -422,12 +422,11 @@ async function drainManifestWrites(key: string, state: ManifestWriteState): Prom
   }
 }
 
-function enqueueManifestWrite(basePath: string, json: string): void {
-  const key = manifestWriteKey(basePath);
+function enqueueManifestWrite(filePath: string, json: string): void {
+  const key = filePath;
   let state = manifestWrites.get(key);
   if (!state) {
     state = {
-      filePath: manifestFilePath(basePath),
       latestJson: null,
       inFlightJson: null,
       syncFlushJson: null,
@@ -445,13 +444,16 @@ function enqueueManifestWrite(basePath: string, json: string): void {
 }
 
 /**
- * Queue current DB state for an async atomic write to .gsd/state-manifest.json.
- * Uses JSON.stringify with 2-space indent for git three-way merge friendliness.
+ * Queue current DB state for an async atomic write to .gsd/state-manifest.json,
+ * plus the state contract v1 projection to .gsd/state.json (read by external
+ * tools like GSD Workbench). Uses JSON.stringify with 2-space indent for git
+ * three-way merge friendliness.
  */
 export function writeManifest(basePath: string): void {
   const manifest = snapshotState();
-  const json = JSON.stringify(manifest, null, 2);
-  enqueueManifestWrite(basePath, json);
+  enqueueManifestWrite(manifestFilePath(basePath), JSON.stringify(manifest, null, 2));
+  const contract = buildStateContract(manifest.milestones, manifest.slices, manifest.exported_at);
+  enqueueManifestWrite(stateContractFilePath(basePath), JSON.stringify(contract, null, 2));
 }
 
 export async function writeManifestAndFlush(basePath: string): Promise<void> {
@@ -468,10 +470,14 @@ async function flushManifestByKey(key: string): Promise<void> {
 }
 
 /**
- * Wait for any queued manifest write for this base path to become durable.
+ * Wait for every queued write under this base path (state-manifest.json and
+ * the state contract projection) to become durable.
  */
 export async function flushManifest(basePath: string): Promise<void> {
-  await flushManifestByKey(manifestWriteKey(basePath));
+  const prefix = join(resolve(basePath), ".gsd") + sep;
+  await Promise.all(
+    Array.from(manifestWrites.keys(), (key) => (key.startsWith(prefix) ? flushManifestByKey(key) : null)),
+  );
 }
 
 export async function flushAllManifests(): Promise<void> {
@@ -483,13 +489,13 @@ function flushAllManifestsSync(): void {
     const json = state.latestJson ?? state.inFlightJson;
     if (json === null) continue;
     try {
-      atomicWriteSync(state.filePath, json);
+      atomicWriteSync(key, json);
       state.latestJson = null;
       state.inFlightJson = null;
       state.syncFlushJson = json;
       manifestWrites.delete(key);
     } catch (err) {
-      logManifestWriteFailure(state.filePath, err);
+      logManifestWriteFailure(key, err);
     }
   }
 }

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -1088,6 +1088,7 @@ const SKIP_EXACT = [
   ".gsd/auto.lock",
   ".gsd/metrics.json",
   ".gsd/state-manifest.json",
+  ".gsd/state.json",
   ".gsd/doctor-history.jsonl",
   ".gsd/event-log.jsonl",
 ];


### PR DESCRIPTION
## Intent

Implement the GSD state contract v1 (defined in gsd-workbench docs/state-contract/v1.md, consumed per its ADR-0002/ADR-0004 by GSD Workbench, which prefers this file over the state manifest or markdown projections). Pi must write .gsd/state.json — contract 1.0.0, flavor pi, milestone = the active milestone display string, phases[] = the active milestone's slices with complete/in_progress/pending status, a next{command,label,reason} hint, and updated_at — whenever it updates gsd.db / state-manifest.json / markdown projections. Deliberate decisions: the writer hooks writeManifest() in workflow-manifest.ts because every DB mutation funnels through it, reusing the existing coalescing atomic-write queue rekeyed by file path (the queue previously keyed by basePath and wrote only state-manifest.json); flushManifest now drains all queued writes under the base path. The contract builder (state-contract.ts) is pure over manifest snapshot rows; active milestone deliberately follows the canonical non-terminal/non-parked rule (isSkippedForDispatch) so queued milestones count as active, matching getActiveMilestoneFromDb. The next hint is intentionally approximate and stale-tolerant per the contract (ADR-0004) — it does NOT reuse the async deriveStateFromDb router or dependency-aware slice selection, to keep the sync write path light; commands are /gsd and /gsd auto. stripIdPrefix is deliberately duplicated locally with a comment because importing workflow-projections would create a module cycle through workflow-manifest. .gsd/state.json is registered as a runtime file in gitignore.ts, git-service.ts RUNTIME_EXCLUSION_PATHS, and worktree-manager.ts SKIP_EXACT, matching state-manifest.json. New tests in tests/state-contract.test.ts; verify:fast, typecheck:extensions, and changed-file unit tests already pass locally.

## What Changed

- Add the GSD state contract v1 projection at `.gsd/state.json`, exposing the active milestone, phase statuses, next-command hint, and update timestamp alongside the state manifest.
- Extend the atomic-write queue and flush behavior to independently persist and fully drain both state projections.
- Keep the new projection out of Git staging and worktree diffs, with focused contract tests and updated runtime-state documentation.

## Risk Assessment

✅ Low: The prior findings are resolved, the runtime exclusion invariant now matches the 23-entry source list, and no remaining material source or intent-conformance risks were found.

## Testing

Author-reported `verify:fast`, `typecheck:extensions`, and changed-file tests were already green and were not rerun because this phase required targeted runtime validation and prohibited static-analysis tools. All focused automated tests and corrected manual checks passed. Evidence demonstrates contract creation, refresh after DB mutation, emission through the user-facing complete-task path, and Git/worktree exclusion. This is a non-UI JSON/runtime change, so screenshot evidence is not applicable.

<details>
<summary>Evidence: Initial generated state contract</summary>

```text
{
  "contract": "1.0.0",
  "flavor": "pi",
  "milestone": "M002 — Reservations",
  "phases": [
    {
      "number": 1,
      "name": "Schema",
      "status": "complete"
    },
    {
      "number": 2,
      "name": "Reader",
      "status": "in_progress"
    },
    {
      "number": 3,
      "name": "API",
      "status": "pending"
    }
  ],
  "next": {
    "command": "/gsd auto",
    "label": "Continue Reader",
    "reason": "Slice 2 in progress"
  },
  "updated_at": "2026-08-08T23:07:15.575Z"
}
```
</details>
<details>
<summary>Evidence: Updated generated state contract</summary>

```text
{
  "contract": "1.0.0",
  "flavor": "pi",
  "milestone": "M002 — Reservations",
  "phases": [
    {
      "number": 1,
      "name": "Schema",
      "status": "complete"
    },
    {
      "number": 2,
      "name": "Reader",
      "status": "complete"
    },
    {
      "number": 3,
      "name": "API",
      "status": "in_progress"
    }
  ],
  "next": {
    "command": "/gsd auto",
    "label": "Continue API",
    "reason": "Slice 3 in progress"
  },
  "updated_at": "2026-08-08T23:07:15.606Z"
}
```
</details>
<details>
<summary>Evidence: Complete-task generated state</summary>

```text
{
  "contract": "1.0.0",
  "flavor": "pi",
  "milestone": "M001 — Reservations",
  "phases": [
    {
      "number": 1,
      "name": "Reader",
      "status": "in_progress"
    }
  ],
  "next": {
    "command": "/gsd auto",
    "label": "Continue Reader",
    "reason": "Slice 1 in progress"
  },
  "updated_at": "2026-08-08T23:09:38.713Z"
}
```
</details>
<details>
<summary>Evidence: Complete-task end-to-end proof</summary>

```text
{
  "command_surface": "handleCompleteTask",
  "tool_result": {
    "taskId": "T01",
    "sliceId": "S01",
    "milestoneId": "M001",
    "summaryPath": "/private/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KZHRQXF2QRYC5WPFPXCJWTR1/complete-task-e2e/.gsd/milestones/M001/slices/S01/tasks/T01-SUMMARY.md"
  },
  "completed_task_status_in_manifest": "complete",
  "summary_projection_exists": true,
  "generated_state": {
    "contract": "1.0.0",
    "flavor": "pi",
    "milestone": "M001 — Reservations",
    "phases": [
      {
        "number": 1,
        "name": "Reader",
        "status": "in_progress"
      }
    ],
    "next": {
      "command": "/gsd auto",
      "label": "Continue Reader",
      "reason": "Slice 1 in progress"
    },
    "updated_at": "2026-08-08T23:09:38.713Z"
  }
}
```
</details>
<details>
<summary>Evidence: Runtime and worktree exclusion proof</summary>

```text
{
  "gitignore_check": ".gsd/state.json",
  "auto_commit_message": "chore: auto-commit after execute-task\n\nGSD-Unit: M002/S03/T01",
  "head_committed_files": [
    "src.ts"
  ],
  "state_json_tracked_after_auto_commit": "",
  "state_json_still_on_disk": true,
  "state_json_content_preserved": true,
  "worktree_gsd_diff_summary": {
    "added": [
      ".gsd/milestones/M002/ROADMAP.md"
    ],
    "modified": [],
    "removed": []
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (2) ✅</summary>

- 🚨 `src/resources/extensions/gsd/workflow-manifest.ts:452` - Required intent says `.gsd/state.json` must be written whenever Pi updates `gsd.db` or markdown projections, but the diff only writes it from `writeManifest()`. Production paths bypass that boundary: `gsd_milestone_generate_id` inserts a queued milestone directly, while queue reorder and park/unpark mutate contract-relevant DB state without calling `writeManifest`. The contract can therefore remain absent or show the prior milestone indefinitely. Either narrow the requirement explicitly or enqueue the contract at the earliest basePath-aware mutation boundary shared by these flows.
- 🚨 `src/resources/extensions/gsd/state-contract.ts:79` - The stated canonical-active invariant is internally inconsistent with the implementation it claims to match. This line selects sequence-first snapshot rows and excludes `deferred` via `isSkippedForDispatch`, while `getActiveMilestoneFromDb()` selects ID-first and includes deferred milestones. A reordered queue or a lower-ID deferred milestone therefore yields different active milestones. Choose the authoritative ordering/status rule and align both semantic owners.
- 🚨 `src/resources/extensions/gsd/workflow-manifest.ts:478` - `Promise.all` rejects as soon as either file queue fails, so `flushManifest()` can return while the other write remains active, contradicting the required guarantee that it drains every queued write under the base path. This can recreate files after caller cleanup or leave durability timing unknown. Await all queues with `Promise.allSettled`, then surface the failure; add a focused regression where one queue fails while the other remains delayed.
- ⚠️ `src/resources/extensions/gsd/tests/state-contract.test.ts:129` - The new integration test uses inline `try/finally`, contrary to CONTRIBUTING.md’s mandatory `t.after()`/lifecycle-hook cleanup rule. Because cleanup is registered only after `openDatabase` succeeds, setup failure can also leak the temporary directory. Register cleanup through the test context before setup proceeds.

🔧 Fix: Harden state contract flush and test cleanup
1 error still open:
- 🚨 `src/resources/extensions/gsd/git-service.ts:381` - Adding `.gsd/state.json` increases `RUNTIME_EXCLUSION_PATHS` to 23 entries, but the exact invariant test still asserts 22 and its ordered expected list omits this path (`tests/integration/git-service.test.ts:296-329`). Source inspection proves that test will fail; update its expected count and list.

🔧 Fix: Update runtime exclusion invariant for state contract
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/state-contract.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern='workflow-manifest: (writeManifest|flushManifest)' src/resources/extensions/gsd/tests/workflow-manifest.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern='GitServiceImpl: smart staging excludes tracked runtime files' src/resources/extensions/gsd/tests/integration/git-service.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern='post-mutation-hook: (state-manifest\.json exists|manifest has version)' src/resources/extensions/gsd/tests/post-mutation-hook.test.ts`
- <code>Production-path harness mutated queued milestone/slice state and called `writeManifestAndFlush()` twice, verifying both contract snapshots and manifest timestamp consistency</code>
- <code>Complete-task harness called `handleCompleteTask()`, then verified task persistence, summary and manifest projections, and the resulting `.gsd/state.json`</code>
- <code>Runtime harness exercised `ensureGitignore()`, `GitServiceImpl.autoCommit()`, `git check-ignore`, `git ls-files`, and `diffWorktreeGSD()` specifically against `.gsd/state.json`</code>
- <code>Initial worktree harness used the wrong `milestone/demo` fixture branch; it was corrected to `worktree/demo` and passed on retry</code>
- <code>`git status --short --branch` confirmed no testing artifacts were left in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ `typecheck:extensions` could not complete because required workspace package `dist` artifacts are absent; no diagnostics referenced the changed files.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->