### PR TITLE
fix(issue): cursor-agent execute-task cannot call gsd_task_complete → missing-executor-result retry wedge; remote_questions null stub still fails validation (1.15.0)

### DIFF
--- a/src/resources/extensions/cursor-cli/stream-adapter.ts
+++ b/src/resources/extensions/cursor-cli/stream-adapter.ts
@@ -93,7 +93,12 @@ export function buildCursorPrompt(context: Context): string {
 		parts.push(
 			`The external Cursor agent may execute its own tools. ` +
 			`GSD will not redispatch Cursor-owned internal tool events locally. ` +
-			`GSD lifecycle tools executed locally: ${bridged.join(", ") || "(none)"}. ` +
+			`GSD lifecycle tools bridged to the local host: ${bridged.join(", ") || "(none)"}. ` +
+			(bridged.length > 0
+				? `To invoke one, emit exactly one final envelope in this form: ` +
+					`<gsd_tool_call>{"name":"gsd_task_complete","arguments":{...}}</gsd_tool_call>. ` +
+					`Use a bridged tool name and its real arguments; GSD removes the envelope and executes it locally. `
+				: "") +
 			`Requested GSD tools: ${names.join(", ")}`,
 		);
 	}
@@ -124,7 +129,11 @@ export function buildCursorAgentRunPlan(
 const CURSOR_BRIDGED_GSD_TOOLS = new Set([
 	"gsd_task_complete",
 	"gsd_complete_task",
+	"gsd_task_recovery_resume",
 ]);
+
+const GSD_TOOL_CALL_OPEN = "<gsd_tool_call>";
+const GSD_TOOL_CALL_CLOSE = "</gsd_tool_call>";
 
 function gsdToolBaseName(name: string): string {
 	return name.replace(/^mcp__.+?__/, "");
@@ -142,6 +151,17 @@ export function isGsdToolName(name: string): boolean {
 
 export function unsupportedCursorGsdToolError(name: string): string {
 	return `tool unsupported under cursor-agent: ${name}`;
+}
+
+function invalidCursorGsdToolEnvelopeError(detail: string): Error {
+	return new Error(`invalid cursor-agent GSD lifecycle envelope: ${detail}`);
+}
+
+function longestToolEnvelopePrefixSuffix(value: string): number {
+	for (let length = Math.min(value.length, GSD_TOOL_CALL_OPEN.length - 1); length > 0; length--) {
+		if (GSD_TOOL_CALL_OPEN.startsWith(value.slice(-length))) return length;
+	}
+	return 0;
 }
 
 function emitCompleteLines(chunk: string, pending: { value: string }, onLine: CursorAgentLineHandler): void {
@@ -403,6 +423,8 @@ export function streamViaCursorAgent(
 			let textStarted = false;
 			const toolCalls = new Map<string, ToolCall>();
 			const content: AssistantMessage["content"] = [];
+			let envelopeBuffer = "";
+			let readingEnvelope = false;
 
 			const partialMessage = (): AssistantMessage => {
 				const partialContent: AssistantMessage["content"] = text ? [{ type: "text", text }, ...content] : [...content];
@@ -413,18 +435,86 @@ export function streamViaCursorAgent(
 				streamStarted = true;
 				stream.push({ type: "start", partial: partialMessage() });
 			};
+			const emitText = (value: string) => {
+				if (!value) return;
+				ensureStart();
+				if (!textStarted) {
+					textStarted = true;
+					stream.push({ type: "text_start", contentIndex: 0 });
+				}
+				text += value;
+				stream.push({ type: "text_delta", contentIndex: 0, delta: value });
+			};
+			const acceptToolCall = (toolCall: ToolCall): void => {
+				if (isGsdToolName(toolCall.name) && !isCursorBridgedGsdTool(toolCall.name)) {
+					throw new Error(unsupportedCursorGsdToolError(toolCall.name));
+				}
+				ensureStart();
+				toolCalls.set(toolCall.id, toolCall);
+				content.push(toolCall);
+				const index = text ? content.length : content.length - 1;
+				stream.push({ type: "toolcall_start", contentIndex: index });
+				stream.push({ type: "toolcall_end", contentIndex: index, toolCall });
+			};
+			const acceptEnvelope = (payload: string): void => {
+				let parsed: Record<string, unknown>;
+				try {
+					const value = objectValue(JSON.parse(payload));
+					if (!value) throw invalidCursorGsdToolEnvelopeError("payload must be a JSON object");
+					parsed = value;
+				} catch (error) {
+					if (error instanceof Error && error.message.startsWith("invalid cursor-agent")) throw error;
+					throw invalidCursorGsdToolEnvelopeError(error instanceof Error ? error.message : String(error));
+				}
+				const requestedName = stringValue(parsed.name);
+				if (!requestedName) throw invalidCursorGsdToolEnvelopeError("missing tool name");
+				const name = gsdToolBaseName(requestedName);
+				if (!isCursorBridgedGsdTool(name)) throw new Error(unsupportedCursorGsdToolError(requestedName));
+				const args = objectValue(parsed.arguments ?? parsed.input);
+				if (!args) throw invalidCursorGsdToolEnvelopeError(`missing arguments for ${name}`);
+				acceptToolCall({
+					type: "toolCall",
+					id: `cursor_gsd_${Date.now()}_${content.length}`,
+					name,
+					arguments: args,
+				});
+			};
+			const acceptText = (value: string, flush = false): void => {
+				envelopeBuffer += value;
+				for (;;) {
+					if (readingEnvelope) {
+						const closeIndex = envelopeBuffer.indexOf(GSD_TOOL_CALL_CLOSE);
+						if (closeIndex < 0) {
+							if (flush) throw invalidCursorGsdToolEnvelopeError(`missing ${GSD_TOOL_CALL_CLOSE}`);
+							return;
+						}
+						acceptEnvelope(envelopeBuffer.slice(0, closeIndex));
+						envelopeBuffer = envelopeBuffer.slice(closeIndex + GSD_TOOL_CALL_CLOSE.length);
+						readingEnvelope = false;
+						continue;
+					}
+
+					const openIndex = envelopeBuffer.indexOf(GSD_TOOL_CALL_OPEN);
+					if (openIndex >= 0) {
+						emitText(envelopeBuffer.slice(0, openIndex));
+						envelopeBuffer = envelopeBuffer.slice(openIndex + GSD_TOOL_CALL_OPEN.length);
+						readingEnvelope = true;
+						continue;
+					}
+
+					const heldSuffixLength = flush ? 0 : longestToolEnvelopePrefixSuffix(envelopeBuffer);
+					const visibleLength = envelopeBuffer.length - heldSuffixLength;
+					emitText(envelopeBuffer.slice(0, visibleLength));
+					envelopeBuffer = envelopeBuffer.slice(visibleLength);
+					return;
+				}
+			};
 			const handleLine = (line: string): void => {
 				const parsed = parseCursorAgentLine(line);
 				if (parsed.type === "ignore") return;
 				if (parsed.type === "error") throw new Error(parsed.message);
 				if (parsed.type === "text") {
-					ensureStart();
-					if (!textStarted) {
-						textStarted = true;
-						stream.push({ type: "text_start", contentIndex: 0 });
-					}
-					text += parsed.text;
-					stream.push({ type: "text_delta", contentIndex: 0, delta: parsed.text });
+					acceptText(parsed.text);
 					return;
 				}
 				if (parsed.type === "usage") {
@@ -432,15 +522,7 @@ export function streamViaCursorAgent(
 					return;
 				}
 				if (parsed.type === "tool_call") {
-					if (isGsdToolName(parsed.toolCall.name) && !isCursorBridgedGsdTool(parsed.toolCall.name)) {
-						throw new Error(unsupportedCursorGsdToolError(parsed.toolCall.name));
-					}
-					ensureStart();
-					toolCalls.set(parsed.toolCall.id, parsed.toolCall);
-					content.push(parsed.toolCall);
-					const index = text ? content.length : content.length - 1;
-					stream.push({ type: "toolcall_start", contentIndex: index });
-					stream.push({ type: "toolcall_end", contentIndex: index, toolCall: parsed.toolCall });
+					acceptToolCall(parsed.toolCall);
 					return;
 				}
 				if (parsed.type === "tool_result") {
@@ -461,6 +543,7 @@ export function streamViaCursorAgent(
 			if (result.code !== 0) {
 				throw new Error((result.stderr || result.stdout || `cursor-agent exited with code ${result.code}`).trim());
 			}
+			acceptText("", true);
 
 			const finalContent: AssistantMessage["content"] = text ? [{ type: "text", text }, ...content] : content;
 			const finalMessage = buildAssistantMessage(model, finalContent, usage);

--- a/src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/cursor-cli/tests/stream-adapter.test.ts
@@ -49,16 +49,21 @@ test("buildCursorPrompt preserves system, message, and tool context", () => {
 	assert.match(prompt, /System instructions:\nBe concise\./);
 	assert.match(prompt, /User:\nHello/);
 	assert.match(prompt, /Requested GSD tools: gsd_plan_slice/);
-	assert.match(prompt, /GSD lifecycle tools executed locally: \(none\)/);
+	assert.match(prompt, /GSD lifecycle tools bridged to the local host: \(none\)/);
 });
 
-test("buildCursorPrompt names bridged GSD lifecycle tools as locally executed (#1764)", () => {
+test("buildCursorPrompt explains the local GSD lifecycle bridge (#1764)", () => {
 	const prompt = buildCursorPrompt({
 		...context,
-		tools: [{ name: "gsd_task_complete" }, { name: "gsd_plan_slice" }],
+		tools: [
+			{ name: "gsd_task_complete" },
+			{ name: "gsd_task_recovery_resume" },
+			{ name: "gsd_plan_slice" },
+		],
 	} as Context);
-	assert.match(prompt, /GSD lifecycle tools executed locally: gsd_task_complete/);
-	assert.match(prompt, /Requested GSD tools: gsd_task_complete, gsd_plan_slice/);
+	assert.match(prompt, /GSD lifecycle tools bridged to the local host: gsd_task_complete, gsd_task_recovery_resume/);
+	assert.match(prompt, /<gsd_tool_call>\{"name":"gsd_task_complete","arguments":\{\.\.\.\}\}<\/gsd_tool_call>/);
+	assert.match(prompt, /Requested GSD tools: gsd_task_complete, gsd_task_recovery_resume, gsd_plan_slice/);
 });
 
 test("parseCursorAgentLine maps text, legacy tool, result, usage, and errors", () => {
@@ -284,11 +289,10 @@ test("streamViaCursorAgent turns NDJSON into assistant events with external tool
 	assert.equal(done.message.usage.output, 4);
 });
 
-test("cursor adapter bridges gsd_task_complete for local host execution (#1764)", async () => {
+test("cursor adapter bridges a streamed gsd_task_complete envelope for local host execution (#1764)", async () => {
 	const lines = [
-		'{"type":"assistant","message":{"content":[{"type":"text","text":"Completing"}]}}',
-		'{"type":"tool_call","id":"tool_1","name":"gsd_task_complete","input":{"milestoneId":"M001"}}',
-		'{"type":"tool_result","tool_call_id":"tool_1","content":"ignored","is_error":false}',
+		'{"type":"assistant","message":{"content":[{"type":"text","text":"Implemented and verified.\\n<gsd_tool_"}]}}',
+		'{"type":"assistant","message":{"content":[{"type":"text","text":"call>{\\"name\\":\\"gsd_task_complete\\",\\"arguments\\":{\\"milestoneId\\":\\"M001\\",\\"sliceId\\":\\"S01\\",\\"taskId\\":\\"T03\\"}}</gsd_tool_call>"}]}}',
 	];
 	const stream = streamViaCursorAgent(model, context, {
 		_cursorAgentRunnerForTest: async () => ({ stdout: `${lines.join("\n")}\n`, stderr: "", code: 0, signal: null }),
@@ -300,7 +304,74 @@ test("cursor adapter bridges gsd_task_complete for local host execution (#1764)"
 	const toolCall = done.message.content.find((block) => block.type === "toolCall");
 	assert.ok(toolCall && toolCall.type === "toolCall");
 	assert.equal(toolCall.name, "gsd_task_complete");
+	assert.deepEqual(toolCall.arguments, { milestoneId: "M001", sliceId: "S01", taskId: "T03" });
 	assert.equal(toolCall.externalResult, undefined);
+	const finalText = done.message.content
+		.filter((block) => block.type === "text")
+		.map((block) => block.text)
+		.join("");
+	assert.equal(finalText, "Implemented and verified.\n");
+	assert.doesNotMatch(finalText, /gsd_tool_call/);
+});
+
+test("cursor adapter bridges gsd_task_recovery_resume envelopes (#1764)", async () => {
+	const line = '{"type":"assistant","message":{"content":[{"type":"text","text":"<gsd_tool_call>{\\"name\\":\\"gsd_task_recovery_resume\\",\\"arguments\\":{\\"recoveryActionId\\":\\"R001\\",\\"repairSummary\\":\\"Fixed\\",\\"evidence\\":{\\"tests\\":[\\"pass\\"]}}}</gsd_tool_call>"}]}}';
+	const stream = streamViaCursorAgent(model, context, {
+		_cursorAgentRunnerForTest: async () => ({ stdout: `${line}\n`, stderr: "", code: 0, signal: null }),
+	});
+	const events = [];
+	for await (const event of stream) events.push(event);
+	const done = events.find((event) => event.type === "done");
+	assert.ok(done && done.type === "done");
+	const toolCall = done.message.content.find((block) => block.type === "toolCall");
+	assert.ok(toolCall && toolCall.type === "toolCall");
+	assert.equal(toolCall.name, "gsd_task_recovery_resume");
+});
+
+test("cursor lifecycle envelope executes gsd_task_complete through the host agent loop (#1764)", async () => {
+	let executedArgs: Record<string, unknown> | undefined;
+	const completionTool = {
+		name: "gsd_task_complete",
+		label: "Complete task",
+		description: "Complete the active task",
+		parameters: {
+			type: "object",
+			properties: {
+				milestoneId: { type: "string" },
+				sliceId: { type: "string" },
+				taskId: { type: "string" },
+			},
+			required: ["milestoneId", "sliceId", "taskId"],
+		},
+		async execute(_toolCallId: string, args: Record<string, unknown>) {
+			executedArgs = args;
+			return {
+				content: [{ type: "text", text: "Staged task T03; awaiting host verification" }],
+				details: {},
+				terminate: true,
+			};
+		},
+	};
+	const prompt: AgentMessage = { role: "user", content: "Implement T03.", timestamp: Date.now() };
+	const stream = agentLoop(
+		[prompt],
+		{ systemPrompt: "Complete the task.", messages: [], tools: [completionTool as any] },
+		{ model, convertToLlm: (messages) => messages as Message[] },
+		undefined,
+		(_model, llmContext) => streamViaCursorAgent(model, llmContext, {
+			_cursorAgentRunnerForTest: async () => ({
+				stdout: '{"type":"assistant","message":{"content":[{"type":"text","text":"<gsd_tool_call>{\\"name\\":\\"gsd_task_complete\\",\\"arguments\\":{\\"milestoneId\\":\\"M001\\",\\"sliceId\\":\\"S01\\",\\"taskId\\":\\"T03\\"}}</gsd_tool_call>"}]}}\n',
+				stderr: "",
+				code: 0,
+				signal: null,
+			}),
+		}),
+	);
+
+	const events: AgentEvent[] = [];
+	for await (const event of stream) events.push(event);
+	assert.deepEqual(executedArgs, { milestoneId: "M001", sliceId: "S01", taskId: "T03" });
+	assert.ok(events.some((event) => event.type === "tool_execution_end" && event.toolName === "gsd_task_complete"));
 });
 
 test("cursor adapter refuses unbridged GSD tool calls (#1764)", async () => {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -648,12 +648,10 @@ export function validatePreferences(preferences: GSDPreferences): {
   // ─── Remote Questions ───────────────────────────────────────────────
   if (preferences.remote_questions !== undefined) {
     const remoteQuestions = preferences.remote_questions as unknown;
-    if (remoteQuestions === null) {
-      // Bare YAML stub (`remote_questions: null`) means absent (#1764).
+    if (remoteQuestions === null || remoteQuestions === false) {
+      // Bare YAML stubs and explicit disable both mean absent (#1764).
     } else if (typeof remoteQuestions === "object") {
       validated.remote_questions = remoteQuestions as GSDPreferences["remote_questions"];
-    } else if (remoteQuestions === false) {
-      // Explicit disable for a globally-configured remote questions channel.
     } else {
       errors.push("remote_questions must be an object");
     }

--- a/src/resources/extensions/gsd/templates/PREFERENCES.md
+++ b/src/resources/extensions/gsd/templates/PREFERENCES.md
@@ -84,11 +84,13 @@ cmux:
   sidebar:
   splits:
   browser:
-remote_questions:
-  channel:
-  channel_id:
-  timeout_minutes:
-  poll_interval_seconds:
+remote_questions: false
+# To enable remote questions, replace `false` with:
+# remote_questions:
+#   channel: telegram
+#   channel_id: "12345"
+#   timeout_minutes: 5
+#   poll_interval_seconds: 5
 uat_dispatch:
 post_unit_hooks: []
 pre_dispatch_hooks: []

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -17,6 +17,7 @@ import { filterDoctorIssues } from "../doctor-format.ts";
 import { checkEngineHealth } from "../doctor-engine-checks.ts";
 import { runGSDDoctor } from "../doctor.ts";
 import { MEMORIES_FTS_REBUILT_KEY } from "../db-memory-fts-schema.ts";
+import { getProjectGSDPreferencesPath } from "../preferences.ts";
 import { appendEvent } from "../workflow-events.ts";
 import { renderPlanFromDb, renderRoadmapFromDb } from "../markdown-renderer.ts";
 
@@ -52,11 +53,18 @@ test("doctor preference diagnostics report diagnostic.scope (#1764)", async (t) 
   mkdirSync(join(base, ".gsd"), { recursive: true });
   process.env.GSD_HOME = home;
   writeFileSync(join(home, "PREFERENCES.md"), "---\nversion: 3\n---\n", "utf-8");
+  const projectPreferencesPath = getProjectGSDPreferencesPath(base);
+  mkdirSync(dirname(projectPreferencesPath), { recursive: true });
+  writeFileSync(projectPreferencesPath, "---\nversion: 3\n---\n", "utf-8");
 
   const report = await runGSDDoctor(base, { fix: false });
-  const issue = report.issues.find((item) => item.code === "invalid_preferences");
-  assert.ok(issue, "doctor should surface the global preferences diagnostic");
-  assert.equal(issue.scope, "global");
+  const issuesByFile = new Map(
+    report.issues
+      .filter((item) => item.code === "invalid_preferences")
+      .map((item) => [item.file, item]),
+  );
+  assert.equal(issuesByFile.get(join(home, "PREFERENCES.md"))?.scope, "global");
+  assert.equal(issuesByFile.get(projectPreferencesPath)?.scope, "project");
 });
 
 test("filterDoctorIssues keeps invalid_preferences issues regardless of preferences file scope", () => {

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -10,7 +10,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import {
@@ -165,6 +165,12 @@ test("remote_questions accepts object config and false disables without error", 
     const invalid = validatePreferences({ remote_questions: value } as any);
     assert.ok(invalid.errors.includes("remote_questions must be an object"));
   }
+});
+
+test("preferences template uses an explicit false remote_questions stub (#1764)", () => {
+  const template = readFileSync(new URL("../templates/PREFERENCES.md", import.meta.url), "utf-8");
+  assert.match(template, /^remote_questions: false$/m);
+  assert.doesNotMatch(template, /^remote_questions:\s*$/m);
 });
 
 test("flat_rate_providers: accepts string array", () => {


### PR DESCRIPTION
## Summary
- Fixed all three #1764 defects with focused lifecycle, preference, and doctor-scope regression coverage.

## Bugs Addressed
- [x] **cursor-agent cannot complete execute-task lifecycle**
- [x] **Preferences validator rejects null remote_questions stubs**
- [x] **Doctor reports global preference diagnostics as project-scoped**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1764
- [#1764 cursor-agent execute-task cannot call gsd_task_complete → missing-executor-result retry wedge; remote_questions null stub still fails validation (1.15.0)](https://github.com/open-gsd/gsd-pi/issues/1764)

## User
- @Kvintus

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1764-cursor-agent-execute-task-cannot-call-gs-1787092286`