### PR TITLE
fix(issue): [Bug]: slow startup when cursor-agent executable is on path without subscription

### DIFF
--- a/src/resources/extensions/cursor-cli/readiness.ts
+++ b/src/resources/extensions/cursor-cli/readiness.ts
@@ -85,15 +85,12 @@ function hasCursorApiKey(): boolean {
 function probeAuth(command: string): boolean | null {
 	if (hasCursorApiKey()) return true;
 
-	for (const args of [["agent", "status", "--json"], ["status", "--json"], ["agent", "status"], ["status"]]) {
-		try {
-			const out = spawnCursorAgent(command, args, STATUS_TIMEOUT_MS).toString();
-			debugLog("status output", args.join(" "), out.slice(0, 200));
-			const parsed = parseCursorAgentStatus(out);
-			if (parsed !== null) return parsed;
-		} catch (error) {
-			debugLog("status failed", args.join(" "), (error as Error).message?.slice(0, 200));
-		}
+	try {
+		const out = spawnCursorAgent(command, ["status"], STATUS_TIMEOUT_MS).toString();
+		debugLog("status output", out.slice(0, 200));
+		return parseCursorAgentStatus(out);
+	} catch (error) {
+		debugLog("status failed", (error as Error).message?.slice(0, 200));
 	}
 
 	return null;

--- a/src/resources/extensions/cursor-cli/tests/readiness.test.ts
+++ b/src/resources/extensions/cursor-cli/tests/readiness.test.ts
@@ -1,6 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildCursorAgentSpawnInvocation, getCursorAgentCommandCandidates, isCursorAgentApiKeyValue, parseCursorAgentStatus } from "../readiness.ts";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	buildCursorAgentSpawnInvocation,
+	getCursorAgentCommandCandidates,
+	isCursorAgentApiKeyValue,
+	isCursorAgentReadyUncached,
+	parseCursorAgentStatus,
+} from "../readiness.ts";
 
 test("getCursorAgentCommandCandidates includes Windows shims", () => {
 	assert.deepEqual(getCursorAgentCommandCandidates("win32"), ["cursor-agent.cmd", "cursor-agent.exe", "cursor-agent"]);
@@ -26,4 +35,48 @@ test("isCursorAgentApiKeyValue rejects external CLI sentinel values", () => {
 	assert.equal(isCursorAgentApiKeyValue("cursor-token"), true);
 	assert.equal(isCursorAgentApiKeyValue("cli"), false);
 	assert.equal(isCursorAgentApiKeyValue("  "), false);
+});
+
+test("readiness checks only the supported status command", () => {
+	const fixtureDir = mkdtempSync(join(tmpdir(), "cursor-readiness-"));
+	const logPath = join(fixtureDir, "invocations.log");
+	const commandPath = join(fixtureDir, process.platform === "win32" ? "cursor-agent.cmd" : "cursor-agent");
+	const originalPath = process.env.PATH;
+	const originalApiKey = process.env.CURSOR_API_KEY;
+	const originalLogPath = process.env.CURSOR_AGENT_TEST_LOG;
+
+	if (process.platform === "win32") {
+		writeFileSync(commandPath, [
+			"@echo off",
+			"echo %*>>\"%CURSOR_AGENT_TEST_LOG%\"",
+			"if \"%1\"==\"--version\" (echo 1.0.0 & exit /b 0)",
+			"if \"%1\"==\"status\" (echo Not authenticated & exit /b 0)",
+			"exit /b 1",
+		].join("\r\n"));
+	} else {
+		writeFileSync(commandPath, [
+			"#!/bin/sh",
+			"printf '%s\\n' \"$*\" >> \"$CURSOR_AGENT_TEST_LOG\"",
+			"[ \"$1\" = \"--version\" ] && { echo 1.0.0; exit 0; }",
+			"[ \"$1\" = \"status\" ] && { echo 'Not authenticated'; exit 0; }",
+			"exit 1",
+		].join("\n"), { mode: 0o755 });
+	}
+
+	try {
+		process.env.PATH = `${fixtureDir}${process.platform === "win32" ? ";" : ":"}${originalPath ?? ""}`;
+		process.env.CURSOR_AGENT_TEST_LOG = logPath;
+		delete process.env.CURSOR_API_KEY;
+
+		assert.equal(isCursorAgentReadyUncached(), false);
+		assert.deepEqual(readFileSync(logPath, "utf8").trim().split(/\r?\n/), ["--version", "status"]);
+	} finally {
+		if (originalPath === undefined) delete process.env.PATH;
+		else process.env.PATH = originalPath;
+		if (originalApiKey === undefined) delete process.env.CURSOR_API_KEY;
+		else process.env.CURSOR_API_KEY = originalApiKey;
+		if (originalLogPath === undefined) delete process.env.CURSOR_AGENT_TEST_LOG;
+		else process.env.CURSOR_AGENT_TEST_LOG = originalLogPath;
+		rmSync(fixtureDir, { recursive: true, force: true });
+	}
 });


### PR DESCRIPTION
## Summary
- Fixed slow Cursor startup probing and verified the focused regression suite passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1712
- [#1712 [Bug]: slow startup when cursor-agent executable is on path without subscription](https://github.com/open-gsd/gsd-pi/issues/1712)

## User
- @erkieh

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1712-bug-slow-startup-when-cursor-agent-execu-1786546561`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->