### PR TITLE
fix(gsd): actionable verification verdicts and honest timeouts

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -671,6 +671,7 @@ verification_commands:
   - npm run test
 verification_auto_fix: true       # auto-retry on failure (default: true)
 verification_max_retries: 2       # max retry attempts (default: 2)
+verification_timeout_ms: 120000   # per-command spawn timeout (default: 120000)
 ```
 
 | Field | Type | Default | Description |
@@ -678,6 +679,7 @@ verification_max_retries: 2       # max retry attempts (default: 2)
 | `verification_commands` | string[] | `[]` | Simple executable commands to run after task execution |
 | `verification_auto_fix` | boolean | `true` | Auto-retry when verification fails |
 | `verification_max_retries` | number | `2` | Maximum auto-fix retry attempts |
+| `verification_timeout_ms` | number | `120000` | Per-command host-verification timeout in milliseconds. Unset keeps the 120s default. A timeout is reported as `failureClass: timeout`, never as exit 127. |
 
 Verification commands must be simple executable commands. Shell piping (`|`) is supported, but logical OR (`||`) is rejected. GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program.
 

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -177,6 +177,7 @@ verification_commands:
   - npm run test
 verification_auto_fix: true       # auto-retry on failure (default)
 verification_max_retries: 2       # max attempts (default: 2)
+verification_timeout_ms: 120000   # per-command spawn timeout (default: 120000)
 ```
 
 Verification commands must be simple executable commands. Shell piping (`|`) is supported, but logical OR (`||`) is rejected. GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program.

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -50,7 +50,8 @@ import { join } from "node:path";
 import { resolveUokFlags } from "./uok/flags.js";
 import { UokGateRunner } from "./uok/gate-runner.js";
 import { verificationRetryKey } from "./auto/verification-retry-policy.js";
-import { decideVerificationVerdict } from "./verification-verdict.js";
+import { decideVerificationVerdict, describeHostVerificationRationale } from "./verification-verdict.js";
+import { DEFAULT_COMMAND_TIMEOUT_MS } from "./constants.js";
 import type { SliceRow } from "./db-task-slice-rows.js";
 import { getSlice } from "./gsd-db.js";
 import { getLedger } from "./metrics.js";
@@ -229,6 +230,9 @@ function recordHostTechnicalVerdict(input: {
         targetSourceRevisions,
         sourceRevisionAfter: input.sourceAfter?.aggregateRevision ?? "unavailable",
         sourceIntegrity: input.sourceError ?? "stable",
+        ...(input.result.checks.some((check) => check.failureClass === "timeout")
+          ? { failureClass: "timeout" }
+          : {}),
       },
     },
   });
