### PR TITLE
fix(hermes): resolve session key live instead of at registration

### DIFF
--- a/integrations/hermes/open_gsd_hermes/__init__.py
+++ b/integrations/hermes/open_gsd_hermes/__init__.py
@@ -13,6 +13,7 @@ from open_gsd_hermes.gsd_client import GsdMcpClient
 from open_gsd_hermes.inject import make_pre_llm_call_handler
 from open_gsd_hermes.memory import GsdMemoryProvider
 from open_gsd_hermes.notifications import NotificationService
+from open_gsd_hermes.session_key import resolve_session_key
 from open_gsd_hermes.supervisor import SupervisorContext, SupervisorFsm
 from open_gsd_hermes.types import BindingContext, DeliveryTarget, PluginContext
 
@@ -23,14 +24,11 @@ def register(ctx: PluginContext) -> None:
     client = GsdMcpClient(config)
     bind_store = SessionBindStore()
 
-    session_key = os.environ.get(
-        "HERMES_SESSION_KEY", "agent:main:cli:direct:local"
-    )
     binding_ctx = BindingContext(cwd=os.getcwd())
     supervisor_ctx = SupervisorContext()
 
-    def get_session_key() -> str:
-        return session_key
+    def get_session_key() -> str | None:
+        return resolve_session_key()
 
     def get_binding_ctx() -> BindingContext:
         return binding_ctx
@@ -42,12 +40,11 @@ def register(ctx: PluginContext) -> None:
         nonlocal supervisor_ctx
         supervisor_ctx = sctx
 
-    delivery_target: DeliveryTarget | None = DeliveryTarget.from_session_key(
-        session_key
-    )
-
     def get_target() -> DeliveryTarget | None:
-        return delivery_target
+        key = get_session_key()
+        if not key:
+            return None
+        return DeliveryTarget.from_session_key(key)
 
     def get_platform_channel() -> tuple[str | None, str | None]:
         t = get_target()
@@ -99,6 +96,8 @@ def register(ctx: PluginContext) -> None:
         "client": client,
         "router": router,
         "supervisor": supervisor,
+        "get_session_key": get_session_key,
+        "get_target": get_target,
     }
 
 

--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -27,7 +27,7 @@ class GsdCommandRouter:
         client: GsdMcpClient,
         bind_store: SessionBindStore,
         supervisor: SupervisorFsm,
-        get_session_key: Callable[[], str],
+        get_session_key: Callable[[], str | None],
         get_binding_ctx: Callable[[], BindingContext],
         get_supervisor_ctx: Callable[[], SupervisorContext],
         set_supervisor_ctx: Callable[[SupervisorContext], None],
