### PR TITLE
fix(issue): recover: legacy-import artifactFor() doesn't recognize flat-phase layout, blocks all recovery for drifted projects

### DIFF
--- a/src/resources/extensions/gsd/legacy-import-preview-gsd-lifecycle.ts
+++ b/src/resources/extensions/gsd/legacy-import-preview-gsd-lifecycle.ts
@@ -945,10 +945,85 @@ export function validateLegacyGsdLifecycleManifest(
   );
 }
 
-function artifactFor(file: SourceFile): LifecycleArtifact | undefined {
+function flatMilestoneId(phase: string, slug: string | undefined, state?: ManifestState): string {
+  const numericId = `M${phase.padStart(3, "0")}`;
+  if (state === undefined) return numericId;
+  const ids = new Set([
+    ...state.milestones.map((record) => textField(record.value, "id")),
+    ...state.slices.map((record) => textField(record.value, "milestone_id")),
+    ...state.tasks.map((record) => textField(record.value, "milestone_id")),
+  ].filter((id): id is string => id !== undefined));
+  const matches = [...ids].filter((id) => Number(/^M0*(\d+)/u.exec(id)?.[1]) === Number(phase));
+  const teamSuffix = /^([a-z0-9]{6})(?:-|$)/u.exec(slug ?? "")?.[1];
+  return matches.find((id) => teamSuffix !== undefined && id.endsWith(`-${teamSuffix}`))
+    ?? (matches.length === 1 ? matches[0] : numericId);
+}
+
+function artifactFor(file: SourceFile, state?: ManifestState): LifecycleArtifact | undefined {
   if (file.encoding !== "utf-8" || file.outcome === "unparsed") return undefined;
   const path = file.entry.logical_path;
-  let match = new RegExp(`^\\.gsd/milestones/(${MILESTONE_ID})/\\1-(ROADMAP|SUMMARY|PARKED)\\.md$`, "u").exec(path);
+  let match = /^\.gsd\/phases\/(\d+)(?:-([^/]+))?\/\1-(ROADMAP|SUMMARY|PARKED)\.md$/u.exec(path);
+  if (match !== null) {
+    const milestoneId = flatMilestoneId(match[1], match[2], state);
+    const sliceId = `S${match[1].padStart(2, "0")}`;
+    if (match[3] === "SUMMARY" && lineMatching(file, new RegExp(`^#\\s+${sliceId}\\b`, "u")) !== undefined) {
+      return { file, role: "slice-summary", milestoneId, sliceId };
+    }
+    const role = {
+      ROADMAP: "milestone-roadmap",
+      SUMMARY: "milestone-summary",
+      PARKED: "milestone-parked",
+    } as const;
+    return { file, role: role[match[3] as keyof typeof role], milestoneId };
+  }
+  match = /^\.gsd\/phases\/(\d+)(?:-([^/]+))?\/(?:\1-)?(\d+)-(PLAN|SUMMARY)\.md$/u.exec(path);
+  if (match !== null) {
+    return {
+      file,
+      role: match[4] === "PLAN" ? "slice-plan" : "slice-summary",
+      milestoneId: flatMilestoneId(match[1], match[2], state),
+      sliceId: `S${match[3].padStart(2, "0")}`,
+    };
+  }
+  match = /^\.gsd\/phases\/(\d+)(?:-([^/]+))?\/(S\d+)-(T\d+)-SUMMARY\.md$/u.exec(path);
+  if (match !== null) {
+    return {
+      file,
+      role: "nested-task-summary",
+      milestoneId: flatMilestoneId(match[1], match[2], state),
+      sliceId: match[3],
+      taskId: match[4],
+    };
+  }
+  match = /^\.gsd\/phases\/(\d+)(?:-([^/]+))?\/(T\d+)-SUMMARY\.md$/u.exec(path);
+  if (match !== null) {
+    const milestoneId = flatMilestoneId(match[1], match[2], state);
+    let sliceId: string | undefined;
+    for (const line of file.lines) {
+      const parent = /^(?:parent|slice):\s*["']?(S\d+)["']?\s*$/u.exec(line.text);
+      if (parent !== null) {
+        sliceId = parent[1];
+        break;
+      }
+    }
+    if (sliceId === undefined) {
+      const matchingSlices = new Set((state?.tasks ?? []).flatMap((record) => (
+        textField(record.value, "milestone_id") === milestoneId
+          && textField(record.value, "id") === match[3]
+          ? textField(record.value, "slice_id") ?? []
+          : []
+      )));
+      if (matchingSlices.size === 1) sliceId = [...matchingSlices][0];
+    }
+    return sliceId === undefined ? undefined : {
+      file,
+      role: "nested-task-summary",
+      milestoneId,
+      sliceId,
+      taskId: match[3],
+    };
+  }
+  match = new RegExp(`^\\.gsd/milestones/(${MILESTONE_ID})/\\1-(ROADMAP|SUMMARY|PARKED)\\.md$`, "u").exec(path);
   if (match !== null) {
     const role = {
       ROADMAP: "milestone-roadmap",
@@ -1546,7 +1621,7 @@ export function interpretLegacyGsdLifecycle(
   );
   if (state === undefined) return;
   interpretVersionedManifestRows(state, candidates, completeRowSets);
-  const artifacts = files.flatMap((file) => artifactFor(file) ?? []);
+  const artifacts = files.flatMap((file) => artifactFor(file, state) ?? []);
   if (state.milestones.length === 0 && state.slices.length === 0 && state.tasks.length === 0) return;
   markArtifacts(artifacts);
   const byRole = artifactsByRole(artifacts);

--- a/src/resources/extensions/gsd/legacy-import-preview-gsd-lifecycle.ts
+++ b/src/resources/extensions/gsd/legacy-import-preview-gsd-lifecycle.ts
@@ -998,6 +998,7 @@ function artifactFor(file: SourceFile, state?: ManifestState): LifecycleArtifact
   match = /^\.gsd\/phases\/(\d+)(?:-([^/]+))?\/(T\d+)-SUMMARY\.md$/u.exec(path);
   if (match !== null) {
     const milestoneId = flatMilestoneId(match[1], match[2], state);
+    const taskId = match[3];
     let sliceId: string | undefined;
     for (const line of file.lines) {
       const parent = /^(?:parent|slice):\s*["']?(S\d+)["']?\s*$/u.exec(line.text);
@@ -1009,7 +1010,7 @@ function artifactFor(file: SourceFile, state?: ManifestState): LifecycleArtifact
     if (sliceId === undefined) {
       const matchingSlices = new Set((state?.tasks ?? []).flatMap((record) => (
         textField(record.value, "milestone_id") === milestoneId
-          && textField(record.value, "id") === match[3]
+          && textField(record.value, "id") === taskId
           ? textField(record.value, "slice_id") ?? []
           : []
       )));
@@ -1020,7 +1021,7 @@ function artifactFor(file: SourceFile, state?: ManifestState): LifecycleArtifact
       role: "nested-task-summary",
       milestoneId,
       sliceId,
-      taskId: match[3],
+      taskId,
     };
   }
   match = new RegExp(`^\\.gsd/milestones/(${MILESTONE_ID})/\\1-(ROADMAP|SUMMARY|PARKED)\\.md$`, "u").exec(path);

--- a/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
+++ b/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
@@ -1367,6 +1367,60 @@ describe("legacy .gsd captured-byte interpretation", () => {
     )));
   });
 
+  test("models lifecycle artifacts in the flat-phase layout", (t) => {
+    const interpretation = interpretLegacyGsdCapture(captureFiles(t, {
+      "state-manifest.json": JSON.stringify({
+        milestones: [{ id: "M001", status: "active" }],
+        slices: [{ milestone_id: "M001", id: "S01", status: "active" }],
+        tasks: [{ milestone_id: "M001", slice_id: "S01", id: "T01", status: "active" }],
+      }),
+      "phases/01-recovery/01-01-PLAN.md": "# S01: Recovery\n\n- [ ] T01: Repair drift\n",
+      "phases/01-recovery/S01-T01-SUMMARY.md": "# T01 Summary\n\nThe repair passed verification.\n",
+    }));
+
+    assert.deepEqual(
+      interpretation.sources.map((source) => [source.path, source.parser_id, source.outcome]),
+      [
+        [".gsd/phases/01-recovery/01-01-PLAN.md", "gsd-lifecycle-truth", "mapped"],
+        [".gsd/phases/01-recovery/S01-T01-SUMMARY.md", "gsd-lifecycle-truth", "mapped"],
+        [".gsd/state-manifest.json", "gsd-lifecycle-truth", "mapped"],
+      ],
+    );
+    assert.ok(interpretation.candidates.some((candidate) => (
+      candidate.target.kind === "task-status"
+      && candidate.target.key === "M001/S01/T01"
+      && candidate.normalized === "complete"
+    )));
+  });
+
+  test("models compatibility and team-mode flat-phase lifecycle paths", (t) => {
+    const interpretation = interpretLegacyGsdCapture(captureFiles(t, {
+      "state-manifest.json": JSON.stringify({
+        milestones: [{ id: "M002-abc123", status: "active" }],
+        slices: [{ milestone_id: "M002-abc123", id: "S01", status: "active" }],
+        tasks: [{ milestone_id: "M002-abc123", slice_id: "S01", id: "T01", status: "active" }],
+      }),
+      "phases/02-abc123-recovery/01-PLAN.md": "# S01: Recovery\n\n- [ ] T01: Repair drift\n",
+      "phases/02-abc123-recovery/T01-SUMMARY.md": [
+        "---",
+        "parent: S01",
+        "---",
+        "# T01 Summary",
+        "",
+        "The repair passed verification.",
+      ].join("\n"),
+    }));
+
+    assert.ok(interpretation.sources.every((source) => (
+      source.parser_id === "gsd-lifecycle-truth" && source.outcome === "mapped"
+    )));
+    assert.ok(interpretation.candidates.some((candidate) => (
+      candidate.target.kind === "task-status"
+      && candidate.target.key === "M002-abc123/S01/T01"
+      && candidate.normalized === "complete"
+    )));
+  });
+
   test("does not fabricate a dependency conflict from complete zero-row evidence", (t) => {
     const captured = captureCase(t, "lifecycle-truth-matrix");
     const evidence = captured.databaseEvidence[0]!;


### PR DESCRIPTION
## Summary
- Added flat-phase artifact classification with resolver-compatible recovery coverage; 72 focused tests passed.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1825
- [#1825 recover: legacy-import artifactFor() doesn't recognize flat-phase layout, blocks all recovery for drifted projects](https://github.com/open-gsd/gsd-pi/issues/1825)

## User
- @jetroh

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1825-recover-legacy-import-artifactfor-doesn--1787064891`