@@ -238,6 +242,29 @@ interface FailedVerdictIdentity {
   verdictId: string;
   evidenceId: string;
   verdict: "fail" | "inconclusive";
+  rationale?: string;
+}
+
+function resolveVerificationTimeoutMs(prefs: GSDPreferences | undefined): number {
+  const raw = prefs?.verification_timeout_ms;
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) return Math.floor(raw);
+  return DEFAULT_COMMAND_TIMEOUT_MS;
+}
+
+export const _resolveVerificationTimeoutMsForTest = resolveVerificationTimeoutMs;
+
+function hostRecoveryRationale(
+  verdict: FailedVerdictIdentity,
+  extras?: { checkName?: string; observed?: string; expected?: string; nextAction?: string },
+): string {
+  return verdict.rationale ?? describeHostVerificationRationale({
+    verdict: verdict.verdict,
+    checkName: extras?.checkName ?? "host-verification",
+    observed: extras?.observed ?? verdict.verdict,
+    expected: extras?.expected ?? "pass",
+    evidenceRef: `${verdict.evidenceId} (verdict ${verdict.verdictId})`,
+    ...(extras?.nextAction ? { nextAction: extras.nextAction } : {}),
+  });
 }
 
 function routeHostTechnicalFailure(
@@ -263,13 +290,13 @@ function routeHostTechnicalFailure(
     classification: { failureKind },
     summary: failureKind === "verification-drift"
       ? "Stored host verification pass no longer matches the current source"
-      : "Built-in host verification did not pass",
+      : `Host verification ${verdict.verdict} for ${verdict.verdictId}`,
     evidence: {
       verdictId: verdict.verdictId,
       evidenceId: verdict.evidenceId,
       verdict: verdict.verdict,
     },
-    rationale: "Route built-in host verification through the durable recovery policy",
+    rationale: hostRecoveryRationale(verdict),
   } as const;
   // A response can be lost after its Domain Operation already committed (a
   // dropped connection, a fault injected between commit and return). Retrying
@@ -370,7 +397,12 @@ export function routeEvidenceCrossReferenceBlock(input: {
   const outcome = routeHostTechnicalFailure(
     authority,
     attempt,
-    { verdictId: recorded.verdictId, evidenceId: recorded.evidenceId, verdict: "fail" },
+    {
+      verdictId: recorded.verdictId,
+      evidenceId: recorded.evidenceId,
+      verdict: "fail",
+      rationale: `Safety evidence cross-reference: ${input.mismatch.reason}`,
+    },
     "verification-failed",
     undefined,
     (recoveryActionId, action) => {
@@ -398,7 +430,14 @@ function invalidateStoredHostPass(
     invocation: internalExecutionInvocation(`internal:auto:attempt.verify-drift:${verdict.verdictId}`),
     attemptId: attempt.attemptId,
     supersedesVerdictId: verdict.verdictId,
-    rationale: `Stored passing host verdict no longer matches the current verification source (${currentSourceRevision}).`,
+    rationale: describeHostVerificationRationale({
+      verdict: "inconclusive",
+      checkName: "gsd-source-integrity",
+      observed: `current source ${currentSourceRevision}`,
+      expected: `stored passing source ${verdict.testedSourceRevision}`,
+      evidenceRef: `db://host-verification/${attempt.attemptId}/source-drift`,
+      nextAction: "To become conclusive, re-run host verification against the current source, or restore the stored revision.",
+    }),
     evidence: {
       evidenceClass: "command",
       commandOrTool: "gsd-source-integrity",
@@ -776,6 +815,16 @@ export async function runPostUnitVerification(
         verdictId: replayedVerdict.verdictId,
         evidenceId: replayedVerdict.evidenceId,
         verdict: replayedVerdict.verdict,
+        rationale: describeHostVerificationRationale({
+          verdict: replayedVerdict.verdict,
+          checkName: "stored-host-verdict",
+          observed: replayedVerdict.verdict,
+          expected: "pass",
+          evidenceRef: `${replayedVerdict.evidenceId} (verdict ${replayedVerdict.verdictId})`,
+          nextAction: replayedVerdict.verdict === "inconclusive"
+            ? "To become conclusive, inspect that evidence and resume with matching verification."
+            : undefined,
+        }),
       }, replayedVerdict.supersedesVerdictId ? "verification-drift" : "verification-failed", recordAbort)
       : null;
     if (!replayedRecovery && !isTaskAttemptAwaitingVerification(latestAttempt)) {
@@ -858,6 +907,14 @@ export async function runPostUnitVerification(
         verdictId: invalidated.verdictId,
         evidenceId: invalidated.evidenceId,
         verdict: "inconclusive",
+        rationale: describeHostVerificationRationale({
+          verdict: "inconclusive",
+          checkName: "gsd-source-integrity",
+          observed: failureContext,
+          expected: "source matching the stored passing verdict",
+          evidenceRef: `${invalidated.evidenceId} (verdict ${invalidated.verdictId})`,
+          nextAction: "To become conclusive, re-run host verification against the current source, or restore the stored revision.",
+        }),
       }, "verification-drift", recordAbort);
       if (recovery === "abort") return "abort";
       return recordDurableVerificationRetry(s, retryKey, failureContext);
@@ -895,6 +952,7 @@ export async function runPostUnitVerification(
         preferenceCommands: prefs?.verification_commands ?? verificationTargets[0]?.preferenceCommands,
         taskPlanVerify,
         taskEvidence,
+        commandTimeoutMs: resolveVerificationTimeoutMs(prefs),
       });
     } else {
       result = runVerificationGateForTargets({
@@ -902,6 +960,7 @@ export async function runPostUnitVerification(
         preferenceCommands: prefs?.verification_commands,
         taskPlanVerify,
         taskEvidence,
+        commandTimeoutMs: resolveVerificationTimeoutMs(prefs),
       });
     }
 
@@ -1220,10 +1279,28 @@ export async function runPostUnitVerification(
       });
       canonicalVerdictWriteStarted = false;
       if (hostTechnicalVerdict !== "pass") {
+        const failingCheck = result.checks.find((check) => check.failureClass === "timeout")
+          ?? result.checks.find((check) => check.exitCode !== 0);
         durableRecovery = routeHostTechnicalFailure(taskAuthority, latestAttempt, {
           verdictId: recordedVerdict.verdictId,
           evidenceId: recordedVerdict.evidenceId,
           verdict: hostTechnicalVerdict,
+          rationale: describeHostVerificationRationale({
+            verdict: hostTechnicalVerdict,
+            checkName: failingCheck?.command ?? "host-verification",
+            observed: failingCheck?.failureClass === "timeout"
+              ? `timeout after ${failingCheck.durationMs}ms (exit ${failingCheck.exitCode})`
+              : failingCheck
+                ? `exit ${failingCheck.exitCode}`
+                : rationale,
+            expected: "exit 0 / pass",
+            evidenceRef: `db://host-verification/${latestAttempt.attemptId} (verdict ${recordedVerdict.verdictId})`,
+            nextAction: hostTechnicalVerdict === "inconclusive"
+              ? "To become conclusive, restore a stable source snapshot and matching evidence, then resume."
+              : failingCheck?.failureClass === "timeout"
+                ? "Raise verification_timeout_ms if this command is expected to run longer."
+                : undefined,
+          }),
         }, "verification-failed", recordAbort);
       }
 
@@ -1361,6 +1438,16 @@ export async function runPostUnitVerification(
         verdictId: storedVerdict.verdictId,
         evidenceId: storedVerdict.evidenceId,
         verdict: storedVerdict.verdict,
+        rationale: describeHostVerificationRationale({
+          verdict: storedVerdict.verdict,
+          checkName: "host-verification",
+          observed: message,
+          expected: "a completed host verdict",
+          evidenceRef: `${storedVerdict.evidenceId} (verdict ${storedVerdict.verdictId})`,
+          nextAction: storedVerdict.verdict === "inconclusive"
+            ? "To become conclusive, re-run host verification after the gate error is resolved."
+            : undefined,
+        }),
       }, storedVerdict.supersedesVerdictId ? "verification-drift" : "verification-failed", recordAbort);
       if (recovery === "abort") return "abort";
       const retryKey = verificationRetryKey(s.currentUnit.type, s.currentUnit.id);
@@ -1382,13 +1469,28 @@ export async function runPostUnitVerification(
         timestamp: Date.now(),
       },
       verdict: "inconclusive",
-      rationale: `Host verification errored before producing a verdict: ${message}`,
+      rationale: describeHostVerificationRationale({
+        verdict: "inconclusive",
+        checkName: "gsd-host-verification",
+        observed: message,
+        expected: "a completed host verdict",
+        evidenceRef: `db://host-verification/${recoverableAttempt.attemptId}`,
+        nextAction: "To become conclusive, re-run host verification after the gate error is resolved.",
+      }),
       sourceError: message,
     });
     const recovery = routeHostTechnicalFailure(recoverableAuthority, recoverableAttempt, {
       verdictId: recorded.verdictId,
       evidenceId: recorded.evidenceId,
       verdict: "inconclusive",
+      rationale: describeHostVerificationRationale({
+        verdict: "inconclusive",
+        checkName: "gsd-host-verification",
+        observed: message,
+        expected: "a completed host verdict",
+        evidenceRef: `${recorded.evidenceId} (verdict ${recorded.verdictId})`,
+        nextAction: "To become conclusive, re-run host verification after the gate error is resolved.",
+      }),
     }, "verification-failed", recordAbort);
     if (recovery === "abort") return "abort";
     const retryKey = verificationRetryKey(s.currentUnit.type, s.currentUnit.id);

--- a/src/resources/extensions/gsd/auto/task-execution-cutover.ts
+++ b/src/resources/extensions/gsd/auto/task-execution-cutover.ts
@@ -22,6 +22,7 @@ import { classifyFailure } from "../recovery-classification.js";
 import type { PublishVerifiedTaskCompletionInput } from "../task-completion-compatibility-adapter.js";
 import { internalExecutionInvocation } from "../execution-invocation.js";
 import type { TaskTechnicalVerdictSnapshot } from "../task-verification-domain-operation.js";
+import { describeHostVerificationRationale } from "../verification-verdict.js";
 import type { UnitPhaseResult } from "./workflow-unit-dispatch.js";
 
 export interface TaskExecutionCutoverInput {
@@ -64,7 +65,7 @@ function routeStoredTechnicalFailure(
     resultId: attempt.resultId,
     owner: "agent",
     classification: { failureKind: "verification-failed" },
-    summary: "Built-in host verification did not pass",
+    summary: `Host verification ${verdict.verdict} for ${verdict.verdictId}`,
     evidence: {
       unitType: input.unitType,
       unitId: input.unitId,
@@ -72,7 +73,16 @@ function routeStoredTechnicalFailure(
       evidenceId: verdict.evidenceId,
       verdict: verdict.verdict,
     },
-    rationale: "Route built-in host verification through the durable recovery policy",
+    rationale: describeHostVerificationRationale({
+      verdict: verdict.verdict,
+      checkName: `${input.unitType} ${input.unitId}`,
+      observed: verdict.verdict,
+      expected: "pass",
+      evidenceRef: `${verdict.evidenceId} (verdict ${verdict.verdictId})`,
+      nextAction: verdict.verdict === "inconclusive"
+        ? "To become conclusive, inspect that evidence and resume with matching verification."
+        : undefined,
+    }),
   });
 }
 

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -154,6 +154,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "verification_commands",
   "verification_auto_fix",
   "verification_max_retries",
+  "verification_timeout_ms",
   "per_unit_cost_cap_usd",
   "unit_cost_spike_multiplier",
   "search_provider",
@@ -552,6 +553,8 @@ export interface GSDPreferences {
   verification_commands?: string[];
   verification_auto_fix?: boolean;
   verification_max_retries?: number;
+  /** Per-command host-verification spawn timeout in ms. Unset uses 120000. */
+  verification_timeout_ms?: number;
   per_unit_cost_cap_usd?: number;
   /** Multiplier over the rolling per-unit cost average that triggers a cost-spike pause. Default: 3.0. The `burn-max` token profile ignores this and never pauses on spikes. */
   unit_cost_spike_multiplier?: number;

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -1351,6 +1351,15 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  if (preferences.verification_timeout_ms !== undefined) {
+    const raw = preferences.verification_timeout_ms;
+    if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+      validated.verification_timeout_ms = Math.floor(raw);
+    } else {
+      errors.push("verification_timeout_ms must be a positive number");
+    }
+  }
+
   if (preferences.per_unit_cost_cap_usd !== undefined) {
     const raw = preferences.per_unit_cost_cap_usd;
     if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -967,6 +967,7 @@ function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPr
     verification_commands: mergeStringLists(base.verification_commands, override.verification_commands),
     verification_auto_fix: override.verification_auto_fix ?? base.verification_auto_fix,
     verification_max_retries: override.verification_max_retries ?? base.verification_max_retries,
+    verification_timeout_ms: override.verification_timeout_ms ?? base.verification_timeout_ms,
     enhanced_verification: override.enhanced_verification ?? base.enhanced_verification,
     enhanced_verification_pre: override.enhanced_verification_pre ?? base.enhanced_verification_pre,
     enhanced_verification_post: override.enhanced_verification_post ?? base.enhanced_verification_post,

--- a/src/resources/extensions/gsd/tests/auto-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-verification.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+	_resolveVerificationTimeoutMsForTest,
 	_routeHostTechnicalFailureForTest,
 	runPostUnitVerification,
 } from "../auto-verification.ts";
+import { DEFAULT_COMMAND_TIMEOUT_MS } from "../constants.ts";
+import { describeHostVerificationRationale } from "../verification-verdict.ts";
 
 function createVerificationContext(currentUnit: { type: string; id: string } | null) {
 	return {
@@ -99,4 +102,55 @@ test("a replayed authorized abort does not surface a recoveryActionId (#1593)", 
 
 	assert.equal(outcome, "retry");
 	assert.deepEqual(surfaced, []);
+});
+
+test("routed fail rationale names the check, observed vs expected, and evidence (#1747)", () => {
+	let routedRationale = "";
+	_routeHostTechnicalFailureForTest({
+		routeTaskFailure: (input: { rationale: string }) => {
+			routedRationale = input.rationale;
+			return { action: "retry", status: "applied", resumeAuthorized: false };
+		},
+	} as never, {
+		attemptId: "attempt-1",
+		resultId: "result-1",
+	} as never, {
+		verdictId: "verdict-1",
+		evidenceId: "evidence-1",
+		verdict: "fail",
+		rationale: describeHostVerificationRationale({
+			verdict: "fail",
+			checkName: "just check-ci",
+			observed: "timeout after 120000ms (exit 124)",
+			expected: "exit 0 / pass",
+			evidenceRef: "db://host-verification/attempt-1 (verdict verdict-1)",
+			nextAction: "Raise verification_timeout_ms if this command is expected to run longer.",
+		}),
+	});
+	assert.match(routedRationale, /just check-ci/);
+	assert.match(routedRationale, /timeout after 120000ms/);
+	assert.match(routedRationale, /exit 0 \/ pass/);
+	assert.match(routedRationale, /evidence-1|verdict-1/);
+	assert.doesNotMatch(routedRationale, /Route built-in host verification through the durable recovery policy/);
+	assert.doesNotMatch(routedRationale, /Built-in host verification did not pass/);
+});
+
+test("inconclusive rationale states what would make it conclusive (#1747)", () => {
+	const rationale = describeHostVerificationRationale({
+		verdict: "inconclusive",
+		checkName: "gsd-source-integrity",
+		observed: "current source sha256:bbb",
+		expected: "stored passing source sha256:aaa",
+		evidenceRef: "db://host-verification/attempt-1/source-drift",
+		nextAction: "To become conclusive, re-run host verification against the current source, or restore the stored revision.",
+	});
+	assert.match(rationale, /inconclusive/);
+	assert.match(rationale, /gsd-source-integrity/);
+	assert.match(rationale, /To become conclusive/);
+});
+
+test("verification_timeout_ms unset stays 120s; set value is enforced (#1759)", () => {
+	assert.equal(_resolveVerificationTimeoutMsForTest(undefined), DEFAULT_COMMAND_TIMEOUT_MS);
+	assert.equal(_resolveVerificationTimeoutMsForTest({}), DEFAULT_COMMAND_TIMEOUT_MS);
+	assert.equal(_resolveVerificationTimeoutMsForTest({ verification_timeout_ms: 2500 }), 2500);
 });

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -557,15 +557,16 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.equal(routed.length, 1);
     const { invocation: routeInvocation, ...routeInput } = routed[0]!;
     assert.match(routeInvocation.idempotencyKey, /attempt\.route:result-test$/);
-    assert.deepEqual(routeInput, {
-      attemptId: "attempt-test",
-      resultId: "result-test",
-      owner: "agent",
-      classification: { failureKind: "verification-failed" },
-      summary: "Built-in host verification did not pass",
-      evidence: { verdictId: "verdict-1", evidenceId: "evidence-1", verdict: "inconclusive" },
-      rationale: "Route built-in host verification through the durable recovery policy",
-    });
+    assert.equal(routeInput.attemptId, "attempt-test");
+    assert.equal(routeInput.resultId, "result-test");
+    assert.equal(routeInput.owner, "agent");
+    assert.deepEqual(routeInput.classification, { failureKind: "verification-failed" });
+    assert.deepEqual(routeInput.evidence, { verdictId: "verdict-1", evidenceId: "evidence-1", verdict: "inconclusive" });
+    assert.match(String(routeInput.summary), /inconclusive/);
+    assert.match(String(routeInput.rationale), /gsd-source-integrity|source/);
+    assert.match(String(routeInput.rationale), /expected/i);
+    assert.doesNotMatch(String(routeInput.rationale), /Route built-in host verification through the durable recovery policy/);
+    assert.doesNotMatch(String(routeInput.summary), /Built-in host verification did not pass/);
   });
 
   test("Git snapshot failure records inconclusive without running verification commands", async () => {

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -72,6 +72,7 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   verification_commands: ["npm test"],
   verification_auto_fix: true,
   verification_max_retries: 1,
+  verification_timeout_ms: 120000,
   per_unit_cost_cap_usd: 5,
   unit_cost_spike_multiplier: 4,
   search_provider: "web",

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -938,6 +938,43 @@ test("validateVerificationCommand rejects logical OR fallback syntax", () => {
   }
 });
 
+test("runVerificationGate: timeout is failureClass timeout, not exit 127 (#1759)", () => {
+  const dir = makeTempDir("gsd-verify-timeout");
+  const result = withRtkDisabled(() => runVerificationGate({
+    cwd: dir,
+    preferenceCommands: ["sleep 5"],
+    commandTimeoutMs: 50,
+  }));
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.length, 1);
+  assert.notEqual(result.checks[0]?.exitCode, 127);
+  assert.equal(result.checks[0]?.failureClass, "timeout");
+  assert.match(result.checks[0]?.stderr ?? "", /timed out after 50ms/);
+  assert.match(result.checks[0]?.stderr ?? "", /verification_timeout_ms/);
+});
+
+test("runVerificationGate: missing binary is still exit 127 (#1759)", () => {
+  const dir = makeTempDir("gsd-verify-enoent");
+  const result = withRtkDisabled(() => runVerificationGate({
+    cwd: dir,
+    preferenceCommands: ["__gsd_missing_binary_1783__"],
+  }));
+  assert.equal(result.passed, false);
+  assert.equal(result.checks[0]?.exitCode, 127);
+  assert.equal(result.checks[0]?.failureClass, undefined);
+});
+
+test("validatePreferences: verification_timeout_ms override and default (#1759)", () => {
+  const set = validatePreferences({ verification_timeout_ms: 2500.9 });
+  assert.equal(set.errors.length, 0);
+  assert.equal(set.preferences.verification_timeout_ms, 2500);
+  assert.equal((set.warnings ?? []).filter((w) => w.includes("unknown")).length, 0);
+  const unset = validatePreferences({});
+  assert.equal(unset.preferences.verification_timeout_ms, undefined);
+  const bad = validatePreferences({ verification_timeout_ms: 0 });
+  assert.ok(bad.errors.some((e) => e.includes("verification_timeout_ms")));
+});
+
 test("validateVerificationCommand rejects arbitrary semicolon command chaining", () => {
   const result = validateVerificationCommand("python3 tools/check-status.py; rm -rf output");
   assert.equal(result.ok, false);

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -89,6 +89,8 @@ export interface VerificationCheck {
   stdout: string;
   stderr: string;
   durationMs: number;
+  /** Distinct from exit 127: a spawn timeout, never command-not-found (#1759). */
+  failureClass?: "timeout";
 }
 
 /** A runtime error captured from bg-shell processes or browser console */

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -709,6 +709,20 @@ function mergeDiscoverySource(
   return "none";
 }
 
+function isSpawnTimeout(
+  result: SpawnSyncReturns<string>,
+  error: NodeJS.ErrnoException & { killed?: boolean },
+): boolean {
+  if (error.code === "ETIMEDOUT") return true;
+  if (error.killed && (result.signal === "SIGTERM" || result.signal === "SIGKILL")) return true;
+  return /etimedout|timed out/i.test(error.message);
+}
+
+function isCommandNotFound(error: NodeJS.ErrnoException): boolean {
+  if (error.code === "ENOENT") return true;
+  return /enoent|not found/i.test(error.message);
+}
+
 /**
  * Run the verification gate: discover commands, execute each via spawnSync,
  * and return a structured result.
@@ -764,13 +778,30 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
     let exitCode: number;
     let stderr: string;
 
+    let failureClass: VerificationCheck["failureClass"];
     if (result.error) {
-      // Command not found or spawn failure
-      exitCode = 127;
-      stderr = truncate(
-        (result.stderr || "") + "\n" + (result.error as Error).message,
-        MAX_OUTPUT_BYTES,
-      );
+      const spawnError = result.error as NodeJS.ErrnoException & { killed?: boolean };
+      if (isSpawnTimeout(result, spawnError)) {
+        const limitMs = options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+        exitCode = 124;
+        failureClass = "timeout";
+        stderr = truncate(
+          `${result.stderr || ""}\ntimed out after ${limitMs}ms. Raise verification_timeout_ms if this command is expected to run longer.`.trim(),
+          MAX_OUTPUT_BYTES,
+        );
+      } else if (isCommandNotFound(spawnError)) {
+        exitCode = 127;
+        stderr = truncate(
+          (result.stderr || "") + "\n" + spawnError.message,
+          MAX_OUTPUT_BYTES,
+        );
+      } else {
+        exitCode = result.status ?? 1;
+        stderr = truncate(
+          (result.stderr || "") + "\n" + spawnError.message,
+          MAX_OUTPUT_BYTES,
+        );
+      }
     } else {
       // status is null when killed by signal — treat as failure
       exitCode = result.status ?? 1;
@@ -785,6 +816,7 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
       stdout: truncate(result.stdout, MAX_OUTPUT_BYTES),
       stderr: truncate(appendStderrWarning(stderr, warning), MAX_OUTPUT_BYTES),
       durationMs,
+      ...(failureClass ? { failureClass } : {}),
     });
   }
 

--- a/src/resources/extensions/gsd/verification-verdict.ts
+++ b/src/resources/extensions/gsd/verification-verdict.ts
@@ -18,6 +18,23 @@ export interface VerificationVerdict {
 export const NO_HOST_CHECKS_FAILURE_CONTEXT =
   "No runnable host-owned verification command was discovered. Add project verification_commands in .gsd/PREFERENCES.md or a runnable task-plan Verify command, then resume with /gsd next.";
 
+/** Diagnostic recovery rationale: check, observed vs expected, evidence, next action (#1747). */
+export function describeHostVerificationRationale(input: {
+  verdict: "fail" | "inconclusive";
+  checkName: string;
+  observed: string;
+  expected: string;
+  evidenceRef: string;
+  nextAction?: string;
+}): string {
+  const next = input.nextAction
+    ? ` ${input.nextAction}`
+    : input.verdict === "inconclusive"
+      ? " To become conclusive, supply the missing or matching evidence and resume."
+      : "";
+  return `Host verification ${input.verdict}: check ${input.checkName} observed ${input.observed}, expected ${input.expected}. Evidence: ${input.evidenceRef}.${next}`;
+}
+
 export function decideVerificationVerdict(
   unitType: string,
   result: VerificationGateResult,


### PR DESCRIPTION
## Change

Host verification blocked auto-mode with a fixed recovery rationale and labeled timeouts as exit 127 (command-not-found).

Recovery now carries the failing check, observed vs expected, evidence ref, and — for inconclusive — what would make it conclusive. `verification_timeout_ms` is a documented preference (default still 120000). Timeouts persist `failureClass: timeout` and never use 127.

Closes #1783

## Outcomes

| ID | Outcome | Evidence |
| --- | --- | --- |
| O-1 | Diagnostic fail/inconclusive rationales; boilerplate gone | `describeHostVerificationRationale` + route sites. Tests assert check/observed/expected/evidence and that the two boilerplate strings are absent. |
| O-2 | `verification_timeout_ms` wired end-to-end | Preference key + validation + merge; gate call sites pass `commandTimeoutMs`. Unset → 120000. |
| O-3 | Timeout is `failureClass: timeout`, not 127 | `sleep 5` with 50ms timeout: not 127, `failureClass: timeout`. Missing binary still 127. Verdict environment records the class. |
| O-4 | Inconclusive states next action | Rationale includes "To become conclusive…" for drift, snapshot, and gate-error paths. |

## Exclusions

- X-1 — Default remains 120000 ms
- X-2 — Same verdicts still block auto-mode
- X-3 — Drift invalidation semantics unchanged
- X-4 — No preference UI; documented in `docs/user-docs/configuration.md` and gitbook preferences

Side effects beyond the contract: none

## Checks

- `verification-gate.test.ts` — 119/119
- `auto-verification.test.ts` + `post-exec-retry-bypass.test.ts` — pass
- `pnpm run verify:fast` — pass

Dependency audit: not applicable

## Walkthrough

Verified at the gate/route seam (not a live auto-mode session):

1. Low `commandTimeoutMs` + slow command → timeout class, names the command, points at `verification_timeout_ms`
2. Inconclusive drift rationale states how to become conclusive
3. Unset preference → 120000 ms

## Risk

Low. Classification and rationale text only. Default timeout unchanged. 127 reserved for command-not-found.