@@ -82,7 +82,7 @@ class GsdCommandRouter:
         base = self._get_binding_ctx()
         return BindingContext(
             slash_path=slash_path,
-            session_bind=self._bind_store.get(sk) or base.session_bind,
+            session_bind=(self._bind_store.get(sk) if sk else None) or base.session_bind,
             platform=platform or base.platform,
             channel_id=channel or base.channel_id,
             cron_project=base.cron_project,
@@ -94,6 +94,8 @@ class GsdCommandRouter:
             return "Usage: `/gsd bind <project-path>`"
         path = rest[0]
         sk = self._get_session_key()
+        if not sk:
+            return "No live session is bound; cannot bind a project."
         try:
             project_dir = resolve_explicit_project_dir(path)
         except BindingError as e:

--- a/integrations/hermes/open_gsd_hermes/inject.py
+++ b/integrations/hermes/open_gsd_hermes/inject.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 from open_gsd_hermes.binding import BindingError, resolve_project_dir
 from open_gsd_hermes.config import GsdConfig
 from open_gsd_hermes.gsd_client import GsdMcpClient
+from open_gsd_hermes.session_key import resolve_session_key
 from open_gsd_hermes.snapshot import format_snapshot
 from open_gsd_hermes.types import BindingContext
 
@@ -19,12 +20,14 @@ def make_pre_llm_call_handler(
     """Return Hermes pre_llm_call hook that injects compact project context."""
 
     def pre_llm_call(**_kwargs: Any) -> dict[str, str]:
+        if not resolve_session_key():
+            return {}
         try:
             project_dir = resolve_project_dir(config, get_binding_ctx())
             progress = client.progress(project_dir)
             return {"context": format_snapshot(progress)}
-        except BindingError as e:
-            return {"context": f"## GSD\n{e}"}
+        except BindingError:
+            return {}
         except Exception as e:
             return {"context": f"## GSD\n(snapshot unavailable: {e})"}
 

--- a/integrations/hermes/open_gsd_hermes/session_key.py
+++ b/integrations/hermes/open_gsd_hermes/session_key.py
@@ -1,0 +1,51 @@
+"""Live Hermes session-key resolution (gateway contextvar, then env)."""
+
+from __future__ import annotations
+
+import os
+from contextvars import ContextVar, Token
+
+HERMES_SESSION_KEY_ENV = "HERMES_SESSION_KEY"
+
+_SESSION_KEY: ContextVar[str | None] = ContextVar("open_gsd_hermes_session_key", default=None)
+
+
+def bind_session_key(key: str) -> Token[str | None]:
+    """Bind a session key for the current context/thread. For tests and callers."""
+    return _SESSION_KEY.set(key)
+
+
+def reset_session_key(token: Token[str | None]) -> None:
+    _SESSION_KEY.reset(token)
+
+
+def _gateway_session_key() -> str | None:
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return None
+    try:
+        key = get_session_env(HERMES_SESSION_KEY_ENV)
+    except Exception:
+        return None
+    if isinstance(key, str) and key.strip():
+        return key
+    return None
+
+
+def resolve_session_key() -> str | None:
+    """Live session key: bound context, then gateway contextvar, then env.
+
+    Unbound context (nothing live, env unset) returns None — do not inject
+    the hardcoded ``agent:main:cli:direct:local`` default.
+    """
+    bound = _SESSION_KEY.get()
+    if bound:
+        return bound
+    live = _gateway_session_key()
+    if live:
+        return live
+    env = os.environ.get(HERMES_SESSION_KEY_ENV)
+    if env and env.strip():
+        return env
+    return None

--- a/integrations/hermes/tests/test_session_key.py
+++ b/integrations/hermes/tests/test_session_key.py
@@ -1,0 +1,114 @@
+"""Live session-key resolution (#1711 / #1788)."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import open_gsd_hermes
+from open_gsd_hermes.config import GsdConfig
+from open_gsd_hermes.inject import make_pre_llm_call_handler
+from open_gsd_hermes.session_key import (
+    bind_session_key,
+    reset_session_key,
+    resolve_session_key,
+)
+from open_gsd_hermes.types import BindingContext, DeliveryTarget
+
+
+def test_resolve_session_key_prefers_bound_context_over_env(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_SESSION_KEY", "agent:main:cli:direct:local")
+    token = bind_session_key("agent:main:telegram:thread:1:4162")
+    try:
+        assert resolve_session_key() == "agent:main:telegram:thread:1:4162"
+    finally:
+        reset_session_key(token)
+    assert resolve_session_key() == "agent:main:cli:direct:local"
+
+
+def test_resolve_session_key_uses_gateway_contextvar_before_env(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_SESSION_KEY", "agent:main:cli:direct:local")
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "gateway",
+        SimpleNamespace(),
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "gateway.session_context",
+        SimpleNamespace(get_session_env=lambda name: "agent:main:telegram:thread:9:7777"),
+    )
+    assert resolve_session_key() == "agent:main:telegram:thread:9:7777"
+
+
+def test_resolve_session_key_unbound_without_env_is_none(monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    assert resolve_session_key() is None
+
+
+def test_delivery_target_is_computed_from_live_key(monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    ctx = MagicMock()
+    monkeypatch.setattr(open_gsd_hermes, "load_config", lambda: GsdConfig())
+    monkeypatch.setattr(open_gsd_hermes, "GsdMcpClient", lambda _config: MagicMock())
+    open_gsd_hermes.register(ctx)
+    get_target = open_gsd_hermes.register._state["get_target"]
+    get_session_key = open_gsd_hermes.register._state["get_session_key"]
+
+    assert get_session_key() is None
+    assert get_target() is None
+
+    token = bind_session_key("agent:main:telegram:thread:1:4162")
+    try:
+        assert get_session_key() == "agent:main:telegram:thread:1:4162"
+        target = get_target()
+        assert target == DeliveryTarget.from_session_key("agent:main:telegram:thread:1:4162")
+        assert target is not None
+        assert target.chat_id == "1:4162"
+    finally:
+        reset_session_key(token)
+
+    token = bind_session_key("agent:main:telegram:thread:2:7777")
+    try:
+        target = get_target()
+        assert target is not None
+        assert target.chat_id == "2:7777"
+    finally:
+        reset_session_key(token)
+
+
+def test_unbound_context_does_not_inject_default_project(monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    client = MagicMock()
+    handler = make_pre_llm_call_handler(
+        MagicMock(default_project="/tmp/default-project"),
+        client,
+        lambda: BindingContext(cwd="/tmp"),
+    )
+    assert handler() == {}
+    client.progress.assert_not_called()
+
+
+def test_concurrent_threads_resolve_distinct_session_keys(monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    results: dict[str, str | None] = {}
+
+    def worker(name: str, key: str) -> None:
+        token = bind_session_key(key)
+        try:
+            results[name] = resolve_session_key()
+        finally:
+            reset_session_key(token)
+
+    threads = [
+        threading.Thread(target=worker, args=("a", "agent:main:telegram:thread:1:A")),
+        threading.Thread(target=worker, args=("b", "agent:main:telegram:thread:1:B")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results["a"] == "agent:main:telegram:thread:1:A"
+    assert results["b"] == "agent:main:telegram:thread:1:B"


### PR DESCRIPTION
## Change

The Hermes plugin captured `HERMES_SESSION_KEY` once at registration and defaulted to `agent:main:cli:direct:local`. The gateway never writes that env var — it uses a contextvar — so every session got the CLI default key and `default_project` snapshot.

`get_session_key()` now reads the live gateway context (then env). `delivery_target` is computed at send time. Unbound context is silent.

Closes #1788

## Outcomes

| ID | Outcome | Evidence |
| --- | --- | --- |
| O-1 | Live key from gateway contextvar, else env | Bind A → key A; env fallback when unbound |
| O-2 | `delivery_target` from the live key at send time | Rebind thread `1:4162` then `2:7777` updates `get_target()` without re-register |
| O-3 | Unbound context is silent | No env + no bind → `resolve_session_key()` is None; inject returns `{}` and does not call progress |
| O-4 | Concurrent threads keep distinct keys | Two threads bind A and B independently |

## Exclusions

- X-1 — Hermes gateway protocol unchanged
- X-2 — `HERMES_SESSION_KEY` remains the CLI/cron fallback
- X-3 — No new dependencies; optional `gateway.session_context` import

Side effects beyond the contract: none

## Checks

- `python3 -m pytest` in `integrations/hermes` — 99/99
- `pnpm run verify:fast` — pass

Dependency audit: not applicable

## Walkthrough

Issue walkthrough is a live gateway session. Path-level checks cover bind → send → rebind and unbound silence.

## Risk

Low. CLI with `HERMES_SESSION_KEY` set is unchanged. Unbound inject is quieter (no error footer).
