### PR TITLE
feat(gsd): auto-mode UnitRun identity (1.15.1 fail-closed, 1.16 collapse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 
 ## [Unreleased]
 
+### Changed
+- **gsd**: collapse auto-mode onto a single UnitRun — the claimed/running `unit_dispatches` row (ADR-048). `advance()` returns `dispatchId`; `getStatus().activeUnit` reads the database; `settle(dispatchId, outcome)` is the closeout seam.
+
 ## [1.15.1] - 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 
 ## [Unreleased]
 
+## [1.15.1] - 2026-08-14
+
+### Fixed
+- **gsd**: fail-closed auto-mode closeout so a unit run cannot silently re-enter the same skip (#1754, #1739, #1726)
+- **gsd**: persist a terminal task-recovery abort and stop re-dispatching that execute-task until resume (#1754)
+- **gsd**: settle the active unit when verified-task publication fails, and recapture the host-verification source after deferred execute-task commit/hooks (#1739)
+- **gsd**: do not re-project a leaked SUMMARY for cancelled/interrupted task attempts (#1726)
+
 ## [1.15.0] - 2026-08-12
 
 ### Added

--- a/docs/dev/ADR-048-unitrun-dispatch-row.md
+++ b/docs/dev/ADR-048-unitrun-dispatch-row.md
@@ -1,0 +1,34 @@
+# ADR-048: UnitRun is the claimed `unit_dispatches` row
+
+- **Status:** Accepted
+- **Date:** 2026-08-14
+- **Driver:** Auto-mode identity wedges (#1754, #1739, #1726) after v1.15.0
+- **Supersedes:** RAM `status.activeUnit` + `lastAdvanceKey` as sources of truth for the in-flight unit
+
+## Context
+
+v1.15 auto-mode kept three identities for the same run: an in-memory `activeUnit` / `lastAdvanceKey` on the orchestrator, a later `unit_dispatches` claim in the loop, and ADR-047 liveness signatures over guard input hashes. `advance()` could return `advanced` before a durable claim existed. The loop then hoped `finally` would clear RAM. Process kill, publication failure, and terminal recovery abort left `activeUnit` set while the ledger row was missing or already terminal, so the next tick string-matched `"idempotent advance: unit already active"` and livelocked.
+
+ADR-047 stays the **block detector**. It must not grow a third identity or new string matches.
+
+## Decision
+
+**UnitRun = the `unit_dispatches` row for this worker with `status IN ('claimed','running')`.**
+
+- `advance()` inserts that claim in the same step that returns `kind: "advanced"` and always includes `dispatchId`. If the claim cannot open, the result is `blocked`/`stopped`, never `advanced`.
+- `getStatus().activeUnit` is a defensive copy of that row, not RAM state.
+- Closeout is `settle(dispatchId, outcome, reason)`. `complete` / `retry` / `abandon` remain wrappers that load the row (or run ADR-047 hashing when the row is already terminal).
+- If this worker already holds a claimed/running row for the **same** unit and `unitExecutionInFlight` is set, `advance()` returns `skipped` with `code: "unit-already-active"`. If the unit is **not** in flight (restart between `advanced` and unit phase), `advance()` returns `advanced` with the existing `dispatchId` (resume). A claimed row for a **different** unit is canceled, then a new claim opens.
+- ADR-047 is unchanged: liveness over guard input hashes. It does not decide the active unit.
+
+## Consequences
+
+- `lastAdvanceKey`, `orchestrationUnitPendingCloseout`, and optional `releaseActiveUnit` are deleted.
+- The canonical loop does not call `openDispatchClaim` after `advance()`. Custom-engine execute-task and sidecar items still claim themselves.
+- Skip reasons keep human-readable strings for logs and liveness payloads; loop branches on `code`, not reason text.
+
+## Rejected alternatives
+
+- Freeze 1.15.x — leaves field users wedged.
+- Backport the full UnitRun collapse onto 1.15.x — too large for a patch (shipped as 1.15.1 fail-closed, then this 1.16 identity change).
+- A new table or a new RAM `UnitRef` — `unit_dispatches` already has the lifecycle.

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -86,6 +86,7 @@ import {
   loadRoadmapCompletedSliceCandidates,
 } from "./auto-prompts.js";
 import { readPendingTaskRecoveryContext } from "./task-recovery-domain-operation.js";
+import { readTerminalTaskRecoveryAbort } from "./artifact-verification.js";
 import { checkNeedsRunUat } from "./uat-dispatch.js";
 import { normalizeModelFieldConfig, resolveModelWithFallbacksForUnit, resolveThinkingLevelForUnit } from "./preferences-models.js";
 import { resolveUokFlags } from "./uok/flags.js";
@@ -784,6 +785,30 @@ export function isVerificationNotApplicable(value: string): boolean {
   const v = (value ?? "").toLowerCase().trim().replace(/[.\s]+$/, "");
   if (!v || v === "none") return true;
   return /^(?:none(?:[\s._\u2014-]+[\s\S]*)?|n\/?a(?:[\s._\u2014-]+[\s\S]*)?|not[\s._-]+(?:applicable|required|needed|provided)|no[\s._-]+operational[\s\S]*)$/i.test(v);
+}
+
+function readExecuteTaskTerminalAbort(
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+): Extract<DispatchAction, { action: "stop" }> | null {
+  if (!isDbAvailable()) return null;
+  let terminalAbort: ReturnType<typeof readTerminalTaskRecoveryAbort>;
+  try {
+    terminalAbort = readTerminalTaskRecoveryAbort(milestoneId, sliceId, taskId);
+  } catch (err) {
+    return {
+      action: "stop",
+      reason: `Cannot dispatch execute-task ${milestoneId}/${sliceId}/${taskId}: ${err instanceof Error ? err.message : String(err)}`,
+      level: "error",
+    };
+  }
+  if (!terminalAbort) return null;
+  return {
+    action: "stop",
+    reason: `Cannot dispatch execute-task ${milestoneId}/${sliceId}/${taskId}: canonical Task Attempt recovery already aborted (recoveryActionId: ${terminalAbort.recoveryActionId}). Resume it with gsd_task_recovery_resume.`,
+    level: "error",
+  };
 }
 
 // ─── Rules ────────────────────────────────────────────────────────────────
@@ -1899,6 +1924,8 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (retryUnitId) {
         const { milestone: retryMid, slice: retrySid, task: retryTid } = parseUnitId(retryUnitId);
         if (retryMid === mid && retrySid === sid && retryTid) {
+          const retryAbort = readExecuteTaskTerminalAbort(retryMid, retrySid, retryTid);
+          if (retryAbort) return retryAbort;
           const retryTitle = state.activeTask?.id === retryTid
             ? state.activeTask.title
             : retryTid;
@@ -1922,6 +1949,8 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (!state.activeTask) return null;
       const tid = state.activeTask.id;
       const tTitle = state.activeTask.title;
+      const terminalAbort = readExecuteTaskTerminalAbort(mid, sid, tid);
+      if (terminalAbort) return terminalAbort;
 
       return {
         action: "dispatch",

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -110,9 +110,9 @@ import {
   isTaskAttemptAwaitingVerification,
   readLatestTaskAttempt,
 } from "./task-execution-domain-operation.js";
-import { recordTaskTechnicalVerdict } from "./task-verification-domain-operation.js";
 import { recordFailureAndSelectRecovery } from "./task-recovery-domain-operation.js";
 import { isTaskExecutionReadyForHostVerification } from "./auto/task-execution-cutover.js";
+import { recaptureVerifiedSourceAfterDeferredCloseout } from "./auto/verified-source-recapture.js";
 import {
   routeEvidenceCrossReferenceBlock,
   type EvidenceCrossReferenceBlockResult,
@@ -2582,6 +2582,15 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
         return "stopped";
       }
       if (gitActionResult === "retry") {
+        return "retry";
+      }
+      if (
+        recaptureVerifiedSourceAfterDeferredCloseout({
+          unitType: s.currentUnit.type,
+          unitId: s.currentUnit.id,
+          basePath: s.basePath,
+        }) === "retry"
+      ) {
         return "retry";
       }
     }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -3,13 +3,14 @@
 /**
  * GSD Auto Mode — Fresh Session Per Unit
  *
- * State machine driven by .gsd/ files on disk. Each "unit" of work
- * (plan slice, execute task, complete slice) gets a fresh session via
+ * State machine driven by the project database and the UnitRun
+ * (`unit_dispatches` row with status claimed|running; ADR-048). Each "unit"
+ * of work (plan slice, execute task, complete slice) gets a fresh session via
  * the stashed ctx.newSession() pattern.
  *
- * The extension reads disk state after each agent_end, determines the
- * next unit type, creates a fresh session, and injects a focused prompt
- * telling the LLM which files to read and what to do.
+ * After each agent_end, the orchestrator decides the next unit, claims it in
+ * the same advance() step, creates a fresh session, and injects a focused
+ * prompt telling the LLM which files to read and what to do.
  */
 
 import type {

--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -20,6 +20,19 @@ export interface UnitRef {
   unitId: string;
 }
 
+export type AutoSkipCode = "unit-already-active" | "completed-no-advance";
+
+export const UNIT_ALREADY_ACTIVE_SKIP_CODE = "unit-already-active" as const;
+export const UNIT_ALREADY_ACTIVE_SKIP_REASON = "idempotent advance: unit already active";
+
+export function isUnitAlreadyActiveSkip(result: {
+  kind: string;
+  code?: string;
+  reason?: string;
+}): boolean {
+  return result.kind === "skipped" && result.code === UNIT_ALREADY_ACTIVE_SKIP_CODE;
+}
+
 export interface AutoStatus {
   phase: "idle" | "running" | "paused" | "stopped" | "error";
   activeUnit?: UnitRef;
@@ -49,8 +62,8 @@ export type AutoTerminalOutcome =
 export type AutoAdvanceResult =
   | { kind: "started" }
   | { kind: "resumed" }
-  | { kind: "advanced"; unit: UnitRef; stateSnapshot: GSDState }
-  | { kind: "skipped"; reason: string; stateSnapshot?: GSDState }
+  | { kind: "advanced"; unit: UnitRef; stateSnapshot: GSDState; dispatchId?: number }
+  | { kind: "skipped"; reason: string; code?: AutoSkipCode; stateSnapshot?: GSDState }
   | {
       kind: "blocked";
       reason: string;

--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -20,7 +20,11 @@ export interface UnitRef {
   unitId: string;
 }
 
-export type AutoSkipCode = "unit-already-active" | "completed-no-advance";
+export type AutoSkipCode =
+  | "unit-already-active"
+  | "completed-no-advance"
+  | "already-closed"
+  | "no-dispatch";
 
 export const UNIT_ALREADY_ACTIVE_SKIP_CODE = "unit-already-active" as const;
 export const UNIT_ALREADY_ACTIVE_SKIP_REASON = "idempotent advance: unit already active";
@@ -62,8 +66,8 @@ export type AutoTerminalOutcome =
 export type AutoAdvanceResult =
   | { kind: "started" }
   | { kind: "resumed" }
-  | { kind: "advanced"; unit: UnitRef; stateSnapshot: GSDState; dispatchId?: number }
-  | { kind: "skipped"; reason: string; code?: AutoSkipCode; stateSnapshot?: GSDState }
+  | { kind: "advanced"; unit: UnitRef; stateSnapshot: GSDState; dispatchId: number }
+  | { kind: "skipped"; reason: string; code: AutoSkipCode; stateSnapshot?: GSDState }
   | {
       kind: "blocked";
       reason: string;
@@ -83,7 +87,11 @@ export type AutoAdvanceResult =
 export interface AutoOrchestrationModule {
   start(sessionContext: AutoSessionContext): Promise<AutoAdvanceResult>;
   advance(): Promise<AutoAdvanceResult>;
-  releaseActiveUnit?(unit: UnitRef): Promise<void>;
+  settle(
+    dispatchId: number,
+    outcome: "completed" | "failed" | "retry" | "canceled",
+    reason: string,
+  ): Promise<void>;
   completeActiveUnit(unit: UnitRef): Promise<void>;
   retryActiveUnit(unit: UnitRef): Promise<void>;
   abandonActiveUnit(unit: UnitRef, reason: string): Promise<void>;

--- a/src/resources/extensions/gsd/auto/iteration-run.ts
+++ b/src/resources/extensions/gsd/auto/iteration-run.ts
@@ -1,0 +1,74 @@
+// Project/App: gsd-pi
+// File Purpose: Single closeout for an auto-mode iteration keyed by dispatchId + unit.
+
+import type { UnitRef } from "./contracts.js";
+import {
+  settleDispatchCompleted,
+  settleDispatchFailed,
+} from "./workflow-dispatch-ledger.js";
+
+export type IterationRunOutcome = "completed" | "failed" | "retry" | "canceled";
+
+export interface IterationRun {
+  dispatchId: number | null;
+  unitType: string;
+  unitId: string;
+}
+
+export interface SettleIterationRunDeps {
+  markFailed: (dispatchId: number, details: { errorSummary: string }) => boolean;
+  markCompleted: (dispatchId: number) => boolean;
+  logWriteFailure: (err: unknown) => void;
+  completeActiveUnit?: (unit: UnitRef) => Promise<void>;
+  retryActiveUnit?: (unit: UnitRef) => Promise<void>;
+  abandonActiveUnit?: (unit: UnitRef, reason: string) => Promise<void>;
+  releaseActiveUnit?: (unit: UnitRef) => Promise<void>;
+}
+
+/**
+ * Settle the durable dispatch row (when present) and clear the orchestrator
+ * active-unit using the matching closeout method. Callers pass iterData /
+ * observed unit identity — not a second RAM UnitRef copy.
+ */
+export async function settleIterationRun(
+  run: IterationRun,
+  outcome: IterationRunOutcome,
+  reason: string,
+  alreadySettled: boolean,
+  deps: SettleIterationRunDeps,
+): Promise<boolean> {
+  const unit: UnitRef = { unitType: run.unitType, unitId: run.unitId };
+  let settled = alreadySettled;
+  if (!settled) {
+    if (outcome === "completed") {
+      settled = settleDispatchCompleted(run.dispatchId, deps);
+    } else {
+      settled = settleDispatchFailed(run.dispatchId, reason, deps);
+    }
+  }
+
+  switch (outcome) {
+    case "completed":
+      await deps.completeActiveUnit?.(unit);
+      break;
+    case "retry":
+      await deps.retryActiveUnit?.(unit);
+      break;
+    case "failed":
+      await deps.abandonActiveUnit?.(unit, reason);
+      break;
+    case "canceled":
+      if (deps.releaseActiveUnit) {
+        await deps.releaseActiveUnit(unit);
+      } else {
+        await deps.abandonActiveUnit?.(unit, reason);
+      }
+      break;
+    default: {
+      const exhaustive: never = outcome;
+      throw new Error(`Unhandled iteration-run outcome: ${String(exhaustive)}`);
+    }
+  }
+
+  return settled;
+}

--- a/src/resources/extensions/gsd/auto/iteration-run.ts
+++ b/src/resources/extensions/gsd/auto/iteration-run.ts
@@ -22,7 +22,6 @@ export interface SettleIterationRunDeps {
   completeActiveUnit?: (unit: UnitRef) => Promise<void>;
   retryActiveUnit?: (unit: UnitRef) => Promise<void>;
   abandonActiveUnit?: (unit: UnitRef, reason: string) => Promise<void>;
-  releaseActiveUnit?: (unit: UnitRef) => Promise<void>;
 }
 
 /**
@@ -58,11 +57,7 @@ export async function settleIterationRun(
       await deps.abandonActiveUnit?.(unit, reason);
       break;
     case "canceled":
-      if (deps.releaseActiveUnit) {
-        await deps.releaseActiveUnit(unit);
-      } else {
-        await deps.abandonActiveUnit?.(unit, reason);
-      }
+      await deps.abandonActiveUnit?.(unit, reason);
       break;
     default: {
       const exhaustive: never = outcome;

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -872,8 +872,9 @@ export async function autoLoop(
             ...details,
           }),
         });
-        observedUnitType = iterData.unitType;
-        observedUnitId = iterData.unitId;
+        const customIterData = iterData;
+        observedUnitType = customIterData.unitType;
+        observedUnitId = customIterData.unitId;
 
         let customDispatchId: number | null = null;
         let customDispatchSettled = false;
@@ -942,8 +943,8 @@ export async function autoLoop(
             WORKER_HEARTBEAT_INTERVAL_MS,
             () => (deps.taskExecutionBoundary ?? runWithTaskExecutionAttempt)(
               {
-                unitType: iterData.unitType,
-                unitId: iterData.unitId,
+                unitType: customIterData.unitType,
+                unitId: customIterData.unitId,
                 dispatchId: customDispatchId,
                 workerId: s.workerId,
                 milestoneLeaseToken: s.milestoneLeaseToken,
@@ -956,7 +957,7 @@ export async function autoLoop(
               () => runUnitPhaseViaContract(
                 dispatchContract,
                 ic,
-                iterData,
+                customIterData,
                 loopState,
                 undefined,
                 unitDispatchDeps,
@@ -1088,14 +1089,14 @@ export async function autoLoop(
           verifyPolicy: async () => {
             if (policy.verifyWithEvidence) {
               const result = await policy.verifyWithEvidence(
-                iterData.unitType,
-                iterData.unitId,
+                customIterData.unitType,
+                customIterData.unitId,
                 { basePath: s.basePath },
               );
               verificationReads.push({ source: "policy", evidence: result.inputPayload });
               return result.outcome;
             }
-            const outcome = await policy.verify(iterData.unitType, iterData.unitId, { basePath: s.basePath });
+            const outcome = await policy.verify(customIterData.unitType, customIterData.unitId, { basePath: s.basePath });
             verificationReads.push({ source: "policy", evidence: JSON.stringify({ outcome }) });
             return outcome;
           },
@@ -1656,6 +1657,7 @@ export async function autoLoop(
       if (!iterData) {
         throw new Error("iteration data missing after dispatch");
       }
+      const unitIterData = iterData;
 
       if (dispatchId === null) {
       // Sidecar (and pending-dispatch tests without a UnitRun id) still claim
@@ -1783,8 +1785,8 @@ export async function autoLoop(
           WORKER_HEARTBEAT_INTERVAL_MS,
           () => (deps.taskExecutionBoundary ?? runWithTaskExecutionAttempt)(
             {
-              unitType: iterData.unitType,
-              unitId: iterData.unitId,
+              unitType: unitIterData.unitType,
+              unitId: unitIterData.unitId,
               dispatchId,
               workerId: s.workerId,
               milestoneLeaseToken: s.milestoneLeaseToken,
@@ -1797,7 +1799,7 @@ export async function autoLoop(
             () => runUnitPhaseViaContract(
               dispatchContract,
               ic,
-              iterData,
+              unitIterData,
               loopState,
               sidecarItem,
               unitDispatchDeps,

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -642,7 +642,6 @@ export async function autoLoop(
           completeActiveUnit: s.orchestration?.completeActiveUnit?.bind(s.orchestration),
           retryActiveUnit: s.orchestration?.retryActiveUnit?.bind(s.orchestration),
           abandonActiveUnit: s.orchestration?.abandonActiveUnit?.bind(s.orchestration),
-          releaseActiveUnit: s.orchestration?.releaseActiveUnit?.bind(s.orchestration),
         },
       );
     };
@@ -1327,6 +1326,7 @@ export async function autoLoop(
                   unitId: existingPendingDispatch.unitId,
                 },
                 stateSnapshot: existingPendingDispatch.state,
+                dispatchId: existingPendingDispatch.dispatchId ?? 0,
               }
             : await orchestration.advance();
 
@@ -1335,11 +1335,20 @@ export async function autoLoop(
             isUnitAlreadyActiveSkip(orchestrationResult) &&
             !s.unitExecutionInFlight
           ) {
-            const staleActiveUnit = orchestration.getStatus().activeUnit;
-            if (staleActiveUnit && orchestration.releaseActiveUnit) {
-              await orchestration.releaseActiveUnit(staleActiveUnit);
-              orchestrationResult = await orchestration.advance();
-            }
+            s.pendingOrchestrationDispatch = null;
+            await deferStopAuto(ctx, pi, markBlockedStopReason(orchestrationResult.reason));
+            finishTurn(
+              "stopped",
+              "none",
+              orchestrationResult.reason,
+              "orchestration-stale-active-unit",
+            );
+            finishIncompleteIteration({
+              status: "stopped",
+              reason: orchestrationResult.reason,
+              failureClass: "manual-attention",
+            });
+            break;
           }
 
           if (orchestrationResult.kind === "blocked") {
@@ -1517,6 +1526,9 @@ export async function autoLoop(
             isRetry: false,
             previousTier: undefined,
           };
+          if (orchestrationResult.dispatchId > 0) {
+            dispatchId = orchestrationResult.dispatchId;
+          }
           const preDispatchResult = deps.runPreDispatchHooks(
             iterData.unitType,
             iterData.unitId,
@@ -1645,12 +1657,9 @@ export async function autoLoop(
         throw new Error("iteration data missing after dispatch");
       }
 
-      // Phase B: claim a unit_dispatches row before invoking the unit. The
-      // partial unique index idx_unit_dispatches_active_per_unit prevents
-      // a second worker from claiming the same unit concurrently. When this
-      // process has a worker identity, make the milestone lease explicit before
-      // claiming so a step-mode handoff cannot leave us running with a stale
-      // in-memory token and no backing lease row.
+      if (dispatchId === null) {
+      // Sidecar (and pending-dispatch tests without a UnitRun id) still claim
+      // here. Canonical advance() already opened the unit_dispatches row.
       let leaseBeforeClaim = ensureDispatchLease(s, iterData.mid, {
         claimMilestoneLease,
         logLeaseRecovered: logDispatchLeaseRecovered,
@@ -1762,6 +1771,7 @@ export async function autoLoop(
         break;
       }
       dispatchId = dispatchDecision.dispatchId;
+      }
 
       let unitPhaseResult: Awaited<ReturnType<typeof runUnitPhaseViaContract>>;
       try {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -15,7 +15,9 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AutoSession } from "./session.js";
-import type { AutoTerminalOutcome, UnitRef } from "./contracts.js";
+import type { AutoTerminalOutcome } from "./contracts.js";
+import { isUnitAlreadyActiveSkip } from "./contracts.js";
+import { settleIterationRun, type IterationRunOutcome } from "./iteration-run.js";
 import type { LoopDeps, StopAutoOptions } from "./loop-deps.js";
 import type { GSDState } from "../types.js";
 import {
@@ -71,7 +73,6 @@ import {
   decideMinRequestInterval,
   decideWorkflowLoop,
   formatDispatchExceptionSummary,
-  formatUnhandledDispatchErrorSummary,
   resolveUnitRequestTimestamp,
   shouldUseCustomEnginePath,
 } from "./workflow-kernel.js";
@@ -80,7 +81,6 @@ import {
   saveCustomVerifyRetryCounts,
 } from "./custom-verify-retry-store.js";
 import {
-  settleDispatchCompleted,
   settleDispatchFailed,
   settleDispatchIfNeeded,
 } from "./workflow-dispatch-ledger.js";
@@ -570,7 +570,7 @@ export async function autoLoop(
       options?: StopAutoOptions;
     } | null = null;
     let ownsUnitExecution = false;
-    let orchestrationUnitPendingCloseout: UnitRef | null = null;
+    let runClosed = false;
     let abnormalUnitExitReason = "unit exited without clean closeout";
     const deferStopAuto: LoopDeps["stopAuto"] = async (_ctx, _pi, reason, options) => {
       pendingStopAuto ??= { reason, options };
@@ -589,7 +589,7 @@ export async function autoLoop(
       guardId: string | null,
       inputPayload?: string,
     ): void => {
-      if (orchestrationUnitPendingCloseout) {
+      if (!runClosed) {
         abnormalUnitExitReason = error ?? guardId ?? status;
       }
       turnReporter.finish({
@@ -612,6 +612,40 @@ export async function autoLoop(
 
     let dispatchId: number | null = null;
     let dispatchSettled = false;
+    let iterData: IterationData | undefined;
+    const closeRun = async (
+      outcome: IterationRunOutcome,
+      reason: string,
+    ): Promise<void> => {
+      if (runClosed) return;
+      const unit = (observedUnitType && observedUnitId
+        ? { unitType: observedUnitType, unitId: observedUnitId }
+        : null)
+        ?? (iterData
+          ? { unitType: iterData.unitType, unitId: iterData.unitId }
+          : null);
+      if (!unit && dispatchId === null) return;
+      runClosed = true;
+      dispatchSettled = await settleIterationRun(
+        {
+          dispatchId,
+          unitType: unit?.unitType ?? "orchestration",
+          unitId: unit?.unitId ?? s.currentMilestoneId ?? "workflow",
+        },
+        outcome,
+        reason,
+        dispatchSettled,
+        {
+          markFailed: markDispatchFailed,
+          markCompleted: markDispatchCompleted,
+          logWriteFailure: logDispatchLedgerWriteFailure,
+          completeActiveUnit: s.orchestration?.completeActiveUnit?.bind(s.orchestration),
+          retryActiveUnit: s.orchestration?.retryActiveUnit?.bind(s.orchestration),
+          abandonActiveUnit: s.orchestration?.abandonActiveUnit?.bind(s.orchestration),
+          releaseActiveUnit: s.orchestration?.releaseActiveUnit?.bind(s.orchestration),
+        },
+      );
+    };
     let iterationEndEmitted = false;
     const emitIterationEnd = (details: Record<string, unknown> = {}): void => {
       if (iterationEndEmitted) return;
@@ -751,7 +785,6 @@ export async function autoLoop(
         nextSeq,
       };
       journalReporter.emit("iteration-start", { iteration });
-      let iterData: IterationData;
 
       // ── Custom engine path ──────────────────────────────────────────────
       // When activeEngineId is a non-dev value, the custom engine drives its own
@@ -892,10 +925,13 @@ export async function autoLoop(
             logClaimFailed: logDispatchClaimFailed,
           });
           if (claim.kind !== "opened") {
-            const reason = claim.kind === "skip" ? claim.reason : "dispatch claim degraded";
+            const reason = claim.kind === "skip" || claim.kind === "degraded"
+              ? claim.reason
+              : "dispatch claim degraded";
             throw new Error(`Custom engine execute-task requires a canonical coordination dispatch: ${reason}`);
           }
           customDispatchId = claim.dispatchId;
+          dispatchId = customDispatchId;
         }
         let unitPhaseResult: Awaited<ReturnType<typeof runUnitPhaseViaContract>>;
         try {
@@ -939,6 +975,7 @@ export async function autoLoop(
               markFailed: markDispatchFailed,
               logWriteFailure: logDispatchLedgerWriteFailure,
             }));
+          dispatchSettled = customDispatchSettled;
           throw err;
         }
         if (unitPhaseResult.action === "next") {
@@ -959,7 +996,9 @@ export async function autoLoop(
           if (customDispatchId !== null && !customDispatchSettled) {
             throw new Error(`Could not terminalize custom-engine dispatch ${customDispatchId} after unit break`);
           }
+          dispatchSettled = customDispatchSettled;
           await pauseForTaskRecoveryAbort(breakReason);
+          await closeRun("failed", breakReason);
           finishIncompleteIteration({
             status: "stopped",
             reason: breakReason,
@@ -979,13 +1018,8 @@ export async function autoLoop(
           if (customDispatchId !== null && !customDispatchSettled) {
             throw new Error(`Could not terminalize custom-engine dispatch ${customDispatchId} before unit retry`);
           }
-          await s.orchestration?.releaseActiveUnit?.(
-            orchestrationUnitPendingCloseout ?? {
-              unitType: iterData.unitType,
-              unitId: iterData.unitId,
-            },
-          );
-          orchestrationUnitPendingCloseout = null;
+          dispatchSettled = customDispatchSettled;
+          await closeRun("canceled", unitPhaseResult.reason);
           finishIncompleteIteration({
             status: "retry",
             reason: unitPhaseResult.reason,
@@ -1197,15 +1231,33 @@ export async function autoLoop(
         }
 
         if (iterData.unitType === "execute-task") {
-          await (deps.taskPublicationBoundary ?? publishVerifiedTaskExecution)({
-            unitType: iterData.unitType,
-            unitId: iterData.unitId,
-            workerId: s.workerId,
-            traceId: flowId,
-            turnId,
-            basePath: s.basePath,
-          }, VERIFIED_TASK_PUBLICATION_DEPS);
+          try {
+            await (deps.taskPublicationBoundary ?? publishVerifiedTaskExecution)({
+              unitType: iterData.unitType,
+              unitId: iterData.unitId,
+              workerId: s.workerId,
+              traceId: flowId,
+              turnId,
+              basePath: s.basePath,
+            }, VERIFIED_TASK_PUBLICATION_DEPS);
+          } catch (publishErr) {
+            const publishReason = publishErr instanceof Error ? publishErr.message : String(publishErr);
+            await closeRun("failed", publishReason);
+            ctx.ui.notify(publishReason, "error");
+            finishIncompleteIteration({
+              status: "stopped",
+              reason: publishReason,
+              unitType: iterData.unitType,
+              unitId: iterData.unitId,
+              failureClass: "closeout",
+            });
+            finishTurn("stopped", "closeout", publishReason, "task-publication-failed");
+            await deferStopAuto(ctx, pi, publishReason);
+            break;
+          }
         }
+
+        await closeRun("completed", "custom-engine-iteration-complete");
 
         // Verification passed — mark step complete
         const reconcileOutcome = await handleCustomEngineReconcile({
@@ -1280,7 +1332,7 @@ export async function autoLoop(
 
           if (
             orchestrationResult.kind === "skipped" &&
-            orchestrationResult.reason === "idempotent advance: unit already active" &&
+            isUnitAlreadyActiveSkip(orchestrationResult) &&
             !s.unitExecutionInFlight
           ) {
             const staleActiveUnit = orchestration.getStatus().activeUnit;
@@ -1323,7 +1375,7 @@ export async function autoLoop(
 
           if (orchestrationResult.kind === "skipped") {
             s.pendingOrchestrationDispatch = null;
-            if (orchestrationResult.reason === "idempotent advance: unit already active") {
+            if (isUnitAlreadyActiveSkip(orchestrationResult)) {
               emitIterationEnd({ skipped: true });
               completeIteration();
               if (s.unitExecutionInFlight) {
@@ -1452,7 +1504,6 @@ export async function autoLoop(
             );
             continue;
           }
-          orchestrationUnitPendingCloseout = { ...orchestrationResult.unit };
           const pendingDispatch = s.pendingOrchestrationDispatch;
           iterData = {
             unitType: pendingDispatch?.unitType ?? orchestrationResult.unit.unitType,
@@ -1590,6 +1641,10 @@ export async function autoLoop(
 
       await enforceMinRequestInterval(s, prefs);
 
+      if (!iterData) {
+        throw new Error("iteration data missing after dispatch");
+      }
+
       // Phase B: claim a unit_dispatches row before invoking the unit. The
       // partial unique index idx_unit_dispatches_active_per_unit prevents
       // a second worker from claiming the same unit concurrently. When this
@@ -1644,7 +1699,7 @@ export async function autoLoop(
           ? { kind: "opened", dispatchId: dispatchClaim.dispatchId }
           : dispatchClaim.kind === "skip"
             ? { kind: "skip", reason: dispatchClaim.reason }
-            : { kind: "degraded" },
+            : { kind: "degraded", reason: dispatchClaim.reason },
       );
       if (dispatchDecision.action === "skip" && dispatchDecision.reason === "stale-lease") {
         const leaseRecovery = ensureDispatchLease(s, iterData.mid, {
@@ -1665,7 +1720,7 @@ export async function autoLoop(
               ? { kind: "opened", dispatchId: dispatchClaim.dispatchId }
               : dispatchClaim.kind === "skip"
                 ? { kind: "skip", reason: dispatchClaim.reason }
-                : { kind: "degraded" },
+                : { kind: "degraded", reason: dispatchClaim.reason },
           );
         } else {
           const msg = leaseConflictNotice(iterData, leaseRecovery.reason);
@@ -1691,6 +1746,20 @@ export async function autoLoop(
           unitId: iterData.unitId,
         });
         continue;
+      }
+      if (dispatchDecision.action === "stop") {
+        const msg = dispatchDecision.message;
+        ctx.ui.notify(msg, "error");
+        finishTurn("stopped", "execution", msg, "dispatch-claim-degraded");
+        finishIncompleteIteration({
+          status: "stopped",
+          reason: msg,
+          unitType: iterData.unitType,
+          unitId: iterData.unitId,
+          failureClass: "execution",
+        });
+        await deferStopAuto(ctx, pi, msg);
+        break;
       }
       dispatchId = dispatchDecision.dispatchId;
 
@@ -1760,11 +1829,7 @@ export async function autoLoop(
       }
       if (unitPhaseResult.action === "break") {
         const breakReason = unitPhaseResult.reason ?? "unit-break";
-        dispatchSettled = settleDispatchIfNeeded(dispatchSettled, () =>
-          settleDispatchFailed(dispatchId, breakReason, {
-            markFailed: markDispatchFailed,
-            logWriteFailure: logDispatchLedgerWriteFailure,
-          }));
+        await closeRun("failed", breakReason);
         await pauseForTaskRecoveryAbort(breakReason);
         finishIncompleteIteration({
           status: "stopped",
@@ -1777,18 +1842,7 @@ export async function autoLoop(
         break;
       }
       if (unitPhaseResult.action === "retry") {
-        dispatchSettled = settleDispatchIfNeeded(dispatchSettled, () =>
-          settleDispatchFailed(dispatchId, unitPhaseResult.reason, {
-            markFailed: markDispatchFailed,
-            logWriteFailure: logDispatchLedgerWriteFailure,
-          }));
-        await s.orchestration?.releaseActiveUnit?.(
-          orchestrationUnitPendingCloseout ?? {
-            unitType: iterData.unitType,
-            unitId: iterData.unitId,
-          },
-        );
-        orchestrationUnitPendingCloseout = null;
+        await closeRun("canceled", unitPhaseResult.reason);
         finishIncompleteIteration({
           status: "retry",
           reason: unitPhaseResult.reason,
@@ -1868,11 +1922,7 @@ export async function autoLoop(
             : { action: "next" },
       );
       if (finalizeDecision.action === "stop") {
-        dispatchSettled = settleDispatchIfNeeded(dispatchSettled, () =>
-          settleDispatchFailed(dispatchId, finalizeDecision.ledgerErrorSummary, {
-            markFailed: markDispatchFailed,
-            logWriteFailure: logDispatchLedgerWriteFailure,
-          }));
+        await closeRun("failed", finalizeDecision.ledgerErrorSummary);
         finishIncompleteIteration({
           status: "stopped",
           reason: finalizeReason ?? "finalize-break",
@@ -1885,18 +1935,7 @@ export async function autoLoop(
       }
       if (finalizeDecision.action === "retry") {
         abortActiveUnitTurn(ctx);
-        dispatchSettled = settleDispatchIfNeeded(dispatchSettled, () =>
-          settleDispatchFailed(dispatchId, finalizeDecision.ledgerErrorSummary, {
-            markFailed: markDispatchFailed,
-            logWriteFailure: logDispatchLedgerWriteFailure,
-          }));
-        await s.orchestration?.retryActiveUnit(
-          orchestrationUnitPendingCloseout ?? {
-            unitType: iterData.unitType,
-            unitId: iterData.unitId,
-          },
-        );
-        orchestrationUnitPendingCloseout = null;
+        await closeRun("retry", finalizeDecision.ledgerErrorSummary);
         finishIncompleteIteration({
           status: "retry",
           reason: "finalize-retry",
@@ -1909,28 +1948,33 @@ export async function autoLoop(
       }
 
       if (iterData.unitType === "execute-task") {
-        await (deps.taskPublicationBoundary ?? publishVerifiedTaskExecution)({
-          unitType: iterData.unitType,
-          unitId: iterData.unitId,
-          workerId: s.workerId,
-          traceId: flowId,
-          turnId,
-          basePath: s.basePath,
-        }, VERIFIED_TASK_PUBLICATION_DEPS);
+        try {
+          await (deps.taskPublicationBoundary ?? publishVerifiedTaskExecution)({
+            unitType: iterData.unitType,
+            unitId: iterData.unitId,
+            workerId: s.workerId,
+            traceId: flowId,
+            turnId,
+            basePath: s.basePath,
+          }, VERIFIED_TASK_PUBLICATION_DEPS);
+        } catch (publishErr) {
+          const publishReason = publishErr instanceof Error ? publishErr.message : String(publishErr);
+          await closeRun("failed", publishReason);
+          ctx.ui.notify(publishReason, "error");
+          finishIncompleteIteration({
+            status: "stopped",
+            reason: publishReason,
+            unitType: iterData.unitType,
+            unitId: iterData.unitId,
+            failureClass: "closeout",
+          });
+          finishTurn("stopped", "closeout", publishReason, "task-publication-failed");
+          await deferStopAuto(ctx, pi, publishReason);
+          break;
+        }
       }
 
-      dispatchSettled = settleDispatchIfNeeded(dispatchSettled, () =>
-        settleDispatchCompleted(dispatchId, {
-          markCompleted: markDispatchCompleted,
-          logWriteFailure: logDispatchLedgerWriteFailure,
-        }));
-      await s.orchestration?.completeActiveUnit(
-        orchestrationUnitPendingCloseout ?? {
-          unitType: iterData.unitType,
-          unitId: iterData.unitId,
-        },
-      );
-      orchestrationUnitPendingCloseout = null;
+      await closeRun("completed", "iteration-complete");
       completeIteration();
       finishTurn("completed", "none", undefined, null);
       if (finalizeDecision.action === "complete-and-break") {
@@ -1942,18 +1986,8 @@ export async function autoLoop(
     } catch (loopErr) {
       // ── Blanket catch: absorb unexpected exceptions, apply graduated recovery ──
       const msg = loopErr instanceof Error ? loopErr.message : String(loopErr);
-      if (orchestrationUnitPendingCloseout) {
+      if (!runClosed) {
         abnormalUnitExitReason = msg;
-      }
-      if (dispatchId !== null && !dispatchSettled && !(loopErr instanceof ModelPolicyDispatchBlockedError)) {
-        dispatchSettled = settleDispatchFailed(
-          dispatchId,
-          formatUnhandledDispatchErrorSummary({ error: loopErr }),
-          {
-            markFailed: markDispatchFailed,
-            logWriteFailure: logDispatchLedgerWriteFailure,
-          },
-        );
       }
 
       // ── Pre-send model-policy block: not a retryable error (#4959 / #4850) ──
@@ -2105,12 +2139,8 @@ export async function autoLoop(
       }
       finishTurn(errorDecision.turnStatus, "execution", msg, "iteration-error");
     } finally {
-      if (orchestrationUnitPendingCloseout) {
-        await s.orchestration?.abandonActiveUnit(
-          orchestrationUnitPendingCloseout,
-          abnormalUnitExitReason,
-        );
-        orchestrationUnitPendingCloseout = null;
+      if (!runClosed && (dispatchId !== null || (observedUnitType && observedUnitId))) {
+        await closeRun("failed", abnormalUnitExitReason);
       }
       if (ownsUnitExecution) {
         s.unitExecutionInFlight = false;

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -75,6 +75,29 @@ import {
 } from "../auto-liveness-backstop.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  recordDispatchClaim,
+  markRunning as markDispatchRunning,
+  markCompleted as markDispatchCompleted,
+  markFailed as markDispatchFailed,
+  markCanceled as markDispatchCanceled,
+  getRecentForUnit as getRecentDispatchesForUnit,
+  getActiveForWorker,
+} from "../db/unit-dispatches.js";
+import { claimMilestoneLease } from "../db/milestone-leases.js";
+import type { IterationRunOutcome } from "./iteration-run.js";
+import {
+  activeUnitFromWorker,
+  claimUnitRun,
+  iterationDataForClaim,
+  resolveExistingUnitRun,
+  unitRefForDispatch,
+  UNIT_RUN_CLAIM_FAIL_LOG,
+  UNIT_RUN_CLAIM_REJECT_LOG,
+  UNIT_RUN_LEASE_FAIL_LOG,
+  UNIT_RUN_LEASE_LOG,
+} from "./unit-run.js";
 import { evaluateAllCompleteSettlement } from "../milestone-settlement.js";
 import { hasHeldMilestoneLease, reclaimMissingMilestoneLease } from "./milestone-lease-reclaim.js";
 import {
@@ -133,7 +156,7 @@ export interface OrchestratorContext {
 /** Result type of a single dispatch decision. */
 export type DispatchDecision =
   | { kind: "blocked"; reason: string; action: "pause" | "stop"; guardId: string }
-  | { kind: "skipped"; reason: string }
+  | { kind: "skipped"; reason: string; code: "no-dispatch" | "already-closed" }
   | { unitType: string; unitId: string; reason: string; preconditions: string[] }
   | null;
 
@@ -287,7 +310,7 @@ export async function decideOrchestratorDispatch(
     ) {
       session.pendingOrchestrationDispatch = null;
       session.pendingVerificationRetry = null;
-      return { kind: "skipped", reason: alreadyClosedReason };
+      return { kind: "skipped", reason: alreadyClosedReason, code: "already-closed" };
     }
     session.pendingVerificationRetryDispatch = null;
     session.pendingOrchestrationDispatch = pendingRetry;
@@ -330,6 +353,7 @@ export async function decideOrchestratorDispatch(
     return {
       kind: "skipped",
       reason: action.matchedRule ?? "dispatch-skip",
+      code: "no-dispatch",
     };
   }
   const alreadyClosedReason = getDispatchAlreadyClosedReason(action.unitType, action.unitId);
@@ -345,7 +369,7 @@ export async function decideOrchestratorDispatch(
       session.pendingOrchestrationDispatch = null;
       session.pendingVerificationRetry = null;
     }
-    return { kind: "skipped", reason: alreadyClosedReason };
+    return { kind: "skipped", reason: alreadyClosedReason, code: "already-closed" };
   }
   if (session) {
     const pending: PendingOrchestrationDispatch = {
@@ -379,7 +403,6 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   private readonly s: AutoSession;
   private readonly flowId: string;
   private seq = 0;
-  private lastAdvanceKey: string | null = null;
   private lastFinalizedUnitKey: string | null = null;
   // ADR-047 liveness backstop: target-row hash captured at dispatch so
   // completeActiveUnit can detect completed-no-advance outcomes, and the last
@@ -895,7 +918,6 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   // ── Lifecycle verbs ──────────────────────────────────────────────────────
 
   public async start(_sessionContext: AutoSessionContext): Promise<AutoAdvanceResult> {
-    this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
     // ADR-047: cross-session liveness state lives in the DB-persisted
     // block-signature ledger, not in-process — a restart resets nothing.
@@ -1152,7 +1174,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
               };
               this.status.phase = "stopped";
               this.status.activeUnit = undefined;
-              this.lastAdvanceKey = null;
+              this.discardActiveUnitRun(stopped.reason);
               this.bumpTransition();
               this.journalTransition({ name: "advance-stopped", reason: stopped.reason });
               this.postAdvanceRecord(stopped);
@@ -1169,7 +1191,6 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
           }
           this.status.phase = "paused";
           this.status.activeUnit = undefined;
-          this.lastAdvanceKey = null;
           this.bumpTransition();
           this.journalTransition({ name: "advance-blocked", reason: settlementBlock.reason });
           this.postAdvanceRecord(settlementBlock);
@@ -1184,15 +1205,17 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         };
         this.status.phase = "stopped";
         this.status.activeUnit = undefined;
-        this.lastAdvanceKey = null;
+        this.discardActiveUnitRun(stopped.reason);
         this.bumpTransition();
         this.journalTransition({ name: "advance-stopped", reason: stopped.reason });
         this.postAdvanceRecord(stopped);
         return stopped;
       }
       if ("kind" in decision && decision.kind === "skipped") {
+        this.discardActiveUnitRun(decision.reason);
         const skipped: AutoAdvanceResult = {
           kind: "skipped",
+          code: decision.code,
           reason: decision.reason,
           stateSnapshot: reconciliation.stateSnapshot,
         };
@@ -1269,13 +1292,13 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         });
       }
 
-      // Idempotency: same key as immediately previous successful advance.
-      // This is the soft, fast-path block kept from #5786 — the unit is still
-      // in flight, so re-polling is benign no matter how often it repeats.
-      // Genuine no-progress loops are the liveness backstop's job (ADR-047).
-      if (this.lastAdvanceKey === nextKey) {
-        // Unit already active — benign no-op. Return skipped so the loop re-polls
-        // without cancelling the in-flight unit (blocked+pause would force-cancel it).
+      const existingRun = resolveExistingUnitRun({
+        workerId: this.s.workerId,
+        unitType: decision.unitType,
+        unitId: decision.unitId,
+        unitExecutionInFlight: this.s.unitExecutionInFlight,
+      });
+      if (existingRun.kind === "skip-in-flight") {
         this.clearPendingDispatch();
         const skipped: AutoAdvanceResult = {
           kind: "skipped",
@@ -1337,9 +1360,16 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         return this.withLivenessInput(blocked, { guardId: "unit-worktree-preparation" });
       }
 
-      this.status.activeUnit = { unitType: decision.unitType, unitId: decision.unitId };
+      const dispatchId = existingRun.kind === "resume"
+        ? existingRun.dispatchId
+        : this.openUnitRun(decision.unitType, decision.unitId, reconciliation.stateSnapshot);
+      if (typeof dispatchId !== "number") {
+        this.clearPendingDispatch();
+        this.postAdvanceRecord(dispatchId);
+        return dispatchId;
+      }
+
       this.status.phase = "running";
-      this.lastAdvanceKey = nextKey;
       this.bumpTransition();
 
       this.journalTransition({
@@ -1348,20 +1378,20 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         unitType: decision.unitType,
         unitId: decision.unitId,
       });
-      // syncAfterUnit was a no-op in the wired WorktreeAdapter.
 
       const advanced: AutoAdvanceResult = {
         kind: "advanced",
         unit: { unitType: decision.unitType, unitId: decision.unitId },
         stateSnapshot: reconciliation.stateSnapshot,
+        dispatchId,
       };
       this.postAdvanceRecord(advanced);
       return advanced;
     } catch (error) {
       const recovery = this.classifyAndRecover({
         error,
-        unitType: this.status.activeUnit?.unitType,
-        unitId: this.status.activeUnit?.unitId,
+        unitType: activeUnitFromWorker(this.s.workerId)?.unitType,
+        unitId: activeUnitFromWorker(this.s.workerId)?.unitId,
       });
       let result: AutoAdvanceResult;
       if (recovery.action === "retry") {
@@ -1384,7 +1414,6 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       }
 
       if (result.kind === "stopped") {
-        this.lastAdvanceKey = null;
         this.lastFinalizedUnitKey = null;
         this.status.activeUnit = undefined;
       }
@@ -1412,7 +1441,6 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   }
 
   public async resume(): Promise<AutoAdvanceResult> {
-    this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
     this.pendingBackstopFailure = null;
     // ADR-047: the DB-persisted signature ledger already spans pause/resume
@@ -1431,10 +1459,9 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     if (this.status.phase === "stopped") {
       return { kind: "stopped", reason };
     }
-    // cleanupOnStop was a no-op in the wired WorktreeAdapter.
+    this.discardActiveUnitRun(reason);
     this.status.phase = "stopped";
     this.status.activeUnit = undefined;
-    this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = null;
     this.lastDerivedPhase = null;
     this.pendingTargetSnapshot = null;
@@ -1445,31 +1472,127 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   }
 
   public getStatus(): AutoStatus {
-    return { ...this.status, activeUnit: this.status.activeUnit ? { ...this.status.activeUnit } : undefined };
+    const activeUnit = activeUnitFromWorker(this.s.workerId);
+    return { ...this.status, activeUnit: activeUnit ? { ...activeUnit } : undefined };
   }
 
-  public async releaseActiveUnit(unit: { unitType: string; unitId: string }): Promise<void> {
-    const unitKey = buildDispatchKey(unit.unitType, unit.unitId);
-    const activeUnitKey = this.status.activeUnit
-      ? buildDispatchKey(this.status.activeUnit.unitType, this.status.activeUnit.unitId)
-      : null;
-    if (activeUnitKey !== unitKey) return;
-
-    this.status.activeUnit = undefined;
-    this.lastAdvanceKey = null;
+  public async settle(
+    dispatchId: number,
+    outcome: IterationRunOutcome,
+    reason: string,
+  ): Promise<void> {
+    const unit = unitRefForDispatch(dispatchId) ?? activeUnitFromWorker(this.s.workerId);
+    if (!unit) return;
+    switch (outcome) {
+      case "completed":
+        markDispatchCompleted(dispatchId);
+        await this.recordCompletedCloseout(unit);
+        break;
+      case "retry":
+        markDispatchFailed(dispatchId, { errorSummary: reason });
+        await this.recordRetryCloseout(unit);
+        break;
+      case "failed":
+        markDispatchFailed(dispatchId, { errorSummary: reason });
+        await this.recordAbandonCloseout(unit, reason);
+        break;
+      case "canceled":
+        markDispatchCanceled(dispatchId, reason);
+        await this.recordAbandonCloseout(unit, reason);
+        break;
+      default: {
+        const exhaustive: never = outcome;
+        throw new Error(`Unhandled settle outcome: ${String(exhaustive)}`);
+      }
+    }
   }
 
   public async completeActiveUnit(unit: { unitType: string; unitId: string }): Promise<void> {
-    const unitKey = buildDispatchKey(unit.unitType, unit.unitId);
-    const activeUnitKey = this.status.activeUnit
-      ? buildDispatchKey(this.status.activeUnit.unitType, this.status.activeUnit.unitId)
-      : null;
-    if (activeUnitKey !== unitKey) return;
+    const row = this.matchingActiveDispatch(unit);
+    if (row) {
+      await this.settle(row.id, "completed", "completeActiveUnit");
+      return;
+    }
+    await this.recordCompletedCloseout(unit);
+  }
 
-    // ADR-047 §4: a unit that returned without moving any of the target rows
-    // it was dispatched to move is a non-advancing outcome — the hottest wedge
-    // class (#1626) never hits an explicit block surface. Hash the same rows
-    // captured at dispatch; an unchanged hash feeds the ledger and trips at 2.
+  public async retryActiveUnit(unit: { unitType: string; unitId: string }): Promise<void> {
+    const row = this.matchingActiveDispatch(unit);
+    if (row) {
+      await this.settle(row.id, "retry", "finalize-retry");
+      return;
+    }
+    await this.recordRetryCloseout(unit);
+  }
+
+  public async abandonActiveUnit(
+    unit: UnitRef,
+    reason: string,
+  ): Promise<void> {
+    const row = this.matchingActiveDispatch(unit);
+    if (row) {
+      await this.settle(row.id, "failed", reason);
+      return;
+    }
+    await this.recordAbandonCloseout(unit, reason);
+  }
+
+  private matchingActiveDispatch(unit: UnitRef) {
+    if (!this.s.workerId) return null;
+    const row = getActiveForWorker(this.s.workerId);
+    if (!row) return null;
+    if (row.unit_type !== unit.unitType || row.unit_id !== unit.unitId) return null;
+    return row;
+  }
+
+  private discardActiveUnitRun(reason: string): void {
+    if (!this.s.workerId) return;
+    const row = getActiveForWorker(this.s.workerId);
+    if (row) markDispatchCanceled(row.id, reason);
+  }
+
+  private openUnitRun(
+    unitType: string,
+    unitId: string,
+    stateSnapshot: GSDState,
+  ): number | AutoAdvanceResult {
+    const claimed = claimUnitRun({
+      session: this.s,
+      flowId: this.s.currentTraceId ?? this.flowId,
+      turnId: this.s.currentTurnId ?? randomUUID(),
+      iterData: iterationDataForClaim(unitType, unitId, stateSnapshot, this.s),
+      leaseDeps: {
+        claimMilestoneLease,
+        logLeaseRecovered: UNIT_RUN_LEASE_LOG,
+        logLeaseRecoveryFailed: UNIT_RUN_LEASE_FAIL_LOG,
+      },
+      claimDeps: {
+        getRecentDispatchesForUnit,
+        recordDispatchClaim,
+        markDispatchRunning,
+        logClaimRejected: UNIT_RUN_CLAIM_REJECT_LOG,
+        logClaimFailed: UNIT_RUN_CLAIM_FAIL_LOG,
+      },
+    });
+    if (claimed.kind === "opened") return claimed.dispatchId;
+    if (claimed.kind === "blocked" || claimed.kind === "degraded") {
+      return {
+        kind: "blocked",
+        reason: claimed.reason,
+        action: "stop",
+        stateSnapshot,
+      };
+    }
+    return {
+      kind: "blocked",
+      reason: `dispatch claim skipped: ${claimed.reason}`,
+      action: "stop",
+      stateSnapshot,
+    };
+  }
+
+  private async recordCompletedCloseout(unit: UnitRef): Promise<void> {
+    const unitKey = buildDispatchKey(unit.unitType, unit.unitId);
     const scopeId = this.backstopScopeId();
     const snapshot = this.pendingTargetSnapshot;
     this.pendingTargetSnapshot = null;
@@ -1496,15 +1619,12 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         if ('error' in outcome) {
           this.pendingBackstopFailure = outcome.error;
         } else if (outcome.tripped) {
-          // Surface immediately; the wedge gate at the next advance() converts
-          // this into the terminal blocked stop (exit 10).
           this.ctx.ui.notify(formatWedgeTripNotice(outcome.wedge), "error");
         }
       }
     }
 
     this.status.activeUnit = undefined;
-    this.lastAdvanceKey = null;
     this.lastFinalizedUnitKey = unitKey;
     this.bumpTransition();
     this.journalTransition({
@@ -1514,17 +1634,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     });
   }
 
-  public async retryActiveUnit(unit: { unitType: string; unitId: string }): Promise<void> {
-    const unitKey = buildDispatchKey(unit.unitType, unit.unitId);
-    const activeUnitKey = this.status.activeUnit
-      ? buildDispatchKey(this.status.activeUnit.unitType, this.status.activeUnit.unitId)
-      : null;
-    if (activeUnitKey !== unitKey && this.lastFinalizedUnitKey !== unitKey) return;
-
-    // ADR-047 §4: a unit break/finalize failure is a non-advancing outcome.
-    // The signature input is the failure the loop just settled into the
-    // dispatch ledger — identical failure payloads twice mean the retry read
-    // the exact inputs that already failed.
+  private async recordRetryCloseout(unit: UnitRef): Promise<void> {
     const scopeId = this.backstopScopeId();
     if (scopeId) {
       const ledgerError = lookupLatestLedgerError(unit.unitType, unit.unitId);
@@ -1543,10 +1653,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       if ('error' in outcome) this.pendingBackstopFailure = outcome.error;
     }
 
-    if (activeUnitKey === unitKey) {
-      this.status.activeUnit = undefined;
-    }
-    this.lastAdvanceKey = null;
+    this.status.activeUnit = undefined;
     this.lastFinalizedUnitKey = null;
     this.bumpTransition();
     this.journalTransition({
@@ -1557,18 +1664,8 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     });
   }
 
-  public async abandonActiveUnit(
-    unit: UnitRef,
-    reason: string,
-  ): Promise<void> {
-    const unitKey = buildDispatchKey(unit.unitType, unit.unitId);
-    const activeUnitKey = this.status.activeUnit
-      ? buildDispatchKey(this.status.activeUnit.unitType, this.status.activeUnit.unitId)
-      : null;
-    if (activeUnitKey !== unitKey) return;
-
+  private async recordAbandonCloseout(unit: UnitRef, reason: string): Promise<void> {
     this.status.activeUnit = undefined;
-    this.lastAdvanceKey = null;
     this.pendingTargetSnapshot = null;
     this.bumpTransition();
     this.journalTransition({

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -13,6 +13,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import type { AutoAdvanceResult, AutoOrchestrationModule, AutoSessionContext, AutoStatus, AutoTerminalOutcome, UnitRef } from "./contracts.js";
+import { UNIT_ALREADY_ACTIVE_SKIP_CODE, UNIT_ALREADY_ACTIVE_SKIP_REASON } from "./contracts.js";
 import type { AutoSession, PendingOrchestrationDispatch } from "./session.js";
 import type { GSDState, Phase } from "../types.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
@@ -1248,6 +1249,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         }
         const skipped: AutoAdvanceResult = {
           kind: "skipped",
+          code: "completed-no-advance",
           reason: `state did not advance after finalized ${decision.unitType} ${decision.unitId}`,
           stateSnapshot: reconciliation.stateSnapshot,
         };
@@ -1275,7 +1277,11 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         // Unit already active — benign no-op. Return skipped so the loop re-polls
         // without cancelling the in-flight unit (blocked+pause would force-cancel it).
         this.clearPendingDispatch();
-        const skipped: AutoAdvanceResult = { kind: "skipped", reason: "idempotent advance: unit already active" };
+        const skipped: AutoAdvanceResult = {
+          kind: "skipped",
+          code: UNIT_ALREADY_ACTIVE_SKIP_CODE,
+          reason: UNIT_ALREADY_ACTIVE_SKIP_REASON,
+        };
         this.journalTransition({
           name: "advance-skipped",
           reason: skipped.reason,

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -68,6 +68,7 @@ export interface PendingOrchestrationDispatch {
   state: import("../types.js").GSDState;
   mid: string | undefined;
   midTitle: string | undefined;
+  dispatchId?: number;
 }
 
 /**

--- a/src/resources/extensions/gsd/auto/task-execution-cutover.ts
+++ b/src/resources/extensions/gsd/auto/task-execution-cutover.ts
@@ -424,12 +424,20 @@ export async function runWithTaskExecutionAttempt(
       retryOfAttemptId = predecessor.attemptId;
     }
   } else if (predecessor) {
+    const terminalRecovery = deps.readTaskRecoveryRoute(predecessor.attemptId);
+    if (
+      terminalRecovery?.recoveryOwner === "agent" &&
+      terminalRecovery.action === "abort" &&
+      !terminalRecovery.resumeAuthorized
+    ) {
+      return taskRecoveryAbortResult(terminalRecovery.recoveryActionId);
+    }
     if (isTaskAttemptAwaitingVerification(predecessor)) {
       return { action: "next", data: {} };
     }
     if (predecessor.nextStage === "route") {
       if (predecessor.outcome === "succeeded") {
-        const recovery = deps.readTaskRecoveryRoute(predecessor.attemptId);
+        const recovery = terminalRecovery;
         if (!recovery) {
           const verdict = deps.readTaskTechnicalVerdict(predecessor.attemptId);
           if (!verdict) {
@@ -439,9 +447,6 @@ export async function runWithTaskExecutionAttempt(
         }
         if (recovery.recoveryOwner !== "agent") {
           return { action: "next", data: {} };
-        }
-        if (recovery.action === "abort" && !recovery.resumeAuthorized) {
-          return taskRecoveryAbortResult(recovery.recoveryActionId);
         }
       } else {
         if (!predecessor.resultId) {

--- a/src/resources/extensions/gsd/auto/unit-run.ts
+++ b/src/resources/extensions/gsd/auto/unit-run.ts
@@ -39,7 +39,7 @@ export type UnitRunAdvanceResolution =
   | { kind: "claim" };
 
 export function resolveExistingUnitRun(input: {
-  workerId: string | undefined;
+  workerId: string | null | undefined;
   unitType: string;
   unitId: string;
   unitExecutionInFlight: boolean;
@@ -68,7 +68,7 @@ export function iterationDataForClaim(
     finalPrompt: "",
     pauseAfterUatDispatch: false,
     state,
-    mid: parsed.milestone || session.currentMilestoneId,
+    mid: parsed.milestone || session.currentMilestoneId || undefined,
     midTitle: state.activeMilestone?.title,
     isRetry: false,
     previousTier: undefined,

--- a/src/resources/extensions/gsd/auto/unit-run.ts
+++ b/src/resources/extensions/gsd/auto/unit-run.ts
@@ -1,0 +1,139 @@
+// Project/App: gsd-pi
+// File Purpose: UnitRun = the claimed/running unit_dispatches row (ADR-048).
+
+import { isDbAvailable, transaction } from "../gsd-db.js";
+import {
+  getActiveForWorker,
+  getDispatchById,
+  markCanceled,
+} from "../db/unit-dispatches.js";
+import { debugLog } from "../debug-logger.js";
+import { parseUnitId } from "../unit-id.js";
+import type { GSDState } from "../types.js";
+import type { UnitRef } from "./contracts.js";
+import type { AutoSession } from "./session.js";
+import type { IterationData } from "./types.js";
+import {
+  ensureDispatchLease,
+  openDispatchClaim,
+  type EnsureDispatchLeaseDeps,
+  type OpenDispatchClaimDeps,
+} from "./workflow-dispatch-claim.js";
+
+export function activeUnitFromWorker(workerId: string | null | undefined): UnitRef | undefined {
+  if (!workerId) return undefined;
+  const row = getActiveForWorker(workerId);
+  if (!row) return undefined;
+  return { unitType: row.unit_type, unitId: row.unit_id };
+}
+
+export function unitRefForDispatch(dispatchId: number): UnitRef | undefined {
+  const row = getDispatchById(dispatchId);
+  if (!row) return undefined;
+  return { unitType: row.unit_type, unitId: row.unit_id };
+}
+
+export type UnitRunAdvanceResolution =
+  | { kind: "skip-in-flight" }
+  | { kind: "resume"; dispatchId: number }
+  | { kind: "claim" };
+
+export function resolveExistingUnitRun(input: {
+  workerId: string | undefined;
+  unitType: string;
+  unitId: string;
+  unitExecutionInFlight: boolean;
+}): UnitRunAdvanceResolution {
+  if (!input.workerId) return { kind: "claim" };
+  const row = getActiveForWorker(input.workerId);
+  if (!row) return { kind: "claim" };
+  const same = row.unit_type === input.unitType && row.unit_id === input.unitId;
+  if (same && input.unitExecutionInFlight) return { kind: "skip-in-flight" };
+  if (same) return { kind: "resume", dispatchId: row.id };
+  markCanceled(row.id, "superseded-by-new-advance");
+  return { kind: "claim" };
+}
+
+export function iterationDataForClaim(
+  unitType: string,
+  unitId: string,
+  state: GSDState,
+  session: AutoSession,
+): IterationData {
+  const parsed = parseUnitId(unitId);
+  return {
+    unitType,
+    unitId,
+    prompt: "",
+    finalPrompt: "",
+    pauseAfterUatDispatch: false,
+    state,
+    mid: parsed.milestone || session.currentMilestoneId,
+    midTitle: state.activeMilestone?.title,
+    isRetry: false,
+    previousTier: undefined,
+  };
+}
+
+export const UNIT_RUN_LEASE_LOG: EnsureDispatchLeaseDeps["logLeaseRecovered"] = (details) => {
+  debugLog("unitRun", {
+    phase: details.recovered ? "dispatch-lease-recovered" : "dispatch-lease-acquired",
+    ...details,
+  });
+};
+
+export const UNIT_RUN_LEASE_FAIL_LOG: EnsureDispatchLeaseDeps["logLeaseRecoveryFailed"] = (details) => {
+  debugLog("unitRun", { phase: "dispatch-lease-recovery-failed", ...details });
+};
+
+export const UNIT_RUN_CLAIM_REJECT_LOG: OpenDispatchClaimDeps["logClaimRejected"] = (details) => {
+  debugLog("unitRun", { phase: "dispatch-claim-rejected", ...details });
+};
+
+export const UNIT_RUN_CLAIM_FAIL_LOG: OpenDispatchClaimDeps["logClaimFailed"] = (err) => {
+  debugLog("unitRun", {
+    phase: "dispatch-claim-failed",
+    error: err instanceof Error ? err.message : String(err),
+  });
+};
+
+export type ClaimUnitRunResult =
+  | { kind: "opened"; dispatchId: number }
+  | { kind: "blocked"; reason: string }
+  | { kind: "degraded"; reason: string }
+  | { kind: "skip"; reason: string };
+
+export function claimUnitRun(input: {
+  session: AutoSession;
+  flowId: string;
+  turnId: string;
+  iterData: IterationData;
+  leaseDeps: EnsureDispatchLeaseDeps;
+  claimDeps: OpenDispatchClaimDeps;
+}): ClaimUnitRunResult {
+  if (!input.session.workerId) {
+    return { kind: "degraded", reason: "missing-worker" };
+  }
+  if (!isDbAvailable()) {
+    return { kind: "degraded", reason: "database-unavailable" };
+  }
+  return transaction(() => {
+    const lease = ensureDispatchLease(input.session, input.iterData.mid, input.leaseDeps);
+    if (lease.kind === "blocked" || lease.kind === "failed") {
+      return { kind: "blocked" as const, reason: lease.reason };
+    }
+    if (lease.kind === "degraded") {
+      return { kind: "degraded" as const, reason: lease.reason };
+    }
+    const claim = openDispatchClaim(
+      input.session,
+      input.flowId,
+      input.turnId,
+      input.iterData,
+      input.claimDeps,
+    );
+    if (claim.kind === "opened") return claim;
+    if (claim.kind === "skip") return { kind: "skip" as const, reason: claim.reason };
+    return { kind: "degraded" as const, reason: claim.reason };
+  });
+}

--- a/src/resources/extensions/gsd/auto/verified-source-recapture.ts
+++ b/src/resources/extensions/gsd/auto/verified-source-recapture.ts
@@ -1,0 +1,74 @@
+// Project/App: gsd-pi
+// File Purpose: Recapture host-verification source after deferred execute-task closeout git.
+
+import { getSlice, getTask } from "../gsd-db.js";
+import { loadEffectiveGSDPreferences } from "../preferences.js";
+import { readLatestTaskAttempt } from "../task-execution-domain-operation.js";
+import {
+  invalidateTaskTechnicalPass,
+  readTaskTechnicalVerdict,
+} from "../task-verification-domain-operation.js";
+import { parseUnitId } from "../unit-id.js";
+import { internalExecutionInvocation } from "../execution-invocation.js";
+import {
+  captureVerificationSourceSnapshot,
+  resolveVerificationRepositoryTargets,
+} from "../verification-source-integrity.js";
+
+export type VerifiedSourceRecaptureResult = "unchanged" | "retry";
+
+/**
+ * After deferred execute-task commit/hooks rewrite files, recapture the
+ * verification source. A passing verdict at R1 must not be published against R2.
+ * Invalidate the pass so the next iteration re-verifies at the coherent revision.
+ */
+export function recaptureVerifiedSourceAfterDeferredCloseout(input: {
+  unitType: string;
+  unitId: string;
+  basePath: string;
+}): VerifiedSourceRecaptureResult {
+  if (input.unitType !== "execute-task") return "unchanged";
+  const { milestone: milestoneId, slice: sliceId, task: taskId } = parseUnitId(input.unitId);
+  if (!milestoneId || !sliceId || !taskId) return "unchanged";
+
+  const attempt = readLatestTaskAttempt({ milestoneId, sliceId, taskId });
+  if (!attempt) return "unchanged";
+  const verdict = readTaskTechnicalVerdict(attempt.attemptId);
+  if (!verdict || verdict.verdict !== "pass") return "unchanged";
+
+  const preferences = loadEffectiveGSDPreferences(input.basePath)?.preferences;
+  const task = getTask(milestoneId, sliceId, taskId);
+  const slice = getSlice(milestoneId, sliceId);
+  const resolved = resolveVerificationRepositoryTargets(input.basePath, preferences, task, slice);
+  const targets = resolved.repositories.length > 0
+    ? resolved.repositories.map((repository) => ({ id: repository.id, cwd: repository.root }))
+    : [{ id: "root", cwd: input.basePath }];
+  const source = captureVerificationSourceSnapshot(targets);
+  const currentRevision = source.ok ? source.snapshot.aggregateRevision : "unavailable";
+  if (source.ok && currentRevision === verdict.testedSourceRevision) return "unchanged";
+
+  const now = new Date().toISOString();
+  invalidateTaskTechnicalPass({
+    invocation: internalExecutionInvocation(`internal:auto:attempt.verify-drift:${verdict.verdictId}`),
+    attemptId: attempt.attemptId,
+    supersedesVerdictId: verdict.verdictId,
+    rationale: `Stored passing host verdict no longer matches the current verification source (${currentRevision}).`,
+    evidence: {
+      evidenceClass: "command",
+      commandOrTool: "gsd-source-integrity",
+      workingDirectory: input.basePath,
+      startedAt: now,
+      endedAt: now,
+      exitCode: 1,
+      observation: "inconclusive",
+      durableOutputRef: `db://host-verification/${attempt.attemptId}/source-drift`,
+      environment: {
+        node: process.version,
+        platform: process.platform,
+        sourceRevisionBefore: verdict.testedSourceRevision,
+        sourceRevisionAfter: currentRevision,
+      },
+    },
+  });
+  return "retry";
+}

--- a/src/resources/extensions/gsd/auto/workflow-dispatch-claim.ts
+++ b/src/resources/extensions/gsd/auto/workflow-dispatch-claim.ts
@@ -7,7 +7,7 @@ import type { IterationData } from "./types.js";
 export type DispatchClaimOutcome =
   | { kind: "opened"; dispatchId: number }
   | { kind: "skip"; reason: "already-active" | "stale-lease"; existingId?: number; existingWorker?: string }
-  | { kind: "degraded" };
+  | { kind: "degraded"; reason: string };
 
 export type DispatchLeaseOutcome =
   | { kind: "ready"; token: number; recovered: boolean }
@@ -133,9 +133,11 @@ export function openDispatchClaim(
   iterData: IterationData,
   deps: OpenDispatchClaimDeps,
 ): DispatchClaimOutcome {
-  if (!s.workerId || typeof s.milestoneLeaseToken !== "number") return { kind: "degraded" };
+  if (!s.workerId || typeof s.milestoneLeaseToken !== "number") {
+    return { kind: "degraded", reason: "missing-worker-or-lease" };
+  }
   const mid = iterData.mid;
-  if (!mid) return { kind: "degraded" };
+  if (!mid) return { kind: "degraded", reason: "missing-milestone" };
 
   const recent = deps.getRecentDispatchesForUnit(iterData.unitId, 1);
   const attemptN = (recent[0]?.attempt_n ?? 0) + 1;
@@ -176,6 +178,6 @@ export function openDispatchClaim(
     return { kind: "opened", dispatchId: claim.dispatchId };
   } catch (err) {
     deps.logClaimFailed(err);
-    return { kind: "degraded" };
+    return { kind: "degraded", reason: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/src/resources/extensions/gsd/auto/workflow-kernel.ts
+++ b/src/resources/extensions/gsd/auto/workflow-kernel.ts
@@ -19,11 +19,12 @@ export type DispatchClaimSkipReason =
 export type DispatchClaimInput =
   | { kind: "opened"; dispatchId: number }
   | { kind: "skip"; reason: DispatchClaimSkipReason }
-  | { kind: "degraded" };
+  | { kind: "degraded"; reason: string };
 
 export type DispatchClaimDecision =
   | { action: "run"; dispatchId: number }
-  | { action: "skip"; reason: DispatchClaimSkipReason };
+  | { action: "skip"; reason: DispatchClaimSkipReason }
+  | { action: "stop"; reason: "dispatch-claim-degraded"; message: string };
 
 export type EngineDispatchInput =
   | { action: "dispatch" }
@@ -266,8 +267,9 @@ export function decideDispatchClaim(input: DispatchClaimInput): DispatchClaimDec
   }
 
   return {
-    action: "skip",
+    action: "stop",
     reason: "dispatch-claim-degraded",
+    message: input.reason,
   };
 }
 

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -510,6 +510,28 @@ export function getLatestForUnit(unitId: string): UnitDispatchRow | null {
   return row ?? null;
 }
 
+export function getDispatchById(dispatchId: number): UnitDispatchRow | null {
+  if (!isDbAvailable()) return null;
+  const db = _getAdapter()!;
+  const row = db.prepare(
+    `SELECT * FROM unit_dispatches WHERE id = :id LIMIT 1`,
+  ).get({ ":id": dispatchId }) as UnitDispatchRow | undefined;
+  return row ?? null;
+}
+
+/** The UnitRun for this worker: the claimed or running dispatch row. */
+export function getActiveForWorker(workerId: string): UnitDispatchRow | null {
+  if (!isDbAvailable()) return null;
+  const db = _getAdapter()!;
+  const row = db.prepare(
+    `SELECT * FROM unit_dispatches
+     WHERE worker_id = :worker_id AND status IN ('claimed','running')
+     ORDER BY id DESC
+     LIMIT 1`,
+  ).get({ ":worker_id": workerId }) as UnitDispatchRow | undefined;
+  return row ?? null;
+}
+
 /**
  * Fetch dispatches for a milestone filtered by status. Useful for janitors
  * + dashboards.

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -13,6 +13,7 @@ import { readFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { createProjectionDirectorySync, removeProjectionFileSync } from "./atomic-write.js";
 import { logWarning } from "./workflow-logger.js";
 import { isClosedStatus, isHiddenFromRoadmap, toStatus } from "./status-guards.js";
+import { readLatestTaskAttempt } from "./task-execution-domain-operation.js";
 import { dirname, join } from "node:path";
 import {
   getAllMilestones,
@@ -907,8 +908,18 @@ export async function renderTaskSummary(
 ): Promise<boolean> {
   const task = getTask(milestoneId, sliceId, taskId);
   const status = task ? toStatus(task.status) : null;
-  if (!task || (status !== "in_progress" && status !== "complete") || !task.full_summary_md) {
-    return false; // No summary to render — skip silently
+  if (!task || !task.full_summary_md) {
+    return false;
+  }
+  if (status === "complete") {
+    // Published completions keep projecting.
+  } else if (status === "in_progress") {
+    const attempt = readLatestTaskAttempt({ milestoneId, sliceId, taskId });
+    if (!attempt || attempt.outcome === "interrupted") {
+      return false;
+    }
+  } else {
+    return false;
   }
 
   await writeTaskSummaryProjection(

--- a/src/resources/extensions/gsd/task-execution-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-execution-domain-operation.ts
@@ -32,7 +32,7 @@ import {
   internalExecutionInvocation,
   type ExecutionInvocation,
 } from "./execution-invocation.js";
-import { isDbAvailable } from "./gsd-db.js";
+import { isDbAvailable, setTaskSummaryMd } from "./gsd-db.js";
 import { ensureHostTechnicalCriterion } from "./task-verification-domain-operation.js";
 import type { RecoveryAction } from "./recovery-classification.js";
 import type { TaskFailureKind } from "./recovery-policy.js";
@@ -452,6 +452,9 @@ export function settleTaskAttempt(input: SettleTaskAttemptInput): SettleTaskAtte
     },
   }, (context) => {
     const attempt = loadAttemptExecution(input.attemptId);
+    if (input.outcome === "interrupted") {
+      setTaskSummaryMd(attempt.milestone_id, attempt.slice_id, attempt.task_id, "");
+    }
     if (input.stagedTaskCompletion) {
       writeStagedTaskCompletion(context, {
         milestoneId: attempt.milestone_id,

--- a/src/resources/extensions/gsd/tests/auto-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-contracts.test.ts
@@ -1,0 +1,33 @@
+// Project/App: gsd-pi
+// File Purpose: Hard tests for AutoAdvanceResult skip-code matching.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isUnitAlreadyActiveSkip } from "../auto/contracts.ts";
+
+test("isUnitAlreadyActiveSkip matches the skip code, not the reason text", () => {
+  assert.equal(
+    isUnitAlreadyActiveSkip({
+      kind: "skipped",
+      code: "unit-already-active",
+      reason: "idempotent advance: unit already active",
+    }),
+    true,
+  );
+  assert.equal(
+    isUnitAlreadyActiveSkip({
+      kind: "skipped",
+      reason: "idempotent advance: unit already active",
+    }),
+    false,
+  );
+  assert.equal(
+    isUnitAlreadyActiveSkip({
+      kind: "skipped",
+      code: "completed-no-advance",
+      reason: "idempotent advance: unit already active",
+    }),
+    false,
+  );
+});

--- a/src/resources/extensions/gsd/tests/auto-loop-break-reason-ledger.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop-break-reason-ledger.test.ts
@@ -17,7 +17,7 @@ test("loop break branches settle the ledger with the resolved break reason", () 
     assert.notEqual(sentinel, -1, "expected a `break;` sentinel to terminate the break branch body");
     const body = branch.slice(0, sentinel);
     assert.match(body, /const breakReason = unitPhaseResult\.reason \?\? "unit-break";/);
-    assert.match(body, /settleDispatchFailed\([^,]+, breakReason,/);
+    assert.match(body, /closeRun\("failed", breakReason\)/);
     // The trailing argument is the ADR-047 liveness guard id — a stable guard
     // identity, deliberately constant so repeat blocks hash to one signature.
     // It is not the break reason, which must stay the resolved reason.

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -285,7 +285,7 @@ function createLoopTestOrchestration(
         return resultForBreak(preDispatchResult.reason, preDispatch);
       }
       if (preDispatchResult.action === "continue") {
-        return { kind: "skipped", reason: "pre-dispatch-skip" };
+        return { kind: "skipped", code: "no-dispatch" as const, reason: "pre-dispatch-skip" };
       }
       if (preDispatchResult.action === "retry") {
         return { kind: "paused", reason: preDispatchResult.reason };
@@ -300,6 +300,7 @@ function createLoopTestOrchestration(
       if (dispatch.result.action === "continue") {
         return {
           kind: "skipped",
+          code: "no-dispatch" as const,
           reason: "dispatch-skip",
           stateSnapshot: preDispatchResult.data.state,
         };
@@ -322,9 +323,13 @@ function createLoopTestOrchestration(
       status.phase = "running";
       status.activeUnit = unit;
       status.transitionCount += 1;
-      return { kind: "advanced", unit, stateSnapshot: data.state };
+      // Real workers still claim in the loop. Fixture-only runs pass a
+      // positive id so the loop does not open a second database claim.
+      const dispatchId = s.workerId ? 0 : 1;
+      s.pendingOrchestrationDispatch.dispatchId = dispatchId;
+      return { kind: "advanced", unit, stateSnapshot: data.state, dispatchId };
     },
-    async releaseActiveUnit() {
+    async settle() {
       clearActiveUnit();
     },
     async completeActiveUnit() {
@@ -2269,7 +2274,9 @@ test("custom-engine recovery break and retry terminalize their dispatch", async 
       });
       let releaseCalls = 0;
       s.orchestration = {
-        releaseActiveUnit: async () => { releaseCalls++; },
+        settle: async () => { releaseCalls++; },
+        retryActiveUnit: async () => { releaseCalls++; },
+        abandonActiveUnit: async () => {},
       };
       let dispatchStatusAtPause: string | undefined;
       const deps = makeMockDeps({
@@ -2295,7 +2302,7 @@ test("custom-engine recovery break and retry terminalize their dispatch", async 
         action === "break" ? "failed" : undefined,
         "a terminal recovery abort must settle its dispatch before pausing",
       );
-      assert.equal(releaseCalls, action === "retry" ? 1 : 0);
+      assert.equal(releaseCalls, 0);
       assert.equal(pi.calls.length, 0, `${action} must exit before invoking the agent`);
     } finally {
       closeDatabase();
@@ -3236,8 +3243,10 @@ test("autoLoop dev path dispatches orchestration.advance results without legacy 
           kind: "advanced" as const,
           unit: { unitType: "execute-task", unitId: "M002/S03/T05" },
           stateSnapshot,
+          dispatchId: 1,
         };
       },
+      settle: async () => {},
       completeActiveUnit: async (unit: { unitType: string; unitId: string }) => {
         finalizedUnits.push(`${unit.unitType}:${unit.unitId}`);
       },
@@ -3322,6 +3331,7 @@ test("autoLoop pauses once when orchestration reports reconciliation drift error
           reason: "Reconciliation drift: Reconciliation repair failed in pass 0",
         };
       },
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},
@@ -3368,6 +3378,7 @@ test("autoLoop retries next iteration when orchestration reports paused", async 
           ? { kind: "paused" as const, reason: "provider transient; retry" }
           : { kind: "stopped" as const, reason: "done retrying" };
       },
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},
@@ -3425,6 +3436,7 @@ test("#1674: unknown orchestration outcomes hash the kind the loop read", async 
         if (kind) return { kind } as any;
         return { kind: "stopped" as const, reason: "done" };
       },
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},
@@ -3484,6 +3496,7 @@ test("autoLoop consumes pending orchestration dispatch without advancing twice",
       advance: async () => {
         throw new Error("advance must not run when a pending dispatch already exists");
       },
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},
@@ -3547,6 +3560,7 @@ test("autoLoop stops orchestrator complete state through completion surface", as
           allMilestonesComplete: true as const,
         },
       }),
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},
@@ -3778,8 +3792,10 @@ test("autoLoop releases orchestration active unit before artifact retry", async 
             kind: "advanced" as const,
             unit: { unitType: "complete-slice", unitId: "M005/S01" },
             stateSnapshot,
+            dispatchId: 1,
           };
         },
+        settle: async () => {},
         completeActiveUnit: async () => {},
         retryActiveUnit: async (unit: { unitType: string; unitId: string }) => {
           retryUnits.push(`${unit.unitType}:${unit.unitId}`);
@@ -4631,7 +4647,9 @@ test("ADR-047: pre-dispatch hook skips feed the loop-boundary ledger", async (t)
       kind: "advanced" as const,
       unit: { unitType: "execute-task", unitId: "M001/S01/T01" },
       stateSnapshot,
+      dispatchId: 1,
     }),
+    settle: async () => {},
     completeActiveUnit: async () => {},
     retryActiveUnit: async () => {},
     abandonActiveUnit: async () => {},
@@ -4771,8 +4789,10 @@ test("#1672: the max-iteration preflight exit persists a block signature across 
       start: async () => ({ kind: "stopped" as const, reason: "unused" }),
       advance: async () => ({
         kind: "skipped" as const,
+        code: "no-dispatch" as const,
         reason: `no-op ${runTag}-${++skipCounter}`,
       }),
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},
@@ -4831,6 +4851,7 @@ test("abnormal unit exit abandons the active orchestration marker before the nex
             kind: "advanced" as const,
             unit: { unitType: "plan-slice", unitId: "M001/S01" },
             stateSnapshot: await makeMockDeps().deriveState(s.basePath),
+            dispatchId: 1,
           };
         }
         if (activeMarker) {
@@ -4838,6 +4859,7 @@ test("abnormal unit exit abandons the active orchestration marker before the nex
         }
         return { kind: "stopped" as const, reason: "no active unit" };
       },
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async (unit, reason) => {
@@ -4881,77 +4903,46 @@ test("abnormal unit exit abandons the active orchestration marker before the nex
   assert.equal(wedgeResult.ok ? wedgeResult.wedge : null, null);
 });
 
-test("#1721: idle active-unit skip releases the stale claim and re-advances immediately", async (t) => {
+test("#1721: idle unit-already-active skip without in-flight stops instead of livelocking", async (t) => {
   _resetPendingResolve();
 
   const ctx = makeMockCtx();
   ctx.ui.setStatus = () => {};
   const pi = makeMockPi();
   const unit = { unitType: "execute-task", unitId: "M001/S01/T01" };
-  const stateSnapshot = await makeMockDeps().deriveState("unused");
   let advanceCalls = 0;
-  let releaseCalls = 0;
-  let claimActive = true;
   const s = makeLoopSession({
     currentMilestoneId: "M001",
     orchestration: {
       start: async () => ({ kind: "stopped" as const, reason: "unused" }),
       advance: async () => {
         advanceCalls++;
-        if (claimActive) {
-          return { kind: "skipped" as const, code: "unit-already-active" as const, reason: "idempotent advance: unit already active" };
-        }
-        s.pendingOrchestrationDispatch = {
-          ...unit,
-          prompt: "retry recovered task",
-          pauseAfterUatDispatch: false,
-          state: stateSnapshot,
-          mid: "M001",
-          midTitle: "Milestone 1",
-        };
-        return { kind: "advanced" as const, unit, stateSnapshot };
+        return { kind: "skipped" as const, code: "unit-already-active" as const, reason: "idempotent advance: unit already active" };
       },
-      releaseActiveUnit: async (released: UnitRef) => {
-        assert.deepEqual(released, unit);
-        releaseCalls++;
-        claimActive = false;
-      },
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
-      abandonActiveUnit: async () => {
-        claimActive = false;
-      },
+      abandonActiveUnit: async () => {},
       resume: async () => ({ kind: "stopped" as const, reason: "unused" }),
       stop: async (reason: string) => ({ kind: "stopped" as const, reason }),
       getStatus: () => ({
         phase: "running" as const,
         transitionCount: advanceCalls,
-        activeUnit: claimActive ? unit : undefined,
+        activeUnit: unit,
       }),
     } satisfies AutoOrchestrationModule,
   });
   openLoopDatabase(t, s);
-  const adjudicated: string[] = [];
   const deps = makeMockDeps({
-    adjudicateNonAdvancingOutcome: (_session, input) => {
-      adjudicated.push(input.guardId);
-      return null;
-    },
-    taskExecutionBoundary: async () => {
-      s.active = false;
-      return { action: "retry" as const, reason: "task-recovery-repair" };
-    },
+    adjudicateNonAdvancingOutcome: () => null,
   });
 
   await autoLoop(ctx, pi, s, deps);
 
-  assert.equal(releaseCalls, 2, "the defensive skip recovery and deferred retry both release the claim");
-  assert.equal(advanceCalls, 2, "the recovered claim must be re-advanced in the same iteration");
-  assert.deepEqual(adjudicated, ["unit-retry"]);
-  assert.equal(
-    adjudicated.includes("orchestration-stale-active-unit"),
-    false,
-    "a recovered stale claim must not feed the stale-unit guard",
+  assert.equal(advanceCalls, 1, "a stale skip must stop instead of re-polling");
+  assert.ok(
+    deps.callLog.includes("stopAuto") || deps.callLog.some(entry => entry.startsWith("stopAuto")),
+    "stale skip must stop auto-mode",
   );
 });
 
@@ -4979,10 +4970,12 @@ test("#1672: an unclearable active-unit marker still makes following skips ledge
             kind: "advanced" as const,
             unit: { unitType: "plan-slice", unitId: "M001/S01" },
             stateSnapshot: await makeMockDeps().deriveState(s.basePath),
+            dispatchId: 1,
           };
         }
         return { kind: "skipped" as const, code: "unit-already-active" as const, reason: "idempotent advance: unit already active" };
       },
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},
@@ -5006,17 +4999,12 @@ test("#1672: an unclearable active-unit marker still makes following skips ledge
 
   await autoLoop(ctx, pi, s, deps);
 
-  assert.equal(advanceCalls, 3, "the second stale skip must trip the backstop, not spin");
+  assert.equal(advanceCalls, 2, "the first stale skip must stop, not spin");
   const stopEntry = deps.callLog.find(entry => entry.startsWith("stopAuto:"));
-  assert.match(stopEntry ?? "", /^stopAuto:Blocked: /, "a tripped stale skip stops through the blocked path");
+  assert.match(stopEntry ?? "", /^stopAuto:Blocked: /, "a stale skip stops through the blocked path");
   const wedgeResult = getOpenWedge(realpathSync(s.basePath));
   assert.equal(wedgeResult.ok, true);
-  const wedge = wedgeResult.ok ? wedgeResult.wedge : null;
-  assert.ok(wedge, "the stale active-unit skip must persist a wedge");
-  assert.equal(wedge!.guardId, "orchestration-stale-active-unit");
-  assert.match(wedge!.sanctionedExit, /`\/gsd auto`/);
-  assert.match(wedge!.sanctionedExit, /gsd_task_recovery_resume/);
-  assert.doesNotMatch(wedge!.sanctionedExit, /Resolve the reported condition/);
+  // One stale skip is enough to stop; ADR-047 still trips only at occurrence 2.
 });
 
 test("finalize exceptions abandon the active orchestration marker before the next advance", async (t) => {
@@ -5044,6 +5032,7 @@ test("finalize exceptions abandon the active orchestration marker before the nex
             kind: "advanced" as const,
             unit: { unitType: "plan-slice", unitId: "M001/S01" },
             stateSnapshot: await makeMockDeps().deriveState(s.basePath),
+            dispatchId: 1,
           };
         }
         if (activeMarker) {
@@ -5051,6 +5040,7 @@ test("finalize exceptions abandon the active orchestration marker before the nex
         }
         return { kind: "stopped" as const, reason: "no active unit" };
       },
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async (unit, reason) => {
@@ -5115,6 +5105,7 @@ test("autoLoop does not pause on repeated idempotent advance skips while a unit 
         if (advanceCalls >= 5) s.active = false;
         return { kind: "skipped" as const, code: "unit-already-active" as const, reason: "idempotent advance: unit already active" };
       },
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},
@@ -5152,6 +5143,7 @@ test("ADR-047 #1655: identical transient pauses trip at the loop outcome boundar
     session.orchestration = {
       start: async () => ({ kind: "stopped" as const, reason: "unused" }),
       advance: async () => ({ kind: "paused" as const, reason: "transient: database is locked" }),
+      settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -4834,7 +4834,7 @@ test("abnormal unit exit abandons the active orchestration marker before the nex
           };
         }
         if (activeMarker) {
-          return { kind: "skipped" as const, reason: "idempotent advance: unit already active" };
+          return { kind: "skipped" as const, code: "unit-already-active" as const, reason: "idempotent advance: unit already active" };
         }
         return { kind: "stopped" as const, reason: "no active unit" };
       },
@@ -4899,7 +4899,7 @@ test("#1721: idle active-unit skip releases the stale claim and re-advances imme
       advance: async () => {
         advanceCalls++;
         if (claimActive) {
-          return { kind: "skipped" as const, reason: "idempotent advance: unit already active" };
+          return { kind: "skipped" as const, code: "unit-already-active" as const, reason: "idempotent advance: unit already active" };
         }
         s.pendingOrchestrationDispatch = {
           ...unit,
@@ -4981,7 +4981,7 @@ test("#1672: an unclearable active-unit marker still makes following skips ledge
             stateSnapshot: await makeMockDeps().deriveState(s.basePath),
           };
         }
-        return { kind: "skipped" as const, reason: "idempotent advance: unit already active" };
+        return { kind: "skipped" as const, code: "unit-already-active" as const, reason: "idempotent advance: unit already active" };
       },
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
@@ -5047,7 +5047,7 @@ test("finalize exceptions abandon the active orchestration marker before the nex
           };
         }
         if (activeMarker) {
-          return { kind: "skipped" as const, reason: "idempotent advance: unit already active" };
+          return { kind: "skipped" as const, code: "unit-already-active" as const, reason: "idempotent advance: unit already active" };
         }
         return { kind: "stopped" as const, reason: "no active unit" };
       },
@@ -5113,7 +5113,7 @@ test("autoLoop does not pause on repeated idempotent advance skips while a unit 
       advance: async () => {
         advanceCalls++;
         if (advanceCalls >= 5) s.active = false;
-        return { kind: "skipped" as const, reason: "idempotent advance: unit already active" };
+        return { kind: "skipped" as const, code: "unit-already-active" as const, reason: "idempotent advance: unit already active" };
       },
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -170,6 +170,7 @@ function makeFixture(opts: FixtureOptions = {}): Fixture {
   session.originalBasePath = base;
   session.currentMilestoneId = "M001";
   session.resourceVersionOnStart = null;
+  session.workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
 
   const ctx: OrchestratorContext = {
     ctx: { model: {}, modelRegistry: { getAll: () => [], getAvailable: () => [] }, ui: { notify() {} } } as never,
@@ -701,6 +702,7 @@ test("advance() is idempotent for the same active unit", async (t) => {
   t.after(() => f.cleanup());
 
   const first = await f.orchestrator.advance();
+  f.session.unitExecutionInFlight = true;
   const second = await f.orchestrator.advance();
 
   assert.equal(first.kind, "advanced");
@@ -718,6 +720,7 @@ test("idempotency skip fires with its own reason before saturation", async (t) =
   t.after(() => f.cleanup());
 
   const first = await f.orchestrator.advance();
+  f.session.unitExecutionInFlight = true;
   const second = await f.orchestrator.advance();
 
   assert.equal(first.kind, "advanced");
@@ -849,7 +852,7 @@ test("retryActiveUnit clears in-flight idempotency without marking the unit fina
   assert.ok(f.journalNames().includes("unit-retry"));
 });
 
-test("releaseActiveUnit clears a deferred dispatch claim without finalizing the unit", async (t) => {
+test("settle canceled clears a deferred dispatch claim without finalizing the unit", async (t) => {
   const f = makeFixture();
   t.after(() => f.cleanup());
 
@@ -857,13 +860,14 @@ test("releaseActiveUnit clears a deferred dispatch claim without finalizing the 
   assert.equal(first.kind, "advanced");
   if (first.kind !== "advanced") throw new Error("expected first advance");
 
-  await f.orchestrator.releaseActiveUnit?.(first.unit);
+  await f.orchestrator.settle(first.dispatchId, "canceled", "deferred-closeout");
   const second = await f.orchestrator.advance();
 
   assert.equal(f.orchestrator.getStatus().activeUnit?.unitId, first.unit.unitId);
   assert.equal(second.kind, "advanced");
   if (second.kind !== "advanced") throw new Error("expected deferred unit to re-advance");
   assert.deepEqual(second.unit, first.unit);
+  assert.notEqual(second.dispatchId, first.dispatchId);
   assert.equal(f.journalNames().includes("unit-finalized"), false);
   const wedge = getOpenWedge(normalizeRealPath(f.base));
   assert.equal(wedge.ok, true);
@@ -907,48 +911,64 @@ test("retryActiveUnit clears finalized same-unit guard for post-hook retries", a
   assert.ok(names.includes("unit-retry"));
 });
 
-test("resume() clears idempotent lock and allows re-advance", async (t) => {
+test("resume() keeps an in-flight UnitRun skip, then resumes the claimed row", async (t) => {
   const f = makeFixture();
   t.after(() => f.cleanup());
 
   const first = await f.orchestrator.advance();
+  f.session.unitExecutionInFlight = true;
   const idempotent = await f.orchestrator.advance();
   const resumed = await f.orchestrator.resume();
+  f.session.unitExecutionInFlight = false;
   const next = await f.orchestrator.advance();
 
   assert.equal(first.kind, "advanced");
+  if (first.kind !== "advanced") throw new Error("expected first advance");
   assert.equal(idempotent.kind, "skipped");
   assert.equal(resumed.kind, "resumed");
   assert.equal(next.kind, "advanced");
+  if (next.kind !== "advanced") throw new Error("expected resume advance");
+  assert.equal(next.dispatchId, first.dispatchId);
 });
 
-test("start() clears prior idempotent lock", async (t) => {
-  const f = makeFixture();
-  t.after(() => f.cleanup());
-
-  await f.orchestrator.advance();
-  const idempotent = await f.orchestrator.advance();
-  const restarted = await f.orchestrator.start(SESSION_CONTEXT);
-  const next = await f.orchestrator.advance();
-
-  assert.equal(idempotent.kind, "skipped");
-  assert.equal(restarted.kind, "started");
-  assert.equal(next.kind, "advanced");
-});
-
-test("stop() clears idempotent unit lock so advance can run again", async (t) => {
+test("start() does not skip-string-match a claimed UnitRun after restart", async (t) => {
   const f = makeFixture();
   t.after(() => f.cleanup());
 
   const first = await f.orchestrator.advance();
+  f.session.unitExecutionInFlight = true;
+  const idempotent = await f.orchestrator.advance();
+  const restarted = await f.orchestrator.start(SESSION_CONTEXT);
+  f.session.unitExecutionInFlight = false;
+  const next = await f.orchestrator.advance();
+
+  assert.equal(first.kind, "advanced");
+  if (first.kind !== "advanced") throw new Error("expected first advance");
+  assert.equal(idempotent.kind, "skipped");
+  assert.equal(restarted.kind, "started");
+  assert.equal(next.kind, "advanced");
+  if (next.kind !== "advanced") throw new Error("expected restarted advance");
+  assert.equal(next.dispatchId, first.dispatchId);
+});
+
+test("stop() cancels the UnitRun so advance can claim again", async (t) => {
+  const f = makeFixture();
+  t.after(() => f.cleanup());
+
+  const first = await f.orchestrator.advance();
+  f.session.unitExecutionInFlight = true;
   const idempotent = await f.orchestrator.advance();
   const stopped = await f.orchestrator.stop("reset");
+  f.session.unitExecutionInFlight = false;
   const second = await f.orchestrator.advance();
 
   assert.equal(first.kind, "advanced");
+  if (first.kind !== "advanced") throw new Error("expected first advance");
   assert.equal(idempotent.kind, "skipped");
   assert.equal(stopped.kind, "stopped");
   assert.equal(second.kind, "advanced");
+  if (second.kind !== "advanced") throw new Error("expected post-stop advance");
+  assert.notEqual(second.dispatchId, first.dispatchId);
 });
 
 test("idempotent path journals advance-skipped and records a health snapshot", async (t) => {
@@ -956,9 +976,28 @@ test("idempotent path journals advance-skipped and records a health snapshot", a
   t.after(() => f.cleanup());
 
   await f.orchestrator.advance();
+  f.session.unitExecutionInFlight = true;
   await f.orchestrator.advance();
 
   assert.ok(f.journalNames().includes("advance-skipped"));
+});
+
+test("a new orchestrator resumes the claimed UnitRun instead of skip-string-matching", async (t) => {
+  const f = makeFixture();
+  t.after(() => f.cleanup());
+
+  const first = await f.orchestrator.advance();
+  assert.equal(first.kind, "advanced");
+  if (first.kind !== "advanced") throw new Error("expected first advance");
+
+  const restarted = createAutoOrchestrator(f.ctx);
+  const second = await restarted.advance();
+
+  assert.equal(second.kind, "advanced");
+  if (second.kind !== "advanced") throw new Error("expected UnitRun resume");
+  assert.equal(second.dispatchId, first.dispatchId);
+  assert.equal(second.unit.unitId, first.unit.unitId);
+  assert.equal(restarted.getStatus().activeUnit?.unitId, first.unit.unitId);
 });
 
 // ─── Stuck-loop ring buffer (issue #5787) ──────────────────────────────────
@@ -1554,6 +1593,7 @@ test("decideOrchestratorDispatch clears verification retry state when skipping a
 
     assert.deepEqual(result, {
       kind: "skipped",
+      code: "already-closed",
       reason: "execute-task M001/S01/T01 is already complete",
     });
     const sess = session as { pendingVerificationRetry: unknown; pendingOrchestrationDispatch: unknown };
@@ -1683,6 +1723,7 @@ test("decideOrchestratorDispatch preserves dispatch skip instead of collapsing i
 
     assert.deepEqual(result, {
       kind: "skipped",
+      code: "no-dispatch",
       reason: "evaluating-gates -> omitted",
     });
   } finally {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -710,6 +710,7 @@ test("advance() is idempotent for the same active unit", async (t) => {
   assert.equal(second.kind, "skipped");
   if (second.kind !== "skipped") return;
   assert.equal(second.reason, "idempotent advance: unit already active");
+  assert.equal(second.code, "unit-already-active");
 });
 
 test("idempotency skip fires with its own reason before saturation", async (t) => {
@@ -723,6 +724,7 @@ test("idempotency skip fires with its own reason before saturation", async (t) =
   assert.equal(second.kind, "skipped");
   if (second.kind !== "skipped") return;
   assert.equal(second.reason, "idempotent advance: unit already active");
+  assert.equal(second.code, "unit-already-active");
 });
 
 test("completeActiveUnit clears in-flight idempotency and stops stale same-unit advance", async (t) => {

--- a/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
@@ -27,6 +27,7 @@ test("getAutoRuntimeSnapshot includes orchestration phase when available", () =>
   autoSession.orchestration = {
     async start() { return { kind: "stopped" as const, reason: "test" }; },
     async advance() { return { kind: "stopped" as const, reason: "test" }; },
+    async settle() {},
     async completeActiveUnit() {},
     async retryActiveUnit() {},
     async abandonActiveUnit() {},

--- a/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
@@ -1077,7 +1077,7 @@ test("a newly routed failed predecessor redispatches before its lineage-linked r
   assert.deepEqual(routed, { action: "retry", reason: "task-recovery-repair" });
   assert.equal(runs, 0);
   assert.equal(domain.claims.length, 0);
-  assert.deepEqual(domain.calls.map((call) => call.name), ["read-latest", "route"]);
+  assert.deepEqual(domain.calls.map((call) => call.name), ["read-latest", "read-recovery", "route"]);
 
   routeStatus = "replayed";
   const resumed = await runWithTaskExecutionAttempt(input({ dispatchId: 42 }), async () => {
@@ -1113,6 +1113,40 @@ test("a succeeded predecessor awaiting verification resumes verification without
   }, domain.deps);
 
   assert.deepEqual(result, { action: "next", data: {} });
+  assert.equal(ran, false);
+  assert.equal(domain.claims.length, 0);
+});
+
+test("an unresumed abort on a failed predecessor stops before a replacement claim", async () => {
+  const { runWithTaskExecutionAttempt } = await subject();
+  const domain = fakeDomain();
+  domain.attempts.push({
+    attemptId: "attempt-1",
+    resultId: "result-1",
+    attemptNumber: 1,
+    state: "settled",
+    outcome: "failed",
+    nextStage: "route",
+    coordinationDispatchId: 40,
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+  });
+  let ran = false;
+
+  const result = await runWithTaskExecutionAttempt(input(), async () => {
+    ran = true;
+    return { action: "next", data: {} };
+  }, {
+    ...domain.deps,
+    readTaskRecoveryRoute() {
+      return { recoveryActionId: "recovery-action-1", recoveryOwner: "agent", action: "abort" };
+    },
+  });
+
+  assert.deepEqual(result, {
+    action: "break",
+    reason: TASK_RECOVERY_ABORT_REASON,
+  });
   assert.equal(ran, false);
   assert.equal(domain.claims.length, 0);
 });

--- a/src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts
+++ b/src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts
@@ -29,6 +29,12 @@ import {
   settleTaskAttempt,
 } from "../task-execution-domain-operation.ts";
 import { readTaskRecoveryRoute } from "../task-recovery-domain-operation.ts";
+import { recaptureVerifiedSourceAfterDeferredCloseout } from "../auto/verified-source-recapture.ts";
+import { captureVerificationSourceSnapshot } from "../verification-source-integrity.ts";
+import {
+  readTaskTechnicalVerdict,
+  recordTaskTechnicalVerdict,
+} from "../task-verification-domain-operation.ts";
 import { cleanup, git, makeTempRepo } from "./test-utils.ts";
 
 function settleCanonicalTaskForHostVerification(basePath: string): void {
@@ -197,6 +203,65 @@ test("blocking evidence-xref routes recovery and clears evidence before pausing"
     );
   } finally {
     resetEvidence();
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("deferred closeout source recapture invalidates a stale passing verdict", () => {
+  const base = makeTempRepo("gsd-source-recapture-");
+  try {
+    writeFileSync(join(base, ".gitignore"), ".gsd/\n");
+    writeFileSync(join(base, "tracked.txt"), "verified\n");
+    git(base, "add", ".gitignore", "tracked.txt");
+    git(base, "commit", "-m", "fixture");
+
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active" });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Add app entrypoint",
+      status: "in_progress",
+    });
+    settleCanonicalTaskForHostVerification(base);
+    const attempt = readLatestTaskAttempt({ milestoneId: "M001", sliceId: "S01", taskId: "T01" });
+    assert.ok(attempt);
+    const source = captureVerificationSourceSnapshot([{ id: "root", cwd: base }]);
+    assert.equal(source.ok, true, source.ok ? undefined : source.error);
+    recordTaskTechnicalVerdict({
+      invocation: {
+        idempotencyKey: "fixture:source-recapture:verdict",
+        sourceTransport: "internal",
+        actorType: "agent",
+      },
+      attemptId: attempt.attemptId,
+      testedSourceRevision: source.snapshot.aggregateRevision,
+      verdict: "pass",
+      rationale: "Host verification passed before deferred closeout git.",
+      evidence: {
+        evidenceClass: "command",
+        commandOrTool: "npm test",
+        workingDirectory: base,
+        startedAt: "2026-07-12T00:02:00.000Z",
+        endedAt: "2026-07-12T00:02:01.000Z",
+        exitCode: 0,
+        observation: "passed",
+        durableOutputRef: "db://host-verification/attempt-1",
+        environment: { runner: "node-test", platform: "test" },
+      },
+    });
+
+    writeFileSync(join(base, "tracked.txt"), "rewritten by pre-commit hook\n");
+    assert.equal(recaptureVerifiedSourceAfterDeferredCloseout({
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      basePath: base,
+    }), "retry");
+    assert.equal(readTaskTechnicalVerdict(attempt.attemptId)?.verdict, "inconclusive");
+  } finally {
     closeDatabase();
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/iteration-run.test.ts
+++ b/src/resources/extensions/gsd/tests/iteration-run.test.ts
@@ -33,9 +33,6 @@ function makeDeps() {
       async abandonActiveUnit(unit: { unitType: string; unitId: string }, reason: string) {
         orch.push({ method: "abandon", ...unit, reason });
       },
-      async releaseActiveUnit(unit: { unitType: string; unitId: string }) {
-        orch.push({ method: "release", ...unit });
-      },
     },
   };
 }
@@ -103,5 +100,10 @@ test("settleIterationRun does not write a ledger row when dispatchId is null", a
   );
   assert.equal(settled, false);
   assert.deepEqual(ledger, []);
-  assert.deepEqual(orch, [{ method: "release", unitType: "execute-task", unitId: "M001/S01/T01" }]);
+  assert.deepEqual(orch, [{
+    method: "abandon",
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    reason: "claim never opened",
+  }]);
 });

--- a/src/resources/extensions/gsd/tests/iteration-run.test.ts
+++ b/src/resources/extensions/gsd/tests/iteration-run.test.ts
@@ -1,0 +1,107 @@
+// Project/App: gsd-pi
+// File Purpose: Hard tests for auto-mode iteration-run closeout.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { settleIterationRun } from "../auto/iteration-run.ts";
+
+function makeDeps() {
+  const ledger: Array<{ kind: string; dispatchId: number; reason?: string }> = [];
+  const orch: Array<{ method: string; unitType: string; unitId: string; reason?: string }> = [];
+  return {
+    ledger,
+    orch,
+    deps: {
+      markFailed(dispatchId: number, details: { errorSummary: string }) {
+        ledger.push({ kind: "failed", dispatchId, reason: details.errorSummary });
+        return true;
+      },
+      markCompleted(dispatchId: number) {
+        ledger.push({ kind: "completed", dispatchId });
+        return true;
+      },
+      logWriteFailure() {
+        throw new Error("ledger write should not throw in this test");
+      },
+      async completeActiveUnit(unit: { unitType: string; unitId: string }) {
+        orch.push({ method: "complete", ...unit });
+      },
+      async retryActiveUnit(unit: { unitType: string; unitId: string }) {
+        orch.push({ method: "retry", ...unit });
+      },
+      async abandonActiveUnit(unit: { unitType: string; unitId: string }, reason: string) {
+        orch.push({ method: "abandon", ...unit, reason });
+      },
+      async releaseActiveUnit(unit: { unitType: string; unitId: string }) {
+        orch.push({ method: "release", ...unit });
+      },
+    },
+  };
+}
+
+test("settleIterationRun completes the dispatch row and the active unit", async () => {
+  const { deps, ledger, orch } = makeDeps();
+  const settled = await settleIterationRun(
+    { dispatchId: 9, unitType: "execute-task", unitId: "M001/S01/T01" },
+    "completed",
+    "ok",
+    false,
+    deps,
+  );
+  assert.equal(settled, true);
+  assert.deepEqual(ledger, [{ kind: "completed", dispatchId: 9 }]);
+  assert.deepEqual(orch, [{ method: "complete", unitType: "execute-task", unitId: "M001/S01/T01" }]);
+});
+
+test("settleIterationRun fails the dispatch and abandons the active unit", async () => {
+  const { deps, ledger, orch } = makeDeps();
+  const settled = await settleIterationRun(
+    { dispatchId: 4, unitType: "plan-slice", unitId: "M001/S01" },
+    "failed",
+    "unit execution crashed",
+    false,
+    deps,
+  );
+  assert.equal(settled, true);
+  assert.deepEqual(ledger, [{ kind: "failed", dispatchId: 4, reason: "unit execution crashed" }]);
+  assert.deepEqual(orch, [{
+    method: "abandon",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+    reason: "unit execution crashed",
+  }]);
+});
+
+test("settleIterationRun skips a second ledger write when already settled", async () => {
+  const { deps, ledger, orch } = makeDeps();
+  const settled = await settleIterationRun(
+    { dispatchId: 4, unitType: "plan-slice", unitId: "M001/S01" },
+    "failed",
+    "late abandon",
+    true,
+    deps,
+  );
+  assert.equal(settled, true);
+  assert.deepEqual(ledger, []);
+  assert.deepEqual(orch, [{
+    method: "abandon",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+    reason: "late abandon",
+  }]);
+});
+
+test("settleIterationRun does not write a ledger row when dispatchId is null", async () => {
+  const { deps, ledger, orch } = makeDeps();
+  const settled = await settleIterationRun(
+    { dispatchId: null, unitType: "execute-task", unitId: "M001/S01/T01" },
+    "canceled",
+    "claim never opened",
+    false,
+    deps,
+  );
+  assert.equal(settled, false);
+  assert.deepEqual(ledger, []);
+  assert.deepEqual(orch, [{ method: "release", unitType: "execute-task", unitId: "M001/S01/T01" }]);
+});

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -847,6 +847,38 @@ test('── markdown-renderer: renderTaskSummary round-trip ──', async () =
   }
 });
 
+test('── markdown-renderer: renderTaskSummary skips in-progress without a succeeded attempt ──', async () => {
+  const tmpDir = makeTmpDir();
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    scaffoldDirs(tmpDir, 'M001', ['S01']);
+
+    insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Slice', status: 'pending' });
+    insertTask({
+      id: 'T01',
+      sliceId: 'S01',
+      milestoneId: 'M001',
+      title: 'Cancelled task with leaked summary',
+      status: 'in_progress',
+      fullSummaryMd: makeTaskSummaryContent('T01'),
+    });
+
+    const ok = await renderTaskSummary(tmpDir, 'M001', 'S01', 'T01');
+    assert.equal(ok, false, 'cancelled/in-progress leaked summaries must not project');
+    const summaryPath = path.join(
+      tmpDir, '.gsd', 'phases', '01-test', 'S01-T01-SUMMARY.md',
+    );
+    assert.equal(fs.existsSync(summaryPath), false, 'SUMMARY.md must not be written');
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
 test('── markdown-renderer: renderTaskSummary skips empty ──', async () => {
   const tmpDir = makeTmpDir();
   const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');

--- a/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts
@@ -103,6 +103,7 @@ function createRetryBridgeContext(
   session.orchestration = {
     start: async () => ({ kind: "started" }),
     advance: async () => ({ kind: "stopped", reason: "unused" }),
+    settle: async () => {},
     completeActiveUnit: async () => {},
     retryActiveUnit,
     abandonActiveUnit: async () => {},
@@ -721,7 +722,8 @@ test("post-unit blocking gate pauses auto-mode on needs-attention verdict", asyn
     s.orchestration = {
       start: async () => ({ kind: "started" }),
       advance: async () => ({ kind: "stopped", reason: "unused" }),
-      completeActiveUnit: async () => {},
+      settle: async () => {},
+    completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
       abandonActiveUnit: async () => {},
       resume: async () => ({ kind: "resumed" }),

--- a/src/resources/extensions/gsd/tests/task-execution-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-execution-domain-operation.test.ts
@@ -366,6 +366,8 @@ test("interruptOrphanedTaskAttempts settles a running Attempt after its lease hi
     );
   `);
 
+  db().exec(`UPDATE tasks SET full_summary_md = 'leaked staged summary' WHERE id = 'T01'`);
+
   const repaired = interruptOrphanedTaskAttempts({
     workerId: "worker-2",
     milestoneId: "M001",
@@ -389,6 +391,7 @@ test("interruptOrphanedTaskAttempts settles a running Attempt after its lease hi
     SELECT outcome, failure_class FROM workflow_attempt_results
   `), { outcome: "interrupted", failure_class: "stale-worker" });
   assert.equal(row("SELECT status FROM unit_dispatches").status, "failed");
+  assert.equal(row("SELECT full_summary_md FROM tasks").full_summary_md, "");
 });
 
 for (const contract of [

--- a/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
@@ -25,6 +25,8 @@ import {
   markLatestActiveForWorkerCanceled,
   getRecentForUnit,
   getLatestForUnit,
+  getActiveForWorker,
+  getDispatchById,
 } from "../db/unit-dispatches.ts";
 
 function makeBase(): string {
@@ -340,4 +342,31 @@ test("recordDispatchClaim rejects claims for missing leases before insert", (t) 
     workerId: "missing-worker",
     milestoneLeaseToken: 1,
   });
+});
+
+test("getActiveForWorker returns the claimed or running row for this worker", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId, leaseToken } = setup(base);
+
+  const claim = recordDispatchClaim({
+    traceId: "active-for-worker",
+    workerId,
+    milestoneLeaseToken: leaseToken,
+    milestoneId: "M001",
+    sliceId: "S01",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(claim.ok, true);
+  if (!claim.ok) throw new Error("expected claim");
+
+  const active = getActiveForWorker(workerId);
+  assert.ok(active);
+  assert.equal(active.id, claim.dispatchId);
+  assert.equal(active.status, "claimed");
+  assert.equal(getDispatchById(claim.dispatchId)?.id, claim.dispatchId);
+
+  markCompleted(claim.dispatchId);
+  assert.equal(getActiveForWorker(workerId), null);
 });

--- a/src/resources/extensions/gsd/tests/unit-run.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-run.test.ts
@@ -1,0 +1,221 @@
+// Project/App: gsd-pi
+// File Purpose: Hard tests for UnitRun claim resolution (ADR-048).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../gsd-db.ts";
+import { registerAutoWorker } from "../db/auto-workers.ts";
+import { claimMilestoneLease } from "../db/milestone-leases.ts";
+import {
+  recordDispatchClaim,
+  getActiveForWorker,
+  getDispatchById,
+} from "../db/unit-dispatches.ts";
+import { AutoSession } from "../auto/session.ts";
+import {
+  claimUnitRun,
+  resolveExistingUnitRun,
+} from "../auto/unit-run.ts";
+import type { GSDState } from "../types.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-unit-run-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+function setup(base: string): { workerId: string; leaseToken: number; session: AutoSession } {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice" });
+  const workerId = registerAutoWorker({ projectRootRealpath: base });
+  const lease = claimMilestoneLease(workerId, "M001");
+  assert.equal(lease.ok, true);
+  if (!lease.ok) throw new Error("expected test lease");
+  const session = new AutoSession();
+  session.workerId = workerId;
+  session.milestoneLeaseToken = lease.token;
+  session.currentMilestoneId = "M001";
+  return { workerId, leaseToken: lease.token, session };
+}
+
+const state = {
+  phase: "executing",
+  activeMilestone: { id: "M001", title: "Test" },
+  activeSlice: { id: "S01" },
+} as GSDState;
+
+test("resolveExistingUnitRun resumes a claimed row when the unit is not in flight", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId, leaseToken } = setup(base);
+
+  const claim = recordDispatchClaim({
+    traceId: "resume-trace",
+    workerId,
+    milestoneLeaseToken: leaseToken,
+    milestoneId: "M001",
+    sliceId: "S01",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(claim.ok, true);
+  if (!claim.ok) throw new Error("expected claim");
+
+  const resolved = resolveExistingUnitRun({
+    workerId,
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+    unitExecutionInFlight: false,
+  });
+  assert.deepEqual(resolved, { kind: "resume", dispatchId: claim.dispatchId });
+});
+
+test("resolveExistingUnitRun skips when the same unit is in flight", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId, leaseToken } = setup(base);
+
+  const claim = recordDispatchClaim({
+    traceId: "inflight-trace",
+    workerId,
+    milestoneLeaseToken: leaseToken,
+    milestoneId: "M001",
+    sliceId: "S01",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(claim.ok, true);
+
+  const resolved = resolveExistingUnitRun({
+    workerId,
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+    unitExecutionInFlight: true,
+  });
+  assert.equal(resolved.kind, "skip-in-flight");
+});
+
+test("resolveExistingUnitRun cancels a different claimed unit before a fresh claim", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId, leaseToken } = setup(base);
+
+  const claim = recordDispatchClaim({
+    traceId: "supersede-trace",
+    workerId,
+    milestoneLeaseToken: leaseToken,
+    milestoneId: "M001",
+    sliceId: "S01",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(claim.ok, true);
+  if (!claim.ok) throw new Error("expected claim");
+
+  const resolved = resolveExistingUnitRun({
+    workerId,
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    unitExecutionInFlight: false,
+  });
+  assert.equal(resolved.kind, "claim");
+  assert.equal(getDispatchById(claim.dispatchId)?.status, "canceled");
+  assert.equal(getActiveForWorker(workerId), null);
+});
+
+test("claimUnitRun opens lease and claim in one transaction", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { session } = setup(base);
+  session.milestoneLeaseToken = null;
+
+  const result = claimUnitRun({
+    session,
+    flowId: "flow-1",
+    turnId: "turn-1",
+    iterData: {
+      unitType: "plan-slice",
+      unitId: "M001/S01",
+      prompt: "",
+      finalPrompt: "",
+      pauseAfterUatDispatch: false,
+      state,
+      mid: "M001",
+      midTitle: "Test",
+      isRetry: false,
+      previousTier: undefined,
+    },
+    leaseDeps: {
+      claimMilestoneLease,
+      logLeaseRecovered() {},
+      logLeaseRecoveryFailed() {},
+    },
+    claimDeps: {
+      getRecentDispatchesForUnit: () => [],
+      recordDispatchClaim,
+      markDispatchRunning: () => {},
+      logClaimRejected() {},
+      logClaimFailed() {},
+    },
+  });
+
+  assert.equal(result.kind, "opened");
+  if (result.kind !== "opened") throw new Error("expected opened");
+  assert.equal(typeof result.dispatchId, "number");
+  assert.notEqual(result.dispatchId, null);
+  const row = getDispatchById(result.dispatchId);
+  assert.ok(row);
+  assert.equal(row.status, "claimed");
+  assert.equal(row.unit_id, "M001/S01");
+});
+
+test("claimUnitRun degrades with a reason when the worker is missing", () => {
+  const session = new AutoSession();
+  const result = claimUnitRun({
+    session,
+    flowId: "flow-missing",
+    turnId: "turn-missing",
+    iterData: {
+      unitType: "plan-slice",
+      unitId: "M001/S01",
+      prompt: "",
+      finalPrompt: "",
+      pauseAfterUatDispatch: false,
+      state,
+      mid: "M001",
+      midTitle: "Test",
+      isRetry: false,
+      previousTier: undefined,
+    },
+    leaseDeps: {
+      claimMilestoneLease: () => {
+        throw new Error("should not claim");
+      },
+      logLeaseRecovered() {},
+      logLeaseRecoveryFailed() {},
+    },
+    claimDeps: {
+      getRecentDispatchesForUnit: () => [],
+      recordDispatchClaim: () => {
+        throw new Error("should not claim");
+      },
+      markDispatchRunning: () => {},
+      logClaimRejected() {},
+      logClaimFailed() {},
+    },
+  });
+  assert.equal(result.kind, "degraded");
+  if (result.kind !== "degraded") throw new Error("expected degraded");
+  assert.equal(typeof result.reason, "string");
+  assert.ok(result.reason.length > 0);
+});

--- a/src/resources/extensions/gsd/tests/unit-run.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-run.test.ts
@@ -18,6 +18,7 @@ import {
 import { AutoSession } from "../auto/session.ts";
 import {
   claimUnitRun,
+  iterationDataForClaim,
   resolveExistingUnitRun,
 } from "../auto/unit-run.ts";
 import type { GSDState } from "../types.ts";
@@ -218,4 +219,25 @@ test("claimUnitRun degrades with a reason when the worker is missing", () => {
   if (result.kind !== "degraded") throw new Error("expected degraded");
   assert.equal(typeof result.reason, "string");
   assert.ok(result.reason.length > 0);
+});
+
+test("resolveExistingUnitRun claims when workerId is null", () => {
+  assert.deepEqual(
+    resolveExistingUnitRun({
+      workerId: null,
+      unitType: "plan-slice",
+      unitId: "M001/S01",
+      unitExecutionInFlight: false,
+    }),
+    { kind: "claim" },
+  );
+});
+
+test("iterationDataForClaim maps a null session milestone to undefined", () => {
+  const session = new AutoSession();
+  session.currentMilestoneId = null;
+  const data = iterationDataForClaim("plan-slice", "/S01", state, session);
+  assert.equal(data.mid, undefined);
+  assert.equal(data.unitType, "plan-slice");
+  assert.equal(data.unitId, "/S01");
 });

--- a/src/resources/extensions/gsd/tests/workflow-dispatch-claim.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-dispatch-claim.test.ts
@@ -75,14 +75,14 @@ test("openDispatchClaim degrades when worker identity or lease token is missing"
     openDispatchClaim(makeSession({ workerId: null }), "flow", "turn", makeIterationData(), makeDeps({
       recordDispatchClaim: () => assert.fail("recordDispatchClaim should not be called"),
     })),
-    { kind: "degraded" },
+    { kind: "degraded", reason: "missing-worker-or-lease" },
   );
 
   assert.deepEqual(
     openDispatchClaim(makeSession({ milestoneLeaseToken: null }), "flow", "turn", makeIterationData(), makeDeps({
       recordDispatchClaim: () => assert.fail("recordDispatchClaim should not be called"),
     })),
-    { kind: "degraded" },
+    { kind: "degraded", reason: "missing-worker-or-lease" },
   );
 });
 
@@ -91,7 +91,7 @@ test("openDispatchClaim degrades when iteration has no milestone id", () => {
     openDispatchClaim(makeSession(), "flow", "turn", makeIterationData({ mid: undefined }), makeDeps({
       recordDispatchClaim: () => assert.fail("recordDispatchClaim should not be called"),
     })),
-    { kind: "degraded" },
+    { kind: "degraded", reason: "missing-milestone" },
   );
 });
 
@@ -189,7 +189,7 @@ test("openDispatchClaim degrades on claim write failures", () => {
     logClaimFailed: err => logged.push(err),
   }));
 
-  assert.deepEqual(outcome, { kind: "degraded" });
+  assert.deepEqual(outcome, { kind: "degraded", reason: "db unavailable" });
   assert.deepEqual(logged, [writeError]);
 });
 

--- a/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
@@ -114,10 +114,14 @@ test("decideDispatchClaim runs with an opened dispatch id", () => {
   );
 });
 
-test("decideDispatchClaim skips degraded dispatches with a stable reason", () => {
+test("decideDispatchClaim stops degraded dispatches with the claim reason", () => {
   assert.deepEqual(
-    decideDispatchClaim({ kind: "degraded" }),
-    { action: "skip", reason: "dispatch-claim-degraded" },
+    decideDispatchClaim({ kind: "degraded", reason: "missing-worker-or-lease" }),
+    {
+      action: "stop",
+      reason: "dispatch-claim-degraded",
+      message: "missing-worker-or-lease",
+    },
   );
 });
 

--- a/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
@@ -108,10 +108,11 @@ test("decideWorkflowLoop preserves session lock loss detail", () => {
 });
 
 test("decideDispatchClaim runs with an opened dispatch id", () => {
-  assert.deepEqual(
-    decideDispatchClaim({ kind: "opened", dispatchId: 42 }),
-    { action: "run", dispatchId: 42 },
-  );
+  const result = decideDispatchClaim({ kind: "opened", dispatchId: 42 });
+  assert.deepEqual(result, { action: "run", dispatchId: 42 });
+  if (result.action !== "run") throw new Error("expected run");
+  assert.equal(typeof result.dispatchId, "number");
+  assert.notEqual(result.dispatchId, null);
 });
 
 test("decideDispatchClaim stops degraded dispatches with the claim reason", () => {


### PR DESCRIPTION
## Summary
- Fail-closed auto-mode closeout for remaining field wedges (#1754, #1739, #1726): persist terminal task-recovery abort, settle on publication failure, and stop re-projecting cancelled SUMMARY files.
- Collapse the in-flight unit onto the existing `unit_dispatches` row (ADR-048): `advance()` claims in the same step that returns `dispatchId`, `getStatus().activeUnit` reads claimed/running, and a restart resumes that row instead of skip-matching a stale RAM active unit.
- Typed skip codes and degraded claims with a reason; idle `unit-already-active` without in-flight execution stops instead of livelocking.

## Test plan
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test` on unit-run, unit-dispatches, iteration-run, workflow-kernel, auto-orchestrator, auto-runtime-state, auto-contracts
- [x] auto-loop coverage for custom-engine recovery terminalization, canonical task publish, and lease heartbeat
- [ ] CI green on this PR
- [ ] Confirm a killed auto process resumes the claimed UnitRun and does not trip `orchestration-stale-active-unit`


Made with [Cursor](https://cursor.com)