### PR TITLE
fix(issue): [Bug]: gsd auto livelocks on a terminal non-resumable task-recovery abort — re-dispatches a superseding attempt, wedges with orchestration-stale-active-unit, blocks gsd_task_recovery_resume (1.15.0)

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -235,31 +235,30 @@ export function refreshRecoveryDbForArtifact(
         message: `Stuck recovery found execute-task ${unitId} artifacts, but its latest canonical Task Attempt has no actionable verify or route Result.`,
       };
     }
-    // #1622: a route-stage Attempt whose agent-owned recovery already aborted is
+    // #1622/#1754: any Attempt whose agent-owned recovery already aborted is
     // NOT recoverable by re-dispatch — the next dispatch breaks instantly with
     // `task-recovery-abort`, orphaning a worktree and leaving auto-mode to
     // silently re-dispatch forever. Fail closed with the operator-actionable
-    // recovery path instead of reporting success.
-    if (readiness === "route") {
-      let terminalAbort: ReturnType<typeof readTerminalTaskRecoveryAbort>;
-      try {
-        terminalAbort = readTerminalTaskRecoveryAbort(mid, sid, tid);
-      } catch (err) {
-        return {
-          ok: false,
-          fatal: true,
-          reason: "execute-task-recovery-route-read-failed",
-          message: `Stuck recovery could not read the canonical Task recovery route for execute-task ${unitId}: ${getErrorMessage(err)}`,
-        };
-      }
-      if (terminalAbort) {
-        return {
-          ok: false,
-          fatal: true,
-          reason: "execute-task-recovery-aborted",
-          message: `Stuck recovery found execute-task ${unitId} artifacts, but its canonical Task Attempt recovery already aborted (recoveryActionId: ${terminalAbort.recoveryActionId}); re-dispatching would break immediately with task-recovery-abort. Resume it with \`gsd_task_recovery_resume\` using recoveryActionId ${terminalAbort.recoveryActionId}, or reconcile the projection drift with \`gsd rebuild markdown\` then \`gsd recover\`.`,
-        };
-      }
+    // recovery path instead of reporting success. A later succeeded Attempt
+    // must not hide a still-operative abort on its predecessor.
+    let terminalAbort: ReturnType<typeof readTerminalTaskRecoveryAbort>;
+    try {
+      terminalAbort = readTerminalTaskRecoveryAbort(mid, sid, tid);
+    } catch (err) {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "execute-task-recovery-route-read-failed",
+        message: `Stuck recovery could not read the canonical Task recovery route for execute-task ${unitId}: ${getErrorMessage(err)}`,
+      };
+    }
+    if (terminalAbort) {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "execute-task-recovery-aborted",
+        message: `Stuck recovery found execute-task ${unitId} artifacts, but its canonical Task Attempt recovery already aborted (recoveryActionId: ${terminalAbort.recoveryActionId}); re-dispatching would break immediately with task-recovery-abort. Resume it with \`gsd_task_recovery_resume\` using recoveryActionId ${terminalAbort.recoveryActionId}, or reconcile the projection drift with \`gsd rebuild markdown\` then \`gsd recover\`.`,
+      };
     }
     // #1622: unlike the plan-slice/complete-milestone branches below, nothing
     // above writes the Task row — this branch only *reads* canonical Attempt

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -146,7 +146,10 @@ import {
   readTaskRecoveryRoute,
   recordFailureAndSelectRecovery,
 } from "../task-recovery-domain-operation.js";
