### PR TITLE
fix(gsd): quote-aware verify substitution and flag-tolerant prose

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -946,6 +946,62 @@ test("validateVerificationCommand rejects arbitrary semicolon command chaining",
   }
 });
 
+// ─── Quote-aware substitution + flag-tolerant prose (#1671, #1724 / #1782) ──
+
+const ISSUE_1671_VERIFY =
+  "node --test tests/hooks-planning.test.ts — exit 0, asserts: (1) toolNames includes discussion_arena when forced + planning, (2) excludes when available-only, (3) excludes when execution phase, (4) prompt instruction contains marker, (5) repeated calls do not duplicate instruction. Plus npm test full suite 0 regressions on 19/41 (now 41+) tests.";
+
+const ISSUE_1671_OCCURRENCE_1 =
+  "npm test -- tests/discussion-arena-coordination.test.ts exit 0 con nuovi test verdi (assenza activation, activation valida, mode invalido, milestone ID con trattino vs underscore, milestones nested profondità). npx tsc --noEmit exit 0.";
+
+const ISSUE_1671_OCCURRENCE_2 =
+  "npm test -- tests/examples-validation.test.ts exit 0. Il parsing dell'esempio produce activation strutturata.";
+
+const ISSUE_1724_RG = "! rg -q '`[a-zA-Z_]+ \\(' module_file.py";
+
+test("validateVerificationCommand: quote-aware substitution truth table (#1724)", () => {
+  assert.equal(validateVerificationCommand(ISSUE_1724_RG).ok, true, "single-quoted backtick in rg pattern");
+  assert.equal(validateVerificationCommand("rg 'foo`bar' notes.md").ok, true, "walkthrough: single-quoted backtick");
+  assert.equal(validateVerificationCommand("rg -q '$(pattern)' file.txt").ok, true, "single-quoted $(");
+
+  const unquotedSub = validateVerificationCommand("echo $(rm -rf /tmp/gsd-verify-x)");
+  assert.equal(unquotedSub.ok, false, "unquoted $( still rejected");
+  if (!unquotedSub.ok) assert.match(unquotedSub.reason, /shell control syntax/);
+
+  const unquotedTick = validateVerificationCommand("echo `rm -rf /tmp/gsd-verify-x`");
+  assert.equal(unquotedTick.ok, false, "unquoted backtick still rejected");
+  if (!unquotedTick.ok) assert.match(unquotedTick.reason, /shell control syntax/);
+
+  const doubleQuotedSub = validateVerificationCommand('echo "$(rm -rf /tmp/gsd-verify-x)"');
+  assert.equal(doubleQuotedSub.ok, false, "double quotes do not protect $(");
+  if (!doubleQuotedSub.ok) assert.match(doubleQuotedSub.reason, /shell control syntax/);
+
+  const doubleQuotedTick = validateVerificationCommand("echo \"`rm -rf /tmp/gsd-verify-x`\"");
+  assert.equal(doubleQuotedTick.ok, false, "double quotes do not protect backticks");
+  if (!doubleQuotedTick.ok) assert.match(doubleQuotedTick.reason, /shell control syntax/);
+});
+
+test("isLikelyCommand: flags after the command word do not suppress prose (#1671)", () => {
+  assert.equal(isLikelyCommand("node --test tests/hooks-planning.test.ts"), true, "plain command with flags");
+  assert.equal(isLikelyCommand(ISSUE_1671_VERIFY), false, "reporter Verify line is prose");
+  assert.equal(isLikelyCommand("git log --oneline -5"), true, "flag-only command stays a command");
+  assert.equal(isLikelyCommand("git log --oneline shows the scaffold commit"), false, "flag then prose marker");
+  assert.equal(isLikelyCommand(`${ISSUE_1671_OCCURRENCE_1} contains a marker`), false);
+  assert.equal(isLikelyCommand(`${ISSUE_1671_OCCURRENCE_2} contains a marker`), false);
+});
+
+test("discoverCommands: #1671 reporter line is not executed; #1724 rg line is", () => {
+  const proseDir = makeTempDir("gsd-verify-1671");
+  const prose = discoverCommands({ cwd: proseDir, taskPlanVerify: ISSUE_1671_VERIFY });
+  assert.deepEqual(prose.commands, [], "appended assertion prose must not become a check");
+  assert.notEqual(prose.source, "task-plan");
+
+  const rgDir = makeTempDir("gsd-verify-1724");
+  const rg = discoverCommands({ cwd: rgDir, taskPlanVerify: ISSUE_1724_RG });
+  assert.deepEqual(rg.commands, [ISSUE_1724_RG]);
+  assert.equal(rg.source, "task-plan");
+});
+
 // ─── Additional Preference Validation Tests (T02) ──────────────────────────
 
 test("verification-gate: verification_commands produces no unknown-key warnings", () => {

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -314,9 +314,6 @@ function isAllowedExitCodeEchoSuffix(suffix: string): boolean {
 
 /** Returns true when command text contains unquoted shell control syntax. */
 function hasUnsafeShellSyntax(cmd: string): boolean {
-  // Command substitution remains unsafe even when quoted with double quotes.
-  if (cmd.includes("$(") || cmd.includes("`")) return true;
-
   let inSingle = false;
   let inDouble = false;
   let escaped = false;
@@ -339,6 +336,10 @@ function hasUnsafeShellSyntax(cmd: string): boolean {
       inDouble = !inDouble;
       continue;
     }
+    // Backtick / $( substitute unless inside single quotes. Double quotes do
+    // not protect them — that matches POSIX shell semantics (#1724).
+    if (!inSingle && ch === "`") return true;
+    if (!inSingle && ch === "$" && cmd[i + 1] === "(") return true;
     if (!inSingle && !inDouble && ch === "|" && cmd[i + 1] === "|") {
       return true;
     }
@@ -518,12 +519,12 @@ const PROSE_MARKER_WORDS = new Set([
 
 /**
  * Does a known-command-prefixed string read as prose rather than a command?
- * True when there is no flag/sub-command structure but there are English
- * function words — e.g. "git log shows the scaffold commit authored by ...".
+ * True when there are English function words after the command word —
+ * e.g. "git log shows the scaffold commit authored by ...".
+ * Flags after the command word do not suppress this check (#1671).
  */
 function readsAsProseAfterCommandWord(tokens: string[]): boolean {
   if (tokens.length < 4) return false;
-  if (tokens.some(t => t.startsWith("-"))) return false;
   return tokens
     .slice(1)
     .some(t => PROSE_MARKER_WORDS.has(t.toLowerCase().replace(/[.,;:!?]+$/, "")));


### PR DESCRIPTION
## Change

Verification-gate parsing treated two safe Verify lines as failures:

- backticks and `$(` were rejected anywhere, including inside single-quoted `rg`/`grep` patterns
- a leading flag such as `--test` disabled prose detection for the whole line, so appended assertion text was executed as shell

This keeps the existing quote-tracking state machine and only changes classification. Unquoted and double-quoted substitution still fail closed.

Closes #1782

## Outcomes

| ID | Outcome | Evidence |
| --- | --- | --- |
| O-1 | Quote-aware substitution scan | `hasUnsafeShellSyntax` flags backticks/`$(` only outside single quotes. Tests: single-quoted `rg 'foo`bar'` and `! rg -q '\`[a-zA-Z_]+ \\(' module_file.py` accepted; unquoted `$(`/backtick rejected. |
| O-2 | Flags no longer suppress prose detection | `readsAsProseAfterCommandWord` no longer returns early on dash-leading tokens. The #1671 reporter line `node --test … — … contains …` classifies as prose and is not discovered as a runnable check. `node --test tests/hooks-planning.test.ts` stays a command. |
| O-3 | Regression tests + truth table | `verification-gate.test.ts`: quoted vs unquoted vs double-quoted substitution; flag-before-prose vs plain command; exact #1671 and #1724 Verify strings. |

## Exclusions

- X-1 — Unquoted `$(`/backtick still rejected with the same shell-control-syntax reason
- X-2 — No new shell-parsing dependency; same quote-tracking loop
- X-3 — Write-gate `uv run python` path untouched
- X-4 — Allow/deny command policy unchanged; this is classification only

Side effects beyond the contract: none

## Checks

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/verification-gate.test.ts` — 119/119 pass
- `src/resources/extensions/gsd/tests/verification-scope-misresolution-1628-1630.test.ts` — 22/22 pass
- `pnpm run verify:fast` — pass

Dependency audit: not applicable

## Walkthrough

Issue manual walkthrough verified at the `validateVerificationCommand` / `discoverCommands` seam (the path that would execute or reject the line). Did not run a live `plan-slice` session.

1. #1671 reporter Verify line → prose, not a task-plan command
2. `rg 'foo`bar'` and the #1724 single-quoted backtick pattern → accepted
3. Unquoted `echo $(rm …)` → still rejected as shell control syntax

## Risk

Low. Classification-only change in one module. Existing command, pipeline, and prose fixtures still pass. Unquoted substitution remains fail-closed. Italian #1671 reproductions without an English prose-marker word are not flipped by O-2's mechanism; the contracted fixture is the English reporter line.
