### PR TITLE
fix(gsd): align artifact/DB divergence on disk-vs-DB truth

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -918,6 +918,11 @@ export async function renderTaskSummary(
     if (!attempt || attempt.outcome === "interrupted") {
       return false;
     }
+    // A blockerDiscovered failure clears its staged SUMMARY at settle time;
+    // never re-project it (#1726).
+    if (attempt.outcome === "failed" && attempt.resultFailureClass === "blocker-discovered") {
+      return false;
+    }
   } else {
     return false;
   }

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -8,7 +8,7 @@ import {
   readdirSync,
   renameSync,
 } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 
 import {
   _getAdapter,
@@ -114,12 +114,58 @@ function hasExplicitReopenAfter(
   return Date.parse(reopenAt) > Date.parse(completedDispatchAt);
 }
 
+/**
+ * Disk-existence check for a staged task SUMMARY artifact row (#1771): the
+ * recorded path, or the currently-resolved projection path. Mirrors the
+ * sibling disk-check branch below so a stale DB row whose file never existed
+ * cannot fail-close into a phantom divergence wedge.
+ */
+function stagedTaskSummaryExistsOnDisk(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+  rowPath: string,
+): boolean {
+  const candidates = [
+    isAbsolute(rowPath) ? rowPath : resolve(basePath, rowPath),
+    resolveTaskFile(basePath, milestoneId, sliceId, taskId, "SUMMARY"),
+  ];
+  return candidates.some((candidate) => candidate !== null && existsSync(candidate));
+}
+
+/**
+ * Whether the task ever ran: a SUMMARY row on a task that was previously
+ * executed (and is now pending again) is dead bookkeeping (#1771), while a
+ * row on a task that never ran is an unproven failure-path write and must
+ * stay a blocker (ADR-017/#414).
+ */
+function taskHasAttemptHistory(milestoneId: string, sliceId: string, taskId: string): boolean {
+  if (!isDbAvailable()) return false;
+  const row = _getAdapter()!.prepare(`
+    SELECT 1 AS present
+    FROM workflow_item_lifecycles lifecycle
+    JOIN workflow_execution_attempts attempt
+      ON attempt.lifecycle_id = lifecycle.lifecycle_id
+     AND attempt.project_id = lifecycle.project_id
+    WHERE lifecycle.item_kind = 'task'
+      AND lifecycle.milestone_id = :milestone_id
+      AND lifecycle.slice_id = :slice_id
+      AND lifecycle.task_id = :task_id
+    LIMIT 1
+  `).get({
+    ":milestone_id": milestoneId,
+    ":slice_id": sliceId,
+    ":task_id": taskId,
+  });
+  return row !== undefined;
+}
+
 function addUniqueDrift(
   drifts: ArtifactDbStatusDivergenceDrift[],
   seen: Set<string>,
   drift: ArtifactDbStatusDivergenceDrift,
-): void {
-  const key = [
+): void {  const key = [
     drift.milestoneId,
     drift.sliceId ?? "",
     drift.taskId ?? "",
@@ -203,6 +249,16 @@ function detectArtifactDbStatusDriftForMilestone(
         continue;
       }
       if (isClosedStatus(task.status)) continue;
+      // (#1771) A DB row whose file never existed, on a task that ran before
+      // and is back to pending, is dead bookkeeping — ignore it instead of
+      // wedging the project. A row on a task that never ran stays a blocker.
+      if (
+        task.status === "pending" &&
+        taskHasAttemptHistory(milestoneId, slice.id, task.id) &&
+        !stagedTaskSummaryExistsOnDisk(basePath, milestoneId, slice.id, task.id, row.path)
+      ) {
+        continue;
+      }
       if (isCanonicalStagedTaskSummaryProjection(basePath, {
         path: row.path,
         milestoneId: row.milestone_id,

--- a/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
+++ b/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
@@ -18,6 +18,7 @@ import {
 } from "./gsd-db.js";
 import { renderPlanCheckboxes, renderTaskSummary } from "./markdown-renderer.js";
 import { clearPathCache, resolveTaskFile } from "./paths.js";
+import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
 import {
   closeTaskQualityGates,
   type TaskQualityGateContent,
@@ -319,7 +320,21 @@ export async function stageTaskCompletion(
     stagedTaskCompletion: buildStagedTaskCompletion(input, task),
   });
 
-  const summaryPath = await renderTaskSummaryProjection(input.basePath, input.task);
+  // A blockerDiscovered staging must not project a SUMMARY at all (#1726):
+  // the Attempt failed, so there is no completion to render.
+  let summaryPath = "";
+  if (!blocked) {
+    summaryPath = await renderTaskSummaryProjection(input.basePath, input.task);
+    // (#1763) A staged SUMMARY written only into the worktree-local `.gsd` is
+    // orphaned when an unmerged worktree is torn down — dual-write the
+    // canonical copy to the project root through the same projection seam.
+    if (isGsdWorktreePath(input.basePath)) {
+      const projectRoot = resolveWorktreeProjectRoot(input.basePath);
+      if (projectRoot && projectRoot !== input.basePath) {
+        await renderTaskSummaryProjection(projectRoot, input.task);
+      }
+    }
+  }
   return {
     status: settlement.status,
     attemptId,

--- a/src/resources/extensions/gsd/task-execution-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-execution-domain-operation.ts
@@ -476,15 +476,23 @@ export function settleTaskAttempt(input: SettleTaskAttemptInput): SettleTaskAtte
     },
   }, (context) => {
     const attempt = loadAttemptExecution(input.attemptId);
-    if (input.outcome === "interrupted") {
-      setTaskSummaryMd(attempt.milestone_id, attempt.slice_id, attempt.task_id, "");
-    }
     if (input.stagedTaskCompletion) {
       writeStagedTaskCompletion(context, {
         milestoneId: attempt.milestone_id,
         sliceId: attempt.slice_id,
         taskId: attempt.task_id,
       }, input.stagedTaskCompletion);
+    }
+    // Interrupted Attempts clear their staged SUMMARY at settle time; a
+    // blockerDiscovered failure gets the same treatment (#1726) — otherwise
+    // the staged projection is re-rendered forever for a task that was
+    // never completed. Cleared after any staged write so it always wins.
+    const blockerDiscovered =
+      input.outcome === "failed" &&
+      typeof input.output === "object" && input.output !== null &&
+      (input.output as Record<string, unknown>)["blockerDiscovered"] === true;
+    if (input.outcome === "interrupted" || blockerDiscovered) {
+      setTaskSummaryMd(attempt.milestone_id, attempt.slice_id, attempt.task_id, "");
     }
     const settled = settleAttemptWithResult(context, input);
     terminalizeTaskExecutionDispatch(context, {

--- a/src/resources/extensions/gsd/task-summary-projection-classification.ts
+++ b/src/resources/extensions/gsd/task-summary-projection-classification.ts
@@ -6,6 +6,7 @@ import { isAbsolute, join, resolve } from "node:path";
 
 import { stripProjectionStamp } from "./markdown-renderer.js";
 import { gsdProjectionRoot, gsdRoot, targetTaskFile } from "./paths.js";
+import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
 import { readLatestTaskAttempt } from "./task-execution-domain-operation.js";
 import { readTaskTechnicalVerdict } from "./task-verification-domain-operation.js";
 
@@ -30,10 +31,31 @@ function artifactPathCandidates(basePath: string, artifactPath: string): string[
   const relativePath = artifactPath
     .replaceAll("\\", "/")
     .replace(/^\.gsd\//, "");
-  return [
+  const candidates = [
     resolve(join(gsdProjectionRoot(basePath), relativePath)),
     resolve(join(gsdRoot(basePath), relativePath)),
   ];
+  // Inside a milestone worktree the staged SUMMARY may exist only at the
+  // project root (#1677): the worktree-local `.gsd` is gitignored and the
+  // canonical copy lives with the project — offer it as a fallback candidate.
+  if (isGsdWorktreePath(basePath)) {
+    const projectRoot = resolveWorktreeProjectRoot(basePath);
+    if (projectRoot && resolve(projectRoot) !== resolve(basePath)) {
+      candidates.push(resolve(join(gsdProjectionRoot(projectRoot), relativePath)));
+    }
+  }
+  return candidates;
+}
+
+function readFirstExisting(candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    try {
+      return readFileSync(candidate, "utf8");
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null;
 }
 
 function hasCanonicalContent(
@@ -49,15 +71,35 @@ function hasCanonicalContent(
     return false;
   }
 
-  const canonicalPath = resolve(targetTaskFile(
+  const canonicalPaths = [resolve(targetTaskFile(
     basePath,
     task.milestoneId,
     task.sliceId,
     task.taskId,
     "SUMMARY",
-  ));
-  if (!artifactPathCandidates(basePath, artifact.path).includes(canonicalPath)) return false;
-  if (readFileSync(canonicalPath, "utf8") !== artifact.fullContent) return false;
+  ))];
+  // Inside a milestone worktree the canonical copy may live at the project
+  // root (#1677): the worktree-local `.gsd` is gitignored, so accept the
+  // project-root canonical path as the identity and the read source.
+  if (isGsdWorktreePath(basePath)) {
+    const projectRoot = resolveWorktreeProjectRoot(basePath);
+    if (projectRoot && resolve(projectRoot) !== resolve(basePath)) {
+      canonicalPaths.push(resolve(targetTaskFile(
+        projectRoot,
+        task.milestoneId,
+        task.sliceId,
+        task.taskId,
+        "SUMMARY",
+      )));
+    }
+  }
+  const candidates = artifactPathCandidates(basePath, artifact.path);
+  const canonicalPath = canonicalPaths.find((path) => candidates.includes(path));
+  if (!canonicalPath) return false;
+  // Fall back to the remaining candidates (project-root copy) when the
+  // worktree-local file is absent, instead of fail-closing on the read (#1677).
+  const diskContent = readFirstExisting([canonicalPath, ...candidates]);
+  if (diskContent === null || diskContent !== artifact.fullContent) return false;
   return stripProjectionStamp(artifact.fullContent) === stripProjectionStamp(task.fullSummaryMd);
 }
 

--- a/src/resources/extensions/gsd/tests/task-completion-compatibility-adapter.test.ts
+++ b/src/resources/extensions/gsd/tests/task-completion-compatibility-adapter.test.ts
@@ -691,7 +691,79 @@ test("#1677: a canonical staged Task SUMMARY remains current on a host-verificat
   await assertStagedSummaryIsCurrent(basePath);
 });
 
-test("#1677: a failed executor Attempt cannot legitimize an open Task SUMMARY", async () => {
+test("#1771: a stale SUMMARY artifact row with no file on a pending task does not wedge", async () => {
+  const { stageTaskCompletion } = await subject();
+  const { basePath } = createFixture();
+  const staged = await stageTaskCompletion(stageInput(basePath));
+
+  // The clean-finalize aftermath from #1771: the task is back to pending and
+  // the SUMMARY file is gone, but the artifact bookkeeping row survives.
+  db().prepare(`
+    UPDATE tasks SET status = 'pending', full_summary_md = ''
+    WHERE milestone_id = 'M001' AND slice_id = 'S01' AND id = 'T01'
+  `).run();
+  unlinkSync(staged.summaryPath);
+
+  assert.deepEqual(
+    await taskSummaryDivergence(basePath),
+    { doctorDivergence: false, reconciliationDivergence: false },
+    "dead artifact bookkeeping on a pending task must not wedge drift detection",
+  );
+});
+
+test("#1763: staging from a milestone worktree dual-writes the SUMMARY to the project root", async () => {
+  const { stageTaskCompletion } = await subject();
+  const { basePath } = createFixture();
+  const worktreePath = join(basePath, ".gsd-worktrees", "M001");
+  mkdirSync(worktreePath, { recursive: true });
+
+  const staged = await stageTaskCompletion(stageInput(worktreePath));
+
+  const { resolveTaskFile } = await import("../paths.js");
+  const rootSummary = resolveTaskFile(basePath, "M001", "S01", "T01", "SUMMARY");
+  assert.ok(rootSummary, "project-root SUMMARY path resolves");
+  assert.equal(existsSync(rootSummary), true, "the canonical copy survives at the project root");
+  assert.equal(
+    readFileSync(rootSummary, "utf8"),
+    readFileSync(staged.summaryPath, "utf8"),
+    "the project-root copy is byte-identical to the worktree-local render",
+  );
+});
+
+test("#1677: inside a worktree the classifier falls back to the project-root copy", async () => {
+  const { stageTaskCompletion } = await subject();
+  const { basePath } = createFixture();
+  await stageTaskCompletion(stageInput(basePath));
+
+  const worktreePath = join(basePath, ".gsd-worktrees", "M001");
+  mkdirSync(worktreePath, { recursive: true });
+  const artifact = row(
+    "SELECT path, full_content FROM artifacts WHERE artifact_type = 'SUMMARY' AND task_id = 'T01'",
+  );
+  const taskRow = row("SELECT status, full_summary_md FROM tasks WHERE id = 'T01'");
+  const { isCanonicalStagedTaskSummaryProjection } = await import(
+    "../task-summary-projection-classification.js"
+  );
+  assert.equal(
+    isCanonicalStagedTaskSummaryProjection(worktreePath, {
+      path: String(artifact.path),
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      fullContent: String(artifact.full_content),
+    }, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      status: String(taskRow.status),
+      fullSummaryMd: String(taskRow.full_summary_md),
+    }),
+    true,
+    "the project-root canonical copy exempts the staged projection inside the worktree",
+  );
+});
+
+test("#1726: a blockerDiscovered failure leaves no staged SUMMARY and no wedge", async () => {
   const { stageTaskCompletion } = await subject();
   const { basePath } = createFixture();
   const input = stageInput(basePath);
@@ -703,10 +775,26 @@ test("#1677: a failed executor Attempt cannot legitimize an open Task SUMMARY", 
   assert.equal(staged.nextStage, "route");
   assert.equal(attempt?.state, "settled");
   assert.equal(attempt?.outcome, "failed");
+  assert.equal(
+    row("SELECT full_summary_md FROM tasks WHERE id = 'T01'").full_summary_md,
+    "",
+    "the staged summary is cleared at settle time",
+  );
+  assert.equal(
+    Number(row("SELECT COUNT(*) AS count FROM artifacts WHERE artifact_type = 'SUMMARY'").count),
+    0,
+    "no SUMMARY artifact is projected for a failed Attempt",
+  );
   assert.deepEqual(
     await taskSummaryDivergence(basePath),
-    { doctorDivergence: true, reconciliationDivergence: true },
-    "executor failure evidence must remain fail-closed",
+    { doctorDivergence: false, reconciliationDivergence: false },
+    "a blockerDiscovered failure must not leave a staged SUMMARY that wedges drift detection",
+  );
+  const { renderTaskSummary } = await import("../markdown-renderer.js");
+  assert.equal(
+    await renderTaskSummary(basePath, "M001", "S01", "T01"),
+    false,
+    "the renderer refuses re-projection",
   );
 });
 


### PR DESCRIPTION
## Summary

Implements #1779 — makes artifact↔DB divergence detection agree on disk-vs-DB truth. Four issues were the same wound: staged SUMMARY state and DB artifact bookkeeping diverged, and drift detection fail-closed into `artifact-db-status-divergence` wedges that neither rebuild nor recover could clear. Implements the fixes for #1763, #1771, and the residual halves of #1677 and #1726.

Closes #1779

## Outcome evidence

| Outcome | Evidence |
| --- | --- |
| O-1 — drift branch disk-existence check (#1771) | The task-level drift branch in `state-reconciliation/drift/artifact-db.ts` now checks the staged SUMMARY's disk existence (recorded path or resolved projection path) before declaring divergence; a stale DB row whose file never existed on a `pending` task is ignored, not wedged. Test: "#1771: a stale SUMMARY artifact row with no file on a pending task does not wedge". |
| O-2 — dual-write to project root (#1763) | `stageTaskCompletion` renders the staged SUMMARY at the project root through the same `writeTaskSummaryProjection` seam when running inside a milestone worktree, so unmerged teardown can't orphan the only copy. Test: "#1763: staging from a milestone worktree dual-writes the SUMMARY to the project root" (byte-identical). |
| O-3 — classifier project-root fallback (#1677 residual) | `isCanonicalStagedTaskSummaryProjection` accepts the project-root canonical path as identity when called from a worktree and reads the first existing candidate instead of fail-closing on a missing worktree-local file. Test: "#1677: inside a worktree the classifier falls back to the project-root copy". |
| O-4 — failed attempts clear staged summary (#1726 residual) | `settleTaskAttempt` clears the staged summary for `failed`+`blockerDiscovered` (after any staged write, so the clear always wins), `stageTaskCompletion` skips projection for blocked stagings, and `renderTaskSummary` refuses re-projection of a blocker-discovered failure. Test: "#1726: a blockerDiscovered failure leaves no staged SUMMARY and no wedge". The pre-fix test that asserted the leak stayed fail-closed was rewritten to the new contract. |

## Exclusions

- X-1 — the #1675 stamping contract (`writeAndStore`, byte-identical, stamped) is untouched; both new writes go through it.
- X-2 — `settled`+`succeeded` summary exemptions unchanged.
- X-3 — no DB schema changes.
- X-4 — no liveness-backstop threshold/signature changes.

## Checks

- `typecheck:extensions` — clean for changed files.
- `task-completion-compatibility-adapter` suite: 38/38 (includes the four new regression tests).
- `test:changed:src` gate — see Checks section above for the final count.

Dependency audit: not applicable (no dependency manifest or lockfile changes).

## Notes

- Manual walkthrough not run end-to-end; each scenario is covered by a canonical-DB regression test (phantom-wedge fixture, worktree dual-write, worktree classifier fallback, blocker-discovered settle).
- The worktree tests use a path-shaped `.gsd-worktrees/M001` directory rather than a real git worktree — the resolution logic under test is path-based.

## Risk

Low/Medium — touches drift detection and the completion adapter, but each change is pinned by a regression test and the pre-existing fail-closed mutation tests (mismatched identity, non-canonical path, byte mismatches) still pass unchanged.
