### PR TITLE
fix(issue): Branch isolation fails on a zero-commit repo: git branch -f milestone/<MID> <unbornBranch> → 'not a valid object name'

### DIFF
--- a/native/crates/engine/src/git.rs
+++ b/native/crates/engine/src/git.rs
@@ -200,9 +200,13 @@ pub fn git_main_branch(repo_path: String) -> Result<String> {
         return Ok("master".to_string());
     }
 
-    let head = repo
-        .head()
-        .map_err(|e| git_err("Failed to read HEAD", e))?;
+    let head = match repo.head() {
+        Ok(head) => head,
+        Err(error) if error.code() == git2::ErrorCode::UnbornBranch => {
+            return Ok(String::new());
+        }
+        Err(error) => return Err(git_err("Failed to read HEAD", error)),
+    };
     Ok(head.shorthand().unwrap_or("HEAD").to_string())
 }
 

--- a/src/resources/extensions/gsd/auto-worktree-branch-lifecycle.ts
+++ b/src/resources/extensions/gsd/auto-worktree-branch-lifecycle.ts
@@ -5,7 +5,7 @@
 // instead of keeping branch policy inside the legacy auto-worktree barrel.
 
 import { GSDError, GSD_GIT_ERROR } from "./errors.js";
-import { readIntegrationBranch } from "./git-service.js";
+import { readIntegrationBranch, runGit } from "./git-service.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { debugLog } from "./debug-logger.js";
 import { checkoutBranchWithStashGuard } from "./worktree-git-recovery.js";
@@ -68,6 +68,27 @@ export function enterBranchModeForMilestone(
         (branchName) => nativeBranchExists(basePath, branchName),
       ) ??
       nativeDetectMainBranch(basePath);
+
+    if (
+      !startPoint ||
+      !runGit(
+        basePath,
+        ["rev-parse", "--verify", "--quiet", `${startPoint}^{commit}`],
+        { allowFailure: true },
+      )
+    ) {
+      // An unborn repository has no commit-backed ref to branch from. Let Git
+      // move symbolic HEAD directly while preserving the index and untracked
+      // project files that will become the first milestone commit.
+      runGit(basePath, ["checkout", "-b", branch]);
+      debugLog("auto-worktree", {
+        action: "enterBranchMode",
+        milestoneId,
+        branch,
+        created: true,
+      });
+      return;
+    }
 
     // TOCTOU ancestry guard (Issue #4980 HIGH-3).
     //

--- a/src/resources/extensions/gsd/auto-worktree-branch-lifecycle.ts
+++ b/src/resources/extensions/gsd/auto-worktree-branch-lifecycle.ts
@@ -131,6 +131,22 @@ export function enterBranchModeForMilestone(
     });
   }
 
