### PR TITLE
fix(issue): Bug: same-session interruptStaleAttempt guard (<=) orphans running Attempts on re-dispatch — blocks slice-complete and task-reopen permanently (1.15.0)

### DIFF
--- a/src/resources/extensions/gsd/auto/task-execution-cutover.ts
+++ b/src/resources/extensions/gsd/auto/task-execution-cutover.ts
@@ -185,42 +185,16 @@ function interruptStaleAttempt(
     // session; this stale session must not settle it, only refuse.
     throw new Error("execute-task cannot replace an active running Attempt without a newer milestone lease");
   }
-  if (identity.milestoneLeaseToken === predecessor.milestoneLeaseToken) {
-    // Settle-before-throw (#1740): same-session re-dispatch must never strand
-    // the running Attempt. A strictly newer replacement lease would use the
-    // fenced attempt.interrupt path below, but an equal token cannot — so this
-    // settles through a plain attempt.settle, which the same-session worker's
-    // own held lease authorizes (V47 dispatch-scope trigger). The throw lands
-    // in runWithTaskExecutionAttempt's settlement-guaranteeing catch, which
-    // routes the interrupted Result through durable recovery.
-    const summary = "execute-task cannot replace an active running Attempt without a newer milestone lease";
-    deps.settleTaskAttempt({
-      invocation: internalExecutionInvocation(
-        `internal:auto:attempt.settle:${predecessor.attemptId}:lease-guard`,
-        { actorId: identity.workerId },
-      ),
-      attemptId: predecessor.attemptId,
-      outcome: "interrupted",
-      failureClass: "stale-worker",
-      summary,
-      output: {
-        unitType: input.unitType,
-        unitId: input.unitId,
-        staleDispatchId: predecessor.coordinationDispatchId,
-        staleWorkerId: predecessor.workerId,
-        staleMilestoneLeaseToken: predecessor.milestoneLeaseToken,
-        rejectedDispatchId: identity.dispatchId,
-        rejectedWorkerId: identity.workerId,
-        rejectedMilestoneLeaseToken: identity.milestoneLeaseToken,
-      },
-    });
-    throw new Error(summary);
-  }
-  const summary = "Replaced stale Task Attempt after milestone lease takeover";
+  const sameSession = identity.milestoneLeaseToken === predecessor.milestoneLeaseToken;
+  const summary = sameSession
+    ? "Replaced stale Task Attempt during same-session re-dispatch"
+    : "Replaced stale Task Attempt after milestone lease takeover";
   const recovery = taskRecoveryClassification(input, "stale-worker", new Error(summary));
   const settlement = deps.settleTaskAttempt({
     invocation: internalExecutionInvocation(
-      `internal:auto:attempt.interrupt:${predecessor.attemptId}:${identity.workerId}:${identity.milestoneLeaseToken}`,
+      sameSession
+        ? `internal:auto:attempt.settle:${predecessor.attemptId}:same-session`
+        : `internal:auto:attempt.interrupt:${predecessor.attemptId}:${identity.workerId}:${identity.milestoneLeaseToken}`,
       { actorId: identity.workerId },
     ),
     attemptId: predecessor.attemptId,
@@ -242,10 +216,14 @@ function interruptStaleAttempt(
         rationale: recovery.rationale,
       },
     },
-    recovery: {
-      workerId: identity.workerId,
-      milestoneLeaseToken: identity.milestoneLeaseToken,
-    },
+    ...(sameSession
+      ? {}
+      : {
+          recovery: {
+            workerId: identity.workerId,
+            milestoneLeaseToken: identity.milestoneLeaseToken,
+          },
+        }),
   });
   return routeTaskFailure(
     input,
@@ -534,13 +512,12 @@ export async function runWithTaskExecutionAttempt(
     result = await run();
   } catch (error) {
     const summary = error instanceof Error ? error.message : String(error);
-    // Settlement guarantee (#1740): the stale-attempt guard settles the running
-    // predecessor before it throws, so when no replacement claim exists yet the
-    // catch owes that predecessor its durable failure route; otherwise the just
-    // claimed Attempt is settled as before. Failures with no running Attempt to
-    // settle (identity parsing, claim rejection) keep propagating untouched.
+    // Once an Attempt is claimed, every executor failure must settle it before
+    // returning. Failures before a claim exists keep propagating untouched.
     const attemptId = claim?.attemptId
-      ?? (predecessor?.state === "running" ? predecessor.attemptId : undefined);
+      ?? (predecessor?.state === "running" && isClaimReplay(predecessor, identity)
+        ? predecessor.attemptId
+        : undefined);
     if (!attemptId) throw error;
     return applyRecoveryDecision(
       settleRunningAttempt(input, attemptId, "executor-error", summary, deps, error),

--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -43,6 +43,7 @@ import { crashResumeHint } from "./guidance.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { effectiveLockFile } from "./session-lock.js";
 import { isInFlightRuntimePhase, listUnitRuntimeRecords, type AutoUnitRuntimeRecord } from "./unit-runtime.js";
+import { settleRunningAttemptsForWorker } from "./task-execution-domain-operation.js";
 
 export interface LockData {
   pid: number;
@@ -273,8 +274,12 @@ export function clearStaleWorkerLock(basePath: string): void {
     if (!worker) return;
     markActiveForWorkerCanceled(worker.worker_id, "crash-recovered");
     markWorkerStopping(worker.worker_id);
-    forceReleaseLeasesForWorker(worker.worker_id);
-    deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
+    try {
+      settleRunningAttemptsForWorker(worker.worker_id);
+    } finally {
+      forceReleaseLeasesForWorker(worker.worker_id);
+      deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
+    }
   } catch {
     // Best-effort.
   }

--- a/src/resources/extensions/gsd/db/writers/slice-lifecycle.ts
+++ b/src/resources/extensions/gsd/db/writers/slice-lifecycle.ts
@@ -208,6 +208,15 @@ function runningAttempt(lifecycleId: string): RunningAttempt | null {
     SELECT attempt.attempt_id, attempt.coordination_dispatch_id,
            attempt.worker_id, attempt.milestone_lease_token
     FROM workflow_execution_attempts attempt
+    JOIN workflow_item_lifecycles lifecycle
+      ON lifecycle.lifecycle_id = attempt.lifecycle_id
+     AND lifecycle.project_id = attempt.project_id
+    JOIN milestone_leases lease
+      ON lease.milestone_id = lifecycle.milestone_id
+     AND lease.worker_id = attempt.worker_id
+     AND lease.fencing_token = attempt.milestone_lease_token
+     AND lease.status = 'held'
+     AND lease.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
     WHERE attempt.lifecycle_id = :lifecycle_id
       AND attempt.attempt_state = 'running'
   `).all({ ":lifecycle_id": lifecycleId }) as Array<Record<string, unknown>>;
@@ -355,11 +364,6 @@ function currentCompletionProof(lifecycleId: string, taskId: string): SliceCompl
     WHERE lifecycle.lifecycle_id = :lifecycle_id
       AND lifecycle.item_kind = 'task'
       AND lifecycle.lifecycle_status = 'completed'
-      AND NOT EXISTS (
-        SELECT 1 FROM workflow_execution_attempts running
-        WHERE running.lifecycle_id = lifecycle.lifecycle_id
-          AND running.attempt_state = 'running'
-      )
   `).get({ ":lifecycle_id": lifecycleId }) as Record<string, unknown> | undefined;
   if (!proof) return null;
   return {

--- a/src/resources/extensions/gsd/task-execution-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-execution-domain-operation.ts
@@ -26,6 +26,7 @@ import {
 import {
   claimMilestoneLease,
   getMilestoneLease,
+  refreshMilestoneLease,
 } from "./db/milestone-leases.js";
 import { autoWorkerHeartbeatTtlSeconds } from "./db/auto-workers.js";
 import {
@@ -543,6 +544,55 @@ export function settleTaskAttempt(input: SettleTaskAttemptInput): SettleTaskAtte
     resultId: result.result_id,
     nextStage: nextStage(result.outcome),
   };
+}
+
+export function settleRunningAttemptsForWorker(workerId: string): string[] {
+  if (!isDbAvailable()) return [];
+  const attempts = getDb().prepare(`
+    SELECT attempt.attempt_id, attempt.milestone_lease_token,
+           lifecycle.milestone_id
+    FROM workflow_execution_attempts attempt
+    JOIN workflow_item_lifecycles lifecycle
+      ON lifecycle.lifecycle_id = attempt.lifecycle_id
+     AND lifecycle.project_id = attempt.project_id
+    WHERE attempt.worker_id = :worker_id
+      AND attempt.attempt_state = 'running'
+      AND lifecycle.item_kind = 'task'
+    ORDER BY attempt.started_at, attempt.attempt_id
+  `).all({ ":worker_id": workerId }) as Array<{
+    attempt_id: string;
+    milestone_lease_token: number;
+    milestone_id: string;
+  }>;
+  const settledAttemptIds: string[] = [];
+  for (const attempt of attempts) {
+    try {
+      // A stale heartbeat and its lease normally expire together. Renew only
+      // the dead worker's still-owned lease long enough to authorize its own
+      // settlement; a lease already taken over by another worker cannot renew.
+      if (!refreshMilestoneLease(
+        workerId,
+        attempt.milestone_id,
+        attempt.milestone_lease_token,
+      )) continue;
+      settleTaskAttempt({
+        invocation: internalExecutionInvocation(
+          `internal:crash-recovery:attempt.settle:${attempt.attempt_id}`,
+          { actorId: workerId },
+        ),
+        attemptId: attempt.attempt_id,
+        outcome: "interrupted",
+        failureClass: "stale-worker",
+        summary: "Interrupted running Task Attempt during stale worker cleanup",
+        output: { staleWorkerId: workerId },
+      });
+      settledAttemptIds.push(attempt.attempt_id);
+    } catch {
+      // Best-effort: lease-aware readers ignore any Attempt whose lease was
+      // concurrently taken over before settlement could commit.
+    }
+  }
+  return settledAttemptIds;
 }
 
 /**

--- a/src/resources/extensions/gsd/task-lifecycle-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-lifecycle-domain-operation.ts
@@ -230,6 +230,15 @@ function currentRunningAttempt(lifecycleId: string): RunningAttempt | null {
            attempt.coordination_dispatch_id, attempt.worker_id,
            attempt.milestone_lease_token
     FROM workflow_execution_attempts attempt
+    JOIN workflow_item_lifecycles lifecycle
+      ON lifecycle.lifecycle_id = attempt.lifecycle_id
+     AND lifecycle.project_id = attempt.project_id
+    JOIN milestone_leases lease
+      ON lease.milestone_id = lifecycle.milestone_id
+     AND lease.worker_id = attempt.worker_id
+     AND lease.fencing_token = attempt.milestone_lease_token
+     AND lease.status = 'held'
+     AND lease.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
     JOIN workflow_kernel_checkpoints checkpoint
       ON checkpoint.lifecycle_id = attempt.lifecycle_id
      AND checkpoint.attempt_id = attempt.attempt_id

--- a/src/resources/extensions/gsd/task-lifecycle-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-lifecycle-domain-operation.ts
@@ -224,21 +224,16 @@ function requireOpenParents(state: TaskState, action: "reopen" | "cancel"): void
   if (terminalParent) throw new Error("cannot mutate Task under a terminal canonical parent lifecycle");
 }
 
-function currentRunningAttempt(lifecycleId: string): RunningAttempt | null {
+function currentRunningAttempt(
+  lifecycleId: string,
+  options: { requireActiveLease?: boolean } = {},
+): RunningAttempt | null {
+  const requireActiveLease = options.requireActiveLease ?? true;
   const rows = getDb().prepare(`
     SELECT attempt.attempt_id, checkpoint.kernel_checkpoint_id,
            attempt.coordination_dispatch_id, attempt.worker_id,
            attempt.milestone_lease_token
     FROM workflow_execution_attempts attempt
-    JOIN workflow_item_lifecycles lifecycle
-      ON lifecycle.lifecycle_id = attempt.lifecycle_id
-     AND lifecycle.project_id = attempt.project_id
-    JOIN milestone_leases lease
-      ON lease.milestone_id = lifecycle.milestone_id
-     AND lease.worker_id = attempt.worker_id
-     AND lease.fencing_token = attempt.milestone_lease_token
-     AND lease.status = 'held'
-     AND lease.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
     JOIN workflow_kernel_checkpoints checkpoint
       ON checkpoint.lifecycle_id = attempt.lifecycle_id
      AND checkpoint.attempt_id = attempt.attempt_id
@@ -246,11 +241,29 @@ function currentRunningAttempt(lifecycleId: string): RunningAttempt | null {
     WHERE attempt.lifecycle_id = :lifecycle_id
       AND attempt.attempt_state = 'running'
       AND checkpoint.next_stage = 'execute'
+      AND (
+        :require_active_lease = 0
+        OR EXISTS (
+          SELECT 1
+          FROM workflow_item_lifecycles lifecycle
+          JOIN milestone_leases lease
+            ON lease.milestone_id = lifecycle.milestone_id
+           AND lease.worker_id = attempt.worker_id
+           AND lease.fencing_token = attempt.milestone_lease_token
+           AND lease.status = 'held'
+           AND lease.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+          WHERE lifecycle.lifecycle_id = attempt.lifecycle_id
+            AND lifecycle.project_id = attempt.project_id
+        )
+      )
       AND NOT EXISTS (
         SELECT 1 FROM workflow_kernel_checkpoints successor
         WHERE successor.previous_kernel_checkpoint_id = checkpoint.kernel_checkpoint_id
       )
-  `).all({ ":lifecycle_id": lifecycleId }) as Array<Record<string, unknown>>;
+  `).all({
+    ":lifecycle_id": lifecycleId,
+    ":require_active_lease": requireActiveLease ? 1 : 0,
+  }) as Array<Record<string, unknown>>;
   if (rows.length > 1) throw new Error("Task lifecycle has multiple running Attempts");
   const attempt = rows[0];
   if (!attempt) return null;
@@ -390,7 +403,10 @@ export function cancelTask(input: {
           lifecycleStatus: "cancelled",
           adoptedFromStatus: "pending",
         });
-    const running = currentRunningAttempt(lifecycle.lifecycleId);
+    // Cancellation owns cleanup of abandoned work as well as actively leased
+    // work, so an expired or released lease must not hide the Attempt that
+    // still needs to be settled.
+    const running = currentRunningAttempt(lifecycle.lifecycleId, { requireActiveLease: false });
     let resultId: string | undefined;
     let kernelCheckpointId: string | undefined;
     if (lifecycle.lifecycleStatus === "in_progress") {

--- a/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
@@ -1445,7 +1445,7 @@ test("a replacement lease routes a stale running Attempt and redispatches before
   assert.equal(domain.claims[0].retryOfAttemptId, "attempt-1");
 });
 
-test("a same-lease running Attempt is settled interrupted before the guard rejects the re-dispatch (#1740)", async () => {
+test("a same-lease running Attempt is interrupted through the same-session recovery path (#1740)", async () => {
   const { runWithTaskExecutionAttempt } = await subject();
   const domain = fakeDomain();
   domain.attempts.push({
@@ -1461,27 +1461,29 @@ test("a same-lease running Attempt is settled interrupted before the guard rejec
 
   const result = await runWithTaskExecutionAttempt(input({ dispatchId: 42 }), async () => {
     ran = true;
+    domain.completeSucceeded("attempt-2");
     return { action: "next", data: {} };
   }, domain.deps);
 
-  assert.deepEqual(result, { action: "retry", reason: "task-recovery-retry" });
-  assert.equal(ran, false);
-  assert.equal(domain.claims.length, 0);
-  assert.equal(domain.settlements.length, 1, "the guard must settle before any throw");
+  assert.deepEqual(result, { action: "next", data: {} });
+  assert.equal(ran, true);
+  assert.equal(domain.claims.length, 1);
+  assert.equal(domain.claims[0].retryOfAttemptId, "attempt-1");
+  assert.equal(domain.settlements.length, 1, "same-session authority must settle the predecessor");
   assert.equal(domain.settlements[0].attemptId, "attempt-1");
   assert.equal(domain.settlements[0].outcome, "interrupted");
   assert.equal(domain.settlements[0].failureClass, "stale-worker");
   assert.equal(
     domain.settlements[0].recovery,
     undefined,
-    "an equal-or-older lease cannot use the fenced interrupt path",
+    "an equal lease settles through the owning worker's lease rather than replacement fencing",
   );
   assert.match(
     domain.settlements[0].summary,
-    /cannot replace an active running Attempt without a newer milestone lease/,
+    /same-session re-dispatch/,
   );
-  assert.equal(domain.attempts[0].state, "settled", "no Attempt may stay running when the guard trips");
-  assert.equal(domain.routes.length, 1, "the catch routes the interrupted Result through durable recovery");
+  assert.equal(domain.attempts[0].state, "settled", "same-session re-dispatch must not strand the prior Attempt");
+  assert.equal(domain.routes.length, 1, "the interrupted Result must route through durable recovery");
 });
 
 test("a same-session re-dispatch with an equal lease token leaves no running Attempt behind (#1740)", async () => {
@@ -1532,8 +1534,8 @@ test("a same-session re-dispatch with an equal lease token leaves no running Att
   `).get() as { summary: string; failure_kind: string };
   assert.match(
     observation.summary,
-    /cannot replace an active running Attempt without a newer milestone lease/,
-    "the guard error must surface through the durable failure route",
+    /same-session re-dispatch/,
+    "the same-session interruption must surface through the durable failure route",
   );
   assert.equal(observation.failure_kind, "stale-worker");
 });

--- a/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
@@ -17,11 +17,13 @@ import {
   openDatabase,
   closeDatabase,
   insertMilestone,
+  insertSlice,
+  insertTask,
   _getAdapter,
 } from "../gsd-db.ts";
 import { getAutoWorker, registerAutoWorker } from "../db/auto-workers.ts";
 import { claimMilestoneLease } from "../db/milestone-leases.ts";
-import { getLatestForUnit, markRunning, recordDispatchClaim } from "../db/unit-dispatches.ts";
+import { getLatestForUnit, recordDispatchClaim } from "../db/unit-dispatches.ts";
 import { setRuntimeKv, getRuntimeKv } from "../db/runtime-kv.ts";
 import {
   writeLock,
@@ -32,6 +34,12 @@ import {
 } from "../crash-recovery.ts";
 import { normalizeRealPath } from "../paths.ts";
 import { writeUnitRuntimeRecord } from "../unit-runtime.ts";
+import { executeDomainOperation } from "../db/domain-operation.ts";
+import {
+  adoptOrTransitionLifecycle,
+  readDomainOperationFence,
+} from "../db/writers/lifecycle-commands.ts";
+import { claimTaskAttempt } from "../task-execution-domain-operation.ts";
 
 function makeBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-crash-recovery-"));
@@ -262,11 +270,13 @@ test("clearLock marks stale worker stopping when no current-process worker match
   assert.equal(readCrashLock(base), null);
 });
 
-test("clearStaleWorkerLock marks stale worker stopping and cancels latest active dispatch", (t) => {
+test("clearStaleWorkerLock settles running Attempts before releasing the stale worker lease", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   openDatabase(join(base, ".gsd", "gsd.db"));
   insertMilestone({ id: "M001", title: "T", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "S", status: "active" });
+  insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", title: "Task", status: "pending" });
   const projectRoot = normalizeRealPath(base);
   const workerId = registerAutoWorker({ projectRootRealpath: projectRoot });
   const lease = claimMilestoneLease(workerId, "M001");
@@ -279,12 +289,59 @@ test("clearStaleWorkerLock marks stale worker stopping and cancels latest active
     milestoneId: "M001",
     sliceId: "S01",
     taskId: "T02",
-    unitType: "hook/codex-review",
+    unitType: "execute-task",
     unitId: "M001/S01/T02",
   });
   assert.equal(claim.ok, true);
   if (!claim.ok) return;
-  markRunning(claim.dispatchId);
+  const fence = readDomainOperationFence();
+  executeDomainOperation({
+    operationType: "test.task.ready",
+    idempotencyKey: "fixture/crash-recovery/task-ready",
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: "test",
+    sourceTransport: "test",
+    payload: { taskId: "T02" },
+  }, (context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T02",
+      lifecycleStatus: "ready",
+    });
+    return {
+      events: [{
+        eventType: "test.task.ready",
+        entityType: "task",
+        entityId: "M001/S01/T02",
+        payload: { taskId: "T02" },
+        destinations: ["test"],
+      }],
+      projections: [{
+        projectionKey: "test/m001/s01/t02",
+        projectionKind: "test",
+        rendererVersion: "1",
+      }],
+    };
+  });
+  const attempt = claimTaskAttempt({
+    invocation: {
+      idempotencyKey: "fixture/crash-recovery/attempt-claim",
+      sourceTransport: "internal",
+      actorType: "agent",
+      actorId: workerId,
+    },
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T02" },
+    workerId,
+    milestoneLeaseToken: lease.token,
+    coordinationDispatchId: claim.dispatchId,
+  });
+  _getAdapter()!.prepare(`
+    UPDATE milestone_leases SET expires_at = '1970-01-01T00:00:00.000Z'
+    WHERE milestone_id = 'M001'
+  `).run();
   setRuntimeKv("worker", workerId, "session_file", "/tmp/pi-session-hook.jsonl");
   setWorkerPid(workerId, 99999);
   expireWorker(workerId);
@@ -298,6 +355,28 @@ test("clearStaleWorkerLock marks stale worker stopping and cancels latest active
   assert.ok(dispatch);
   assert.equal(dispatch!.status, "canceled");
   assert.equal(dispatch!.exit_reason, "crash-recovered");
+  const attemptRow = _getAdapter()!.prepare(`
+    SELECT attempt.attempt_state, attempt.settle_outcome, attempt.ended_at,
+           result.failure_class
+    FROM workflow_execution_attempts attempt
+    JOIN workflow_attempt_results result ON result.attempt_id = attempt.attempt_id
+    WHERE attempt.attempt_id = :attempt_id
+  `).get({ ":attempt_id": attempt.attemptId }) as {
+    attempt_state: string;
+    settle_outcome: string;
+    ended_at: string | null;
+    failure_class: string;
+  } | undefined;
+  assert.deepEqual(attemptRow && {
+    attempt_state: attemptRow.attempt_state,
+    settle_outcome: attemptRow.settle_outcome,
+    failure_class: attemptRow.failure_class,
+  }, {
+    attempt_state: "settled",
+    settle_outcome: "interrupted",
+    failure_class: "stale-worker",
+  });
+  assert.ok(attemptRow?.ended_at, "stale worker cleanup must timestamp the Attempt settlement");
   const leaseRow = _getAdapter()!.prepare(
     `SELECT status FROM milestone_leases WHERE fencing_token = :ft`,
   ).get({ ":ft": lease.token }) as { status: string } | undefined;

--- a/src/resources/extensions/gsd/tests/slice-completion-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-completion-domain-operation.test.ts
@@ -29,6 +29,7 @@ import { recordTaskTechnicalVerdict } from "../task-verification-domain-operatio
 import {
   grantTaskWaiver,
   recordTaskRequirementDisposition,
+  reopenTask,
 } from "../task-recovery-domain-operation.ts";
 
 const tempDirs = new Set<string>();
@@ -562,6 +563,41 @@ test("Slice completion rejects pending and running descendants without durable r
     /running attempt|running descendant/i,
   );
   assert.deepEqual(durableSnapshot(), runningBefore, "running-descendant rejection must leave exact zero residue");
+});
+
+test("Slice completion ignores a running Attempt after its owning lease is released", () => {
+  makeBase();
+  const orphanedAttemptId = claimTask("T02");
+  finishTaskWithOptionalEvidence(true);
+  db().prepare(`UPDATE milestone_leases SET status = 'released' WHERE milestone_id = 'M001'`).run();
+
+  const result = completeSlice(validInput("slice-complete/released-lease-attempt"));
+
+  assert.equal(result.status, "committed");
+  assert.deepEqual(row(`
+    SELECT attempt_state, ended_at
+    FROM workflow_execution_attempts WHERE attempt_id = '${orphanedAttemptId}'
+  `), { attempt_state: "running", ended_at: null });
+});
+
+test("Task reopen ignores a running Attempt after its owning lease is released", () => {
+  makeBase();
+  const orphanedAttemptId = claimTask("T02");
+  finishTaskWithOptionalEvidence(true);
+  db().prepare(`UPDATE milestone_leases SET status = 'released' WHERE milestone_id = 'M001'`).run();
+
+  const result = reopenTask({
+    invocation: invocation("task-reopen/released-lease-attempt"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T02" },
+    reason: "The previously omitted work is required again.",
+  });
+
+  assert.equal(result.canonicalStatus, "ready");
+  assert.equal(result.legacyStatus, "pending");
+  assert.deepEqual(row(`
+    SELECT attempt_state, ended_at
+    FROM workflow_execution_attempts WHERE attempt_id = '${orphanedAttemptId}'
+  `), { attempt_state: "running", ended_at: null });
 });
 
 test("Slice completion rejects a deep canonical and legacy mismatch with exact zero residue", () => {


### PR DESCRIPTION
## Summary
- Fixed all three Attempt recovery bugs and passed 107 changed-source tests plus fast gates.

## Bugs Addressed
- [x] **Same-session re-dispatch cannot interrupt a running Attempt**
- [x] **Stale worker cleanup leaves running Attempts unsettled**
- [x] **Released-lease Attempts incorrectly block slice lifecycle operations**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1740
- [#1740 Bug: same-session interruptStaleAttempt guard (<=) orphans running Attempts on re-dispatch — blocks slice-complete and task-reopen permanently (1.15.0)](https://github.com/open-gsd/gsd-pi/issues/1740)

## User
- @afkayla

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1740-bug-same-session-interruptstaleattempt-g-1786944710`