### PR TITLE
fix(pi-ai): run vitest in CI and close remaining suite rot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,9 @@ jobs:
           GSD_SKIP_NATIVE_PACKAGE_TESTS: ${{ needs.fast-gates.outputs.portability-changed == 'true' && '0' || '1' }}
         run: pnpm run test:packages:compiled
 
+      - name: Run pi-ai vitest suite
+        run: pnpm --filter @gsd/pi-ai test
+
       - name: Run daemon package tests
         run: pnpm run test:daemon
 

--- a/docs/dev/test-confidence-stack.md
+++ b/docs/dev/test-confidence-stack.md
@@ -44,6 +44,7 @@ same-stem test file.
 | `src/` + GSD extension | `node --test` on compiled `dist-test/` | `test:unit` | Primary app unit tests; compile via `test:compile` |
 | Extension integration suites | `node --test` + `resolve-ts.mjs` | `test:integration` | ollama, async-jobs, browser-tools, search-the-web, bg-shell, slash-commands |
 | `packages/*` | `node --test` (compiled to dist-test) | `test:packages` | Every linkable package must have ≥1 test (`verify:workspace-coverage`) |
+| `@gsd/pi-ai` vitest | `vitest --run` | `pnpm --filter @gsd/pi-ai test` | Wired into CI `build` and `verify:merge`; not covered by `test:packages` |
 | Extensions with ≥5 source files | `tests/*.test.*` required | `verify:extension-coverage` | Enforced in `verify:merge` |
 | `scripts/__tests__` | `node --test` | `verify:fast` | CI contract/policy regressions |
 | `tests/e2e/` | `node --test` against built binary | `test:e2e` | Requires `GSD_SMOKE_BINARY=dist/loader.js` |
@@ -57,7 +58,7 @@ same-stem test file.
 When `heavy-code-changed=true`, CI runs the Linux build and test stack in one job to avoid repeated checkout/setup/install/artifact restore overhead:
 
 1. `build` — compile, web host, `validate-pack`, workspace coverage gate
-2. `build` — compiled unit tests, package tests, integration tests, and e2e smoke
+2. `build` — compiled unit tests, package tests, `@gsd/pi-ai` vitest, integration tests, and e2e smoke
 3. `build` — Docker e2e when `docker-changed=true`
 
 Native package tests are skipped in the main Linux package-test step unless native/portability paths changed; otherwise a full Rust native rebuild can dominate unrelated CI runs.

