### PR TITLE
fix(gsd): stop live derive from treating markdown as state authority

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -12,7 +12,7 @@ import { ALWAYS_PRESERVED_SHIM_TOOL_NAMES } from "@gsd/pi-ai";
 import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-extension-api.js";
 import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
 
-import { buildMilestoneFileName, canonicalPhaseDirName, clearPathCache, milestonesDir, legacyMilestonesDir, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
+import { buildMilestoneFileName, canonicalPhaseDirName, clearPathCache, milestonesDir, legacyMilestonesDir, relMilestoneFile, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
 import { applyAskUserQuestionsGateResult, clearDiscussionFlowState, currentWriteGateSnapshot, formatPendingAskUserQuestionsGateMessage, formatTimedOutAskUserQuestionsGateMessage, hostWriteGateAdapter, isApprovalGateVerifiedInSnapshot, isDepthConfirmationAnswer, isMilestoneDepthVerifiedInSnapshot, isQueuePhaseActive, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeBash, shouldBlockWorktreeWrite, isGateQuestionId, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId, type WriteGateSnapshot } from "./write-gate.js";
 import { canonicalToolName } from "../engine-hook-contract.js";
 import { resolveManifest } from "../unit-context-manifest.js";
@@ -953,10 +953,25 @@ async function saveDiscussionQuestionRound(
       "Use it so `/gsd` can resume the in-flight milestone discussion.",
       "",
     ].join("\n");
-  await saveFile(
-    draftPath,
-    `${draftHeader.trimEnd()}\n\n## Captured Question Round — ${timestamp}\n\n${exchange}`,
-  );
+  const draftContent = `${draftHeader.trimEnd()}\n\n## Captured Question Round — ${timestamp}\n\n${exchange}`;
+  await saveFile(draftPath, draftContent);
+
+  try {
+    const { ensureDbOpen } = await import("./dynamic-tools.js");
+    if (await ensureDbOpen(basePath)) {
+      const { insertArtifact } = await import("../gsd-db.js");
+      insertArtifact({
+        path: relMilestoneFile(basePath, milestoneId, "CONTEXT-DRAFT").replace(/^\.gsd\//, ""),
+        artifact_type: "CONTEXT-DRAFT",
+        milestone_id: milestoneId,
+        slice_id: null,
+        task_id: null,
+        full_content: draftContent,
+      });
+    }
+  } catch (err) {
+    safetyLogWarning("guided", `failed to persist CONTEXT-DRAFT artifact for ${milestoneId}: ${(err as Error).message}`);
+  }
 }
 
 function withDepthGateDisplayReason<T extends { block: boolean; reason?: string }>(

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -88,6 +88,7 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
 
   // Standard-tier models
   "claude-sonnet-4-6": "standard",
+  "claude-sonnet-5": "standard",           // GA on GitHub Copilot, Anthropic, Vertex, Bedrock
   "claude-sonnet-4-5-20250514": "standard",
   "claude-3-5-sonnet-latest": "standard",
   "gpt-4o": "standard",
@@ -129,6 +130,7 @@ const MODEL_COST_PER_1K_INPUT: Record<string, number> = {
   "claude-haiku-4-5": 0.0008,
   "claude-3-5-haiku-latest": 0.0008,
   "claude-sonnet-4-6": 0.003,
+  "claude-sonnet-5": 0.003,                // $3.00/M input; matches Sonnet 4.x pricing
   "claude-sonnet-4-5-20250514": 0.003,
   "claude-opus-4-6": 0.005,
   "claude-opus-4-7": 0.005,
@@ -175,6 +177,7 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   "claude-opus-4-8":              { coding: 97, debugging: 92, research: 87, reasoning: 97, speed: 30, longContext: 85, instruction: 92 },
   "claude-fable-5":               { coding: 97, debugging: 92, research: 87, reasoning: 97, speed: 30, longContext: 85, instruction: 92 },
   "claude-sonnet-4-6":            { coding: 85, debugging: 80, research: 75, reasoning: 80, speed: 60, longContext: 75, instruction: 85 },
+  "claude-sonnet-5":              { coding: 90, debugging: 85, research: 80, reasoning: 87, speed: 55, longContext: 80, instruction: 88 },
   "claude-sonnet-4-5-20250514":   { coding: 85, debugging: 80, research: 75, reasoning: 80, speed: 60, longContext: 75, instruction: 85 },
   "claude-3-5-sonnet-latest":     { coding: 82, debugging: 78, research: 72, reasoning: 78, speed: 62, longContext: 70, instruction: 82 },
   "claude-haiku-4-5":             { coding: 60, debugging: 50, research: 45, reasoning: 50, speed: 95, longContext: 50, instruction: 75 },

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -256,9 +256,12 @@ export async function getActiveMilestoneId(basePath: string): Promise<string | n
       }
       return null;
     }
+    return null;
   }
 
-  // Filesystem fallback for unmigrated projects or empty DB
+  // Filesystem fallback for unmigrated projects when no workflow DB is open.
+  // An open DB with zero milestone rows is authoritative emptiness — do not
+  // parse markdown as a substitute (T007 live-path cutover).
   const milestoneIds = findMilestoneIds(basePath);
   for (const mid of milestoneIds) {
     const parkedFile = resolveMilestoneFile(basePath, mid, "PARKED");

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -8,18 +8,16 @@
 // resolveMilestoneValidationVerdict) is pinned by D005 and unchanged.
 
 import type { ActiveRef, GSDState, MilestoneRegistryEntry, Phase } from '../../types.js';
-import { join } from 'node:path';
-import { existsSync, readFileSync } from 'node:fs';
 import { isClosedStatus, isDeferredStatus } from '../../status-guards.js';
-import {
-  buildMilestoneFileName,
-  resolveFile,
-  resolveGsdRootFile,
-  resolveMilestonePath,
-} from '../../paths.js';
 import { parseProject } from '../../schemas/parsers.js';
 import {
+  queryDecisions,
+  queryDecisionsFromMemories,
+} from '../../context-store.js';
+import {
   getAllMilestones,
+  getArtifact,
+  getMilestoneScopedArtifacts,
   getPendingGateCountForTurn,
   getReplanHistory,
   getRequirementCounts,
@@ -89,7 +87,7 @@ function buildDerivedState(
     activeSlice: context.activeSlice ?? null,
     activeTask: context.activeTask ?? null,
     phase,
-    recentDecisions: [],
+    recentDecisions: loadRecentDecisionsFromDb(),
     blockers: options.blockers ?? [],
     nextAction,
     ...(options.lastCompletedMilestone !== undefined
@@ -127,30 +125,28 @@ function buildCompletenessSet(basePath: string, milestones: MilestoneRow[]) {
   return { completeMilestoneIds, parkedMilestoneIds };
 }
 
-function milestoneArtifactExistsInResolvedDir(
-  milestoneDir: string | null,
-  milestoneId: string,
-  suffix: string,
-): boolean {
-  if (!milestoneDir) return false;
-  const flatPath = join(milestoneDir, buildMilestoneFileName(milestoneId, suffix));
-  return existsSync(flatPath) || resolveFile(milestoneDir, milestoneId, suffix) !== null;
+function loadRecentDecisionsFromDb(): string[] {
+  const fromMemories = queryDecisionsFromMemories();
+  const rows = fromMemories.length > 0 ? fromMemories : queryDecisions();
+  return rows.slice(-5).map(
+    (d) => `${d.id} (${d.when_context}): ${d.decision} -> ${d.choice}`,
+  );
 }
 
 // The IDs the user actually committed to as their roadmap, read from the
-// PROJECT.md "Milestone Sequence". A content-less queued milestone that appears
-// here is a real, not-yet-planned roadmap stage (e.g. the first milestone right
-// after deep-project setup) and is safe to promote to active. A content-less
-// queued row that is NOT listed here is a phantom left by
-// gsd_milestone_generate_id that was never made part of the roadmap (#1524) and
-// must not be promoted. Returns an empty set when PROJECT.md is absent or
-// unparsable, which keeps phantom-only repos out of the promotion path.
-function loadProjectSequenceIds(basePath: string): Set<string> {
-  const projectPath = resolveGsdRootFile(basePath, 'PROJECT');
-  if (!existsSync(projectPath)) return new Set<string>();
+// PROJECT.md artifact stored in the DB. A content-less queued milestone that
+// appears here is a real, not-yet-planned roadmap stage (e.g. the first
+// milestone right after deep-project setup) and is safe to promote to active.
+// A content-less queued row that is NOT listed here is a phantom left by
+// gsd_milestone_generate_id that was never made part of the roadmap (#1524)
+// and must not be promoted. Returns an empty set when the PROJECT artifact is
+// absent or unparsable, which keeps phantom-only repos out of the promotion
+// path. Disk PROJECT.md is a projection and is never opened here.
+function loadProjectSequenceIds(): Set<string> {
+  const project = getArtifact("PROJECT.md");
+  if (!project?.full_content) return new Set<string>();
   try {
-    const parsed = parseProject(readFileSync(projectPath, 'utf-8'));
-    return new Set(parsed.milestones.map((m) => m.id));
+    return new Set(parseProject(project.full_content).milestones.map((m) => m.id));
   } catch (e) {
     logWarning('state', `failed to parse PROJECT.md milestone sequence: ${(e as Error).message}`);
     return new Set<string>();
@@ -158,7 +154,6 @@ function loadProjectSequenceIds(basePath: string): Set<string> {
 }
 
 async function buildRegistryAndFindActive(
-  basePath: string,
   milestones: MilestoneRow[],
   completeMilestoneIds: Set<string>,
   parkedMilestoneIds: Set<string>
@@ -170,7 +165,7 @@ async function buildRegistryAndFindActive(
   let activeMilestoneHasDraft = false;
   let firstPromotableQueuedShell: { id: string; title: string; deps: string[]; hasDraftContext: boolean } | null = null;
 
-  const projectSequenceIds = loadProjectSequenceIds(basePath);
+  const projectSequenceIds = loadProjectSequenceIds();
 
   const activeMilestoneIds = milestones
     .filter((m) => !parkedMilestoneIds.has(m.id))
@@ -197,9 +192,9 @@ async function buildRegistryAndFindActive(
     const allSlicesDone = slices.length > 0 && slices.every(s => isStatusDone(s.status));
 
     const title = stripMilestonePrefix(m.title) || m.id;
-    const milestoneDir = resolveMilestonePath(basePath, m.id);
-    const hasContext = milestoneArtifactExistsInResolvedDir(milestoneDir, m.id, "CONTEXT");
-    const hasDraftContext = !hasContext && milestoneArtifactExistsInResolvedDir(milestoneDir, m.id, "CONTEXT-DRAFT");
+    const artifacts = getMilestoneScopedArtifacts(m.id);
+    const hasContext = artifacts.some((a) => a.artifact_type === "CONTEXT");
+    const hasDraftContext = !hasContext && artifacts.some((a) => a.artifact_type === "CONTEXT-DRAFT");
     const readiness = classifyMilestoneReadiness({
       status: m.status,
       hasContext,
@@ -219,7 +214,7 @@ async function buildRegistryAndFindActive(
       if (readiness.kind === 'queued-shell') {
         // Only a *promotable* queued-shell may become active in the fallback
         // below: one that carries draft context (discuss-milestone was started)
-        // or is listed in the PROJECT.md roadmap sequence (a real, not-yet-
+        // or is listed in the PROJECT artifact roadmap sequence (a real, not-yet-
         // planned stage). A content-less shell that is neither is a phantom left
         // by gsd_milestone_generate_id that was never planned; promoting it
         // strands the user on an empty milestone (#1524), so we record it only
@@ -255,7 +250,7 @@ async function buildRegistryAndFindActive(
 
   // Promote the first promotable queued-shell as a fallback when no other
   // milestone became active. "Promotable" (tracked above) means it either
-  // carries draft context or is part of the PROJECT.md roadmap sequence.
+  // carries draft context or is part of the PROJECT artifact roadmap sequence.
   // Content-less phantom rows never reach here, so state falls through to
   // handleNoActiveMilestone and the doctor can flag them as orphans (#1524).
   // A draft-bearing shell resumes discussion (needs-discussion); an in-sequence
@@ -439,7 +434,7 @@ function checkReplanTrigger(basePath: string, milestoneId: string, sliceId: stri
 
 export async function deriveStateFromDb(
   basePath: string,
-  artifactReadRoot: string = basePath,
+  _artifactReadRoot: string = basePath,
 ): Promise<GSDState> {
   if (!ensureExistingWorkflowDbOpen(basePath)) {
     return buildDbUnavailableState();
@@ -469,7 +464,7 @@ export async function deriveStateFromDb(
 
   const { completeMilestoneIds, parkedMilestoneIds } = buildCompletenessSet(basePath, milestones);
   
-  const registryContext = await buildRegistryAndFindActive(basePath, milestones, completeMilestoneIds, parkedMilestoneIds);
+  const registryContext = await buildRegistryAndFindActive(milestones, completeMilestoneIds, parkedMilestoneIds);
   const { registry, activeMilestone, activeMilestoneSlices, activeMilestoneHasDraft } = registryContext;
   
   const milestoneProgress = {

--- a/src/resources/extensions/gsd/state/derive/index.ts
+++ b/src/resources/extensions/gsd/state/derive/index.ts
@@ -2,8 +2,6 @@
 // File Purpose: deriveState orchestrator — cache, DB open, pure DB projection.
 
 import type { GSDState } from '../../types.js';
-import { loadFile } from '../../files.js';
-import { resolveGsdRootFile } from '../../paths.js';
 import { isDbAvailable } from '../../gsd-db.js';
 import { wasWorkflowDatabaseOpenAttempted } from '../../db-workspace.js';
 import { debugCount, debugTime } from '../../debug-logger.js';
@@ -33,43 +31,6 @@ export {
   resetDeriveTelemetry,
 };
 
-async function loadRecentDecisions(basePath: string): Promise<string[]> {
-  const decisionsPath = resolveGsdRootFile(basePath, "DECISIONS");
-  const content = await loadFile(decisionsPath);
-  if (!content) return [];
-
-  const fromTable = content
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith("|"))
-    .map((line) => {
-      const cells = line
-        .split("|")
-        .map((cell) => cell.trim())
-        .filter((cell) => cell.length > 0);
-      if (cells.length < 6) return null;
-      const id = cells[0];
-      if (!/^D\d+$/i.test(id)) return null;
-      const whenContext = cells[1];
-      const decision = cells[3];
-      const choice = cells[4];
-      if (!decision || !choice) return null;
-      return `${id} (${whenContext}): ${decision} -> ${choice}`;
-    })
-    .filter((value): value is string => value != null);
-
-  if (fromTable.length > 0) return fromTable.slice(-5);
-
-  const fromBullets = content
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => /^-\s+/.test(line))
-    .map((line) => line.replace(/^-+\s+/, ""))
-    .filter((line) => /^D\d+\b/i.test(line));
-
-  return fromBullets.slice(-5);
-}
-
 export async function deriveState(
   basePath: string,
   opts?: DeriveStateOptions,
@@ -96,7 +57,6 @@ export async function deriveState(
     result = buildDbUnavailableState();
   }
 
-  result.recentDecisions = await loadRecentDecisions(cacheKey);
   stopTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
   debugCount("deriveStateCalls");
   writeCachedDeriveState(cacheKey, result);

--- a/src/resources/extensions/gsd/tests/db-authority-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/db-authority-regression.test.ts
@@ -19,7 +19,7 @@ import {
 import { migrateHierarchyToDb } from "../md-importer.ts";
 import { checkMarkdownHierarchyAgainstDb, countMarkdownHierarchy } from "../migration-auto-check.ts";
 import { queryDecisions } from "../context-store.ts";
-import { deriveStateFromDb, invalidateStateCache } from "../state.ts";
+import { deriveState, deriveStateFromDb, invalidateStateCache } from "../state.ts";
 import type { Requirement } from "../types.ts";
 
 function makeBase(prefix = "gsd-db-authority-"): string {
@@ -121,7 +121,7 @@ test("DB authority: REQUIREMENTS.md and DECISIONS.md projections do not populate
   insertMilestone({ id: "M999", title: "DB Milestone", status: "active" });
 
   invalidateStateCache();
-  const state = await deriveStateFromDb(base);
+  const state = await deriveState(base);
 
   assert.deepEqual(state.requirements, {
     active: 0,
@@ -132,6 +132,7 @@ test("DB authority: REQUIREMENTS.md and DECISIONS.md projections do not populate
     total: 0,
   });
   assert.deepEqual(queryDecisions(), []);
+  assert.deepEqual(state.recentDecisions, [], "DECISIONS.md projection must not populate recentDecisions");
 });
 
 test("DB authority: DB requirements remain canonical when REQUIREMENTS.md disagrees", async (t) => {

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../guided-flow.ts";
 import {
   closeDatabase,
+  insertArtifact,
   insertMilestone,
   openDatabase,
 } from "../gsd-db.ts";
@@ -375,6 +376,14 @@ test("deep project setup: bootstrap continues queued M002 without milestone cont
     openDatabase(join(base, ".gsd", "gsd.db"));
     insertMilestone({ id: "M001", title: "First milestone", status: "complete" });
     insertMilestone({ id: "M002", title: "Second milestone", status: "queued" });
+    insertArtifact({
+      path: "PROJECT.md",
+      artifact_type: "PROJECT",
+      milestone_id: null,
+      slice_id: null,
+      task_id: null,
+      full_content: readFileSync(join(base, ".gsd", "PROJECT.md"), "utf-8"),
+    });
     closeDatabase();
 
     const messages: unknown[] = [];

--- a/src/resources/extensions/gsd/tests/derive-seam-authority.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-seam-authority.test.ts
@@ -27,6 +27,8 @@ import {
   insertMilestone,
   insertSlice,
   insertTask,
+  insertDecision,
+  insertArtifact,
 } from '../gsd-db.ts';
 
 // ─── Fixture Helpers ───────────────────────────────────────────────────────
@@ -136,12 +138,29 @@ describe('derive-seam-authority', () => {
       .replace('- [ ] **T01:', '- [x] **T01:')
       .replace('- [x] **T02:', '- [ ] **T02:'));
     writeFile(base, 'STATE.md', STATE_PROJECTION);
+    writeFile(base, 'DECISIONS.md', [
+      '# Decisions',
+      '',
+      '| # | When / Context | Scope | Decision | Choice | Rationale | Revisable | Made By |',
+      '|---|----------------|-------|----------|--------|-----------|----------|---------|',
+      '| D001 | Now | global | Projection-only decision | Ignore | DB is authority | Yes | human |',
+      '',
+    ].join('\n'));
+    writeFile(base, 'PROJECT.md', [
+      '# Project',
+      '',
+      '## Milestone Sequence',
+      '',
+      '- [ ] M099: Phantom From Disk - Must not steer derive.',
+      '',
+    ].join('\n'));
 
     invalidateStateCache();
     const after = await deriveState(base);
 
     assert.deepStrictEqual(after, before, 'seam: derived state is byte-identical after projection edits');
     assert.equal(after.activeTask?.id, 'T01', 'seam: plan-projection edit does not flip the active task');
+    assert.deepStrictEqual(after.recentDecisions, [], 'seam: DECISIONS.md projection does not populate recentDecisions');
   });
 
   // (b) DB unavailable: the seam fails closed via buildDbUnavailableState.
@@ -179,9 +198,6 @@ describe('derive-seam-authority', () => {
   // (c) The live derive path does not open markdown projections for parsing.
   // Spy on both fs.readFileSync and fs.promises.readFile (the two read
   // channels used under the seam) and assert no state projection is read.
-  // Note: deriveState appends recentDecisions by reading DECISIONS.md itself
-  // (seam-owned enrichment, not projection authority), so DECISIONS.md is
-  // deliberately excluded from the forbidden set.
   test('derive-seam-authority: live derive path never opens markdown projections', async (t) => {
     const base = createFixtureBase();
 
@@ -209,6 +225,8 @@ describe('derive-seam-authority', () => {
     });
 
     writeProjectionFixture(base);
+    writeFile(base, 'DECISIONS.md', '| D001 | Now | global | Disk | Ignore | x | Yes | human |\n');
+    writeFile(base, 'PROJECT.md', '# Project\n\n## Milestone Sequence\n\n- [ ] M099: Disk Only\n');
 
     assert.equal(openDatabase(':memory:'), true);
     insertDbHierarchy();
@@ -219,6 +237,8 @@ describe('derive-seam-authority', () => {
 
     const projectionReads = readPaths.filter(p =>
       /STATE\.md$/i.test(p)
+      || /DECISIONS\.md$/i.test(p)
+      || /PROJECT\.md$/i.test(p)
       || /-ROADMAP\.md$/i.test(p)
       || /-PLAN\.md$/i.test(p)
       || /-SUMMARY\.md$/i.test(p)
@@ -230,5 +250,96 @@ describe('derive-seam-authority', () => {
       [],
       `live derive path must not open markdown projections, read: ${projectionReads.join(', ')}`,
     );
+  });
+
+  test('derive-seam-authority: recentDecisions come from DB rows, not DECISIONS.md', async (t) => {
+    const base = createFixtureBase();
+    t.after(() => {
+      closeDatabase();
+      cleanup(base);
+    });
+
+    writeProjectionFixture(base);
+    writeFile(base, 'DECISIONS.md', [
+      '# Decisions',
+      '',
+      '| # | When / Context | Scope | Decision | Choice | Rationale | Revisable | Made By |',
+      '|---|----------------|-------|----------|--------|-----------|----------|---------|',
+      '| D999 | Disk | global | Projection-only decision | Ignore | not authority | Yes | human |',
+      '',
+    ].join('\n'));
+
+    assert.equal(openDatabase(':memory:'), true);
+    insertDbHierarchy();
+    insertDecision({
+      id: 'D001',
+      when_context: 'Now',
+      scope: 'global',
+      decision: 'DB is authority',
+      choice: 'Query the decisions table',
+      rationale: 'Live derive must not parse DECISIONS.md',
+      revisable: 'Yes',
+      made_by: 'human',
+      source: 'discussion',
+      superseded_by: null,
+    });
+
+    invalidateStateCache();
+    const state = await deriveState(base);
+    assert.equal(state.recentDecisions.length, 1, 'seam: one DB decision is surfaced');
+    assert.match(
+      state.recentDecisions[0] ?? '',
+      /D001 \(Now\): DB is authority -> Query the decisions table/,
+      'seam: recentDecisions format matches DB fields',
+    );
+    assert.ok(
+      !state.recentDecisions.some((line) => line.includes('D999') || line.includes('Projection-only')),
+      'seam: DECISIONS.md projection is not mixed into recentDecisions',
+    );
+  });
+
+  test('derive-seam-authority: PROJECT.md on disk does not promote a queued shell', async (t) => {
+    const base = createFixtureBase();
+    t.after(() => {
+      closeDatabase();
+      cleanup(base);
+    });
+
+    writeFile(base, 'PROJECT.md', [
+      '# Project',
+      '',
+      '## Milestone Sequence',
+      '',
+      '- [ ] M001: Foundation - Disk projection only.',
+      '',
+    ].join('\n'));
+
+    assert.equal(openDatabase(':memory:'), true);
+    insertMilestone({ id: 'M001', title: 'Foundation', status: 'queued' });
+
+    invalidateStateCache();
+    const fromDisk = await deriveState(base);
+    assert.equal(fromDisk.activeMilestone, null, 'seam: disk PROJECT.md must not promote a queued shell');
+
+    insertArtifact({
+      path: 'PROJECT.md',
+      artifact_type: 'PROJECT',
+      milestone_id: null,
+      slice_id: null,
+      task_id: null,
+      full_content: [
+        '# Project',
+        '',
+        '## Milestone Sequence',
+        '',
+        '- [ ] M001: Foundation - Establish the first runnable slice.',
+        '',
+      ].join('\n'),
+    });
+
+    invalidateStateCache();
+    const fromDb = await deriveState(base);
+    assert.equal(fromDb.activeMilestone?.id, 'M001', 'seam: PROJECT artifact promotes the in-sequence shell');
+    assert.equal(fromDb.phase, 'pre-planning', 'seam: in-sequence shell goes to pre-planning');
   });
 });

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -1376,12 +1376,14 @@ describe('derive-state-db', async () => {
       const dbState = await deriveStateFromDb(base);
 
       // A content-less queued shell (no CONTEXT, no CONTEXT-DRAFT, no slices)
-      // is a phantom and must NOT be promoted to active (#1524).
+      // is a phantom and must NOT be promoted to active (#1524). Readiness
+      // comes from the artifacts table, so derive must not probe the milestone
+      // directory on disk.
       assert.equal(dbState.activeMilestone, null, 'single-resolve: content-less queued shell is not promoted');
       assert.equal(
         phaseDirExistsChecks,
-        3,
-        'single-resolve: one directory resolve plus two artifact probes re-check the milestone directory via resolveFile',
+        0,
+        'single-resolve: live derive does not probe the milestone directory for CONTEXT files',
       );
 
       closeDatabase();
@@ -1502,6 +1504,10 @@ describe('derive-state-db', async () => {
       openDatabase(':memory:');
       insertMilestone({ id: 'M001', title: 'First', status: 'complete' });
       insertMilestone({ id: 'M002', title: 'Second', status: 'queued' });
+      insertArtifactRow('milestones/M002/M002-CONTEXT.md', '# M002 Context\n\nPlanned milestone.', {
+        artifact_type: 'CONTEXT',
+        milestone_id: 'M002',
+      });
 
       // isGhostMilestone should NOT treat M002 as ghost when DB row + content files exist
       assert.ok(!isGhostMilestone(base, 'M002'), 'ghost-dbrow: M002 with DB row and content is NOT a ghost');

--- a/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-queued-milestone.test.ts
@@ -20,6 +20,7 @@ import {
   insertMilestone,
   insertSlice,
   insertTask,
+  insertArtifact,
 } from "../gsd-db.ts";
 
 function createFixtureBase(): string {
@@ -32,6 +33,32 @@ function writeFile(base: string, relativePath: string, content: string): void {
   const full = join(base, ".gsd", relativePath);
   mkdirSync(join(full, ".."), { recursive: true });
   writeFileSync(full, content);
+}
+
+function seedMilestoneArtifact(
+  milestoneId: string,
+  artifactType: "CONTEXT" | "CONTEXT-DRAFT",
+  content: string,
+): void {
+  insertArtifact({
+    path: `milestones/${milestoneId}/${milestoneId}-${artifactType}.md`,
+    artifact_type: artifactType,
+    milestone_id: milestoneId,
+    slice_id: null,
+    task_id: null,
+    full_content: content,
+  });
+}
+
+function seedProjectSequence(content: string): void {
+  insertArtifact({
+    path: "PROJECT.md",
+    artifact_type: "PROJECT",
+    milestone_id: null,
+    slice_id: null,
+    task_id: null,
+    full_content: content,
+  });
 }
 
 describe("stale queued milestone selection (#3470)", () => {
@@ -107,7 +134,9 @@ describe("stale queued milestone selection (#3470)", () => {
 
     // M068: queued but has context (discussion started) — should be activatable
     insertMilestone({ id: "M068", title: "Queued With Context", status: "queued" });
-    writeFile(base, "milestones/M068/M068-CONTEXT.md", "# M068: Queued With Context\n\nDiscussion started.");
+    const queuedContext = "# M068: Queued With Context\n\nDiscussion started.";
+    writeFile(base, "milestones/M068/M068-CONTEXT.md", queuedContext);
+    seedMilestoneArtifact("M068", "CONTEXT", queuedContext);
 
     invalidateStateCache();
     const state = await deriveStateFromDb(base);
@@ -121,7 +150,9 @@ describe("stale queued milestone selection (#3470)", () => {
 
     // M068: queued but has draft (discussion in progress)
     insertMilestone({ id: "M068", title: "Queued With Draft", status: "queued" });
-    writeFile(base, "milestones/M068/M068-CONTEXT-DRAFT.md", "# M068: Queued With Draft\n\nDraft in progress.");
+    const queuedDraft = "# M068: Queued With Draft\n\nDraft in progress.";
+    writeFile(base, "milestones/M068/M068-CONTEXT-DRAFT.md", queuedDraft);
+    seedMilestoneArtifact("M068", "CONTEXT-DRAFT", queuedDraft);
 
     invalidateStateCache();
     const state = await deriveStateFromDb(base);
@@ -229,9 +260,7 @@ describe("stale queued milestone selection (#3470)", () => {
     // phantom) and must be promoted to active so the user can plan it.
     insertMilestone({ id: "M001", title: "Foundation", status: "queued" });
     insertMilestone({ id: "M002", title: "Polish", status: "queued" });
-    writeFile(
-      base,
-      "PROJECT.md",
+    seedProjectSequence(
       [
         "# Project",
         "",
@@ -314,7 +343,9 @@ describe("stale queued milestone selection (#3470)", () => {
 
     // M068: queued, no slices, has a CONTEXT-DRAFT — should resume discussion
     insertMilestone({ id: "M068", title: "Draft Only", status: "queued" });
-    writeFile(base, "milestones/M068/M068-CONTEXT-DRAFT.md", "# M068: Draft Only\n\nPartial context from first question round.");
+    const draftOnly = "# M068: Draft Only\n\nPartial context from first question round.";
+    writeFile(base, "milestones/M068/M068-CONTEXT-DRAFT.md", draftOnly);
+    seedMilestoneArtifact("M068", "CONTEXT-DRAFT", draftOnly);
 
     invalidateStateCache();
     const state = await deriveStateFromDb(base);
@@ -332,7 +363,9 @@ describe("stale queued milestone selection (#3470)", () => {
 
     // M020: a real resumable draft milestone encountered later.
     insertMilestone({ id: "M020", title: "Draft Later", status: "queued" });
-    writeFile(base, "milestones/M020/M020-CONTEXT-DRAFT.md", "# M020: Draft Later\n\nPartial context from an in-progress discussion.");
+    const laterDraft = "# M020: Draft Later\n\nPartial context from an in-progress discussion.";
+    writeFile(base, "milestones/M020/M020-CONTEXT-DRAFT.md", laterDraft);
+    seedMilestoneArtifact("M020", "CONTEXT-DRAFT", laterDraft);
 
     invalidateStateCache();
     const state = await deriveStateFromDb(base);


### PR DESCRIPTION
## TL;DR

**What:** Live `deriveState` no longer reads DECISIONS.md, PROJECT.md, or CONTEXT files as workflow authority.
**Why:** The DB cutover claimed files were projections, but those three still steered phase, promotion, and recent decisions.
**How:** Read decisions from the memories/decisions tables, PROJECT sequence from the PROJECT artifact row, and CONTEXT readiness from milestone-scoped artifacts.

## What

Closes the remaining filesystem-state holes on the live derive path (T007):

- `recentDecisions` comes from `queryDecisionsFromMemories()` (legacy `decisions` table as fallback), not `.gsd/DECISIONS.md`.
- Queued-shell promotion (#1524) uses the DB `PROJECT.md` artifact, not the on-disk file.
- Milestone readiness uses CONTEXT / CONTEXT-DRAFT artifact rows, not `existsSync` on disk.
- An open DB with zero milestone rows is authoritative emptiness; `getActiveMilestoneId` no longer falls through to markdown.

Wave 4 deletions (`parsers-legacy`, `_deriveStateImpl`) and D005 lifecycle-shadow are unchanged.

## Why

After v1.12–v1.15, derive still overlaid markdown on every DB-backed `deriveState` call. Editing projections could change `recentDecisions`, promote phantom queued shells from a disk-only PROJECT.md, or flip needs-discussion from a CONTEXT file that was never saved to the DB.

## How

- `state/derive/from-db.ts` is the sole live-path reader for those three signals.
- `state/derive/index.ts` no longer overlays `recentDecisions` from disk after DB derive.
- Derive-seam tests now forbid DECISIONS.md / PROJECT.md reads and prove disk projections cannot promote a queued shell or populate decisions.
- Structured question rounds persist CONTEXT-DRAFT as an artifact so discussion can resume after the cutover.
- `claude-sonnet-5` model-router registry rows restored so CI is not blocked by a main-branch gap from #1705.

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Test plan

- [x] `derive-seam-authority.test.ts` — projection edits, no markdown reads, DB decisions, disk PROJECT.md does not promote
- [x] `stale-queued-milestone.test.ts` — #1524 phantom vs in-sequence shells with artifact fixtures
- [x] `db-authority-regression.test.ts` — DECISIONS.md projection does not populate `recentDecisions`
- [x] `derive-state-db.test.ts` — no disk CONTEXT probes; queued+CONTEXT uses artifact row
- [x] CI green on this PR