### PR TITLE
fix(gsd): settle migration before drift reconciliation

### DIFF
--- a/src/resources/extensions/gsd/file-lock.ts
+++ b/src/resources/extensions/gsd/file-lock.ts
@@ -17,6 +17,7 @@ export interface FileLockOptions {
   retries?: number;
   /** proper-lockfile stale threshold in ms (default 10000). */
   stale?: number;
+  /** Resolve the target before locking (default true); false keeps the lock beside the lexical path. */
   realpath?: boolean;
 }
 

--- a/src/resources/extensions/gsd/file-lock.ts
+++ b/src/resources/extensions/gsd/file-lock.ts
@@ -17,6 +17,7 @@ export interface FileLockOptions {
   retries?: number;
   /** proper-lockfile stale threshold in ms (default 10000). */
   stale?: number;
+  realpath?: boolean;
 }
 
 const DEFAULT_RETRIES = 5;
@@ -35,11 +36,12 @@ function acquireLockSyncWithRetry(
   filePath: string,
   retries: number,
   stale: number,
+  realpath: boolean,
 ): () => void {
   let lastErr: any;
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      return lockfile.lockSync(filePath, { stale });
+      return lockfile.lockSync(filePath, { realpath, stale });
     } catch (err: any) {
       lastErr = err;
       if (err?.code !== "ELOCKED") throw err;
@@ -57,11 +59,12 @@ export function withFileLockSync<T>(
   if (!existsSync(filePath)) return fn();
 
   const stale = opts.stale ?? DEFAULT_STALE_MS;
+  const realpath = opts.realpath ?? true;
   const onLocked: OnLocked = opts.onLocked ?? "fail";
   const retries = onLocked === "skip" ? 0 : (opts.retries ?? DEFAULT_RETRIES);
 
   try {
-    const release = acquireLockSyncWithRetry(filePath, retries, stale);
+    const release = acquireLockSyncWithRetry(filePath, retries, stale, realpath);
     try {
       return fn();
     } finally {
@@ -84,10 +87,11 @@ export async function withFileLock<T>(
 
   const retries = opts.retries ?? DEFAULT_RETRIES;
   const stale = opts.stale ?? DEFAULT_STALE_MS;
+  const realpath = opts.realpath ?? true;
   const onLocked: OnLocked = opts.onLocked ?? "fail";
 
   try {
-    const release = await lockfile.lock(filePath, { retries, stale });
+    const release = await lockfile.lock(filePath, { realpath, retries, stale });
     try {
       return await fn();
     } finally {

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -1,6 +1,6 @@
 // Project/App: gsd-pi
 // File Purpose: One-time migration from legacy nested .gsd/milestones/ to
-// flat-phase .gsd/phases/. Runs on startup when the legacy structure is detected.
+// flat-phase .gsd/phases/. Used by startup and pre-reconciliation layout settlement.
 
 import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -432,7 +432,8 @@ export function pruneStaleFlatPhaseBackups(basePath: string): number {
  * 5. Prune legacy milestones/ artifact rows
  * 6. Remove the renamed legacy tree
  *
- * Idempotent: if .gsd/milestones/ doesn't exist, returns immediately.
+ * Idempotent and resumable: no-ops when migration is complete and resumes an
+ * interrupted `.gsd/milestones.migrating/` tree when present.
  */
 export async function migrateToFlatPhase(basePath: string): Promise<void> {
   if (!needsFlatPhaseMigration(basePath)) return;

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -33,6 +33,9 @@ import {
 } from "./atomic-write.js";
 
 const LEGACY_MIGRATING_SEGMENT = "milestones.migrating";
+const EXPLICIT_RECOVERY_REQUIRED =
+  "flat-phase migration skipped: legacy markdown contains state absent from the canonical DB. " +
+  "Recommended: run `/gsd recover` and approve its exact Preview hash to import explicitly.";
 const RM_RETRY_OPTIONS = { recursive: true, force: true, maxRetries: 5, retryDelay: 100 } as const;
 type FlatPhaseMigrationStage = "before-remove" | "after-remove" | "before-move" | "after-move";
 let flatPhaseMigrationBoundaryForTest: ((stage: FlatPhaseMigrationStage, path: string) => void) | null = null;
@@ -438,6 +441,13 @@ export function pruneStaleFlatPhaseBackups(basePath: string): number {
 export async function migrateToFlatPhase(basePath: string): Promise<void> {
   if (!needsFlatPhaseMigration(basePath)) return;
 
+  // With no milestone rows, every content-bearing legacy milestone is outside
+  // database authority. Refuse before creating the persistent lock anchors so
+  // an implicit migration attempt remains read-only.
+  if (getAllMilestones().length === 0) {
+    throw new Error(EXPLICIT_RECOVERY_REQUIRED);
+  }
+
   const migrationLockTarget = flatPhaseMigrationLockTarget(basePath);
 
   // Headless runs the gsd extension in two processes (host + RPC child) and both
@@ -487,10 +497,7 @@ async function migrateToFlatPhaseLocked(basePath: string): Promise<void> {
   // for known identities is archived in the migration backup, then rebuilt from DB.
   const legacySource = resumingInterrupted ? migratingPath : milestonesPath;
   if (legacyHierarchyContainsUnknownIdentity(basePath, legacySource)) {
-    throw new Error(
-      "flat-phase migration skipped: legacy markdown contains state absent from the canonical DB. " +
-      "Recommended: run `/gsd recover` and approve its exact Preview hash to import explicitly.",
-    );
+    throw new Error(EXPLICIT_RECOVERY_REQUIRED);
   }
 
   const milestonesBefore = getAllMilestones().length;

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -416,6 +416,9 @@ export function pruneStaleFlatPhaseBackups(basePath: string): number {
 export async function migrateToFlatPhase(basePath: string): Promise<void> {
   if (!needsFlatPhaseMigration(basePath)) return;
 
+  const migrationLockTarget = join(basePath, ".gsd", "migration", "flat-phase-migration");
+  mkdirSync(migrationLockTarget, { recursive: true });
+
   // Headless runs the gsd extension in two processes (host + RPC child) and both
   // fire session_start, so two migrations race over the same tree: one moves
   // milestones/ aside or clears phases/ while the other is mid-render, and the
@@ -425,7 +428,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
   // entire projection and can legitimately run for minutes on a large project.
   try {
     await withFileLock(
-      join(basePath, ".gsd"),
+      migrationLockTarget,
       async () => {
         // Re-check under the lock: the winner may have completed the migration
         // while this process was waiting, which makes the loser a clean no-op

--- a/src/resources/extensions/gsd/flat-phase-migration.ts
+++ b/src/resources/extensions/gsd/flat-phase-migration.ts
@@ -47,6 +47,27 @@ function legacyMigratingPath(basePath: string): string {
   return join(basePath, ".gsd", LEGACY_MIGRATING_SEGMENT);
 }
 
+function ensureMigrationLockDirectory(path: string): void {
+  try {
+    mkdirSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`flat-phase migration lock path contains an unsupported symbolic link or non-directory: ${path}`);
+  }
+}
+
+function flatPhaseMigrationLockTarget(basePath: string): string {
+  const migrationRoot = join(gsdProjectionRoot(basePath), "migration");
+  ensureMigrationLockDirectory(migrationRoot);
+  const lockTarget = join(migrationRoot, "flat-phase-migration");
+  ensureMigrationLockDirectory(lockTarget);
+  return lockTarget;
+}
+
 function removeManagedPath(path: string): void {
   flatPhaseMigrationBoundaryForTest?.("before-remove", path);
   if (!existsSync(path)) return;
@@ -416,8 +437,7 @@ export function pruneStaleFlatPhaseBackups(basePath: string): number {
 export async function migrateToFlatPhase(basePath: string): Promise<void> {
   if (!needsFlatPhaseMigration(basePath)) return;
 
-  const migrationLockTarget = join(basePath, ".gsd", "migration", "flat-phase-migration");
-  mkdirSync(migrationLockTarget, { recursive: true });
+  const migrationLockTarget = flatPhaseMigrationLockTarget(basePath);
 
   // Headless runs the gsd extension in two processes (host + RPC child) and both
   // fire session_start, so two migrations race over the same tree: one moves
@@ -441,7 +461,7 @@ export async function migrateToFlatPhase(basePath: string): Promise<void> {
       // stale window therefore has to exceed the whole migration, not the gap
       // between keepalives, or a waiting process declares the lock dead and
       // steals it mid-render.
-      { retries: 30, stale: 600_000 },
+      { realpath: false, retries: 30, stale: 600_000 },
     );
   } catch (err) {
     // If the lock was stolen anyway, the holder's release() throws even though

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -8,6 +8,7 @@ import {
 } from "../state.js";
 import { clearParseCache as defaultClearParseCache } from "../files.js";
 import { clearPathCache } from "../paths.js";
+import { resolveWorktreeOwningProjectRoot } from "../worktree-root.js";
 import { logWarning } from "../workflow-logger.js";
 import type { GSDState } from "../types.js";
 
@@ -104,8 +105,9 @@ export async function reconcileBeforeDispatch(
     const { isDbAvailable } = await import("../gsd-db.js");
     if (isDbAvailable()) {
       const { needsFlatPhaseMigration, migrateToFlatPhase } = await import("../flat-phase-migration.js");
-      if (needsFlatPhaseMigration(basePath)) {
-        await migrateToFlatPhase(basePath);
+      const migrationBasePath = resolveWorktreeOwningProjectRoot(basePath);
+      if (needsFlatPhaseMigration(migrationBasePath)) {
+        await migrateToFlatPhase(migrationBasePath);
         // The tree layout just changed (possibly by the lock holder we waited
         // on) — drop cached listings so detection sees the settled layout.
         clearParseCache();

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -86,6 +86,29 @@ export async function reconcileBeforeDispatch(
   const repaired: DriftRecord[] = [];
 
   if (!deps.dryRun) {
+    // Startup race (#1774): session_start's flat-phase migration (legacy
+    // .gsd/milestones/ → .gsd/phases/) may still be pending or in flight — in
+    // this process or a sibling headless process — when the first dispatch
+    // reconciles. Detectors then see the transient mid-move gap (projection in
+    // neither layout → phantom roadmap-missing drift), and a repair write into
+    // the legacy tree dies with ENOENT when the migration renames it
+    // mid-write, permanently wedging auto-mode. migrateToFlatPhase is
+    // idempotent and serialized by a cross-process lock, so awaiting it here
+    // settles the layout exactly once; afterwards this is a cheap readdir.
+    // Gated on !dryRun to keep detection read-only and on isDbAvailable
+    // because the migration renders from DB rows.
+    const { isDbAvailable } = await import("../gsd-db.js");
+    if (isDbAvailable()) {
+      const { needsFlatPhaseMigration, migrateToFlatPhase } = await import("../flat-phase-migration.js");
+      if (needsFlatPhaseMigration(basePath)) {
+        await migrateToFlatPhase(basePath);
+        // The tree layout just changed (possibly by the lock holder we waited
+        // on) — drop cached listings so detection sees the settled layout.
+        clearParseCache();
+        clearPathCache();
+      }
+    }
+
     // Self-heal phantom projection entries (#1257): a renamed/removed phase
     // directory leaves stale `.compat.json` projection paths that no detector
     // ever prunes (they all skip missing files), so the marker drifts from disk

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -64,8 +64,12 @@ function stateBlockerDetails(state: GSDState): ReconciliationBlockerDetail[] {
 /**
  * Drift-driven pre-dispatch reconciliation per ADR-017.
  *
- * Lifecycle: derive → detect drift → apply repairs → re-derive. Capped at
- * MAX_PASSES (=2) cycles. The loop runs only when the prior pass fully
+ * Before non-dry-run detection, settles a pending flat-phase migration when
+ * the workflow DB is available and clears layout caches after a migration.
+ * Dry-run leaves migration state untouched.
+ *
+ * Repair lifecycle: derive → detect drift → apply repairs → re-derive.
+ * Capped at MAX_PASSES (=2) cycles. The loop runs only when the prior pass fully
  * succeeded but re-derive surfaces NEW drift (cascading repairs — e.g.
  * fixing milestone registration uncovers a downstream completion-timestamp
  * drift).

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -46,7 +46,7 @@ import { claimMilestoneLease, getMilestoneLease, releaseMilestoneLease } from ".
 import { recordDispatchClaim, markFailed } from "../db/unit-dispatches.js";
 import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.js";
 import { internalExecutionInvocation } from "../execution-invocation.js";
-import { normalizeRealPath } from "../paths.js";
+import { normalizeRealPath, resolveMilestoneFile } from "../paths.js";
 import { acquireSessionLock, releaseSessionLock } from "../session-lock.js";
 import { queryJournal } from "../journal.js";
 import { invalidateAllCaches } from "../cache.js";
@@ -124,7 +124,18 @@ function makeFixture(opts: FixtureOptions = {}): Fixture {
   invalidateStateCache();
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "Milestone", status: opts.complete ? "complete" : "active" });
-  if (!opts.noTask && !opts.complete) {
+  if (opts.complete) {
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Slice",
+      status: "complete",
+      risk: "low",
+      depends: [],
+      demo: "",
+      sequence: 1,
+    });
+  } else if (!opts.noTask) {
     insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active", risk: "low", depends: [], demo: "", sequence: 1 });
     insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Task", status: "active" });
   }
@@ -374,7 +385,9 @@ test("advance() preserves an external projection edit without blocking valid wor
   assert.equal(result.kind, "advanced");
   if (result.kind !== "advanced") return;
   assert.deepEqual(result.unit, { unitType: "execute-task", unitId: "M001/S01/T01" });
-  assert.match(readFileSync(rendered.roadmapPath, "utf-8"), /S01: Slice/);
+  const currentRoadmapPath = resolveMilestoneFile(f.base, "M001", "ROADMAP");
+  assert.ok(currentRoadmapPath);
+  assert.match(readFileSync(currentRoadmapPath, "utf-8"), /S01: Slice/);
   const quarantineRoot = join(f.base, ".gsd", "quarantine", "projections");
   const preservedPath = readdirSync(quarantineRoot, { recursive: true })
     .map(String)
@@ -616,16 +629,6 @@ test("advance() merges a completed milestone worktree before all-complete stop",
   const f = makeFixture({ complete: true, noTask: true });
   t.after(() => f.cleanup());
 
-  insertSlice({
-    id: "S01",
-    milestoneId: "M001",
-    title: "Slice",
-    status: "complete",
-    risk: "low",
-    depends: [],
-    demo: "",
-    sequence: 1,
-  });
   insertAssessment({
     path: "milestones/M001/M001-VALIDATION.md",
     milestoneId: "M001",

--- a/src/resources/extensions/gsd/tests/file-lock.test.ts
+++ b/src/resources/extensions/gsd/tests/file-lock.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -50,6 +50,29 @@ test("withFileLock: executes callback when file does not exist", async () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("withFileLock: realpath=false keeps the lock beside a symlink", async (t) => {
+  if (!hasProperLockfile() || process.platform === "win32") {
+    t.skip("requires proper-lockfile and POSIX directory symlinks");
+    return;
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), "gsd-file-lock-test-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const external = join(dir, "external");
+  const linked = join(dir, "linked");
+  mkdirSync(external);
+  symlinkSync(external, linked, "dir");
+
+  await withFileLock(
+    linked,
+    async () => {
+      assert.equal(existsSync(`${linked}.lock`), true, "lock stays beside the lexical target");
+      assert.equal(existsSync(`${external}.lock`), false, "lock does not follow the target symlink");
+    },
+    { realpath: false },
+  );
 });
 
 test("withFileLockSync: throws ELOCKED by default (no silent fallback)", () => {

--- a/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-phase-migration.test.ts
@@ -2,7 +2,7 @@
 // File Purpose: Tests the one-time migration from nested to flat-phase layout.
 import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, renameSync, rmSync, writeFileSync, existsSync, readdirSync, readFileSync, utimesSync } from "node:fs";
+import { mkdtempSync, mkdirSync, renameSync, rmSync, symlinkSync, writeFileSync, existsSync, readdirSync, readFileSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -19,6 +19,7 @@ import { writeCompatMarker } from "../compat/compat-marker.ts";
 import { resolveMilestonePath } from "../paths.ts";
 
 const tmpDirs: string[] = [];
+const DIRECTORY_SYMLINK_TYPE = process.platform === "win32" ? "junction" : "dir";
 function makeTmp(options: { withTask?: boolean } = {}): string {
   const base = mkdtempSync(join(tmpdir(), `gsd-mig-${randomUUID()}`));
   // Create legacy nested structure
@@ -131,6 +132,56 @@ test("concurrent migrations in separate processes do not corrupt each other", as
   assert.equal(needsFlatPhaseMigration(base), false, "migration must be complete after the race");
   assert.equal(existsSync(join(base, ".gsd", "phases")), true, "flat-phase layout must exist");
   assert.equal(existsSync(join(base, ".gsd", "milestones")), false, "legacy layout must be gone");
+});
+
+test("migrateToFlatPhase supports a top-level .gsd symlink", async () => {
+  const base = makeTmp();
+  closeDatabase();
+  const externalRoot = mkdtempSync(join(tmpdir(), `gsd-mig-linked-${randomUUID()}`));
+  tmpDirs.push(externalRoot);
+  const externalGsd = join(externalRoot, "state");
+  renameSync(join(base, ".gsd"), externalGsd);
+  symlinkSync(externalGsd, join(base, ".gsd"), DIRECTORY_SYMLINK_TYPE);
+  openDatabase(join(externalGsd, "gsd.db"));
+
+  await migrateToFlatPhase(base);
+
+  assert.equal(existsSync(join(externalGsd, "phases")), true, "migration writes through canonical .gsd state");
+  assert.equal(existsSync(join(externalGsd, "milestones")), false, "canonical legacy layout is removed");
+});
+
+test("migrateToFlatPhase rejects a symlinked migration lock parent", async () => {
+  const base = makeTmp();
+  const outside = mkdtempSync(join(tmpdir(), `gsd-mig-outside-${randomUUID()}`));
+  tmpDirs.push(outside);
+  symlinkSync(outside, join(base, ".gsd", "migration"), DIRECTORY_SYMLINK_TYPE);
+
+  await assert.rejects(
+    migrateToFlatPhase(base),
+    /unsupported symbolic link or non-directory/,
+  );
+  assert.deepEqual(readdirSync(outside), [], "migration lock must not create state outside .gsd");
+});
+
+test("migrateToFlatPhase rejects a symlinked migration lock target", async () => {
+  const base = makeTmp();
+  const outsideRoot = mkdtempSync(join(tmpdir(), `gsd-mig-outside-${randomUUID()}`));
+  tmpDirs.push(outsideRoot);
+  const outsideTarget = join(outsideRoot, "target");
+  mkdirSync(outsideTarget);
+  const migrationRoot = join(base, ".gsd", "migration");
+  mkdirSync(migrationRoot);
+  symlinkSync(
+    outsideTarget,
+    join(migrationRoot, "flat-phase-migration"),
+    DIRECTORY_SYMLINK_TYPE,
+  );
+
+  await assert.rejects(
+    migrateToFlatPhase(base),
+    /unsupported symbolic link or non-directory/,
+  );
+  assert.equal(existsSync(`${outsideTarget}.lock`), false, "migration lock must not follow its target");
 });
 
 test("needsFlatPhaseMigration returns true when .gsd/milestones/ exists", () => {

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -30,6 +30,16 @@ function makeFixtureBase(): string {
   return base;
 }
 
+function flatPhaseDir(base: string): string {
+  return join(base, ".gsd", "phases", "01-test");
+}
+
+function makeFlatFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-"));
+  mkdirSync(flatPhaseDir(base), { recursive: true });
+  return base;
+}
+
 function writePreferences(base: string, phasesBlock: string): void {
   const prefsPath = join(base, ".gsd", "PREFERENCES.md");
   const body = [
@@ -74,6 +84,11 @@ function seedMilestoneWithSketchedS02(base: string): void {
 function writeS01Artifacts(base: string): void {
   writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"), "# S01 Plan\n");
   writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"), "# S01 Summary\n");
+}
+
+function writeFlatS01Artifacts(base: string): void {
+  writeFileSync(join(flatPhaseDir(base), "01-01-PLAN.md"), "# S01 Plan\n");
+  writeFileSync(join(flatPhaseDir(base), "01-01-SUMMARY.md"), "# S01 Summary\n");
 }
 
 // A *real* decomposed PLAN (>= 1 genuine task). #1287: the stale-sketch-flag
@@ -192,14 +207,14 @@ test("ADR-011: refining + flag flipped OFF mid-milestone → falls through to pl
 
 test("ADR-011: existing PLAN + stale sketch flag heals via reconcileBeforeDispatch, then dispatch routes past refining (progressive_planning ON)", async (t) => {
   const originalCwd = process.cwd();
-  const base = makeFixtureBase();
+  const base = makeFlatFixtureBase();
   t.after(() => cleanup(base, originalCwd));
 
   seedMilestoneWithSketchedS02(base);
-  writeS01Artifacts(base);
+  writeFlatS01Artifacts(base);
   writePreferences(base, "phases:\n  progressive_planning: true");
   writeFileSync(
-    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    join(flatPhaseDir(base), "01-02-PLAN.md"),
     realPlanContent("S02"),
   );
   process.chdir(base);
@@ -258,15 +273,15 @@ test("ADR-011: autoHealSketchFlags flips is_sketch=0 when PLAN file exists", asy
 
 test("ADR-011: reconcileBeforeDispatch auto-heals stale sketch flag when PLAN exists", async (t) => {
   const originalCwd = process.cwd();
-  const base = makeFixtureBase();
+  const base = makeFlatFixtureBase();
   t.after(() => cleanup(base, originalCwd));
 
   seedMilestoneWithSketchedS02(base);
-  writeS01Artifacts(base);
+  writeFlatS01Artifacts(base);
   writePreferences(base, "phases:\n  skip_research: false");
   // Simulate plan-slice completion where PLAN exists but is_sketch was not flipped.
   writeFileSync(
-    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    join(flatPhaseDir(base), "01-02-PLAN.md"),
     realPlanContent("S02"),
   );
   process.chdir(base);
@@ -289,14 +304,14 @@ test("ADR-011: reconcileBeforeDispatch auto-heals stale sketch flag when PLAN ex
 
 test("ADR-011: deriveState stays pure across worktree/canonical-root; healing belongs to reconcile at the canonical artifact root", async (t) => {
   const originalCwd = process.cwd();
-  const base = makeFixtureBase();
+  const base = makeFlatFixtureBase();
   t.after(() => cleanup(base, originalCwd));
 
   seedMilestoneWithSketchedS02(base);
-  writeS01Artifacts(base);
+  writeFlatS01Artifacts(base);
   writePreferences(base, "phases:\n  skip_research: false");
   writeFileSync(
-    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    join(flatPhaseDir(base), "01-02-PLAN.md"),
     realPlanContent("S02"),
   );
   const worktreePath = join(base, "worker");

--- a/src/resources/extensions/gsd/tests/reconcile-settles-migration-before-detect.test.ts
+++ b/src/resources/extensions/gsd/tests/reconcile-settles-migration-before-detect.test.ts
@@ -22,6 +22,11 @@ import {
   openDatabase,
 } from "../gsd-db.ts";
 import { needsFlatPhaseMigration } from "../flat-phase-migration.ts";
+import {
+  acquireSessionLock,
+  releaseSessionLock,
+  validateSessionLock,
+} from "../session-lock.ts";
 import { reconcileBeforeDispatch } from "../state-reconciliation.ts";
 import type { GSDState } from "../types.ts";
 
@@ -92,14 +97,19 @@ function flatRoadmapPath(base: string): string {
   return join(base, ".gsd", "phases", "01-test", "01-ROADMAP.md");
 }
 
-test("reconcile settles a pending flat-phase migration before detecting drift", async (t) => {
+test("reconcile settles a pending flat-phase migration while the session lock is held", async (t) => {
   const base = makeBase("gsd-recon-mig-pending-");
-  t.after(() => cleanup(base));
+  t.after(() => {
+    releaseSessionLock(base);
+    cleanup(base);
+  });
 
   openDatabase(join(base, ".gsd", "gsd.db"));
   seedDb();
   writeLegacyTree(join(base, ".gsd"));
   assert.equal(needsFlatPhaseMigration(base), true, "fixture must need migration");
+  const sessionLock = acquireSessionLock(base);
+  assert.equal(sessionLock.acquired, true, "production session lock must be held");
 
   const result = await reconcileBeforeDispatch(base, {
     invalidateStateCache: () => {},
@@ -115,6 +125,7 @@ test("reconcile settles a pending flat-phase migration before detecting drift", 
   assert.ok(existsSync(flatRoadmapPath(base)), "migration must have rendered the flat-phase ROADMAP");
   assert.equal(existsSync(join(base, ".gsd", "milestones")), false, "legacy tree must be gone after settling");
   assert.equal(needsFlatPhaseMigration(base), false, "layout must be settled afterwards");
+  assert.equal(validateSessionLock(base), true, "reconciliation must preserve the session lock");
 
   // Convergence proof: a second pass detects nothing.
   const second = await reconcileBeforeDispatch(base, {

--- a/src/resources/extensions/gsd/tests/reconcile-settles-migration-before-detect.test.ts
+++ b/src/resources/extensions/gsd/tests/reconcile-settles-migration-before-detect.test.ts
@@ -1,0 +1,182 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests for the NPM Publish @dev verify failure
+// (actions run 31923706955) and #1774: reconcileBeforeDispatch ran while the
+// startup flat-phase migration was still pending or in flight (headless fires
+// session_start in two processes). Detectors saw the transient mid-move gap —
+// ROADMAP in neither layout — as phantom roadmap-missing drift, and the repair
+// write into the legacy tree died with ENOENT when the migration renamed the
+// directory mid-write, permanently wedging auto-mode. Reconciliation must
+// settle the migration (idempotent, cross-process locked) before detecting.
+
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../gsd-db.ts";
+import { needsFlatPhaseMigration } from "../flat-phase-migration.ts";
+import { reconcileBeforeDispatch } from "../state-reconciliation.ts";
+import type { GSDState } from "../types.ts";
+
+function makeState(): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Test" },
+    activeSlice: null,
+    activeTask: null,
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "Execute task",
+    registry: [],
+    requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+    progress: { milestones: { done: 0, total: 1 } },
+  };
+}
+
+afterEach(() => {
+  try { closeDatabase(); } catch { /* already closed */ }
+});
+
+function makeBase(prefix: string): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+function seedDb(): void {
+  insertMilestone({
+    id: "M001",
+    title: "Test",
+    status: "active",
+    planning: { vision: "Settle layout migration before drift detection." },
+  });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Foundation",
+    status: "pending",
+    risk: "low",
+    depends: [],
+    demo: "S01 demo.",
+    sequence: 1,
+  });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Plan S01", status: "pending" });
+}
+
+/** Minimal recovered-project legacy tree (mirrors the acceptance bed fixture). */
+function writeLegacyTree(gsdDir: string): void {
+  const sliceDir = join(gsdDir, "milestones", "M001", "slices", "S01");
+  mkdirSync(join(sliceDir, "tasks"), { recursive: true });
+  writeFileSync(join(gsdDir, "milestones", "M001", "M001-CONTEXT.md"), "# M001: Test\n");
+  writeFileSync(
+    join(gsdDir, "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001: Test\n\n## Slices\n\n- [ ] **S01: Foundation** `risk:low` `depends:[]`\n  > S01 demo.\n",
+  );
+  writeFileSync(join(sliceDir, "S01-PLAN.md"), "# S01: Foundation\n");
+  writeFileSync(join(sliceDir, "tasks", "T01-PLAN.md"), "# T01: Plan S01\n");
+}
+
+function flatRoadmapPath(base: string): string {
+  return join(base, ".gsd", "phases", "01-test", "01-ROADMAP.md");
+}
+
+test("reconcile settles a pending flat-phase migration before detecting drift", async (t) => {
+  const base = makeBase("gsd-recon-mig-pending-");
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  seedDb();
+  writeLegacyTree(join(base, ".gsd"));
+  assert.equal(needsFlatPhaseMigration(base), true, "fixture must need migration");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.repaired.filter((d) => d.kind === "roadmap-missing").length,
+    0,
+    "no phantom roadmap-missing repair may run against the pre-migration layout",
+  );
+  assert.ok(existsSync(flatRoadmapPath(base)), "migration must have rendered the flat-phase ROADMAP");
+  assert.equal(existsSync(join(base, ".gsd", "milestones")), false, "legacy tree must be gone after settling");
+  assert.equal(needsFlatPhaseMigration(base), false, "layout must be settled afterwards");
+
+  // Convergence proof: a second pass detects nothing.
+  const second = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+  assert.equal(second.ok, true);
+  assert.equal(second.repaired.length, 0, "second pass must be clean");
+});
+
+test("reconcile waits out an in-flight migration instead of repairing the transient gap", async (t) => {
+  const base = makeBase("gsd-recon-mig-inflight-");
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  seedDb();
+  writeLegacyTree(join(base, ".gsd"));
+  // Simulate a sibling process mid-migration: the legacy tree sits renamed
+  // aside and .gsd/phases/ has not been rendered yet — projections exist in
+  // neither layout. This is exactly the window that wedged the @dev verify bed.
+  renameSync(join(base, ".gsd", "milestones"), join(base, ".gsd", "milestones.migrating"));
+  assert.equal(needsFlatPhaseMigration(base), true, "interrupted migration must still need settling");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.repaired.filter((d) => d.kind === "roadmap-missing").length,
+    0,
+    "the transient gap is not drift — the migration resume owns the render",
+  );
+  assert.ok(existsSync(flatRoadmapPath(base)), "resumed migration must render the flat-phase ROADMAP");
+  assert.equal(
+    existsSync(join(base, ".gsd", "milestones.migrating")),
+    false,
+    "the migrating tree must be cleaned up",
+  );
+});
+
+test("dry-run reconcile stays read-only and never runs the migration", async (t) => {
+  const base = makeBase("gsd-recon-mig-dryrun-");
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  seedDb();
+  writeLegacyTree(join(base, ".gsd"));
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    dryRun: true,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    existsSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md")),
+    true,
+    "dry-run must leave the legacy tree untouched",
+  );
+  assert.equal(existsSync(join(base, ".gsd", "phases")), false, "dry-run must not render phases/");
+  assert.equal(needsFlatPhaseMigration(base), true, "migration must remain pending after a dry run");
+});

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1370,8 +1370,11 @@ test("ADR-017 (#391): roadmap-divergence skips slices before task planning compl
 test("ADR-017 (#870): roadmap-divergence accepts recovered S00 blocker sequence", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-s00-"));
   const milestoneId = "M002-a1rwmq";
-  const milestoneDir = join(base, ".gsd", "milestones", milestoneId);
-  const roadmapPath = join(milestoneDir, `${milestoneId}-ROADMAP.md`);
+  // Flat-phase layout: startup migrates legacy milestones/ on contact, and
+  // reconcileBeforeDispatch now settles a pending migration before detecting
+  // drift — a legacy fixture would be converted mid-reconcile.
+  const milestoneDir = join(base, ".gsd", "phases", "02-a1rwmq-support-command-policy-hardening");
+  const roadmapPath = join(milestoneDir, "02-ROADMAP.md");
   mkdirSync(milestoneDir, { recursive: true });
   const originalRoadmap = [
     "# M002-a1rwmq: Support Command Policy Hardening",
@@ -1435,8 +1438,11 @@ test("ADR-017 (#870): roadmap-divergence accepts recovered S00 blocker sequence"
 test("ADR-017 (#1619): skipped slices are excluded from the divergence view", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-skipped-"));
   const milestoneId = "M017";
-  const milestoneDir = join(base, ".gsd", "milestones", milestoneId);
-  const roadmapPath = join(milestoneDir, `${milestoneId}-ROADMAP.md`);
+  // Flat-phase layout: startup migrates legacy milestones/ on contact, and
+  // reconcileBeforeDispatch now settles a pending migration before detecting
+  // drift — a legacy fixture would be converted mid-reconcile.
+  const milestoneDir = join(base, ".gsd", "phases", "17-blocker-skipped-milestone");
+  const roadmapPath = join(milestoneDir, "17-ROADMAP.md");
   mkdirSync(milestoneDir, { recursive: true });
   // The projection omits the skipped S00-blocker, so S01 renders first.
   const originalRoadmap = [


### PR DESCRIPTION
## Intent

Fix the failing NPM Publish post-publish verify job (Actions run 31923706955) for good. Root cause proven by instrumented acceptance-bed runs: the first dispatch-time drift reconciliation (reconcileBeforeDispatch in state-reconciliation/index.ts) raced session_start's flat-phase migration (legacy .gsd/milestones/ -> .gsd/phases/). Detectors saw the transient mid-move gap as phantom roadmap-missing drift, and the repair write into the legacy tree hit ENOENT when the migration renamed it mid-write, permanently wedging auto-mode with exit 10. The fix awaits the idempotent, cross-process-locked migrateToFlatPhase at the top of reconcileBeforeDispatch (only when the DB is available and not a dry-run), then clears parse/path caches so detection sees the settled layout. Deliberate decisions: fix lives in reconcileBeforeDispatch rather than in session_start ordering, because reconcile is the first consumer that must see a settled layout and the migration lock already serializes cross-process; dynamic imports avoid a module cycle with gsd-db/flat-phase-migration; dry-run is intentionally exempt to keep detection read-only. Added a new regression test (pending migration settled before detect, in-flight milestones.migrating resume, dry-run untouched) and converted two existing drift-test fixtures from legacy milestones layout to flat-phase layout because reconcile now migrates legacy fixtures on contact, which changed what their byte-identity assertions observed. Verified: typecheck clean, 73/73 relevant tests pass, auto-acceptance bed (previously wedged deterministically) passes 3x with exit 0. Commit must not credit AI. Refs issues #1774 and #1755.

## What Changed

- Settle pending or interrupted flat-phase migrations before DB-backed, non-dry-run drift detection, then clear layout caches so reconciliation reads the completed projection.
- Use a dedicated migration lock separate from the session lock, with safeguards against nested symlink escapes while preserving supported top-level `.gsd` symlinks.
- Add regression coverage for migration settlement, dry-run behavior, session-lock coexistence, and symlink-safe locking; update affected drift fixtures to use flat-phase paths.

## Risk Assessment

✅ Low: The follow-up is narrowly scoped, preserves existing lock behavior by default, and closes the reported static symlink escapes using a canonical no-follow lock target with behavioral regression coverage.

## Testing

Using the supplied clean typecheck, 73-test, and three-run baseline as context, this phase independently passed focused race/lock/layout checks and three complete CLI acceptance runs; initial source-mode attempts stopped before recovery on absent build artifacts, the corrected transpiled runtime completed every run with exit 0 and settled flat state, and no screenshot applies because this is a CLI/runtime change.

<details>
<summary>Evidence: Acceptance run 1 verdict</summary>

`COMPLETED; firstBlock=null; exitCode=0`

```text
{
  "result": "COMPLETED",
  "firstBlock": null,
  "exitCode": 0,
  "runDir": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01M059MWJ2PRS15MRAAQSJMB5K/auto-acceptance/bed-run-4"
}
```
</details>
<details>
<summary>Evidence: Acceptance run 2 verdict</summary>

`COMPLETED; firstBlock=null; exitCode=0`

```text
{
  "result": "COMPLETED",
  "firstBlock": null,
  "exitCode": 0,
  "runDir": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01M059MWJ2PRS15MRAAQSJMB5K/auto-acceptance/bed-run-5"
}
```
</details>
<details>
<summary>Evidence: Acceptance run 3 verdict</summary>

`COMPLETED; firstBlock=null; exitCode=0`

```text
{
  "result": "COMPLETED",
  "firstBlock": null,
  "exitCode": 0,
  "runDir": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01M059MWJ2PRS15MRAAQSJMB5K/auto-acceptance/bed-run-6"
}
```
</details>
<details>
<summary>Evidence: End-user CLI notifications</summary>

`Auto-mode stopped — Milestone M001 complete.`

```text
Auto-mode started. Will loop until milestone complete.
Dynamic routing: enabled — simple tasks may use cheaper models (ceiling: gsd-fake/gsd-fake-model)
Thinking level 'medium' not supported by gsd-fake/gsd-fake-model; using 'off'.
    [34m╭─[0m [32m[1m✓ Verification Gate[0m
       [36m1/1 checks passed[0m
    [34m╰────────────────────────────────────────[0m
    [34m╭─[0m [32m[1m✓ Commit[0m
       [36mfeat: Updated answer() to return ready.[0m
    [34m╰────────────────────────────────────────[0m
Auto-mode stopped — Milestone M001 complete.
```
</details>
<details>
<summary>Evidence: Persisted settled GSD state</summary>

Source: Persisted settled GSD state (local file: <code>/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/no-mistakes-evidence/01M059MWJ2PRS15MRAAQSJMB5K/auto-acceptance/bed-run-4/gsd-state</code>)

```text
Flat phases present; milestones and milestones.migrating absent; STATE.md reports complete with no blockers.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `src/resources/extensions/gsd/state-reconciliation/index.ts:104` - In a supported non-isolated auto run, bootstrap already holds a long-lived proper-lockfile on the canonical `.gsd` directory. Line 104 enters `migrateToFlatPhase()`, which locks that same non-reentrant target, so a pending `milestones/` or resumed `milestones.migrating/` migration can exhaust retries with `ELOCKED` instead of settling. The new direct tests do not acquire the production session lock. Create a dedicated migration lock target shared by all migration callers but separate from the auto-session lock, and cover reconciliation while holding the real session lock.

🔧 Fix: Separate migration and session lock targets
2 errors still open:
- 🚨 `src/resources/extensions/gsd/flat-phase-migration.ts:420` - The new lock target follows repository-controlled nested symlinks. A tracked `.gsd/migration` symlink makes the recursive mkdir write outside managed state; a final `flat-phase-migration` symlink is then followed by proper-lockfile, which creates/removes an external `.lock`. Canonicalize the supported top-level `.gsd` link, reject nested symlinks, and acquire the lock without following its final component.
- 🚨 `src/resources/extensions/gsd/state-reconciliation/index.ts:103` - The intent requires reconciliation to “await” migration so “detection sees the settled layout,” but the added `needsFlatPhaseMigration(basePath)` checks the active worktree. If canonical `session_start` has renamed `milestones/` to `milestones.migrating`, worktree projection copies neither that tree nor the unfinished `phases/`; reconciliation sees no local migration and still detects phantom roadmap drift. Settle through the canonical project owner/lock and refresh the worktree projection, or detect from canonical state, before continuing.

🔧 Fix: Harden migration lock against symlink escapes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/reconcile-settles-migration-before-detect.test.ts`
- <code>Focused `file-lock.test.ts` selector: `withFileLock: realpath=false keeps the lock beside a symlink`</code>
- <code>Focused `flat-phase-migration.test.ts` selectors covering two-process concurrency, cache-following layout resolution, top-level `.gsd` symlink support, and lock-path symlink rejection</code>
- <code>Focused `state-reconciliation-drift.test.ts` selectors for `#870` and `#1619`</code>
- <code>Focused `runtime-invariant-modules.test.ts` reconciliation selector with the DB unavailable</code>
- <code>`pnpm run test:compile` plus transient production-shaped package outputs for acceptance setup; no typecheck, lint, formatter, or static analysis was run</code>
- <code>`BED_SCRATCH_ROOT=… GSD_SMOKE_BINARY=$PWD/dist-test/src/loader.js pnpm run test:auto-acceptance` — three consecutive successful runs</code>
- <code>Manual persisted-state checks for `phases/`, absence of `milestones/` and `milestones.migrating`, migration lock location, and wedge/error signatures</code>
- <code>`node --test …/bed-run-4/project/test/answer.test.js` against the delivered acceptance project</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