--- a/packages/pi-ai/src/providers/google-shared.ts
+++ b/packages/pi-ai/src/providers/google-shared.ts
@@ -733,11 +733,11 @@ export function convertTools(
 export function mapToolChoice(choice: string): FunctionCallingConfigMode {
 	switch (choice) {
 		case "none":
-			return "NONE";
+			return "NONE" as FunctionCallingConfigMode;
 		case "any":
-			return "ANY";
+			return "ANY" as FunctionCallingConfigMode;
 		default:
-			return "AUTO";
+			return "AUTO" as FunctionCallingConfigMode;
 	}
 }
 

--- a/packages/pi-ai/src/providers/google-shared.ts
+++ b/packages/pi-ai/src/providers/google-shared.ts
@@ -2,7 +2,7 @@
  * Shared utilities for Google Generative AI and Google Vertex providers.
  */
 
-import { type Content, FinishReason, FunctionCallingConfigMode, type Part } from "@google/genai";
+import type { Content, FinishReason, FunctionCallingConfigMode, Part } from "@google/genai";
 import type { Context, ImageContent, Model, StopReason, TextContent, Tool } from "../types.js";
 import { sanitizeToolSchema } from "../utils/sanitize-tool-schema.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
@@ -732,47 +732,22 @@ export function convertTools(
  */
 export function mapToolChoice(choice: string): FunctionCallingConfigMode {
 	switch (choice) {
-		case "auto":
-			return FunctionCallingConfigMode.AUTO;
 		case "none":
-			return FunctionCallingConfigMode.NONE;
+			return "NONE";
 		case "any":
-			return FunctionCallingConfigMode.ANY;
+			return "ANY";
 		default:
-			return FunctionCallingConfigMode.AUTO;
+			return "AUTO";
 	}
 }
 
 /**
  * Map Gemini FinishReason to our StopReason.
  */
-export function mapStopReason(reason: FinishReason): StopReason {
-	switch (reason) {
-		case FinishReason.STOP:
-			return "stop";
-		case FinishReason.MAX_TOKENS:
-			return "length";
-		case FinishReason.BLOCKLIST:
-		case FinishReason.PROHIBITED_CONTENT:
-		case FinishReason.SPII:
-		case FinishReason.SAFETY:
-		case FinishReason.IMAGE_SAFETY:
-		case FinishReason.IMAGE_PROHIBITED_CONTENT:
-		case FinishReason.IMAGE_RECITATION:
-		case FinishReason.IMAGE_OTHER:
-		case FinishReason.RECITATION:
-		case FinishReason.FINISH_REASON_UNSPECIFIED:
-		case FinishReason.OTHER:
-		case FinishReason.LANGUAGE:
-		case FinishReason.MALFORMED_FUNCTION_CALL:
-		case FinishReason.UNEXPECTED_TOOL_CALL:
-		case FinishReason.NO_IMAGE:
-			return "error";
-		default: {
-			const _exhaustive: never = reason;
-			throw new Error(`Unhandled stop reason: ${_exhaustive}`);
-		}
-	}
+export function mapStopReason(reason: FinishReason | string | undefined): StopReason {
+	if (reason === "STOP") return "stop";
+	if (reason === "MAX_TOKENS") return "length";
+	return "error";
 }
 
 /**

--- a/packages/pi-ai/test/faux-provider.test.ts
+++ b/packages/pi-ai/test/faux-provider.test.ts
@@ -590,8 +590,9 @@ describe("faux provider", () => {
 		registration.setResponses([fauxAssistantMessage("hello")]);
 		registration.unregister();
 
+		const model = registration.getModel();
 		await expect(
-			complete(registration.getModel(), { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] }),
-		).rejects.toThrow(`No API provider registered for api: ${registration.api}`);
+			complete(model, { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] }),
+		).rejects.toThrow(`No API provider registered for provider/api: ${model.provider}/${registration.api}`);
 	});
 });

--- a/packages/pi-ai/test/google-shared-convert-tools.test.ts
+++ b/packages/pi-ai/test/google-shared-convert-tools.test.ts
@@ -232,7 +232,6 @@ describe("google-shared convertTools", () => {
 				runtime: {
 					type: "string",
 					enum: ["bash", "node", "python"],
-					description: "Interpreter: bash (-c), node (-e), or python3 (-c).",
 				},
 			},
 			required: ["runtime"],
@@ -260,7 +259,6 @@ describe("google-shared convertTools", () => {
 		expect(runtime?.mode).toEqual({
 			type: "string",
 			enum: ["build", "query"],
-			description: "build = recompute graph, query = inspect edges",
 		});
 	});
 
@@ -394,7 +392,6 @@ describe("google-shared convertTools", () => {
 		expect(properties?.keyFiles).toEqual({
 			type: "array",
 			items: { type: "string" },
-			description: "Key files created or modified",
 		});
 		expect(properties?.verificationEvidence).toEqual({
 			type: "array",
@@ -405,7 +402,6 @@ describe("google-shared convertTools", () => {
 					exitCode: { type: "number" },
 				},
 				required: ["command", "exitCode"],
-				description: "Structured object preferred; a plain string fallback is also accepted.",
 			},
 		});
 	});

--- a/packages/pi-ai/test/google-shared-gemini3-unsigned-tool-call.test.ts
+++ b/packages/pi-ai/test/google-shared-gemini3-unsigned-tool-call.test.ts
@@ -62,7 +62,7 @@ function makeContext(model: { api: string; provider: string; id: string }, thoug
 }
 
 describe("google-shared convertMessages — Gemini 3 unsigned tool calls", () => {
-	it("does not add skip_thought_signature_validator for unsigned Google Gen AI tool calls", () => {
+	it("adds skip_thought_signature_validator for unsigned Google Gen AI tool calls", () => {
 		const model = makeGemini3Model("google-generative-ai", "google");
 		const contents = convertMessages(model, makeContext({ ...model, id: "other-model" }));
 
@@ -71,25 +71,23 @@ describe("google-shared convertMessages — Gemini 3 unsigned tool calls", () =>
 
 		const functionCallParts = modelTurn?.parts?.filter((p) => p.functionCall !== undefined) ?? [];
 		expect(functionCallParts).toHaveLength(2);
-		expect(functionCallParts[0]?.thoughtSignature).toBeUndefined();
-		expect(functionCallParts[1]?.thoughtSignature).toBeUndefined();
-		expect(JSON.stringify(modelTurn)).not.toContain("skip_thought_signature_validator");
+		expect(functionCallParts[0]?.thoughtSignature).toBe("skip_thought_signature_validator");
+		expect(functionCallParts[1]?.thoughtSignature).toBe("skip_thought_signature_validator");
 
 		const textParts = modelTurn?.parts?.filter((p) => p.text !== undefined) ?? [];
 		const historicalText = textParts.filter((p) => p.text?.includes("Historical context"));
 		expect(historicalText).toHaveLength(0);
 	});
 
-	it("does not add skip_thought_signature_validator for unsigned Vertex tool calls", () => {
+	it("adds skip_thought_signature_validator for unsigned Vertex tool calls", () => {
 		const model = makeGemini3Model("google-vertex", "google-vertex");
 		const contents = convertMessages(model, makeContext(model));
 		const modelTurn = contents.find((c) => c.role === "model");
 		const functionCallParts = modelTurn?.parts?.filter((p) => p.functionCall !== undefined) ?? [];
 
 		expect(functionCallParts).toHaveLength(2);
-		expect(functionCallParts[0]?.thoughtSignature).toBeUndefined();
-		expect(functionCallParts[1]?.thoughtSignature).toBeUndefined();
-		expect(JSON.stringify(modelTurn)).not.toContain("skip_thought_signature_validator");
+		expect(functionCallParts[0]?.thoughtSignature).toBe("skip_thought_signature_validator");
+		expect(functionCallParts[1]?.thoughtSignature).toBe("skip_thought_signature_validator");
 	});
 
 	it("preserves valid thoughtSignature when present for the same provider and model", () => {
@@ -101,7 +99,7 @@ describe("google-shared convertMessages — Gemini 3 unsigned tool calls", () =>
 
 		expect(functionCallParts).toHaveLength(2);
 		expect(functionCallParts[0]?.thoughtSignature).toBe(validSig);
-		expect(functionCallParts[1]?.thoughtSignature).toBeUndefined();
+		expect(functionCallParts[1]?.thoughtSignature).toBe("skip_thought_signature_validator");
 	});
 
 	it("does not add a thoughtSignature for non-Gemini-3 models", () => {

--- a/scripts/verify-merge.sh
+++ b/scripts/verify-merge.sh
@@ -33,6 +33,9 @@ pnpm run test:unit
 echo "── test:packages ──"
 pnpm run test:packages
 
+echo "── test:pi-ai (vitest) ──"
+pnpm --filter @gsd/pi-ai test
+
 echo "── test:integration ──"
 pnpm run test:integration
 

--- a/src/resources/extensions/gsd/tests/headless-auto-pause-roadmap-fixture.test.ts
+++ b/src/resources/extensions/gsd/tests/headless-auto-pause-roadmap-fixture.test.ts
@@ -1,0 +1,104 @@
+// Project/App: gsd-pi
+// File Purpose: #1774 fixture contract — recovered ROADMAP must stay
+// git-tracked so auto-start cannot migrate .gsd/ out from under pass-0
+// reconciliation (roadmap-missing flake).
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test } from "node:test";
+
+import { hasGitTrackedGsdFiles } from "../gitignore.ts";
+import { migrateToExternalState } from "../migrate-external.ts";
+import { resolveMilestoneFile } from "../paths.ts";
+
+function git(dir: string, args: string[]): string {
+  return execFileSync("git", args, { cwd: dir, stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" }).trim();
+}
+
+function writeRecoveredRoadmap(dir: string): string {
+  const milestoneDir = join(dir, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  const roadmapPath = join(milestoneDir, "M001-ROADMAP.md");
+  writeFileSync(
+    roadmapPath,
+    [
+      "# M001: Provider Pause Fixture",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Update answer** `risk:low` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+  return roadmapPath;
+}
+
+function makeRepo(gitignore: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-1774-")));
+  git(dir, ["init", "--initial-branch=main"]);
+  git(dir, ["config", "user.email", "e2e@gsd.test"]);
+  git(dir, ["config", "user.name", "GSD E2E"]);
+  writeFileSync(join(dir, ".gitignore"), gitignore);
+  writeFileSync(join(dir, "README.md"), "# fixture\n");
+  git(dir, ["add", ".gitignore", "README.md"]);
+  git(dir, ["commit", "-m", "test: seed"]);
+  return dir;
+}
+
+const created: string[] = [];
+afterEach(() => {
+  for (const dir of created.splice(0)) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* tmp */ }
+  }
+});
+
+test("#1774: umbrella .gsd ignore leaves recovered ROADMAP untracked", () => {
+  const dir = makeRepo(".gsd/\n");
+  created.push(dir);
+  writeRecoveredRoadmap(dir);
+  assert.equal(
+    hasGitTrackedGsdFiles(dir),
+    false,
+    "ignored ROADMAP must stay untracked — that is the flake setup",
+  );
+});
+
+test("#1774: tracked recovered ROADMAP stays resolvable and skips external migration", () => {
+  const dir = makeRepo(".gsd/worktrees/\n");
+  created.push(dir);
+  const roadmapPath = writeRecoveredRoadmap(dir);
+  git(dir, ["add", ".gsd/milestones/M001/M001-ROADMAP.md"]);
+  git(dir, ["commit", "-m", "test: seed recovered milestone projections"]);
+
+  assert.equal(hasGitTrackedGsdFiles(dir), true, "committed ROADMAP must count as tracked .gsd state");
+
+  const previousStateDir = process.env.GSD_STATE_DIR;
+  const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-1774-state-")));
+  created.push(stateDir);
+  process.env.GSD_STATE_DIR = stateDir;
+  try {
+    const result = migrateToExternalState(dir);
+    assert.equal(result.migrated, false, "tracked projections must skip external migration");
+    assert.equal(result.error, undefined, "skip is silent, not an error");
+  } finally {
+    if (previousStateDir === undefined) delete process.env.GSD_STATE_DIR;
+    else process.env.GSD_STATE_DIR = previousStateDir;
+  }
+
+  assert.ok(existsSync(roadmapPath), "ROADMAP must remain at the in-project path");
+  assert.equal(
+    resolveMilestoneFile(dir, "M001", "ROADMAP"),
+    roadmapPath,
+    "pass-0 reconciliation must see the recovered ROADMAP",
+  );
+});

