### PR TITLE
docs: explain unauthenticated LAN interlock and per-OS env examples

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -322,6 +322,26 @@ With this configuration, a Haiku-4-5 subagent sees only `gsd-workflow` and `goog
 | `GSD_TOOL_LOOP_REPEATED_REPEATABLE_CAP` | (from preferences) | Per-turn per-tool cap for inherently repeatable tools. Overrides `tool_call_loop_guard.repeated_tool.repeatable_cap`. |
 | `GSD_TOOL_LOOP_EXEMPT_TOOLS` | (from preferences) | Comma-separated tool names exempted from the per-tool cap. Added to the built-in exempt defaults and any `tool_call_loop_guard.repeated_tool.exempt_tools`. |
 
+How to set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN` (copy-paste for each OS family):
+
+```bash
+# POSIX shell (bash, zsh)
+export GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1
+gsd --web --host 0.0.0.0 --no-auth
+```
+
+```powershell
+# PowerShell
+$env:GSD_WEB_ALLOW_UNAUTHENTICATED_LAN="1"
+gsd --web --host 0.0.0.0 --no-auth
+```
+
+```bat
+REM CMD
+set GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1
+gsd --web --host 0.0.0.0 --no-auth
+```
+
 ### Developer and test environment variables
 
 These are for contributors debugging locally or running specific test tiers — not for normal use. See [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/user-docs/web-interface.md
+++ b/docs/user-docs/web-interface.md
@@ -23,9 +23,11 @@ gsd --web --host 0.0.0.0 --port 8080 --allowed-origins "https://example.com"
 | `--allowed-origins` | (none) | Comma-separated list of allowed CORS origins |
 | `--no-auth` | disabled | Disable the built-in bearer token gate |
 
-`--no-auth` leaves the web interface unprotected unless another layer controls access. By default, GSD only allows unauthenticated web mode on loopback hosts such as `127.0.0.1`, `localhost`, `::1`, or another `127.x.x.x` address. If you combine `--no-auth` or `GSD_WEB_NO_AUTH=1` with a non-loopback bind such as `--host 0.0.0.0`, startup is refused.
+`--no-auth` leaves the web interface unprotected unless another layer controls access.
 
-To deliberately run unauthenticated web mode on a LAN-facing host, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` in the same environment:
+**Unauthenticated LAN interlock.** `--no-auth` (or `GSD_WEB_NO_AUTH=1`) disables the built-in bearer token. On a non-loopback bind such as `--host 0.0.0.0`, that would expose terminal and file APIs to anyone who can reach the host. GSD therefore refuses startup unless `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` is also set. Loopback hosts (`127.0.0.1`, `localhost`, `::1`, other `127.x.x.x` addresses) are exempt — `--no-auth` works there without the override.
+
+To deliberately run unauthenticated web mode on a LAN-facing host, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` in the same environment (see [configuration.md](configuration.md) for POSIX, PowerShell, and CMD examples):
 
 ```bash
 GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 gsd --web --host 0.0.0.0 --no-auth

--- a/gitbook/features/web-interface.md
+++ b/gitbook/features/web-interface.md
@@ -23,9 +23,11 @@ gsd --web --host 0.0.0.0 --port 8080 --allowed-origins "https://example.com"
 | `--allowed-origins` | (none) | Comma-separated CORS origins |
 | `--no-auth` | disabled | Disable the built-in bearer token gate |
 
-`--no-auth` leaves the web interface unprotected unless another layer controls access. By default, GSD only allows unauthenticated web mode on loopback hosts such as `127.0.0.1`, `localhost`, `::1`, or another `127.x.x.x` address. If you combine `--no-auth` or `GSD_WEB_NO_AUTH=1` with a non-loopback bind such as `--host 0.0.0.0`, startup is refused.
+`--no-auth` leaves the web interface unprotected unless another layer controls access.
 
-To deliberately run unauthenticated web mode on a LAN-facing host, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` in the same environment:
+**Unauthenticated LAN interlock.** `--no-auth` (or `GSD_WEB_NO_AUTH=1`) disables the built-in bearer token. On a non-loopback bind such as `--host 0.0.0.0`, that would expose terminal and file APIs to anyone who can reach the host. GSD therefore refuses startup unless `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` is also set. Loopback hosts (`127.0.0.1`, `localhost`, `::1`, other `127.x.x.x` addresses) are exempt — `--no-auth` works there without the override.
+
+To deliberately run unauthenticated web mode on a LAN-facing host, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` in the same environment (see [CLI flags](../reference/cli-flags.md) for POSIX, PowerShell, and CMD examples):
 
 ```bash
 GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 gsd --web --host 0.0.0.0 --no-auth

--- a/gitbook/reference/cli-flags.md
+++ b/gitbook/reference/cli-flags.md
@@ -65,4 +65,22 @@
 | `--allowed-origins` | (none) | CORS origins |
 | `--no-auth` | disabled | Disable the built-in bearer token gate |
 
-`--no-auth` is refused on non-loopback hosts by default. To deliberately combine unauthenticated web mode with a LAN-facing bind such as `--host 0.0.0.0`, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1`; this exposes terminal and file APIs unless trusted external access control is in place.
+`--no-auth` is refused on non-loopback hosts by default (loopback is exempt). To deliberately combine unauthenticated web mode with a LAN-facing bind such as `--host 0.0.0.0`, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1`; this exposes terminal and file APIs unless trusted external access control is in place.
+
+```bash
+# POSIX shell (bash, zsh)
+export GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1
+gsd --web --host 0.0.0.0 --no-auth
+```
+
+```powershell
+# PowerShell
+$env:GSD_WEB_ALLOW_UNAUTHENTICATED_LAN="1"
+gsd --web --host 0.0.0.0 --no-auth
+```
+
+```bat
+REM CMD
+set GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1
+gsd --web --host 0.0.0.0 --no-auth
+```

--- a/src/tests/integration/web-mode-network-flags.test.ts
+++ b/src/tests/integration/web-mode-network-flags.test.ts
@@ -185,6 +185,8 @@ test('launchWebMode refuses --no-auth on non-loopback host without override', as
   assert.equal(status.ok, false)
   if (status.ok) throw new Error('expected failure')
   assert.match(status.failureReason, /refusing to disable auth/)
+  assert.match(status.failureReason, /GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1/)
+  assert.match(status.failureReason, /docs\/user-docs\/web-interface\.md/)
 })
 
 test('launchWebMode allows --no-auth on non-loopback host with explicit override', async (t) => {

--- a/src/web-mode.ts
+++ b/src/web-mode.ts
@@ -655,7 +655,7 @@ export async function launchWebMode(
       hostKind: 'unresolved',
       hostPath: null,
       hostRoot: null,
-      failureReason: `refusing to disable auth on non-loopback host ${host}: this exposes terminal and file APIs to the network. Bind to 127.0.0.1, keep token auth on, or set GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 to override.`,
+      failureReason: `refusing to disable auth on non-loopback host ${host}: this exposes terminal and file APIs to the network. Bind to 127.0.0.1, keep token auth on, or set GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 to override. See docs/user-docs/web-interface.md.`,
       candidates: [],
     }
     emitLaunchStatus(stderr, failure)


### PR DESCRIPTION
## Change

`gsd --web --no-auth` on a non-loopback host is refused unless `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1`. That interlock is intentional. The docs named the env var without explaining why or how to set it per OS, so users filed it as a bug.

This is documentation plus a pointer in the existing refusal message. The interlock itself is unchanged.

Closes #1789

## Outcomes

| ID | Outcome | Evidence |
| --- | --- | --- |
| O-1 | Web-interface docs explain the interlock, why, and loopback exemption | `docs/user-docs/web-interface.md` and `gitbook/features/web-interface.md` |
| O-2 | Per-OS examples | POSIX `export`, PowerShell `$env:…="1"`, CMD `set` in `configuration.md` and `cli-flags.md` |
| O-3 | Refusal message names the env var and the doc | Message already named the var; now also `See docs/user-docs/web-interface.md`. Interlock at web-mode.ts:665-673 untouched |

## Exclusions

- X-1 — Interlock behavior unchanged
- X-2 — No decision on whether `--no-auth` should imply the LAN override
- X-3 — Docs-only except the O-3 error pointer

Side effects beyond the contract: none

## Checks

- `launchWebMode refuses --no-auth on non-loopback host without override` — pass
- `pnpm run verify:fast` — pass

Dependency audit: not applicable

## Walkthrough

Read the refusal string and the four doc surfaces. Interlock code path is the same as PR #1323.

## Risk

Low. Docs plus one sentence on the existing refusal message.
