### PR TITLE
fix(issue): auto: orphaned gsd processes lock the workflow DB (SQLITE_BUSY) and /gsd doctor --fix reports Clean, never repairs — permanent wedge (1.16.0)

### DIFF
--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -14,6 +14,7 @@ It checks:
 - Completion state consistency
 - Database artifact rows whose rendered files are missing on disk, including warning-only diagnostics for missing user-authored context and research files
 - Git worktree health (worktree and branch modes only — skipped in none mode)
+- Workflow database availability and lock-holder diagnosis
 - Stale DB-backed runtime records and orphaned runtime files
 - Disk-only orphan milestone stub directories
 - Preference parse and validation diagnostics (malformed `PREFERENCES.md` frontmatter or invalid settings)
@@ -104,6 +105,28 @@ Replace the path with the exact global bin directory from your pnpm error messag
 - The LLM didn't produce the expected artifact file
 
 **Fix:** Run `/gsd doctor` to repair state, then resume with `/gsd auto`. If the issue persists, check that the expected artifact file exists on disk.
+
+### Auto mode reports that `gsd.db` is locked
+
+**Symptoms:** Auto mode stops before dispatch with a message that the workflow database is locked by another GSD process, possibly including one or more PIDs. `/gsd doctor` reports the `db_locked` error instead of the general `db_unavailable` warning.
+
+**Cause:** Another process still holds `.gsd/gsd.db`, its write-ahead log, or its shared-memory file. This is commonly an orphaned GSD process left behind after a crash. GSD blocks auto mode because the database-backed liveness checks are unavailable while the lock remains.
+
+**Automatic recovery on macOS and Linux:** Run `/gsd doctor --fix` from the project root. Doctor sends `SIGTERM` only when it can prove that a holder is safe to terminate: the process belongs to the current user, is a recognized GSD process, has been sleeping or idle for at least five minutes, matches a stale local worker record whose heartbeat is at least five minutes old, and still has the same process-start identity immediately before signaling. Doctor must also be able to open the database read-only. It then retries the database open and reports the PIDs it released.
+
+If any of those checks fail, doctor leaves the process running and continues to report `db_locked`. This protects active GSD sessions, processes owned by other users, and unrelated processes from automatic termination.
+
+**Manual PID recovery on macOS and Linux:** Inspect every PID printed by auto mode or doctor before stopping it:
+
+```bash
+ps -p <PID> -o pid,etime,state,command
+kill <PID>
+/gsd doctor
+```
+
+Stop the process through its terminal or service manager when possible. Use `kill <PID>` only after confirming it is the stale holder, then rerun `/gsd doctor` and `/gsd auto`. If doctor cannot discover a PID, use `lsof` (macOS/Linux) or `fuser` (Linux) against `.gsd/gsd.db`, `.gsd/gsd.db-wal`, and `.gsd/gsd.db-shm`. Do not delete these database files to clear the lock.
+
+**Windows limitation:** Automatic holder discovery and termination are unavailable, so `/gsd doctor --fix` cannot release `db_locked`. Open Resource Monitor, search **Associated Handles** for `gsd.db`, confirm the owning process is a stale GSD instance, and stop that process manually. Then rerun `/gsd doctor` and `/gsd auto`.
 
 ### Reactive execute writes `S##-REACTIVE-BLOCKER.md`
 

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -206,7 +206,7 @@ export async function openProjectDbIfPresent(basePath: string): Promise<void> {
   if (!existsSync(gsdDbPath) || isDbAvailable()) return;
 
   const result = openExistingWorkflowDatabase(basePath);
-  if (!result.ok && result.reason === "open-failed") {
+  if (!result.ok && (result.reason === "open-failed" || result.reason === "locked")) {
     logWarning("engine", `gsd-db: failed to open existing database: ${result.error?.message ?? "open failed"}`);
   }
 }
@@ -1823,12 +1823,12 @@ export async function bootstrapAutoSession(
     // ── DB lifecycle ──
     const gsdDbPath = resolveProjectRootDbPath(s.basePath);
     const initialDbOpen = openWorkflowDatabase(s.basePath);
-    if (!initialDbOpen.ok && initialDbOpen.reason === "open-failed") {
+    if (!initialDbOpen.ok && (initialDbOpen.reason === "open-failed" || initialDbOpen.reason === "locked")) {
       logError("engine", `failed to initialize project database: ${initialDbOpen.error?.message ?? "open failed"}`);
     }
     if (_shouldAbortBootstrapForUnavailableDbForTest(gsdDbPath, isDbAvailable())) {
       const retryDbOpen = openWorkflowDatabase(s.basePath);
-      if (!retryDbOpen.ok && retryDbOpen.reason === "open-failed") {
+      if (!retryDbOpen.ok && (retryDbOpen.reason === "open-failed" || retryDbOpen.reason === "locked")) {
         logError("engine", `failed to open existing database: ${retryDbOpen.error?.message ?? "open failed"}`);
       }
     }
@@ -1840,7 +1840,9 @@ export async function bootstrapAutoSession(
     // re-dispatches the same task — producing an infinite loop (#2419).
     if (existsSync(gsdDbPath) && !isDbAvailable()) {
       const dbStatus = getWorkflowDatabaseStatus();
-      const phaseHint = dbStatus.lastPhase === "open"
+      const phaseHint = dbStatus.lastPhase === "locked"
+        ? "The database is locked by another GSD process"
+        : dbStatus.lastPhase === "open"
         ? "The database file could not be opened"
         : dbStatus.lastPhase === "initSchema"
           ? "The database schema could not be initialized"

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -232,7 +232,12 @@ import {
   getSlice,
   getTask,
 } from "./gsd-db.js";
-import { checkpointWorkflowDatabase, closeWorkflowDatabase } from "./db-workspace.js";
+import {
+  checkpointWorkflowDatabase,
+  closeWorkflowDatabase,
+  getWorkflowDatabaseStatus,
+  resolveProjectRootDbPath,
+} from "./db-workspace.js";
 import { markActiveForWorkerCanceled } from "./db/unit-dispatches.js";
 import { writeUnitRuntimeRecord } from "./unit-runtime.js";
 import { countPendingCaptures } from "./captures.js";
@@ -242,6 +247,10 @@ import { formatWedgeRefusalNotice, getOpenWedge } from "./auto-liveness-backstop
 import { getValidationBlockMessageForBase } from "./validation-block-guard.js";
 import { getUnmergedMilestoneBlockMessageForBase } from "./unmerged-milestone-guard.js";
 import { clearSessionModelOverride } from "./session-model-override.js";
+import {
+  formatLockedWorkflowDatabaseNotice,
+  listWorkflowDbLockHolderPids,
+} from "./workflow-db-locks.js";
 
 function makeCmuxEmitters(pi: ExtensionAPI) {
   return {
@@ -2645,6 +2654,15 @@ export async function startAuto(
   // longer a silent counter reset. `/gsd auto --resume-wedge <id>` is the one
   // sanctioned re-entry.
   if (!(await ensureDbOpen(base))) {
+    const dbStatus = getWorkflowDatabaseStatus();
+    if (dbStatus.lastPhase === "locked") {
+      const holderPids = listWorkflowDbLockHolderPids(resolveProjectRootDbPath(base));
+      ctx.ui.notify(
+        formatLockedWorkflowDatabaseNotice(holderPids),
+        "error",
+      );
+      return;
+    }
     ctx.ui.notify(
       "Auto-mode blocked — liveness backstop unavailable: workflow database could not be opened. Run `/gsd doctor --fix` before retrying.",
       "error",

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -130,6 +130,7 @@ function sqliteProviderHint(status: WorkflowDatabaseStatus, nodeVersion: string)
 }
 
 function dbOpenPhaseHint(status: WorkflowDatabaseStatus): string {
+  if (status.lastPhase === "locked") return "The database is locked by another process";
   if (status.lastPhase === "open") return "The database file could not be opened";
   if (status.lastPhase === "initSchema") return "The database schema could not be initialized";
   if (status.lastPhase === "vacuum-recovery") return "Corruption recovery (VACUUM) failed";

--- a/src/resources/extensions/gsd/db-open-state.ts
+++ b/src/resources/extensions/gsd/db-open-state.ts
@@ -1,7 +1,7 @@
 // Project/App: gsd-pi
 // File Purpose: Tracks database open attempt and error status for the GSD database facade.
 
-export type DbOpenPhase = "open" | "initSchema" | "vacuum-recovery";
+export type DbOpenPhase = "open" | "initSchema" | "locked" | "vacuum-recovery";
 
 export interface DbOpenStateSnapshot {
   attempted: boolean;

--- a/src/resources/extensions/gsd/db-workspace.ts
+++ b/src/resources/extensions/gsd/db-workspace.ts
@@ -76,6 +76,7 @@ export {
 import { resolveGsdPathContract, gsdRoot } from "./paths.js";
 import { logWarning, setLogBasePath } from "./workflow-logger.js";
 import { parseDecisionsTable } from "./decision-markdown-parser.js";
+import { isSqliteBusyError } from "./sqlite-errors.js";
 
 export interface WorkflowDatabaseLocation {
   projectRoot: string;
@@ -88,6 +89,7 @@ export type WorkflowDatabaseOpenReason =
   | "created-empty"
   | "missing-database"
   | "missing-gsd-dir"
+  | "locked"
   | "open-failed"
   | "schema-too-new";
 
@@ -99,7 +101,7 @@ export type WorkflowDatabaseOpenResult =
     }
   | {
       ok: false;
-      reason: "missing-database" | "missing-gsd-dir" | "open-failed";
+      reason: "missing-database" | "missing-gsd-dir" | "locked" | "open-failed";
       location: WorkflowDatabaseLocation;
       error?: Error;
     }
@@ -174,6 +176,14 @@ export function openWorkflowDatabase(basePath: string): WorkflowDatabaseOpenResu
       return {
         ok: false,
         reason: "schema-too-new",
+        location,
+        error,
+      };
+    }
+    if (isSqliteBusyError(error)) {
+      return {
+        ok: false,
+        reason: "locked",
         location,
         error,
       };

--- a/src/resources/extensions/gsd/db/domain-operation.ts
+++ b/src/resources/extensions/gsd/db/domain-operation.ts
@@ -17,6 +17,7 @@ import {
 } from "../legacy-import-preview.js";
 import type { LegacyImportForwardRepairPlan } from "../legacy-import-forward-repair-plan.js";
 import type { LegacyImportValue } from "../legacy-import-contract.js";
+import { isSqliteBusyError } from "../sqlite-errors.js";
 import {
   assertDatabaseReplacementReceiptIntent,
   getDb,
@@ -951,12 +952,6 @@ function staleAuthority(request: DomainOperationRequestIdentity, authority: Auth
     GSD_REVISION_CONFLICT,
     `stale authority epoch: expected ${request.expectedAuthorityEpoch}, current ${authority.authority_epoch}`,
   );
-}
-
-function isSqliteBusyError(error: unknown): boolean {
-  const code = String((error as { code?: unknown })?.code ?? "");
-  const message = String((error as { message?: unknown })?.message ?? error);
-  return code.includes("SQLITE_BUSY") || /SQLITE_BUSY|database is locked/i.test(message);
 }
 
 function runDomainOperationTransaction(fn: () => DomainOperationResult): DomainOperationResult {

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -123,6 +123,7 @@ import {
   type SqliteFileIdentity,
 } from "../sqlite-readonly.js";
 import { processStartIdentity } from "../process-start-identity.js";
+import { isSqliteBusyError } from "../sqlite-errors.js";
 import {
   createSqliteProviderLoader,
   suppressSqliteWarning,
@@ -807,6 +808,8 @@ let pendingStartupCleanup: StartupCleanupState | undefined;
 let pendingDatabaseMaintenanceCleanup: DatabaseMaintenanceCleanupState | undefined;
 let _exitHandlerRegistered = false;
 const _dbOpenState = createDbOpenState();
+const DB_OPEN_BUSY_BACKOFF_MS = [100, 200] as const;
+const DB_OPEN_BUSY_SLEEP = new Int32Array(new SharedArrayBuffer(4));
 let _databaseOpenAfterIntentCheckForTest: ((path: string) => void) | null = null;
 let _startupInitializationBoundaryForTest: ((path: string) => void) | null = null;
 type StartupRepairBoundaryPoint = "before-journal" | "after-journal" | "after-backup" | "before-vacuum";
@@ -2319,14 +2322,14 @@ function openDatabaseInternal(path: string, allowReplacementWrite: boolean): boo
       _databaseAdapterFileIdentities.set(adapter, strictFileIdentity(path, "canonical database"));
       _replacementObservationDatabases.add(adapter);
     } catch (error) {
-      _dbOpenState.recordError("open", error);
+      _dbOpenState.recordError(isSqliteBusyError(error) ? "locked" : "open", error);
       throw error;
     }
   } else {
     try {
       ({ raw: rawDb, identity: openedIdentity } = openCorrelatedRawDatabase(path, () => providerLoader.openRaw(path)));
     } catch (error) {
-      _dbOpenState.recordError("open", error);
+      _dbOpenState.recordError(isSqliteBusyError(error) ? "locked" : "open", error);
       throw error;
     }
     if (!rawDb) return false;
@@ -2356,7 +2359,7 @@ function openDatabaseInternal(path: string, allowReplacementWrite: boolean): boo
       }
     }
   } catch (err) {
-    _dbOpenState.recordError("initSchema", err);
+    _dbOpenState.recordError(isSqliteBusyError(err) ? "locked" : "initSchema", err);
     if (pendingStartupCleanup?.adapter !== adapter) {
       retainOrCloseFailedOpen(adapter, startupMaintenance, startupExclusiveOwnershipHeld);
     }
@@ -2370,7 +2373,7 @@ function openDatabaseInternal(path: string, allowReplacementWrite: boolean): boo
       _startupReopenCloseForTest?.(adapter);
       adapter.close();
     } catch (error) {
-      _dbOpenState.recordError("open", error);
+      _dbOpenState.recordError(isSqliteBusyError(error) ? "locked" : "open", error);
       quarantineStartupCleanup({
         adapter,
         claim: startupMaintenance.claim,
@@ -2396,7 +2399,7 @@ function openDatabaseInternal(path: string, allowReplacementWrite: boolean): boo
       completeDatabaseMaintenanceCleanup(startupMaintenance);
       startupMaintenance = undefined;
     } catch (error) {
-      _dbOpenState.recordError("open", error);
+      _dbOpenState.recordError(isSqliteBusyError(error) ? "locked" : "open", error);
       retainOrCloseFailedOpen(adapter, startupMaintenance, false, !runtimeAdapterOpened);
       throw error;
     }
@@ -2412,7 +2415,15 @@ function openDatabaseInternal(path: string, allowReplacementWrite: boolean): boo
 }
 
 export function openDatabase(path: string): boolean {
-  return openDatabaseInternal(path, false);
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return openDatabaseInternal(path, false);
+    } catch (error) {
+      const backoffMs = DB_OPEN_BUSY_BACKOFF_MS[attempt];
+      if (!isSqliteBusyError(error) || backoffMs === undefined) throw error;
+      Atomics.wait(DB_OPEN_BUSY_SLEEP, 0, 0, backoffMs);
+    }
+  }
 }
 
 export function promoteDatabaseForReplacementRecovery(): void {

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { hostname } from "node:os";
 import { isAbsolute, join, relative, sep } from "node:path";
 
 import type { DoctorIssue } from "./doctor-types.js";
@@ -34,6 +35,15 @@ import { parseProjectionPlan } from "./schemas/parsers.js";
 import { LAYOUT_SEGMENTS } from "./layout-policy.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { isCanonicalStagedTaskSummaryProjection } from "./task-summary-projection-classification.js";
+import {
+  getWorkflowDatabaseStatus,
+  openExistingWorkflowDatabase,
+  openWorkflowDatabaseIsolated,
+} from "./db-workspace.js";
+import {
+  inspectWorkflowDbLockHolders,
+  terminateDormantWorkflowDbLockHolders,
+} from "./workflow-db-locks.js";
 
 const USER_AUTHORED_ARTIFACT_TYPES = new Set(["CONTEXT", "RESEARCH"]);
 
@@ -499,20 +509,102 @@ export async function checkEngineHealth(
   basePath: string,
   issues: DoctorIssue[],
   fixesApplied: string[],
-  options?: { repair?: boolean },
+  options?: {
+    repair?: boolean;
+    repairDbLock?: boolean;
+    lockRecovery?: {
+      inspectHolders: typeof inspectWorkflowDbLockHolders;
+      terminateHolders: typeof terminateDormantWorkflowDbLockHolders;
+      reopen: typeof openExistingWorkflowDatabase;
+    };
+  },
 ): Promise<void> {
   const dbPath = resolveGsdPathContract(basePath).projectDb;
 
   if (!isDbAvailable() && existsSync(dbPath)) {
-    issues.push({
-      severity: "warning",
-      code: "db_unavailable",
-      scope: "project",
-      unitId: "project",
-      message: "Database unavailable — using filesystem state derivation (degraded mode). State queries may be slower and less reliable.",
-      file: ".gsd/gsd.db",
-      fixable: false,
-    });
+    const status = getWorkflowDatabaseStatus();
+    if (status.lastPhase === "locked") {
+      const readOnly = openWorkflowDatabaseIsolated(dbPath);
+      const staleWorkerStartedAtByPid = new Map<number, number>();
+      if (readOnly) {
+        try {
+          const cutoff = new Date(Date.now() - 5 * 60_000).toISOString();
+          const rows = readOnly.prepare(
+            `SELECT pid, started_at FROM workers
+             WHERE host = :host
+               AND status IN ('active', 'stopping')
+               AND last_heartbeat_at < :cutoff`,
+          ).all({ ":host": hostname(), ":cutoff": cutoff });
+          for (const row of rows) {
+            const pid = Number(row["pid"]);
+            const startedAtMs = Date.parse(String(row["started_at"]));
+            if (Number.isSafeInteger(pid) && pid > 0 && Number.isFinite(startedAtMs)) {
+              staleWorkerStartedAtByPid.set(
+                pid,
+                Math.max(staleWorkerStartedAtByPid.get(pid) ?? 0, startedAtMs),
+              );
+            }
+          }
+        } catch {
+          // Older schemas may not have the worker registry; report holders but do not terminate them.
+        }
+      }
+      const readOnlyProbeSucceeded = readOnly !== null;
+      readOnly?.close();
+      const lockRecovery = options?.lockRecovery;
+      const holders = (lockRecovery?.inspectHolders ?? inspectWorkflowDbLockHolders)(dbPath);
+      let repaired = false;
+      let remainingAfterFix: number[] = [];
+      if (options?.repairDbLock && readOnlyProbeSucceeded) {
+        const result = await (lockRecovery?.terminateHolders ?? terminateDormantWorkflowDbLockHolders)(
+          holders,
+          staleWorkerStartedAtByPid,
+        );
+        remainingAfterFix = result.remaining;
+        if (result.signaled.length > 0 && (lockRecovery?.reopen ?? openExistingWorkflowDatabase)(basePath).ok) {
+          fixesApplied.push(`released workflow database lock held by dormant PID(s): ${result.signaled.join(", ")}`);
+          repaired = true;
+        }
+      }
+
+      if (!repaired) {
+        const pids = holders.map((holder) => holder.pid);
+        const killablePids = holders
+          .filter((holder) => holder.sameUser)
+          .map((holder) => holder.pid);
+        const holderDetail = pids.length > 0
+          ? ` Lock-holder PID(s): ${pids.join(", ")}.`
+          : process.platform === "win32"
+            ? " Automatic holder discovery is unavailable on Windows; use Resource Monitor to identify the process using gsd.db."
+            : " No lock-holder PID could be discovered with lsof/fuser.";
+        const killDetail = remainingAfterFix.length > 0
+          ? ` SIGTERM did not stop PID(s) ${remainingAfterFix.join(", ")}; stop them manually: ${remainingAfterFix.map((pid) => `kill ${pid}`).join("; ")}.`
+          : killablePids.length > 0
+            ? ` Stop them manually if active: ${killablePids.map((pid) => `kill ${pid}`).join("; ")}.`
+            : "";
+        issues.push({
+          severity: "error",
+          code: "db_locked",
+          scope: "project",
+          unitId: "project",
+          message:
+            `Workflow database is write-locked by another process; the read-only probe ${readOnlyProbeSucceeded ? "succeeded" : "also failed"}.` +
+            holderDetail + killDetail,
+          file: ".gsd/gsd.db",
+          fixable: process.platform !== "win32",
+        });
+      }
+    } else {
+      issues.push({
+        severity: "warning",
+        code: "db_unavailable",
+        scope: "project",
+        unitId: "project",
+        message: "Database unavailable — using filesystem state derivation (degraded mode). State queries may be slower and less reliable.",
+        file: ".gsd/gsd.db",
+        fixable: false,
+      });
+    }
   }
 
   // ── DB constraint violation detection (full doctor only, not pre-dispatch per D-10) ──

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -91,6 +91,7 @@ export type DoctorIssueCode =
   | "checkbox_db_status_divergence"
   | "completed_milestone_reopened"
   | "db_duplicate_id"
+  | "db_locked"
   | "db_unavailable"
   | "liveness_backstop_schema_missing"
   | "memories_fts_rebuild_missing"
@@ -119,6 +120,7 @@ export type DoctorIssueCode =
  * fixed by an explicit manual doctor run (fixLevel="all").
  */
 export const GLOBAL_STATE_CODES = new Set<DoctorIssueCode>([
+  "db_locked",
   "orphaned_project_state",
   "orphaned_completed_units",
 ]);

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -278,7 +278,10 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
   const envMs = Date.now() - t0env;
 
   // Engine health checks — DB constraints and projection drift
-  await checkEngineHealth(basePath, issues, fixesApplied, { repair: fix && !dryRun });
+  await checkEngineHealth(basePath, issues, fixesApplied, {
+    repair: fix && !dryRun,
+    repairDbLock: shouldFix("db_locked"),
+  });
 
   const milestonesPath = milestonesDir(basePath);
   const legacyMilestonesPath2 = legacyMilestonesDir(basePath);

--- a/src/resources/extensions/gsd/guidance.ts
+++ b/src/resources/extensions/gsd/guidance.ts
@@ -224,6 +224,8 @@ export function crashResumeHint(unitType: string, unitId: string): string | unde
 // guidance is authored — the gap is visible in one place.
 
 const DOCTOR_FIX_HINTS: Partial<Record<DoctorIssueCode, string>> = {
+  db_locked:
+    "On macOS/Linux, run `/gsd doctor --fix` to stop proven dormant GSD holders, or stop the listed PID(s) manually. On Windows, identify the process using gsd.db in Resource Monitor and stop it.",
   db_unavailable:
     "The workflow database could not be opened — state derivation is degraded. Restart the session; if it persists, run `/gsd doctor` from the project root.",
   stale_crash_lock: "Run `/gsd doctor fix` to clear the stale lock, then `/gsd auto` to resume.",

--- a/src/resources/extensions/gsd/sqlite-errors.ts
+++ b/src/resources/extensions/gsd/sqlite-errors.ts
@@ -1,0 +1,11 @@
+// Project/App: gsd-pi
+// File Purpose: Shared SQLite error classification used by open and write paths.
+
+export function isSqliteBusyError(error: unknown): boolean {
+  const record = error as { code?: unknown; errcode?: unknown; message?: unknown };
+  const code = String(record?.code ?? "");
+  const message = String(record?.message ?? error);
+  return record?.errcode === 5
+    || code.includes("SQLITE_BUSY")
+    || /SQLITE_BUSY|database is locked/i.test(message);
+}

--- a/src/resources/extensions/gsd/tests/db-open-state.test.ts
+++ b/src/resources/extensions/gsd/tests/db-open-state.test.ts
@@ -40,6 +40,14 @@ describe("db-open-state", () => {
     assert.equal(state.snapshot().lastPhase, null);
   });
 
+  test("tracks SQLite lock failures distinctly", () => {
+    const state = createDbOpenState();
+    state.markAttempted();
+    state.recordError("locked", Object.assign(new Error("database is locked"), { errcode: 5 }));
+
+    assert.equal(state.snapshot().lastPhase, "locked");
+  });
+
   test("reset clears attempt and error state", () => {
     const state = createDbOpenState();
 

--- a/src/resources/extensions/gsd/tests/db-open-version-stamp.test.ts
+++ b/src/resources/extensions/gsd/tests/db-open-version-stamp.test.ts
@@ -23,6 +23,8 @@ import {
   SchemaTooNewError,
   SCHEMA_VERSION,
   _getAdapter,
+  _setStartupSchemaDetectionForTest,
+  getDbStatus,
 } from "../gsd-db.ts";
 import { openWorkflowDatabase } from "../db-workspace.ts";
 import { recordSchemaVersion } from "../db-schema-metadata.ts";
@@ -36,6 +38,7 @@ function makeTempDir(): string {
 }
 
 afterEach(() => {
+  _setStartupSchemaDetectionForTest(null);
   closeDatabase();
   for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
   tempDirs.clear();
@@ -150,4 +153,42 @@ test("non-version open failures keep the open-failed reason", () => {
   assert.equal(result.ok, false);
   if (result.ok) return;
   assert.equal(result.reason, "open-failed");
+});
+
+test("SQLite busy failures surface a locked reason and open phase", () => {
+  const dir = makeTempDir();
+  const gsdDir = join(dir, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+  const dbPath = join(gsdDir, "gsd.db");
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+
+  _setStartupSchemaDetectionForTest(() => {
+    throw Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY", errcode: 5 });
+  });
+  const result = openWorkflowDatabase(dir);
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, "locked");
+  assert.equal(getDbStatus().lastPhase, "locked");
+});
+
+test("openDatabase retries transient SQLite busy failures", () => {
+  const dir = makeTempDir();
+  const dbPath = join(dir, "gsd.db");
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+
+  let attempts = 0;
+  _setStartupSchemaDetectionForTest(() => {
+    attempts += 1;
+    if (attempts === 1) {
+      throw Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY", errcode: 5 });
+    }
+  });
+
+  assert.equal(openDatabase(dbPath), true);
+  assert.equal(attempts, 2);
+  assert.equal(getDbStatus().lastPhase, null);
 });

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -8,7 +8,9 @@ import {
   insertSlice,
   insertTask,
   getTask,
+  isDbAvailable,
   openDatabase,
+  _setStartupSchemaDetectionForTest,
 } from "../gsd-db.ts";
 import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -19,8 +21,10 @@ import { runGSDDoctor } from "../doctor.ts";
 import { MEMORIES_FTS_REBUILT_KEY } from "../db-memory-fts-schema.ts";
 import { appendEvent } from "../workflow-events.ts";
 import { renderPlanFromDb, renderRoadmapFromDb } from "../markdown-renderer.ts";
+import { openWorkflowDatabase } from "../db-workspace.ts";
 
 afterEach(() => {
+  _setStartupSchemaDetectionForTest(null);
   closeDatabase();
 });
 
@@ -92,6 +96,60 @@ test("checkEngineHealth reports db_unavailable when gsd.db exists but the DB is 
   assert.ok(dbIssue, "doctor should surface degraded DB mode when a DB file exists");
   assert.equal(dbIssue.unitId, "project");
   assert.equal(dbIssue.file, ".gsd/gsd.db");
+});
+
+test("checkEngineHealth reports a busy workflow DB as fixable db_locked", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-db-locked-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+  assert.equal(openDatabase(join(gsdDir, "gsd.db")), true);
+  closeDatabase();
+  _setStartupSchemaDetectionForTest(() => {
+    throw Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY", errcode: 5 });
+  });
+  assert.equal(openWorkflowDatabase(base).ok, false);
+  _setStartupSchemaDetectionForTest(null);
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  const locked = issues.find((issue) => issue.code === "db_locked");
+  assert.ok(locked);
+  assert.equal(locked.severity, "error");
+  assert.equal(locked.fixable, process.platform !== "win32");
+  assert.equal(issues.some((issue) => issue.code === "db_unavailable"), false);
+});
+
+test("checkEngineHealth repair signals proven holders and reopens the database", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-db-lock-repair-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+  assert.equal(openDatabase(join(gsdDir, "gsd.db")), true);
+  closeDatabase();
+  _setStartupSchemaDetectionForTest(() => {
+    throw Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY", errcode: 5 });
+  });
+  assert.equal(openWorkflowDatabase(base).ok, false);
+  _setStartupSchemaDetectionForTest(null);
+
+  const issues: any[] = [];
+  const fixes: string[] = [];
+  await checkEngineHealth(base, issues, fixes, {
+    repairDbLock: true,
+    lockRecovery: {
+      inspectHolders: () => [],
+      terminateHolders: async () => ({ signaled: [777], terminated: [777], remaining: [] }),
+      reopen: (path) => openWorkflowDatabase(path),
+    },
+  });
+
+  assert.equal(isDbAvailable(), true);
+  assert.equal(issues.some((issue) => issue.code === "db_locked"), false);
+  assert.deepEqual(fixes, ["released workflow database lock held by dormant PID(s): 777"]);
 });
 
 test("checkEngineHealth reports memories_fts without the rebuild marker", async (t) => {

--- a/src/resources/extensions/gsd/tests/sqlite-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/sqlite-errors.test.ts
@@ -1,0 +1,14 @@
+// Project/App: gsd-pi
+// File Purpose: SQLite busy error classification regression tests (#1826).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isSqliteBusyError } from "../sqlite-errors.ts";
+
+test("isSqliteBusyError recognizes provider codes, errcode 5, and lock messages", () => {
+  assert.equal(isSqliteBusyError({ code: "SQLITE_BUSY" }), true);
+  assert.equal(isSqliteBusyError({ errcode: 5 }), true);
+  assert.equal(isSqliteBusyError(new Error("database is locked")), true);
+  assert.equal(isSqliteBusyError(new Error("database disk image is malformed")), false);
+});

--- a/src/resources/extensions/gsd/tests/workflow-db-locks.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-db-locks.test.ts
@@ -1,0 +1,90 @@
+// Project/App: gsd-pi
+// File Purpose: Workflow DB lock-holder parsing regression tests (#1826).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isDormantWorkflowDbLockHolderSafeToTerminate,
+  formatLockedWorkflowDatabaseNotice,
+  parseElapsedSeconds,
+  parseLsofProcessFields,
+  terminateDormantWorkflowDbLockHolders,
+  type WorkflowDbLockHolder,
+} from "../workflow-db-locks.ts";
+
+test("parseLsofProcessFields extracts holder PIDs, commands, and numeric users", () => {
+  assert.deepEqual(parseLsofProcessFields("p123\ncnode\nu501\nf21\np456\ncgsd\nu501\nf22"), [
+    { pid: 123, command: "node", uid: 501 },
+    { pid: 456, command: "gsd", uid: 501 },
+  ]);
+});
+
+test("parseElapsedSeconds handles day and clock forms", () => {
+  assert.equal(parseElapsedSeconds("03:04"), 184);
+  assert.equal(parseElapsedSeconds("02:03:04"), 7_384);
+  assert.equal(parseElapsedSeconds("1-02:03:04"), 93_784);
+});
+
+test("automatic termination also requires a stale worker heartbeat", () => {
+  const holder: WorkflowDbLockHolder = {
+    pid: 123,
+    command: "node /opt/@opengsd/gsd-pi/dist/loader.js",
+    uid: 501,
+    state: "S",
+    elapsedSeconds: 600,
+    sameUser: true,
+    gsdProcess: true,
+    dormant: true,
+    processStartIdentity: "sha256:test-process",
+    processStartedAtMs: 1_000,
+  };
+
+  assert.equal(isDormantWorkflowDbLockHolderSafeToTerminate(holder, new Map()), false);
+  assert.equal(isDormantWorkflowDbLockHolderSafeToTerminate(holder, new Map([[123, 2_000]])), true);
+  assert.equal(
+    isDormantWorkflowDbLockHolderSafeToTerminate({ ...holder, sameUser: false }, new Map([[123, 2_000]])),
+    false,
+  );
+  assert.equal(
+    isDormantWorkflowDbLockHolderSafeToTerminate(
+      { ...holder, processStartedAtMs: 100_000 },
+      new Map([[123, 2_000]]),
+    ),
+    false,
+  );
+});
+
+test("termination signals only a stale, same-instance GSD holder", async () => {
+  const holder: WorkflowDbLockHolder = {
+    pid: 123,
+    command: "node /opt/@opengsd/gsd-pi/dist/loader.js",
+    uid: 501,
+    state: "S",
+    elapsedSeconds: 600,
+    sameUser: true,
+    gsdProcess: true,
+    dormant: true,
+    processStartIdentity: "sha256:test-process",
+    processStartedAtMs: 1_000,
+  };
+  const signaled: number[] = [];
+  const result = await terminateDormantWorkflowDbLockHolders(
+    [holder, { ...holder, pid: 456, processStartIdentity: "sha256:active" }],
+    new Map([[123, 2_000], [456, 2_000]]),
+    {
+      signal: (pid) => { signaled.push(pid); },
+      isAlive: () => false,
+      wait: async () => {},
+      processIdentity: (pid) => pid === 123 ? "sha256:test-process" : "sha256:reused",
+    },
+  );
+
+  assert.deepEqual(signaled, [123]);
+  assert.deepEqual(result, { signaled: [123], terminated: [123], remaining: [] });
+});
+
+test("locked auto notice includes discovered holder PIDs and remediation", () => {
+  assert.match(formatLockedWorkflowDatabaseNotice([123, 456]), /PIDs 123, 456/);
+  assert.match(formatLockedWorkflowDatabaseNotice([123, 456]), /doctor --fix/);
+});

--- a/src/resources/extensions/gsd/workflow-db-locks.ts
+++ b/src/resources/extensions/gsd/workflow-db-locks.ts
@@ -1,0 +1,191 @@
+// Project/App: gsd-pi
+// File Purpose: Diagnose and safely terminate dormant GSD processes holding workflow SQLite files.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { processStartIdentity } from "./process-start-identity.js";
+
+const DORMANT_HOLDER_SECONDS = 5 * 60;
+
+export interface WorkflowDbLockHolder {
+  pid: number;
+  command: string;
+  uid: number | null;
+  state: string;
+  elapsedSeconds: number;
+  sameUser: boolean;
+  gsdProcess: boolean;
+  dormant: boolean;
+  processStartIdentity: string | null;
+  processStartedAtMs: number | null;
+}
+
+function commandOutput(command: string, args: string[]): string | null {
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 5_000,
+    }).trim();
+  } catch (error) {
+    const stdout = (error as { stdout?: unknown }).stdout;
+    return typeof stdout === "string" && stdout.trim() ? stdout.trim() : null;
+  }
+}
+
+export function parseLsofProcessFields(output: string): Array<{ pid: number; command: string; uid: number | null }> {
+  const holders: Array<{ pid: number; command: string; uid: number | null }> = [];
+  let current: { pid: number; command: string; uid: number | null } | null = null;
+  for (const line of output.split(/\r?\n/)) {
+    const field = line[0];
+    const value = line.slice(1);
+    if (field === "p") {
+      if (current) holders.push(current);
+      current = { pid: Number(value), command: "unknown", uid: null };
+    } else if (current && field === "c") {
+      current.command = value;
+    } else if (current && field === "u") {
+      const uid = Number(value);
+      current.uid = Number.isSafeInteger(uid) ? uid : null;
+    }
+  }
+  if (current) holders.push(current);
+  return holders.filter((holder) => Number.isSafeInteger(holder.pid) && holder.pid > 0);
+}
+
+export function parseElapsedSeconds(value: string): number {
+  const match = value.trim().match(/^(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)$/);
+  if (!match) return 0;
+  const [, days = "0", hours = "0", minutes = "0", seconds = "0"] = match;
+  return Number(days) * 86_400 + Number(hours) * 3_600 + Number(minutes) * 60 + Number(seconds);
+}
+
+function inspectProcess(
+  holder: { pid: number; command: string; uid: number | null },
+): WorkflowDbLockHolder {
+  const ps = commandOutput("ps", ["-o", "uid=,state=,etime=,command=", "-p", String(holder.pid)]);
+  const match = ps?.match(/^\s*(\d+)\s+(\S+)\s+(\S+)\s+(.+)$/);
+  const uid = match ? Number(match[1]) : holder.uid;
+  const state = match?.[2] ?? "";
+  const elapsedSeconds = parseElapsedSeconds(match?.[3] ?? "");
+  const command = match?.[4] ?? holder.command;
+  const currentUid = process.getuid?.();
+  const sameUser = currentUid !== undefined && uid === currentUid;
+  const gsdProcess = /^gsd(?:-|$)/i.test(holder.command)
+    || /(?:^|[\s/])gsd(?:-pi)?(?:[\s/]|$)|@opengsd\/gsd-pi/i.test(command);
+  const dormant = /^[SI]/.test(state) && elapsedSeconds >= DORMANT_HOLDER_SECONDS;
+  return {
+    pid: holder.pid,
+    command,
+    uid,
+    state,
+    elapsedSeconds,
+    sameUser,
+    gsdProcess,
+    dormant,
+    processStartIdentity: processStartIdentity(holder.pid),
+    processStartedAtMs: elapsedSeconds > 0 ? Date.now() - elapsedSeconds * 1_000 : null,
+  };
+}
+
+function findWorkflowDbLockHolders(
+  databasePath: string,
+): Array<{ pid: number; command: string; uid: number | null }> {
+  if (process.platform === "win32") return [];
+  const paths = [databasePath, `${databasePath}-wal`, `${databasePath}-shm`].filter(existsSync);
+  if (paths.length === 0) return [];
+
+  const lsof = commandOutput("lsof", ["-nP", "-l", "-Fpcu", ...paths]);
+  let holders = lsof ? parseLsofProcessFields(lsof) : [];
+  if (holders.length === 0 && process.platform === "linux") {
+    const fuser = commandOutput("fuser", paths);
+    holders = [...new Set(fuser?.match(/\d+/g) ?? [])].map((pid) => ({
+      pid: Number(pid),
+      command: "unknown",
+      uid: null,
+    }));
+  }
+
+  return holders.filter((holder) => holder.pid !== process.pid);
+}
+
+export function listWorkflowDbLockHolderPids(databasePath: string): number[] {
+  return findWorkflowDbLockHolders(databasePath).map((holder) => holder.pid);
+}
+
+export function inspectWorkflowDbLockHolders(databasePath: string): WorkflowDbLockHolder[] {
+  return findWorkflowDbLockHolders(databasePath).map(inspectProcess);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export async function terminateDormantWorkflowDbLockHolders(
+  holders: WorkflowDbLockHolder[],
+  staleWorkerStartedAtByPid: ReadonlyMap<number, number>,
+  dependencies?: {
+    signal?: (pid: number) => void;
+    isAlive?: (pid: number) => boolean;
+    wait?: () => Promise<void>;
+    processIdentity?: (pid: number) => string | null;
+  },
+): Promise<{ signaled: number[]; terminated: number[]; remaining: number[] }> {
+  const signaled: number[] = [];
+  const signal = dependencies?.signal ?? ((pid: number) => { process.kill(pid, "SIGTERM"); });
+  const isAlive = dependencies?.isAlive ?? processIsAlive;
+  const identity = dependencies?.processIdentity ?? processStartIdentity;
+  for (const holder of holders) {
+    if (!isDormantWorkflowDbLockHolderSafeToTerminate(holder, staleWorkerStartedAtByPid)) continue;
+    if (holder.processStartIdentity === null || identity(holder.pid) !== holder.processStartIdentity) continue;
+    try {
+      signal(holder.pid);
+      signaled.push(holder.pid);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") continue;
+      signaled.push(holder.pid);
+    }
+  }
+
+  if (signaled.length > 0) {
+    await (dependencies?.wait?.() ?? new Promise((resolve) => setTimeout(resolve, 500)));
+  }
+  const remaining = signaled.filter(isAlive);
+  return {
+    signaled,
+    terminated: signaled.filter((pid) => !remaining.includes(pid)),
+    remaining,
+  };
+}
+
+export function isDormantWorkflowDbLockHolderSafeToTerminate(
+  holder: WorkflowDbLockHolder,
+  staleWorkerStartedAtByPid: ReadonlyMap<number, number>,
+): boolean {
+  const workerStartedAtMs = staleWorkerStartedAtByPid.get(holder.pid);
+  return holder.sameUser
+    && holder.gsdProcess
+    && holder.dormant
+    && holder.processStartedAtMs !== null
+    && workerStartedAtMs !== undefined
+    // A worker registers after its containing process starts. If the current
+    // process started later, the stale row belongs to an earlier PID instance.
+    && holder.processStartedAtMs <= workerStartedAtMs + 60_000;
+}
+
+export function formatLockedWorkflowDatabaseNotice(holderPids: readonly number[]): string {
+  const pidDetail = holderPids.length === 1
+    ? ` (PID ${holderPids[0]!})`
+    : holderPids.length > 1
+      ? ` (PIDs ${holderPids.join(", ")})`
+      : "";
+  return (
+    `Auto-mode blocked — liveness backstop unavailable: workflow database is locked by another GSD process${pidDetail}. ` +
+    "Run `/gsd doctor --fix` to clean orphaned holders or stop that process."
+  );
+}


### PR DESCRIPTION
## Summary
- Added safe SQLite lock diagnosis and recovery with bounded retries, verified by 11 focused tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1826
- [#1826 auto: orphaned gsd processes lock the workflow DB (SQLITE_BUSY) and /gsd doctor --fix reports Clean, never repairs — permanent wedge (1.16.0)](https://github.com/open-gsd/gsd-pi/issues/1826)

## User
- @Freston1605

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1826-auto-orphaned-gsd-processes-lock-the-wor-1787066218`