### PR TITLE
fix(gsd): bridge cursor-agent lifecycle tools and persist stdio MCP trust

### DIFF
--- a/src/resources/extensions/cursor-cli/stream-adapter.ts
+++ b/src/resources/extensions/cursor-cli/stream-adapter.ts
@@ -88,10 +88,13 @@ export function buildCursorPrompt(context: Context): string {
 	if (context.systemPrompt?.trim()) parts.push(`System instructions:\n${context.systemPrompt.trim()}`);
 	if (context.messages.length > 0) parts.push(context.messages.map(messageToText).join("\n\n"));
 	if (context.tools?.length) {
+		const names = context.tools.map((tool) => tool.name);
+		const bridged = names.filter((name) => isCursorBridgedGsdTool(name));
 		parts.push(
 			`The external Cursor agent may execute its own tools. ` +
 			`GSD will not redispatch Cursor-owned internal tool events locally. ` +
-			`Requested GSD tools: ${context.tools.map((tool) => tool.name).join(", ")}`,
+			`GSD lifecycle tools executed locally: ${bridged.join(", ") || "(none)"}. ` +
+			`Requested GSD tools: ${names.join(", ")}`,
 		);
 	}
 	return parts.join("\n\n").trim();
@@ -116,6 +119,29 @@ export function buildCursorAgentRunPlan(
 		["-p", prompt, "--output-format", "stream-json", "--model", modelId, "--workspace", cwd, "--trust"],
 		platform,
 	);
+}
+
+const CURSOR_BRIDGED_GSD_TOOLS = new Set([
+	"gsd_task_complete",
+	"gsd_complete_task",
+]);
+
+function gsdToolBaseName(name: string): string {
+	return name.replace(/^mcp__.+?__/, "");
+}
+
+export function isCursorBridgedGsdTool(name: string): boolean {
+	const base = gsdToolBaseName(name);
+	return CURSOR_BRIDGED_GSD_TOOLS.has(name) || CURSOR_BRIDGED_GSD_TOOLS.has(base);
+}
+
+export function isGsdToolName(name: string): boolean {
+	const base = gsdToolBaseName(name);
+	return base.startsWith("gsd_") || name.startsWith("gsd_");
+}
+
+export function unsupportedCursorGsdToolError(name: string): string {
+	return `tool unsupported under cursor-agent: ${name}`;
 }
 
 function emitCompleteLines(chunk: string, pending: { value: string }, onLine: CursorAgentLineHandler): void {
@@ -406,6 +432,9 @@ export function streamViaCursorAgent(
 					return;
 				}
 				if (parsed.type === "tool_call") {
+					if (isGsdToolName(parsed.toolCall.name) && !isCursorBridgedGsdTool(parsed.toolCall.name)) {
+						throw new Error(unsupportedCursorGsdToolError(parsed.toolCall.name));
+					}
 					ensureStart();
 					toolCalls.set(parsed.toolCall.id, parsed.toolCall);
 					content.push(parsed.toolCall);
@@ -417,6 +446,7 @@ export function streamViaCursorAgent(
 				}
 				if (parsed.type === "tool_result") {
 					const toolCall = toolCalls.get(parsed.toolCallId);
+					if (toolCall && isCursorBridgedGsdTool(toolCall.name)) return;
 					if (toolCall) toolCall.externalResult = parsed.result;
 				}
 			};

--- a/src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts
@@ -9,6 +9,7 @@ import {
 	buildCursorSpawnInvocation,
 	parseCursorAgentLine,
 	streamViaCursorAgent,
+	unsupportedCursorGsdToolError,
 } from "../stream-adapter.ts";
 
 const model = {
@@ -48,6 +49,16 @@ test("buildCursorPrompt preserves system, message, and tool context", () => {
 	assert.match(prompt, /System instructions:\nBe concise\./);
 	assert.match(prompt, /User:\nHello/);
 	assert.match(prompt, /Requested GSD tools: gsd_plan_slice/);
+	assert.match(prompt, /GSD lifecycle tools executed locally: \(none\)/);
+});
+
+test("buildCursorPrompt names bridged GSD lifecycle tools as locally executed (#1764)", () => {
+	const prompt = buildCursorPrompt({
+		...context,
+		tools: [{ name: "gsd_task_complete" }, { name: "gsd_plan_slice" }],
+	} as Context);
+	assert.match(prompt, /GSD lifecycle tools executed locally: gsd_task_complete/);
+	assert.match(prompt, /Requested GSD tools: gsd_task_complete, gsd_plan_slice/);
 });
 
 test("parseCursorAgentLine maps text, legacy tool, result, usage, and errors", () => {
@@ -271,4 +282,38 @@ test("streamViaCursorAgent turns NDJSON into assistant events with external tool
 	assert.deepEqual(toolCall.externalResult, { content: [{ type: "text", text: "ok" }], isError: false });
 	assert.equal(done.message.usage.input, 3);
 	assert.equal(done.message.usage.output, 4);
+});
+
+test("cursor adapter bridges gsd_task_complete for local host execution (#1764)", async () => {
+	const lines = [
+		'{"type":"assistant","message":{"content":[{"type":"text","text":"Completing"}]}}',
+		'{"type":"tool_call","id":"tool_1","name":"gsd_task_complete","input":{"milestoneId":"M001"}}',
+		'{"type":"tool_result","tool_call_id":"tool_1","content":"ignored","is_error":false}',
+	];
+	const stream = streamViaCursorAgent(model, context, {
+		_cursorAgentRunnerForTest: async () => ({ stdout: `${lines.join("\n")}\n`, stderr: "", code: 0, signal: null }),
+	});
+	const events = [];
+	for await (const event of stream) events.push(event);
+	const done = events.find((event) => event.type === "done");
+	assert.ok(done && done.type === "done");
+	const toolCall = done.message.content.find((block) => block.type === "toolCall");
+	assert.ok(toolCall && toolCall.type === "toolCall");
+	assert.equal(toolCall.name, "gsd_task_complete");
+	assert.equal(toolCall.externalResult, undefined);
+});
+
+test("cursor adapter refuses unbridged GSD tool calls (#1764)", async () => {
+	const lines = [
+		'{"type":"tool_call","id":"tool_1","name":"gsd_exec","input":{"command":"ls"}}',
+	];
+	const stream = streamViaCursorAgent(model, context, {
+		_cursorAgentRunnerForTest: async () => ({ stdout: `${lines.join("\n")}\n`, stderr: "", code: 0, signal: null }),
+	});
+	const events = [];
+	for await (const event of stream) events.push(event);
+	const error = events.find((event) => event.type === "error");
+	assert.ok(error && error.type === "error");
+	assert.match(error.error.errorMessage ?? "", /tool unsupported under cursor-agent: gsd_exec/);
+	assert.equal(unsupportedCursorGsdToolError("gsd_exec"), "tool unsupported under cursor-agent: gsd_exec");
 });

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -126,7 +126,7 @@ export const GLOBAL_STATE_CODES = new Set<DoctorIssueCode>([
 export interface DoctorIssue {
   severity: DoctorSeverity;
   code: DoctorIssueCode;
-  scope: "project" | "milestone" | "slice" | "task";
+  scope: "project" | "global" | "milestone" | "slice" | "task";
   unitId: string;
   message: string;
   file?: string;

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -229,7 +229,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
     issues.push({
       severity: diagnostic.severity,
       code: "invalid_preferences",
-      scope: "project",
+      scope: diagnostic.scope,
       unitId: "project",
       message: `GSD preferences ${diagnostic.kind}: ${formatPreferenceDiagnosticDetail(diagnostic)}`,
       file: diagnostic.path,

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -648,7 +648,9 @@ export function validatePreferences(preferences: GSDPreferences): {
   // ─── Remote Questions ───────────────────────────────────────────────
   if (preferences.remote_questions !== undefined) {
     const remoteQuestions = preferences.remote_questions as unknown;
-    if (typeof remoteQuestions === "object" && remoteQuestions !== null) {
+    if (remoteQuestions === null) {
+      // Bare YAML stub (`remote_questions: null`) means absent (#1764).
+    } else if (typeof remoteQuestions === "object") {
       validated.remote_questions = remoteQuestions as GSDPreferences["remote_questions"];
     } else if (remoteQuestions === false) {
       // Explicit disable for a globally-configured remote questions channel.

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -15,6 +15,7 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { filterDoctorIssues } from "../doctor-format.ts";
 import { checkEngineHealth } from "../doctor-engine-checks.ts";
+import { runGSDDoctor } from "../doctor.ts";
 import { MEMORIES_FTS_REBUILT_KEY } from "../db-memory-fts-schema.ts";
 import { appendEvent } from "../workflow-events.ts";
 import { renderPlanFromDb, renderRoadmapFromDb } from "../markdown-renderer.ts";
@@ -35,6 +36,27 @@ test("filterDoctorIssues keeps project and environment issues in scoped reports"
     filtered.map((issue) => issue.unitId),
     ["environment", "project", "M016/S01"],
   );
+});
+
+test("doctor preference diagnostics report diagnostic.scope (#1764)", async (t) => {
+  const originalGsdHome = process.env.GSD_HOME;
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-pref-scope-"));
+  const home = mkdtempSync(join(tmpdir(), "gsd-doctor-pref-home-"));
+  t.after(() => {
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(base, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  process.env.GSD_HOME = home;
+  writeFileSync(join(home, "PREFERENCES.md"), "---\nversion: 3\n---\n", "utf-8");
+
+  const report = await runGSDDoctor(base, { fix: false });
+  const issue = report.issues.find((item) => item.code === "invalid_preferences");
+  assert.ok(issue, "doctor should surface the global preferences diagnostic");
+  assert.equal(issue.scope, "global");
 });
 
 test("filterDoctorIssues keeps invalid_preferences issues regardless of preferences file scope", () => {

--- a/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+import { after, before, test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -13,6 +13,18 @@ import mcpClientExtension, {
   _resetMcpClientStateForTest,
 } from "../../mcp-client/index.ts";
 import type { ManagedMcpServerConfig } from "../../mcp-client/manager.ts";
+import { hasPersistedStdioTrust } from "../../mcp-client/stdio-trust-store.ts";
+
+const originalGsdHome = process.env.GSD_HOME;
+const isolatedGsdHome = mkdtempSync(join(tmpdir(), "gsd-mcp-trust-home-"));
+before(() => {
+  process.env.GSD_HOME = isolatedGsdHome;
+});
+after(() => {
+  if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+  else process.env.GSD_HOME = originalGsdHome;
+  rmSync(isolatedGsdHome, { recursive: true, force: true });
+});
 
 // Note: four source-grep tests that scanned `mcp-client/index.ts` for
 // Map<> shapes, catch-block structure, and closeAll body were removed
@@ -402,5 +414,34 @@ test("MCP stdio discover deduplicates concurrent first calls for the same server
     else process.env.GSD_HOME = previousGsdHome;
     rmSync(projectDir, { recursive: true, force: true });
     rmSync(gsdHomeDir, { recursive: true, force: true });
+  }
+});
+
+test("headless stdio trust fails until persisted interactive approval (#1772)", async () => {
+  process.env.GSD_HOME = isolatedGsdHome;
+  const config = { ...makeStdioConfig("headless-trust"), env: { CUSTOM_KEY: "placeholder-value" } };
+  await assert.rejects(
+    _assertTrustedStdioServerForTest(config, { hasUI: false } as any),
+    /project-shared stdio command.*Trust required, run once interactively/s,
+  );
+  await assert.rejects(
+    _assertTrustedStdioServerForTest({ ...config, sourceKind: "project-local" }, { hasUI: false } as any),
+    /project-local stdio command.*Trust required, run once interactively/s,
+  );
+  const harness = createConfirmHarness();
+  try {
+    const pending = _assertTrustedStdioServerForTest(config, harness.ctx as any);
+    await waitForCondition("interactive trust", () => harness.prompts.length === 1);
+    harness.prompts[0]?.resolve(true);
+    await pending;
+    assert.equal(hasPersistedStdioTrust(config), true);
+    const store = readFileSync(join(isolatedGsdHome, "mcp-stdio-trust.json"), "utf-8");
+    assert.equal(store.includes("placeholder-value"), false);
+    assert.equal(store.includes("CUSTOM_KEY"), false);
+    await _resetMcpClientStateForTest();
+    await _assertTrustedStdioServerForTest(config, { hasUI: false } as any);
+  } finally {
+    for (const prompt of harness.prompts) prompt.reject(new Error("test cleanup"));
+    await _resetMcpClientStateForTest();
   }
 });

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -144,6 +144,10 @@ test("invalid value types produce errors and fall back to undefined", () => {
 });
 
 test("remote_questions accepts object config and false disables without error", () => {
+  const stub = validatePreferences({ remote_questions: null } as any);
+  assert.equal(stub.errors.length, 0);
+  assert.equal(stub.preferences.remote_questions, undefined);
+
   const disabled = validatePreferences({ remote_questions: false } as any);
   assert.equal(disabled.errors.length, 0);
   assert.equal(disabled.preferences.remote_questions, undefined);

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -33,6 +33,7 @@ import {
 	resolveMcpEnv,
 	type ManagedMcpServerConfig,
 } from "./manager.js";
+import { hasPersistedStdioTrust, persistStdioTrust, stdioPersistTrustKey } from "./stdio-trust-store.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -62,14 +63,7 @@ const activeStdioTrustApprovalAborts = new Set<(err: Error) => void>();
 const queuedStdioTrustApprovalAborts = new Set<(err: Error) => void>();
 
 function stdioTrustKey(config: McpServerConfig): string {
-	return JSON.stringify({
-		name: config.name,
-		sourcePath: config.sourcePath,
-		command: config.command,
-		args: config.args ?? [],
-		cwd: config.cwd,
-		env: config.env ?? {},
-	});
+	return stdioPersistTrustKey(config);
 }
 
 function readConfigs(): McpServerConfig[] {
@@ -219,12 +213,15 @@ async function assertTrustedStdioServer(
 ): Promise<string | undefined> {
 	if (config.transport !== "stdio") return undefined;
 	const trustKey = stdioTrustKey(config);
-	if (trustedStdioServers.has(trustKey)) return undefined;
+	if (trustedStdioServers.has(trustKey) || hasPersistedStdioTrust(config)) {
+		trustedStdioServers.add(trustKey);
+		return undefined;
+	}
 
 	if (!ctx?.hasUI) {
 		throw new Error(
-			`MCP server "${config.name}" is a project-local stdio command from ${config.sourcePath}. ` +
-			"Run this from an interactive GSD session and approve the server before use.",
+			`MCP server "${config.name}" is a ${config.sourceKind} stdio command from ${config.sourcePath}. ` +
+			"Trust required, run once interactively to approve this server before use.",
 		);
 	}
 
@@ -243,6 +240,7 @@ async function assertTrustedStdioServer(
 		if (!approved) {
 			throw new Error(`MCP server "${config.name}" was not approved by the user.`);
 		}
+		persistStdioTrust(config);
 		return trustKey;
 	});
 }

--- a/src/resources/extensions/mcp-client/stdio-trust-store.ts
+++ b/src/resources/extensions/mcp-client/stdio-trust-store.ts
@@ -1,0 +1,56 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+import type { ManagedMcpServerConfig } from "./manager.js";
+
+interface TrustStoreFile {
+	version: 1;
+	entries: string[];
+}
+
+function gsdHomeDir(): string {
+	return process.env.GSD_HOME ? resolve(process.env.GSD_HOME) : join(homedir(), ".gsd");
+}
+
+function trustStorePath(): string {
+	return join(gsdHomeDir(), "mcp-stdio-trust.json");
+}
+
+export function stdioPersistTrustKey(config: ManagedMcpServerConfig, projectRoot: string = process.cwd()): string {
+	return JSON.stringify({
+		project: resolve(projectRoot),
+		name: config.name,
+		sourcePath: config.sourcePath,
+		command: config.command,
+		args: config.args ?? [],
+		cwd: config.cwd ?? null,
+	});
+}
+
+function readStore(): TrustStoreFile {
+	const path = trustStorePath();
+	if (!existsSync(path)) return { version: 1, entries: [] };
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as TrustStoreFile;
+		if (parsed?.version !== 1 || !Array.isArray(parsed.entries)) return { version: 1, entries: [] };
+		return { version: 1, entries: parsed.entries.filter((entry) => typeof entry === "string") };
+	} catch {
+		return { version: 1, entries: [] };
+	}
+}
+
+export function hasPersistedStdioTrust(config: ManagedMcpServerConfig, projectRoot?: string): boolean {
+	const key = stdioPersistTrustKey(config, projectRoot);
+	return readStore().entries.includes(key);
+}
+
+export function persistStdioTrust(config: ManagedMcpServerConfig, projectRoot?: string): void {
+	const key = stdioPersistTrustKey(config, projectRoot);
+	const store = readStore();
+	if (store.entries.includes(key)) return;
+	store.entries.push(key);
+	const path = trustStorePath();
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+}


### PR DESCRIPTION
## Change

Two executor-integration gaps blocked auto-mode for non-Claude runners.

Cursor-agent named GSD tools in the prompt with no local bridge, so `gsd_task_complete` became a missing-executor-result retry loop. A bare YAML `remote_questions: null` stub failed validation, and doctor preference diagnostics hardcoded project scope.

Stdio MCP trust lived in an in-memory Set. Headless and `--mode json` paths threw before any persist lookup, so there was no way to start a trusted server without a UI.

Closes #1786

## Outcomes

| ID | Outcome | Evidence |
| --- | --- | --- |
| O-1 | Bridged GSD lifecycle tools stay host-executed; unbridged GSD tools fail at dispatch | `gsd_task_complete` has no `externalResult`; `gsd_exec` errors with `tool unsupported under cursor-agent` |
| O-2 | `remote_questions: null` validates as absent | `validatePreferences({ remote_questions: null })` → no errors, key undefined; object/false keep current semantics |
| O-3 | Doctor preference diagnostics use `diagnostic.scope` | Isolated global `PREFERENCES.md` (`version: 3`) reports `scope: "global"` |
| O-4 | Persisted stdio trust lets headless start after one interactive approval | First `hasUI: false` throws; after confirm, reset + headless succeeds |
| O-5 | Trust error uses `sourceKind` | `project-shared` and `project-local` both appear in the trust-required message |

## Exclusions

- X-1 — Headless still does not auto-trust; first run must be interactive
- X-2 — Bridge covers `gsd_task_complete` / `gsd_complete_task` only
- X-3 — Trust store keys are server identity (name, source, command, args, cwd, project). No env/secrets persisted (asserted)
- X-4 — `remote_questions: false` and object forms unchanged

Side effects beyond the contract: none

## Checks

- stream-adapter + preferences + mcp-client-security + doctor-scope: 188/188
- `pnpm run typecheck:extensions` — pass
- `pnpm run verify:fast` — pass

Dependency audit: not applicable

## Walkthrough

Issue walkthrough is a live cursor-agent / interactive-trust session. Path-level checks cover the same branches: lifecycle tool calls are bridged or refused, `remote_questions: null` validates, doctor reports global scope, and persisted trust unblocks headless after one confirm.

## Risk

Low. Dispatch refusal is explicit. Persist is identity-only. Validation and doctor changes are scoped to the named stub and diagnostic.scope mapping.
