### PR TITLE
fix(gsd): out-of-surface blocker, convergent schema retries, plan-task cap

### DIFF
--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -18,6 +18,11 @@ import {
 	validateToolArguments,
 } from "@gsd/pi-ai";
 import { resolveAgentTool } from "./resolve-agent-tool.js";
+import {
+	collectValidationErrorFields,
+	decideSchemaOverloadBreaker,
+	narrowedSchemaRetryInstruction,
+} from "./schema-overload-convergence.js";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -185,6 +190,8 @@ async function runLoop(
 	// Check for steering messages at start (user may have typed while waiting)
 	let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
 	let consecutiveAllToolErrorTurns = 0;
+	let previousValidationFields: string[] = [];
+	let narrowedSchemaRetryGranted = false;
 
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {
@@ -242,9 +249,37 @@ async function runLoop(
 					consecutiveAllToolErrorTurns++;
 				} else if (!hasPreparationErrors) {
 					consecutiveAllToolErrorTurns = 0;
+					previousValidationFields = [];
+					narrowedSchemaRetryGranted = false;
 				}
 
-				if (consecutiveAllToolErrorTurns >= MAX_CONSECUTIVE_VALIDATION_FAILURES) {
+				const currentValidationFields = collectValidationErrorFields(
+					toolResults.map(toolResultText),
+				);
+				const overload = decideSchemaOverloadBreaker({
+					consecutive: consecutiveAllToolErrorTurns,
+					cap: MAX_CONSECUTIVE_VALIDATION_FAILURES,
+					previousFields: previousValidationFields,
+					currentFields: currentValidationFields,
+					narrowedRetryGranted: narrowedSchemaRetryGranted,
+				});
+				if (allToolsFailedPreparation) {
+					previousValidationFields = currentValidationFields;
+				}
+
+				if (overload.grantNarrowedRetry) {
+					narrowedSchemaRetryGranted = true;
+					consecutiveAllToolErrorTurns = MAX_CONSECUTIVE_VALIDATION_FAILURES - 1;
+					const retryMessage: AgentMessage = {
+						role: "user",
+						content: [{ type: "text", text: narrowedSchemaRetryInstruction(currentValidationFields) }],
+						timestamp: Date.now(),
+					};
+					currentContext.messages.push(retryMessage);
+					newMessages.push(retryMessage);
+					await emit({ type: "message_start", message: retryMessage });
+					await emit({ type: "message_end", message: retryMessage });
+				} else if (overload.trip) {
 					const stopMessage: AssistantMessage = {
 						role: "assistant",
 						content: [
@@ -912,6 +947,13 @@ async function finalizeExecutedToolCall(
 		result,
 		isError,
 	};
+}
+
+function toolResultText(result: ToolResultMessage): string {
+	return result.content
+		.filter((block): block is { type: "text"; text: string } => block.type === "text")
+		.map((block) => block.text)
+		.join("\n");
 }
 
 function createErrorToolResult(message: string, displayReason?: string): AgentToolResult<any> {

--- a/packages/pi-agent-core/src/index.ts
+++ b/packages/pi-agent-core/src/index.ts
@@ -2,6 +2,7 @@
 export * from "./agent.js";
 // Loop functions
 export * from "./agent-loop.js";
+export * from "./schema-overload-convergence.js";
 export * from "./harness/agent-harness.js";
 export {
 	type BranchPreparation,

--- a/packages/pi-agent-core/src/schema-overload-convergence.ts
+++ b/packages/pi-agent-core/src/schema-overload-convergence.ts
@@ -1,0 +1,50 @@
+/** Parse TypeBox-style validation field paths from a tool-error body. */
+export function extractValidationErrorFields(text: string): string[] {
+  const fields = new Set<string>();
+  for (const match of text.matchAll(/^\s*-\s+(\/[^\s:]+):/gm)) {
+    const path = match[1];
+    if (path) fields.add(path);
+  }
+  return [...fields].sort();
+}
+
+export function collectValidationErrorFields(texts: readonly string[]): string[] {
+  const fields = new Set<string>();
+  for (const text of texts) {
+    for (const field of extractValidationErrorFields(text)) fields.add(field);
+  }
+  return [...fields].sort();
+}
+
+/** True when the current error-field set is a nonempty proper subset of the previous set. */
+export function isConvergingValidationFieldSet(previous: readonly string[], current: readonly string[]): boolean {
+  if (previous.length === 0 || current.length === 0) return false;
+  if (current.length >= previous.length) return false;
+  const prev = new Set(previous);
+  return current.every((field) => prev.has(field));
+}
+
+export function decideSchemaOverloadBreaker(input: {
+  consecutive: number;
+  cap: number;
+  previousFields: readonly string[];
+  currentFields: readonly string[];
+  narrowedRetryGranted: boolean;
+}): { trip: boolean; grantNarrowedRetry: boolean } {
+  if (input.consecutive < input.cap) return { trip: false, grantNarrowedRetry: false };
+  if (
+    !input.narrowedRetryGranted
+    && isConvergingValidationFieldSet(input.previousFields, input.currentFields)
+  ) {
+    return { trip: false, grantNarrowedRetry: true };
+  }
+  return { trip: true, grantNarrowedRetry: false };
+}
+
+export function narrowedSchemaRetryInstruction(fields: readonly string[]): string {
+  const listed = fields.length > 0 ? fields.join(", ") : "the remaining invalid fields";
+  return (
+    `Schema validation is converging. Retry with a minimal diff: only fix ${listed}. ` +
+    `Do not rewrite fields that already validated.`
+  );
+}

--- a/packages/pi-agent-core/test/schema-overload-convergence.test.ts
+++ b/packages/pi-agent-core/test/schema-overload-convergence.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+	collectValidationErrorFields,
+	decideSchemaOverloadBreaker,
+	extractValidationErrorFields,
+	isConvergingValidationFieldSet,
+	narrowedSchemaRetryInstruction,
+} from "../src/schema-overload-convergence.js";
+
+const cap = 3;
+
+describe("schema-overload convergence", () => {
+	it("extracts field paths from TypeBox validation errors", () => {
+		const text = [
+			'Validation failed for tool "gsd_reassess_roadmap":',
+			"  - /milestoneId: Expected string",
+			"  - /findings: Expected array",
+			"",
+			"Received arguments:",
+			'{"milestoneId":1}',
+		].join("\n");
+		expect(extractValidationErrorFields(text)).toEqual(["/findings", "/milestoneId"]);
+	});
+
+	it("treats a shrinking field set as converging", () => {
+		expect(isConvergingValidationFieldSet(["/a", "/b", "/c"], ["/a", "/b"])).toBe(true);
+		expect(isConvergingValidationFieldSet(["/a", "/b"], ["/a", "/b"])).toBe(false);
+		expect(isConvergingValidationFieldSet(["/a", "/b"], ["/a", "/c"])).toBe(false);
+		expect(isConvergingValidationFieldSet(["/a"], ["/a", "/b"])).toBe(false);
+	});
+
+	it("grants one narrowed retry when errors shrink at the cap", () => {
+		expect(
+			decideSchemaOverloadBreaker({
+				consecutive: cap,
+				cap,
+				previousFields: ["/a", "/b"],
+				currentFields: ["/a"],
+				narrowedRetryGranted: false,
+			}),
+		).toEqual({ trip: false, grantNarrowedRetry: true });
+	});
+
+	it("trips at the cap when the field set is not shrinking", () => {
+		expect(
+			decideSchemaOverloadBreaker({
+				consecutive: cap,
+				cap,
+				previousFields: ["/a", "/b"],
+				currentFields: ["/a", "/b"],
+				narrowedRetryGranted: false,
+			}),
+		).toEqual({ trip: true, grantNarrowedRetry: false });
+	});
+
+	it("trips after the narrowed retry even if still shrinking", () => {
+		expect(
+			decideSchemaOverloadBreaker({
+				consecutive: cap,
+				cap,
+				previousFields: ["/a", "/b"],
+				currentFields: ["/a"],
+				narrowedRetryGranted: true,
+			}),
+		).toEqual({ trip: true, grantNarrowedRetry: false });
+	});
+
+	it("collects fields across multiple tool errors and names them in the retry instruction", () => {
+		const fields = collectValidationErrorFields([
+			"  - /milestoneId: Expected string\n",
+			"  - /sliceId: Expected string\n",
+		]);
+		expect(fields).toEqual(["/milestoneId", "/sliceId"]);
+		expect(narrowedSchemaRetryInstruction(fields)).toMatch(/minimal diff/);
+		expect(narrowedSchemaRetryInstruction(fields)).toMatch(/\/milestoneId/);
+	});
+});

--- a/src/resources/extensions/gsd/bootstrap/core-session-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/core-session-tools.ts
@@ -29,6 +29,7 @@ const NON_REPEATABLE_FROM_MINIMAL_BASE = new Set<string>([
 /** Additional core tools not in MINIMAL_AUTO_BASE but routinely multi-called per turn. */
 const EXTRA_INHERENTLY_REPEATABLE = [
   "gsd_exec",
+  "gsd_plan_task",
   "multi_edit",
   "todo_write",
   "notebook_edit",

--- a/src/resources/extensions/gsd/guidance.ts
+++ b/src/resources/extensions/gsd/guidance.ts
@@ -54,13 +54,21 @@ const RECOVERY_REMEDIATION: Record<RecoveryGuidanceKey, string> = {
     "A derived Phase edge rejected by the Phase Transition Invariant survived reconciliation; inspect deriveState and the State Reconciliation Module before resuming.",
   "projection-lock-transient":
     "Another Windows process temporarily holds the projection root. Retry through the existing transient budget; if contention persists, use `/gsd doctor` to inspect stale workers and orphaned worktrees.",
-  "runtime-unknown": "Inspect the runtime error and add a dedicated classification if it is repeatable.",
+  "runtime-unknown":
+    "Inspect the observed runtime error, then recover with /gsd doctor and /gsd auto. If it repeats, add a dedicated recovery classification.",
   "provider-transient": "Retry after the provider/network condition clears.",
   "provider-permanent": "Inspect provider credentials, model entitlement, or request shape.",
 };
 
-export function recoveryRemediation(key: RecoveryGuidanceKey): string {
-  return RECOVERY_REMEDIATION[key];
+export function recoveryRemediation(key: RecoveryGuidanceKey, observedError?: string): string {
+  const catalog = RECOVERY_REMEDIATION[key];
+  if (key !== "runtime-unknown") return catalog;
+  const observed = observedError?.trim() || "an unclassified runtime error";
+  return (
+    `Runtime error: ${observed}. ` +
+    `Recovery options: inspect that error, run /gsd doctor, then /gsd auto to resume. ` +
+    `If it repeats, add a dedicated recovery classification.`
+  );
 }
 
 // ─── Milestone validation blockers ──────────────────────────────────────

--- a/src/resources/extensions/gsd/out-of-surface-blocker.ts
+++ b/src/resources/extensions/gsd/out-of-surface-blocker.ts
@@ -1,0 +1,32 @@
+// Named execute-task / run-uat blocker when a plan needs a tool the unit cannot call.
+
+export const OUT_OF_SURFACE_TOOL_BLOCKER = "out-of-surface-tool";
+
+export type BlockerRoute = "surface-widen" | "replan";
+
+const CATEGORY_RE = /\bout-of-surface-tool\b/i;
+
+export function extractBlockerCategory(
+  ...texts: Array<string | undefined | null>
+): string | undefined {
+  for (const text of texts) {
+    if (typeof text === "string" && CATEGORY_RE.test(text)) {
+      return OUT_OF_SURFACE_TOOL_BLOCKER;
+    }
+  }
+  return undefined;
+}
+
+export function routeBlockerCategory(category: string | undefined | null): BlockerRoute {
+  return category === OUT_OF_SURFACE_TOOL_BLOCKER ? "surface-widen" : "replan";
+}
+
+export function outOfSurfaceBlockerGuidance(taskId: string, sliceId: string): string {
+  return [
+    `Task ${taskId} reported blocker category ${OUT_OF_SURFACE_TOOL_BLOCKER}.`,
+    `The plan needs a tool outside this unit's surface.`,
+    `Do not retry the same unit — that burns a failed attempt.`,
+    `Widen the unit tool contract for the missing tool, or replan slice ${sliceId} so the work stays inside the current surface.`,
+    `Then run /gsd auto to resume.`,
+  ].join(" ");
+}

--- a/src/resources/extensions/gsd/prompts/execute-task.md
+++ b/src/resources/extensions/gsd/prompts/execute-task.md
@@ -46,6 +46,8 @@ You execute. The inlined task plan is authoritative. Verify referenced files and
 
 **Phase boundary:** Complete only `{{taskId}}`. Do NOT call `gsd_slice_complete`, `gsd_validate_milestone`, `gsd_complete_milestone`, complete any other task, or spawn `Workflow`. The orchestrator owns slice/milestone closure and phase transitions.
 
+**Out-of-surface blocker:** If the plan legitimately requires a tool outside this unit's surface (for example `gsd_requirement_*` or slice-closure tools), do **not** call that tool. Call `gsd_task_complete` with `blockerDiscovered: true` and name category `out-of-surface-tool` in `narrative` / `knownIssues`. The orchestrator routes that category to a surface-widening or human path instead of a generic failed attempt.
+
 **Background process rule:** never run bare `command &`. Redirect output first, e.g. `command > /dev/null 2>&1 &`, or use `bg_shell` when available.
 
 ## Gates And Verification
@@ -71,7 +73,7 @@ You write task closeout artifacts; **GSD auto-mode** decides when the task is ac
 - For downstream-impacting ambiguity that cannot be resolved from code, plans, or decisions, include an `escalation` object with question, options, recommendation, rationale, and `continueWithDefault`.
 - Capture meaningful architecture/pattern/observability decisions with `gsd_capture_thought` (or MCP-scoped `mcp__...__gsd_capture_thought`) when workflow MCP tools are presented; capture non-obvious gotchas or conventions only when they save future investigation.
 - Use the inlined Task Summary template below. Read `{{taskSummaryTemplatePath}}` only if the inlined template is absent or visibly truncated.
-- Call `gsd_task_complete` with camelCase fields `milestoneId`, `sliceId`, `taskId`, `oneLiner`, `narrative`, `verification`, and `verificationEvidence`. Include `blockerDiscovered: true` when a stale-path safety failure or other plan-invalidating blocker prevents execution.
+- Call `gsd_task_complete` with camelCase fields `milestoneId`, `sliceId`, `taskId`, `oneLiner`, `narrative`, `verification`, and `verificationEvidence`. Include `blockerDiscovered: true` when a stale-path safety failure, out-of-surface-tool need, or other plan-invalidating blocker prevents execution.
 - The DB-backed tool is the canonical write path. Do **not** manually write `{{taskSummaryPath}}` or edit PLAN.md checkboxes; the tool renders the summary and updates state.
 - Do not run git commands; the system commits from your summary.
 

--- a/src/resources/extensions/gsd/prompts/run-uat.md
+++ b/src/resources/extensions/gsd/prompts/run-uat.md
@@ -37,7 +37,9 @@ You are the UAT runner. Execute every check defined in `{{uatPath}}` as deeply a
 
 ### Evidence tools
 
-The **Tool Surface** block prepended above lists unavailable tools for this unit. In short:
+The **Tool Surface** block prepended above lists unavailable tools for this unit. If a UAT check legitimately requires a tool outside this unit's surface, do **not** call that tool. Record the check as `NEEDS-HUMAN` (or overall `PARTIAL`) and name category `out-of-surface-tool` in `notes` so the orchestrator can widen the surface or ask a human — do not burn a failed attempt by calling the blocked tool.
+
+In short:
 
 - Run automated checks with `gsd_uat_exec`
   - Use `uat-artifact-check` as `intent` for static file, grep, structure, or artifact checks.

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -68,7 +68,7 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
       action: transient ? "retry" : "escalate",
       reason: message,
       exitReason: `provider-${providerClass.kind}`,
-      remediation: recoveryRemediation(transient ? "provider-transient" : "provider-permanent"),
+      remediation: recoveryRemediation(transient ? "provider-transient" : "provider-permanent", message),
       providerClass: providerClass.kind,
     };
   }
@@ -79,7 +79,7 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
     action,
     reason: label ? `${label}${unitSuffix(input)}: ${message}` : message,
     exitReason: failureKind,
-    remediation: recoveryRemediation(failureKind),
+    remediation: recoveryRemediation(failureKind, message),
   };
 }
 

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -35,6 +35,10 @@ import {
   needsAttentionBlockerGuidance as formatNeedsAttentionBlocker,
   needsRemediationBlockerGuidance as formatNeedsRemediationBlocker,
 } from '../../guidance.js';
+import {
+  outOfSurfaceBlockerGuidance,
+  routeBlockerCategory,
+} from '../../out-of-surface-blocker.js';
 import { detectPendingEscalation } from '../../escalation.js';
 import { countUnmappedActiveRequirements, formatCompletePhaseNextAction } from '../../requirements-backlog.js';
 import { logWarning } from '../../workflow-logger.js';
@@ -598,6 +602,18 @@ export async function deriveStateFromDb(
 
   const blockerTaskId = await detectBlockers(basePath, activeMilestone.id, activeSlice.id, tasks);
   if (blockerTaskId) {
+    const blockerTask = tasks.find((task) => task.id === blockerTaskId);
+    if (routeBlockerCategory(blockerTask?.blocker_source) === "surface-widen") {
+      return buildDerivedState(
+        activeTaskStateContext,
+        "escalating-task",
+        outOfSurfaceBlockerGuidance(blockerTaskId, activeSlice.id),
+        {
+          blockers: [outOfSurfaceBlockerGuidance(blockerTaskId, activeSlice.id)],
+          includeActiveWorkspace: true,
+        },
+      );
+    }
     const replanHistory = getReplanHistory(activeMilestone.id, activeSlice.id);
     if (replanHistory.length === 0) {
       return buildDerivedState(

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -20,6 +20,7 @@ import {
   insertRequirement,
   insertSlice,
   insertTask,
+  setTaskBlockerSource,
   getAllMilestones,
   setMilestoneQueueOrder,
   transaction,
@@ -294,6 +295,33 @@ describe('derive-state-helpers', () => {
 
       assert.equal(state.phase, 'replanning-slice', 'blocker: phase is replanning-slice');
       assert.ok(state.blockers.some(b => b.includes('T02')), 'blocker: blockers mention T02');
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('out-of-surface-tool blocker routes to escalating-task, not a burned replan (#1693)', async () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
+      writeFile(base, 'milestones/M001/slices/S01/S01-PLAN.md', PLAN_CONTENT);
+      writeFile(base, 'milestones/M001/slices/S01/tasks/.gitkeep', '');
+      writeFile(base, 'milestones/M001/slices/S01/tasks/T01-PLAN.md', '# T01 Plan');
+
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+      insertSlice({ id: 'S01', milestoneId: 'M001', title: 'First', status: 'active', risk: 'low', depends: [] });
+      insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'First Task', status: 'pending' });
+      insertTask({ id: 'T02', sliceId: 'S01', milestoneId: 'M001', title: 'Blocked Task', status: 'complete', blockerDiscovered: true });
+      setTaskBlockerSource('M001', 'S01', 'T02', 'out-of-surface-tool');
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+
+      assert.equal(state.phase, 'escalating-task');
+      assert.match(state.blockers.join(' '), /out-of-surface-tool/);
+      assert.match(state.blockers.join(' '), /Do not retry the same unit/);
     } finally {
       closeDatabase();
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/execute-task-rendering.test.ts
+++ b/src/resources/extensions/gsd/tests/execute-task-rendering.test.ts
@@ -53,6 +53,7 @@ test("execute-task prompt renders compact execution and completion gates", async
   assert.match(prompt, /Build real behavior/);
   assert.match(prompt, /Background process rule/);
   assert.match(prompt, /blocker_discovered: true/);
+  assert.match(prompt, /out-of-surface-tool/);
   assert.match(prompt, /Use the inlined Task Summary template below/);
   assert.match(prompt, /Read `C:\\Users\\Test\\.gsd\\agent\\extensions\\gsd\\templates\\task-summary\.md` only if the inlined template is absent or visibly truncated/);
   assert.match(prompt, /### Output Template: Task Summary/);

--- a/src/resources/extensions/gsd/tests/guidance.test.ts
+++ b/src/resources/extensions/gsd/tests/guidance.test.ts
@@ -70,6 +70,21 @@ describe("guidance catalog", () => {
     }
   });
 
+  test("runtime-unknown names the observed error and recovery options (#1693)", () => {
+    const text = recoveryRemediation("runtime-unknown", "ENOENT: missing /tmp/unit.lock");
+    assert.match(text, /ENOENT: missing \/tmp\/unit\.lock/);
+    assert.match(text, /\/gsd doctor/);
+    assert.match(text, /\/gsd auto/);
+    assert.match(text, /dedicated recovery classification/);
+  });
+
+  test("classifyFailure runtime-unknown remediation includes the thrown message", () => {
+    const result = classifyFailure({ error: new Error("unclassified foobar widget") });
+    assert.equal(result.failureKind, "runtime-unknown");
+    assert.match(result.remediation, /unclassified foobar widget/);
+    assert.match(result.remediation, /\/gsd doctor/);
+  });
+
   test("formatGuidance numbers steps under the summary", () => {
     const text = formatGuidance({ summary: "It broke.", steps: ["Fix it.", "Retry."] });
     assert.equal(text, "It broke.\n\n1. Fix it.\n2. Retry.");

--- a/src/resources/extensions/gsd/tests/out-of-surface-blocker.test.ts
+++ b/src/resources/extensions/gsd/tests/out-of-surface-blocker.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extractBlockerCategory,
+  OUT_OF_SURFACE_TOOL_BLOCKER,
+  outOfSurfaceBlockerGuidance,
+  routeBlockerCategory,
+} from "../out-of-surface-blocker.ts";
+
+test("extractBlockerCategory finds the named out-of-surface category (#1693)", () => {
+  assert.equal(extractBlockerCategory("Need gsd_requirement_update"), undefined);
+  assert.equal(
+    extractBlockerCategory("blockerCategory: out-of-surface-tool"),
+    OUT_OF_SURFACE_TOOL_BLOCKER,
+  );
+  assert.equal(
+    extractBlockerCategory(undefined, "OUT-OF-SURFACE-TOOL required"),
+    OUT_OF_SURFACE_TOOL_BLOCKER,
+  );
+});
+
+test("routeBlockerCategory sends out-of-surface-tool to surface-widen, not replan", () => {
+  assert.equal(routeBlockerCategory(undefined), "replan");
+  assert.equal(routeBlockerCategory("reject-escalation"), "replan");
+  assert.equal(routeBlockerCategory(OUT_OF_SURFACE_TOOL_BLOCKER), "surface-widen");
+});
+
+test("out-of-surface guidance names the category and avoids a burned retry", () => {
+  const text = outOfSurfaceBlockerGuidance("T01", "S01");
+  assert.match(text, /out-of-surface-tool/);
+  assert.match(text, /Do not retry the same unit/);
+  assert.match(text, /Widen the unit tool contract|replan slice S01/);
+  assert.match(text, /\/gsd auto/);
+});

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -134,6 +134,7 @@ test("run-uat prompt branches on dynamic UAT mode and supports runtime evidence"
   assert.match(prompt, /live-runtime/);
   assert.match(prompt, /browser\/runtime\/network/i);
   assert.match(prompt, /NEEDS-HUMAN/);
+  assert.match(prompt, /out-of-surface-tool/);
   assert.doesNotMatch(prompt, /uatType:\s*artifact-driven/);
   assert.doesNotMatch(prompt, /Call `gsd_summary_save`/);
 });

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -424,6 +424,24 @@ console.log('\n── Loop guard: non-exempt repeatable tools get high cap ─�
 // default cap (6), not the repeatable cap (15).
 // ═══════════════════════════════════════════════════════════════════════════
 
+console.log('\n── Loop guard: gsd_plan_task is inherently repeatable (#1739) ──');
+
+{
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 8; i++) {
+    const result = checkToolCallLoop('gsd_plan_task', { taskId: `T0${i}`, title: `Task ${i}` });
+    assert.ok(result.block === false, `distinct gsd_plan_task call ${i} should be allowed`);
+  }
+
+  resetToolCallLoopGuard();
+  for (let i = 1; i <= 4; i++) {
+    const result = checkToolCallLoop('gsd_plan_task', { taskId: 'T01', title: 'Same' });
+    assert.ok(result.block === false, `identical gsd_plan_task call ${i} should be allowed`);
+  }
+  const identicalBlocked = checkToolCallLoop('gsd_plan_task', { taskId: 'T01', title: 'Same' });
+  assert.ok(identicalBlocked.block === true, '7th identical-args gsd_plan_task must still trip Guard 1');
+}
+
 console.log('\n── Loop guard: ToolSearch (excluded from repeatable set) hits default cap ──');
 
 {

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -67,6 +67,7 @@ import {
   escalationArtifactPath,
   writeEscalationArtifact,
 } from "../escalation.js";
+import { extractBlockerCategory } from "../out-of-surface-blocker.js";
 
 export interface CompleteTaskResult {
   taskId: string;
@@ -373,7 +374,9 @@ function paramsToTaskRow(params: CompleteTaskParams, completedAt: string): TaskR
     observability_impact: "",
     full_plan_md: "",
     sequence: 0,
-    blocker_source: "",
+    blocker_source: params.blockerDiscovered
+      ? extractBlockerCategory(params.narrative, params.knownIssues, params.oneLiner) ?? ""
+      : "",
     escalation_pending: 0,
     escalation_awaiting_review: 0,
     escalation_artifact_path: null,


### PR DESCRIPTION
## Change

Three scoped-unit gaps burned failed attempts on recoverable situations.

Execute-task/run-uat had no named path when a plan needed a tool outside the unit surface. The schema-overload breaker treated converging malformed payloads the same as flailing. And `gsd_plan_task` hit the default 6-call cap, so 7+ task slices were under-planned.

Closes #1787

## Outcomes

| ID | Outcome | Evidence |
| --- | --- | --- |
| O-1 | Named `out-of-surface-tool` blocker; orchestrator routes to surface-widen, not a burned attempt | Prompts document the category; `blocker_source` persist; derive-state → `escalating-task` |
| O-2 | `runtime-unknown` names the observed error and recovery options | `recoveryRemediation("runtime-unknown", "ENOENT…")` includes the error, `/gsd doctor`, `/gsd auto` |
| O-3 | Shrinking validation field sets get one narrowed retry before the breaker trips | `decideSchemaOverloadBreaker` grants retry when fields shrink; constant set still trips at 3 |
| O-4 | Distinct `gsd_plan_task` calls are inherently repeatable | 8 distinct task plans allowed; identical-args still trip Guard 1 |

## Exclusions

- X-1 — Unit tool contracts are not widened
- X-2 — Existing tool-schema → model-fallback path is unchanged
- X-3 — Identical-argument `gsd_plan_task` calls still trip the loop guard
- X-4 — Tool validation schemas themselves are unchanged

Side effects beyond the contract: none

## Checks

- out-of-surface-blocker + guidance + execute-task-rendering + prompt-contracts + tool-call-loop-guard + derive-state-helpers — pass
- `packages/pi-agent-core` schema-overload-convergence — 6/6
- `pnpm exec tsc --noEmit --project packages/pi-agent-core/tsconfig.json` — pass
- `pnpm run typecheck:extensions` — pass
- `pnpm run verify:fast` — pass

Dependency audit: not applicable

## Walkthrough

Issue walkthrough is a live execute-task / weak-model / 8-task plan session. Path-level checks cover the same branches: named blocker routes to escalate, runtime-unknown quotes the error, shrinking schema errors get one retry, and 8 distinct plan-task calls are allowed.

## Risk

Low. Prompt and routing are additive. Schema breaker still trips non-converging failures. Loop-guard identical-args behavior is unchanged.