+  // A zero-commit repo has no commit-backed ref for the milestone branch even
+  // when it is already checked out, and `git checkout <branch>` then fails with
+  // "pathspec did not match". HEAD already points at the (unborn) milestone
+  // branch in that case, so branch entry is complete.
+  if (
+    !runGit(
+      basePath,
+      ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`],
+      { allowFailure: true },
+    ) &&
+    runGit(basePath, ["branch", "--show-current"], { allowFailure: true }) ===
+      branch
+  ) {
+    return;
+  }
+
   checkoutBranchWithStashGuard(
     basePath,
     branch,

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -253,8 +253,12 @@ export function nativeDetectMainBranch(basePath: string): string {
   const masterExists = gitExec(basePath, ["show-ref", "--verify", "refs/heads/master"], true);
   if (masterExists) return "master";
 
+  // An unborn HEAD (zero-commit repo) still reports a current branch name,
+  // which callers would use as a start point and hit "not a valid object
+  // name". Report "" instead — but only when this really is a repo, so a
+  // non-repo path keeps throwing the way the native path does.
   const head = gitExec(basePath, ["rev-parse", "--verify", "--quiet", "HEAD"], true);
-  if (!head) return "";
+  if (!head && gitExec(basePath, ["rev-parse", "--git-dir"], true)) return "";
 
   return gitExec(basePath, ["branch", "--show-current"]);
 }

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -253,6 +253,9 @@ export function nativeDetectMainBranch(basePath: string): string {
   const masterExists = gitExec(basePath, ["show-ref", "--verify", "refs/heads/master"], true);
   if (masterExists) return "master";
 
+  const head = gitExec(basePath, ["rev-parse", "--verify", "--quiet", "HEAD"], true);
+  if (!head) return "";
+
   return gitExec(basePath, ["branch", "--show-current"]);
 }
 

--- a/src/resources/extensions/gsd/tests/unborn-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/unborn-branch.test.ts
@@ -107,6 +107,18 @@ test("branch isolation enters the milestone branch in an unborn repo", () => {
   }
 });
 
+test("nativeDetectMainBranch: still throws for a path that is not a repo", () => {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-nonrepo-")));
+  try {
+    // "" is reserved for an unborn HEAD inside a real repo. A non-repo path
+    // must keep failing loudly so callers (e.g. the orchestrator's branch
+    // discovery guard) still take their error path.
+    assert.throws(() => nativeDetectMainBranch(dir));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("nativeBranchExists: still works for real branches with commits", () => {
   const dir = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-test-")));
   try {

--- a/src/resources/extensions/gsd/tests/unborn-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/unborn-branch.test.ts
@@ -10,12 +10,16 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 
-import { nativeBranchExists } from "../native-git-bridge.ts";
+import {
+  nativeBranchExists,
+  nativeDetectMainBranch,
+} from "../native-git-bridge.ts";
+import { enterBranchModeForMilestone } from "../auto-worktree-branch-lifecycle.ts";
 
 function git(args: string[], cwd: string): string {
   return execFileSync("git", args, {
@@ -58,6 +62,41 @@ test("nativeBranchExists: returns false for non-existent branch in unborn repo",
     assert.strictEqual(exists, false, "non-current branch should not exist in unborn repo");
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("branch isolation enters the milestone branch in an unborn repo", () => {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-test-")));
+  const previousCwd = process.cwd();
+  const previousGsdHome = process.env.GSD_HOME;
+  const gsdHome = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-home-")));
+  try {
+    process.chdir(dir);
+    process.env.GSD_HOME = gsdHome;
+    git(["init", "--initial-branch=main"], dir);
+    writeFileSync(join(dir, "project.txt"), "untracked project content\n");
+    mkdirSync(join(dir, ".gsd"));
+    writeFileSync(
+      join(dir, ".gsd", "M001-META.json"),
+      JSON.stringify({ integrationBranch: "main" }),
+    );
+
+    assert.equal(nativeDetectMainBranch(dir), "");
+
+    enterBranchModeForMilestone(dir, "M001");
+
+    assert.equal(git(["branch", "--show-current"], dir), "milestone/M001");
+    assert.equal(
+      git(["status", "--short"], dir),
+      "?? .gsd/\n?? project.txt",
+      "branch creation should preserve untracked project content",
+    );
+  } finally {
+    process.chdir(previousCwd);
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(gsdHome, { recursive: true, force: true });
   }
 });
 

--- a/src/resources/extensions/gsd/tests/unborn-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/unborn-branch.test.ts
@@ -86,6 +86,13 @@ test("branch isolation enters the milestone branch in an unborn repo", () => {
     enterBranchModeForMilestone(dir, "M001");
 
     assert.equal(git(["branch", "--show-current"], dir), "milestone/M001");
+
+    // Re-entry while the repo is still unborn must not fail: the milestone
+    // branch has no commit-backed ref yet, so a plain checkout would abort
+    // with "pathspec did not match".
+    enterBranchModeForMilestone(dir, "M001");
+
+    assert.equal(git(["branch", "--show-current"], dir), "milestone/M001");
     assert.equal(
       git(["status", "--short"], dir),
       "?? .gsd/\n?? project.txt",


### PR DESCRIPTION
## Summary
- Fixed zero-commit branch isolation and verified it with focused regression tests and native compilation.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1688
- [#1688 Branch isolation fails on a zero-commit repo: git branch -f milestone/<MID> <unbornBranch> → 'not a valid object name'](https://github.com/open-gsd/gsd-pi/issues/1688)

## User
- @BGarber42

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1688-branch-isolation-fails-on-a-zero-commit--1786389581`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->