### PR TITLE
release: v1.16.0 backfill and release-push resilience

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -730,12 +730,35 @@ jobs:
           RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: node scripts/verify-npm-release.mjs "${RELEASE_VERSION}"
 
-      - name: Push release commit and tag
+      # The tag goes first and on its own: npm is already published at this
+      # point, so the tag is what keeps the next release from recomputing the
+      # same version. Branch rulesets do not apply to tags, but they do apply
+      # to main - in v1.16.0 the combined push failed on main and took the tag
+      # down with it, leaving npm at 1.16.0 with no tag and no GitHub release.
+      - name: Push release tag
         env:
           RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
+        run: git push origin "v${RELEASE_VERSION}"
+
+      - name: Push release commit to main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: |
-          git push origin main
-          git push origin "v${RELEASE_VERSION}"
+          if git push origin main; then
+            echo "Release commit pushed to main."
+            exit 0
+          fi
+          # main enforces a merge queue plus required checks and the Actions
+          # token is not on the ruleset bypass list, so a direct push is
+          # rejected. The tag and npm are already consistent, so land the
+          # version bump through the queue instead of failing the release.
+          BRANCH="release/v${RELEASE_VERSION}"
+          git push origin "HEAD:refs/heads/${BRANCH}"
+          gh pr create --base main --head "${BRANCH}" \
+            --title "release: v${RELEASE_VERSION}" \
+            --body "Version bump for v${RELEASE_VERSION}. Direct push to main was rejected by branch rules, so the release commit lands through the merge queue. npm, the \`v${RELEASE_VERSION}\` tag and the GitHub release are already published."
+          echo "::warning::Direct push to main was rejected; the v${RELEASE_VERSION} version bump is waiting in branch ${BRANCH} and must be merged."
 
       - name: Create GitHub Release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,69 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-08-17
