### PR TITLE
fix(issue): [Bug]: Symlinked .gsd project store breaks the closeout consistency gate — milestone merge fails with 'fatal: not a git repository'

### DIFF
--- a/src/resources/extensions/gsd/closeout-consistency-gate.ts
+++ b/src/resources/extensions/gsd/closeout-consistency-gate.ts
@@ -33,6 +33,7 @@ import {
 } from "./db/milestone-closeout-readiness.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { captureMilestoneVerificationSourceRevision } from "./verification-source-integrity.js";
+import { resolveRepositoryProjectRoot } from "./repository-registry.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { atomicWriteSync, removeProjectionFileSync } from "./atomic-write.js";
 
@@ -81,7 +82,10 @@ function isFileBackedDbPath(path: string | null): boolean {
 function artifactBasePathFromDb(): string | undefined {
   const dbPath = getWorkflowDatabasePath();
   if (!isFileBackedDbPath(dbPath)) return undefined;
-  return dirname(dirname(dbPath!));
+  const dbBasePath = dirname(dirname(dbPath!));
+  return existsSync(join(dbBasePath, ".git"))
+    ? dbBasePath
+    : resolveRepositoryProjectRoot(process.cwd());
 }
 
 function allSlicesHaveCloseoutSummaryEvidence(milestoneId: string, artifactBasePath: string): boolean {

--- a/src/resources/extensions/gsd/tests/adopted-milestone-validation-waiver.test.ts
+++ b/src/resources/extensions/gsd/tests/adopted-milestone-validation-waiver.test.ts
@@ -3,7 +3,7 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
@@ -31,6 +31,7 @@ import {
   readDomainOperationFence,
   upsertQualityGate,
 } from "../gsd-db.ts";
+import { openWorkflowDatabase } from "../db-workspace.ts";
 import { handleCompleteMilestone } from "../tools/complete-milestone.ts";
 import { handleValidateMilestone } from "../tools/validate-milestone.ts";
 import { deriveStateFromDb } from "../state.ts";
@@ -389,6 +390,28 @@ test("legacy skipped status cannot bypass adopted canonical authorization", () =
 
   assert.equal(result.ok, false);
   if (!result.ok) assert.equal(result.reason, "validation-not-pass");
+});
+
+test("closeout consistency snapshots the repo when .gsd links to an external store", async () => {
+  const savedCwd = process.cwd();
+  const basePath = makeFixture();
+  const storeRoot = mkdtempSync(join(tmpdir(), "gsd-adopted-validation-store-"));
+  tempDirs.add(storeRoot);
+
+  try {
+    closeDatabase();
+
+    const externalGsd = join(storeRoot, "project");
+    renameSync(join(basePath, ".gsd"), externalGsd);
+    symlinkSync(externalGsd, join(basePath, ".gsd"), process.platform === "win32" ? "junction" : "dir");
+    assert.equal(openWorkflowDatabase(basePath).ok, true);
+
+    process.chdir(basePath);
+    await recordPassingValidation(basePath, "test/milestone.validate/symlinked-store");
+    assert.deepEqual(checkCloseoutConsistencyGate("M001", { allowOpenMilestone: true }), { ok: true });
+  } finally {
+    process.chdir(savedCwd);
+  }
 });
 
 test("adopted legacy skipped status is not terminal while canonical lifecycle remains open", async () => {


### PR DESCRIPTION
## Summary
- Fixed symlinked .gsd closeout root resolution and verified it with 21 focused passing tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1668
- [#1668 [Bug]: Symlinked .gsd project store breaks the closeout consistency gate — milestone merge fails with 'fatal: not a git repository'](https://github.com/open-gsd/gsd-pi/issues/1668)

## User
- @jquacinella

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1668-bug-symlinked-gsd-project-store-breaks-t-1786247387`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->