--- a/tests/e2e/headless-auto-pause-blocked.e2e.test.ts
+++ b/tests/e2e/headless-auto-pause-blocked.e2e.test.ts
@@ -50,6 +50,17 @@ function recoverFixture(dir: string): ReturnType<typeof gsdSync> {
 	return gsdSync(["headless", "recover", `--preview=${previewHash}`], { cwd: dir, timeoutMs: 30_000 });
 }
 
+function commitRecoveredMilestone(dir: string): void {
+	// Track projections so auto-start's migrateToExternalState aborts (#1364).
+	// An ignored in-project .gsd/ is eligible for that move, and pass-0
+	// reconciliation then flakes on roadmap-missing instead of the provider error.
+	commitPaths(dir, [
+		".gsd/milestones/M001/M001-CONTEXT.md",
+		".gsd/milestones/M001/M001-ROADMAP.md",
+		".gsd/milestones/M001/slices/S01/S01-PLAN.md",
+	], "test: seed recovered milestone projections");
+}
+
 function writeRecoveredMilestone(dir: string): void {
 	const milestoneDir = join(dir, ".gsd", "milestones", "M001");
 	const sliceDir = join(milestoneDir, "slices", "S01");
@@ -204,7 +215,7 @@ describe("headless auto pause e2e (fake LLM)", () => {
 		const project = createTmpProject({
 			git: true,
 			files: {
-				".gitignore": ".gsd/\n",
+				".gitignore": ".gsd/worktrees/\n",
 				"package.json": JSON.stringify({ type: "module", scripts: { test: "node --test test/answer.test.js" } }, null, 2) + "\n",
 				"src/answer.js": "export function answer() {\n\treturn \"pending\";\n}\n",
 				"test/answer.test.js": [
@@ -222,12 +233,17 @@ describe("headless auto pause e2e (fake LLM)", () => {
 		t.after(project.cleanup);
 		commitFixture(project.dir);
 		writeRecoveredMilestone(project.dir);
+		commitRecoveredMilestone(project.dir);
 
 		const recover = recoverFixture(project.dir);
 		assert.equal(
 			recover.code,
 			0,
 			`expected recover exit 0, got ${recover.code}. stderr=${recover.stderrClean.slice(0, 800)}`,
+		);
+		assert.ok(
+			existsSync(join(project.dir, ".gsd", "milestones", "M001", "M001-ROADMAP.md")),
+			"recovered ROADMAP must stay on disk so auto pass-0 cannot emit roadmap-missing",
 		);
 
 		const transcript = writeTranscript([


### PR DESCRIPTION
## Change

Wires `pnpm --filter @gsd/pi-ai test` into the existing CI `build` job (and `verify:merge`). Stops `google-shared.ts` from eagerly loading `@google/genai` so the barrel stays lazy. Includes the already-open #1775 assertion updates and the #1774 recovered-ROADMAP fixture so this branch is complete against current `main`.

Closes #1791

## Outcomes

| ID | Outcome | Evidence |
| --- | --- | --- |
| O-1 | pi-ai vitest runs on every heavy-code PR | `.github/workflows/ci.yml` `Run pi-ai vitest suite`; `scripts/verify-merge.sh` |
| O-2 | All listed failing tests pass or match new intent | Full `pnpm --filter @gsd/pi-ai test`: 349 passed, 0 failed (includes #1775 cluster + lazy-module-load ×3). `cross-provider-handoff` is skipped on this suite, not failing. |
| O-3 | Auto-pause e2e does not flake on pass-0 `roadmap-missing` | Cherry-picked #1774 fixture: track recovered ROADMAP so migrateToExternalState aborts |

## Exclusions

- X-1 — no tests skipped to hide failures
- X-2 — `scripts/run-package-tests.cjs` untouched
- X-3 — existing `ci.yml` `build` job; no provider/workflow migration

Side effects beyond the contract: none

## Checks

- `pnpm --filter @gsd/pi-ai test` — 349 passed, 716 skipped, 0 failed
- `headless-auto-pause-roadmap-fixture.test.ts` — 2/2
- Full e2e not run locally (`GSD_SMOKE_BINARY` unset); CI `build` runs it

Dependency audit: not applicable

## Walkthrough

This PR's CI `build` job must run `Run pi-ai vitest suite` and pass. Overlaps open #1815 (O-3) and #1816 (7 of O-2); those PRs become empty/conflicting if this merges first.

## Risk

Low — type-only import + string-literal mapping (same AUTO/NONE/ANY and STOP/MAX_TOKENS/error results); CI adds one existing package script.

Dependency audit for 23be426cce2d4ecc8c1f0073cfc331c99ff3af12: baseline compared
```json
{
  "schema": "gsd-loop/dependency-audit-v1",
  "baselineSha": "287c88f48ec7a77195588aa0ff55225ade265a5f",
  "headSha": "23be426cce2d4ecc8c1f0073cfc331c99ff3af12",
  "audits": []
}
```