### PR TITLE
fix(issue): [Bug]: cancelled attempt leaks staged task summary that renderer perpetually re-projects into an unrecoverable artifact-db-status-divergence wedge (1.15.0)

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -788,6 +788,20 @@ export function setTaskSummaryMd(milestoneId: string, sliceId: string, taskId: s
   ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId, ":md": md }));
 }
 
+export function clearTaskSummaryProjectionState(milestoneId: string, sliceId: string, taskId: string): void {
+  if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  transaction(() => {
+    getDbOrNull()!.prepare(
+      `UPDATE tasks SET full_summary_md = '' WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
+    ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+    getDbOrNull()!.prepare(
+      `DELETE FROM artifacts
+       WHERE artifact_type = 'SUMMARY'
+         AND milestone_id = :mid AND slice_id = :sid AND task_id = :tid`,
+    ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+  });
+}
+
 export function setSliceSummaryMd(milestoneId: string, sliceId: string, summaryMd: string, uatMd: string): void {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   transaction(() => getDbOrNull()!.prepare(

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -13,7 +13,7 @@ import { readFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { createProjectionDirectorySync, removeProjectionFileSync } from "./atomic-write.js";
 import { logWarning } from "./workflow-logger.js";
 import { isClosedStatus, isHiddenFromRoadmap, toStatus } from "./status-guards.js";
-import { readLatestTaskAttempt } from "./task-execution-domain-operation.js";
+import { isCanonicalStagedTaskSummaryState } from "./task-summary-projection-policy.js";
 import { dirname, join } from "node:path";
 import {
   getAllMilestones,
@@ -913,17 +913,10 @@ export async function renderTaskSummary(
   }
   if (status === "complete") {
     // Published completions keep projecting.
-  } else if (status === "in_progress") {
-    const attempt = readLatestTaskAttempt({ milestoneId, sliceId, taskId });
-    if (!attempt || attempt.outcome === "interrupted") {
-      return false;
-    }
-    // A blockerDiscovered failure clears its staged SUMMARY at settle time;
-    // never re-project it (#1726).
-    if (attempt.outcome === "failed" && attempt.resultFailureClass === "blocker-discovered") {
-      return false;
-    }
-  } else {
+  } else if (
+    status !== "in_progress" ||
+    !isCanonicalStagedTaskSummaryState({ milestoneId, sliceId, taskId })
+  ) {
     return false;
   }
 
@@ -1332,7 +1325,16 @@ function projectionRenderIntents(basePath: string): ProjectionRenderIntent[] {
 
       for (const task of getSliceTasks(milestone.id, slice.id)) {
         const taskStatus = toStatus(task.status);
-        if ((taskStatus !== "in_progress" && taskStatus !== "complete") || !task.full_summary_md) continue;
+        const stagedSummaryIsCanonical = taskStatus === "in_progress" &&
+          isCanonicalStagedTaskSummaryState({
+            milestoneId: milestone.id,
+            sliceId: slice.id,
+            taskId: task.id,
+          });
+        if (
+          (taskStatus !== "complete" && !stagedSummaryIsCanonical) ||
+          !task.full_summary_md
+        ) continue;
         record(
           targetTaskFile(basePath, milestone.id, slice.id, task.id, "SUMMARY", milestone.title),
           task.full_summary_md,

--- a/src/resources/extensions/gsd/projection-observation.ts
+++ b/src/resources/extensions/gsd/projection-observation.ts
@@ -110,6 +110,17 @@ function preserveOne(
   });
 }
 
+/** Move one known-stale managed projection into the standard quarantine. */
+export function quarantineProjectionEvidence(
+  basePath: string,
+  absPath: string,
+): PreservedProjectionEvidence | null {
+  const observedBytes = readProjectionBytes(absPath);
+  if (!observedBytes) return null;
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return preserveOne(basePath, absPath, stamp, observedBytes);
+}
+
 /**
  * Preserve every modeled projection whose current bytes differ from its
  * writer-owned baseline, plus any caller-supplied legacy drift paths.

--- a/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/artifact-db.ts
@@ -5,6 +5,7 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  readFileSync,
   readdirSync,
   renameSync,
 } from "node:fs";
@@ -12,6 +13,7 @@ import { basename, isAbsolute, join, resolve } from "node:path";
 
 import {
   _getAdapter,
+  clearTaskSummaryProjectionState,
   getAllMilestones,
   getMilestoneSlices,
   getSliceTasks,
@@ -32,6 +34,10 @@ import { invalidateStateCache } from "../../state.js";
 import type { GSDState } from "../../types.js";
 import { isAfter, latestExplicitReopenAt } from "../../milestone-reopen-events.js";
 import { isCanonicalStagedTaskSummaryProjection } from "../../task-summary-projection-classification.js";
+import { readLatestTaskAttempt } from "../../task-execution-domain-operation.js";
+import { quarantineProjectionEvidence } from "../../projection-observation.js";
+import { computeProjectionSha, deriveCompatProjectionKey, readCompatMarker } from "../../compat/compat-marker.js";
+import { stripProjectionStamp } from "../../markdown-renderer.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
 type DiskSliceIdDivergenceDrift = Extract<
@@ -159,6 +165,71 @@ function taskHasAttemptHistory(milestoneId: string, sliceId: string, taskId: str
     ":task_id": taskId,
   });
   return row !== undefined;
+}
+
+function isAbandonedStagedTaskSummary(
+  record: ArtifactDbStatusDivergenceDrift,
+  basePath: string,
+): boolean {
+  if (!record.sliceId || !record.taskId || record.artifactType !== "SUMMARY") return false;
+  const task = getSliceTasks(record.milestoneId, record.sliceId)
+    .find((candidate) => candidate.id === record.taskId);
+  if (task?.status !== "in_progress") return false;
+  const attempt = readLatestTaskAttempt({
+    milestoneId: record.milestoneId,
+    sliceId: record.sliceId,
+    taskId: record.taskId,
+  });
+  if (attempt?.state !== "settled" || attempt.outcome === "succeeded") return false;
+
+  const projectionPath = resolveTaskSummaryDriftPath(basePath, record);
+  const canonicalPath = resolveTaskFile(
+    basePath,
+    record.milestoneId,
+    record.sliceId,
+    record.taskId,
+    "SUMMARY",
+  );
+  if (!projectionPath || !canonicalPath || resolve(projectionPath) !== resolve(canonicalPath)) return false;
+  let content: string;
+  try {
+    content = readFileSync(projectionPath, "utf8");
+  } catch {
+    return false;
+  }
+  if (
+    task.full_summary_md &&
+    stripProjectionStamp(content) === stripProjectionStamp(task.full_summary_md)
+  ) return true;
+
+  const projectionKey = deriveCompatProjectionKey(
+    projectionPath,
+    [gsdProjectionRoot(basePath), join(basePath, ".gsd")],
+  );
+  return readCompatMarker(basePath).projections[projectionKey]?.sha === computeProjectionSha(content);
+}
+
+function resolveTaskSummaryDriftPath(
+  basePath: string,
+  record: ArtifactDbStatusDivergenceDrift,
+): string | null {
+  if (record.artifactPath) {
+    if (isAbsolute(record.artifactPath)) return record.artifactPath;
+    const candidates = [
+      join(gsdProjectionRoot(basePath), record.artifactPath),
+      join(basePath, ".gsd", record.artifactPath),
+    ];
+    const existing = candidates.find((candidate) => existsSync(candidate));
+    if (existing) return existing;
+  }
+  if (!record.sliceId || !record.taskId) return null;
+  return resolveTaskFile(
+    basePath,
+    record.milestoneId,
+    record.sliceId,
+    record.taskId,
+    "SUMMARY",
+  );
 }
 
 function addUniqueDrift(
@@ -615,13 +686,13 @@ function diskSliceIdDivergenceGuidance(record: DiskSliceIdDivergenceDrift): stri
   );
 }
 
-export function repairArtifactDbDrift(
+export async function repairArtifactDbDrift(
   record:
     | DiskSliceIdDivergenceDrift
     | ArtifactDbStatusDivergenceDrift
     | CompletedMilestoneReopenedDrift,
   ctx: DriftContext,
-): void {
+): Promise<void> {
   if (record.kind === "disk-slice-id-divergence") {
     if (record.disposition === "delete-empty") {
       removeProjectionTreeSync(record.sliceDir);
@@ -640,6 +711,16 @@ export function repairArtifactDbDrift(
     throw new Error(completedMilestoneReopenedGuidance(record));
   }
 
+  if (isAbandonedStagedTaskSummary(record, ctx.basePath)) {
+    const projectionPath = resolveTaskSummaryDriftPath(ctx.basePath, record);
+    if (projectionPath) quarantineProjectionEvidence(ctx.basePath, projectionPath);
+    clearTaskSummaryProjectionState(record.milestoneId, record.sliceId!, record.taskId!);
+    clearPathCache();
+    clearParseCache();
+    invalidateStateCache();
+    return;
+  }
+
   throw new Error(
     `Artifact/DB status drift in ${record.milestoneId}` +
       `${record.sliceId ? `/${record.sliceId}` : ""}` +
@@ -654,6 +735,7 @@ export function describeArtifactDbDriftBlocker(
     | DiskSliceIdDivergenceDrift
     | ArtifactDbStatusDivergenceDrift
     | CompletedMilestoneReopenedDrift,
+  ctx?: DriftContext,
 ): string | null {
   if (record.kind === "disk-slice-id-divergence") {
     if (record.disposition !== "block-meaningful") return null;
@@ -663,6 +745,8 @@ export function describeArtifactDbDriftBlocker(
   if (record.kind === "completed-milestone-reopened") {
     return completedMilestoneReopenedGuidance(record);
   }
+
+  if (ctx && isAbandonedStagedTaskSummary(record, ctx.basePath)) return null;
 
   return (
     `Artifact/DB status drift in ${record.milestoneId}` +

--- a/src/resources/extensions/gsd/task-execution-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-execution-domain-operation.ts
@@ -32,7 +32,7 @@ import {
   internalExecutionInvocation,
   type ExecutionInvocation,
 } from "./execution-invocation.js";
-import { isDbAvailable, setTaskSummaryMd } from "./gsd-db.js";
+import { clearTaskSummaryProjectionState, isDbAvailable } from "./gsd-db.js";
 import { ensureHostTechnicalCriterion } from "./task-verification-domain-operation.js";
 import type { RecoveryAction } from "./recovery-classification.js";
 import type { TaskFailureKind } from "./recovery-policy.js";
@@ -483,16 +483,10 @@ export function settleTaskAttempt(input: SettleTaskAttemptInput): SettleTaskAtte
         taskId: attempt.task_id,
       }, input.stagedTaskCompletion);
     }
-    // Interrupted Attempts clear their staged SUMMARY at settle time; a
-    // blockerDiscovered failure gets the same treatment (#1726) — otherwise
-    // the staged projection is re-rendered forever for a task that was
-    // never completed. Cleared after any staged write so it always wins.
-    const blockerDiscovered =
-      input.outcome === "failed" &&
-      typeof input.output === "object" && input.output !== null &&
-      (input.output as Record<string, unknown>)["blockerDiscovered"] === true;
-    if (input.outcome === "interrupted" || blockerDiscovered) {
-      setTaskSummaryMd(attempt.milestone_id, attempt.slice_id, attempt.task_id, "");
+    // A non-success Result cannot own a staged completion projection. Clear
+    // both DB sources after any staged write so cancellation always wins.
+    if (input.outcome !== "succeeded") {
+      clearTaskSummaryProjectionState(attempt.milestone_id, attempt.slice_id, attempt.task_id);
     }
     const settled = settleAttemptWithResult(context, input);
     terminalizeTaskExecutionDispatch(context, {

--- a/src/resources/extensions/gsd/task-summary-projection-classification.ts
+++ b/src/resources/extensions/gsd/task-summary-projection-classification.ts
@@ -7,8 +7,7 @@ import { isAbsolute, join, resolve } from "node:path";
 import { stripProjectionStamp } from "./markdown-renderer.js";
 import { gsdProjectionRoot, gsdRoot, targetTaskFile } from "./paths.js";
 import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
-import { readLatestTaskAttempt } from "./task-execution-domain-operation.js";
-import { readTaskTechnicalVerdict } from "./task-verification-domain-operation.js";
+import { isCanonicalStagedTaskSummaryState } from "./task-summary-projection-policy.js";
 
 interface TaskSummaryProjectionArtifact {
   path: string;
@@ -117,19 +116,11 @@ export function isCanonicalStagedTaskSummaryProjection(
       return false;
     }
 
-    const attempt = readLatestTaskAttempt({
+    return isCanonicalStagedTaskSummaryState({
       milestoneId: task.milestoneId,
       sliceId: task.sliceId,
       taskId: task.taskId,
     });
-    if (attempt?.state !== "settled" || attempt.outcome !== "succeeded") {
-      return false;
-    }
-    if (attempt.nextStage === "verify") return true;
-    if (attempt.nextStage !== "route") return false;
-
-    const verdict = readTaskTechnicalVerdict(attempt.attemptId);
-    return verdict !== null && verdict.verdict !== "pass";
   } catch {
     return false;
   }

--- a/src/resources/extensions/gsd/task-summary-projection-policy.ts
+++ b/src/resources/extensions/gsd/task-summary-projection-policy.ts
@@ -1,0 +1,21 @@
+// Project/App: gsd-pi
+// File Purpose: Shared eligibility policy for staged Task SUMMARY projections.
+
+import { readLatestTaskAttempt } from "./task-execution-domain-operation.js";
+import { readTaskTechnicalVerdict } from "./task-verification-domain-operation.js";
+
+export function isCanonicalStagedTaskSummaryState(input: {
+  milestoneId: string;
+  sliceId: string;
+  taskId: string;
+}): boolean {
+  const attempt = readLatestTaskAttempt(input);
+  if (attempt?.state !== "settled" || attempt.outcome !== "succeeded") {
+    return false;
+  }
+  if (attempt.nextStage === "verify") return true;
+  if (attempt.nextStage !== "route") return false;
+
+  const verdict = readTaskTechnicalVerdict(attempt.attemptId);
+  return verdict !== null && verdict.verdict !== "pass";
+}

--- a/src/resources/extensions/gsd/tests/task-completion-compatibility-adapter.test.ts
+++ b/src/resources/extensions/gsd/tests/task-completion-compatibility-adapter.test.ts
@@ -7,6 +7,7 @@ import {
   existsSync,
   mkdtempSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   unlinkSync,
@@ -33,6 +34,7 @@ import { clearPathCache } from "../paths.js";
 import {
   claimTaskAttempt,
   readLatestTaskAttempt,
+  settleTaskAttempt,
 } from "../task-execution-domain-operation.js";
 import { recordTaskTechnicalVerdict } from "../task-verification-domain-operation.js";
 import { captureVerificationSourceSnapshot } from "../verification-source-integrity.js";
@@ -43,7 +45,11 @@ import {
 import { checkEngineHealth } from "../doctor-engine-checks.js";
 import type { DoctorIssue } from "../doctor-types.js";
 import type { ExecutionInvocation } from "../execution-invocation.js";
-import { detectArtifactDbDrift } from "../state-reconciliation/drift/artifact-db.js";
+import {
+  describeArtifactDbDriftBlocker,
+  detectArtifactDbDrift,
+  repairArtifactDbDrift,
+} from "../state-reconciliation/drift/artifact-db.js";
 import type { GSDState } from "../types.js";
 
 interface TaskIdentity {
@@ -795,6 +801,77 @@ test("#1726: a blockerDiscovered failure leaves no staged SUMMARY and no wedge",
     await renderTaskSummary(basePath, "M001", "S01", "T01"),
     false,
     "the renderer refuses re-projection",
+  );
+});
+
+test("#1726: an interrupted retry quarantines its abandoned staged SUMMARY without a blocker", async () => {
+  const { stageTaskCompletion } = await subject();
+  const { basePath, attemptId } = createFixture();
+  const staged = await stageTaskCompletion(stageInput(basePath));
+  db().prepare(`
+    INSERT INTO unit_dispatches (
+      trace_id, turn_id, worker_id, milestone_lease_token,
+      milestone_id, slice_id, task_id, unit_type, unit_id,
+      status, attempt_n, started_at
+    ) VALUES (
+      'trace-dispatch-2', 'turn-dispatch-2', 'worker-1', 7,
+      'M001', 'S01', 'T01', 'execute-task', 'M001/S01/T01',
+      'claimed', 2, '2026-07-12T00:10:00.000Z'
+    )
+  `).run();
+  const retry = claimTaskAttempt({
+    invocation: invocation("task-completion/interrupted-retry-claim"),
+    task: TASK,
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+    coordinationDispatchId: Number(row("SELECT MAX(id) AS id FROM unit_dispatches").id),
+    retryOfAttemptId: attemptId,
+  });
+
+  settleTaskAttempt({
+    invocation: invocation("task-completion/interrupted-retry-settle"),
+    attemptId: retry.attemptId,
+    outcome: "interrupted",
+    failureClass: "operator-cancelled",
+    summary: "The retry was cancelled",
+    output: { cancelled: true },
+  });
+
+  assert.equal(row("SELECT full_summary_md FROM tasks WHERE id = 'T01'").full_summary_md, "");
+  assert.equal(count("artifacts"), 0, "settlement removes the stale artifact row atomically");
+  assert.equal(existsSync(staged.summaryPath), true, "the abandoned disk projection awaits quarantine");
+  const { renderTaskSummary } = await import("../markdown-renderer.js");
+  assert.equal(await renderTaskSummary(basePath, "M001", "S01", "T01"), false);
+
+  const state = reconciliationState();
+  const drift = detectArtifactDbDrift(state, { basePath, state }).find((record) =>
+    record.kind === "artifact-db-status-divergence" && record.taskId === "T01"
+  );
+  assert.ok(drift && drift.kind === "artifact-db-status-divergence");
+  const noncanonicalPath = join(basePath, ".gsd", "phases", "01-test", "T01-ALT-SUMMARY.md");
+  writeFileSync(noncanonicalPath, readFileSync(staged.summaryPath));
+  assert.match(
+    describeArtifactDbDriftBlocker({ ...drift, artifactPath: noncanonicalPath }, { basePath, state }) ?? "",
+    /Artifact\/DB status drift/,
+    "noncanonical cancellation artifacts remain fail-closed",
+  );
+  unlinkSync(noncanonicalPath);
+  assert.equal(
+    describeArtifactDbDriftBlocker(drift, { basePath, state }),
+    null,
+    "abandoned staging is auto-repairable",
+  );
+  await repairArtifactDbDrift(drift, { basePath, state });
+
+  assert.equal(existsSync(staged.summaryPath), false);
+  const quarantineRoot = join(basePath, ".gsd", "quarantine", "projections");
+  const quarantined = readdirSync(quarantineRoot, { recursive: true })
+    .map(String)
+    .find((path) => path.endsWith("T01-SUMMARY.md"));
+  assert.ok(quarantined, "the abandoned projection is preserved in quarantine");
+  assert.deepEqual(
+    await taskSummaryDivergence(basePath),
+    { doctorDivergence: false, reconciliationDivergence: false },
   );
 });
 


### PR DESCRIPTION
## Summary
- Fixed cancelled-attempt summary leakage and verified reconciliation, rendering, and settlement regressions.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1726
- [#1726 [Bug]: cancelled attempt leaks staged task summary that renderer perpetually re-projects into an unrecoverable artifact-db-status-divergence wedge (1.15.0)](https://github.com/open-gsd/gsd-pi/issues/1726)

## User
- @Freston1605

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1726-bug-cancelled-attempt-leaks-staged-task--1787064889`