### PR TITLE
fix(issue): Sticky isolationDegraded flag strands branch-mode milestone: hard-blocks /gsd auto after one failure, no recovery until process restart

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1040,6 +1040,10 @@ export async function bootstrapAutoSession(
   deps: BootstrapDeps,
   interrupted: InterruptedSessionAssessment,
 ): Promise<boolean> {
+  // A failed bootstrap can return without the normal stop/reset path. Do not
+  // let its process-wide isolation failure poison the next independent run.
+  s.isolationDegraded = false;
+
   const {
     shouldUseWorktreeIsolation,
     registerSigtermHandler,

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 
 import { bootstrapAutoSession } from "../auto-start.ts";
 import { AutoSession } from "../auto/session.ts";
+import type { InterruptedSessionAssessment } from "../interrupted-session.ts";
 import {
   closeDatabase,
   insertMilestone,
@@ -248,6 +249,26 @@ function makeCtx(notifications: Array<{ message: string; level?: string }>) {
     },
   };
 }
+
+test("fresh bootstrap clears isolation degradation from a prior auto run (#1689)", async () => {
+  const s = new AutoSession();
+  s.isolationDegraded = true;
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  const ready = await bootstrapAutoSession(
+    s,
+    makeCtx(notifications) as any,
+    {} as any,
+    tmpdir(),
+    false,
+    false,
+    {} as any,
+    {} as unknown as InterruptedSessionAssessment,
+  );
+
+  assert.equal(ready, false, "the system temp root should stop bootstrap at directory validation");
+  assert.equal(s.isolationDegraded, false, "fresh bootstrap must not inherit degradation");
+});
 
 test("bootstrap aborts before starting next milestone when completed orphan merge fails", async () => {
   const base = makeRepoWithUnmergedCompletedMilestone();

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -277,9 +277,44 @@ test("enterMilestone honors stranded branch recovery instead of recreating the w
   );
 });
 
-test("enterMilestone returns ok:false reason:isolation-degraded when session degraded", () => {
-  const s = makeSession({ isolationDegraded: true });
-  const deps = makeDeps({ getIsolationMode: () => "branch" });
+test("enterMilestone retries branch isolation when session is degraded", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase({ isolation: "branch" });
+  t.after(() => cleanupRepoBase(base, previousCwd));
+
+  const s = makeSession({
+    basePath: base,
+    originalBasePath: base,
+    isolationDegraded: true,
+  });
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.mode, "branch");
+    assert.equal(result.path, base);
+  }
+  assert.equal(s.isolationDegraded, false);
+  assert.equal(s.basePath, base);
+  assert.equal(s.milestoneLeaseToken, null);
+});
+
+test("enterMilestone remains degraded when branch isolation retry fails", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase({ isolation: "branch" });
+  t.after(() => cleanupRepoBase(base, previousCwd));
+  rmSync(join(base, ".git"), { recursive: true, force: true });
+
+  const s = makeSession({
+    basePath: base,
+    originalBasePath: base,
+    isolationDegraded: true,
+  });
+  const deps = makeDeps();
   const ctx = makeCtx();
   const lifecycle = new WorktreeLifecycle(s, deps);
 
@@ -289,8 +324,7 @@ test("enterMilestone returns ok:false reason:isolation-degraded when session deg
   if (!result.ok) {
     assert.equal(result.reason, "isolation-degraded");
   }
-  assert.equal(s.basePath, "/project");
-  assert.equal(s.milestoneLeaseToken, null);
+  assert.equal(s.isolationDegraded, true);
 });
 
 test("enterMilestone falls back to branch mode when session is degraded in worktree isolation", (t) => {

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -792,13 +792,18 @@ export function _enterMilestoneCore(
     getIsolationMode(basePath);
 
   if (s.isolationDegraded) {
-    if (mode === "worktree") {
+    if (mode === "worktree" || mode === "branch") {
       try {
         lifecycleEnterBranchMode(deps, basePath, milestoneId);
         s.basePath = basePath;
         rebuildGitService(s, deps);
         invalidateAllCaches();
-        ctx.notify(isolationDegradedFallbackGuidance(milestoneId), "warning");
+        if (mode === "branch") s.isolationDegraded = false;
+        if (mode === "worktree") {
+          ctx.notify(isolationDegradedFallbackGuidance(milestoneId), "warning");
+        } else {
+          ctx.notify(`Recovered branch isolation on milestone/${milestoneId}.`, "info");
+        }
         return { ok: true, mode: "branch", path: basePath };
       } catch (err) {
         debugLog("WorktreeLifecycle", {


### PR DESCRIPTION
## Summary
- Cleared stale isolation state between auto runs and restored branch-mode recovery with passing focused tests.

## Bugs Addressed
- [x] **Isolation-degraded state persists across auto runs**
- [x] **Branch isolation cannot recover from degraded state**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1689
- [#1689 Sticky isolationDegraded flag strands branch-mode milestone: hard-blocks /gsd auto after one failure, no recovery until process restart](https://github.com/open-gsd/gsd-pi/issues/1689)

## User
- @BGarber42

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1689-sticky-isolationdegraded-flag-strands-br-1786382631`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->