### PR TITLE
fix(gsd): parse plan numbers from suffixed slice IDs

### DIFF
--- a/src/resources/extensions/gsd/layout-policy.ts
+++ b/src/resources/extensions/gsd/layout-policy.ts
@@ -60,11 +60,11 @@ export function milestoneIdUniqueSuffix(milestoneId: string): string | undefined
 }
 
 /**
- * Extract the numeric portion of a slice id (S01 → 1).
+ * Extract the numeric portion of a slice id (S01 → 1, S01-replan → 1).
  * Used by the renderer to derive the plan number from the DB's slice_id.
  */
 export function sliceIdToPlanNum(sliceId: string): number {
-  const m = sliceId.match(/^S0*(\d+)$/i);
+  const m = sliceId.match(/^S0*(\d+)(?:-.*)?$/i);
   return m ? Number.parseInt(m[1]!, 10) : 1;
 }
 

--- a/src/resources/extensions/gsd/tests/layout-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/layout-policy.test.ts
@@ -44,6 +44,11 @@ test("milestoneIdToPhaseNum extracts the numeric portion", () => {
 test("sliceIdToPlanNum extracts the numeric portion", () => {
   assert.equal(sliceIdToPlanNum("S01"), 1);
   assert.equal(sliceIdToPlanNum("S03"), 3);
+  assert.equal(sliceIdToPlanNum("S1"), 1);
+  assert.equal(sliceIdToPlanNum("S01-replan"), 1);
+  assert.equal(sliceIdToPlanNum("S02-db-repair"), 2);
+  assert.equal(sliceIdToPlanNum("s03-x"), 3);
+  assert.equal(sliceIdToPlanNum("garbage"), 1);
 });
 
 test("derivePhaseSlug is stable and deterministic", () => {

--- a/src/resources/extensions/gsd/tests/slice-id-suffix-plan-files.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-id-suffix-plan-files.test.ts
@@ -1,0 +1,39 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildSliceFileName, resolveSliceFile, targetSliceFile, _clearGsdRootCache } from "../paths.ts";
+
+test("suffixed slice IDs produce distinct plan files at all three call sites (#1664)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-slice-suffix-"));
+  try {
+    _clearGsdRootCache();
+    const phaseDir = join(base, ".gsd", "phases", "01-suffix");
+    mkdirSync(phaseDir, { recursive: true });
+
+    assert.equal(buildSliceFileName("S01-replan", "PLAN"), "01-PLAN.md");
+    assert.equal(buildSliceFileName("S02-db-repair", "PLAN"), "02-PLAN.md");
+    assert.notEqual(
+      buildSliceFileName("S01-replan", "PLAN"),
+      buildSliceFileName("S02-db-repair", "PLAN"),
+    );
+
+    const first = targetSliceFile(base, "M001", "S01-replan", "PLAN", "suffix");
+    const second = targetSliceFile(base, "M001", "S02-db-repair", "PLAN", "suffix");
+    assert.notEqual(first, second);
+    assert.match(first, /01-01-PLAN\.md$/);
+    assert.match(second, /01-02-PLAN\.md$/);
+
+    writeFileSync(first, "# S01-replan\n");
+    writeFileSync(second, "# S02-db-repair\n");
+    assert.equal(existsSync(first), true);
+    assert.equal(existsSync(second), true);
+    assert.equal(resolveSliceFile(base, "M001", "S01-replan", "PLAN"), first);
+    assert.equal(resolveSliceFile(base, "M001", "S02-db-repair", "PLAN"), second);
+  } finally {
+    _clearGsdRootCache();
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Change

`sliceIdToPlanNum()` only matched bare `S01` IDs. Suffixed IDs such as `S01-replan` and `S02-db-repair` both fell through to plan 1 and wrote the same flat-phase PLAN file.

The numeric prefix is now extracted (`S02-db-repair` → 2). Bare IDs and unparseable input keep the previous behavior.

Closes #1785

## Outcomes

| ID | Outcome | Evidence |
| --- | --- | --- |
| O-1 | Suffixed IDs yield the numeric plan | `S01-replan`→1, `S02-db-repair`→2, `S1`→1, `s03-x`→3, garbage→1 |
| O-2 | Three call sites produce distinct files | `buildSliceFileName`, `targetSliceFile`, and `resolveSliceFile` write/read `01-01-PLAN.md` vs `01-02-PLAN.md` |

## Exclusions

- X-1 — Unparseable IDs still fall back to plan 1
- X-2 — Filename layout unchanged beyond the extracted number
- X-3 — Match stays case-insensitive

Side effects beyond the contract: none

## Checks

- `layout-policy.test.ts` + `slice-id-suffix-plan-files.test.ts` — 10/10
- `pnpm run verify:fast` — pass

Dependency audit: not applicable

## Walkthrough

Verified at the path helpers (not a live plan-slice session): two suffixed slices resolve to two PLAN files.

## Risk

Low. One regex, same fallback, existing bare-ID tests still pass.
