### PR TITLE
fix(gsd): sweep orphaned dispatches and self-heal Q8 gate rows

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -233,7 +233,7 @@ import {
   getTask,
 } from "./gsd-db.js";
 import { checkpointWorkflowDatabase, closeWorkflowDatabase } from "./db-workspace.js";
-import { markLatestActiveForWorkerCanceled } from "./db/unit-dispatches.js";
+import { markActiveForWorkerCanceled } from "./db/unit-dispatches.js";
 import { writeUnitRuntimeRecord } from "./unit-runtime.js";
 import { countPendingCaptures } from "./captures.js";
 import { CMUX_CHANNELS, type CmuxLogLevel } from "../shared/cmux-events.js";
@@ -792,7 +792,7 @@ function closeOutSignalInterruptedUnit(currentBasePath: string): void {
   }
 
   try {
-    if (s.workerId) markLatestActiveForWorkerCanceled(s.workerId, "signal-exit");
+    if (s.workerId) markActiveForWorkerCanceled(s.workerId, "signal-exit");
   } catch (err) {
     logWarning("engine", `signal dispatch cleanup failed: ${getErrorMessage(err)}`, { file: "auto.ts" });
   }

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -49,7 +49,7 @@ import {
   markCompleted as markDispatchCompleted,
   markFailed as markDispatchFailed,
   getRecentForUnit as getRecentDispatchesForUnit,
-  markLatestActiveForWorkerCanceled,
+  markActiveForWorkerCanceled,
 } from "../db/unit-dispatches.js";
 import {
   claimMilestoneLease,
@@ -1670,7 +1670,7 @@ export async function autoLoop(
       if (leaseBeforeClaim.kind === "blocked" && leaseBeforeClaim.holderWorkerId) {
         const holderWorkerId = leaseBeforeClaim.holderWorkerId;
         if (isDeadLocalLeaseHolder(holderWorkerId, s.canonicalProjectRoot)) {
-          markLatestActiveForWorkerCanceled(holderWorkerId, "crash-recovered");
+          markActiveForWorkerCanceled(holderWorkerId, "crash-recovered");
           markWorkerCrashed(holderWorkerId);
           forceReleaseLeasesForWorker(holderWorkerId);
           const retryLease = ensureDispatchLease(s, iterData.mid, {

--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -35,7 +35,7 @@ import {
   type AutoWorkerRow,
 } from "./db/auto-workers.js";
 import { forceReleaseLeasesForWorker } from "./db/milestone-leases.js";
-import { markLatestActiveForWorkerCanceled, type DispatchStatus } from "./db/unit-dispatches.js";
+import { markActiveForWorkerCanceled, type DispatchStatus } from "./db/unit-dispatches.js";
 import { getRuntimeKv, setRuntimeKv, deleteRuntimeKv } from "./db/runtime-kv.js";
 import { _getAdapter, isDbAvailable } from "./gsd-db.js";
 import { gsdRoot, normalizeRealPath } from "./paths.js";
@@ -271,7 +271,7 @@ export function clearStaleWorkerLock(basePath: string): void {
     const projectRoot = normalizeRealPath(basePath);
     const worker = findStaleWorkerForProject(projectRoot);
     if (!worker) return;
-    markLatestActiveForWorkerCanceled(worker.worker_id, "crash-recovered");
+    markActiveForWorkerCanceled(worker.worker_id, "crash-recovered");
     markWorkerStopping(worker.worker_id);
     forceReleaseLeasesForWorker(worker.worker_id);
     deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);

--- a/src/resources/extensions/gsd/db/auto-workers.ts
+++ b/src/resources/extensions/gsd/db/auto-workers.ts
@@ -262,6 +262,23 @@ function isWorkerProcessAlive(candidate: Pick<AutoWorkerRow, "host" | "pid">): b
  *
  * Returns null if no stale worker exists for this project root.
  */
+/**
+ * Stale-worker detection scope (#1773): active workers, plus workers already
+ * marked `stopping` that still own a running dispatch — a stopping worker can
+ * strand its dispatches just as permanently as an active one.
+ */
+const STALE_WORKER_STATUS_SCOPE_SQL = `(
+  status = 'active'
+  OR (
+    status = 'stopping'
+    AND EXISTS (
+      SELECT 1 FROM unit_dispatches dispatch
+      WHERE dispatch.worker_id = workers.worker_id
+        AND dispatch.status = 'running'
+    )
+  )
+)`;
+
 export function findStaleWorkerForProject(
   projectRootRealpath: string,
 ): AutoWorkerRow | null {
@@ -275,7 +292,7 @@ export function findStaleWorkerForProject(
             last_heartbeat_at, status, project_root_realpath
      FROM workers
      WHERE project_root_realpath = :project_root
-       AND status = 'active'
+       AND ${STALE_WORKER_STATUS_SCOPE_SQL}
      ORDER BY started_at DESC
      LIMIT 1`,
   ).get({ ":project_root": projectRootRealpath }) as AutoWorkerRow | undefined;
@@ -286,7 +303,7 @@ export function findStaleWorkerForProject(
             last_heartbeat_at, status, project_root_realpath
      FROM workers
      WHERE project_root_realpath = :project_root
-       AND status = 'active'
+       AND ${STALE_WORKER_STATUS_SCOPE_SQL}
        AND last_heartbeat_at < :cutoff
      ORDER BY started_at DESC
      LIMIT 1`,
@@ -300,7 +317,7 @@ export function findStaleWorkerForProject(
     `SELECT worker_id, host, pid, started_at, version,
             last_heartbeat_at, status, project_root_realpath
      FROM workers
-     WHERE status = 'active'
+     WHERE ${STALE_WORKER_STATUS_SCOPE_SQL}
        AND last_heartbeat_at < :cutoff
      ORDER BY started_at DESC`,
   ).all({ ":cutoff": cutoffIso }) as unknown as AutoWorkerRow[];

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -445,10 +445,12 @@ export function markCanceled(dispatchId: number, reason: string): boolean {
 }
 
 /**
- * Best-effort signal/crash cleanup: cancel the latest active dispatch owned by
- * a worker when the process is exiting before the normal loop can settle it.
+ * Best-effort signal/crash cleanup: cancel every active dispatch owned by a
+ * worker when the process is exiting before the normal loop can settle them.
+ * Cancels all pending/claimed/running rows — sweeping only the latest leaves
+ * older orphaned dispatches wedged forever (#1773).
  */
-export function markLatestActiveForWorkerCanceled(workerId: string, reason: string): boolean {
+export function markActiveForWorkerCanceled(workerId: string, reason: string): boolean {
   if (!isDbAvailable()) return false;
   const now = new Date().toISOString();
   const db = _getAdapter()!;
@@ -456,13 +458,8 @@ export function markLatestActiveForWorkerCanceled(workerId: string, reason: stri
     return db.prepare(
       `UPDATE unit_dispatches
        SET status = 'canceled', ended_at = :ended_at, exit_reason = :reason
-       WHERE id = (
-         SELECT id FROM unit_dispatches
-         WHERE worker_id = :worker_id
-           AND status IN ('pending','claimed','running')
-         ORDER BY id DESC
-         LIMIT 1
-       )`,
+       WHERE worker_id = :worker_id
+         AND status IN ('pending','claimed','running')`,
     ).run({
       ":ended_at": now,
       ":reason": reason,

--- a/src/resources/extensions/gsd/db/writers/slice-lifecycle.ts
+++ b/src/resources/extensions/gsd/db/writers/slice-lifecycle.ts
@@ -530,6 +530,10 @@ export function completeSliceHierarchy(
   const rationale = readiness
     ? "Operational Readiness section populated in slice summary"
     : "Operational Readiness section left empty — recorded as omitted";
+  // Self-heal a missing slice-scope Q8 row before enforcing the precondition
+  // (#1679): slices that reached completion via replan/reopen paths never had
+  // the companion gate seeded, and throwing here permanently blocked closeout.
+  ensurePendingSliceQ8(context, slice);
   const q8Rows = getDb().prepare(`
     SELECT status FROM quality_gates
     WHERE milestone_id = :milestone_id AND slice_id = :slice_id

--- a/src/resources/extensions/gsd/milestone-id-utils.ts
+++ b/src/resources/extensions/gsd/milestone-id-utils.ts
@@ -23,7 +23,13 @@ export function findMilestoneIds(basePath: string): string[] {
       .filter((entry) => entry.isDirectory())
       .map((entry) => {
         const match = entry.name.match(/^(M\d+(?:-[a-z0-9]{6})?)/);
-        return match ? match[1] : entry.name;
+        if (match) return match[1];
+        // Flat-phase layout: `01-some-slug` directories carry the canonical
+        // M001-form ID; returning the raw dirname orphans every ID-keyed
+        // lookup (dispatch sweep, orphan detection) against the milestone.
+        const flatPhase = entry.name.match(/^(\d+)-/);
+        if (flatPhase) return `M${flatPhase[1]!.padStart(3, "0")}`;
+        return entry.name;
       })
       .sort(milestoneIdSort);
   } catch {

--- a/src/resources/extensions/gsd/tests/auto-workers.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-workers.test.ts
@@ -132,3 +132,48 @@ test("findStaleWorkerForProject returns dead PID immediately even before heartbe
   assert.ok(stale, "dead pid should be detected as stale immediately");
   assert.equal(stale!.worker_id, id);
 });
+
+test("findStaleWorkerForProject detects a stopping worker that still holds a running dispatch (#1773)", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = registerAutoWorker({ projectRootRealpath: base });
+  markWorkerStopping(id);
+  _getAdapter()!.prepare(
+    `UPDATE workers SET pid = -1 WHERE worker_id = :worker_id`,
+  ).run({ ":worker_id": id });
+  _getAdapter()!.prepare(
+    `INSERT INTO unit_dispatches (
+      trace_id, turn_id, worker_id, milestone_lease_token,
+      milestone_id, slice_id, task_id, unit_type, unit_id,
+      status, attempt_n, started_at
+    ) VALUES (
+      'trace-orphan', 'turn-orphan', :worker_id, 7,
+      'M001', 'S01', 'T01', 'validate-milestone', 'M001',
+      'running', 1, '2026-07-13T00:00:00.000Z'
+    )`,
+  ).run({ ":worker_id": id });
+
+  const stale = findStaleWorkerForProject(base);
+  assert.ok(stale, "a stopping worker with a running dispatch must be sweepable");
+  assert.equal(stale!.worker_id, id);
+});
+
+test("findStaleWorkerForProject ignores a stopping worker with no running dispatch (#1773)", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = registerAutoWorker({ projectRootRealpath: base });
+  markWorkerStopping(id);
+  _getAdapter()!.prepare(
+    `UPDATE workers SET pid = -1 WHERE worker_id = :worker_id`,
+  ).run({ ":worker_id": id });
+
+  assert.equal(
+    findStaleWorkerForProject(base),
+    null,
+    "a stopping worker with nothing running is a normal shutdown, not an orphan",
+  );
+});

--- a/src/resources/extensions/gsd/tests/complete-slice-gate-closure.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-gate-closure.test.ts
@@ -159,6 +159,24 @@ describe("complete-slice closes complete-slice-owned gates", () => {
     assert.equal(q8.verdict, "omitted");
   });
 
+  test("a missing Q8 row self-heals instead of blocking closeout (#1679)", async () => {
+    // Replan/reopen-era slices can reach completion without the seeded Q8
+    // companion row; completion must seed it and proceed, not throw.
+    const { _getAdapter } = await import("../gsd-db.ts");
+    _getAdapter()!.prepare(
+      "DELETE FROM quality_gates WHERE milestone_id = 'M001' AND slice_id = 'S01' AND gate_id = 'Q8'",
+    ).run();
+
+    const params = makeValidSliceParams({ operationalReadiness: "" });
+    const result = await handleCompleteSlice(params, basePath);
+    assert.ok(!("error" in result), `handler failed: ${(result as any).error}`);
+
+    const gates = getGateResults("M001", "S01", "slice");
+    const q8Rows = gates.filter((g) => g.gate_id === "Q8");
+    assert.equal(q8Rows.length, 1, "exactly one Q8 row after self-heal");
+    assert.equal(q8Rows[0]!.status, "complete");
+  });
+
   test("Q8 also closes when operationalReadiness is omitted entirely", async () => {
     // A model that doesn't pass operationalReadiness at all must still
     // move Q8 out of 'pending' — leaving it pending produces the stall.

--- a/src/resources/extensions/gsd/tests/milestone-id-utils.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-id-utils.test.ts
@@ -1,0 +1,41 @@
+// Project/App: gsd-pi
+// File Purpose: findMilestoneIds flat-phase directory normalization (#1773).
+
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findMilestoneIds } from "../milestone-id-utils.ts";
+
+test("flat-phase NN-slug directories resolve to canonical M-form IDs (#1773)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-milestone-id-utils-"));
+  try {
+    const phases = join(base, ".gsd", "phases");
+    mkdirSync(join(phases, "01-minimal-python-hello-world"), { recursive: true });
+    mkdirSync(join(phases, "12-another-phase"), { recursive: true });
+
+    assert.deepEqual(findMilestoneIds(base), ["M001", "M012"]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("legacy M-form and bare numeric directory names keep their exact behavior", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-milestone-id-utils-"));
+  try {
+    const legacy = join(base, ".gsd", "milestones");
+    mkdirSync(join(legacy, "M002"), { recursive: true });
+    writeFileSync(join(legacy, "M002", "M002-ROADMAP.md"), "# M002\n");
+    mkdirSync(join(legacy, "M001-abc123"), { recursive: true });
+    mkdirSync(join(legacy, "15"), { recursive: true });
+
+    const ids = findMilestoneIds(base);
+    assert.ok(ids.includes("M002"));
+    assert.ok(ids.includes("M001-abc123"));
+    assert.ok(ids.includes("15"), "bare numeric legacy dirs stay raw");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/slice-completion-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-completion-domain-operation.test.ts
@@ -522,20 +522,23 @@ test("Slice completion rejects a cancelled child without a current authorized Wa
   assert.deepEqual(durableSnapshot(), before, "unwaived-child rejection must leave exact zero residue");
 });
 
-test("Slice completion rejects a missing Q8 gate without durable residue", () => {
+test("Slice completion self-heals a missing Q8 gate (#1679)", () => {
   makeBase();
   finishTaskWithOptionalEvidence(true);
   db().prepare(`
     DELETE FROM quality_gates
     WHERE milestone_id = 'M001' AND slice_id = 'S01' AND gate_id = 'Q8'
   `).run();
-  const before = durableSnapshot();
 
-  assert.throws(
-    () => completeSlice(validInput("slice-complete/missing-q8")),
-    /Q8|quality gate/i,
-  );
-  assert.deepEqual(durableSnapshot(), before, "missing-Q8 rejection must leave exact zero residue");
+  const result = completeSlice(validInput("slice-complete/missing-q8"));
+
+  assert.equal(result.status, "committed");
+  const q8 = db().prepare(`
+    SELECT status FROM quality_gates
+    WHERE milestone_id = 'M001' AND slice_id = 'S01' AND gate_id = 'Q8'
+  `).all() as Array<Record<string, unknown>>;
+  assert.equal(q8.length, 1, "exactly one Q8 row after self-heal");
+  assert.equal(String(q8[0]!["status"]), "complete");
 });
 
 test("Slice completion rejects pending and running descendants without durable residue", () => {

--- a/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
@@ -22,7 +22,7 @@ import {
   markStuck,
   markPaused,
   markCanceled,
-  markLatestActiveForWorkerCanceled,
+  markActiveForWorkerCanceled,
   getRecentForUnit,
   getLatestForUnit,
   getActiveForWorker,
@@ -249,7 +249,7 @@ test("markStuck and markCanceled set their respective statuses", (t) => {
   assert.equal(getLatestForUnit("M001/S01/T01")!.status, "canceled");
 });
 
-test("markLatestActiveForWorkerCanceled cancels only the latest active dispatch for a worker", (t) => {
+test("markActiveForWorkerCanceled cancels every active dispatch for a worker (#1773)", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   const { workerId, leaseToken } = setup(base);
@@ -260,7 +260,6 @@ test("markLatestActiveForWorkerCanceled cancels only the latest active dispatch 
   });
   assert.equal(first.ok, true);
   if (!first.ok) return;
-  markCompleted(first.dispatchId);
 
   const second = recordDispatchClaim({
     traceId: "tc-2", workerId, milestoneLeaseToken: leaseToken,
@@ -270,12 +269,14 @@ test("markLatestActiveForWorkerCanceled cancels only the latest active dispatch 
   if (!second.ok) return;
   markRunning(second.dispatchId);
 
-  assert.equal(markLatestActiveForWorkerCanceled(workerId, "signal-exit"), true);
-  assert.equal(getLatestForUnit("M001/S01")!.status, "completed");
+  // Both the claimed and the running row are canceled — sweeping only the
+  // latest leaves the older orphan wedged forever.
+  assert.equal(markActiveForWorkerCanceled(workerId, "signal-exit"), true);
+  assert.equal(getLatestForUnit("M001/S01")!.status, "canceled");
   const latest = getLatestForUnit("M001/S01/T01")!;
   assert.equal(latest.status, "canceled");
   assert.equal(latest.exit_reason, "signal-exit");
-  assert.equal(markLatestActiveForWorkerCanceled(workerId, "signal-exit"), false);
+  assert.equal(markActiveForWorkerCanceled(workerId, "signal-exit"), false);
 });
 
 test("terminal transitions do not overwrite an already terminal dispatch", (t) => {


### PR DESCRIPTION
## Summary

Implements #1778 — doctor orphan sweep for dispatches/workers and self-healing Q8 gate rows. Closes the two fail-closed gaps that stranded otherwise healthy projects: the orphaned-`running`-dispatch deadlock (#1773) and the missing Q8 gate row that permanently blocked slice closeout (#1679).

Closes #1778

## Outcome evidence

| Outcome | Evidence |
| --- | --- |
| O-1 — flat-phase dirs produce canonical milestone IDs | `findMilestoneIds` (milestone-id-utils.ts) normalizes `01-some-slug` to `M001` instead of returning the raw dirname. Test: `tests/milestone-id-utils.test.ts` covers the flat-phase mapping and pins legacy M-form / bare-numeric behavior byte-for-byte (X-3). |
| O-2 — sweep detects `stopping` workers | `findStaleWorkerForProject` scope widened: workers in `stopping` that still own a `running` dispatch are stale candidates alongside `active` ones (same dead-PID/heartbeat checks). Tests: stopping+running-dispatch detected; stopping with nothing running stays untouched. |
| O-3 — cancel all active dispatch rows | `markLatestActiveForWorkerCanceled` → `markActiveForWorkerCanceled`: cancels every `pending`/`claimed`/`running` row for the worker, not just the latest. The old "only the latest" test was rewritten to the new contract (both a claimed and a running row are canceled). |
| O-4 — Q8 seeding + self-heal | Replan/reopen seeding already landed on main (`ensurePendingSliceQ8`, covered by `replan-slice-domain-replay` and `reopen-task` tests). This change adds the completion-side self-heal: `completeSliceHierarchy` calls `ensurePendingSliceQ8` before the pending-gate precondition instead of throwing. Test: deleting the Q8 row, then completing, succeeds with exactly one closed Q8 row. |

## Exclusions

- X-1 — no schema version bump; all fixes work within existing tables (SCHEMA_VERSION untouched).
- X-2 — gate semantics/content unchanged; only the row's existence is repaired.
- X-3 — legacy milestone layouts verified byte-for-byte by test.
- X-4 — worker lease/heartbeat semantics unchanged; only detection and sweep completeness widened.

## Checks

- `typecheck:extensions` — clean for changed files.
- Focused suites green (82 tests): `unit-dispatches`, `auto-workers`, `milestone-id-utils`, `complete-slice-gate-closure`, `replan-slice-domain-replay`, `reopen-task`, `complete-slice`, `reopen-slice`, `crash-recovery`.
- `test:changed:src` gate — 55 tests green.

Dependency audit: not applicable (no dependency manifest or lockfile changes).

## Notes

- The O-3 rename (`markLatestActiveForWorkerCanceled` → `markActiveForWorkerCanceled`) touches the three call sites (`auto.ts`, `auto/loop.ts`, `crash-recovery.ts`) so the name stops lying about the sweep scope.
- `milestone-id-utils.ts` and `milestone-ids.ts` both export a `findMilestoneIds`; the latter already normalizes flat-phase names. This fix brings the former (used by the `/gsd auto` command path) in line. Consolidating the duplicate is deliberately out of scope.
- Manual walkthrough not run end-to-end; each step is covered by a canonical-DB regression test instead.

## Risk

Low — four narrow changes, each pinned by a regression test; no schema or lease-semantics changes.
