### PR TITLE
ci: run CI for merge queue entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ on:
       - '.github/workflows/build-native.yml'
       - '.github/workflows/cleanup-dev-versions.yml'
       - 'LICENSE'
+  # Merge queue entries report ci-gate from this event. merge_group does not
+  # support path filters, so it is declared bare rather than mirroring the
+  # paths-ignore lists above.
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

`main` is guarded by the `gsd-loop required CI` ruleset, which requires `ci-gate` with `strict_required_status_checks_policy: true`. Every merge therefore pushes all other open PRs to `BEHIND`, and only one PR can merge per CI cycle. With 25+ open PRs that cannot converge by updating branches.

A GitHub merge queue fixes this by batching entries — but the queue reports its required checks from `merge_group` events. This workflow only triggered on `push` and `pull_request`, so `ci-gate` would never report for a queued entry and **all** merging would jam.

This PR is the prerequisite. **It must merge before the merge queue is enabled on `main`.**

## Change

One trigger key. `merge_group` does not support `paths-ignore`, so it is declared bare rather than mirroring the filters on the other two triggers.

## Why no script changes

Both helpers already degrade correctly when no PR base sha is present, which is the `merge_group` case:

- `scripts/ci-fetch-diff-base.sh` — `BASE_REF="\${BASE_REF:-main}"` resolves the empty `github.base_ref` to `main`, so `CI_DIFF_REF` becomes `origin/main`.
- `scripts/ci-classify-changes.sh` — with `EVENT_NAME=merge_group` and both `PR_BASE_SHA` and `PUSH_BEFORE_SHA` empty, it falls through to `BASE="\${CI_DIFF_REF:-origin/main}"` and diffs the merge-group head against `origin/main`. For a batched entry that diff is the union of the queued PRs' changes, which is the intended classification input.

`ci-gate` is `if: always()` over its `needs`, so it reports on any event the workflow runs on. The concurrency group falls back to `github.run_id` when `github.event.pull_request` is absent, so queue runs are never cancelled by one another — required behaviour for a merge queue.

## Verification

No unit test applies to a workflow trigger; the check is CI itself. Confirmed locally that the file still parses and exposes `push`, `pull_request`, `merge_group`, `workflow_dispatch`. Real verification is `ci-gate` reporting on the `merge_group` event once the queue is enabled.