### PR TITLE
fix(issue): Auto-mode stuck-loop: blocking runtime-error verification failure writes empty verdict rationale → SQLite CHECK constraint throws in finalize → infinite re-dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -1196,7 +1196,8 @@ export async function runPostUnitVerification(
         : "fail";
     let durableRecovery: "retry" | "abort" | null = null;
     if (mid && sid && tid) {
-      let rationale = verdict.failureContext || postExecFailureSummary || formatFailureContext(result);
+      let rationale = verdict.failureContext || postExecFailureSummary || formatFailureContext(result) ||
+        "Host-owned technical verification failed.";
       if (sourceError) {
         rationale = sourceError;
       } else if (postExecInfrastructureError) {

--- a/src/resources/extensions/gsd/db/writers/task-verification.ts
+++ b/src/resources/extensions/gsd/db/writers/task-verification.ts
@@ -101,6 +101,8 @@ export function insertHostTechnicalVerdict(
   if (requireActiveDomainOperationContext(context) !== "attempt.verify") {
     throw new Error("Host Technical Verdict creation requires an attempt.verify Domain Operation");
   }
+  const rationale = input.rationale.trim();
+  if (!rationale) throw new Error("rationale must not be blank");
   const verdictId = randomUUID();
   const evidenceId = randomUUID();
   getDb().prepare(`
@@ -121,7 +123,7 @@ export function insertHostTechnicalVerdict(
     ":attempt_id": input.scope.attemptId,
     ":source_revision": input.testedSourceRevision,
     ":verdict": input.verdict,
-    ":rationale": input.rationale,
+    ":rationale": rationale,
     ":supersedes_verdict_id": input.supersedesVerdictId ?? null,
     ":created_at": input.createdAt,
     ":operation_id": context.operationId,

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -647,6 +647,44 @@ function seedSucceededVerificationFailure(
   };
 }
 
+test("host Technical Verdict rejects a blank rationale before SQLite persistence", () => {
+  const seeded = seedReadyTask();
+  const claim = claimTaskAttempt({
+    invocation: invocation("blank-rationale/claim"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+    coordinationDispatchId: seeded.dispatchId,
+  });
+  settleTaskAttempt({
+    invocation: invocation("blank-rationale/settle"),
+    attemptId: claim.attemptId,
+    outcome: "succeeded",
+    failureClass: "none",
+    summary: "executor produced its result",
+    output: { changedFiles: ["src/task.ts"] },
+  });
+
+  assert.throws(() => recordTaskTechnicalVerdict({
+    invocation: invocation("blank-rationale/verdict"),
+    attemptId: claim.attemptId,
+    testedSourceRevision: "git:current-head",
+    verdict: "fail",
+    rationale: "   ",
+    evidence: {
+      evidenceClass: "command",
+      commandOrTool: "runtime-error-capture",
+      workingDirectory: "/tmp/project",
+      startedAt: "2026-07-13T01:00:00.000Z",
+      endedAt: "2026-07-13T01:00:01.000Z",
+      observation: "failed",
+      durableOutputRef: "db://host-verification/runtime-errors",
+      environment: { source: "bg-shell" },
+    },
+  }), /rationale must not be blank/);
+  assert.equal(count("workflow_technical_verdicts"), 0);
+});
+
 function supersedeFailedVerdict(scope: VerificationFailureScope): void {
   const fence = readDomainOperationFence();
   executeDomainOperation({

--- a/src/resources/extensions/gsd/tests/verification-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-verdict.test.ts
@@ -69,6 +69,44 @@ test("execute-task command failure remains retryable verification failure", () =
   assert.equal(verdict.retryable, true);
 });
 
+test("blocking runtime errors provide failure context when host checks pass", () => {
+  const verdict = decideVerificationVerdict(
+    "execute-task",
+    makeResult({
+      passed: false,
+      discoverySource: "package-json",
+      checks: [
+        {
+          command: "npm test",
+          exitCode: 0,
+          stdout: "ok",
+          stderr: "",
+          durationMs: 10,
+        },
+      ],
+      runtimeErrors: [
+        {
+          source: "bg-shell",
+          severity: "crash",
+          message: "vite preview exited with code 143",
+          blocking: true,
+        },
+        {
+          source: "browser",
+          severity: "warning",
+          message: "non-blocking console warning",
+          blocking: false,
+        },
+      ],
+    }),
+  );
+
+  assert.equal(verdict.passed, false);
+  assert.equal(verdict.reason, "checks-failed");
+  assert.equal(verdict.retryable, true);
+  assert.equal(verdict.failureContext, "[bg-shell] vite preview exited with code 143");
+});
+
 test("execute-task passes when a discovered host check succeeds", () => {
   const verdict = decideVerificationVerdict(
     "execute-task",

--- a/src/resources/extensions/gsd/verification-verdict.ts
+++ b/src/resources/extensions/gsd/verification-verdict.ts
@@ -22,6 +22,19 @@ export function decideVerificationVerdict(
   unitType: string,
   result: VerificationGateResult,
 ): VerificationVerdict {
+  if (!result.passed) {
+    const failureContext = (result.runtimeErrors ?? [])
+      .filter((error) => error.blocking)
+      .map((error) => `[${error.source}] ${error.message}`)
+      .join("\n");
+    return {
+      passed: false,
+      reason: "checks-failed",
+      retryable: true,
+      failureContext,
+    };
+  }
+
   if (unitType === "execute-task" && result.discoverySource === "task-plan-prose" && result.checks.length === 0) {
     return {
       passed: true,
@@ -37,15 +50,6 @@ export function decideVerificationVerdict(
       reason: "no-host-checks",
       retryable: false,
       failureContext: NO_HOST_CHECKS_FAILURE_CONTEXT,
-    };
-  }
-
-  if (!result.passed) {
-    return {
-      passed: false,
-      reason: "checks-failed",
-      retryable: true,
-      failureContext: "",
     };
   }
 


### PR DESCRIPTION
## Summary
- Fixed blank runtime-error verdict rationales with defensive persistence validation and passing focused regression tests.

## Bugs Addressed
- [x] **Blank rationale crashes runtime-error verification finalization**
- [ ] **Abnormal finalization leaves the orchestrator active unit stale** _(skipped: main already contains #1719’s active-unit abandonment fix and regression coverage.)_

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1730
- [#1730 Auto-mode stuck-loop: blocking runtime-error verification failure writes empty verdict rationale → SQLite CHECK constraint throws in finalize → infinite re-dispatch](https://github.com/open-gsd/gsd-pi/issues/1730)

## User
- @thanhnndev

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1730-auto-mode-stuck-loop-blocking-runtime-er-1786606913`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-pi/pr/1733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->