### PR TITLE
fix(issue): [Bug]: Repository Discord invite is stale despite consistency test

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/@opengsd/gsd-pi?label=npm&logo=npm)](https://www.npmjs.com/package/@opengsd/gsd-pi)
 [![npm downloads](https://img.shields.io/npm/dm/@opengsd/gsd-pi?label=downloads&logo=npm&color=red)](https://www.npmjs.com/package/@opengsd/gsd-pi)
 [![CI](https://img.shields.io/github/actions/workflow/status/open-gsd/gsd-pi/ci.yml?branch=main&label=tests&logo=github)](https://github.com/open-gsd/gsd-pi/actions/workflows/ci.yml)
-[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/8NnkKuepmQ)
+[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/vY2bv3FrzX)
 [![GitHub stars](https://img.shields.io/github/stars/open-gsd/gsd-pi?label=stars&logo=github)](https://github.com/open-gsd/gsd-pi/stargazers)
 [![License: MIT](https://img.shields.io/github/license/open-gsd/gsd-pi?label=license)](https://github.com/open-gsd/gsd-pi/blob/main/LICENSE)
 
@@ -223,7 +223,7 @@ Historical tags and archived refs may exist for traceability, but active release
 
 ## Community
 
-Join the [GSD Discord community](https://discord.gg/8NnkKuepmQ).
+Join the [GSD Discord community](https://discord.gg/vY2bv3FrzX).
 
 ## Star History
 

--- a/docs/dev/what-is-pi/15-pi-packages-the-ecosystem.md
+++ b/docs/dev/what-is-pi/15-pi-packages-the-ecosystem.md
@@ -38,6 +38,6 @@ Or just use conventional directory names (`extensions/`, `skills/`, `prompts/`, 
 
 - [Package gallery](https://shittycodingagent.ai/packages)
 - [npm search](https://www.npmjs.com/search?q=keywords%3Api-package)
-- [Discord community](https://discord.gg/8NnkKuepmQ)
+- [Discord community](https://discord.gg/vY2bv3FrzX)
 
 ---

--- a/packages/pi-coding-agent/README.md
+++ b/packages/pi-coding-agent/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://discord.gg/8NnkKuepmQ"><img alt="Discord" src="https://img.shields.io/badge/discord-community-5865F2?style=flat-square&logo=discord&logoColor=white" /></a>
+  <a href="https://discord.gg/vY2bv3FrzX"><img alt="Discord" src="https://img.shields.io/badge/discord-community-5865F2?style=flat-square&logo=discord&logoColor=white" /></a>
   <a href="https://www.npmjs.com/package/@earendil-works/pi-coding-agent"><img alt="npm" src="https://img.shields.io/npm/v/@earendil-works/pi-coding-agent?style=flat-square" /></a>
 </p>
 <p align="center">

--- a/src/resources/extensions/gsd/tests/discord-invite-links.test.ts
+++ b/src/resources/extensions/gsd/tests/discord-invite-links.test.ts
@@ -13,7 +13,7 @@ import { join } from "node:path";
 const ROOT = process.cwd();
 
 /** Canonical Discord invite for the GSD community. */
-const VALID_INVITE = "https://discord.gg/8NnkKuepmQ";
+const VALID_INVITE = "https://discord.gg/vY2bv3FrzX";
 
 /** Files that contain user-facing Discord invite links. */
 const FILES_WITH_INVITE_LINKS: string[] = [


### PR DESCRIPTION
## Summary
- Updated all Discord links and the regression test to the current invite, with focused tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1827
- [#1827 [Bug]: Repository Discord invite is stale despite consistency test](https://github.com/open-gsd/gsd-pi/issues/1827)

## User
- @pimmink

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1827-bug-repository-discord-invite-is-stale-d-1787070511`