### PR TITLE
fix(gsd): classify Anthropic cache_control.ttl 400 as model-error

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -83,8 +83,9 @@ const TOOL_SURFACE_NOT_READY_RE = new RegExp(TOOL_SURFACE_NOT_READY, "i");
 // Provider rejected the request shape for the selected model (400 bad request,
 // grammar limits, etc.). Not transient — try a different model/fallback.
 // Context-window 400s stay in SERVER_RE (checked earlier).
+// Anthropic cache_control.ttl block-ordering 400s (#1709).
 const MODEL_ERROR_RE =
-  /\b400\b.*\binvalid argument\b|\binvalid argument\b.*\b400\b|grammar is too complex|\b400\b.*\binvalid params\b(?!.*context)|invalid json payload.*unknown name ["'](?:const|patternProperties)["']|input_schema: JSON schema is invalid/i;
+  /\b400\b.*\binvalid argument\b|\binvalid argument\b.*\b400\b|grammar is too complex|\b400\b.*\binvalid params\b(?!.*context)|invalid json payload.*unknown name ["'](?:const|patternProperties)["']|input_schema: JSON schema is invalid|\b400\b.*\bcache_control\.ttl\b/i;
 // Provider adapters throw "No API key for provider: X" at request time when a
 // stored credential is expired or unrefreshable — selection-time hasAuth()
 // passed, but no usable key materialized. This is exactly the condition

--- a/src/resources/extensions/gsd/tests/provider-error-guidance.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-error-guidance.test.ts
@@ -45,6 +45,14 @@ test("classifyError: xAI grammar limit is model-error", () => {
   assert.equal(result.kind, "model-error");
 });
 
+test("classifyError: Anthropic cache_control.ttl ordering 400 is model-error (#1709)", () => {
+  const result = classifyError(
+    "API Error: 400 messages.16.content.0.cache_control.ttl: a ttl='1h' cache_control block must not come after a ttl='5m' cache_control block. Note that blocks are processed in the following order: `tools`, `system`, `messages`.",
+  );
+  assert.equal(result.kind, "model-error");
+  assert.equal(isTransient(result), false);
+});
+
 test("classifyError: context window 400 stays server (transient)", () => {
   const result = classifyError("400 invalid params, context window exceeds limit (2013)");
   assert.equal(result.kind, "server");


### PR DESCRIPTION
## Linked issue

Closes #1709

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Anthropic `cache_control.ttl` ordering 400s now classify as `model-error`.
**Why:** They fell through to `unknown`, so auto-mode paused instead of trying the configured fallback chain.
**How:** Extend `MODEL_ERROR_RE` with `\b400\b.*\bcache_control\.ttl\b` and add a regression test using the production message.

## What

`classifyError()` in `error-classifier.ts` had no pattern for Anthropic's cache-control block-ordering rejection. That 400 is a request-shape rejection for the selected model — the class `MODEL_ERROR_RE` already exists to catch.

## Why

The production message contains none of the existing `invalid argument` / `invalid params` / schema phrases, so it classified as `unknown`. In `agent-end-recovery`, `unknown` skips `tryProviderModelFallback` and pauses auto-mode.

## How

Same maintenance pattern as #1533: add the observed phrasing to `MODEL_ERROR_RE`. Context-window 400s still match `SERVER_RE` first.

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Test plan

- [x] RED: test failed with `unknown` vs `model-error` before the regex change
- [x] GREEN: `provider-error-guidance.test.ts` (11 tests)
- [x] Sabotage: removing the new alternative returned `unknown` again
- [x] CI green on this PR