-import { verifyExpectedArtifact } from "../artifact-verification.js";
+import {
+  readTerminalTaskRecoveryAbort,
+  verifyExpectedArtifact,
+} from "../artifact-verification.js";
 
 /**
  * Returns true if workerId is an active worker in this project whose OS
@@ -211,6 +214,11 @@ const ORCHESTRATION_MISSING_REASON =
 const TASK_EXECUTION_CUTOVER_DEPS = {
   claimTaskAttempt,
   readLatestTaskAttempt,
+  readTerminalTaskRecoveryAbort: (task: {
+    milestoneId: string;
+    sliceId: string;
+    taskId: string;
+  }) => readTerminalTaskRecoveryAbort(task.milestoneId, task.sliceId, task.taskId),
   readTaskAttempt,
   readTaskRecoveryRoute,
   readTaskTechnicalVerdict,
@@ -998,8 +1006,8 @@ export async function autoLoop(
             throw new Error(`Could not terminalize custom-engine dispatch ${customDispatchId} after unit break`);
           }
           dispatchSettled = customDispatchSettled;
-          await pauseForTaskRecoveryAbort(breakReason);
           await closeRun("failed", breakReason);
+          await pauseForTaskRecoveryAbort(breakReason);
           finishIncompleteIteration({
             status: "stopped",
             reason: breakReason,

--- a/src/resources/extensions/gsd/auto/task-execution-cutover.ts
+++ b/src/resources/extensions/gsd/auto/task-execution-cutover.ts
@@ -38,6 +38,9 @@ export interface TaskExecutionCutoverInput {
 
 export interface TaskExecutionCutoverDeps {
   readLatestTaskAttempt(task: ClaimTaskAttemptInput["task"]): TaskExecutionAttemptSnapshot | null;
+  readTerminalTaskRecoveryAbort(
+    task: ClaimTaskAttemptInput["task"],
+  ): { recoveryActionId: string } | null;
   readTaskAttempt(attemptId: string): TaskExecutionAttemptSnapshot | null;
   readTaskRecoveryRoute(attemptId: string): Pick<
     TaskRecoveryRouteSnapshot,
@@ -456,6 +459,8 @@ export async function runWithTaskExecutionAttempt(
   const task = parseTaskIdentity(input.unitId);
   const identity = requireTaskClaimIdentity(input);
   const predecessor = deps.readLatestTaskAttempt(task);
+  const terminalAbort = deps.readTerminalTaskRecoveryAbort(task);
+  if (terminalAbort) return taskRecoveryAbortResult(terminalAbort.recoveryActionId);
   let claim: ClaimTaskAttemptReceipt | undefined;
   let result: UnitPhaseResult;
   try {

--- a/src/resources/extensions/gsd/db/writers/lifecycle-commands.ts
+++ b/src/resources/extensions/gsd/db/writers/lifecycle-commands.ts
@@ -345,10 +345,6 @@ export function isTaskRecoveryResumeAuthorized(
      AND kernel.lifecycle_id = attempt.lifecycle_id
      AND kernel.attempt_id = attempt.attempt_id
      AND kernel.next_stage = 'route'
-     AND NOT EXISTS (
-       SELECT 1 FROM workflow_kernel_checkpoints successor
-       WHERE successor.previous_kernel_checkpoint_id = kernel.kernel_checkpoint_id
-     )
     JOIN workflow_work_checkpoints checkpoint
       ON checkpoint.project_id = resumed.project_id
      AND checkpoint.operation_id = resumed.operation_id

--- a/src/resources/extensions/gsd/task-recovery-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-recovery-domain-operation.ts
@@ -425,7 +425,11 @@ export function readPendingTaskRecoveryContext(
   };
 }
 
-function loadRoutedFailureScope(attemptId: string, resultId: string): FailedAttemptScope {
+function loadRoutedFailureScope(
+  attemptId: string,
+  resultId: string,
+  requireCurrentHead = true,
+): FailedAttemptScope {
   const scope = getDb().prepare(`
     SELECT lifecycle.lifecycle_id, lifecycle.milestone_id, lifecycle.slice_id,
            lifecycle.task_id, attempt.attempt_id, result.result_id,
@@ -450,10 +454,10 @@ function loadRoutedFailureScope(attemptId: string, resultId: string): FailedAtte
         (result.outcome = 'succeeded' AND ${CURRENT_EVIDENCE_BACKED_FAILURE_VERDICT_SQL})
       )
       AND checkpoint.next_stage = 'route'
-      AND NOT EXISTS (
+      ${requireCurrentHead ? `AND NOT EXISTS (
         SELECT 1 FROM workflow_kernel_checkpoints successor
         WHERE successor.previous_kernel_checkpoint_id = checkpoint.kernel_checkpoint_id
-      )
+      )` : ""}
   `).get({ ":attempt_id": attemptId, ":result_id": resultId }) as Record<string, unknown> | undefined;
   if (!scope) throw new Error("Task recovery requires a current execute or verification failure route head");
   return {
@@ -640,7 +644,11 @@ function requireResumableAbortScope(recoveryActionId: string): FailedAttemptScop
       )
   `).get({ ":recovery_action_id": recoveryActionId }) as Record<string, unknown> | undefined;
   if (!stored) throw new Error("Task recovery resume requires the current agent-owned abort");
-  return loadRoutedFailureScope(String(stored["attempt_id"]), String(stored["result_id"]));
+  return loadRoutedFailureScope(
+    String(stored["attempt_id"]),
+    String(stored["result_id"]),
+    false,
+  );
 }
 
 function loadTaskRecoveryResumeReceipt(

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2276,9 +2276,10 @@ test("custom-engine recovery break and retry terminalize their dispatch", async 
       s.orchestration = {
         settle: async () => { releaseCalls++; },
         retryActiveUnit: async () => { releaseCalls++; },
-        abandonActiveUnit: async () => {},
+        abandonActiveUnit: async () => { releaseCalls++; },
       };
       let dispatchStatusAtPause: string | undefined;
+      let releaseCallsAtPause: number | undefined;
       const deps = makeMockDeps({
         isDbAvailable: () => true,
         taskExecutionBoundary: async () => {
@@ -2287,6 +2288,7 @@ test("custom-engine recovery break and retry terminalize their dispatch", async 
         },
         pauseAuto: async () => {
           dispatchStatusAtPause = getLatestForUnit("M001/S01/T01")?.status;
+          releaseCallsAtPause = releaseCalls;
         },
       });
 
@@ -2302,7 +2304,12 @@ test("custom-engine recovery break and retry terminalize their dispatch", async 
         action === "break" ? "failed" : undefined,
         "a terminal recovery abort must settle its dispatch before pausing",
       );
-      assert.equal(releaseCalls, action === "retry" ? 1 : 0);
+      assert.equal(
+        releaseCallsAtPause,
+        action === "break" ? 1 : undefined,
+        "a terminal recovery abort must release its active unit before pausing",
+      );
+      assert.equal(releaseCalls, 1);
       assert.equal(pi.calls.length, 0, `${action} must exit before invoking the agent`);
     } finally {
       closeDatabase();
@@ -4326,7 +4333,7 @@ test("autoLoop pauses a predecessor task-recovery abort before any agent turn", 
   const pi = makeMockPi();
   const s = makeLoopSession();
   let pauseReason: string | undefined;
-  let recoveryReads = 0;
+  let terminalAbortReads = 0;
   const abortReason =
     "task-recovery-abort (recoveryActionId: recovery-action-1; resume with gsd_task_recovery_resume)";
 
@@ -4352,14 +4359,12 @@ test("autoLoop pauses a predecessor task-recovery abort before any agent turn", 
             milestoneLeaseToken: 7,
           };
         },
+        readTerminalTaskRecoveryAbort() {
+          terminalAbortReads += 1;
+          return { recoveryActionId: "recovery-action-1" };
+        },
         readTaskRecoveryRoute() {
-          recoveryReads += 1;
-          return {
-            recoveryActionId: "recovery-action-1",
-            recoveryOwner: "agent",
-            action: "abort",
-            resumeAuthorized: false,
-          };
+          throw new Error("all-attempt terminal abort guard must run before the latest-route fallback");
         },
       }),
     pauseAuto: async (_ctx, _pi, errorContext) => {
@@ -4371,7 +4376,7 @@ test("autoLoop pauses a predecessor task-recovery abort before any agent turn", 
   await autoLoop(ctx, pi, s, deps);
 
   assert.equal(pi.calls.length, 0, "the predecessor abort must stop before an agent turn");
-  assert.equal(recoveryReads, 1, "the durable predecessor abort must be read exactly once");
+  assert.equal(terminalAbortReads, 1, "the durable predecessor abort must be read exactly once");
   assert.equal(pauseReason, abortReason);
   assert.match(notifications.join("\n"), /recoveryActionId: recovery-action-1/);
   assert.match(notifications.join("\n"), /gsd_task_recovery_resume/);

--- a/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
@@ -37,6 +37,7 @@ import {
 } from "../task-verification-domain-operation.js";
 import { publishVerifiedTaskCompletion } from "../task-completion-compatibility-adapter.js";
 import { captureVerificationSourceSnapshot } from "../verification-source-integrity.js";
+import { readTerminalTaskRecoveryAbort } from "../artifact-verification.js";
 
 // The stuck-state resume key must ride along with every terminal abort break so an
 // operator can call gsd_task_recovery_resume without querying the database by hand.
@@ -82,6 +83,7 @@ interface CutoverInput {
 
 interface CutoverDeps {
   readLatestTaskAttempt(task: TaskIdentity): AttemptSnapshot | null;
+  readTerminalTaskRecoveryAbort(task: TaskIdentity): { recoveryActionId: string } | null;
   readTaskAttempt(attemptId: string): AttemptSnapshot | null;
   readTaskRecoveryRoute(attemptId: string): {
     recoveryActionId: string;
@@ -259,6 +261,9 @@ function fakeDomain() {
       // later settlements must not mutate what a caller already saw.
       return attempt ? { ...attempt } : null;
     },
+    readTerminalTaskRecoveryAbort() {
+      return null;
+    },
     readTaskAttempt(attemptId) {
       calls.push({ name: "read-attempt", value: attemptId });
       const attempt = attempts.find((candidate) => candidate.attemptId === attemptId);
@@ -432,6 +437,9 @@ function insertClaimedDispatch(attemptNumber: number): number {
 function canonicalDeps(): CutoverDeps {
   return {
     readLatestTaskAttempt,
+    readTerminalTaskRecoveryAbort(task) {
+      return readTerminalTaskRecoveryAbort(task.milestoneId, task.sliceId, task.taskId);
+    },
     readTaskAttempt,
     readTaskRecoveryRoute,
     readTaskTechnicalVerdict,
@@ -927,6 +935,54 @@ test("a durable abort overrides an executor retry", async () => {
     reason: TASK_RECOVERY_ABORT_REASON,
   });
   assert.equal(domain.routes.length, 1);
+});
+
+test("a superseded terminal abort stops before a succeeded head can redispatch", async () => {
+  const { runWithTaskExecutionAttempt } = await subject();
+  const domain = fakeDomain();
+  domain.attempts.push(
+    {
+      attemptId: "attempt-aborted",
+      resultId: "result-aborted",
+      attemptNumber: 1,
+      state: "settled",
+      outcome: "failed",
+      nextStage: "route",
+      coordinationDispatchId: 40,
+      workerId: "worker-1",
+      milestoneLeaseToken: 7,
+    },
+    {
+      attemptId: "attempt-superseding",
+      resultId: "result-superseding",
+      attemptNumber: 2,
+      retryOfAttemptId: "attempt-aborted",
+      state: "settled",
+      outcome: "succeeded",
+      nextStage: "verify",
+      coordinationDispatchId: 41,
+      workerId: "worker-1",
+      milestoneLeaseToken: 7,
+    },
+  );
+  let runs = 0;
+
+  const result = await runWithTaskExecutionAttempt(input({ dispatchId: 42 }), async () => {
+    runs += 1;
+    return { action: "next", data: {} };
+  }, {
+    ...domain.deps,
+    readTerminalTaskRecoveryAbort() {
+      return { recoveryActionId: "recovery-action-aborted" };
+    },
+  });
+
+  assert.deepEqual(result, {
+    action: "break",
+    reason: "task-recovery-abort (recoveryActionId: recovery-action-aborted; resume with gsd_task_recovery_resume)",
+  });
+  assert.equal(runs, 0);
+  assert.equal(domain.claims.length, 0);
 });
 
 test("an explicitly resumed durable abort claims one later Attempt", async () => {

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -42,6 +42,7 @@ import { buildCustomEngineIterationData } from "../auto/workflow-custom-engine-i
 import { handleReplanTask } from "../tools/replan-task.ts";
 import { resolveDispatch } from "../auto-dispatch.ts";
 import { verifyExpectedArtifact, readTerminalTaskRecoveryAbort } from "../artifact-verification.ts";
+import { refreshRecoveryDbForArtifact } from "../auto-recovery.ts";
 
 const tempDirs = new Set<string>();
 
@@ -1410,6 +1411,8 @@ test("a terminal abort on a superseded Attempt stops dispatch and resumes (#1754
   db().exec(`
     DROP TRIGGER trg_workflow_attempt_route_authority_v39;
     DROP TRIGGER trg_workflow_attempt_settlement_insert_shape_v36;
+    DROP TRIGGER trg_workflow_kernel_checkpoint_chain;
+    DROP TRIGGER trg_workflow_kernel_checkpoint_attempt_claim;
   `);
   const secondOperation = row(`
     SELECT project_id, settle_operation_id, settle_project_revision, settle_authority_epoch
@@ -1438,6 +1441,51 @@ test("a terminal abort on a superseded Attempt stops dispatch and resumes (#1754
     ":project_revision": secondOperation.settle_project_revision,
     ":authority_epoch": secondOperation.settle_authority_epoch,
   });
+  const routeHead = row(`
+    SELECT kernel_checkpoint_id, sequence
+    FROM workflow_kernel_checkpoints
+    WHERE lifecycle_id = :lifecycle_id
+    ORDER BY sequence DESC LIMIT 1
+  `, { ":lifecycle_id": firstFailure.lifecycleId });
+  db().prepare(`
+    INSERT INTO workflow_attempt_results (
+      result_id, project_id, lifecycle_id, attempt_id, outcome,
+      failure_class, summary, output_json, created_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES (
+      'result-superseding', :project_id, :lifecycle_id, 'attempt-superseding',
+      'succeeded', 'none', 'Superseding execution succeeded', '{}',
+      '2026-07-13T00:04:00.000Z', :operation_id, :project_revision, :authority_epoch
+    )
+  `).run({
+    ":project_id": secondOperation.project_id,
+    ":lifecycle_id": firstFailure.lifecycleId,
+    ":operation_id": secondOperation.settle_operation_id,
+    ":project_revision": secondOperation.settle_project_revision,
+    ":authority_epoch": secondOperation.settle_authority_epoch,
+  });
+  db().prepare(`
+    INSERT INTO workflow_kernel_checkpoints (
+      kernel_checkpoint_id, project_id, lifecycle_id, attempt_id,
+      next_stage, sequence, previous_kernel_checkpoint_id, created_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES
+      ('kernel-superseding-execute', :project_id, :lifecycle_id, 'attempt-superseding',
+       'execute', :execute_sequence, :route_head, '2026-07-13T00:03:00.000Z',
+       :operation_id, :project_revision, :authority_epoch),
+      ('kernel-superseding-verify', :project_id, :lifecycle_id, 'attempt-superseding',
+       'verify', :verify_sequence, 'kernel-superseding-execute', '2026-07-13T00:04:00.000Z',
+       :operation_id, :project_revision, :authority_epoch)
+  `).run({
+    ":project_id": secondOperation.project_id,
+    ":lifecycle_id": firstFailure.lifecycleId,
+    ":execute_sequence": Number(routeHead.sequence) + 1,
+    ":verify_sequence": Number(routeHead.sequence) + 2,
+    ":route_head": routeHead.kernel_checkpoint_id,
+    ":operation_id": secondOperation.settle_operation_id,
+    ":project_revision": secondOperation.settle_project_revision,
+    ":authority_epoch": secondOperation.settle_authority_epoch,
+  });
   assert.equal(
     row("SELECT attempt_id AS id FROM workflow_execution_attempts ORDER BY attempt_number DESC LIMIT 1").id,
     "attempt-superseding",
@@ -1448,6 +1496,9 @@ test("a terminal abort on a superseded Attempt stops dispatch and resumes (#1754
   // resume predicate accepts it instead of throwing (#1754 residual).
   const terminal = readTerminalTaskRecoveryAbort("M001", "S01", "T01");
   assert.equal(terminal?.recoveryActionId, aborted.recoveryActionId);
+  const recovery = refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01", firstFailure.basePath);
+  assert.equal(recovery.ok, false);
+  assert.equal(recovery.ok ? undefined : recovery.reason, "execute-task-recovery-aborted");
   const resumed = resumeTaskRecovery({
     invocation: invocation("recovery/superseded/resume"),
     recoveryActionId: aborted.recoveryActionId,


### PR DESCRIPTION
## Summary
- Fixed terminal task-recovery abort livelocks and verified the recovery paths with 293 focused tests, build, typechecking, and fast checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1754
- [#1754 [Bug]: gsd auto livelocks on a terminal non-resumable task-recovery abort — re-dispatches a superseding attempt, wedges with orchestration-stale-active-unit, blocks gsd_task_recovery_resume (1.15.0)](https://github.com/open-gsd/gsd-pi/issues/1754)

## User
- @rager306

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1754-bug-gsd-auto-livelocks-on-a-terminal-non-1787092127`