### PR TITLE
fix(issue): [Bug]: checkCloseoutConsistencyGate checks for pending gates before closing them — order-of-operations wedge blocks milestone closeout

### DIFF
--- a/src/resources/extensions/gsd/closeout-consistency-gate.ts
+++ b/src/resources/extensions/gsd/closeout-consistency-gate.ts
@@ -292,6 +292,10 @@ export function checkCloseoutConsistencyGate(
     ? inspectQualityGatesFromEvidence(milestoneId, gateClosureOptions)
     : { repaired: [], unresolved: [] };
 
+  if (!adoptedMilestone && gateClosureOptions) {
+    closeQualityGatesFromEvidence(milestoneId, gateClosureOptions);
+  }
+
   for (const slice of slices) {
     if (isDeferredStatus(slice.status)) continue;
     if (!isClosedStatus(slice.status)) {
@@ -323,10 +327,6 @@ export function checkCloseoutConsistencyGate(
         `Closeout consistency blocked for ${milestoneId}: quality gate ${pendingGate.gate_id} is still pending for ${slice.id}.`,
       );
     }
-  }
-
-  if (!adoptedMilestone && gateClosureOptions) {
-    closeQualityGatesFromEvidence(milestoneId, gateClosureOptions);
   }
 
   return { ok: true };

--- a/src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts
@@ -11,8 +11,11 @@ import { execFileSync } from "node:child_process";
 import { mergeMilestoneToMain } from "../auto-worktree-merge.ts";
 import { checkCloseoutConsistencyGate } from "../closeout-consistency-gate.ts";
 import {
+  _getAdapter,
   closeDatabase,
+  getGateResults,
   insertAssessment,
+  insertGateRow,
   insertMilestone,
   insertSlice,
   insertTask,
@@ -90,4 +93,33 @@ test("closeout consistency treats deferred slices as inactive", () => {
   } finally {
     closeDatabase();
   }
+});
+
+test("closeout consistency persists evidence-backed gate closures before checking pending gates", (t) => {
+  const artifactBasePath = realpathSync(mkdtempSync(join(tmpdir(), "closeout-gate-order-")));
+  t.after(() => {
+    closeDatabase();
+    rmSync(artifactBasePath, { recursive: true, force: true });
+  });
+  assert.equal(openDatabase(":memory:"), true);
+  insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+  insertAssessment({
+    path: "milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+  _getAdapter()!.prepare(
+    `INSERT INTO quality_gates (milestone_id, slice_id, gate_id, scope, task_id, status)
+     VALUES ('M001', 'S01', 'unknown', 'slice', '', 'pending')`,
+  ).run();
+
+  const result = checkCloseoutConsistencyGate("M001", { artifactBasePath });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.reason, "quality-gate-pending");
+  assert.equal(getGateResults("M001", "S01").find((gate) => gate.gate_id === "Q3")?.status, "complete");
 });


### PR DESCRIPTION
## Summary
- Reordered quality-gate closure before pending checks and verified it with focused regression tests and fast gates.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1836
- [#1836 [Bug]: checkCloseoutConsistencyGate checks for pending gates before closing them — order-of-operations wedge blocks milestone closeout](https://github.com/open-gsd/gsd-pi/issues/1836)

## User
- @Freston1605

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1836-bug-checkcloseoutconsistencygate-checks--1787092445`