### PR TITLE
feat(gsd): verify-after-write receipts for save-tool units

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1074,6 +1074,43 @@ function artifactValidationKind(unitType: string): "project" | "requirements" | 
 
 const TASK_COMPLETION_TOOL_NAMES = new Set(["gsd_task_complete", "gsd_complete_task"]);
 
+/**
+ * Verify-after-write receipt check (#1714/#1761): a run-uat or
+ * validate-milestone unit may only complete when its save actually persisted.
+ * Returns null when the durable receipt exists, else an error naming the
+ * missing artifact and the owning save tool.
+ */
+function missingDurableSaveReceipt(unitType: string, unitId: string): string | null {
+  if (!isDbAvailable()) return null;
+  const db = _getAdapter();
+  if (!db) return null;
+  if (unitType === "run-uat") {
+    const { milestone, slice } = parseUnitId(unitId);
+    const row = db.prepare(`
+      SELECT status FROM quality_gates
+      WHERE milestone_id = :milestone_id AND slice_id = :slice_id
+        AND gate_id = 'UAT' AND (task_id = '' OR task_id IS NULL)
+    `).get({ ":milestone_id": milestone, ":slice_id": slice }) as Record<string, unknown> | undefined;
+    if (!row) {
+      return `Artifact verification failed: UAT verdict for ${unitId} was not durably persisted (no quality_gates UAT row). Re-call gsd_uat_result_save with the existing evidence.`;
+    }
+    return null;
+  }
+  if (unitType === "validate-milestone") {
+    const { milestone } = parseUnitId(unitId);
+    const row = db.prepare(`
+      SELECT 1 AS present FROM assessments
+      WHERE milestone_id = :milestone_id AND scope = 'milestone-validation'
+      LIMIT 1
+    `).get({ ":milestone_id": milestone });
+    if (!row) {
+      return `Artifact verification failed: milestone validation verdict for ${milestone} was not durably persisted (no milestone-validation assessment row). Re-run gsd_validate_milestone.`;
+    }
+    return null;
+  }
+  return null;
+}
+
 function hasTaskCompletionToolCall(agentEndMessages?: unknown[] | null): boolean {
   if (!Array.isArray(agentEndMessages)) return false;
   for (const rawMessage of agentEndMessages) {
@@ -1098,8 +1135,7 @@ function describeArtifactVerificationFailure(
   unitId: string,
   basePath: string,
   agentEndMessages?: unknown[] | null,
-): string {
-  const worktreeFailure = diagnoseWorktreeIntegrityFailure(basePath);
+): string {  const worktreeFailure = diagnoseWorktreeIntegrityFailure(basePath);
   if (worktreeFailure) {
     return `${worktreeFailure} Unit: ${unitType} ${unitId}.`;
   }
@@ -1132,6 +1168,7 @@ function describeArtifactVerificationFailure(
   return `Artifact verification failed: ${relPath} exists but did not satisfy the ${unitType} completion contract${expected ? ` (${expected})` : ""}.`;
 }
 export const _describeArtifactVerificationFailureForTest = describeArtifactVerificationFailure;
+export const _missingDurableSaveReceiptForTest = missingDurableSaveReceipt;
 
 async function repairCompleteSliceRoadmapProjection(
   unitType: string,
@@ -2003,6 +2040,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
     // Artifact verification
     const verificationBasePath = s.currentUnit.workspaceRoot ?? s.basePath;
     let triggerArtifactVerified = false;
+    let durableReceiptFailure: string | null = null;
     if (!s.currentUnit.type.startsWith("hook/")) {
       try {
         triggerArtifactVerified =
@@ -2013,6 +2051,24 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         }
       } catch (e) {
         debugLog("postUnit", { phase: "artifact-verify", error: String(e) });
+      }
+
+      // Verify-after-write (#1714/#1761): a run-uat or validate-milestone unit
+      // whose save never persisted is an explicit unit error, not a silent pass.
+      if (
+        triggerArtifactVerified &&
+        (s.currentUnit.type === "run-uat" || s.currentUnit.type === "validate-milestone")
+      ) {
+        durableReceiptFailure = missingDurableSaveReceipt(s.currentUnit.type, s.currentUnit.id);
+        if (durableReceiptFailure) {
+          triggerArtifactVerified = false;
+          debugLog("postUnit", {
+            phase: "durable-save-receipt-missing",
+            unitType: s.currentUnit.type,
+            unitId: s.currentUnit.id,
+            reason: durableReceiptFailure,
+          });
+        }
       }
 
       try {
@@ -2468,7 +2524,9 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
             );
           }
           const attempt = (s.verificationRetryCount.get(retryKey) ?? 0) + 1;
-          const failureDetails = describeArtifactVerificationFailure(
+          // A missing durable save receipt names the artifact and the owning
+          // save tool (#1761 O-4); everything else keeps the artifact ladder.
+          const failureDetails = durableReceiptFailure ?? describeArtifactVerificationFailure(
             s.currentUnit.type,
             s.currentUnit.id,
             verificationBasePath,

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1150,7 +1150,13 @@ function describeArtifactVerificationFailure(
     const completionToolHint = unitType === "execute-task" && !hasTaskCompletionToolCall(agentEndMessages)
       ? " No completion tool call detected (`gsd_task_complete`/alias)."
       : "";
-    return `Artifact verification failed: ${relPath} was not found on disk after unit execution${expected ? ` (${expected})` : ""}.${completionToolHint}`;
+    const saveToolHint =
+      unitType === "run-uat"
+        ? " Re-call gsd_uat_result_save."
+        : unitType === "validate-milestone"
+          ? " Re-run gsd_validate_milestone."
+          : "";
+    return `Artifact verification failed: ${relPath} was not found on disk after unit execution${expected ? ` (${expected})` : ""}.${completionToolHint}${saveToolHint}`;
   }
 
   const validationKind = artifactValidationKind(unitType);

--- a/src/resources/extensions/gsd/prompts/run-uat.md
+++ b/src/resources/extensions/gsd/prompts/run-uat.md
@@ -69,6 +69,8 @@ After running all checks, compute the **overall verdict**:
 
 Call `gsd_uat_result_save` once after all checks are complete. The tool computes the assessment path, persists to DB/disk, saves attempt history, and saves the aggregate UAT gate.
 
+**Verify the save before ending your turn.** If `gsd_uat_result_save` returns an error (for example a schema validation error on `checks`), fix the payload and retry — exactly once. If the retry also fails, end the unit with an explicit error naming the validation failure; do not narrate success. A `run-uat` unit that ends without a persisted `quality_gates` UAT row and its ASSESSMENT artifact is a failed unit, not a completed one.
+
 Pass these top-level fields:
 
 ```ts

--- a/src/resources/extensions/gsd/tests/auto-post-unit-artifact-diagnostic.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-artifact-diagnostic.test.ts
@@ -36,6 +36,24 @@ test("missing execute-task artifact skips completion-tool hint when completion t
   assert.doesNotMatch(msg, /No completion tool call detected \(`gsd_task_complete`\/alias\)/);
 });
 
+test("missing run-uat artifact names gsd_uat_result_save (#1781 O-4)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-artifact-diag-uat-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+  const msg = _describeArtifactVerificationFailureForTest("run-uat", "M001/S01", base);
+  assert.match(msg, /ASSESSMENT\.md was not found on disk after unit execution/);
+  assert.match(msg, /gsd_uat_result_save/);
+});
+
+test("missing validate-milestone artifact names gsd_validate_milestone (#1781 O-4)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-artifact-diag-validate-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+
+  const msg = _describeArtifactVerificationFailureForTest("validate-milestone", "M001", base);
+  assert.match(msg, /was not found on disk after unit execution/);
+  assert.match(msg, /gsd_validate_milestone/);
+});
+
 test("parallel research cost spike writes durable PARALLEL-BLOCKER", () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-parallel-cost-blocker-"));
   try {

--- a/src/resources/extensions/gsd/tests/durable-save-receipt.test.ts
+++ b/src/resources/extensions/gsd/tests/durable-save-receipt.test.ts
@@ -1,0 +1,77 @@
+// Project/App: gsd-pi
+// File Purpose: Verify-after-write receipt checks for save-tool units (#1714/#1761).
+
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test } from "node:test";
+
+import { _getAdapter, closeDatabase, openDatabase } from "../gsd-db.ts";
+import { _missingDurableSaveReceiptForTest } from "../auto-post-unit.ts";
+
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  closeDatabase();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+function openFixture(): void {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-save-receipt-"));
+  tempDirs.add(dir);
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  assert.equal(openDatabase(join(dir, ".gsd", "gsd.db")), true);
+  db().exec(`
+    INSERT INTO milestones (id, title, status, created_at)
+    VALUES ('M001', 'Receipts', 'active', '2026-07-13T00:00:00.000Z');
+    INSERT INTO slices (milestone_id, id, title, status, created_at)
+    VALUES ('M001', 'S01', 'Receipt slice', 'active', '2026-07-13T00:00:00.000Z');
+  `);
+}
+
+function db() {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  return adapter;
+}
+
+test("run-uat without a persisted UAT gate row is an explicit error naming gsd_uat_result_save", () => {
+  openFixture();
+  const error = _missingDurableSaveReceiptForTest("run-uat", "M001/S01");
+  assert.ok(error);
+  assert.match(error, /not durably persisted/);
+  assert.match(error, /gsd_uat_result_save/);
+});
+
+test("run-uat with a persisted UAT gate row passes the receipt check", () => {
+  openFixture();
+  db().prepare(`
+    INSERT INTO quality_gates (milestone_id, slice_id, gate_id, scope, task_id, status)
+    VALUES ('M001', 'S01', 'UAT', 'slice', '', 'complete')
+  `).run();
+  assert.equal(_missingDurableSaveReceiptForTest("run-uat", "M001/S01"), null);
+});
+
+test("validate-milestone without a persisted verdict names gsd_validate_milestone", () => {
+  openFixture();
+  const error = _missingDurableSaveReceiptForTest("validate-milestone", "M001");
+  assert.ok(error);
+  assert.match(error, /not durably persisted/);
+  assert.match(error, /gsd_validate_milestone/);
+});
+
+test("validate-milestone with a persisted verdict passes the receipt check", () => {
+  openFixture();
+  db().prepare(`
+    INSERT INTO assessments (path, milestone_id, slice_id, task_id, status, scope, full_content)
+    VALUES ('.gsd/milestones/M001/M001-VALIDATION.md', 'M001', NULL, NULL, 'pass', 'milestone-validation', '# Validation')
+  `).run();
+  assert.equal(_missingDurableSaveReceiptForTest("validate-milestone", "M001"), null);
+});
+
+test("other unit types have no save receipt to verify", () => {
+  openFixture();
+  assert.equal(_missingDurableSaveReceiptForTest("execute-task", "M001/S01/T01"), null);
+});


### PR DESCRIPTION
## Summary

Implements #1781 — verify-after-write: durable-state receipts at unit end. Units narrated success while their final save silently failed to persist; the operator discovered it only later as a generic finalize-retry liveness wedge (#1714, #1761 — same defect class, filed twice; one should be closed as duplicate when this merges).

Closes #1781

## Outcome evidence

| Outcome | Evidence |
| --- | --- |
| O-1 — run-uat verifies the durable receipt | After artifact verification passes, `postUnitPreVerification` now checks the `quality_gates` UAT row for the slice; a missing receipt flips the unit into the explicit failure path. Test: `tests/durable-save-receipt.test.ts` (missing row → error; persisted row → pass). |
| O-2 — same for `gsd_validate_milestone` | The same check covers `validate-milestone` units against the milestone-validation assessment row. Test: same file. |
| O-3 — validation errors surface in-turn, one bounded retry | The `run-uat.md` prompt no longer instructs a single blind save: the agent must verify the save, retry exactly once on a validation error, and end with an explicit error if it still fails. (Tool-side validation errors already surface in the tool result; the blind spot was the unit-level silence.) |
| O-4 — wedge message names the save tool | A missing receipt produces `Artifact verification failed: … was not durably persisted … Re-call gsd_uat_result_save / Re-run gsd_validate_milestone`, threaded through the retry/blocker failure details instead of the generic "not found on disk" message. |

## Exclusions

- X-1 — no schema changes; receipts read existing `quality_gates`/assessment rows.
- X-2 — no per-evidence incremental persistence redesign.
- X-3 — exactly one retry, instructed in the prompt; no retry loops in code.
- X-4 — evidence-kind validation (#1498) untouched.

## Checks

- `tests/durable-save-receipt.test.ts` — 5/5 (both unit types, both directions, non-save units exempt).
- post-unit suites: `auto-post-unit-artifact-diagnostic`, `auto-post-unit-evidence-crossref-4909`, `auto-post-unit-step-message`, `auto-post-unit-milestone-github-order`, `dispatch-run-uat-browser-tools` — 24/24.
- `test:changed:src` gate — green (see Checks).
- `typecheck:extensions` — no new errors from this diff.

Dependency audit: not applicable (no dependency manifest or lockfile changes).

## Notes

- The receipt check is skipped when the DB is unavailable (degraded mode keeps current behavior).
- Manual walkthrough not run end-to-end; the receipt matrix is covered by the new unit tests and the failure message is exercised through the existing post-unit suites.

## Risk

Low/Medium — a new gate on unit completion for two unit types; a false negative would show as a run-uat/validate unit error naming the save tool, which is the intended loud failure.
