### PR TITLE
fix(issue): Auto-mode: complete-slice tool error is finalized as "next" (no-artifact never converted to a retry → deterministic liveness wedge)

### DIFF
--- a/src/resources/extensions/gsd/auto/unit-phase.ts
+++ b/src/resources/extensions/gsd/auto/unit-phase.ts
@@ -42,6 +42,7 @@ import { classifyError, isTransient } from "../error-classifier.js";
 import { setCurrentPhase, clearCurrentPhase } from "../../shared/gsd-phase-state.js";
 import { setAutoActiveStatus } from "../auto-dashboard.js";
 import { runUnit } from "./run-unit.js";
+import { verificationRetryKey } from "./verification-retry-policy.js";
 import { validateSourceWriteWorktreeSafety } from "./worktree-safety-phase.js";
 import { isTaskExecutionReadyForHostVerification } from "./task-execution-cutover.js";
 import {
@@ -977,6 +978,64 @@ export async function runUnitPhase(
       debugLog("runUnitPhase", { phase: "checkpoint-cleaned", unitId });
     }
     s.checkpointSha = null;
+  }
+
+  if (unitEndStatus === "no-artifact" && unitType === "complete-slice") {
+    let failedToolResult: { toolName?: unknown; content?: unknown } | undefined;
+    const messages = s.lastUnitAgentEndMessages;
+    if (Array.isArray(messages)) {
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i];
+        if (!message || typeof message !== "object") continue;
+        const result = message as { role?: unknown; toolName?: unknown; isError?: unknown; content?: unknown };
+        const toolName = typeof result.toolName === "string" ? result.toolName : "";
+        if (
+          result.role === "toolResult" &&
+          result.isError === true &&
+          (toolName.endsWith("gsd_slice_complete") || toolName.endsWith("gsd_complete_slice"))
+        ) {
+          failedToolResult = result;
+          break;
+        }
+      }
+    }
+    const toolResultContent = failedToolResult?.content;
+    const extractedToolError = typeof toolResultContent === "string"
+      ? toolResultContent.trim()
+      : Array.isArray(toolResultContent)
+        ? toolResultContent
+            .filter((part): part is { text: string } =>
+              Boolean(part) && typeof part === "object" && typeof (part as { text?: unknown }).text === "string")
+            .map(part => part.text)
+            .join("\n")
+            .trim()
+        : null;
+    const toolError = extractedToolError || (failedToolResult
+      ? `${String(failedToolResult.toolName)} returned an error`
+      : null);
+    if (toolError) {
+      const retryKey = verificationRetryKey(unitType, unitId);
+      const attempt = (s.verificationRetryCount.get(retryKey) ?? 0) + 1;
+      s.verificationRetryCount.set(retryKey, attempt);
+      s.pendingVerificationRetry = {
+        unitId,
+        failureContext: `gsd_slice_complete failed without writing the slice completion artifacts:\n\n${toolError}`,
+        attempt,
+      };
+      rememberRetryDispatch(s, { type: unitType, id: unitId }, iterData);
+      ctx.ui.notify(
+        `complete-slice ${unitId} returned a tool error without writing its artifacts. Retrying with the tool error context.`,
+        "warning",
+      );
+      return {
+        action: "retry",
+        reason: "complete-slice-tool-error",
+        data: {
+          unitStartedAt: _resolveCurrentUnitStartedAtForTest(s.currentUnit),
+          requestDispatchedAt: unitResult.requestDispatchedAt,
+        },
+      };
+    }
   }
 
   return { action: "next", data: { unitStartedAt: _resolveCurrentUnitStartedAtForTest(s.currentUnit), requestDispatchedAt: unitResult.requestDispatchedAt } };

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -440,6 +440,55 @@ test("runUnitPhase emits unit-start and unit-end with causedBy reference", async
   assert.equal(endEvents[0].causedBy!.seq, startEvents[0].seq, "unit-end causedBy.seq must match unit-start.seq");
 });
 
+test("runUnitPhase retries complete-slice tool errors with their failure context", async () => {
+  const capture = createEventCapture();
+  const { resolveAgentEnd, _resetPendingResolve } = await import("../auto/resolve.js");
+  _resetPendingResolve();
+
+  const deps = makeMockDeps(capture);
+  const ic = makeIC(deps);
+  const iterData: IterationData = {
+    unitType: "complete-slice",
+    unitId: "M001/S01",
+    prompt: "complete the slice",
+    finalPrompt: "complete the slice",
+    pauseAfterUatDispatch: false,
+    state: { phase: "summarizing", activeMilestone: { id: "M001" }, activeSlice: { id: "S01" }, registry: [], blockers: [] } as any,
+    mid: "M001",
+    midTitle: "Test",
+    isRetry: false,
+    previousTier: undefined,
+  };
+  const loopState: LoopState = { consecutiveFinalizeTimeouts: 0 };
+  const toolError = "UAT requires browser verification. Re-author the UAT Type section and complete the slice again.";
+
+  const unitPromise = runUnitPhase(ic, iterData, loopState);
+  await new Promise(r => setTimeout(r, 50));
+  resolveAgentEnd({
+    messages: [{
+      role: "toolResult",
+      toolName: "gsd_slice_complete",
+      isError: true,
+      content: [{ type: "text", text: toolError }],
+    }],
+  });
+
+  const result = await unitPromise;
+  assert.equal(result.action, "retry");
+  assert.equal((result as { reason?: string }).reason, "complete-slice-tool-error");
+  assert.equal(
+    ic.s.pendingVerificationRetry?.failureContext,
+    `gsd_slice_complete failed without writing the slice completion artifacts:\n\n${toolError}`,
+  );
+  assert.equal(ic.s.pendingVerificationRetryDispatch?.unitType, "complete-slice");
+  assert.equal(ic.s.pendingVerificationRetryDispatch?.unitId, "M001/S01");
+
+  const endEvents = capture.events.filter(e => e.eventType === "unit-end");
+  assert.equal(endEvents.length, 1);
+  assert.equal((endEvents[0].data as any).status, "no-artifact");
+  assert.equal((endEvents[0].data as any).artifactVerified, false);
+});
+
 test("runUnitPhase increments unitDispatchCount for repeated artifact-missing retries", async () => {
   const capture = createEventCapture();
   const { resolveAgentEnd, _resetPendingResolve } = await import("../auto/resolve.js");


### PR DESCRIPTION
## Summary
- Fixed complete-slice tool errors to retry with preserved error context; focused tests and typechecking pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1794
- [#1794 Auto-mode: complete-slice tool error is finalized as "next" (no-artifact never converted to a retry → deterministic liveness wedge)](https://github.com/open-gsd/gsd-pi/issues/1794)

## User
- @sandersietses

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1794-auto-mode-complete-slice-tool-error-is-f-1786936192`