### PR TITLE
fix(gsd): harden release and workflow state recovery

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -258,6 +258,9 @@ jobs:
           export GSD_SMOKE_BINARY
           pnpm run test:live-regression
 
+      - name: Build auto-mode acceptance bed helpers
+        run: pnpm run build:core
+
       - name: Run auto-mode acceptance bed (against installed binary)
         run: |
           GSD_SMOKE_BINARY=$(which gsd)

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -258,6 +258,12 @@ jobs:
           export GSD_SMOKE_BINARY
           pnpm run test:live-regression
 
+      - name: Run auto-mode acceptance bed (against installed binary)
+        run: |
+          GSD_SMOKE_BINARY=$(which gsd)
+          export GSD_SMOKE_BINARY
+          pnpm run test:auto-acceptance
+
       - name: Warn on verify failure
         if: failure()
         env:

--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -55,7 +55,7 @@ After commit: regenerate markdown artifacts → write to disk → invalidate cac
 - Keyed by workspace `identityKey` (realpath of project root)
 - Sibling worktrees share the same `.gsd/gsd.db` via SQLite WAL
 - Only one connection is "active" at a time; others cached for fast re-activation
-- Fresh, active, and cached opens verify startup schema invariants before reuse. Missing non-versioned ADR-047 liveness tables or the open-wedge index force the same guarded startup-maintenance reopen used for other schema repairs; this preserves version stamps and existing rows.
+- Fresh, active, and cached opens verify the registered non-versioned schema invariants described under [ADR-047 liveness ledger](#adr-047-liveness-ledger-non-versioned) before reuse.
 - On process exit: close without checkpointing; coordinated maintenance owns checkpoint and vacuum
 - Before file-backed schema migrations, `db-migration-backup.ts` checkpoints WAL and replaces `.gsd/gsd.db.backup-vN` with a copy of the database being migrated. The copy must report the expected schema version and pass SQLite `quick_check`; checkpoint, copy, or validation failures warn and fail closed before migration DDL.
 
@@ -678,11 +678,13 @@ result_json  TEXT
 
 #### ADR-047 liveness ledger (non-versioned)
 
-`db-liveness-backstop-schema.ts` is the authoritative schema source for the
-liveness tables and open-wedge index. These objects are startup invariants
-rather than a numbered migration: missing objects are recreated through guarded
-startup maintenance without changing `schema_version`, `application_id`, or
-`user_version`; `/gsd doctor` records a detected repair.
+`db-required-schema.ts` is the registration and completeness authority for
+non-versioned schema features required on every database open. It currently
+registers the ADR-047 liveness feature; `db-liveness-backstop-schema.ts` owns
+that feature's table and open-wedge-index DDL. Startup repair and `/gsd doctor`
+query the same registry, so missing required objects trigger guarded startup
+maintenance without changing `schema_version`, `application_id`, or
+`user_version`; doctor records a detected repair.
 
 ---
 
@@ -1999,6 +2001,11 @@ execution evidence remain authoritative.
 | `gsd_save_gate_result` | quality_gates | quality_gates, gate_runs (same transaction) | — |
 | `capture_thought` | memories | memories | KNOWLEDGE.md projection for Patterns/Lessons (both backfilled and newly captured) |
 | `memory_query` | memories, memories_fts, memory_embeddings | memories (hit_count++) | — |
+
+Slice lifecycle writers own the taskless Q8 companion gate. Planning or
+replanning a Slice, and reopening its Task, Slice, or Milestone hierarchy,
+must establish exactly one Q8 row for that Slice and reset it to `pending`;
+duplicate companion rows fail the operation instead of being silently retained.
 
 The six planning mutations above commit legacy hierarchy changes, lifecycle
 adoption or transition, one domain event/outbox destination, Projection Work,

--- a/docs/dev/FILE-SYSTEM-MAP.md
+++ b/docs/dev/FILE-SYSTEM-MAP.md
@@ -508,6 +508,8 @@
 | gsd/db/domain-operation.ts | Database, State Machine | Revision-checked Domain Operation transaction and durable replay receipt boundary |
 | gsd/db/lifecycle-shadow-comparison.ts | Database, State Machine | Pure legacy-to-canonical lifecycle normalization and semantic shadow comparison |
 | gsd/db/writers/lifecycle-commands.ts | Database, State Machine | Transaction-bound lifecycle adoption/transition, Attempt, Result, replay-fence, and Kernel checkpoint writers; planning handlers use the lifecycle and fence subset |
+| gsd/db/writers/slice-companion-state.ts | Database, State Machine | Transaction-bound owner of the taskless Q8 companion gate required by Slice planning and reopen lifecycle operations |
+| gsd/db-required-schema.ts | Database, Loader/Bootstrap | Registry and shared completeness checks for non-versioned schema features required on every database open |
 | gsd/planning-domain-operation.ts | Database, GSD Workflow | Shared atomic planning-operation adapter that combines legacy hierarchy writes, canonical lifecycle comparison, events, and Projection Work |
 | gsd/planning-invocation.ts | GSD Workflow, Tool System | Private invocation identity helpers for direct calls and transport-stable Pi-extension planning calls; workflow MCP mirrors the envelope at its package boundary |
 | gsd/projection-cleanup.ts | Database, File System | Removes stale PLAN projections and artifact/compat records only when their current content is still writer-owned |
@@ -541,6 +543,7 @@
 | gsd/namespaced-resolver.ts | GSD Workflow | Namespace and scoped resource resolution |
 | gsd/error-utils.ts | GSD Workflow | Error handling and formatting |
 | gsd/errors.ts | GSD Workflow | Error type definitions |
+| gsd/projection-root-errors.ts | Auto Engine, GSD Workflow | Typed classification boundary for transient native projection-root sharing violations |
 | gsd/diff-context.ts | GSD Workflow | Diff-based context extraction |
 | gsd/memory-extractor.ts | GSD Workflow | Memory and context extraction from state |
 | gsd/structured-data-formatter.ts | GSD Workflow | Structured output formatting |

--- a/docs/dev/ci-cd-pipeline.md
+++ b/docs/dev/ci-cd-pipeline.md
@@ -152,6 +152,7 @@ Content inside fenced code blocks (` ``` `) is excluded — patterns in code exa
 - **Smoke tests** (`npm run test:smoke`) — against the freshly built `dist/loader.js`, then again in `prerelease-verify` against the globally installed published package
 - **Native platform packages** (`npm run verify:native-platform-packages`) and **package validation** (`npm run validate-pack`)
 - **Live regression tests** (`npm run test:live-regression`) — against the installed prerelease binary, and again against the release build in `prod-release`
+- **Auto-mode acceptance bed** (`npm run test:auto-acceptance`) — a blocking `prerelease-verify` gate against the globally installed published binary; `channel=latest` must pass this gate on `@dev` before production release planning can begin
 - **Live LLM tests** (`npm run test:live`, `npm run test:live-workflow`) — `prod-release` only, `continue-on-error: true` (non-blocking warnings)
 - **Release verification** (`node scripts/verify-npm-release.mjs <version>`) — final gate confirming the main, engine, and workspace packages are all on npm at the release version before the tag is pushed
 
@@ -160,7 +161,7 @@ Content inside fenced code blocks (` ``` `) is excluded — patterns in code exa
 1. In GitHub Actions, run **NPM Publish**.
 2. Set `channel` to `dev` or `next`. `dev` defaults to the `main` branch and `next` defaults to the `next` branch; override with the `ref` input for a standalone publish from another branch or SHA.
 3. Leave `publish_auth` at `trusted` (OIDC) unless you are bootstrapping a package that does not exist on npm yet — see [First-time packages](#first-time-packages-bootstrap-with-token).
-4. `prerelease-publish` builds, stamps the prerelease version, runs the gates, publishes with `--tag <channel>`, and polls npm until the version installs. `prerelease-verify` then installs the published package globally and runs smoke + live-regression tests against it.
+4. `prerelease-publish` builds, stamps the prerelease version, runs the gates, publishes with `--tag <channel>`, and polls npm until the version installs. `prerelease-verify` then installs the published package globally and runs the installed-binary gates listed above.
 
 Nothing moves to `@latest` as a side effect of this. A production release is a separate dispatch.
 
@@ -254,11 +255,12 @@ There is no recorded-fixture replay system. The suites that exercise a real bina
 ```bash
 npm run test:smoke             # tests/smoke — CLI smoke tests against GSD_SMOKE_BINARY
 npm run test:live-regression   # tests/live-regression — runtime regressions against an installed binary
+npm run test:auto-acceptance   # tests/acceptance-bed — auto milestone flow against an installed binary
 npm run test:live              # tests/live — real provider calls, needs API keys (GSD_LIVE_TESTS=1)
 npm run test:live-workflow     # tests/live-workflow — real end-to-end workflow run
 ```
 
-`test:smoke` and `test:live-regression` read `GSD_SMOKE_BINARY` — point it at
+`test:smoke`, `test:live-regression`, and `test:auto-acceptance` read `GSD_SMOKE_BINARY` — point it at
 `dist/loader.js` for a local build or at `$(which gsd)` for an installed
 package, exactly as `npm-publish.yml` does.
 

--- a/docs/dev/state-db-cutover-projection-contract.md
+++ b/docs/dev/state-db-cutover-projection-contract.md
@@ -81,6 +81,12 @@ Render entry points (all route through the single `writeAndStore` seam in
 `renderTaskSummary`, `renderReplanFromDb`, `renderAssessmentFromDb`, and the
 sweep `renderAllFromDb`.
 
+Every task-summary producer routes through `writeTaskSummaryProjection`, which
+owns layout-aware placement and delegates stamping, disk persistence, artifact
+lineage, compatibility-marker updates, and cache invalidation to
+`writeAndStore`. A lineage-write failure is surfaced to the caller; the disk
+copy remains a non-authoritative projection for reconciliation evidence.
+
 ### 2.3 What the freeze covers
 
 Frozen: file names, directory shapes, both layouts, section ordering, heading

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -140,7 +140,7 @@ Common block reasons and operator actions:
 | `preflight-unmerged-conflicts` | Milestone merge preflight found unresolved Git conflict stages in the working tree (shared with the global workspace git gate). | Resolve conflicts manually (`git status`, fix files, stage resolutions), then run `/gsd auto` to resume. Auto mode **pauses** on pre-dispatch health gate product conflicts; an unrecoverable git probe **stops** the loop. |
 | `preflight-dirty-overlap` | Milestone merge preflight found local dirty files that overlap files changed by the milestone branch. | Commit or stash your local edits manually, or move them out of the way, then rerun `/gsd auto`. |
 
-Recovery classification now treats deterministic policy, tool-schema, stale-worker, and invalid-worktree failures as non-transient stops. Provider failures still use provider-specific transient classification and may retry automatically, while verification drift and unknown runtime failures escalate for inspection because repeating the same dispatch can preserve the drift.
+Recovery classification now treats deterministic policy, tool-schema, stale-worker, and invalid-worktree failures as non-transient stops. A Windows projection-root sharing violation is normalized as transient and consumes the existing transient-execution retry budget; sustained contention still exhausts that budget and stops. Provider failures still use provider-specific transient classification and may retry automatically, while genuine projection gaps, verification drift, and unknown runtime failures escalate for inspection because repeating the same dispatch can preserve the drift.
 
 ### Preference Diagnostics at Preflight
 

--- a/docs/user-docs/git-strategy.md
+++ b/docs/user-docs/git-strategy.md
@@ -32,6 +32,12 @@ Work happens in the project root on a `milestone/<MID>` branch. No worktree is c
 
 Use this when worktrees cause problems — submodule-heavy repos, repos with hardcoded paths, or environments where worktree symlinks don't behave.
 
+Branch mode also works in a zero-commit repository: GSD creates and enters the
+unborn `milestone/<MID>` branch without requiring a commit target. Re-entering
+that same unborn branch is a no-op, so staged and unstaged first-commit work is
+preserved across auto-mode runs. A new run retries the configured isolation
+mode instead of inheriting an earlier run's degraded-isolation flag.
+
 ## Branching Model (Worktree Mode)
 
 ```

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -185,7 +185,7 @@ Replace the path with the exact global bin directory from your pnpm error messag
 
 **Symptoms:** GSD exits during startup with a message like `flat-phase migration failed` or `flat-phase migration required but the workflow database could not be opened`.
 
-**Cause:** The project still has the legacy nested `.gsd/milestones/` layout. On startup, GSD must migrate it to the flat `.gsd/phases/` layout before path resolvers and state checks run. This migration is fail-closed: if the SQLite database cannot be opened, the backup/rename/delete step fails, or the rendered flat-phase projection cannot be verified, startup stops instead of continuing against mixed disk state.
+**Cause:** The project still has the legacy nested `.gsd/milestones/` layout. On startup, GSD must migrate it to the flat `.gsd/phases/` layout before path resolvers and state checks run. Markdown for milestone, slice, and task identities already known to the database is archived in the migration backup and re-rendered from database authority; it is not imported during startup. An unknown or ambiguous identity, a database hierarchy gap, an unavailable database, a backup/rename/delete failure, or an unverifiable flat-phase render stops startup before GSD can continue against mixed or invented state.
 
 **Fix:**
 - Make sure you are starting GSD from the project root and that `.gsd/gsd.db*`, `.gsd/`, and `.gsd-backups/` are readable and writable on local disk.
@@ -414,6 +414,8 @@ In these states GSD does not auto-stash and does not auto-fix; it stops so you c
 **Cause:** Antivirus, indexers, editors, or filesystem watchers can briefly lock the destination or temp file just as GSD performs the atomic rename.
 
 **Current behavior:** GSD now retries those transient rename failures with a short bounded backoff before surfacing an error. The retry is intentionally limited so genuine filesystem problems still fail loudly instead of hanging forever.
+
+Native projection-root operations on Windows also identify `ERROR_SHARING_VIOLATION` (`os error 32`) as transient. Auto mode routes that typed failure through its existing transient-execution retry budget; other projection failures are not reclassified, and sustained handle contention still surfaces as an error after the budget is exhausted.
 
 **Fix:**
 - Re-run the operation; most transient lock races clear quickly.

--- a/native/crates/engine/src/projection_root_identity_lock.rs
+++ b/native/crates/engine/src/projection_root_identity_lock.rs
@@ -1908,6 +1908,7 @@ fn projection_error(error: impl std::fmt::Display) -> Error {
     )
 }
 
+#[cfg(any(windows, test))]
 fn is_windows_sharing_violation(error: &std::io::Error) -> bool {
     error.raw_os_error() == Some(32)
 }
@@ -6351,8 +6352,12 @@ mod sharing_violation_tests {
 
     #[test]
     fn windows_sharing_violation_is_the_only_transient_projection_error() {
-        assert!(is_windows_sharing_violation(&std::io::Error::from_raw_os_error(32)));
-        assert!(!is_windows_sharing_violation(&std::io::Error::from_raw_os_error(5)));
+        assert!(is_windows_sharing_violation(
+            &std::io::Error::from_raw_os_error(32)
+        ));
+        assert!(!is_windows_sharing_violation(
+            &std::io::Error::from_raw_os_error(5)
+        ));
     }
 }
 

--- a/native/crates/engine/src/projection_root_identity_lock.rs
+++ b/native/crates/engine/src/projection_root_identity_lock.rs
@@ -1908,12 +1908,22 @@ fn projection_error(error: impl std::fmt::Display) -> Error {
     )
 }
 
+fn is_windows_sharing_violation(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(32)
+}
+
 /// Windows open/create/scan failures must name the path they faulted on: the
 /// exclusively held (share_mode(0)) projection root rejects any by-path re-open
 /// with ERROR_SHARING_VIOLATION (os error 32), and a bare "projection root
 /// operation failed" gives no way to tell which open collided with the hold.
 #[cfg(windows)]
-fn projection_path_error(path: &Path, error: impl std::fmt::Display) -> Error {
+fn projection_path_error(path: &Path, error: std::io::Error) -> Error {
+    if is_windows_sharing_violation(&error) {
+        return projection_error(format!(
+            "transient projection root sharing violation at {}: another process holds an incompatible handle ({error})",
+            path.display(),
+        ));
+    }
     projection_error(format!("{}: {error}", path.display()))
 }
 
@@ -6333,6 +6343,17 @@ fn rename_relative_between_exclusive(
         Status::GenericFailure,
         "identity-bound recursive publication is unavailable on this platform".to_owned(),
     ))
+}
+
+#[cfg(test)]
+mod sharing_violation_tests {
+    use super::is_windows_sharing_violation;
+
+    #[test]
+    fn windows_sharing_violation_is_the_only_transient_projection_error() {
+        assert!(is_windows_sharing_violation(&std::io::Error::from_raw_os_error(32)));
+        assert!(!is_windows_sharing_violation(&std::io::Error::from_raw_os_error(5)));
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "docker:build-builder": "docker build --target builder -t ghcr.io/open-gsd/gsd-ci-builder .",
     "prepublishOnly": "pnpm run sync-pkg-version && pnpm run sync-platform-versions && pnpm run verify:version-sync && pnpm run verify:native-platform-packages && node scripts/prepublish-check.mjs && pnpm run build && pnpm run typecheck:extensions && pnpm run validate-pack",
     "test:live-regression": "node --experimental-strip-types tests/live-regression/run.ts",
+    "test:auto-acceptance": "node tests/acceptance-bed/auto-milestone-bed.mjs",
     "test:e2e": "node --experimental-strip-types --test --test-concurrency=1 \"tests/e2e/*.e2e.test.ts\"",
     "test:e2e:windows-smoke": "node --experimental-strip-types --test tests/e2e/sanity.e2e.test.ts tests/e2e/migration.e2e.test.ts tests/e2e/native-abi.e2e.test.ts",
     "test:e2e:docker": "node --experimental-strip-types --test \"tests/e2e/docker/**/*.e2e.test.ts\""

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -203,10 +203,19 @@ test("production release runs optional live workflow test on the configured Open
 
 test("prerelease verification blocks release planning on the auto-mode acceptance bed", () => {
   const steps = workflow.jobs["prerelease-verify"].steps;
+  const buildHelpersIndex = steps.findIndex(
+    (step) => step.name === "Build auto-mode acceptance bed helpers",
+  );
+  const acceptanceBedIndex = steps.findIndex(
+    (step) => step.name === "Run auto-mode acceptance bed (against installed binary)",
+  );
   const acceptanceBed = steps.find(
     (step) => step.name === "Run auto-mode acceptance bed (against installed binary)",
   );
 
+  assert.ok(buildHelpersIndex > -1, "prerelease verification must build the acceptance bed helpers");
+  assert.match(steps[buildHelpersIndex].run, /pnpm run build:core/);
+  assert.ok(buildHelpersIndex < acceptanceBedIndex, "acceptance bed helpers must exist before the bed runs");
   assert.ok(acceptanceBed, "prerelease verification must run the auto-mode acceptance bed");
   assert.notEqual(
     acceptanceBed["continue-on-error"],

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -9,6 +9,7 @@ import YAML from "yaml";
 const workflow = YAML.parse(
   readFileSync(".github/workflows/npm-publish.yml", "utf8"),
 );
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 
 const latestCondition = "${{ github.event.inputs.channel == 'latest' }}";
 const prereleaseChannel =
@@ -198,6 +199,27 @@ test("production release runs optional live workflow test on the configured Open
   assert.equal(step.env.OPENAI_API_KEY, "${{ secrets.OPENAI_API_KEY }}");
   assert.equal(step.env.GSD_LIVE_TESTS, "1");
   assert.equal(step.env.GSD_LIVE_WORKFLOW_MODEL, "openai/gpt-5.4-mini");
+});
+
+test("prerelease verification blocks release planning on the auto-mode acceptance bed", () => {
+  const steps = workflow.jobs["prerelease-verify"].steps;
+  const acceptanceBed = steps.find(
+    (step) => step.name === "Run auto-mode acceptance bed (against installed binary)",
+  );
+
+  assert.ok(acceptanceBed, "prerelease verification must run the auto-mode acceptance bed");
+  assert.notEqual(
+    acceptanceBed["continue-on-error"],
+    true,
+    "a wedged acceptance bed must block the release",
+  );
+  assert.match(acceptanceBed.run, /GSD_SMOKE_BINARY=\$\(which gsd\)/);
+  assert.match(acceptanceBed.run, /pnpm run test:auto-acceptance/);
+  assert.equal(
+    packageJson.scripts["test:auto-acceptance"],
+    "node tests/acceptance-bed/auto-milestone-bed.mjs",
+  );
+  assert.equal(workflow.jobs["prod-release-plan"].needs, "prerelease-verify");
 });
 
 test("production release publishes workspace packages and verifies ALL packages before cutting the GitHub release", () => {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -135,6 +135,7 @@ import {
   formatCloseoutProofBlock,
   proveMilestoneCloseout,
 } from "./milestone-closeout-proof.js";
+import { throwIfTransientProjectionLockError } from "./projection-root-errors.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -1789,6 +1790,10 @@ export const DISPATCH_RULES: DispatchRule[] = [
               `gsd-projection-heal: re-rendered missing slice PLAN for ${unitId} from the DB at ${rendered.planPath}\n`,
             );
           } catch (err) {
+            // A Windows sharing violation is transient contention, not a DB
+            // projection gap. Preserve it as a typed throw so Recovery
+            // Classification routes through the loop's existing retry budget.
+            throwIfTransientProjectionLockError(err);
             // Fail loud below: a DB that genuinely lacks the slice rows is a
             // real error, and the stop diagnosis reports it verbatim.
             planRenderError = err instanceof Error ? err.message : String(err);

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -124,7 +124,10 @@ import {
   resolveDefaultSessionModel,
   resolveDynamicRoutingConfig,
 } from "./preferences-models.js";
-import type { WorktreeLifecycle } from "./worktree-lifecycle.js";
+import {
+  prepareIsolationForNewRun,
+  type WorktreeLifecycle,
+} from "./worktree-lifecycle.js";
 import { getSessionModelOverride } from "./session-model-override.js";
 import { setAutoActiveStatus } from "./auto-dashboard.js";
 
@@ -1040,6 +1043,8 @@ export async function bootstrapAutoSession(
   deps: BootstrapDeps,
   interrupted: InterruptedSessionAssessment,
 ): Promise<boolean> {
+  prepareIsolationForNewRun(s);
+
   const {
     shouldUseWorktreeIsolation,
     registerSigtermHandler,

--- a/src/resources/extensions/gsd/auto-worktree-branch-lifecycle.ts
+++ b/src/resources/extensions/gsd/auto-worktree-branch-lifecycle.ts
@@ -12,7 +12,9 @@ import { checkoutBranchWithStashGuard } from "./worktree-git-recovery.js";
 import {
   nativeBranchExists,
   nativeBranchForceReset,
+  nativeCheckoutNewBranch,
   nativeDetectMainBranch,
+  nativeHasCommittedHead,
   nativeIsAncestor,
   nativeUpdateRef,
   nativeWorktreeList,
@@ -57,6 +59,18 @@ export function enterBranchModeForMilestone(
   const branchExists = nativeBranchExists(basePath, branch);
 
   if (!branchExists) {
+    if (!nativeHasCommittedHead(basePath)) {
+      nativeCheckoutNewBranch(basePath, branch);
+      debugLog("auto-worktree", {
+        action: "enterBranchMode",
+        milestoneId,
+        branch,
+        repositoryState: "unborn",
+        created: true,
+      });
+      return;
+    }
+
     // Create the milestone branch from the integration branch start-point.
     const integrationBranch =
       readIntegrationBranch(basePath, milestoneId) ?? undefined;

--- a/src/resources/extensions/gsd/db-base-schema.ts
+++ b/src/resources/extensions/gsd/db-base-schema.ts
@@ -2,7 +2,7 @@
 // File Purpose: Base table, index, and view DDL for the GSD database facade.
 
 import type { DbAdapter } from "./db-adapter.js";
-import { createLivenessBackstopSchema } from "./db-liveness-backstop-schema.js";
+import { createRequiredSchemaObjects } from "./db-required-schema.js";
 
 export interface BaseSchemaHooks {
   tryCreateMemoriesFts(db: DbAdapter): boolean;
@@ -420,5 +420,5 @@ export function createBaseSchemaObjects(db: DbAdapter, hooks: BaseSchemaHooks): 
   // Registered as idempotent base objects (not a numbered migration) so the
   // backstop's restart-surviving ledger exists on every open without moving
   // the schema-version boundary the legacy-import contract pins at v46.
-  createLivenessBackstopSchema(db);
+  createRequiredSchemaObjects(db);
 }

--- a/src/resources/extensions/gsd/db-required-schema.ts
+++ b/src/resources/extensions/gsd/db-required-schema.ts
@@ -1,0 +1,37 @@
+// Project/App: gsd-pi
+// File Purpose: Registry for non-versioned schema features required on every database open.
+
+import type { DbAdapter } from "./db-adapter.js";
+import {
+  createLivenessBackstopSchema,
+  hasLivenessBackstopSchema,
+} from "./db-liveness-backstop-schema.js";
+
+interface RequiredSchemaFeature {
+  readonly id: string;
+  readonly isPresent: (db: DbAdapter) => boolean;
+  readonly create: (db: DbAdapter) => void;
+}
+
+const REQUIRED_SCHEMA_FEATURES = [
+  {
+    id: "liveness-backstop",
+    isPresent: hasLivenessBackstopSchema,
+    create: createLivenessBackstopSchema,
+  },
+] as const satisfies readonly RequiredSchemaFeature[];
+
+export type RequiredSchemaFeatureId = (typeof REQUIRED_SCHEMA_FEATURES)[number]["id"];
+
+export function createRequiredSchemaObjects(db: DbAdapter): void {
+  for (const feature of REQUIRED_SCHEMA_FEATURES) feature.create(db);
+}
+
+export function hasRequiredSchemaObjects(db: DbAdapter): boolean {
+  return REQUIRED_SCHEMA_FEATURES.every((feature) => feature.isPresent(db));
+}
+
+export function hasRequiredSchemaFeature(db: DbAdapter, featureId: RequiredSchemaFeatureId): boolean {
+  const feature = REQUIRED_SCHEMA_FEATURES.find(({ id }) => id === featureId);
+  return feature?.isPresent(db) ?? false;
+}

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -42,7 +42,7 @@ import type { GsdWorkspace, MilestoneScope } from "../workspace.js";
 import { logError, logWarning } from "../workflow-logger.js";
 import { createDbAdapter, type DbAdapter } from "../db-adapter.js";
 import { createBaseSchemaObjects } from "../db-base-schema.js";
-import { hasLivenessBackstopSchema } from "../db-liveness-backstop-schema.js";
+import { hasRequiredSchemaObjects } from "../db-required-schema.js";
 import { createCoordinationTablesV24 } from "../db-coordination-schema.js";
 import { createDbConnectionCache, type DbConnectionCacheEntry } from "../db-connection-cache.js";
 import { backupDatabaseBeforeMigration, isMigrationBackupError } from "../db-migration-backup.js";
@@ -213,7 +213,7 @@ function assessStartupRepair(db: DbAdapter): StartupRepairAssessment {
     || !hasCanonicalOutboxInvariantsV31(db)
     || !hasVerificationEvidenceDedupIndex(db)
     || !hasRuntimeKvSchemaV25(db)
-    || !hasLivenessBackstopSchema(db)
+    || !hasRequiredSchemaObjects(db)
     || (fts.supported && (!fts.schemaComplete || !fts.rebuildMarked));
   return {
     required,

--- a/src/resources/extensions/gsd/db/writers/milestone-lifecycle.ts
+++ b/src/resources/extensions/gsd/db/writers/milestone-lifecycle.ts
@@ -22,6 +22,7 @@ import {
   recordRequirementDisposition,
   terminateRecoveryWaiver,
 } from "./task-recovery.js";
+import { ensurePendingSliceQ8 } from "./slice-companion-state.js";
 
 export interface MilestoneCompletionHierarchyInput {
   milestoneId: string;
@@ -311,37 +312,6 @@ function revokeCancellationWaivers(
     revokedWaiverIds.push(waiver.waiver_id);
   }
   return { revokedWaiverIds, supersedingDispositionIds };
-}
-
-function resetSliceQ8(milestoneId: string, sliceId: string): void {
-  const q8Rows = getDb().prepare(`
-    SELECT 1 FROM quality_gates
-    WHERE milestone_id = :milestone_id AND slice_id = :slice_id
-      AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
-  `).all({ ":milestone_id": milestoneId, ":slice_id": sliceId });
-  if (q8Rows.length > 1) {
-    throw new MilestoneLifecycleValidationError(
-      `Milestone reopen found multiple Q8 quality gates for Slice ${sliceId}`,
-    );
-  }
-  const q8Write = q8Rows.length === 0
-    ? getDb().prepare(`
-        INSERT INTO quality_gates (
-          milestone_id, slice_id, gate_id, scope, task_id, status
-        ) VALUES (
-          :milestone_id, :slice_id, 'Q8', 'slice', '', 'pending'
-        )
-      `).run({ ":milestone_id": milestoneId, ":slice_id": sliceId })
-    : getDb().prepare(`
-        UPDATE quality_gates
-        SET status = 'pending', verdict = '', rationale = '',
-            findings = '', evaluated_at = NULL
-        WHERE milestone_id = :milestone_id AND slice_id = :slice_id
-          AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
-      `).run({ ":milestone_id": milestoneId, ":slice_id": sliceId });
-  if (changedRows(q8Write) !== 1) {
-    throw new Error(`Milestone reopen must establish one pending Q8 quality gate for Slice ${sliceId}`);
-  }
 }
 
 function currentSliceCancellationAuthorization(
@@ -740,7 +710,7 @@ export function reopenMilestoneHierarchy(
     if (changedRows(updated) !== 1) {
       throw new Error(`Milestone reopen must update Slice ${sliceId}`);
     }
-    resetSliceQ8(milestoneId, sliceId);
+    ensurePendingSliceQ8(context, { milestoneId, sliceId });
     reopenedSliceIds.push(sliceId);
   }
 

--- a/src/resources/extensions/gsd/db/writers/slice-companion-state.ts
+++ b/src/resources/extensions/gsd/db/writers/slice-companion-state.ts
@@ -1,0 +1,49 @@
+// Project/App: gsd-pi
+// File Purpose: Establish the database-owned companion state required by Slice lifecycle operations.
+
+import type { DomainOperationContext } from "../domain-operation.js";
+import { getDb } from "../engine.js";
+import { requireActiveDomainOperationContext } from "./lifecycle-commands.js";
+
+export interface SliceCompanionIdentity {
+  milestoneId: string;
+  sliceId: string;
+}
+
+export function ensurePendingSliceQ8(
+  context: Readonly<DomainOperationContext>,
+  slice: SliceCompanionIdentity,
+): void {
+  requireActiveDomainOperationContext(context);
+  const parameters = {
+    ":milestone_id": slice.milestoneId,
+    ":slice_id": slice.sliceId,
+  };
+  const rows = getDb().prepare(`
+    SELECT 1 FROM quality_gates
+    WHERE milestone_id = :milestone_id AND slice_id = :slice_id
+      AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
+  `).all(parameters);
+  if (rows.length > 1) {
+    throw new Error(`Slice ${slice.sliceId} has multiple Q8 companion gates`);
+  }
+
+  const result = rows.length === 0
+    ? getDb().prepare(`
+        INSERT INTO quality_gates (
+          milestone_id, slice_id, gate_id, scope, task_id, status
+        ) VALUES (
+          :milestone_id, :slice_id, 'Q8', 'slice', '', 'pending'
+        )
+      `).run(parameters)
+    : getDb().prepare(`
+        UPDATE quality_gates
+        SET status = 'pending', verdict = '', rationale = '',
+            findings = '', evaluated_at = NULL
+        WHERE milestone_id = :milestone_id AND slice_id = :slice_id
+          AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
+      `).run(parameters);
+  if (Number((result as { changes?: number }).changes ?? 0) !== 1) {
+    throw new Error(`Slice ${slice.sliceId} must have one pending Q8 companion gate`);
+  }
+}

--- a/src/resources/extensions/gsd/db/writers/slice-lifecycle.ts
+++ b/src/resources/extensions/gsd/db/writers/slice-lifecycle.ts
@@ -16,6 +16,7 @@ import {
 } from "./lifecycle-commands.js";
 import { compareLifecycleShadow, normalizeLegacyLifecycleStatus } from "../lifecycle-shadow-comparison.js";
 import { terminalizeTaskExecutionDispatch } from "./task-execution.js";
+import { ensurePendingSliceQ8 } from "./slice-companion-state.js";
 
 interface SliceIdentity {
   milestoneId: string;
@@ -952,32 +953,7 @@ export function reopenSliceHierarchy(
     WHERE milestone_id = :milestone_id AND id = :slice_id
   `).run({ ":milestone_id": slice.milestoneId, ":slice_id": slice.sliceId });
   if (Number((updated as { changes?: number }).changes ?? 0) !== 1) throw new Error("Slice reopen must update one Slice");
-  const q8Rows = getDb().prepare(`
-    SELECT 1 FROM quality_gates
-    WHERE milestone_id = :milestone_id AND slice_id = :slice_id
-      AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
-  `).all({ ":milestone_id": slice.milestoneId, ":slice_id": slice.sliceId });
-  if (q8Rows.length > 1) {
-    throw new SliceLifecycleValidationError("Slice reopen found multiple Q8 quality gates");
-  }
-  const q8Write = q8Rows.length === 0
-    ? getDb().prepare(`
-        INSERT INTO quality_gates (
-          milestone_id, slice_id, gate_id, scope, task_id, status
-        ) VALUES (
-          :milestone_id, :slice_id, 'Q8', 'slice', '', 'pending'
-        )
-      `).run({ ":milestone_id": slice.milestoneId, ":slice_id": slice.sliceId })
-    : getDb().prepare(`
-        UPDATE quality_gates
-        SET status = 'pending', verdict = '', rationale = '',
-            findings = '', evaluated_at = NULL
-        WHERE milestone_id = :milestone_id AND slice_id = :slice_id
-          AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
-      `).run({ ":milestone_id": slice.milestoneId, ":slice_id": slice.sliceId });
-  if (Number((q8Write as { changes?: number }).changes ?? 0) !== 1) {
-    throw new Error("Slice reopen must establish exactly one pending Q8 quality gate");
-  }
+  ensurePendingSliceQ8(context, slice);
   const shadows = [
     readLifecycleShadowComparison(context, { itemKind: "slice", ...slice }),
     ...reopenedTaskIds.map((taskId) => readLifecycleShadowComparison(context, { itemKind: "task", ...slice, taskId })),

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -7,7 +7,7 @@ import {
   openWorkflowDatabaseIsolated,
   resolveWorkflowDatabaseLocation,
 } from "./db-workspace.js";
-import { hasLivenessBackstopSchema } from "./db-liveness-backstop-schema.js";
+import { hasRequiredSchemaFeature } from "./db-required-schema.js";
 import { resolveMilestoneFile, milestonesDir, legacyMilestonesDir, resolveGsdRootFile } from "./paths.js";
 import { deriveState } from "./state.js";
 import { invalidateAllCaches } from "./cache.js";
@@ -40,7 +40,7 @@ function inspectLivenessBackstopSchema(basePath: string): boolean | undefined {
   const db = openWorkflowDatabaseIsolated(databasePath);
   if (!db) return undefined;
   try {
-    return hasLivenessBackstopSchema(db);
+    return hasRequiredSchemaFeature(db, "liveness-backstop");
   } catch {
     return undefined;
   } finally {
@@ -54,7 +54,7 @@ function recordLivenessBackstopStartupRepair(
   fixesApplied: string[],
 ): void {
   if (wasComplete !== false) return;
-  const repaired = isDbAvailable() && hasLivenessBackstopSchema(_getAdapter()!);
+  const repaired = isDbAvailable() && hasRequiredSchemaFeature(_getAdapter()!, "liveness-backstop");
   issues.push({
     severity: repaired ? "info" : "error",
     code: "liveness_backstop_schema_missing",

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -127,10 +127,9 @@ function canonicalLegacyMilestoneId(
   if (!bare) return null;
 
   const candidates = new Set<string>();
-  const numericId = String(Number(bare[1]));
-  if (dbMilestones.has(numericId)) candidates.add(numericId);
   const suffixedIdPattern = new RegExp(`^${legacyId}-[a-z0-9]{6}$`);
   for (const dbId of dbMilestones) {
+    if (/^\d+$/.test(dbId) && `M${dbId.padStart(3, "0")}` === legacyId) candidates.add(dbId);
     if (suffixedIdPattern.test(dbId)) candidates.add(dbId);
   }
   return candidates.size === 1 ? [...candidates][0]! : null;

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -118,6 +118,33 @@ function milestoneIdFromLegacyDirName(name: string): string | null {
   return name.match(/^(M\d{3}(?:-[a-z0-9]{6})?)(?:-|$)/)?.[1] ?? null;
 }
 
+function canonicalLegacyMilestoneId(
+  legacyId: string,
+  dbMilestones: ReadonlySet<string>,
+): string | null {
+  if (dbMilestones.has(legacyId)) return legacyId;
+  const bare = legacyId.match(/^M(\d{3})$/);
+  if (!bare) return null;
+
+  const candidates = new Set<string>();
+  const numericId = String(Number(bare[1]));
+  if (dbMilestones.has(numericId)) candidates.add(numericId);
+  const suffixedIdPattern = new RegExp(`^${legacyId}-[a-z0-9]{6}$`);
+  for (const dbId of dbMilestones) {
+    if (suffixedIdPattern.test(dbId)) candidates.add(dbId);
+  }
+  return candidates.size === 1 ? [...candidates][0]! : null;
+}
+
+function alignLegacyHierarchyIdentity(
+  identity: string,
+  milestoneAliases: ReadonlyMap<string, string>,
+): string | null {
+  const [milestoneId, ...rest] = identity.split("/");
+  const canonicalMilestoneId = milestoneAliases.get(milestoneId!);
+  return canonicalMilestoneId ? [canonicalMilestoneId, ...rest].join("/") : null;
+}
+
 function legacyHierarchyContainsUnknownIdentity(basePath: string, legacyRoot: string): boolean {
   const milestones = getAllMilestones();
   const dbMilestones = new Set(milestones.map((milestone) => milestone.id));
@@ -133,15 +160,18 @@ function legacyHierarchyContainsUnknownIdentity(basePath: string, legacyRoot: st
     }
   }
 
-  const legacyMilestoneIds = new Set<string>();
+  const milestoneAliases = new Map<string, string>();
   for (const milestoneEntry of readdirSync(legacyRoot, { withFileTypes: true })) {
     if (!milestoneEntry.isDirectory()) continue;
     const milestonePath = join(legacyRoot, milestoneEntry.name);
     if (!dirIsContentBearingLegacyMilestone(milestonePath)) continue;
 
-    const milestoneId = milestoneIdFromLegacyDirName(milestoneEntry.name);
-    if (!milestoneId || !dbMilestones.has(milestoneId)) return true;
-    legacyMilestoneIds.add(milestoneId);
+    const legacyMilestoneId = milestoneIdFromLegacyDirName(milestoneEntry.name);
+    if (!legacyMilestoneId) return true;
+    const milestoneId = canonicalLegacyMilestoneId(legacyMilestoneId, dbMilestones);
+    if (!milestoneId) return true;
+    milestoneAliases.set(legacyMilestoneId, milestoneId);
+    milestoneAliases.set(milestoneId, milestoneId);
 
     const slicesPath = join(milestonePath, "slices");
     if (!existsSync(slicesPath)) continue;
@@ -162,9 +192,18 @@ function legacyHierarchyContainsUnknownIdentity(basePath: string, legacyRoot: st
 
   const markdown = scanMarkdownHierarchy(basePath);
   return (
-    [...markdown.milestones].some((id) => legacyMilestoneIds.has(id) && !dbMilestones.has(id)) ||
-    [...markdown.slices].some((id) => legacyMilestoneIds.has(id.split("/")[0]!) && !dbSlices.has(id)) ||
-    [...markdown.tasks].some((id) => legacyMilestoneIds.has(id.split("/")[0]!) && !dbTasks.has(id))
+    [...markdown.milestones].some((id) => {
+      const aligned = alignLegacyHierarchyIdentity(id, milestoneAliases);
+      return aligned !== null && !dbMilestones.has(aligned);
+    }) ||
+    [...markdown.slices].some((id) => {
+      const aligned = alignLegacyHierarchyIdentity(id, milestoneAliases);
+      return aligned !== null && !dbSlices.has(aligned);
+    }) ||
+    [...markdown.tasks].some((id) => {
+      const aligned = alignLegacyHierarchyIdentity(id, milestoneAliases);
+      return aligned !== null && !dbTasks.has(aligned);
+    })
   );
 }
 

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -2,7 +2,7 @@
 // File Purpose: One-time migration from legacy nested .gsd/milestones/ to
 // flat-phase .gsd/phases/. Runs on startup when the legacy structure is detected.
 
-import { cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { renderAllFromDb, renderRoadmapFromDb } from "./markdown-renderer.js";
@@ -145,27 +145,6 @@ function legacyHierarchyContainsUnknownIdentity(basePath: string, legacyRoot: st
     [...markdown.slices].some((id) => legacyMilestoneIds.has(id.split("/")[0]!) && !dbSlices.has(id)) ||
     [...markdown.tasks].some((id) => legacyMilestoneIds.has(id.split("/")[0]!) && !dbTasks.has(id))
   );
-}
-
-function legacyTreeContainsUnrepresentedMarkdown(
-  legacyRoot: string,
-  prefix = "",
-  artifacts = new Map(
-    getArtifactsByPathPrefix("milestones/").map((artifact) => [artifact.path, artifact.full_content]),
-  ),
-): boolean {
-  for (const entry of readdirSync(legacyRoot, { withFileTypes: true })) {
-    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
-    const absolutePath = join(legacyRoot, entry.name);
-    if (entry.isDirectory()) {
-      if (legacyTreeContainsUnrepresentedMarkdown(absolutePath, relativePath, artifacts)) return true;
-      continue;
-    }
-    if (!entry.isFile()) return true;
-    if (!entry.name.toLowerCase().endsWith(".md")) continue;
-    if (artifacts.get(`milestones/${relativePath}`) !== readFileSync(absolutePath, "utf-8")) return true;
-  }
-  return false;
 }
 
 function backupFlatProjectionIfPresent(basePath: string, phasesPath: string, backupDir: string): void {
@@ -422,13 +401,11 @@ async function migrateToFlatPhaseLocked(basePath: string): Promise<void> {
     !hasLegacyMilestoneSubdirs(milestonesPath) && hasLegacyMilestoneSubdirs(migratingPath);
 
   // Markdown is a projection, never startup authority. Refuse the layout
-  // conversion before touching disk when the legacy tree contains identities
-  // the canonical DB does not hold; explicit recovery owns that import.
+  // conversion before touching disk only when the legacy tree contains identities
+  // the canonical DB does not hold; explicit recovery owns that import. Content
+  // for known identities is archived in the migration backup, then rebuilt from DB.
   const legacySource = resumingInterrupted ? migratingPath : milestonesPath;
-  if (
-    legacyHierarchyContainsUnknownIdentity(basePath, legacySource) ||
-    legacyTreeContainsUnrepresentedMarkdown(legacySource)
-  ) {
+  if (legacyHierarchyContainsUnknownIdentity(basePath, legacySource)) {
     throw new Error(
       "flat-phase migration skipped: legacy markdown contains state absent from the canonical DB. " +
       "Recommended: run `/gsd recover` and approve its exact Preview hash to import explicitly.",

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -119,13 +119,6 @@ function milestoneIdFromLegacyDirName(name: string): string | null {
 }
 
 function legacyHierarchyContainsUnknownIdentity(basePath: string, legacyRoot: string): boolean {
-  const markdown = scanMarkdownHierarchy(basePath);
-  const legacyMilestoneIds = new Set(
-    readdirSync(legacyRoot, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => milestoneIdFromLegacyDirName(entry.name))
-      .filter((id): id is string => id !== null),
-  );
   const milestones = getAllMilestones();
   const dbMilestones = new Set(milestones.map((milestone) => milestone.id));
   const dbSlices = new Set<string>();
@@ -140,6 +133,34 @@ function legacyHierarchyContainsUnknownIdentity(basePath: string, legacyRoot: st
     }
   }
 
+  const legacyMilestoneIds = new Set<string>();
+  for (const milestoneEntry of readdirSync(legacyRoot, { withFileTypes: true })) {
+    if (!milestoneEntry.isDirectory()) continue;
+    const milestonePath = join(legacyRoot, milestoneEntry.name);
+    if (!dirIsContentBearingLegacyMilestone(milestonePath)) continue;
+
+    const milestoneId = milestoneIdFromLegacyDirName(milestoneEntry.name);
+    if (!milestoneId || !dbMilestones.has(milestoneId)) return true;
+    legacyMilestoneIds.add(milestoneId);
+
+    const slicesPath = join(milestonePath, "slices");
+    if (!existsSync(slicesPath)) continue;
+    for (const sliceEntry of readdirSync(slicesPath, { withFileTypes: true })) {
+      if (!sliceEntry.isDirectory()) continue;
+      const sliceId = sliceEntry.name.match(/^(S\d+)(?:-|$)/i)?.[1]?.toUpperCase();
+      if (!sliceId || !dbSlices.has(`${milestoneId}/${sliceId}`)) return true;
+
+      const tasksPath = join(slicesPath, sliceEntry.name, "tasks");
+      if (!existsSync(tasksPath)) continue;
+      for (const taskEntry of readdirSync(tasksPath, { withFileTypes: true })) {
+        const taskId = taskEntry.name.match(/^(T\d+)(?:-|$)/i)?.[1]?.toUpperCase();
+        if (taskId && !dbTasks.has(`${milestoneId}/${sliceId}/${taskId}`)) return true;
+        if (!taskId && taskEntry.isDirectory()) return true;
+      }
+    }
+  }
+
+  const markdown = scanMarkdownHierarchy(basePath);
   return (
     [...markdown.milestones].some((id) => legacyMilestoneIds.has(id) && !dbMilestones.has(id)) ||
     [...markdown.slices].some((id) => legacyMilestoneIds.has(id.split("/")[0]!) && !dbSlices.has(id)) ||
@@ -421,35 +442,24 @@ async function migrateToFlatPhaseLocked(basePath: string): Promise<void> {
     return;
   }
 
-  let backupDir: string;
-  let backupCreatedThisRun = false;
-  if (!resumingInterrupted) {
-    // 2. Backup (only reached when the DB has rows and migration will proceed).
-    // The comparison above proved that the legacy projection holds no identity
-    // absent from the DB. If a prior successful migration already snapshotted
-    // the legacy tree, a re-fire of this gate must not leak a fresh
-    // .gsd-backups/migrate-<ts>/ on every startup. Reuse the existing snapshot
-    // as the rollback fallback instead of creating a duplicate.
-    const priorBackup = existingMigrateBackup(basePath);
-    if (priorBackup) {
-      backupDir = priorBackup;
-      logWarning(
-        "migration",
-        `flat-phase migration re-fired; reusing existing backup ${priorBackup} instead of re-snapshotting (issue #1292)`,
-      );
-    } else {
-      const ts = Date.now();
-      backupDir = join(basePath, ".gsd-backups", `migrate-${ts}`);
-      try {
-        mkdirSync(join(basePath, ".gsd-backups"), { recursive: true });
-        cpSync(milestonesPath, backupDir, { recursive: true });
-        backupCreatedThisRun = true;
-      } catch (err) {
-        logWarning("migration", `flat-phase migration backup failed: ${(err as Error).message}`);
-        throw err;
-      }
-    }
+  const priorBackup = existingMigrateBackup(basePath);
+  const backupDir = priorBackup ?? join(basePath, ".gsd-backups", `migrate-${Date.now()}`);
+  const backupCreatedThisRun = !priorBackup;
+  try {
+    mkdirSync(join(basePath, ".gsd-backups"), { recursive: true });
+    cpSync(legacySource, backupDir, { recursive: true, force: true });
+  } catch (err) {
+    logWarning("migration", `flat-phase migration backup failed: ${(err as Error).message}`);
+    throw err;
+  }
+  if (priorBackup) {
+    logWarning(
+      "migration",
+      `flat-phase migration re-fired; refreshed existing backup ${priorBackup} instead of creating another (issue #1292)`,
+    );
+  }
 
+  if (!resumingInterrupted) {
     if (existsSync(migratingPath)) {
       removeManagedPath(migratingPath);
     }
@@ -462,25 +472,6 @@ async function migrateToFlatPhaseLocked(basePath: string): Promise<void> {
     } catch (err) {
       logWarning("migration", `failed to move legacy milestones/ before render: ${(err as Error).message}`);
       throw err;
-    }
-  } else {
-    const priorBackup = existingMigrateBackup(basePath);
-    if (priorBackup) {
-      backupDir = priorBackup;
-    } else {
-      const ts = Date.now();
-      backupDir = join(basePath, ".gsd-backups", `migrate-${ts}`);
-      try {
-        mkdirSync(join(basePath, ".gsd-backups"), { recursive: true });
-        cpSync(migratingPath, backupDir, { recursive: true });
-        backupCreatedThisRun = true;
-      } catch (err) {
-        logWarning(
-          "migration",
-          `flat-phase migration backup failed during resume: ${(err as Error).message}`,
-        );
-        throw err;
-      }
     }
   }
 

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -72,12 +72,10 @@ function expectedPhaseDirs(basePath: string): string[] {
 /**
  * Return the most-recent existing `.gsd-backups/migrate-<ts>/` snapshot, or null.
  *
- * The flat-phase migration can re-fire on later dispatches when the legacy
- * `.gsd/milestones/` layout reappears (issue #1292). Re-snapshotting an
- * identical legacy projection on every startup only leaks a fresh
- * `migrate-<ts>/` directory each time. When a prior snapshot already exists we
- * reuse it as the rollback fallback instead of creating a duplicate, bounding
- * the accumulation to one recovery copy.
+ * The flat-phase migration can re-fire when the legacy `.gsd/milestones/`
+ * layout reappears (issue #1292). Creating a new snapshot on every startup
+ * leaks `migrate-<ts>/` directories. Refresh an existing snapshot in place to
+ * retain one recovery copy of the current legacy projection.
  */
 function existingMigrateBackup(basePath: string): string | null {
   const backupRoot = join(basePath, ".gsd-backups");

--- a/src/resources/extensions/gsd/guidance.ts
+++ b/src/resources/extensions/gsd/guidance.ts
@@ -52,6 +52,8 @@ const RECOVERY_REMEDIATION: Record<RecoveryGuidanceKey, string> = {
     "Run `/gsd doctor` to surface the persistent or repair-failed drift kinds, apply its fixes, then run `/gsd auto` to resume.",
   "illegal-transition":
     "A derived Phase edge rejected by the Phase Transition Invariant survived reconciliation; inspect deriveState and the State Reconciliation Module before resuming.",
+  "projection-lock-transient":
+    "Another Windows process temporarily holds the projection root. Retry through the existing transient budget; if contention persists, use `/gsd doctor` to inspect stale workers and orphaned worktrees.",
   "runtime-unknown": "Inspect the runtime error and add a dedicated classification if it is repeatable.",
   "provider-transient": "Retry after the provider/network condition clears.",
   "provider-permanent": "Inspect provider credentials, model entitlement, or request shape.",

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -43,7 +43,7 @@ import { gsdHome } from "./gsd-home.js";
 import {
   gsdRoot, milestonesDir, legacyMilestonesDir, resolveMilestoneFile,
   resolveSliceFile, resolveSlicePath, resolveGsdRootFile, relGsdRootFile,
-  relMilestoneFile, relSliceFile, clearPathCache,
+  relMilestoneFile, relSliceFile, relSlicePath, clearPathCache,
 } from "./paths.js";
 import { join } from "node:path";
 import { readFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
@@ -931,7 +931,6 @@ function resolveAvailableModel<T extends { id: string; provider: string }>(
  * Used by all three "new milestone" paths (first ever, no active, all complete).
  */
 function buildDiscussPrompt(nextId: string, preamble: string, basePath: string, pi: ExtensionAPI, ctx: ExtensionCommandContext, preparationContext?: string): string {
-  const milestoneRel = `.gsd/milestones/${nextId}`;
   const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
   const inlinedTemplates = [
     inlineTemplate("project", "Project"),
@@ -945,8 +944,8 @@ function buildDiscussPrompt(nextId: string, preamble: string, basePath: string, 
     preamble,
     preparationContext: preparationContext ?? "",
     structuredQuestionsAvailable,
-    contextPath: `${milestoneRel}/${nextId}-CONTEXT.md`,
-    roadmapPath: `${milestoneRel}/${nextId}-ROADMAP.md`,
+    contextPath: relMilestoneFile(basePath, nextId, "CONTEXT"),
+    roadmapPath: relMilestoneFile(basePath, nextId, "ROADMAP"),
     inlinedTemplates,
     commitInstruction: buildDocsCommitInstruction(`docs(${nextId}): context, requirements, and roadmap`),
     multiMilestoneCommitInstruction: buildDocsCommitInstruction("docs: project plan — N milestones"),
@@ -970,7 +969,6 @@ function prependLanguageDirective(basePath: string, prompt: string): string {
  * Uses the discuss-headless prompt template with seed context injected.
  */
 function buildHeadlessDiscussPrompt(nextId: string, seedContext: string, basePath: string): string {
-  const milestoneRel = `.gsd/milestones/${nextId}`;
   const inlinedTemplates = [
     inlineTemplate("project", "Project"),
     inlineTemplate("requirements", "Requirements"),
@@ -981,8 +979,8 @@ function buildHeadlessDiscussPrompt(nextId: string, seedContext: string, basePat
   return prependLanguageDirective(basePath, loadPrompt("discuss-headless", {
     milestoneId: nextId,
     seedContext,
-    contextPath: `${milestoneRel}/${nextId}-CONTEXT.md`,
-    roadmapPath: `${milestoneRel}/${nextId}-ROADMAP.md`,
+    contextPath: relMilestoneFile(basePath, nextId, "CONTEXT"),
+    roadmapPath: relMilestoneFile(basePath, nextId, "ROADMAP"),
     inlinedTemplates,
     commitInstruction: buildDocsCommitInstruction(`docs(${nextId}): context, requirements, and roadmap`),
     multiMilestoneCommitInstruction: buildDocsCommitInstruction("docs: project plan — N milestones"),
@@ -1274,8 +1272,8 @@ export async function buildDiscussSlicePrompt(
     ? capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`)
     : `## Inlined Context\n\n_(no context files found yet — go in blind and ask broad questions)_`;
 
-  const sliceDirPath = `.gsd/milestones/${mid}/slices/${sid}`;
-  const sliceContextPath = `${sliceDirPath}/${sid}-CONTEXT.md`;
+  const sliceDirPath = relSlicePath(base, mid, sid);
+  const sliceContextPath = relSliceFile(base, mid, sid, "CONTEXT");
 
   // When re-discussing, inject a preamble so the agent treats this as an update interview
   const rediscussPreamble = options?.rediscuss

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -911,16 +911,17 @@ export async function writeTaskSummaryProjection(
   sliceId: string,
   taskId: string,
   content: string,
-): Promise<string> {
+): Promise<{ artifactPath: string; content: string }> {
   const absPath = targetTaskFile(basePath, milestoneId, sliceId, taskId, "SUMMARY", getMilestone(milestoneId)?.title);
   const artifactPath = toArtifactPath(absPath, basePath);
 
-  return writeAndStore(absPath, artifactPath, content, {
+  const stamped = await writeAndStore(absPath, artifactPath, content, {
     artifact_type: "SUMMARY",
     milestone_id: milestoneId,
     slice_id: sliceId,
     task_id: taskId,
   }, basePath);
+  return { artifactPath, content: stamped };
 }
 
 // ─── Slice Summary Rendering ──────────────────────────────────────────────

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -124,6 +124,19 @@ export interface ProjectStateVersion {
   authorityEpoch: number;
 }
 
+export class ProjectionWriteError extends Error {
+  readonly stage = "artifact-persistence" as const;
+
+  constructor(artifactPath: string, artifactType: string, taskScoped: boolean, cause: unknown) {
+    const scope = taskScoped ? "task " : "";
+    super(
+      `${scope}${artifactType} projection artifact persistence failed: ${artifactPath}`,
+      cause instanceof Error ? { cause } : undefined,
+    );
+    this.name = "ProjectionWriteError";
+  }
+}
+
 /**
  * Current DB project revision/authority epoch — the same authority row the
  * cutover receipt (T006) advances. Falls back to 0:0 when the DB or its
@@ -275,9 +288,16 @@ async function writeAndStore(
       task_id: opts.task_id ?? null,
       full_content: stamped,
     });
-  } catch {
-    // Non-fatal: file is on disk, DB is best-effort
-    logWarning("renderer", `failed to update artifact in DB: ${artifactPath}`);
+  } catch (error) {
+    // Disk is a rebuildable projection, but callers must not report success
+    // without its authoritative artifact lineage. The unstored disk copy is
+    // intentionally left for drift reconciliation and post-mortem evidence.
+    throw new ProjectionWriteError(
+      artifactPath,
+      opts.artifact_type,
+      Boolean(opts.task_id),
+      error,
+    );
   }
 
   // Record the projection write so invalidateCaches() can refresh the compat

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -869,17 +869,38 @@ export async function renderTaskSummary(
     return false; // No summary to render — skip silently
   }
 
+  await writeTaskSummaryProjection(
+    basePath,
+    milestoneId,
+    sliceId,
+    taskId,
+    task.full_summary_md,
+  );
+
+  return true;
+}
+
+/**
+ * Persist task-summary projection bytes through the canonical projection seam.
+ * Callers may render content differently, but stamping, disk placement,
+ * artifact lineage, compatibility markers, and cache invalidation stay here.
+ */
+export async function writeTaskSummaryProjection(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+  content: string,
+): Promise<string> {
   const absPath = targetTaskFile(basePath, milestoneId, sliceId, taskId, "SUMMARY", getMilestone(milestoneId)?.title);
   const artifactPath = toArtifactPath(absPath, basePath);
 
-  await writeAndStore(absPath, artifactPath, task.full_summary_md, {
+  return writeAndStore(absPath, artifactPath, content, {
     artifact_type: "SUMMARY",
     milestone_id: milestoneId,
     slice_id: sliceId,
     task_id: taskId,
   }, basePath);
-
-  return true;
 }
 
 // ─── Slice Summary Rendering ──────────────────────────────────────────────

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -266,15 +266,32 @@ export function nativeDetectMainBranch(basePath: string): string {
 export function nativeBranchExists(basePath: string, branch: string): boolean {
   const native = loadNative();
   if (native) {
+    const refExists = native.gitBranchExists(basePath, branch);
+    if (refExists) return true;
     return branchExistsIncludingUnborn(
-      native.gitBranchExists(basePath, branch),
-      native.gitCurrentBranch(basePath),
+      false,
+      currentBranchIncludingUnborn(
+        () => native.gitCurrentBranch(basePath),
+        () => gitExec(basePath, ["symbolic-ref", "--quiet", "--short", "HEAD"], true),
+      ),
       branch,
     );
   }
   const result = gitExec(basePath, ["show-ref", "--verify", `refs/heads/${branch}`], true);
-  const current = gitExec(basePath, ["branch", "--show-current"], true);
+  const current = gitExec(basePath, ["symbolic-ref", "--quiet", "--short", "HEAD"], true);
   return branchExistsIncludingUnborn(result !== "", current, branch);
+}
+
+export function currentBranchIncludingUnborn(
+  nativeCurrentBranch: () => string | null,
+  symbolicCurrentBranch: () => string,
+): string | null {
+  try {
+    const currentBranch = nativeCurrentBranch();
+    if (currentBranch) return currentBranch;
+  } catch {
+  }
+  return symbolicCurrentBranch() || null;
 }
 
 export function branchExistsIncludingUnborn(

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -1032,6 +1032,16 @@ export function nativeCheckoutBranch(basePath: string, branch: string): void {
   });
 }
 
+/** Create and enter a branch when HEAD is unborn and has no commit target. */
+export function nativeCheckoutNewBranch(basePath: string, branch: string): void {
+  execFileSync("git", ["checkout", "-b", branch], {
+    cwd: basePath,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+    env: GIT_NO_PROMPT_ENV,
+  });
+}
+
 /**
  * Resolve index conflicts by accepting "theirs" version.
  * Native: libgit2 index conflict resolution.

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -266,15 +266,23 @@ export function nativeDetectMainBranch(basePath: string): string {
 export function nativeBranchExists(basePath: string, branch: string): boolean {
   const native = loadNative();
   if (native) {
-    return native.gitBranchExists(basePath, branch);
+    return branchExistsIncludingUnborn(
+      native.gitBranchExists(basePath, branch),
+      native.gitCurrentBranch(basePath),
+      branch,
+    );
   }
   const result = gitExec(basePath, ["show-ref", "--verify", `refs/heads/${branch}`], true);
-  if (result !== "") return true;
-
-  // show-ref fails for unborn branches (zero commits). Fall back to checking
-  // whether the requested branch is the current (unborn) branch.
   const current = gitExec(basePath, ["branch", "--show-current"], true);
-  return current === branch;
+  return branchExistsIncludingUnborn(result !== "", current, branch);
+}
+
+export function branchExistsIncludingUnborn(
+  refExists: boolean,
+  currentBranch: string | null,
+  branch: string,
+): boolean {
+  return refExists || currentBranch === branch;
 }
 
 /**

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -419,6 +419,15 @@ export function nativeHasCommittedHead(basePath: string): boolean {
   }
 }
 
+export function nativeIsCurrentUnbornBranch(basePath: string, branch: string): boolean {
+  const native = loadNative();
+  const currentBranch = currentBranchIncludingUnborn(
+    () => native?.gitCurrentBranch(basePath) ?? null,
+    () => gitExec(basePath, ["symbolic-ref", "--quiet", "--short", "HEAD"], true),
+  );
+  return currentBranch === branch && !nativeHasCommittedHead(basePath);
+}
+
 /**
  * Check if there are staged changes (index differs from HEAD).
  * Native: libgit2 tree-to-index diff.
@@ -1045,12 +1054,8 @@ export function nativeCommit(
  * Fallback: `git checkout <branch>`.
  */
 export function nativeCheckoutBranch(basePath: string, branch: string): void {
+  if (nativeIsCurrentUnbornBranch(basePath, branch)) return;
   const native = loadNative();
-  const currentBranch = currentBranchIncludingUnborn(
-    () => native?.gitCurrentBranch(basePath) ?? null,
-    () => gitExec(basePath, ["symbolic-ref", "--quiet", "--short", "HEAD"], true),
-  );
-  if (currentBranch === branch && !nativeHasCommittedHead(basePath)) return;
   if (native) {
     native.gitCheckoutBranch(basePath, branch);
     return;

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -1046,6 +1046,11 @@ export function nativeCommit(
  */
 export function nativeCheckoutBranch(basePath: string, branch: string): void {
   const native = loadNative();
+  const currentBranch = currentBranchIncludingUnborn(
+    () => native?.gitCurrentBranch(basePath) ?? null,
+    () => gitExec(basePath, ["symbolic-ref", "--quiet", "--short", "HEAD"], true),
+  );
+  if (currentBranch === branch && !nativeHasCommittedHead(basePath)) return;
   if (native) {
     native.gitCheckoutBranch(basePath, branch);
     return;

--- a/src/resources/extensions/gsd/projection-root-errors.ts
+++ b/src/resources/extensions/gsd/projection-root-errors.ts
@@ -1,0 +1,28 @@
+// Project/App: gsd-pi
+// File Purpose: Preserve typed transient projection-root lock failures across the native boundary.
+
+const WINDOWS_SHARING_VIOLATION = /(?:transient projection root sharing violation|projection root operation failed:.*(?:os error 32|sharing violation))/i;
+
+export class ProjectionLockTransientError extends Error {
+  readonly failureKind = "projection-lock-transient" as const;
+
+  constructor(cause: unknown) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    super(message, cause instanceof Error ? { cause } : undefined);
+    this.name = "ProjectionLockTransientError";
+  }
+}
+
+export function isTransientProjectionLockError(error: unknown): boolean {
+  if (error instanceof ProjectionLockTransientError) return true;
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return WINDOWS_SHARING_VIOLATION.test(message);
+}
+
+export function throwIfTransientProjectionLockError(error: unknown): void {
+  if (isTransientProjectionLockError(error)) {
+    throw error instanceof ProjectionLockTransientError
+      ? error
+      : new ProjectionLockTransientError(error);
+  }
+}

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -7,6 +7,10 @@ import { recoveryRemediation } from "./guidance.js";
 import { isTerminalToolSurfaceError } from "./tool-surface-readiness.js";
 import { ReconciliationFailedError } from "./state-reconciliation.js";
 import { IllegalPhaseTransitionError } from "./state-transition-matrix.js";
+import {
+  isTransientProjectionLockError,
+  ProjectionLockTransientError,
+} from "./projection-root-errors.js";
 
 export type RecoveryFailureKind =
   | "tool-schema"
@@ -19,6 +23,7 @@ export type RecoveryFailureKind =
   | "verification-drift"
   | "reconciliation-drift"
   | "illegal-transition"
+  | "projection-lock-transient"
   | "provider"
   | "runtime-unknown";
 
@@ -51,6 +56,8 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
       ? "reconciliation-drift"
       : input.error instanceof IllegalPhaseTransitionError
         ? "illegal-transition"
+        : input.error instanceof ProjectionLockTransientError
+          ? "projection-lock-transient"
         : input.failureKind ?? inferFailureKind(message);
 
   if (failureKind === "provider") {
@@ -91,6 +98,7 @@ const FAILURE_TAXONOMY: Record<
   "verification-drift": { action: "escalate", label: "Verification drift" },
   "reconciliation-drift": { action: "escalate", label: "Reconciliation drift" },
   "illegal-transition": { action: "escalate", label: "Illegal phase transition" },
+  "projection-lock-transient": { action: "retry", label: "Projection root busy" },
   "runtime-unknown": { action: "escalate", label: null },
 };
 
@@ -102,6 +110,7 @@ function inferFailureKind(message: string): RecoveryFailureKind {
   // would otherwise route it to retry. See #783.
   if (isTerminalToolSurfaceError(message)) return "runtime-unknown";
   if (isToolUnavailableError(message)) return "tool-unavailable";
+  if (isTransientProjectionLockError(message)) return "projection-lock-transient";
   if (/tool contract|auto-unit tool scope|phase-boundary gate|not permitted.*own/i.test(message)) return "tool-contract";
   if (/lifecycle progression|required artifact|missing .*assessment|missing .*closeout|cannot legally (?:advance|progress)/i.test(message)) return "lifecycle-progression";
   if (/schema|invalid.*tool|tool.*invalid|enum/i.test(message)) return "tool-schema";

--- a/src/resources/extensions/gsd/recovery-policy.ts
+++ b/src/resources/extensions/gsd/recovery-policy.ts
@@ -98,6 +98,7 @@ function budgetedRule(
   switch (classification.failureKind) {
     case "transient-execution":
     case "tool-unavailable":
+    case "projection-lock-transient":
       return { action: "retry", policyClass: "transient-execution", maxUses: 2 };
     case "provider":
       return classification.action === "retry"

--- a/src/resources/extensions/gsd/task-lifecycle-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-lifecycle-domain-operation.ts
@@ -27,6 +27,7 @@ import {
 } from "./db/writers/task-recovery.js";
 import { terminalizeTaskExecutionDispatch } from "./db/writers/task-execution.js";
 import type { ExecutionInvocation } from "./execution-invocation.js";
+import { ensurePendingSliceQ8 } from "./db/writers/slice-companion-state.js";
 
 export interface TaskLifecycleIdentity {
   milestoneId: string;
@@ -325,6 +326,7 @@ export function reopenTask(input: {
       adoptedFromStatus: legacyStatus,
     });
     reopenLegacyTaskState(context, input.task);
+    ensurePendingSliceQ8(context, input.task);
     const checkpoint = appendRecoveryWorkCheckpoint(context, {
       lifecycleId: lifecycle.lifecycleId,
       scopeKey: checkpointScope(input.task),

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 
 import { bootstrapAutoSession } from "../auto-start.ts";
 import { AutoSession } from "../auto/session.ts";
+import type { InterruptedSessionAssessment } from "../interrupted-session.ts";
 import {
   closeDatabase,
   insertMilestone,
@@ -248,6 +249,26 @@ function makeCtx(notifications: Array<{ message: string; level?: string }>) {
     },
   };
 }
+
+test("fresh bootstrap clears isolation degradation from a prior auto run (#1689)", async () => {
+  const s = new AutoSession();
+  s.isolationDegraded = true;
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  const ready = await bootstrapAutoSession(
+    s,
+    makeCtx(notifications) as any,
+    {} as any,
+    tmpdir(),
+    false,
+    false,
+    {} as any,
+    {} as unknown as InterruptedSessionAssessment,
+  );
+
+  assert.equal(ready, false, "the system temp root should stop bootstrap at directory validation");
+  assert.equal(s.isolationDegraded, false, "fresh bootstrap must not inherit degradation");
+});
 
 test("bootstrap aborts before starting next milestone when completed orphan merge fails", async () => {
   const base = makeRepoWithUnmergedCompletedMilestone();

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -358,6 +358,11 @@ console.log('\n=== complete-task: handler happy path ===');
     assertMatch(summaryContent, /## What Happened/, 'summary should have What Happened section');
     assertMatch(summaryContent, /## Verification Evidence/, 'summary should have Verification Evidence section');
     assertMatch(summaryContent, /npm run test:unit/, 'summary evidence should contain command');
+    assertMatch(summaryContent, /<!-- gsd:state-version=\d+:\d+ -->/, 'summary should carry the canonical projection stamp');
+    const summaryArtifact = adapter.prepare(
+      "SELECT full_content FROM artifacts WHERE artifact_type = 'SUMMARY' AND task_id = 'T01'"
+    ).get();
+    assertEq(summaryArtifact?.['full_content'], summaryContent, 'summary artifact should match stamped disk bytes');
 
     // (d) Verify plan checkbox changed to [x]
     const planContent = fs.readFileSync(planPath, 'utf-8');

--- a/src/resources/extensions/gsd/tests/db-base-schema.test.ts
+++ b/src/resources/extensions/gsd/tests/db-base-schema.test.ts
@@ -55,6 +55,7 @@ describe("db-base-schema", () => {
     assert.ok(db.execCalls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS schema_version")));
     assert.ok(db.execCalls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS tasks")));
     assert.ok(db.execCalls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS quality_gates")));
+    assert.ok(db.execCalls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS liveness_block_signatures")));
     assert.ok(db.execCalls.some((sql) => sql.includes("CREATE INDEX IF NOT EXISTS idx_tasks_active")));
     assert.ok(db.execCalls.some((sql) => sql.includes("CREATE VIEW IF NOT EXISTS active_decisions")));
     assert.ok(db.execCalls.some((sql) => sql.includes("CREATE VIEW IF NOT EXISTS active_memories")));

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -588,6 +588,24 @@ test("migrateToFlatPhase aligns a padded legacy milestone with one numeric DB id
   assert.ok(resolveMilestonePath(base, "1"));
 });
 
+test("migrateToFlatPhase aligns a legacy milestone with a zero-padded numeric DB identity", async () => {
+  const base = makeAliasTmp(["001"]);
+
+  await migrateToFlatPhase(base);
+
+  assert.equal(existsSync(join(base, ".gsd", "milestones")), false);
+  assert.ok(resolveMilestonePath(base, "001"));
+});
+
+test("migrateToFlatPhase rejects ambiguous numeric milestone aliases", async () => {
+  const base = makeAliasTmp(["1", "001"]);
+
+  await assert.rejects(() => migrateToFlatPhase(base), /Recommended: run `\/gsd recover`/);
+
+  assert.equal(existsSync(join(base, ".gsd", "milestones", "M001")), true);
+  assert.equal(existsSync(join(base, ".gsd", "phases")), false);
+});
+
 test("migrateToFlatPhase rejects ambiguous bare milestone aliases", async () => {
   const base = makeAliasTmp(["M001-abc123", "M001-def456"]);
 

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -42,6 +42,35 @@ function makeTmp(options: { withTask?: boolean } = {}): string {
   tmpDirs.push(base);
   return base;
 }
+
+function makeAliasTmp(milestoneIds: string[]): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-mig-alias-${randomUUID()}`));
+  mkdirSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01"),
+    { recursive: true },
+  );
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  for (const milestoneId of milestoneIds) {
+    insertMilestone({ id: milestoneId, title: "Foundation", status: "active" });
+    insertSlice({
+      milestoneId,
+      id: "S01",
+      title: "Set up tooling",
+      status: "pending",
+      sequence: 1,
+    });
+    insertTask({
+      milestoneId,
+      sliceId: "S01",
+      id: "T01",
+      title: "Init repo",
+      status: "pending",
+      sequence: 1,
+    });
+  }
+  tmpDirs.push(base);
+  return base;
+}
 afterEach(() => {
   _setFlatPhaseMigrationBoundaryForTest(null);
   closeDatabase();
@@ -539,6 +568,33 @@ test("migrateToFlatPhase rejects content-bearing unparseable milestone directori
 
   assert.equal(existsSync(join(base, ".gsd", "phases")), false);
   assert.equal(existsSync(join(unknownMilestone, "CONTEXT.md")), true);
+});
+
+test("migrateToFlatPhase aligns a bare legacy milestone with one suffixed DB identity", async () => {
+  const base = makeAliasTmp(["M001-abc123"]);
+
+  await migrateToFlatPhase(base);
+
+  assert.equal(existsSync(join(base, ".gsd", "milestones")), false);
+  assert.ok(resolveMilestonePath(base, "M001-abc123"));
+});
+
+test("migrateToFlatPhase aligns a padded legacy milestone with one numeric DB identity", async () => {
+  const base = makeAliasTmp(["1"]);
+
+  await migrateToFlatPhase(base);
+
+  assert.equal(existsSync(join(base, ".gsd", "milestones")), false);
+  assert.ok(resolveMilestonePath(base, "1"));
+});
+
+test("migrateToFlatPhase rejects ambiguous bare milestone aliases", async () => {
+  const base = makeAliasTmp(["M001-abc123", "M001-def456"]);
+
+  await assert.rejects(() => migrateToFlatPhase(base), /Recommended: run `\/gsd recover`/);
+
+  assert.equal(existsSync(join(base, ".gsd", "milestones", "M001")), true);
+  assert.equal(existsSync(join(base, ".gsd", "phases")), false);
 });
 
 test("pruneStaleFlatPhaseBackups removes migrate-* dirs older than retention window", async () => {

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -469,7 +469,7 @@ test("migration ignores an empty/partial leftover backup and writes a complete o
   );
 });
 
-test("migrateToFlatPhase leaves unrepresented slice sidecars for explicit recovery", async () => {
+test("migrateToFlatPhase archives resurrected projections for known DB identities", async () => {
   const base = makeTmp({ withTask: false });
   const legacySliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
   writeFileSync(join(legacySliceDir, "S01-CONTEXT.md"), "# Final Slice Context\n\nPrior discussion.", "utf-8");
@@ -481,16 +481,33 @@ test("migrateToFlatPhase leaves unrepresented slice sidecars for explicit recove
     "utf-8",
   );
 
+  await migrateToFlatPhase(base);
+
+  assert.equal(existsSync(join(base, ".gsd", "phases", "01-foundation")), true);
+  assert.equal(existsSync(join(base, ".gsd", "milestones")), false);
+  const backup = readdirSync(join(base, ".gsd-backups"))
+    .map((entry) => join(base, ".gsd-backups", entry))
+    .find((candidate) => existsSync(join(candidate, "M001", "slices", "S01", "S01-CONTEXT.md")));
+  assert.ok(backup, "the stale projection must remain available in the migration backup");
+  assert.equal(
+    readFileSync(join(backup, "M001", "slices", "S01", "S01-CONTEXT.md"), "utf-8"),
+    "# Final Slice Context\n\nPrior discussion.",
+  );
+});
+
+test("migrateToFlatPhase still rejects legacy projections with unknown identities", async () => {
+  const base = makeTmp();
+  const unknownDir = join(base, ".gsd", "milestones", "M999");
+  mkdirSync(unknownDir, { recursive: true });
+  writeFileSync(join(unknownDir, "M999-CONTEXT.md"), "# Unknown Milestone\n", "utf-8");
+
   await assert.rejects(
     () => migrateToFlatPhase(base),
     /Recommended: run `\/gsd recover`/,
   );
 
   assert.equal(existsSync(join(base, ".gsd", "phases")), false);
-  assert.equal(readFileSync(join(legacySliceDir, "S01-CONTEXT.md"), "utf-8"), "# Final Slice Context\n\nPrior discussion.");
-  assert.equal(readFileSync(join(legacySliceDir, "S01-RESEARCH.md"), "utf-8"), "# Slice Research\n\nPrior research.");
-  assert.equal(readFileSync(join(legacySliceDir, "S01-CONTINUE.md"), "utf-8"), "# Continue\n\nCompacted marker.");
-  assert.equal(existsSync(join(base, ".gsd-backups")), false);
+  assert.equal(existsSync(join(unknownDir, "M999-CONTEXT.md")), true);
 });
 
 test("pruneStaleFlatPhaseBackups removes migrate-* dirs older than retention window", async () => {

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -410,13 +410,20 @@ test("re-fired migration reuses the existing backup instead of leaking a new mig
   // Simulate the re-fire: the legacy .gsd/milestones/ layout reappears (e.g. a
   // marker-key mismatch re-imports the whole tree). The DB rows still exist, so
   // the migration gate proceeds again — it must not snapshot a second backup.
+  const resurrectedContext = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-CONTEXT.md");
   mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01"), { recursive: true });
+  writeFileSync(resurrectedContext, "# Resurrected context\n", "utf-8");
   assert.equal(needsFlatPhaseMigration(base), true, "reappeared legacy layout re-triggers migration");
 
   await migrateToFlatPhase(base);
 
   const afterBackups = readdirSync(backupRoot).filter((d) => d.startsWith("migrate-"));
   assert.deepEqual(afterBackups, firstBackups, "re-fire must not leak a second migrate-* backup");
+  assert.equal(
+    readFileSync(join(backupRoot, firstBackups[0]!, "M001", "slices", "S01", "S01-CONTEXT.md"), "utf-8"),
+    "# Resurrected context\n",
+    "the retained backup must archive the current legacy tree",
+  );
   assert.equal(existsSync(join(base, ".gsd", "milestones")), false, "legacy milestones/ removed again");
 });
 
@@ -508,6 +515,30 @@ test("migrateToFlatPhase still rejects legacy projections with unknown identitie
 
   assert.equal(existsSync(join(base, ".gsd", "phases")), false);
   assert.equal(existsSync(join(unknownDir, "M999-CONTEXT.md")), true);
+});
+
+test("migrateToFlatPhase rejects structurally unknown slice identities", async () => {
+  const base = makeTmp();
+  const unknownSlice = join(base, ".gsd", "milestones", "M001", "slices", "S99");
+  mkdirSync(unknownSlice, { recursive: true });
+  writeFileSync(join(unknownSlice, "S99-CONTEXT.md"), "# Unknown Slice\n", "utf-8");
+
+  await assert.rejects(() => migrateToFlatPhase(base), /Recommended: run `\/gsd recover`/);
+
+  assert.equal(existsSync(join(base, ".gsd", "phases")), false);
+  assert.equal(existsSync(join(unknownSlice, "S99-CONTEXT.md")), true);
+});
+
+test("migrateToFlatPhase rejects content-bearing unparseable milestone directories", async () => {
+  const base = makeTmp();
+  const unknownMilestone = join(base, ".gsd", "milestones", "unparseable-milestone");
+  mkdirSync(unknownMilestone, { recursive: true });
+  writeFileSync(join(unknownMilestone, "CONTEXT.md"), "# Unknown Milestone\n", "utf-8");
+
+  await assert.rejects(() => migrateToFlatPhase(base), /Recommended: run `\/gsd recover`/);
+
+  assert.equal(existsSync(join(base, ".gsd", "phases")), false);
+  assert.equal(existsSync(join(unknownMilestone, "CONTEXT.md")), true);
 });
 
 test("pruneStaleFlatPhaseBackups removes migrate-* dirs older than retention window", async () => {

--- a/src/resources/extensions/gsd/tests/guided-flow.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow.test.ts
@@ -22,3 +22,13 @@ test("guided milestone discussion callsites pass workingDirectory to loadPrompt"
   const calls = [...source.matchAll(/\bawait buildDiscussMilestonePrompt\(/g)];
   assert.equal(calls.length, 9, "all guided-flow guided-discuss-milestone callsites should be covered");
 });
+
+test("guided discussion prompts do not synthesize legacy milestone paths", () => {
+  const source = readFileSync(join(__dirname, "..", "guided-flow.ts"), "utf-8");
+
+  assert.doesNotMatch(
+    source,
+    /`\.gsd\/milestones\/\$\{/,
+    "discussion prompts must obtain write targets from the layout-aware path module",
+  );
+});

--- a/src/resources/extensions/gsd/tests/guided-flow.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow.test.ts
@@ -22,13 +22,3 @@ test("guided milestone discussion callsites pass workingDirectory to loadPrompt"
   const calls = [...source.matchAll(/\bawait buildDiscussMilestonePrompt\(/g)];
   assert.equal(calls.length, 9, "all guided-flow guided-discuss-milestone callsites should be covered");
 });
-
-test("guided discussion prompts do not synthesize legacy milestone paths", () => {
-  const source = readFileSync(join(__dirname, "..", "guided-flow.ts"), "utf-8");
-
-  assert.doesNotMatch(
-    source,
-    /`\.gsd\/milestones\/\$\{/,
-    "discussion prompts must obtain write targets from the layout-aware path module",
-  );
-});

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -875,29 +875,28 @@ test('── markdown-renderer: renderTaskSummary skips empty ──', async () 
   }
 });
 
-test('── markdown-renderer: task summary artifact failure is observable ──', async () => {
+test('── markdown-renderer: task summary artifact failure is observable ──', async (t) => {
   const tmpDir = makeTmpDir();
+  t.after(() => {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  });
   openDatabase(path.join(tmpDir, '.gsd', 'gsd.db'));
   clearAllCaches();
 
-  try {
-    scaffoldDirs(tmpDir, 'M001', ['S01']);
-    insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
-    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Slice', status: 'pending' });
-    insertTask({
-      id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Task', status: 'done',
-      fullSummaryMd: makeTaskSummaryContent('T01'),
-    });
-    _getAdapter()!.exec('DROP TABLE artifacts');
+  scaffoldDirs(tmpDir, 'M001', ['S01']);
+  insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Slice', status: 'pending' });
+  insertTask({
+    id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Task', status: 'done',
+    fullSummaryMd: makeTaskSummaryContent('T01'),
+  });
+  _getAdapter()!.exec('DROP TABLE artifacts');
 
-    await assert.rejects(
-      () => renderTaskSummary(tmpDir, 'M001', 'S01', 'T01'),
-      /task summary projection.*artifact persistence failed/i,
-    );
-  } finally {
-    closeDatabase();
-    cleanupDir(tmpDir);
-  }
+  await assert.rejects(
+    () => renderTaskSummary(tmpDir, 'M001', 'S01', 'T01'),
+    /task summary projection.*artifact persistence failed/i,
+  );
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -875,6 +875,31 @@ test('── markdown-renderer: renderTaskSummary skips empty ──', async () 
   }
 });
 
+test('── markdown-renderer: task summary artifact failure is observable ──', async () => {
+  const tmpDir = makeTmpDir();
+  openDatabase(path.join(tmpDir, '.gsd', 'gsd.db'));
+  clearAllCaches();
+
+  try {
+    scaffoldDirs(tmpDir, 'M001', ['S01']);
+    insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Slice', status: 'pending' });
+    insertTask({
+      id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Task', status: 'done',
+      fullSummaryMd: makeTaskSummaryContent('T01'),
+    });
+    _getAdapter()!.exec('DROP TABLE artifacts');
+
+    await assert.rejects(
+      () => renderTaskSummary(tmpDir, 'M001', 'S01', 'T01'),
+      /task summary projection.*artifact persistence failed/i,
+    );
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Slice Summary Rendering
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tests/projection-root-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/projection-root-errors.test.ts
@@ -1,0 +1,34 @@
+// Project/App: gsd-pi
+// File Purpose: Regression coverage for Windows projection-root sharing violation classification.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isTransientProjectionLockError,
+  ProjectionLockTransientError,
+  throwIfTransientProjectionLockError,
+} from "../projection-root-errors.ts";
+import { classifyFailure } from "../recovery-classification.ts";
+
+test("Windows sharing violations become typed transient recovery failures", () => {
+  const nativeError = new Error(
+    "projection root operation failed: C:\\repo\\.gsd\\worktrees\\M001: The process cannot access the file because it is being used by another process. (os error 32)",
+  );
+
+  assert.equal(isTransientProjectionLockError(nativeError), true);
+  assert.throws(
+    () => throwIfTransientProjectionLockError(nativeError),
+    ProjectionLockTransientError,
+  );
+  const classified = classifyFailure({ error: new ProjectionLockTransientError(nativeError) });
+  assert.equal(classified.failureKind, "projection-lock-transient");
+  assert.equal(classified.action, "retry");
+});
+
+test("other projection-root failures remain non-transient", () => {
+  const error = new Error("projection root operation failed: access denied (os error 5)");
+
+  assert.equal(isTransientProjectionLockError(error), false);
+  assert.doesNotThrow(() => throwIfTransientProjectionLockError(error));
+});

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -807,19 +807,16 @@ describe("prompt-budget: execute-task inline cap (039)", () => {
 });
 
 describe("prompt-budget: discuss-slice inline cap (039)", () => {
-  it("uses the flat-phase context target in its write contract", async () => {
+  it("uses the flat-phase context target in its write contract", async (t) => {
     const base = createFixtureBase();
-    try {
-      mkdirSync(join(base, ".gsd", "phases", "01-foundation"), { recursive: true });
+    t.after(() => cleanup(base));
+    mkdirSync(join(base, ".gsd", "phases", "01-foundation"), { recursive: true });
 
-      const prompt = await buildDiscussSlicePrompt("M001", "S01", "Current", base);
-      const expectedPath = relSlicePath(base, "M001", "S01");
+    const prompt = await buildDiscussSlicePrompt("M001", "S01", "Current", base);
+    const expectedPath = relSlicePath(base, "M001", "S01");
 
-      assert.ok(prompt.includes(expectedPath), `prompt must write ${expectedPath}`);
-      assert.doesNotMatch(prompt, /\.gsd\/milestones\/M001/);
-    } finally {
-      cleanup(base);
-    }
+    assert.ok(prompt.includes(expectedPath), `prompt must write ${expectedPath}`);
+    assert.doesNotMatch(prompt, /\.gsd\/milestones\/M001/);
   });
 
   it("prepends the configured response language", async () => {

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from "node:url";
 import { buildExecuteTaskPrompt, buildPlanSlicePrompt, buildReactiveExecutePrompt, buildResearchSlicePrompt, inlineDependencySummaries } from "../auto-prompts.js";
 import { buildDiscussSlicePrompt } from "../guided-flow.js";
 import { computeBudgets, truncateAtSectionBoundary } from "../context-budget.js";
+import { relSlicePath } from "../paths.js";
 import {
   closeDatabase,
   insertMilestone,
@@ -806,6 +807,21 @@ describe("prompt-budget: execute-task inline cap (039)", () => {
 });
 
 describe("prompt-budget: discuss-slice inline cap (039)", () => {
+  it("uses the flat-phase context target in its write contract", async () => {
+    const base = createFixtureBase();
+    try {
+      mkdirSync(join(base, ".gsd", "phases", "01-foundation"), { recursive: true });
+
+      const prompt = await buildDiscussSlicePrompt("M001", "S01", "Current", base);
+      const expectedPath = relSlicePath(base, "M001", "S01");
+
+      assert.ok(prompt.includes(expectedPath), `prompt must write ${expectedPath}`);
+      assert.doesNotMatch(prompt, /\.gsd\/milestones\/M001/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("prepends the configured response language", async () => {
     const base = createFixtureBase();
     const gsdHome = mkdtempSync(join(tmpdir(), "gsd-discuss-slice-language-home-"));

--- a/src/resources/extensions/gsd/tests/register-hooks-flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-flat-phase-migration.test.ts
@@ -1,5 +1,6 @@
 // Project/App: gsd-pi
-// File Purpose: Verifies session bootstrap fails closed on unrepresented legacy Markdown.
+// File Purpose: Verifies session bootstrap fails closed on legacy Markdown whose
+// identities the canonical database does not hold.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -48,7 +49,7 @@ function makeContext(basePath: string) {
   };
 }
 
-test("session_start rejects unrepresented legacy Markdown with explicit recovery guidance", async (t) => {
+test("session_start rejects legacy Markdown identities absent from the DB with explicit recovery guidance", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-bootstrap-flat-migration-"));
   t.after(() => {
     closeDatabase();
@@ -57,11 +58,14 @@ test("session_start rejects unrepresented legacy Markdown with explicit recovery
 
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
   writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# M001: Foundation\n", "utf-8");
+  // M999 has no canonical DB identity, so the legacy tree carries state the
+  // database does not hold and only explicit recovery may import it. Known
+  // identities (M001) are archived and rebuilt from the DB instead.
+  mkdirSync(join(base, ".gsd", "milestones", "M999"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "milestones", "M999", "M999-CONTEXT.md"), "# M999: Unknown\n", "utf-8");
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "Foundation", status: "active" });
   closeDatabase();
-
-  writeFileSync(join(base, ".gsd-backups"), "not a directory\n", "utf-8");
 
   const sessionStart = createSessionStartHandler();
 
@@ -70,4 +74,10 @@ test("session_start rejects unrepresented legacy Markdown with explicit recovery
     /flat-phase migration.*\/gsd recover/,
   );
   assert.ok(existsSync(join(base, ".gsd", "milestones", "M001")), "legacy layout should remain for recovery");
+  assert.ok(existsSync(join(base, ".gsd", "milestones", "M999")), "unknown identity should remain for recovery");
+  assert.equal(
+    existsSync(join(base, ".gsd-backups")),
+    false,
+    "rejection must happen before the migration touches disk",
+  );
 });

--- a/src/resources/extensions/gsd/tests/reopen-task.test.ts
+++ b/src/resources/extensions/gsd/tests/reopen-task.test.ts
@@ -122,28 +122,25 @@ test('handleReopenTask: commits canonical ready with legacy pending', async () =
   }
 });
 
-test('handleReopenTask: restores the slice pending Q8 companion gate', async () => {
+test('handleReopenTask: restores the slice pending Q8 companion gate', async (t) => {
   const base = makeTmpBase();
+  t.after(() => cleanup(base));
   openDatabase(join(base, '.gsd', 'gsd.db'));
-  try {
-    seedCompleteTask();
+  seedCompleteTask();
 
-    const result = await handleReopenTask({
-      milestoneId: 'M001', sliceId: 'S01', taskId: 'T01', reason: 'regression found',
-    }, base, invocation('test/public-reopen/restore-q8'));
+  const result = await handleReopenTask({
+    milestoneId: 'M001', sliceId: 'S01', taskId: 'T01', reason: 'regression found',
+  }, base, invocation('test/public-reopen/restore-q8'));
 
-    assert.ok(!('error' in result));
-    const adapter = _getAdapter();
-    assert.ok(adapter);
-    assert.deepEqual(adapter.prepare(`
-      SELECT gate_id, scope, status
-      FROM quality_gates
-      WHERE milestone_id = 'M001' AND slice_id = 'S01'
-        AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
-    `).all(), [{ gate_id: 'Q8', scope: 'slice', status: 'pending' }]);
-  } finally {
-    cleanup(base);
-  }
+  assert.ok(!('error' in result));
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  assert.deepEqual(adapter.prepare(`
+    SELECT gate_id, scope, status
+    FROM quality_gates
+    WHERE milestone_id = 'M001' AND slice_id = 'S01'
+      AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
+  `).all(), [{ gate_id: 'Q8', scope: 'slice', status: 'pending' }]);
 });
 
 test('handleReopenTask: projection cleanup failure cannot roll back committed recovery', async () => {

--- a/src/resources/extensions/gsd/tests/reopen-task.test.ts
+++ b/src/resources/extensions/gsd/tests/reopen-task.test.ts
@@ -122,6 +122,30 @@ test('handleReopenTask: commits canonical ready with legacy pending', async () =
   }
 });
 
+test('handleReopenTask: restores the slice pending Q8 companion gate', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+  try {
+    seedCompleteTask();
+
+    const result = await handleReopenTask({
+      milestoneId: 'M001', sliceId: 'S01', taskId: 'T01', reason: 'regression found',
+    }, base, invocation('test/public-reopen/restore-q8'));
+
+    assert.ok(!('error' in result));
+    const adapter = _getAdapter();
+    assert.ok(adapter);
+    assert.deepEqual(adapter.prepare(`
+      SELECT gate_id, scope, status
+      FROM quality_gates
+      WHERE milestone_id = 'M001' AND slice_id = 'S01'
+        AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
+    `).all(), [{ gate_id: 'Q8', scope: 'slice', status: 'pending' }]);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handleReopenTask: projection cleanup failure cannot roll back committed recovery', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tests/replan-slice-domain-replay.test.ts
+++ b/src/resources/extensions/gsd/tests/replan-slice-domain-replay.test.ts
@@ -202,6 +202,37 @@ test("slice replan exact retry replays once and changed reuse conflicts without 
   }
 });
 
+test("slice replan restores its pending Q8 companion gate", async () => {
+  const base = makeBase();
+  try {
+    await seedPlannedSlice(base);
+    const adapter = _getAdapter();
+    assert.ok(adapter);
+    adapter.prepare(`
+      DELETE FROM quality_gates
+      WHERE milestone_id = 'M001' AND slice_id = 'S01'
+        AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
+    `).run();
+
+    const result = await handleReplanSlice(
+      replanParams(),
+      base,
+      invocation("replan-slice/restore-q8"),
+    );
+
+    assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+    assert.deepEqual(rows(`
+      SELECT gate_id, scope, status
+      FROM quality_gates
+      WHERE milestone_id = 'M001' AND slice_id = 'S01'
+        AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
+    `), [{ gate_id: "Q8", scope: "slice", status: "pending" }]);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("slice replan retry preserves a newer durable replan projection", async () => {
   const base = makeBase();
   try {

--- a/src/resources/extensions/gsd/tests/replan-slice-domain-replay.test.ts
+++ b/src/resources/extensions/gsd/tests/replan-slice-domain-replay.test.ts
@@ -202,35 +202,34 @@ test("slice replan exact retry replays once and changed reuse conflicts without 
   }
 });
 
-test("slice replan restores its pending Q8 companion gate", async () => {
+test("slice replan restores its pending Q8 companion gate", async (t) => {
   const base = makeBase();
-  try {
-    await seedPlannedSlice(base);
-    const adapter = _getAdapter();
-    assert.ok(adapter);
-    adapter.prepare(`
-      DELETE FROM quality_gates
-      WHERE milestone_id = 'M001' AND slice_id = 'S01'
-        AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
-    `).run();
-
-    const result = await handleReplanSlice(
-      replanParams(),
-      base,
-      invocation("replan-slice/restore-q8"),
-    );
-
-    assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
-    assert.deepEqual(rows(`
-      SELECT gate_id, scope, status
-      FROM quality_gates
-      WHERE milestone_id = 'M001' AND slice_id = 'S01'
-        AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
-    `), [{ gate_id: "Q8", scope: "slice", status: "pending" }]);
-  } finally {
+  t.after(() => {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });
-  }
+  });
+  await seedPlannedSlice(base);
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  adapter.prepare(`
+    DELETE FROM quality_gates
+    WHERE milestone_id = 'M001' AND slice_id = 'S01'
+      AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
+  `).run();
+
+  const result = await handleReplanSlice(
+    replanParams(),
+    base,
+    invocation("replan-slice/restore-q8"),
+  );
+
+  assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+  assert.deepEqual(rows(`
+    SELECT gate_id, scope, status
+    FROM quality_gates
+    WHERE milestone_id = 'M001' AND slice_id = 'S01'
+      AND gate_id = 'Q8' AND (task_id = '' OR task_id IS NULL)
+  `), [{ gate_id: "Q8", scope: "slice", status: "pending" }]);
 });
 
 test("slice replan retry preserves a newer durable replan projection", async () => {

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -247,6 +247,7 @@ test("Recovery Classification covers ADR-015 failure families", () => {
     ["stale worker lease", "stale-worker", "stop"],
     ["worktree root missing .git", "worktree-invalid", "stop"],
     ["verification drift in state snapshot", "verification-drift", "escalate"],
+    ["projection root operation failed: C:\\repo\\.gsd\\worktrees\\M001: The process cannot access the file because it is being used by another process. (os error 32)", "projection-lock-transient", "retry"],
     ["rate limit 429", "provider", "retry"],
     ["unexpected invariant", "runtime-unknown", "escalate"],
   ] as const;

--- a/src/resources/extensions/gsd/tests/unborn-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/unborn-branch.test.ts
@@ -15,7 +15,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 
-import { nativeBranchExists } from "../native-git-bridge.ts";
+import { branchExistsIncludingUnborn, nativeBranchExists } from "../native-git-bridge.ts";
 
 function git(args: string[], cwd: string): string {
   return execFileSync("git", args, {
@@ -59,6 +59,17 @@ test("nativeBranchExists: returns false for non-existent branch in unborn repo",
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("native branch lookup recognizes symbolic unborn HEAD across reruns", () => {
+  assert.equal(
+    branchExistsIncludingUnborn(false, "milestone/M001", "milestone/M001"),
+    true,
+  );
+  assert.equal(
+    branchExistsIncludingUnborn(false, "milestone/M001", "milestone/M002"),
+    false,
+  );
 });
 
 test("nativeBranchExists: still works for real branches with commits", () => {

--- a/src/resources/extensions/gsd/tests/unborn-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/unborn-branch.test.ts
@@ -15,7 +15,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 
-import { branchExistsIncludingUnborn, nativeBranchExists } from "../native-git-bridge.ts";
+import {
+  branchExistsIncludingUnborn,
+  currentBranchIncludingUnborn,
+  nativeBranchExists,
+} from "../native-git-bridge.ts";
 
 function git(args: string[], cwd: string): string {
   return execFileSync("git", args, {
@@ -70,6 +74,18 @@ test("native branch lookup recognizes symbolic unborn HEAD across reruns", () =>
     branchExistsIncludingUnborn(false, "milestone/M001", "milestone/M002"),
     false,
   );
+});
+
+test("native branch lookup falls back when unborn HEAD throws", () => {
+  const currentBranch = currentBranchIncludingUnborn(
+    () => {
+      throw new Error("unborn HEAD");
+    },
+    () => "milestone/M001",
+  );
+
+  assert.equal(currentBranch, "milestone/M001");
+  assert.equal(branchExistsIncludingUnborn(false, currentBranch, "milestone/M001"), true);
 });
 
 test("nativeBranchExists: still works for real branches with commits", () => {

--- a/src/resources/extensions/gsd/tests/unborn-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/unborn-branch.test.ts
@@ -89,15 +89,17 @@ test("native branch lookup falls back when unborn HEAD throws", () => {
   assert.equal(branchExistsIncludingUnborn(false, currentBranch, "milestone/M001"), true);
 });
 
-test("branch mode re-enters the current unborn milestone branch", (t) => {
+test("branch mode re-enters a dirty current unborn milestone branch", (t) => {
   const dir = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-test-")));
   t.after(() => rmSync(dir, { recursive: true, force: true }));
   git(["init"], dir);
 
   enterBranchModeForMilestone(dir, "M001");
+  writeFileSync(join(dir, "draft.txt"), "uncommitted work\n");
   enterBranchModeForMilestone(dir, "M001");
 
   assert.equal(git(["symbolic-ref", "--short", "HEAD"], dir), "milestone/M001");
+  assert.equal(git(["status", "--short", "draft.txt"], dir), "?? draft.txt");
 });
 
 test("nativeBranchExists: still works for real branches with commits", () => {

--- a/src/resources/extensions/gsd/tests/unborn-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/unborn-branch.test.ts
@@ -20,6 +20,7 @@ import {
   currentBranchIncludingUnborn,
   nativeBranchExists,
 } from "../native-git-bridge.ts";
+import { enterBranchModeForMilestone } from "../auto-worktree-branch-lifecycle.ts";
 
 function git(args: string[], cwd: string): string {
   return execFileSync("git", args, {
@@ -86,6 +87,17 @@ test("native branch lookup falls back when unborn HEAD throws", () => {
 
   assert.equal(currentBranch, "milestone/M001");
   assert.equal(branchExistsIncludingUnborn(false, currentBranch, "milestone/M001"), true);
+});
+
+test("branch mode re-enters the current unborn milestone branch", (t) => {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-test-")));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  git(["init"], dir);
+
+  enterBranchModeForMilestone(dir, "M001");
+  enterBranchModeForMilestone(dir, "M001");
+
+  assert.equal(git(["symbolic-ref", "--short", "HEAD"], dir), "milestone/M001");
 });
 
 test("nativeBranchExists: still works for real branches with commits", () => {

--- a/src/resources/extensions/gsd/tests/workflow-projections.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-projections.test.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { regenerateIfMissing, renderPlanContent, renderPlanProjection, renderStateProjection, renderSummaryProjection } from '../workflow-projections.ts';
 import type { SliceRow, TaskRow } from '../gsd-db.ts';
-import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from '../gsd-db.ts';
+import { closeDatabase, getArtifactsByPathPrefix, insertMilestone, insertSlice, insertTask, openDatabase } from '../gsd-db.ts';
 import { clearPathCache, _clearGsdRootCache, normalizeRealPath, resolveMilestoneFile, resolveTaskFile } from '../paths.ts';
 import { invalidateStateCache } from '../state.ts';
 import { clearParseCache } from '../files.ts';
@@ -370,6 +370,7 @@ test('workflow-projections: regenerateIfMissing SUMMARY is idempotent for flat-p
       duration: '5m',
       keyFiles: ['src/example.ts'],
       keyDecisions: ['Use centralized task summary paths.'],
+      fullSummaryMd: '---\nid: T01\nparent: S01\nmilestone: M001\n---\n\n# T01: Completed the flat task.\n',
     });
 
     const summaryPath = join(phaseDir, 'S01-T01-SUMMARY.md');
@@ -381,7 +382,11 @@ test('workflow-projections: regenerateIfMissing SUMMARY is idempotent for flat-p
     assert.equal(first, true, 'first call regenerates the missing task summary');
     assert.equal(second, false, 'second call sees the flat-phase task summary and does not rewrite it');
     assert.equal(normalizeRealPath(resolveTaskFile(base, 'M001', 'S01', 'T01', 'SUMMARY') ?? ''), normalizeRealPath(summaryPath));
-    assert.match(readFileSync(summaryPath, 'utf-8'), /# T01: Completed the flat task\./);
+    const diskContent = readFileSync(summaryPath, 'utf-8');
+    const [artifact] = getArtifactsByPathPrefix('phases/01-milestone/S01-T01-SUMMARY.md');
+    assert.match(diskContent, /# T01: Completed the flat task\./);
+    assert.match(diskContent, /<!-- gsd:state-version=\d+:\d+ -->/);
+    assert.equal(artifact?.full_content, diskContent, 'artifact lineage stores the exact stamped disk bytes');
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });
@@ -463,7 +468,7 @@ test('workflow-projections: renderSummaryProjection uses milestone title when cr
     const titleSummaryPath = join(base, '.gsd', 'phases', '01-milestone', 'S01-T01-SUMMARY.md');
     const idSummaryPath = join(base, '.gsd', 'phases', '01-m001', 'S01-T01-SUMMARY.md');
 
-    renderSummaryProjection(base, 'M001', 'S01', 'T01');
+    await renderSummaryProjection(base, 'M001', 'S01', 'T01');
 
     assert.ok(existsSync(titleSummaryPath), 'fresh summary projection uses the milestone title slug');
     assert.equal(existsSync(idSummaryPath), false, 'fresh summary projection does not create an id-slug orphan dir');

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -328,6 +328,35 @@ test("executeSummarySave surfaces task summary projection failures", async (t) =
   assert.equal(getArtifact(artifactPath), null);
 });
 
+test("executeSummarySave surfaces task summary worktree mirror failures", async (t) => {
+  const base = makeTmpBase();
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+  mkdirSync(join(worktree, ".gsd"), { recursive: true });
+  writeFileSync(join(worktree, ".git"), "gitdir: ../../../.git/worktrees/M001\n");
+  openTestDb(base);
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  seedSlice("M001", "S01", "in_progress");
+  mkdirSync(join(base, ".gsd", "phases", "01-foundation"), { recursive: true });
+  const artifactPath = "phases/01-foundation/S01-T01-SUMMARY.md";
+  mkdirSync(join(worktree, ".gsd", artifactPath), { recursive: true });
+
+  const result = await inProjectDir(worktree, () => executeSummarySave({
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T01",
+    artifact_type: "SUMMARY",
+    content: "# T01 Summary\n\nMirror failure must be visible.\n",
+  }, worktree));
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0]!.text, /Error saving artifact/);
+  assert.ok(getArtifact(artifactPath));
+});
+
 test("executeSummarySave persists UI-SPEC artifacts at the computed flat-phase path", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -276,6 +276,58 @@ test("executeSummarySave persists artifact and returns computed path", async () 
   }
 });
 
+test("executeSummarySave task summaries use the canonical projection seam", async (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+  openTestDb(base);
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  seedSlice("M001", "S01", "in_progress");
+  mkdirSync(join(base, ".gsd", "phases", "01-foundation"), { recursive: true });
+
+  const result = await inProjectDir(base, () => executeSummarySave({
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T01",
+    artifact_type: "SUMMARY",
+    content: "# T01 Summary\n\nCanonical task output.\n",
+  }, base));
+
+  const artifactPath = "phases/01-foundation/S01-T01-SUMMARY.md";
+  const fileContent = readFileSync(join(base, ".gsd", artifactPath), "utf-8");
+  assert.notEqual(result.isError, true);
+  assert.equal(result.details.path, artifactPath);
+  assert.match(fileContent, /<!-- gsd:state-version=\d+:\d+ -->/);
+  assert.equal(getArtifact(artifactPath)?.full_content, fileContent);
+});
+
+test("executeSummarySave surfaces task summary projection failures", async (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+  openTestDb(base);
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  seedSlice("M001", "S01", "in_progress");
+  const artifactPath = "phases/01-foundation/S01-T01-SUMMARY.md";
+  mkdirSync(join(base, ".gsd", artifactPath), { recursive: true });
+
+  const result = await inProjectDir(base, () => executeSummarySave({
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T01",
+    artifact_type: "SUMMARY",
+    content: "# T01 Summary\n\nMust not report success.\n",
+  }, base));
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0]!.text, /Error saving artifact/);
+  assert.equal(getArtifact(artifactPath), null);
+});
+
 test("executeSummarySave persists UI-SPEC artifacts at the computed flat-phase path", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -88,6 +88,7 @@ function makeDeps(
  */
 function makeGitRepoBase(opts?: {
   isolation?: "worktree" | "branch" | "none";
+  unborn?: boolean;
 }): string {
   const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-lifecycle-git-")));
   const git = (args: string[]): void => {
@@ -105,8 +106,10 @@ function makeGitRepoBase(opts?: {
       `## Git\n- isolation: ${opts.isolation}\n`,
     );
   }
-  git(["add", "."]);
-  git(["commit", "-m", "init"]);
+  if (!opts?.unborn) {
+    git(["add", "."]);
+    git(["commit", "-m", "init"]);
+  }
   return base;
 }
 
@@ -277,9 +280,65 @@ test("enterMilestone honors stranded branch recovery instead of recreating the w
   );
 });
 
-test("enterMilestone returns ok:false reason:isolation-degraded when session degraded", () => {
-  const s = makeSession({ isolationDegraded: true });
-  const deps = makeDeps({ getIsolationMode: () => "branch" });
+test("enterMilestone retries branch isolation when session is degraded", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase({ isolation: "branch" });
+  t.after(() => cleanupRepoBase(base, previousCwd));
+
+  const s = makeSession({
+    basePath: base,
+    originalBasePath: base,
+    isolationDegraded: true,
+  });
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.mode, "branch");
+    assert.equal(result.path, base);
+  }
+  assert.equal(s.isolationDegraded, false);
+  assert.equal(s.basePath, base);
+  assert.equal(s.milestoneLeaseToken, null);
+});
+
+test("enterMilestone enters branch isolation in a zero-commit repository (#1688)", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase({ isolation: "branch", unborn: true });
+  t.after(() => cleanupRepoBase(base, previousCwd));
+
+  const s = makeSession({ basePath: base, originalBasePath: base });
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  const result = lifecycle.enterMilestone("M001", makeCtx());
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    execFileSync("git", ["branch", "--show-current"], { cwd: base, encoding: "utf8" }).trim(),
+    "milestone/M001",
+  );
+  assert.throws(
+    () => execFileSync("git", ["rev-parse", "--verify", "HEAD"], { cwd: base, stdio: "pipe" }),
+    "branch entry must not fabricate a commit",
+  );
+});
+
+test("enterMilestone remains degraded when branch isolation retry fails", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase({ isolation: "branch" });
+  t.after(() => cleanupRepoBase(base, previousCwd));
+  rmSync(join(base, ".git"), { recursive: true, force: true });
+
+  const s = makeSession({
+    basePath: base,
+    originalBasePath: base,
+    isolationDegraded: true,
+  });
+  const deps = makeDeps();
   const ctx = makeCtx();
   const lifecycle = new WorktreeLifecycle(s, deps);
 
@@ -289,8 +348,7 @@ test("enterMilestone returns ok:false reason:isolation-degraded when session deg
   if (!result.ok) {
     assert.equal(result.reason, "isolation-degraded");
   }
-  assert.equal(s.basePath, "/project");
-  assert.equal(s.milestoneLeaseToken, null);
+  assert.equal(s.isolationDegraded, true);
 });
 
 test("enterMilestone falls back to branch mode when session is degraded in worktree isolation", (t) => {

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -45,9 +45,9 @@ import {
 } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, taskUnitKey } from "../unit-ownership.js";
-import { saveFile, clearParseCache, normalizePlannedFileReference } from "../files.js";
+import { clearParseCache, normalizePlannedFileReference } from "../files.js";
 import { invalidateStateCache } from "../state.js";
-import { renderPlanCheckboxes } from "../markdown-renderer.js";
+import { renderPlanCheckboxes, writeTaskSummaryProjection } from "../markdown-renderer.js";
 import {
   renderMilestoneShellProjections,
   renderSummaryContent,
@@ -172,7 +172,13 @@ async function repairMissingTaskSummaryProjection(
   let stale = false;
 
   try {
-    await saveFile(summaryPath, summaryMd);
+    await writeTaskSummaryProjection(
+      artifactBasePath,
+      taskRow.milestone_id,
+      taskRow.slice_id,
+      taskRow.id,
+      summaryMd,
+    );
     await renderPlanCheckboxes(artifactBasePath, taskRow.milestone_id, taskRow.slice_id);
   } catch (renderErr) {
     stale = true;
@@ -631,7 +637,13 @@ export async function handleCompleteTask(
   );
 
   try {
-    await saveFile(summaryPath, summaryMd);
+    await writeTaskSummaryProjection(
+      artifactBasePath,
+      params.milestoneId,
+      params.sliceId,
+      params.taskId,
+      summaryMd,
+    );
 
     // Toggle or regenerate the plan projection from DB. Missing projection
     // files are rebuilt by the renderer instead of being skipped.

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -29,7 +29,11 @@ import {
   setTaskEscalationPending,
   setTaskEscalationAwaitingReview,
 } from "../gsd-db.js";
-import { getWorkflowDatabasePath, ensureWorkflowDbAtPath } from "../db-workspace.js";
+import {
+  getWorkflowDatabasePath,
+  ensureWorkflowDbAtPath,
+  isWorkflowDatabaseOpen,
+} from "../db-workspace.js";
 import { closeTaskQualityGates } from "../quality-gate-closure.js";
 import {
   buildFlatTaskFileName,
@@ -47,7 +51,7 @@ import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, taskUnitKey } from "../unit-ownership.js";
 import { clearParseCache, normalizePlannedFileReference } from "../files.js";
 import { invalidateStateCache } from "../state.js";
-import { renderPlanCheckboxes, writeTaskSummaryProjection } from "../markdown-renderer.js";
+import { ProjectionWriteError, renderPlanCheckboxes, writeTaskSummaryProjection } from "../markdown-renderer.js";
 import {
   renderMilestoneShellProjections,
   renderSummaryContent,
@@ -149,10 +153,50 @@ export function resolveTaskSummaryPath(
   );
 }
 
+/**
+ * Persist a task-summary projection through the canonical projection seam,
+ * tolerating a workflow database handle that disappears across the summary
+ * write's await boundary.
+ *
+ * The seam records artifact lineage in the DB *after* the disk bytes land, so a
+ * handle lost mid-write surfaces as a `ProjectionWriteError` even though the
+ * database file is intact and reopenable. That is the same recoverable loss the
+ * plan-render step already reopens for; treating it as a stale projection would
+ * report a repairable handle loss as durable drift. Genuine persistence
+ * failures (a missing database file, or a failing insert against a live handle)
+ * still fail loud.
+ */
+async function persistTaskSummaryProjection(
+  artifactBasePath: string,
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+  summaryMd: string,
+  workflowDbPath: string | null,
+): Promise<void> {
+  try {
+    await writeTaskSummaryProjection(artifactBasePath, milestoneId, sliceId, taskId, summaryMd);
+    return;
+  } catch (err) {
+    const reopened =
+      err instanceof ProjectionWriteError &&
+      !isWorkflowDatabaseOpen() &&
+      ensureWorkflowDbAtPath(workflowDbPath);
+    if (!reopened) throw err;
+    logWarning(
+      "projection",
+      `complete_task reopened the workflow database to record task summary lineage for ${milestoneId}/${sliceId}/${taskId}`,
+    );
+  }
+
+  await writeTaskSummaryProjection(artifactBasePath, milestoneId, sliceId, taskId, summaryMd);
+}
+
 async function repairMissingTaskSummaryProjection(
   artifactBasePath: string,
   taskRow: TaskRow,
 ): Promise<{ summaryPath: string; stale: boolean }> {
+  const workflowDbPath = getWorkflowDatabasePath();
   const summaryPath = taskSummaryPath(
     artifactBasePath,
     taskRow.milestone_id,
@@ -172,12 +216,13 @@ async function repairMissingTaskSummaryProjection(
   let stale = false;
 
   try {
-    await writeTaskSummaryProjection(
+    await persistTaskSummaryProjection(
       artifactBasePath,
       taskRow.milestone_id,
       taskRow.slice_id,
       taskRow.id,
       summaryMd,
+      workflowDbPath,
     );
     await renderPlanCheckboxes(artifactBasePath, taskRow.milestone_id, taskRow.slice_id);
   } catch (renderErr) {
@@ -637,12 +682,13 @@ export async function handleCompleteTask(
   );
 
   try {
-    await writeTaskSummaryProjection(
+    await persistTaskSummaryProjection(
       artifactBasePath,
       params.milestoneId,
       params.sliceId,
       params.taskId,
       summaryMd,
+      workflowDbPath,
     );
 
     // Toggle or regenerate the plan projection from DB. Missing projection

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -40,6 +40,7 @@ import {
 import {
   type PlanningInvocation,
 } from "../planning-invocation.js";
+import { ensurePendingSliceQ8 } from "../db/writers/slice-companion-state.js";
 
 
 export interface PlanSliceTaskInput {
@@ -585,7 +586,7 @@ export async function handlePlanSlice(
             insertGateRow({ milestoneId: params.milestoneId, sliceId: params.sliceId, gateId: gid, scope: "task", taskId: task.taskId });
           }
         }
-        insertGateRow({ milestoneId: params.milestoneId, sliceId: params.sliceId, gateId: "Q8", scope: "slice" });
+        ensurePendingSliceQ8(context, params);
       },
     });
     operationStatus = receipt.status;

--- a/src/resources/extensions/gsd/tools/replan-slice.ts
+++ b/src/resources/extensions/gsd/tools/replan-slice.ts
@@ -29,6 +29,7 @@ import {
   planningOperationPayload,
 } from "../planning-domain-operation.js";
 import { readLatestTaskAttempt } from "../task-execution-domain-operation.js";
+import { ensurePendingSliceQ8 } from "../db/writers/slice-companion-state.js";
 
 export interface ReplanSliceTaskInput {
   taskId: string;
@@ -334,6 +335,7 @@ export async function handleReplanSlice(
             status: "skipped",
           });
         }
+        ensurePendingSliceQ8(context, params);
       },
     });
     operationStatus = receipt.status;

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -436,6 +436,7 @@ async function mirrorArtifactToActiveWorktreeProjection(
   basePath: string,
   relativePath: string,
   content: string,
+  required: boolean = false,
 ): Promise<void> {
   const contract = resolveGsdPathContract(basePath);
   if (!contract.worktreeGsd) return;
@@ -451,6 +452,7 @@ async function mirrorArtifactToActiveWorktreeProjection(
     logWarning("tool", `gsd_summary_save worktree projection mirror failed: ${(err as Error).message}`, {
       path: relativePath,
     });
+    if (required) throw err;
   }
 }
 
@@ -673,14 +675,15 @@ export async function executeSummarySave(
       }
     }
 
+    const isTaskSummary = params.artifact_type === "SUMMARY" && !!params.milestone_id && !!params.slice_id && !!params.task_id;
     let projectedContent = contentToSave;
-    if (params.artifact_type === "SUMMARY" && params.milestone_id && params.slice_id && params.task_id) {
+    if (isTaskSummary) {
       const contract = resolveGsdPathContract(basePath);
       const projection = await writeTaskSummaryProjection(
         contract.projectRoot,
-        params.milestone_id,
-        params.slice_id,
-        params.task_id,
+        params.milestone_id!,
+        params.slice_id!,
+        params.task_id!,
         contentToSave,
       );
       relativePath = projection.artifactPath;
@@ -698,7 +701,7 @@ export async function executeSummarySave(
         basePath,
       );
     }
-    await mirrorArtifactToActiveWorktreeProjection(basePath, relativePath, projectedContent);
+    await mirrorArtifactToActiveWorktreeProjection(basePath, relativePath, projectedContent, isTaskSummary);
 
     if (params.artifact_type === "CONTEXT" && !params.task_id) {
       try {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -89,7 +89,7 @@ import { flushWorkflowProjections } from "../projection-flush.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { parseProject } from "../schemas/parsers.js";
 import { autoSession, getAutoRuntimeSnapshot, isAutoActive } from "../auto-runtime-state.js";
-import { renderPlanFromDb } from "../markdown-renderer.js";
+import { renderPlanFromDb, writeTaskSummaryProjection } from "../markdown-renderer.js";
 import { readUnitHarnessAbort, type UnitHarnessAbortRecord } from "../unit-runtime.js";
 import {
   prepareUatRun,
@@ -673,18 +673,32 @@ export async function executeSummarySave(
       }
     }
 
-    await saveArtifactToDb(
-      {
-        path: relativePath,
-        artifact_type: params.artifact_type,
-        content: contentToSave,
-        milestone_id: isRootArtifact ? undefined : params.milestone_id,
-        slice_id: isRootArtifact ? undefined : params.slice_id,
-        task_id: isRootArtifact ? undefined : params.task_id,
-      },
-      basePath,
-    );
-    await mirrorArtifactToActiveWorktreeProjection(basePath, relativePath, contentToSave);
+    let projectedContent = contentToSave;
+    if (params.artifact_type === "SUMMARY" && params.milestone_id && params.slice_id && params.task_id) {
+      const contract = resolveGsdPathContract(basePath);
+      const projection = await writeTaskSummaryProjection(
+        contract.projectRoot,
+        params.milestone_id,
+        params.slice_id,
+        params.task_id,
+        contentToSave,
+      );
+      relativePath = projection.artifactPath;
+      projectedContent = projection.content;
+    } else {
+      await saveArtifactToDb(
+        {
+          path: relativePath,
+          artifact_type: params.artifact_type,
+          content: contentToSave,
+          milestone_id: isRootArtifact ? undefined : params.milestone_id,
+          slice_id: isRootArtifact ? undefined : params.slice_id,
+          task_id: isRootArtifact ? undefined : params.task_id,
+        },
+        basePath,
+      );
+    }
+    await mirrorArtifactToActiveWorktreeProjection(basePath, relativePath, projectedContent);
 
     if (params.artifact_type === "CONTEXT" && !params.task_id) {
       try {

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -324,7 +324,8 @@ ${taskRow.key_files && taskRow.key_files.length > 0 ? taskRow.key_files.map(f =>
 
 /**
  * Render SUMMARY.md projection to disk for a specific task.
- * Queries DB via helper functions, renders content, writes via atomicWriteSync.
+ * Queries DB via helper functions, renders content, and persists through the
+ * canonical task-summary projection seam.
  */
 export async function renderSummaryProjection(basePath: string, milestoneId: string, sliceId: string, taskId: string): Promise<boolean> {
   const taskRows = getSliceTasks(milestoneId, sliceId);

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -17,16 +17,16 @@ import type { MilestoneRow } from "./db-milestone-artifact-rows.js";
 import type { SliceRow, TaskRow } from "./db-task-slice-rows.js";
 import type { VerificationEvidenceRow } from "./db-verification-evidence-rows.js";
 import { atomicWriteSync } from "./atomic-write.js";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { mkdirSync, existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { logWarning } from "./workflow-logger.js";
 import { isClosedStatus } from "./status-guards.js";
 import { deriveState } from "./state.js";
 import type { GSDState } from "./types.js";
-import { renderPlanFromDb, renderRoadmapFromDb } from "./markdown-renderer.js";
+import { renderPlanFromDb, renderRoadmapFromDb, writeTaskSummaryProjection } from "./markdown-renderer.js";
 import { readManifest } from "./workflow-manifest.js";
-import { gsdRoot, resolveMilestoneFile, resolveSliceFile, resolveTaskFile, targetTaskFile } from "./paths.js";
+import { gsdRoot, resolveMilestoneFile, resolveSliceFile, resolveTaskFile } from "./paths.js";
 import { removeOwnedPlanProjection } from "./projection-cleanup.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
@@ -100,7 +100,7 @@ export function renderPlanContent(sliceRow: SliceRow, taskRows: TaskRow[]): stri
 
 /**
  * Render PLAN.md projection to disk for a specific slice.
- * Queries DB via helper functions, renders content, writes via atomicWriteSync.
+ * Queries DB via helper functions and persists through the canonical projection writer.
  */
 export function renderPlanProjection(basePath: string, milestoneId: string, sliceId: string): void {
   const sliceRows = getMilestoneSlices(milestoneId);
@@ -326,17 +326,16 @@ ${taskRow.key_files && taskRow.key_files.length > 0 ? taskRow.key_files.map(f =>
  * Render SUMMARY.md projection to disk for a specific task.
  * Queries DB via helper functions, renders content, writes via atomicWriteSync.
  */
-export function renderSummaryProjection(basePath: string, milestoneId: string, sliceId: string, taskId: string): void {
+export async function renderSummaryProjection(basePath: string, milestoneId: string, sliceId: string, taskId: string): Promise<boolean> {
   const taskRows = getSliceTasks(milestoneId, sliceId);
   const taskRow = taskRows.find(t => t.id === taskId);
-  if (!taskRow) return;
+  if (!taskRow) return false;
 
   const evidenceRows = getVerificationEvidence(milestoneId, sliceId, taskId);
   const content = renderSummaryContent(taskRow, sliceId, milestoneId, evidenceRows);
 
-  const summaryPath = targetTaskFile(basePath, milestoneId, sliceId, taskId, "SUMMARY", getMilestone(milestoneId)?.title);
-  mkdirSync(dirname(summaryPath), { recursive: true });
-  atomicWriteSync(summaryPath, content);
+  await writeTaskSummaryProjection(basePath, milestoneId, sliceId, taskId, content);
+  return true;
 }
 
 // ─── STATE.md Projection ────────────────────────────────────────────────
@@ -514,7 +513,7 @@ export async function renderAllProjections(
 
     for (const task of doneTasks) {
       try {
-        renderSummaryProjection(basePath, milestoneId, slice.id, task.id);
+        await renderSummaryProjection(basePath, milestoneId, slice.id, task.id);
       } catch (err) {
         stale = true;
         logWarning("projection", `renderSummaryProjection failed for ${milestoneId}/${slice.id}/${task.id}: ${(err as Error).message}`);
@@ -566,8 +565,9 @@ export async function regenerateIfMissing(
     for (const task of doneTasks) {
       if (!resolveTaskFile(basePath, milestoneId, sliceId, task.id, "SUMMARY")) {
         try {
-          renderSummaryProjection(basePath, milestoneId, sliceId, task.id);
-          regenerated++;
+          if (await renderSummaryProjection(basePath, milestoneId, sliceId, task.id)) {
+            regenerated++;
+          }
         } catch (err) {
           logWarning("projection", `regenerateIfMissing SUMMARY failed for ${task.id}: ${(err as Error).message}`);
         }

--- a/src/resources/extensions/gsd/worktree-git-recovery.ts
+++ b/src/resources/extensions/gsd/worktree-git-recovery.ts
@@ -38,6 +38,7 @@ import {
   nativeAddPaths,
   nativeCheckoutBranch,
   nativeConflictFiles,
+  nativeIsCurrentUnbornBranch,
   nativeLsFiles,
   nativeMergeAbort,
   nativeWorkingTreeStatus,
@@ -197,6 +198,8 @@ export function checkoutBranchWithStashGuard(
   branch: string,
   reason: string,
 ): void {
+  if (nativeIsCurrentUnbornBranch(basePath, branch)) return;
+
   let stashMarker: string | null = null;
   let stashed = false;
 

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -639,6 +639,13 @@ function validateMilestoneId(milestoneId: string): void {
 
 // ─── Implementation core ─────────────────────────────────────────────────
 
+/** Start an independent auto run without inheriting a prior run's failure. */
+export function prepareIsolationForNewRun(
+  s: Pick<AutoSession, "isolationDegraded">,
+): void {
+  s.isolationDegraded = false;
+}
+
 /**
  * Shared implementation of milestone entry. Called by both
  * `WorktreeLifecycle.enterMilestone` and the legacy
@@ -792,13 +799,18 @@ export function _enterMilestoneCore(
     getIsolationMode(basePath);
 
   if (s.isolationDegraded) {
-    if (mode === "worktree") {
+    if (mode === "worktree" || mode === "branch") {
       try {
         lifecycleEnterBranchMode(deps, basePath, milestoneId);
         s.basePath = basePath;
         rebuildGitService(s, deps);
         invalidateAllCaches();
-        ctx.notify(isolationDegradedFallbackGuidance(milestoneId), "warning");
+        if (mode === "branch") {
+          s.isolationDegraded = false;
+          ctx.notify(`Recovered branch isolation on milestone/${milestoneId}.`, "info");
+        } else {
+          ctx.notify(isolationDegradedFallbackGuidance(milestoneId), "warning");
+        }
         return { ok: true, mode: "branch", path: basePath };
       } catch (err) {
         debugLog("WorktreeLifecycle", {


### PR DESCRIPTION
## Intent

Harden the GSD release pipeline against the regression classes reported since the 1.12 and 1.14 releases. Make installed-binary auto-mode acceptance a blocking publish gate; centralize and fail loudly on task-summary projection persistence; register required schema completeness once for startup and doctor; recover branch/worktree isolation across runs including unborn repositories; make the slice Q8 companion gate a lifecycle-owned invariant; keep guided discussion writes layout-aware while treating known-identity legacy Markdown as archived projection rather than authority; and classify Windows projection-root sharing violations as transient through the existing retry budget. Preserve fail-closed behavior for unknown identities, genuine projection gaps, and sustained contention. The implementation is split into atomic commits with focused RED/GREEN/sabotage tests and a built-loader acceptance bed.

## What Changed

- Block npm publishing on installed-binary auto-mode acceptance and update release and projection-contract documentation.
- Centralize fail-loud task-summary persistence and schema registration, make Q8 companion state lifecycle-owned, and archive known legacy projections while rejecting unknown or ambiguous identities.
- Restore branch/worktree isolation across repeated and unborn-repository runs, surface projection failures, and retry Windows projection-root sharing violations through the existing recovery budget.

## Risk Assessment

✅ Low: The latest correction closes the remaining dirty-unborn re-entry path at the shared pre-stash boundary without weakening materialized, different, or detached branch checkout behavior, and no other material source risks remain.

## Testing

Preflight confirmed the requested clean target; focused tests covered release gating, loud summary persistence failures, startup/doctor schema repair, rerun and unborn Git isolation, Q8 restoration, migration authority and fail-closed identities, layout-aware discussion output, and Windows retry exhaustion. The exact checkout was built, packed, installed in the evidence directory, and completed a real headless milestone with persisted summaries, validation, commits, and 1/1-complete CLI status; sabotage proved the fixture assertion was sensitive, generated worktree artifacts were removed, and no UI screenshot was applicable to this CLI/storage change.

<details>
<summary>Evidence: Auto-mode acceptance verdict</summary>

`Installed target package completed auto mode: COMPLETED, exitCode 0, no blocker.`

```text
{
  "result": "COMPLETED",
  "firstBlock": null,
  "exitCode": 0,
  "runDir": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KZPJVGNEC90GC1Z64AHVX9Y7/acceptance/bed-run-1"
}
```
</details>
<details>
<summary>Evidence: Installed binary status</summary>

`Phase: complete; milestones 1/1; M001 complete.`

```text
[headless] signal-handlers-ready
[phase]   zz-notifications
[phase]   gsd-fast
[headless] Running /gsd status...
[phase]   ollama
[phase]   zz-notifications
[gsd]     GSD Status

● Progressing well

Phase: complete
Progress: milestones 1/1
Next: All milestones complete.

Milestones:
  ✓ M001: Acceptance Bed Fixture (complete)

Environment:
  ✗ node_modules missing — run npm install
  ⚠ Port 5173 is already in use by node (PID 96841)
[headless] Status: complete
[headless] Duration: 29.5s
[headless] Events: 14 total, 0 tool calls
```
</details>
<details>
<summary>Evidence: Auto-mode notifications</summary>

`Auto-mode stopped — Milestone M001 complete.`

```text
Auto-mode started. Will loop until milestone complete.
Dynamic routing: enabled — simple tasks may use cheaper models (ceiling: gsd-fake/gsd-fake-model)
Thinking level 'medium' not supported by gsd-fake/gsd-fake-model; using 'off'.
    [34m╭─[0m [32m[1m✓ Verification Gate[0m
       [36m1/1 checks passed[0m
    [34m╰────────────────────────────────────────[0m
    [34m╭─[0m [32m[1m✓ Commit[0m
       [36mfeat: Updated answer() to return ready.[0m
    [34m╰────────────────────────────────────────[0m
[session] Lock heartbeat caught up after 10s — long LLM call, no action needed.
Auto-mode stopped — Milestone M001 complete.
```
</details>
<details>
<summary>Evidence: Persisted task summary</summary>

`Generated task summary contains persisted verification evidence and a state-version marker.`

```text
---
id: T01
parent: S01
milestone: M001
key_files:
  - src/answer.js
key_decisions:
  - Keep the fixture to one source file so the workflow signal is isolated.
duration: 
verification_result: passed
completed_at: 
blocker_discovered: false
---

# T01: Updated answer() to return ready.

**Updated answer() to return ready.**

## What Happened

Changed the answer module and verified the behavior with the planned command.

## Verification

`node --test test/answer.test.js` exited 0.

## Verification Evidence

| # | Command | Exit Code | Verdict | Duration |
|---|---------|-----------|---------|----------|
| 1 | `node --test test/answer.test.js` | 0 | pass | 100ms |

## Deviations

None.

## Known Issues

None.

## Files Created/Modified

- `src/answer.js`
<!-- gsd:state-version=8:0 -->
```
</details>
<details>
<summary>Evidence: Persisted milestone validation</summary>

`Generated milestone validation records verdict: pass and requirement/contract evidence.`

```text
---
verdict: pass
remediation_round: 0
---

# Milestone Validation: M001

## Success Criteria Checklist
- PASS: answer() returns ready. Evidence: S01 summary and task verification.

## Slice Delivery Audit
| Slice | Status | Evidence |
| --- | --- | --- |
| S01 | PASS | S01 summary and task summary are present. |

## Cross-Slice Integration
Single-slice milestone; no cross-slice boundary exists.

## Requirement Coverage
R001 is covered by S01/T01 and verified by `node --test test/answer.test.js`.

## Verification Class Compliance
| Class | Planned Check | Evidence | Verdict |
| --- | --- | --- | --- |
| Contract | Local command exits 0. | `node --test test/answer.test.js` exited 0 in T01. | PASS |


## Verdict Rationale
All planned source, task, slice, requirement, and contract evidence passed.
```
</details>
<details>
<summary>Evidence: Windows retry-budget behavior</summary>

`Windows sharing violation retries within the existing budget and aborts when exhausted.`

```text
{
  "classification": {
    "failureKind": "projection-lock-transient",
    "action": "retry",
    "reason": "Projection root busy for execute-task T01: projection root operation failed: C:\\\\repo\\\\.gsd\\\\worktrees\\\\M001: sharing violation (os error 32)",
    "exitReason": "projection-lock-transient",
    "remediation": "Another Windows process temporarily holds the projection root. Retry through the existing transient budget; if contention persists, use `/gsd doctor` to inspect stale workers and orphaned worktrees."
  },
  "beforeExhaustion": {
    "owner": "agent",
    "action": "retry",
    "budget": {
      "policyClass": "transient-execution",
      "maxUses": 2
    },
    "policyVersion": "task-recovery-v1"
  },
  "atExhaustion": {
    "owner": "agent",
    "action": "abort",
    "budget": null,
    "policyVersion": "task-recovery-v1"
  }
}
```
</details>
<details>
<summary>Evidence: Acceptance sensitivity proof</summary>

`Changing the delivered answer from ready to pending produced the intended assertion failure; restoration passed.`

```text
✖ answer returns ready (2.118083ms)
ℹ tests 1
ℹ suites 0
ℹ pass 0
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 117.554042

✖ failing tests:

test at ../../../../../../private/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KZPJVGNEC90GC1Z64AHVX9Y7/acceptance/bed-run-1/project/test/answer.test.js:5:1
✖ answer returns ready (2.118083ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  'pending' !== 'ready'
  
      at TestContext.<anonymous> (file:///private/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01KZPJVGNEC90GC1Z64AHVX9Y7/acceptance/bed-run-1/project/test/answer.test.js:6:9)
      at Test.runInAsyncScope (node:async_hooks:226:14)
      at Test.run (node:internal/test_runner/test:1201:25)
      at Test.start (node:internal/test_runner/test:1096:17)
      at startSubtestAfterBootstrap (node:internal/test_runner/harness:385:17) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: 'pending',
    expected: 'ready',
    operator: 'strictEqual',
    diff: 'simple'
  }
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (5) ✅</summary>

- 🚨 `.github/workflows/npm-publish.yml:265` - Contradicts “Make installed-binary auto-mode acceptance a blocking publish gate.” This job never builds the checkout, but the acceptance bed imports untracked checkout-local `dist/resources/extensions/gsd/{verification-source-integrity,gitignore}.js`; a fresh runner therefore fails with module-not-found before exercising the installed binary. Build those helpers first or resolve them from the installed package.
- 🚨 `src/resources/extensions/gsd/flat-phase-migration.ts:408` - Contradicts “Preserve fail-closed behavior for unknown identities.” The remaining check derives slice/task identities only from ROADMAP/PLAN contents, so `M001/slices/S99/S99-CONTEXT.md` or a content-bearing directory with an unparseable milestone name is not detected; migration then removes it. Walk the legacy tree structurally at this pre-mutation boundary and reject every identity absent from the DB.
- 🚨 `src/resources/extensions/gsd/flat-phase-migration.ts:408` - Contradicts “treating known-identity legacy Markdown as archived projection rather than authority.” When a prior `migrate-*` backup exists, newly resurrected known-identity Markdown is allowed through this guard but the old backup is reused; the current legacy tree is later deleted without being added to that archive. Snapshot or merge the current tree into an archival location before removal.
- 🚨 `src/resources/extensions/gsd/tests/guided-flow.test.ts:27` - This new test reads `guided-flow.ts` and regex-checks its implementation, violating CONTRIBUTING.md’s explicit prohibition on source-grep tests. Remove it; the behavioral prompt assertion in `prompt-budget-enforcement.test.ts` already exercises the layout-aware result.
- 🚨 `src/resources/extensions/gsd/tests/markdown-renderer.test.ts:883` - The new test uses inline `try/finally` cleanup despite CONTRIBUTING.md requiring `t.after()` or lifecycle hooks. The same newly introduced pattern appears in `prompt-budget-enforcement.test.ts:812`, `reopen-task.test.ts:128`, and `replan-slice-domain-replay.test.ts:207`; convert all four additions to registered cleanup.

🔧 Fix: Fix migration preservation and release acceptance setup
3 errors still open:
- 🚨 `src/resources/extensions/gsd/markdown-renderer.ts:908` - Contradicts “centralize and fail loudly on task-summary projection persistence.” The new canonical helper is still bypassed by `gsd_summary_save`, which accepts task-scoped `SUMMARY` artifacts, routes them through `saveArtifactToDbByScope`, suppresses disk-write failures, and then reports “Saved …”. Route this path through the canonical seam or a shared lower boundary.
- 🚨 `src/resources/extensions/gsd/flat-phase-migration.ts:143` - Contradicts “treating known-identity legacy Markdown as archived projection rather than authority.” This exact membership check rejects supported aliases: a legacy `M001/` tree is classified as unknown when its canonical DB row is `M001-abc123` or numeric `1`. Apply the existing unambiguous bare-to-suffixed/numeric identity alignment before structural checks, while continuing to fail closed on ambiguous aliases.
- 🚨 `src/resources/extensions/gsd/auto-worktree-branch-lifecycle.ts:61` - Contradicts “recover branch/worktree isolation across runs including unborn repositories.” With native Git enabled, the first run can switch symbolic HEAD to unborn `milestone/M001`, but native branch detection checks only materialized refs. A later zero-commit run therefore treats the current branch as absent and repeats `git checkout -b milestone/M001`, which fails. Make native branch detection recognize symbolic unborn HEAD like the CLI fallback.

🔧 Fix: Fix summary persistence, migration aliases, and unborn reruns
3 errors still open:
- 🚨 `src/resources/extensions/gsd/native-git-bridge.ts:271` - Contradicts “recover branch/worktree isolation across runs including unborn repositories.” This evaluates native `gitCurrentBranch` before `branchExistsIncludingUnborn`; its Rust implementation calls `repo.head()`, which errors for unborn HEAD, so the helper never receives the symbolic branch name. Resolve native current branch from symbolic `HEAD` without requiring a commit, or catch and use the CLI symbolic-ref fallback.
- 🚨 `src/resources/extensions/gsd/flat-phase-migration.ts:130` - Contradicts “treating known-identity legacy Markdown as archived projection rather than authority.” The alias fix converts `M001` only to numeric `1`, while the existing supported rule pads digit IDs and therefore also recognizes DB ID `001`. That known tree remains rejected, while DB IDs `1` and `001` together are incorrectly treated as unambiguous. Collect every numeric DB ID whose padded form matches the legacy ID and require exactly one candidate.
- 🚨 `src/resources/extensions/gsd/tools/workflow-tool-executors.ts:701` - Contradicts “centralize and fail loudly on task-summary projection persistence.” In a GSD worktree, the canonical project write can succeed while the required worktree mirror fails; `mirrorArtifactToActiveWorktreeProjection` suppresses that failure and this path still returns “Saved,” although worktree-local readers resolve to the missing mirror. Propagate task-summary mirror failures or include mirroring inside the canonical fail-loud seam.

🔧 Fix: Harden unborn lookup, migration aliases, and summary mirrors
1 error still open:
- 🚨 `src/resources/extensions/gsd/native-git-bridge.ts:271` - Contradicts “recover branch/worktree isolation across runs including unborn repositories.” This now recognizes symbolic unborn HEAD as an existing branch, but `enterBranchModeForMilestone` then calls the normal checkout path; native `git_checkout_branch` resolves `refs/heads/&lt;branch&gt;`, which does not exist before the first commit. A second zero-commit run still fails. Treat checkout of the already-current symbolic unborn branch as a no-op at the shared checkout boundary.

🔧 Fix: Make unborn branch re-entry checkout a no-op
1 error still open:
- 🚨 `src/resources/extensions/gsd/native-git-bridge.ts:1053` - Contradicts “recover branch/worktree isolation across runs including unborn repositories.” On a second zero-commit run with any dirty or untracked file, `checkoutBranchWithStashGuard` executes `git stash push --include-untracked` before reaching this new no-op; Git cannot create a stash without an initial commit, so re-entry still fails. Detect the already-current unborn branch at the shared stash-guard boundary before inspecting or stashing changes.

🔧 Fix: Preserve dirty unborn work during branch re-entry
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Preflight: `git status --short --branch`, target/base diff inventory, branch containment, and `git rev-parse HEAD`.</code>
- <code>Release gate: `node --test --test-name-pattern=&#39;prerelease verification blocks release planning on the auto-mode acceptance bed&#39; scripts/__tests__/npm-publish-workflow.test.mjs`.</code>
- <code>Focused GSD behaviors: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern=&#39;task summary|every open surface repairs|same-process doctor fix|fresh bootstrap clears|zero-commit repository|dirty current unborn|restores.*Q8|archives resurrected|unknown identities|structurally unknown|unparseable milestone|ambiguous.*alias|flat-phase context target|Windows sharing violations|other projection-root|Recovery Classification covers|agent transient recovery is bounded|artifact failure is observable&#39;` against the relevant changed test files.</code>
- <code>Native predicate: initial over-qualified `cargo test … -- --exact` matched zero tests; corrected with `cargo test -p gsd-engine windows_sharing_violation_is_the_only_transient_projection_error --lib`.</code>
- <code>Exact-checkout packaging: `pnpm run build:core`, `npm pack --ignore-scripts --pack-destination …/package`, and isolated `npm install --global --prefix …/install --ignore-scripts …/opengsd-gsd-pi-1.14.0.tgz`.</code>
- <code>Installed package check: `node …/install/bin/gsd --version`.</code>
- <code>End-to-end acceptance: `GSD_SMOKE_BINARY=…/install/bin/gsd BED_SCRATCH_ROOT=…/acceptance node tests/acceptance-bed/auto-milestone-bed.mjs`.</code>
- <code>End-user status: `GSD_NON_INTERACTIVE=1 HOME=…/bed-home node …/install/bin/gsd headless status`.</code>
- <code>Delivered fixture behavior: `node --test …/project/test/answer.test.js`.</code>
- <code>Sensitivity check: temporarily changed the evidence fixture’s `answer()` result to `pending`, confirmed its behavioral test failed, restored `ready`, reran successfully, and confirmed the fixture repository was clean.</code>
- <code>Retry exhaustion check: invoked `classifyFailure` and `selectRecoveryDecision` for Windows sharing violation error 32 before and at budget exhaustion.</code>
- <code>Cleanup: dry-ran and then removed only generated ignored build directories with targeted `git clean -fdX -- …`; final `git status --short --branch` remained clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->