### PR TITLE
fix(issue): execute-task staged SUMMARY is written only into the worktree's gitignored .gsd — unmerged teardown orphans the file into an artifact-db-status-divergence wedge (1.15.0)

### DIFF
--- a/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
+++ b/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
@@ -17,8 +17,7 @@ import {
   getSlice,
 } from "./gsd-db.js";
 import { renderPlanCheckboxes, renderTaskSummary } from "./markdown-renderer.js";
-import { clearPathCache, resolveTaskFile } from "./paths.js";
-import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
+import { clearPathCache, resolveGsdPathContract, resolveTaskFile } from "./paths.js";
 import {
   closeTaskQualityGates,
   type TaskQualityGateContent,
@@ -268,11 +267,21 @@ async function renderTaskSummaryProjection(
   return summaryPath;
 }
 
+async function renderTaskSummaryProjections(
+  basePath: string,
+  task: TaskCompletionIdentity,
+): Promise<string> {
+  const contract = resolveGsdPathContract(basePath);
+  const canonicalPath = await renderTaskSummaryProjection(contract.projectRoot, task);
+  if (!contract.isWorktree || contract.workRoot === contract.projectRoot) return canonicalPath;
+  return renderTaskSummaryProjection(contract.workRoot, task);
+}
+
 async function renderPublishedTaskCompletionProjections(
   basePath: string,
   task: TaskCompletionIdentity,
 ): Promise<string> {
-  const summaryPath = await renderTaskSummaryProjection(basePath, task);
+  const summaryPath = await renderTaskSummaryProjections(basePath, task);
   try {
     const wrotePlan = await renderPlanCheckboxes(basePath, task.milestoneId, task.sliceId);
     if (!wrotePlan) throw new Error("plan projection write returned false");
@@ -324,16 +333,7 @@ export async function stageTaskCompletion(
   // the Attempt failed, so there is no completion to render.
   let summaryPath = "";
   if (!blocked) {
-    summaryPath = await renderTaskSummaryProjection(input.basePath, input.task);
-    // (#1763) A staged SUMMARY written only into the worktree-local `.gsd` is
-    // orphaned when an unmerged worktree is torn down — dual-write the
-    // canonical copy to the project root through the same projection seam.
-    if (isGsdWorktreePath(input.basePath)) {
-      const projectRoot = resolveWorktreeProjectRoot(input.basePath);
-      if (projectRoot && projectRoot !== input.basePath) {
-        await renderTaskSummaryProjection(projectRoot, input.task);
-      }
-    }
+    summaryPath = await renderTaskSummaryProjections(input.basePath, input.task);
   }
   return {
     status: settlement.status,

--- a/src/resources/extensions/gsd/tests/task-completion-compatibility-adapter.test.ts
+++ b/src/resources/extensions/gsd/tests/task-completion-compatibility-adapter.test.ts
@@ -730,6 +730,34 @@ test("#1763: staging from a milestone worktree dual-writes the SUMMARY to the pr
   );
 });
 
+test("#1763: verified publication from a milestone worktree restores both SUMMARY projections", async () => {
+  const { publishVerifiedTaskCompletion, stageTaskCompletion } = await subject();
+  const { basePath, planPath, attemptId } = createFixture();
+  writeFileSync(join(basePath, ".git", "info", "exclude"), ".gsd-worktrees/\n");
+  const worktreePath = join(basePath, ".gsd-worktrees", "M001");
+  const worktreePhaseDir = join(worktreePath, ".gsd", "phases", "01-test");
+  mkdirSync(worktreePhaseDir, { recursive: true });
+  writeFileSync(join(worktreePhaseDir, "01-01-PLAN.md"), readFileSync(planPath, "utf8"));
+  const staged = await stageTaskCompletion(stageInput(worktreePath));
+
+  const { resolveTaskFile } = await import("../paths.js");
+  const rootSummary = resolveTaskFile(basePath, "M001", "S01", "T01", "SUMMARY");
+  assert.ok(rootSummary, "project-root SUMMARY path resolves");
+  unlinkSync(rootSummary);
+  unlinkSync(staged.summaryPath);
+  recordPassingHostVerdict(basePath, attemptId);
+
+  const published = await publishVerifiedTaskCompletion(publishInput(worktreePath, attemptId));
+
+  assert.equal(existsSync(rootSummary), true, "publication restores the canonical copy");
+  assert.equal(existsSync(published.summaryPath), true, "publication restores the worktree copy");
+  assert.equal(
+    readFileSync(rootSummary, "utf8"),
+    readFileSync(published.summaryPath, "utf8"),
+    "the project-root and worktree copies are byte-identical",
+  );
+});
+
 test("#1677: inside a worktree the classifier falls back to the project-root copy", async () => {
   const { stageTaskCompletion } = await subject();
   const { basePath } = createFixture();


### PR DESCRIPTION
## Summary
- Canonical-first task SUMMARY projection now covers staging and verified publication, with 39 adapter tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1763
- [#1763 execute-task staged SUMMARY is written only into the worktree's gitignored .gsd — unmerged teardown orphans the file into an artifact-db-status-divergence wedge (1.15.0)](https://github.com/open-gsd/gsd-pi/issues/1763)

## User
- @Freston1605

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1763-execute-task-staged-summary-is-written-o-1787093662`