### PR TITLE
fix(issue): Windows: native projection root identity lock fails on 2nd+ acquisition, blocking plan-task/plan-slice renders

### DIFF
--- a/native/crates/engine/src/projection_root_identity_lock.rs
+++ b/native/crates/engine/src/projection_root_identity_lock.rs
@@ -39,6 +39,8 @@ use std::os::windows::fs::OpenOptionsExt;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 #[cfg(windows)]
+use std::os::windows::io::IntoRawHandle;
+#[cfg(windows)]
 use std::path::Path;
 
 #[cfg(unix)]
@@ -100,6 +102,7 @@ static MUTATION_BOUNDARY_FAULT: DisabledMutationBoundaryFault = DisabledMutation
 #[cfg(windows)]
 #[link(name = "kernel32")]
 extern "system" {
+    fn CloseHandle(handle: *mut std::ffi::c_void) -> i32;
     fn GetFileInformationByHandle(
         handle: *mut std::ffi::c_void,
         information: *mut WindowsFileInformation,
@@ -1559,8 +1562,19 @@ impl ProjectionRootIdentityLock {
     }
 
     #[napi]
-    pub fn close(&mut self) {
-        self.file.take();
+    pub fn close(&mut self) -> Result<()> {
+        let Some(file) = self.file.take() else {
+            return Ok(());
+        };
+        #[cfg(windows)]
+        {
+            return close_windows_root_directory(file);
+        }
+        #[cfg(not(windows))]
+        {
+            drop(file);
+            Ok(())
+        }
     }
 }
 
@@ -2008,6 +2022,19 @@ fn open_windows_root_directory(path: &Path) -> Result<File> {
         ));
     }
     Ok(file)
+}
+
+#[cfg(windows)]
+fn close_windows_root_directory(file: File) -> Result<()> {
+    // Transfer ownership out of `File` and close the root handle explicitly so
+    // close failures reach JavaScript instead of being discarded by `File`'s
+    // infallible Drop. This is the only handle whose sharing contract excludes
+    // another projection mutation owner.
+    let handle = file.into_raw_handle();
+    if unsafe { CloseHandle(handle) } == 0 {
+        return Err(projection_error(std::io::Error::last_os_error()));
+    }
+    Ok(())
 }
 
 #[cfg(windows)]

--- a/packages/native/src/__tests__/file-identity-fallback.test.mjs
+++ b/packages/native/src/__tests__/file-identity-fallback.test.mjs
@@ -116,7 +116,9 @@ test("projection root lock permits root writes, excludes a second owner, and rea
   assert.equal(lock.readFile("PROJECT.md").toString(), "# Project\n");
   assert.ok(lock.listDirectory("").includes("PROJECT.md"));
 
-  lock.close();
-  lock = acquireProjectionRootIdentityLock(root, stat.dev.toString(), stat.ino.toString());
-  assert.equal(lock.readFile("PROJECT.md").toString(), "# Project\n");
+  for (let acquisition = 2; acquisition <= 4; acquisition++) {
+    lock.close();
+    lock = acquireProjectionRootIdentityLock(root, stat.dev.toString(), stat.ino.toString());
+    assert.equal(lock.readFile("PROJECT.md").toString(), "# Project\n", `acquisition ${acquisition}`);
+  }
 });

--- a/packages/native/src/__tests__/file-identity-fallback.test.mjs
+++ b/packages/native/src/__tests__/file-identity-fallback.test.mjs
@@ -87,7 +87,7 @@ test("loaded addon exposes the file-identity and directory-sync N-API exports", 
   assert.equal(output.syncDirectoryEntry, "function", "addon is stale: syncDirectoryEntry export missing");
 });
 