+
+### Added
+- **gsd**: verify-after-write receipts for save-tool units (#1802)
+- **gsd**: settle orphaned task attempts and add gsd_task_settle operator tool (#1777)
+- **gsd**: collapse auto-mode onto the unit_dispatches UnitRun (ADR-048)
+- **pi-ai**: add MAI Code 1.1 Flash routing
+- **models**: add Claude Opus 5 across catalogs and registries
+- **gsd**: delete leftover filesystem-state read path
+
+### Fixed
+- **gsd**: Windows projection-lock resilience — backoff, EXDEV fallback, transient-aware liveness (#1801)
+- **output**: normalize markdown table separator formatting to pass MD055/MD056 (#1610)
+- **gsd**: optimize streaming render pipeline to reduce TUI CPU churn (#1686)
+- **verification-gate**: detect package manager and use correct run command (#1706)
+- **gsd**: apply canonical list predicates before SQL limit (#1732)
+- **gsd**: align canonical read errors across native and MCP (#1734)
+- **pi-ai**: decouple delta events from accumulated message to eliminate O(n²) payload overhead  (#1736)
+- **issue**: Auto-mode wedge: task-recovery-* retry branch omits retryActiveUnit → pinned lastAdvanceKey → orchestration-stale-active-unit wedge (1.15.0) (#1770)
+- **doctor**: task_file_not_in_plan fires on every sibling slice in flat-phase layouts (#1797)
+- **gsd**: sweep orphaned dispatches and self-heal Q8 gate rows (#1799)
+- **gsd**: align artifact/DB divergence on disk-vs-DB truth (#1800)
+- **gsd**: quote-aware verify substitution and flag-tolerant prose (#1807)
+- **gsd**: actionable verification verdicts and honest timeouts (#1808)
+- **gsd**: prefer project venvs for Python verification (#1809)
+- **gsd**: parse plan numbers from suffixed slice IDs (#1810)
+- **gsd**: bridge cursor-agent lifecycle tools and persist stdio MCP trust (#1811)
+- **gsd**: out-of-surface blocker, convergent schema retries, plan-task cap (#1812)
+- **gsd**: settle migration before drift reconciliation (#1806)
+- **hermes**: resolve session key live instead of at registration (#1813)
+- **pi-ai**: cast Gemini tool-choice literals for string-enum assignability
+- **pi-ai**: keep google-shared type-only on genai and run vitest in CI
+- **gsd**: register gsd_task_settle in workflow contracts and update v47 test fixtures
+- **gsd**: satisfy tsc on UnitRun iteration narrowing and null identities
+- **gsd**: fail-closed auto-mode closeout for remaining field wedges (#1754, #1739, #1726)
+- **gsd**: group MAI cost under Copilot section
+- **gsd**: group MAI cost under Copilot
+- **issue**: fix(auto): degraded dispatch-claim silently proceeds with null dispatchId, execute-task throws 'requires a positive coordination dispatch identity' and wedges
+- **issue**: Orphaned Task Attempt from a killed auto-mode process can never be settled (milestone_leases keeps no history)
+- **read**: add requirement class filtering
+- **bug-1**: Blank rationale crashes runtime-error verification finalization runtime-error verification failures now persist a meaningful, nonblank rationale.
+- **read**: isolate canonical reads from global db handle
+- **model-router**: remove duplicate claude-sonnet-5 registry rows
+- **model-router**: drop duplicate claude-sonnet-5 rows that break tsc
+- **issue**: auto-mode wedge: stale active-unit marker after abnormal unit exit triggers orchestration-stale-active-unit
+- **gsd**: classify Anthropic cache_control.ttl 400 as model-error
+- **issue**: [Bug]: slow startup when cursor-agent executable is on path without subscription
+- **gsd**: restore single claude-sonnet-5 entry in model-router tables
+- **issue**: [Bug]: auto-mode wedges with orchestration-stale-active-unit after task-recovery deferral leaves the orchestrator active-unit claim dangling (1.15.0)
+- **model-router**: restore claude-sonnet-5 registry rows dropped by a merge
+- **gsd**: persist CONTEXT-DRAFT artifacts from structured question rounds
+- **gsd**: stop live derive from treating markdown as state authority
+- **model-router**: restore claude-sonnet-5 registry entries dropped in #1705 merge
+- **issue**: [Bug]: Worktree-isolated plan-milestone deadlocks against its own milestone lease (reentrancy gates key on project_root_realpath, which diverges across worktrees)
+
+### Changed
+- **gsd**: remove unused MEDIUM files and package deps (#1760)
+- **gsd**: drop unused root packaging hoists and @types/picomatch (#1767)
+- **gsd**: un-export unused src CLI symbols after glance (#1768)
+- **gsd**: delete unused studio Electron scaffold
+- **gsd**: delete unused gsd barrels, safe-fs, and interrupted-work
+- **gsd**: delete unused pi-ai shims and mcp-server readers barrel
+
 ### Changed
 - **gsd**: collapse auto-mode onto a single UnitRun — the claimed/running `unit_dispatches` row (ADR-048). `advance()` returns `dispatchId`; `getStatus().activeUnit` reads the database; `settle(dispatchId, outcome)` is the closeout seam.
 

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ See [CHANGELOG.md](./CHANGELOG.md) for release-by-release fixes and [Legacy Rele
 ## Latest Release Highlights
 
 <!-- release-highlights:start -->
-Latest release: **v1.15.0**
+Latest release: **v1.16.0**
 
-- **model-router:** Add claude-sonnet-5 to model capability registries.
-- **tools:** Add gsd_requirement_list/get and gsd_decision_list/get (#1608).
-- **pi-ai:** Add missing kimi-coding subscription models to catalog.
-- **pi-ai:** Add Kimi Code (subscription) OAuth provider.
-- **ci:** Retrigger PR checks.
-- **gsd:** Deepen projection delivery ownership.
-- **gsd:** Own slice companion gate lifecycle.
-- **gsd:** Register required schema features once.
+- **gsd:** Verify-after-write receipts for save-tool units (#1802).
+- **gsd:** Settle orphaned task attempts and add gsd_task_settle operator tool (#1777).
+- **gsd:** Collapse auto-mode onto the unit_dispatches UnitRun (ADR-048).
+- **pi-ai:** Add MAI Code 1.1 Flash routing.
+- **models:** Add Claude Opus 5 across catalogs and registries.
+- **gsd:** Delete leftover filesystem-state read path.
+- **gsd:** Remove unused MEDIUM files and package deps (#1760).
+- **gsd:** Drop unused root packaging hoists and @types/picomatch (#1767).
 
 <!-- release-highlights:end -->
 

--- a/extensions/google-search/package.json
+++ b/extensions/google-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-extensions/google-search",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Web search via Google with AI-synthesized answers and source citations",
   "type": "module",
   "keywords": [

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -215,7 +215,7 @@ class GsdMcpClient:
                 "params": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.15.0"},
+                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.16.0"},
                 },
             }
         )

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-gsd-hermes"
-version = "1.15.0"
+version = "1.16.0"
 description = "Hermes Agent plugin — GSD structured delivery engine integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-ast"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "ast-grep-core",
  "globset",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-engine"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "arboard",
  "dashmap",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-grep"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "grep-matcher",
  "grep-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "1.15.0"
+version = "1.16.0"
 edition = "2021"
 license = "MIT"
 authors = ["GSD Contributors"]

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-arm64",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-x64",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-arm64-gnu",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-x64-gnu",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-win32-x64-msvc",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
   "repository": {
@@ -207,11 +207,11 @@
   },
   "optionalDependencies": {
     "@mariozechner/clipboard": "0.3.6",
-    "@opengsd/engine-darwin-arm64": "1.15.0",
-    "@opengsd/engine-darwin-x64": "1.15.0",
-    "@opengsd/engine-linux-arm64-gnu": "1.15.0",
-    "@opengsd/engine-linux-x64-gnu": "1.15.0",
-    "@opengsd/engine-win32-x64-msvc": "1.15.0",
+    "@opengsd/engine-darwin-arm64": "1.16.0",
+    "@opengsd/engine-darwin-x64": "1.16.0",
+    "@opengsd/engine-linux-arm64-gnu": "1.16.0",
+    "@opengsd/engine-linux-x64-gnu": "1.16.0",
+    "@opengsd/engine-win32-x64-msvc": "1.16.0",
     "fsevents": "~2.3.3",
     "koffi": "^2.9.0",
     "node-pty": "^1.1.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/contracts",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Shared public contracts for GSD workspace boundaries",
   "license": "MIT",
   "gsd": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/daemon",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "GSD daemon — background process for project monitoring and Discord integration",
   "license": "MIT",
   "repository": {

--- a/packages/gsd-agent-core/package.json
+++ b/packages/gsd-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-core",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "GSD session orchestration layer on top of @gsd/pi-coding-agent",
   "type": "module",
   "gsd": {

--- a/packages/gsd-agent-modes/package.json
+++ b/packages/gsd-agent-modes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-modes",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "GSD run modes and CLI layer",
   "type": "module",
   "gsd": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/mcp-server",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "MCP server exposing GSD orchestration tools for compatible clients",
   "license": "MIT",
   "gsd": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/native",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Native Rust bindings for GSD — high-performance native modules via N-API",
   "type": "commonjs",
   "gsd": {

--- a/packages/pi-agent-core/package.json
+++ b/packages/pi-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-agent-core",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "General-purpose agent with transport abstraction, state management, and attachment support",
   "type": "module",
   "gsd": {

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-ai",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Unified LLM API with automatic model discovery and provider configuration",
   "type": "module",
   "gsd": {

--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-coding-agent",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Coding agent CLI (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-tui",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Terminal UI library (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/rpc-client/package.json
+++ b/packages/rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/rpc-client",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Standalone RPC client SDK for GSD — zero internal dependencies",
   "license": "MIT",
   "gsd": {

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glittercowboy/gsd",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "piConfig": {
     "name": "gsd",
     "configDir": ".gsd"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,20 +169,20 @@ importers:
         specifier: 0.3.6
         version: 0.3.6
       '@opengsd/engine-darwin-arm64':
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.0
+        version: 1.16.0
       '@opengsd/engine-darwin-x64':
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.0
+        version: 1.16.0
       '@opengsd/engine-linux-arm64-gnu':
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.0
+        version: 1.16.0
       '@opengsd/engine-linux-x64-gnu':
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.0
+        version: 1.16.0
       '@opengsd/engine-win32-x64-msvc':
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.0
+        version: 1.16.0
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -2001,28 +2001,28 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@opengsd/engine-darwin-arm64@1.15.0':
-    resolution: {integrity: sha512-2JndkRL7nSuXFM/tba/iaPPZEr7YZz2l3oyEmDVzbnMSK2G73qpYUlQW9VJnjh4w+AtwtSd2VYaVBasOGSjCVw==}
+  '@opengsd/engine-darwin-arm64@1.16.0':
+    resolution: {integrity: sha512-hwdl7Nff9XpKUk2S+YyKMvksWiAQmUAOPwqjNy7bTIrPn4NFMggTS8Ymk7UbgXsiZ0MqulIkj1pLiTzWOdZGlQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@opengsd/engine-darwin-x64@1.15.0':
-    resolution: {integrity: sha512-AJNsQs9oAqVDJ8eqwY68bO0GC3UQBEfwVyV16LV0YPzHWJhrf1glVN63uRGFgsoi2mMJN2d6C+0PYWKNPg4IHw==}
+  '@opengsd/engine-darwin-x64@1.16.0':
+    resolution: {integrity: sha512-B5UXE7b763f3vdoo/O1UlUlvevo1bjrmMlEoe3vSkh+Q2MIYC6p478YaHRNDuRrop+nhwzNekFu6/lpfvU1fKQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@opengsd/engine-linux-arm64-gnu@1.15.0':
-    resolution: {integrity: sha512-/Qxo8kj3+sIz32ojRoZJRJSv6O9BU6SlBMc4C3G/4NVpL4hwHbBzGz9EJNpNpkaCOcw9nAijkAeNFCHRuO5QCg==}
+  '@opengsd/engine-linux-arm64-gnu@1.16.0':
+    resolution: {integrity: sha512-03b0wzAVY92HbjLs6V89G/geyZxqOAEUMKZaM/v/Bio7VeJehIantnVDTUinewzb3/K84lqVCYYa0U2PNXO8fg==}
     cpu: [arm64]
     os: [linux]
 
-  '@opengsd/engine-linux-x64-gnu@1.15.0':
-    resolution: {integrity: sha512-sAPiBB+mooi8qVLUxOehoDAUKf5AueDZRTsSdbPHXa89wnXzWn4foOitYXBSsGaX4+guOG1ZMBsMpLmPyUoSnQ==}
+  '@opengsd/engine-linux-x64-gnu@1.16.0':
+    resolution: {integrity: sha512-YSfm4kED7bxBYEold9l9Y48M/KiXFSv1UkoANH4gHwuLm8nIgnMVck5UsQKHAR7LFciLY7AjjAqpaLV/IOEUlA==}
     cpu: [x64]
     os: [linux]
 
-  '@opengsd/engine-win32-x64-msvc@1.15.0':
-    resolution: {integrity: sha512-9ssQb5K7bk8eo6MDRt/cx0SebWEMQBiSasQ+sXBL8VorgbBcYAeq0Wj759TnU+2eYAPf6RuJ0OdRBpXzmeHoCA==}
+  '@opengsd/engine-win32-x64-msvc@1.16.0':
+    resolution: {integrity: sha512-3eaXtQTOoTK5HQkM1KjOhn56NGtlRt/YnR1KQoLIqnzdHKXZvN08dR15DLURr6LJhxsf59SXZe7YX+avh2EIkA==}
     cpu: [x64]
     os: [win32]
 
@@ -7714,19 +7714,19 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@opengsd/engine-darwin-arm64@1.15.0':
+  '@opengsd/engine-darwin-arm64@1.16.0':
     optional: true
 
-  '@opengsd/engine-darwin-x64@1.15.0':
+  '@opengsd/engine-darwin-x64@1.16.0':
     optional: true
 
-  '@opengsd/engine-linux-arm64-gnu@1.15.0':
+  '@opengsd/engine-linux-arm64-gnu@1.16.0':
     optional: true
 
-  '@opengsd/engine-linux-x64-gnu@1.15.0':
+  '@opengsd/engine-linux-x64-gnu@1.16.0':
     optional: true
 
-  '@opengsd/engine-win32-x64-msvc@1.15.0':
+  '@opengsd/engine-win32-x64-msvc@1.16.0':
     optional: true
 
   '@opengsd/gsd-browser@0.2.2': {}
@@ -9814,7 +9814,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -9847,7 +9847,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9862,7 +9862,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/scripts/__tests__/npm-publish-workflow.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow.test.mjs
@@ -238,7 +238,8 @@ test("production release publishes workspace packages and verifies ALL packages 
   const workspacePublish = idx("Publish workspace packages to npm");
   const mainPublish = idx("Publish release to npm @latest");
   const verifyAll = idx("Verify all required packages are published on npm");
-  const pushTag = idx("Push release commit and tag");
+  const pushTag = idx("Push release tag");
+  const pushMain = idx("Push release commit to main");
   const ghRelease = idx("Create GitHub Release");
 
   // Workspace packages publish before the main package.
@@ -253,6 +254,15 @@ test("production release publishes workspace packages and verifies ALL packages 
   assert.ok(verifyAll > mainPublish, "verify must run after the main package is published");
   assert.ok(verifyAll < pushTag, "verify must run before the release tag is pushed");
   assert.ok(verifyAll < ghRelease, "verify must run before the GitHub release is created");
+
+  // The tag is pushed on its own and first. Branch rulesets do not apply to
+  // tags but do apply to main, so chaining both pushes in one step lets a
+  // rejected main push take the tag down with it - which is how v1.16.0
+  // reached npm with no tag and no GitHub release.
+  assert.ok(pushTag > -1, "prod-release must push the release tag");
+  assert.ok(pushMain > -1, "prod-release must push the release commit to main");
+  assert.ok(pushTag < pushMain, "the release tag must be pushed before the main branch push");
+  assert.doesNotMatch(steps[pushTag].run, /push origin main/, "the tag push must not also push main");
 });
 
 test("production release updates README highlights in the release commit", () => {


### PR DESCRIPTION
The v1.16.0 Production Release job published all 10 packages to npm, then failed on `git push origin main`: the `gsd-loop required CI` ruleset (added 2026-08-15) requires the merge queue and a passing `ci-gate` on main, and the Actions token is not on its bypass list. Because the tag push was chained after the branch push in the same step, the tag went down with it — npm was at 1.16.0 with no tag, no GitHub release, and no Docker image.

Already repaired out-of-band:
- `v1.16.0` tag pushed at 09ae3c22c (the exact release source SHA)
- GitHub release v1.16.0 created from the run's release notes

This PR carries the two remaining pieces:

**`release: v1.16.0`** — the version bump the failed job never landed, regenerated with the same scripts the workflow runs (`bump-version.mjs`, `update-changelog.mjs`, `update-readme-release-highlights.mjs`). `verify:version-sync` passes and the lockfile resolves `@opengsd/engine-*` at 1.16.0, so no fold-in step is needed.

**`fix(ci): push release tag before main and fall back to a PR`** — splits the push into two steps. The tag is pushed first and alone (branch rulesets do not apply to tags), so npm and the tag can no longer diverge. The main push then falls back to opening a PR through the merge queue instead of failing the release, and emits a warning. This works whether or not a ruleset bypass is added later.