### PR TITLE
fix: isolate canonical read tools from global DB handle

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1287,6 +1287,30 @@ async function runSerializedWorkflowDbOperation<T>(
   });
 }
 
+async function runSerializedCanonicalReadOperation<T>(
+  projectDir: string,
+  fn: (adapter: { close(): void }) => Promise<T>,
+): Promise<T> {
+  return runSerializedWorkflowOperation(async () => {
+    const { resolveProjectRootDbPath, openWorkflowDatabaseIsolated } = await importWorkflowRuntimeModule<any>(
+      "../../../src/resources/extensions/gsd/db-workspace.js",
+    );
+    const dbPath = resolveProjectRootDbPath(projectDir);
+    if (!existsSync(dbPath)) {
+      throw new Error("Database adapter not available (db_unavailable)");
+    }
+    const adapter = openWorkflowDatabaseIsolated(dbPath);
+    if (!adapter) {
+      throw new Error("Database adapter not available (db_unavailable)");
+    }
+    try {
+      return await fn(adapter);
+    } finally {
+      adapter.close();
+    }
+  });
+}
+
 async function enforceWorkflowWriteGate(
   toolName: string,
   projectDir: string,
@@ -2623,22 +2647,38 @@ export function registerWorkflowTools(
     },
     async (args: Record<string, unknown>) => {
       const { projectDir, ...params } = parseWorkflowArgs(decisionListSchema, args);
-      return runSerializedWorkflowDbOperation(projectDir, async () => {
-        const { queryDecisionsWithLimit } = await importWorkflowRuntimeModule<any>(
-          "../../../src/resources/extensions/gsd/context-store.js",
-        );
-        const limit = Math.min(params.limit ?? 200, 500);
-        const results = queryDecisionsWithLimit({
-          scope: params.scope ?? undefined,
-          milestoneId: params.milestoneId ?? undefined,
-          includeSuperseded: params.includeSuperseded ?? false,
-          limit,
+      try {
+        return await runSerializedCanonicalReadOperation(projectDir, async (adapter: any) => {
+          const { queryDecisionsWithLimit } = await importWorkflowRuntimeModule<any>(
+            "../../../src/resources/extensions/gsd/context-store.js",
+          );
+          const limit = Math.min(params.limit ?? 200, 500);
+          const results = queryDecisionsWithLimit(
+            {
+              scope: params.scope ?? undefined,
+              milestoneId: params.milestoneId ?? undefined,
+              includeSuperseded: params.includeSuperseded ?? false,
+              limit,
+            },
+            adapter,
+          );
+          return {
+            content: [{ type: "text" as const, text: `Found ${results.length} decision(s).` }],
+            details: { operation: "list_decisions", count: results.length, decisions: results },
+          };
         });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const dbUnavailable = msg.includes("db_unavailable");
         return {
-          content: [{ type: "text" as const, text: `Found ${results.length} decision(s).` }],
-          details: { operation: "list_decisions", count: results.length, decisions: results },
+          content: [{ type: "text" as const, text: dbUnavailable ? "Error: GSD database is not available." : `Error listing decisions: ${msg}` }],
+          details: {
+            operation: "list_decisions",
+            error: dbUnavailable ? "db_unavailable" : "query_error",
+            ...(dbUnavailable ? {} : { message: msg }),
+          },
         };
-      });
+      }
     },
   );
 
@@ -2658,22 +2698,40 @@ export function registerWorkflowTools(
     },
     async (args: Record<string, unknown>) => {
       const { projectDir, ...params } = parseWorkflowArgs(decisionGetSchema, args);
-      return runSerializedWorkflowDbOperation(projectDir, async () => {
-        const { getDecisionByIdStrict } = await importWorkflowRuntimeModule<any>(
-          "../../../src/resources/extensions/gsd/context-store.js",
-        );
-        const decision = getDecisionByIdStrict(params.id, params.includeSuperseded ?? false);
-        if (!decision) {
+      try {
+        return await runSerializedCanonicalReadOperation(projectDir, async (adapter: any) => {
+          const { getDecisionByIdStrict } = await importWorkflowRuntimeModule<any>(
+            "../../../src/resources/extensions/gsd/context-store.js",
+          );
+          const decision = getDecisionByIdStrict(
+            params.id,
+            params.includeSuperseded ?? false,
+            adapter,
+          );
+          if (!decision) {
+            return {
+              content: [{ type: "text" as const, text: `Decision ${params.id} not found.` }],
+              details: { operation: "get_decision", id: params.id, error: "not_found" },
+            };
+          }
           return {
-            content: [{ type: "text" as const, text: `Decision ${params.id} not found.` }],
-            details: { operation: "get_decision", id: params.id, error: "not_found" },
+            content: [{ type: "text" as const, text: `Decision ${decision.id}: ${decision.decision}` }],
+            details: { operation: "get_decision", id: decision.id, decision },
           };
-        }
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const dbUnavailable = msg.includes("db_unavailable");
         return {
-          content: [{ type: "text" as const, text: `Decision ${decision.id}: ${decision.decision}` }],
-          details: { operation: "get_decision", id: decision.id, decision },
+          content: [{ type: "text" as const, text: dbUnavailable ? "Error: GSD database is not available." : `Error fetching decision: ${msg}` }],
+          details: {
+            operation: "get_decision",
+            id: params.id,
+            error: dbUnavailable ? "db_unavailable" : "query_error",
+            ...(dbUnavailable ? {} : { message: msg }),
+          },
         };
-      });
+      }
     },
   );
 
@@ -2763,23 +2821,38 @@ export function registerWorkflowTools(
     },
     async (args: Record<string, unknown>) => {
       const { projectDir, ...params } = parseWorkflowArgs(requirementListSchema, args);
-      return runSerializedWorkflowDbOperation(projectDir, async () => {
-        const { queryRequirementsWithLimit } = await importWorkflowRuntimeModule<any>(
-          "../../../src/resources/extensions/gsd/context-store.js",
-        );
-        const limit = Math.min(params.limit ?? 200, 500);
-        const results = queryRequirementsWithLimit({
-          class: params.class ?? undefined,
-          status: params.status ?? undefined,
-          milestoneId: params.milestoneId ?? undefined,
-          limit,
+      try {
+        return await runSerializedCanonicalReadOperation(projectDir, async (adapter: any) => {
+          const { queryRequirementsWithLimit } = await importWorkflowRuntimeModule<any>(
+            "../../../src/resources/extensions/gsd/context-store.js",
+          );
+          const limit = Math.min(params.limit ?? 200, 500);
+          const results = queryRequirementsWithLimit(
+            {
+              status: params.status ?? undefined,
+              milestoneId: params.milestoneId ?? undefined,
+              limit,
+            },
+            adapter,
+          );
+          const filtered = params.class ? results.filter((r: any) => r.class === params.class) : results;
+          return {
+            content: [{ type: "text" as const, text: `Found ${filtered.length} requirement(s).` }],
+            details: { operation: "list_requirements", count: filtered.length, requirements: filtered },
+          };
         });
-        const filtered = params.class ? results.filter((r: any) => r.class === params.class) : results;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const dbUnavailable = msg.includes("db_unavailable");
         return {
-          content: [{ type: "text" as const, text: `Found ${filtered.length} requirement(s).` }],
-          details: { operation: "list_requirements", count: filtered.length, requirements: filtered },
+          content: [{ type: "text" as const, text: dbUnavailable ? "Error: GSD database is not available." : `Error listing requirements: ${msg}` }],
+          details: {
+            operation: "list_requirements",
+            error: dbUnavailable ? "db_unavailable" : "query_error",
+            ...(dbUnavailable ? {} : { message: msg }),
+          },
         };
-      });
+      }
     },
   );
 
@@ -2797,22 +2870,36 @@ export function registerWorkflowTools(
     },
     async (args: Record<string, unknown>) => {
       const { projectDir, ...params } = parseWorkflowArgs(requirementGetSchema, args);
-      return runSerializedWorkflowDbOperation(projectDir, async () => {
-        const { getRequirementByIdStrict } = await importWorkflowRuntimeModule<any>(
-          "../../../src/resources/extensions/gsd/context-store.js",
-        );
-        const req = getRequirementByIdStrict(params.id);
-        if (!req) {
+      try {
+        return await runSerializedCanonicalReadOperation(projectDir, async (adapter: any) => {
+          const { getRequirementByIdStrict } = await importWorkflowRuntimeModule<any>(
+            "../../../src/resources/extensions/gsd/context-store.js",
+          );
+          const req = getRequirementByIdStrict(params.id, adapter);
+          if (!req) {
+            return {
+              content: [{ type: "text" as const, text: `Requirement ${params.id} not found.` }],
+              details: { operation: "get_requirement", id: params.id, error: "not_found" },
+            };
+          }
           return {
-            content: [{ type: "text" as const, text: `Requirement ${params.id} not found.` }],
-            details: { operation: "get_requirement", id: params.id, error: "not_found" },
+            content: [{ type: "text" as const, text: `Requirement ${req.id}: ${req.description}` }],
+            details: { operation: "get_requirement", id: req.id, requirement: req },
           };
-        }
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const dbUnavailable = msg.includes("db_unavailable");
         return {
-          content: [{ type: "text" as const, text: `Requirement ${req.id}: ${req.description}` }],
-          details: { operation: "get_requirement", id: req.id, requirement: req },
+          content: [{ type: "text" as const, text: dbUnavailable ? "Error: GSD database is not available." : `Error fetching requirement: ${msg}` }],
+          details: {
+            operation: "get_requirement",
+            id: params.id,
+            error: dbUnavailable ? "db_unavailable" : "query_error",
+            ...(dbUnavailable ? {} : { message: msg }),
+          },
         };
-      });
+      }
     },
   );
 

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -4,11 +4,17 @@ import { StringEnum, Type } from "@gsd/pi-ai";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { Text } from "@gsd/pi-tui";
 import { SUMMARY_SAVE_CONTENT_MAX_LENGTH } from "@opengsd/contracts";
+import { existsSync } from "node:fs";
 import { getErrorMessage } from "../error-utils.js";
 import { piExecutionInvocation } from "../execution-invocation.js";
 import { incrementLegacyTelemetry } from "../legacy-telemetry.js";
 import { piPlanningInvocation } from "../planning-invocation.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
+import type { DbAdapter } from "../db-adapter.js";
+import {
+	openWorkflowDatabaseIsolated,
+	resolveProjectRootDbPath,
+} from "../db-workspace.js";
 import { prepareSaveGateResultArguments } from "../tools/save-gate-result-args.js";
 import { logError } from "../workflow-logger.js";
 import { importWorkflowExecutorsModule } from "../workflow-mcp.js";
@@ -136,6 +142,25 @@ function formatToolErrorText(result: any, details: any): string {
 	return typeof message === "string" && message.startsWith("Error")
 		? message
 		: `Error: ${message}`;
+}
+
+function withCanonicalReadAdapter<T>(
+	basePath: string,
+	run: (adapter: DbAdapter) => Promise<T>,
+): Promise<T> {
+	const dbPath = resolveProjectRootDbPath(basePath);
+	if (!existsSync(dbPath)) {
+		throw new Error("Database adapter not available (db_unavailable)");
+	}
+	const adapter = openWorkflowDatabaseIsolated(dbPath);
+	if (!adapter) {
+		throw new Error("Database adapter not available (db_unavailable)");
+	}
+	return Promise.resolve()
+		.then(() => run(adapter))
+		.finally(() => {
+			adapter.close();
+		});
 }
 
 const UAT_EVIDENCE_KIND_VALUES = [
@@ -2771,38 +2796,30 @@ export function registerDbTools(pi: ExtensionAPI): void {
 		_ctx: unknown,
 	) => {
 		const basePath = resolveCtxCwd(_ctx);
-		const dbAvailable = await ensureDbOpen(basePath);
-		if (!dbAvailable) {
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text: "Error: GSD database is not available.",
-					},
-				],
-				details: {
-					operation: "list_requirements",
-					error: "db_unavailable",
-				} as any,
-			};
-		}
-
 		try {
 			const { queryRequirementsWithLimit } = await import(
 				"../context-store.js"
 			);
-			const limit = Math.min(params.limit ?? 200, 500);
-			const results = queryRequirementsWithLimit({
-				status: params.status ?? undefined,
-				milestoneId: params.milestoneId ?? undefined,
-				sliceId: params.sliceId ?? undefined,
-				limit,
-			});
+			const filtered = await withCanonicalReadAdapter(
+				basePath,
+				async (adapter) => {
+					const limit = Math.min(params.limit ?? 200, 500);
+					const results = queryRequirementsWithLimit(
+						{
+							status: params.status ?? undefined,
+							milestoneId: params.milestoneId ?? undefined,
+							sliceId: params.sliceId ?? undefined,
+							limit,
+						},
+						adapter,
+					);
 
-			// JS-level class filter (not in DB query)
-			const filtered = params.class
-				? results.filter((r: any) => r.class === params.class)
-				: results;
+					// JS-level class filter (not in DB query)
+					return params.class
+						? results.filter((r: any) => r.class === params.class)
+						: results;
+				},
+			);
 
 			return {
 				content: [
@@ -2940,25 +2957,11 @@ export function registerDbTools(pi: ExtensionAPI): void {
 		_ctx: unknown,
 	) => {
 		const basePath = resolveCtxCwd(_ctx);
-		const dbAvailable = await ensureDbOpen(basePath);
-		if (!dbAvailable) {
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text: "Error: GSD database is not available.",
-					},
-				],
-				details: {
-					operation: "get_requirement",
-					id: params.id,
-					error: "db_unavailable",
-				} as any,
-			};
-		}
 		try {
 			const { getRequirementByIdStrict } = await import("../context-store.js");
-			const req = getRequirementByIdStrict(params.id);
+			const req = await withCanonicalReadAdapter(basePath, async (adapter) =>
+				getRequirementByIdStrict(params.id, adapter),
+			);
 
 			if (!req) {
 				// getRequirementByIdStrict returns null for not found (absent or superseded)
@@ -3101,30 +3104,20 @@ export function registerDbTools(pi: ExtensionAPI): void {
 		_ctx: unknown,
 	) => {
 		const basePath = resolveCtxCwd(_ctx);
-		const dbAvailable = await ensureDbOpen(basePath);
-		if (!dbAvailable) {
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text: "Error: GSD database is not available.",
-					},
-				],
-				details: {
-					operation: "list_decisions",
-					error: "db_unavailable",
-				} as any,
-			};
-		}
 		try {
 			const { queryDecisionsWithLimit } = await import("../context-store.js");
 
-			const limit = Math.min(params.limit ?? 200, 500);
-			const results = queryDecisionsWithLimit({
-				scope: params.scope ?? undefined,
-				milestoneId: params.milestoneId ?? undefined,
-				includeSuperseded: params.includeSuperseded === true,
-				limit,
+			const results = await withCanonicalReadAdapter(basePath, async (adapter) => {
+				const limit = Math.min(params.limit ?? 200, 500);
+				return queryDecisionsWithLimit(
+					{
+						scope: params.scope ?? undefined,
+						milestoneId: params.milestoneId ?? undefined,
+						includeSuperseded: params.includeSuperseded === true,
+						limit,
+					},
+					adapter,
+				);
 			});
 
 			return {
@@ -3260,27 +3253,14 @@ export function registerDbTools(pi: ExtensionAPI): void {
 		_ctx: unknown,
 	) => {
 		const basePath = resolveCtxCwd(_ctx);
-		const dbAvailable = await ensureDbOpen(basePath);
-		if (!dbAvailable) {
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text: "Error: GSD database is not available.",
-					},
-				],
-				details: {
-					operation: "get_decision",
-					id: params.id,
-					error: "db_unavailable",
-				} as any,
-			};
-		}
 		try {
 			const { getDecisionByIdStrict } = await import("../context-store.js");
-			const decision = getDecisionByIdStrict(
-				params.id,
-				params.includeSuperseded === true,
+			const decision = await withCanonicalReadAdapter(basePath, async (adapter) =>
+				getDecisionByIdStrict(
+					params.id,
+					params.includeSuperseded === true,
+					adapter,
+				),
 			);
 
 			if (!decision) {

--- a/src/resources/extensions/gsd/context-store.ts
+++ b/src/resources/extensions/gsd/context-store.ts
@@ -20,6 +20,7 @@ export interface RequirementQueryOpts {
 	milestoneId?: string;
 	sliceId?: string;
 	status?: string;
+	class?: string;
 }
 
 function resolveReadAdapter(adapter?: DbAdapter): DbAdapter {
@@ -294,6 +295,11 @@ export function queryRequirements(opts?: RequirementQueryOpts): Requirement[] {
 		if (opts?.status) {
 			clauses.push("status = :status");
 			params[":status"] = opts.status;
+		}
+
+		if (opts?.class) {
+			clauses.push("class = :class");
+			params[":class"] = opts.class;
 		}
 
 		const sql = `SELECT * FROM requirements WHERE ${clauses.join(" AND ")} ORDER BY id`;

--- a/src/resources/extensions/gsd/context-store.ts
+++ b/src/resources/extensions/gsd/context-store.ts
@@ -5,6 +5,7 @@
 // All functions degrade gracefully: return empty results when DB unavailable, never throw.
 
 import { _getAdapter, isDbAvailable } from "./gsd-db.js";
+import type { DbAdapter } from "./db-adapter.js";
 import type { Decision, DecisionMadeBy, Requirement } from "./types.js";
 
 // ─── Query Functions ───────────────────────────────────────────────────────
@@ -19,6 +20,14 @@ export interface RequirementQueryOpts {
 	milestoneId?: string;
 	sliceId?: string;
 	status?: string;
+}
+
+function resolveReadAdapter(adapter?: DbAdapter): DbAdapter {
+	const resolved = adapter ?? _getAdapter();
+	if (!resolved) {
+		throw new Error("Database adapter not available (db_unavailable)");
+	}
+	return resolved;
 }
 
 /**
@@ -712,11 +721,9 @@ export function getDecisionById(
  */
 export function queryRequirementsWithLimit(
 	opts?: RequirementQueryOpts & { limit?: number },
+ 	adapter?: DbAdapter,
 ): Requirement[] {
-	const adapter = _getAdapter();
-	if (!adapter) {
-		throw new Error("Database adapter not available (db_unavailable)");
-	}
+	const db = resolveReadAdapter(adapter);
 
 	const clauses: string[] = ["superseded_by IS NULL"];
 	const params: Record<string, unknown> = {};
@@ -748,7 +755,7 @@ export function queryRequirementsWithLimit(
 	const sql = `SELECT * FROM requirements WHERE ${clauses.join(" AND ")} ORDER BY id LIMIT :limit`;
 	params[":limit"] = limit;
 
-	const rows = adapter.prepare(sql).all(params);
+	const rows = db.prepare(sql).all(params);
 
 	return rows.map((row) => ({
 		id: row["id"] as string,
@@ -772,11 +779,9 @@ export function queryRequirementsWithLimit(
  */
 export function queryDecisionsWithLimit(
 	opts?: DecisionQueryOpts & { limit?: number },
+ 	adapter?: DbAdapter,
 ): Decision[] {
-	const adapter = _getAdapter();
-	if (!adapter) {
-		throw new Error("Database adapter not available (db_unavailable)");
-	}
+	const db = resolveReadAdapter(adapter);
 
 	const clauses: string[] = [
 		"category = 'architecture'",
@@ -807,7 +812,7 @@ export function queryDecisionsWithLimit(
 	const sql = `SELECT seq, structured_fields FROM memories WHERE ${clauses.join(" AND ")} ORDER BY seq DESC LIMIT :limit`;
 	params[":limit"] = limit;
 
-	const rows = adapter.prepare(sql).all(params) as Array<
+	const rows = db.prepare(sql).all(params) as Array<
 		Record<string, unknown>
 	>;
 
@@ -832,13 +837,13 @@ export function queryDecisionsWithLimit(
 /**
  * Fetch single requirement by ID. Throws on query errors.
  */
-export function getRequirementByIdStrict(id: string): Requirement | null {
-	const adapter = _getAdapter();
-	if (!adapter) {
-		throw new Error("Database adapter not available (db_unavailable)");
-	}
+export function getRequirementByIdStrict(
+	id: string,
+	adapter?: DbAdapter,
+): Requirement | null {
+	const db = resolveReadAdapter(adapter);
 
-	const row = adapter
+	const row = db
 		.prepare(
 			"SELECT * FROM requirements WHERE id = :id AND superseded_by IS NULL",
 		)
@@ -868,16 +873,14 @@ export function getRequirementByIdStrict(id: string): Requirement | null {
 export function getDecisionByIdStrict(
 	id: string,
 	includeSuperseded = false,
+ 	adapter?: DbAdapter,
 ): Decision | null {
-	const adapter = _getAdapter();
-	if (!adapter) {
-		throw new Error("Database adapter not available (db_unavailable)");
-	}
+	const db = resolveReadAdapter(adapter);
 
 	const supersededClause = includeSuperseded
 		? ""
 		: "AND json_extract(structured_fields, '$.superseded_by') IS NULL";
-	const rows = adapter
+	const rows = db
 		.prepare(
 			`SELECT seq, structured_fields FROM memories
        WHERE category = 'architecture'

--- a/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
@@ -1,539 +1,239 @@
-// Tests for gsd_requirement_list, gsd_requirement_get,
-//            gsd_decision_list,    gsd_decision_get
-//
-// Strategy: unit-test the two new context-store helpers
-// (getRequirementById, getDecisionById) and the JS-level filter/limit
-// logic exercised by the tool executors. We do NOT spin up a real SQLite
-// DB — instead we mock the `isDbAvailable` / `_getAdapter` boundary so
-// the tests are fast, hermetic, and free of I/O.
-//
-// Why no source-file grep: per CONTRIBUTING.md, tests must import the
-// module and exercise its behaviour, not grep source text.
-//
-// Runner: node:test + node:assert/strict (no Vitest, no Jest).
-
-import { describe, it, before, after, mock } from 'node:test';
-import assert from 'node:assert/strict';
-
-// ─── Shared fake DB adapter ────────────────────────────────────────────────
-
-/**
- * Minimal fake adapter: supports `prepare(sql).get(params)` and
- * `prepare(sql).all(params)`. Row sets are injected per test via
- * `fakeRows` and `fakeRow`.
- */
-function makeFakeAdapter(rows: Record<string, unknown>[], singleRow?: Record<string, unknown>) {
-  return {
-    prepare: (_sql: string) => ({
-      get: (_params: unknown) => singleRow ?? undefined,
-      all: (_params: unknown) => rows,
-    }),
-  };
-}
-
-// ─── gsd_requirement_list / gsd_requirement_get ───────────────────────────
-
-describe('getRequirementById', () => {
-  it('returns null when DB is unavailable', async () => {
-    // Use dynamic import so we can intercept after mocking.
-    // We test the graceful-degrade path: isDbAvailable() => false.
-    // Because context-store does `if (!isDbAvailable()) return null/[]`,
-    // we verify the null return without needing a real DB.
-    //
-    // NOTE: The isolation approach here is behavioural: we supply a fake
-    // adapter to confirm the code path, not to inspect internal SQL.
-    // A real DB integration test would live in a separate fixture file.
-    assert.ok(true, 'graceful-degrade path verified by design (no DB in unit scope)');
-  });
-
-  it('requirement list filter: class filter applied in JS after DB query', () => {
-    // Simulate the JS-level class filter that requirementListExecute applies
-    // on top of queryRequirements results.
-    const allRequirements = [
-      { id: 'R001', class: 'core-capability', status: 'active', description: 'A' },
-      { id: 'R002', class: 'constraint', status: 'active', description: 'B' },
-      { id: 'R003', class: 'core-capability', status: 'deferred', description: 'C' },
-    ];
-
-    // Mirror the JS filter from requirementListExecute
-    const filtered = allRequirements.filter((r) => r.class === 'core-capability');
-    assert.equal(filtered.length, 2);
-    assert.ok(filtered.every((r) => r.class === 'core-capability'));
-  });
-
-  it('requirement list limit: hard cap at 500', () => {
-    // Mirror the limit logic from requirementListExecute
-    const applyLimit = (results: unknown[], requestedLimit?: number): unknown[] => {
-      const limit = Math.min(requestedLimit ?? 200, 500);
-      return results.slice(0, limit);
-    };
-
-    const fakeResults = Array.from({ length: 600 }, (_, i) => ({ id: `R${i}` }));
-
-    // No limit → defaults to 200
-    assert.equal(applyLimit(fakeResults).length, 200);
-    // Explicit limit 50 → 50
-    assert.equal(applyLimit(fakeResults, 50).length, 50);
-    // Explicit limit 600 → hard-capped to 500
-    assert.equal(applyLimit(fakeResults, 600).length, 500);
-    // Explicit limit 500 → exactly 500
-    assert.equal(applyLimit(fakeResults, 500).length, 500);
-  });
-
-  it('requirement list limit: caller requesting 201 is capped to 200 default behaviour', () => {
-    const applyLimit = (results: unknown[], requestedLimit?: number): unknown[] => {
-      const limit = Math.min(requestedLimit ?? 200, 500);
-      return results.slice(0, limit);
-    };
-    const fakeResults = Array.from({ length: 300 }, (_, i) => ({ id: `R${i}` }));
-    // 201 is within the 500 hard cap, so 201 results are returned
-    assert.equal(applyLimit(fakeResults, 201).length, 201);
-  });
-});
-
-// ─── gsd_decision_list / gsd_decision_get ────────────────────────────────
-
-describe('getDecisionById', () => {
-  it('decision list: includeSuperseded=false excludes superseded rows (JS filter)', () => {
-    // Mirror the JS filter applied in decisionListExecute when includeSuperseded=true
-    // and then a scope filter is applied.
-    const allDecisions = [
-      { id: 'D001', scope: 'architecture', when_context: 'M001', superseded_by: null },
-      { id: 'D002', scope: 'architecture', when_context: 'M002', superseded_by: 'D003' },
-      { id: 'D003', scope: 'library', when_context: 'M002', superseded_by: null },
-    ];
-
-    // Active-only path (queryDecisionsFromMemories already excludes superseded)
-    // This is the implicit guarantee we can assert on in JS
-    const active = allDecisions.filter((d) => d.superseded_by === null);
-    assert.equal(active.length, 2);
-    assert.ok(active.every((d) => d.superseded_by === null));
-  });
-
-  it('decision list: scope filter applied in JS for includeSuperseded=true path', () => {
-    const allDecisions = [
-      { id: 'D001', scope: 'architecture', when_context: 'M001', superseded_by: null },
-      { id: 'D002', scope: 'library', when_context: 'M001', superseded_by: null },
-      { id: 'D003', scope: 'architecture', when_context: 'M002', superseded_by: 'D004' },
-    ];
-
-    // Mirror JS filter from decisionListExecute (includeSuperseded=true path)
-    const filtered = allDecisions.filter((d) => d.scope === 'architecture');
-    assert.equal(filtered.length, 2);
-    assert.ok(filtered.every((d) => d.scope === 'architecture'));
-  });
-
-  it('decision list: milestoneId filter applied in JS for includeSuperseded=true path', () => {
-    const allDecisions = [
-      { id: 'D001', scope: 'architecture', when_context: 'M001', superseded_by: null },
-      { id: 'D002', scope: 'architecture', when_context: 'M002', superseded_by: null },
-      { id: 'D003', scope: 'library', when_context: 'M001-S02', superseded_by: null },
-    ];
-
-    // Mirror milestoneId filter from decisionListExecute
-    const filtered = allDecisions.filter((d) => d.when_context.includes('M001'));
-    assert.equal(filtered.length, 2, 'M001 substring matches M001 and M001-S02');
-  });
-
-  it('decision list limit: hard cap at 500 (same logic as requirements)', () => {
-    const applyLimit = (results: unknown[], requestedLimit?: number): unknown[] => {
-      const limit = Math.min(requestedLimit ?? 200, 500);
-      return results.slice(0, limit);
-    };
-    const fakeResults = Array.from({ length: 600 }, (_, i) => ({ id: `D${i}` }));
-
-    assert.equal(applyLimit(fakeResults).length, 200);
-    assert.equal(applyLimit(fakeResults, 10).length, 10);
-    assert.equal(applyLimit(fakeResults, 600).length, 500);
-  });
-
-  it('getDecisionById: structured_fields parse — deleted tombstone returns null', () => {
-    // Mirror the tombstone check in getDecisionById
-    const parsedSf = { sourceDecisionId: 'D007', deleted: true, decision: 'Some decision' };
-    const isTombstone = parsedSf['deleted'] === true;
-    assert.ok(isTombstone, 'deleted: true marks a tombstone and must produce null');
-  });
-
-  it('getDecisionById: structured_fields parse — superseded_by check', () => {
-    // Mirror the superseded guard in getDecisionById
-    const checkSuperseded = (
-      sf: Record<string, unknown>,
-      includeSuperseded: boolean,
-    ): boolean => {
-      const supersededBy =
-        typeof sf['superseded_by'] === 'string' ? sf['superseded_by'] : null;
-      return !includeSuperseded && supersededBy !== null;
-    };
-
-    const sfSuperseded = { superseded_by: 'D008' };
-    const sfActive = { superseded_by: null };
-
-    assert.ok(checkSuperseded(sfSuperseded, false), 'superseded + includeSuperseded=false → skip');
-    assert.ok(!checkSuperseded(sfSuperseded, true), 'superseded + includeSuperseded=true → include');
-    assert.ok(!checkSuperseded(sfActive, false), 'active + includeSuperseded=false → include');
-  });
-
-  it('getDecisionById: reconstructed Decision shape has all required fields', () => {
-    // Mirror the shape reconstruction in getDecisionById to confirm
-    // the output contract is fully populated.
-    const sf: Record<string, unknown> = {
-      sourceDecisionId: 'D005',
-      when_context: 'M003',
-      scope: 'architecture',
-      decision: 'Use Postgres',
-      choice: 'Postgres + Prisma',
-      rationale: 'Locked ADR-0004',
-      revisable: 'No',
-      made_by: 'human',
-      source: 'planning',
-      superseded_by: null,
-    };
-
-    const decision = {
-      seq: 42,
-      id: sf['sourceDecisionId'] as string,
-      when_context: typeof sf['when_context'] === 'string' ? sf['when_context'] : '',
-      scope: typeof sf['scope'] === 'string' ? sf['scope'] : '',
-      decision: typeof sf['decision'] === 'string' ? sf['decision'] : '',
-      choice: typeof sf['choice'] === 'string' ? sf['choice'] : '',
-      rationale: typeof sf['rationale'] === 'string' ? sf['rationale'] : '',
-      revisable: typeof sf['revisable'] === 'string' ? sf['revisable'] : '',
-      made_by: typeof sf['made_by'] === 'string' ? sf['made_by'] : 'agent',
-      source: typeof sf['source'] === 'string' ? sf['source'] : 'discussion',
-      superseded_by: typeof sf['superseded_by'] === 'string' ? sf['superseded_by'] : null,
-    };
-
-    assert.equal(decision.id, 'D005');
-    assert.equal(decision.scope, 'architecture');
-    assert.equal(decision.made_by, 'human');
-    assert.equal(decision.superseded_by, null);
-    assert.equal(decision.source, 'planning');
-  });
-
-  it('getDecisionById: missing sourceDecisionId in structured_fields → skip row', () => {
-    // Rows without a valid sourceDecisionId should be skipped entirely.
-    const rows = [
-      { seq: 1, structured_fields: JSON.stringify({ decision: 'no ID here' }) },
-      { seq: 2, structured_fields: JSON.stringify({ sourceDecisionId: '' }) },
-      { seq: 3, structured_fields: 'invalid json{{' },
-    ];
-
-    const validRows = rows.filter((row) => {
-      try {
-        const sf = JSON.parse(row.structured_fields) as Record<string, unknown>;
-        const id = sf['sourceDecisionId'];
-        return typeof id === 'string' && id.length > 0;
-      } catch {
-        return false;
-      }
-    });
-
-    assert.equal(validRows.length, 0, 'no rows should survive the guard — all malformed');
-  });
-});
-
-// ─── Error response shape contracts ────────────────────────────────────────
-
-describe('tool error response contracts', () => {
-  it('db_unavailable response has correct details shape', () => {
-    // Mirror the shape returned when ensureDbOpen returns false.
-    const response = {
-      content: [{ type: 'text', text: 'Error: GSD database is not available.' }],
-      details: { operation: 'list_requirements', error: 'db_unavailable' },
-    };
-    assert.equal(response.details.error, 'db_unavailable');
-    assert.ok(response.content[0].text.includes('not available'));
-  });
-
-  it('not_found response distinguishes itself from db_unavailable', () => {
-    const notFound = { operation: 'get_requirement', id: 'R999', error: 'not_found' };
-    const dbDown = { operation: 'get_requirement', id: 'R999', error: 'db_unavailable' };
-
-    assert.notEqual(notFound.error, dbDown.error);
-    assert.equal(notFound.error, 'not_found');
-    assert.equal(dbDown.error, 'db_unavailable');
-  });
-
-  it('requirement list success response has count and requirements array', () => {
-    const response = {
-      content: [{ type: 'text', text: 'Found 3 requirement(s).' }],
-      details: {
-        operation: 'list_requirements',
-        count: 3,
-        requirements: [{ id: 'R001' }, { id: 'R002' }, { id: 'R003' }],
-      },
-    };
-    assert.equal(response.details.count, 3);
-    assert.equal(response.details.requirements.length, 3);
-  });
-
-  it('decision list success response has count and decisions array', () => {
-    const response = {
-      content: [{ type: 'text', text: 'Found 2 decision(s).' }],
-      details: {
-        operation: 'list_decisions',
-        count: 2,
-        decisions: [{ id: 'D001' }, { id: 'D002' }],
-      },
-    };
-    assert.equal(response.details.count, 2);
-    assert.equal(response.details.decisions.length, 2);
-  });
-});
-
-// ─── Phase 4 Extended Tests: Robustness & Safety ────────────────────────────
-
-describe('Phase 4: Race Condition & Side-Effect Safety', () => {
-  it('concurrent DB adapter switches do not corrupt query results', () => {
-    // Scenario: Two queries execute concurrently; each gets a fresh adapter view.
-    // We verify that results from Query A do not bleed into Query B.
-    const results1 = [
-      { id: 'R001', class: 'core-capability', description: 'Feature A' },
-    ];
-    const results2 = [
-      { id: 'R002', class: 'constraint', description: 'Feature B' },
-      { id: 'R003', class: 'constraint', description: 'Feature C' },
-    ];
-
-    // Simulate concurrent execution by mixing accesses
-    const mixed = [
-      ...results1,
-      ...results2,
-    ];
-
-    // Filter each result set independently
-    const filtered1 = results1.filter((r) => r.class === 'core-capability');
-    const filtered2 = results2.filter((r) => r.class === 'constraint');
-
-    assert.equal(filtered1.length, 1, 'Q1 isolation: only core-capability');
-    assert.equal(filtered2.length, 2, 'Q2 isolation: only constraints');
-    assert.notEqual(filtered1[0]?.id, filtered2[0]?.id, 'No cross-contamination');
-  });
-
-  it('DB read operations do not mutate state (side-effect-free)', () => {
-    // Simulate a DB read: fetch a requirement, check it's unchanged
-    const originalDb = [
-      { id: 'R001', status: 'active', description: 'Original description' },
-    ];
-
-    // Read operation
-    const read = originalDb[0];
-    const retrieved = { ...read };
-
-    // Verify original is untouched
-    assert.equal(read.description, 'Original description');
-    assert.equal(retrieved.description, 'Original description');
-    assert.deepEqual(read, retrieved, 'Read did not mutate DB state');
-  });
-
-  it('SQL LIMIT is applied at query level, not after materialization', () => {
-    // The "Strict" query functions use SQL LIMIT: :limit in the SQL,
-    // not slice() after fetching all rows. We verify the contract.
-    // In-process: queryRequirementsWithLimit, queryDecisionsWithLimit apply
-    // LIMIT at SQL level.
-
-    // Simulate: if a DB had 10,000 requirements, SQL LIMIT 50 should
-    // fetch ~50 rows from the DB, not fetch 10,000 and slice.
-    // We test the logic (not the actual DB behavior).
-    const hugeDataset = Array.from({ length: 10000 }, (_, i) => ({
-      id: `R${i}`,
-      status: 'active',
-    }));
-
-    // Wrong approach: slice after full load
-    const wrongApproach = (data: unknown[], limit: number) => data.slice(0, limit);
-    const wrongResult = wrongApproach(hugeDataset, 50);
-    assert.equal(wrongResult.length, 50, 'slice() works but loads all 10k rows first');
-
-    // Right approach: limit is enforced in SQL (simulated here)
-    const rightApproach = (limit: number) => {
-      const sqlLimit = Math.min(limit, 500);
-      // The DB query uses LIMIT :limit in SQL
-      // We just verify the contract: caller gets max(requestedLimit, 500)
-      return sqlLimit;
-    };
-    const rightLimit = rightApproach(50);
-    assert.equal(rightLimit, 50, 'SQL LIMIT applied at query level');
-  });
-
-  it('error propagation: query_error is distinguished from not_found', () => {
-    // Simulate error flow for requirementGetExecute and decisionGetExecute.
-    // When getRequirementByIdStrict or getDecisionByIdStrict throws:
-    //   - "db_unavailable" in message -> error: db_unavailable
-    //   - other errors -> error: query_error
-    // When they return null -> error: not_found
-
-    const scenarios = [
-      {
-        name: 'null result',
-        errorMsg: null,
-        expected: 'not_found',
-      },
-      {
-        name: 'db_unavailable thrown',
-        errorMsg: 'Database adapter not available (db_unavailable)',
-        expected: 'db_unavailable',
-      },
-      {
-        name: 'query syntax error',
-        errorMsg: 'SQLITE_SYNTAX near "FROM"',
-        expected: 'query_error',
-      },
-      {
-        name: 'network timeout',
-        errorMsg: 'ECONNREFUSED',
-        expected: 'query_error',
-      },
-    ];
-
-    for (const scenario of scenarios) {
-      let errorType: string;
-
-      if (!scenario.errorMsg) {
-        errorType = 'not_found';
-      } else if (scenario.errorMsg.includes('db_unavailable')) {
-        errorType = 'db_unavailable';
-      } else {
-        errorType = 'query_error';
-      }
-
-      assert.equal(
-        errorType,
-        scenario.expected,
-        `${scenario.name}: expected "${scenario.expected}", got "${errorType}"`,
-      );
-    }
-  });
-
-  it('list operations respect hard limit cap (500) even with large requested limits', () => {
-    // Verify that both requirements and decisions enforce max 500.
-    const applyLimit = (requestedLimit: number): number => Math.min(requestedLimit ?? 200, 500);
-
-    const testCases = [
-      { requested: 100, expected: 100 },
-      { requested: 200, expected: 200 },
-      { requested: 500, expected: 500 },
-      { requested: 501, expected: 500 },
-      { requested: 1000, expected: 500 },
-      { requested: 10000, expected: 500 },
-      { requested: undefined, expected: 200 },
-    ];
-
-    for (const tc of testCases) {
-      const result = applyLimit(tc.requested as any);
-      assert.equal(
-        result,
-        tc.expected,
-        `limit(${tc.requested ?? 'default'}) = ${result}, expected ${tc.expected}`,
-      );
-    }
-  });
-
-  it('requirement class filter and decision scope filter are mutually safe', () => {
-    // Verify that filtering by class does not affect unrelated fields.
-    const reqs = [
-      { id: 'R001', class: 'core-capability', status: 'active', scope: 'architecture' },
-      { id: 'R002', class: 'constraint', status: 'active', scope: 'architecture' },
-    ];
-
-    const decisions = [
-      { id: 'D001', scope: 'architecture', class: 'policy' },
-      { id: 'D002', scope: 'library', class: 'policy' },
-    ];
-
-    // Filter requirements by class
-    const filteredReqs = reqs.filter((r) => r.class === 'core-capability');
-    assert.equal(filteredReqs.length, 1);
-    assert.equal(filteredReqs[0]?.id, 'R001');
-    // scope field is untouched
-    assert.equal(filteredReqs[0]?.scope, 'architecture');
-
-    // Filter decisions by scope (does not affect requirements)
-    const filteredDecs = decisions.filter((d) => d.scope === 'architecture');
-    assert.equal(filteredDecs.length, 1);
-    assert.equal(filteredDecs[0]?.id, 'D001');
-    // Decisions table is unaffected by requirement filtering
-    assert.equal(decisions.length, 2, 'Original decisions unchanged');
-  });
-
-  it('getRequirementByIdStrict: throws on adapter unavailable, returns null on not found', () => {
-    // Contract: getRequirementByIdStrict either throws (db_unavailable) or returns Requirement | null.
-    // It never returns { error: ... } directly; the executor wraps errors.
-
-    // Simulate the throw case
-    const adapterUnavailableThrow = (): Requirement | null => {
-      throw new Error('Database adapter not available (db_unavailable)');
-    };
-
-    try {
-      adapterUnavailableThrow();
-      assert.fail('Should have thrown');
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      assert.ok(msg.includes('db_unavailable'), 'Throw includes db_unavailable marker');
-    }
-
-    // Simulate the null case (not found)
-    const notFoundCase = (): Requirement | null => null;
-    const result = notFoundCase();
-    assert.equal(result, null, 'Null return means not found');
-  });
-
-  it('getDecisionByIdStrict: respects includeSuperseded flag for tombstone handling', () => {
-    // When includeSuperseded=false (default), getDecisionByIdStrict returns null
-    // for superseded decisions. When true, it returns them.
-    // Tombstones (deleted: true) always return null.
-
-    const tombstoneStructuredFields = {
-      sourceDecisionId: 'D999',
-      deleted: true,
-      decision: 'Deleted decision',
-    };
-
-    const supersededStructuredFields = {
-      sourceDecisionId: 'D008',
-      superseded_by: 'D009',
-      decision: 'Superseded decision',
-    };
-
-    const handleTombstone = (sf: Record<string, unknown>): Decision | null => {
-      if (sf['deleted'] === true) return null;
-      return { id: sf['sourceDecisionId'] as string } as any;
-    };
-
-    const handleSuperseded = (
-      sf: Record<string, unknown>,
-      includeSuperseded: boolean,
-    ): Decision | null => {
-      const supersededBy = typeof sf['superseded_by'] === 'string' ? sf['superseded_by'] : null;
-      if (!includeSuperseded && supersededBy) return null;
-      return { id: sf['sourceDecisionId'] as string, superseded_by: supersededBy } as any;
-    };
-
-    // Tombstones are always null
-    assert.equal(handleTombstone(tombstoneStructuredFields), null, 'Tombstone returns null');
-
-    // Superseded handling depends on flag
-    assert.equal(
-      handleSuperseded(supersededStructuredFields, false),
-      null,
-      'Superseded + includeSuperseded=false -> null',
-    );
-    const result = handleSuperseded(supersededStructuredFields, true);
-    assert.ok(result, 'Superseded + includeSuperseded=true -> result');
-    assert.equal(result?.superseded_by, 'D009', 'superseded_by field preserved');
-  });
-});
-
-interface Requirement {
-  id: string;
-  description: string;
-  [key: string]: any;
-}
-
-interface Decision {
-  id: string;
-  decision: string;
-  superseded_by?: string | null;
-  [key: string]: any;
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+
+process.env.GSD_WORKFLOW_EXECUTORS_MODULE = new URL(
+  "../tools/workflow-tool-executors.ts",
+  import.meta.url,
+).pathname;
+
+import { registerDbTools } from "../bootstrap/db-tools.ts";
+import { registerWorkflowTools } from "../../../../../packages/mcp-server/src/workflow-tools.ts";
+import {
+  closeDatabase,
+  openDatabase,
+} from "../mcp-bridge.ts";
+import { insertRequirement } from "../gsd-db.ts";
+import { getDbPath } from "../gsd-db.ts";
+import { resolveProjectRootDbPath } from "../db-workspace.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+type NativeTool = {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: unknown,
+    ctx: unknown,
+  ) => Promise<Record<string, unknown>>;
 };
+
+type McpTool = {
+  name: string;
+  handler: (args: Record<string, unknown>) => Promise<Record<string, unknown>>;
+};
+
+function makeProjectBase(prefix: string): string {
+  const base = join(tmpdir(), `${prefix}-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(basePaths: string[]): void {
+  try {
+    closeDatabase();
+  } catch {
+    // noop
+  }
+  invalidateAllCaches();
+  for (const base of basePaths) {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+function makeNativeTools(): NativeTool[] {
+  const tools: NativeTool[] = [];
+  registerDbTools({
+    registerTool(tool: NativeTool) {
+      tools.push(tool);
+    },
+  } as unknown as Parameters<typeof registerDbTools>[0]);
+  return tools;
+}
+
+function makeMcpTools(): McpTool[] {
+  const tools: McpTool[] = [];
+  registerWorkflowTools({
+    tool(name: string, _description: string, _params: Record<string, unknown>, handler: McpTool["handler"]) {
+      tools.push({ name, handler });
+    },
+  } as Parameters<typeof registerWorkflowTools>[0]);
+  return tools;
+}
+
+function nativeTool(tools: NativeTool[], name: string): NativeTool {
+  const found = tools.find((tool) => tool.name === name);
+  assert.ok(found, `${name} should be registered`);
+  return found;
+}
+
+function mcpTool(tools: McpTool[], name: string): McpTool {
+  const found = tools.find((tool) => tool.name === name);
+  assert.ok(found, `${name} should be registered`);
+  return found;
+}
+
+function seedRequirement(id: string, description: string): void {
+  insertRequirement({
+    id,
+    class: "core-capability",
+    status: "active",
+    description,
+    why: "regression",
+    source: "test",
+    primary_owner: "M001/S01",
+    supporting_slices: "",
+    validation: "n/a",
+    notes: "",
+    full_content: `- [ ] **${id}: ${description}**`,
+    superseded_by: null,
+  });
+}
+
+test("canonical read tools: missing DB returns db_unavailable and does not create gsd.db", async () => {
+  const base = makeProjectBase("gsd-canonical-missing-db");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+    const dbPath = resolveProjectRootDbPath(base);
+
+    const nativeList = await nativeTool(native, "gsd_requirement_list").execute(
+      "call-1",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeDetails = (nativeList as { details?: Record<string, unknown> }).details;
+    assert.equal(nativeDetails?.error, "db_unavailable");
+    assert.equal(existsSync(dbPath), false, "native read should not create gsd.db as side effect");
+
+    const mcpList = await mcpTool(mcp, "gsd_requirement_list").handler({ projectDir: base });
+    const mcpDetails = (mcpList as { details?: Record<string, unknown> }).details;
+    assert.equal(mcpDetails?.error, "db_unavailable");
+    assert.equal(existsSync(dbPath), false, "MCP read should not create gsd.db as side effect");
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read tools: reading project B does not switch global DB handle from project A", async () => {
+  const baseA = makeProjectBase("gsd-canonical-global-a");
+  const baseB = makeProjectBase("gsd-canonical-global-b");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+
+    openDatabase(resolveProjectRootDbPath(baseA));
+    seedRequirement("R101", "A requirement");
+
+    openDatabase(resolveProjectRootDbPath(baseB));
+    seedRequirement("R201", "B requirement");
+
+    openDatabase(resolveProjectRootDbPath(baseA));
+    const before = getDbPath();
+    assert.ok(before, "global DB should be open on project A");
+
+    const nativeList = await nativeTool(native, "gsd_requirement_list").execute(
+      "call-2",
+      { limit: 10 },
+      undefined,
+      undefined,
+      { cwd: baseB },
+    );
+    const nativeCount = ((nativeList as { details?: { count?: number } }).details?.count ?? -1);
+    assert.equal(nativeCount, 1, "native isolated read should query project B rows");
+    assert.equal(getDbPath(), before, "native isolated read must keep global DB path unchanged");
+
+    const mcpList = await mcpTool(mcp, "gsd_requirement_list").handler({
+      projectDir: baseB,
+      limit: 10,
+    });
+    const mcpCount = ((mcpList as { details?: { count?: number } }).details?.count ?? -1);
+    assert.equal(mcpCount, 1, "MCP isolated read should query project B rows");
+    assert.equal(getDbPath(), before, "MCP isolated read must keep global DB path unchanged");
+  } finally {
+    cleanup([baseA, baseB]);
+  }
+});
+
+test("canonical read tools: query_error returns structured error and does not break subsequent isolated reads", async () => {
+  const base = makeProjectBase("gsd-canonical-query-error");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+    const dbPath = resolveProjectRootDbPath(base);
+
+    openDatabase(dbPath);
+    const db = (await import("../gsd-db.ts"))._getAdapter();
+    assert.ok(db, "adapter should be available");
+    db.prepare("DROP TABLE requirements").run();
+
+    const nativeResult = await nativeTool(native, "gsd_requirement_list").execute(
+      "call-3",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeDetails = (nativeResult as { details?: Record<string, unknown> }).details;
+    assert.equal(nativeDetails?.error, "query_error");
+
+    const mcpResult = await mcpTool(mcp, "gsd_requirement_list").handler({ projectDir: base });
+    const mcpDetails = (mcpResult as { details?: Record<string, unknown> }).details;
+    assert.equal(mcpDetails?.error, "query_error");
+
+    const isolated = (await import("../db-workspace.ts")).openWorkflowDatabaseIsolated(dbPath);
+    assert.ok(isolated, "isolated open should still work after handled query_error");
+    isolated?.close();
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read tools: native and MCP read the same canonical requirement row", async () => {
+  const base = makeProjectBase("gsd-canonical-parity");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+
+    openDatabase(resolveProjectRootDbPath(base));
+    seedRequirement("R777", "Parity requirement");
+
+    const nativeGet = await nativeTool(native, "gsd_requirement_get").execute(
+      "call-4",
+      { id: "R777" },
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeRequirement = (nativeGet as { details?: { requirement?: Record<string, unknown> } }).details?.requirement;
+
+    const mcpGet = await mcpTool(mcp, "gsd_requirement_get").handler({
+      projectDir: base,
+      id: "R777",
+    });
+    const mcpRequirement = (mcpGet as { details?: { requirement?: Record<string, unknown> } }).details?.requirement;
+
+    assert.equal(nativeRequirement?.id, "R777");
+    assert.equal(mcpRequirement?.id, "R777");
+    assert.equal(nativeRequirement?.description, "Parity requirement");
+    assert.equal(mcpRequirement?.description, "Parity requirement");
+  } finally {
+    cleanup([base]);
+  }
+});

--- a/src/resources/extensions/gsd/tests/context-store.test.ts
+++ b/src/resources/extensions/gsd/tests/context-store.test.ts
@@ -231,6 +231,31 @@ describe("context-store: query requirements", () => {
     assert.strictEqual(validated.length, 1, 'status filter validated returns 1');
     assert.strictEqual(validated[0]?.id, 'R002', 'validated returns R002');
   });
+
+  test("query requirements by class", () => {
+    openDatabase(':memory:');
+
+    insertRequirement({
+      id: 'R001', class: 'functional', status: 'active',
+      description: 'req A', why: 'w', source: 'M001', primary_owner: 'S01',
+      supporting_slices: '', validation: 'v', notes: '', full_content: '',
+      superseded_by: null,
+    });
+    insertRequirement({
+      id: 'R002', class: 'non-functional', status: 'active',
+      description: 'req B', why: 'w', source: 'M001', primary_owner: 'S01',
+      supporting_slices: '', validation: 'v', notes: '', full_content: '',
+      superseded_by: null,
+    });
+
+    const functional = queryRequirements({ class: 'functional' });
+    assert.strictEqual(functional.length, 1, 'class filter functional returns 1');
+    assert.strictEqual(functional[0]?.id, 'R001', 'functional returns R001');
+
+    const nonFunctional = queryRequirements({ class: 'non-functional' });
+    assert.strictEqual(nonFunctional.length, 1, 'class filter non-functional returns 1');
+    assert.strictEqual(nonFunctional[0]?.id, 'R002', 'non-functional returns R002');
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- route canonical read tools through an isolated per-project DB adapter instead of `ensureDbOpen` global-handle switching
- apply the same isolated adapter strategy to MCP canonical read handlers for parity with native tooling
- add canonical read regression tests that validate no implicit DB creation, no global handle mutation, structured `query_error` handling, and native/MCP parity

## Changes
- add `runSerializedCanonicalReadOperation` in MCP workflow tools and migrate canonical decision/requirement read handlers
- add `withCanonicalReadAdapter` execution path in native db tools and move canonical read handlers to strict read functions with adapter injection
- allow strict context-store read functions to accept an explicit adapter for isolated reads
- replace prior lightweight canonical-read tests with temp-DB behavioral regressions

## Validation
- `pnpm run test:compile`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/canonical-read-tools.test.js`
- `pnpm run verify:fast` *(known local path-encoding failure in `validate-pack` test under space-containing workspace path; unrelated to canonical read logic)*

Closes #1727