-test("projection root lock permits root writes while excluding a second owner", (t) => {
+test("projection root lock permits root writes, excludes a second owner, and reacquires after close", (t) => {
   const root = mkdtempSync(join(tmpdir(), "gsd-native-projection-root-"));
   const previousNativePreference = process.env.GSD_NATIVE_PREFER_LOCAL;
   let lock;
@@ -115,4 +115,8 @@ test("projection root lock permits root writes while excluding a second owner", 
   lock.writeFile("PROJECT.md", Buffer.from("# Project\n"));
   assert.equal(lock.readFile("PROJECT.md").toString(), "# Project\n");
   assert.ok(lock.listDirectory("").includes("PROJECT.md"));
+
+  lock.close();
+  lock = acquireProjectionRootIdentityLock(root, stat.dev.toString(), stat.ino.toString());
+  assert.equal(lock.readFile("PROJECT.md").toString(), "# Project\n");
 });

--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -35,6 +35,8 @@ const HISTORY_LOGICAL_PATH = "migration/managed-outputs.json";
 const JOURNAL_LOGICAL_ROOT = "migration/projection-mutations";
 const UNBOUND_EVIDENCE_LOGICAL_PATH = "migration/unbound-projection-evidence.json";
 const NATIVE_EVIDENCE_LOGICAL_ROOT = "migration/native-projection-evidence";
+const PROJECTION_ROOT_LOCK_RETRY_DELAYS_MS = [5, 10, 20, 40] as const;
+const projectionRootLockRetrySleep = new Int32Array(new SharedArrayBuffer(4));
 
 interface NativeProjectionEvidenceDescriptor {
   readonly version: 2;
@@ -206,6 +208,46 @@ function openManagedProjectionRoot(targetRoot: string): ProjectionRootIdentityLo
     stat.dev.toString(),
     stat.ino.toString(),
   );
+}
+
+function isTransientProjectionRootLockError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current !== null && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const candidate = current as { code?: unknown; message?: unknown; cause?: unknown };
+    if (candidate.code === "EBUSY") return true;
+    if (typeof candidate.message === "string"
+      && /\bEBUSY\b|sharing violation|os error 32|projection root is busy/iu.test(candidate.message)) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
+function openManagedProjectionRootWithRetry<T>(
+  open: () => T,
+  wait: (delayMs: number) => void = (delayMs) => {
+    Atomics.wait(projectionRootLockRetrySleep, 0, 0, delayMs);
+  },
+): T {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return open();
+    } catch (error) {
+      const delay = PROJECTION_ROOT_LOCK_RETRY_DELAYS_MS[attempt];
+      if (delay === undefined || !isTransientProjectionRootLockError(error)) throw error;
+      wait(delay);
+    }
+  }
+}
+
+export function _openManagedProjectionRootWithRetryForTest<T>(
+  open: () => T,
+  wait: (delayMs: number) => void,
+): T {
+  return openManagedProjectionRootWithRetry(open, wait);
 }
 
 function withManagedProjectionRoot<T>(
@@ -2106,7 +2148,7 @@ export function beginManagedProjectionMutation(
     return null;
   }
   const root = journalRoot(target.targetRoot);
-  const handle = openManagedProjectionRoot(target.targetRoot);
+  const handle = openManagedProjectionRootWithRetry(() => openManagedProjectionRoot(target.targetRoot));
   try {
     recoverManagedProjectionMutations(target.targetRoot, handle);
     recoverEvidenceResolutions(handle);

--- a/src/resources/extensions/gsd/tests/managed-projection-root-retry.test.ts
+++ b/src/resources/extensions/gsd/tests/managed-projection-root-retry.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { _openManagedProjectionRootWithRetryForTest } from "../managed-projection-history.ts";
+
+test("managed projection root acquisition retries transient lock failures with exponential backoff", () => {
+  const waits: number[] = [];
+  let attempts = 0;
+
+  const result = _openManagedProjectionRootWithRetryForTest(
+    () => {
+      attempts++;
+      if (attempts < 3) {
+        throw new Error("native projection root identity locking failed", {
+          cause: new Error("projection root operation failed: sharing violation (os error 32)"),
+        });
+      }
+      return "acquired";
+    },
+    (delay) => waits.push(delay),
+  );
+
+  assert.equal(result, "acquired");
+  assert.equal(attempts, 3);
+  assert.deepEqual(waits, [5, 10]);
+});
+
+test("managed projection root acquisition stops after the bounded retry budget", () => {
+  const waits: number[] = [];
+  let attempts = 0;
+  const failure = new Error("native projection root identity locking failed", {
+    cause: new Error("projection root is busy"),
+  });
+
+  assert.throws(
+    () => _openManagedProjectionRootWithRetryForTest(
+      () => {
+        attempts++;
+        throw failure;
+      },
+      (delay) => waits.push(delay),
+    ),
+    (error: unknown) => error === failure,
+  );
+  assert.equal(attempts, 5);
+  assert.deepEqual(waits, [5, 10, 20, 40]);
+});
+
+test("managed projection root acquisition does not retry permanent identity failures", () => {
+  const waits: number[] = [];
+  let attempts = 0;
+  const failure = new Error("native projection root identity locking failed", {
+    cause: new Error("projection root identity changed"),
+  });
+
+  assert.throws(
+    () => _openManagedProjectionRootWithRetryForTest(
+      () => {
+        attempts++;
+        throw failure;
+      },
+      (delay) => waits.push(delay),
+    ),
+    (error: unknown) => error === failure,
+  );
+  assert.equal(attempts, 1);
+  assert.deepEqual(waits, []);
+});


### PR DESCRIPTION
## Summary
- Added bounded native projection-lock retries and reacquisition coverage; syntax and diff checks passed.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1694
- [#1694 Windows: native projection root identity lock fails on 2nd+ acquisition, blocking plan-task/plan-slice renders](https://github.com/open-gsd/gsd-pi/issues/1694)

## User
- @BGarber42

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1694-windows-native-projection-root-identity--1786388861`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->