### PR TITLE
fix(issue): Orphaned active unit starves the liveness backstop (zero-iteration idle sessions) and task recovery is session-locked

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -2851,11 +2851,17 @@ async function resolveExecuteTaskPlan(input: {
   const inlinePlan = input.slicePlanContent
     ? extractInlineTaskPlan(input.slicePlanContent, input.taskId)
     : null;
+  const slicePlanRelativePath = relSliceFile(
+    input.basePath,
+    input.milestoneId,
+    input.sliceId,
+    "PLAN",
+  );
   return {
     content: inlinePlan,
-    relativePath,
+    relativePath: inlinePlan ? slicePlanRelativePath : relativePath,
     source: inlinePlan
-      ? `\`${relSliceFile(input.basePath, input.milestoneId, input.sliceId, "PLAN")}\``
+      ? `\`${slicePlanRelativePath}\``
       : `\`${relativePath}\``,
   };
 }

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -37,6 +37,7 @@ import {
   getPendingGates,
   getPendingGatesForTurn,
   getSlice,
+  getTask,
   isDbAvailable,
 } from "./gsd-db.js";
 import {
@@ -2788,6 +2789,77 @@ export interface ExecuteTaskPromptOptions {
   contextModeRenderMode?: ContextModeRenderMode;
 }
 
+function extractInlineTaskPlan(slicePlan: string, taskId: string): string | null {
+  const escapedTaskId = taskId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const xmlTask = new RegExp(`<task\\b[^>]*\\bid=["']${escapedTaskId}["'][^>]*>([\\s\\S]*?)<\\/task>`, "i")
+    .exec(slicePlan);
+  if (xmlTask?.[0]) return xmlTask[0].trim();
+
+  const taskLines = slicePlan.split("\n");
+  const start = taskLines.findIndex((line) =>
+    new RegExp(`^\\s*-\\s*\\[[ xX]\\]\\s+\\*\\*${escapedTaskId}(?:\\*\\*|:)`, "i").test(line),
+  );
+  if (start >= 0) {
+    let end = start + 1;
+    while (end < taskLines.length && !/^\s*-\s*\[[ xX]\]\s+\*\*/.test(taskLines[end]!)) {
+      if (/^<\/tasks>\s*$/.test(taskLines[end]!.trim())) break;
+      end++;
+    }
+    return taskLines.slice(start, end).join("\n").trim();
+  }
+
+  const tasksBlock = /<tasks>([\s\S]*?)<\/tasks>/i.exec(slicePlan)?.[0];
+  return tasksBlock?.includes(taskId) ? tasksBlock.trim() : null;
+}
+
+async function resolveExecuteTaskPlan(input: {
+  basePath: string;
+  milestoneId: string;
+  sliceId: string;
+  taskId: string;
+  slicePlanContent: string | null;
+}): Promise<{ content: string | null; relativePath: string; source: string }> {
+  const relativePath = relTaskFile(
+    input.basePath,
+    input.milestoneId,
+    input.sliceId,
+    input.taskId,
+    "PLAN",
+  );
+  const standalonePath = resolveTaskFile(
+    input.basePath,
+    input.milestoneId,
+    input.sliceId,
+    input.taskId,
+    "PLAN",
+  );
+  if (standalonePath) {
+    return { content: await loadFile(standalonePath), relativePath, source: `\`${relativePath}\`` };
+  }
+
+  const durablePlan = isDbAvailable()
+    ? getTask(input.milestoneId, input.sliceId, input.taskId)?.full_plan_md.trim() || null
+    : null;
+  if (durablePlan) {
+    return {
+      content: durablePlan,
+      relativePath,
+      source: `durable task planning state for ${input.milestoneId}/${input.sliceId}/${input.taskId}`,
+    };
+  }
+
+  const inlinePlan = input.slicePlanContent
+    ? extractInlineTaskPlan(input.slicePlanContent, input.taskId)
+    : null;
+  return {
+    content: inlinePlan,
+    relativePath,
+    source: inlinePlan
+      ? `\`${relSliceFile(input.basePath, input.milestoneId, input.sliceId, "PLAN")}\``
+      : `\`${relativePath}\``,
+  };
+}
+
 export async function buildTaskRecoveryReplanPrompt(
   mid: string,
   sid: string,
@@ -2841,24 +2913,30 @@ export async function buildExecuteTaskPrompt(
     ? priorSummaries.map(p => `- \`${p}\``).join("\n")
     : "- (no prior tasks)";
 
-  const taskPlanPath = resolveTaskFile(base, mid, sid, tid, "PLAN");
-  const taskPlanContent = taskPlanPath ? await loadFile(taskPlanPath) : null;
-  const taskPlanRelPath = relTaskFile(base, mid, sid, tid, "PLAN");
+  const slicePlanPath = resolveSliceFile(base, mid, sid, "PLAN");
+  const slicePlanContent = slicePlanPath ? await loadFile(slicePlanPath) : null;
+  const taskPlan = await resolveExecuteTaskPlan({
+    basePath: base,
+    milestoneId: mid,
+    sliceId: sid,
+    taskId: tid,
+    slicePlanContent,
+  });
+  const taskPlanContent = taskPlan.content;
+  const taskPlanRelPath = taskPlan.relativePath;
   const taskPlanContext = taskPlanContent
     ? [
       "## Inlined Task Plan (authoritative local execution contract)",
-      `Source: \`${taskPlanRelPath}\``,
+      `Source: ${taskPlan.source}`,
       "",
       taskPlanContent.trim(),
     ].join("\n")
     : [
       "## Inlined Task Plan (authoritative local execution contract)",
-      `Task plan not found at dispatch time. Read \`${taskPlanRelPath}\` before executing.`,
+      `Task plan not found at dispatch time. Read ${taskPlan.source} before executing.`,
     ].join("\n");
   trackPromptContext(contextTelemetry, "task-plan", taskPlanContent ? "inline" : "on-demand", taskPlanContext, taskPlanContent ? undefined : "missing at dispatch");
 
-  const slicePlanPath = resolveSliceFile(base, mid, sid, "PLAN");
-  const slicePlanContent = slicePlanPath ? await loadFile(slicePlanPath) : null;
   const slicePlanContext = extractSliceExecutionExcerpt(slicePlanContent, relSliceFile(base, mid, sid, "PLAN"));
   trackPromptContext(contextTelemetry, "slice-plan", slicePlanContext ? "excerpt" : "skipped", slicePlanContext, slicePlanContext ? undefined : "missing");
 
@@ -4165,6 +4243,8 @@ export async function buildReactiveExecutePrompt(
   );
   const contextTelemetry: PromptContextTelemetryEntry[] = [];
   trackPromptContext(contextTelemetry, "graph-context", "inline", graphContext);
+  const slicePlanPath = resolveSliceFile(base, mid, sid, "PLAN");
+  const slicePlanContent = slicePlanPath ? await loadFile(slicePlanPath) : null;
 
   for (const tid of readyTaskIds) {
     const node = graph.find((n) => n.id === tid);
@@ -4176,19 +4256,24 @@ export async function buildReactiveExecutePrompt(
       mid, sid, tid, node?.dependsOn ?? [], base,
     );
 
-    const taskPlanPath = resolveTaskFile(base, mid, sid, tid, "PLAN");
-    const taskPlanContent = taskPlanPath ? await loadFile(taskPlanPath) : null;
-    const taskPlanRelPath = relTaskFile(base, mid, sid, tid, "PLAN");
+    const taskPlan = await resolveExecuteTaskPlan({
+      basePath: base,
+      milestoneId: mid,
+      sliceId: sid,
+      taskId: tid,
+      slicePlanContent,
+    });
+    const taskPlanContent = taskPlan.content;
     const taskPlanInline = taskPlanContent
       ? [
           "## Inlined Task Plan (authoritative local execution contract)",
-          `Source: \`${taskPlanRelPath}\``,
+          `Source: ${taskPlan.source}`,
           "",
           taskPlanContent.trim(),
         ].join("\n")
       : [
           "## Inlined Task Plan (authoritative local execution contract)",
-          `Task plan not found at dispatch time. Read \`${taskPlanRelPath}\` before executing.`,
+          `Task plan not found at dispatch time. Read ${taskPlan.source} before executing.`,
         ].join("\n");
     const carryForwardSection = await buildCarryForwardSection(depPaths, base);
     const finalCarryForwardSection = carryForwardSection.length > perSubagentCarryForwardBudget

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -85,7 +85,7 @@ import {
   markCanceled as markDispatchCanceled,
   getRecentForUnit as getRecentDispatchesForUnit,
   getActiveForWorker,
-  getLatestForUnit,
+  getDispatchById,
 } from "../db/unit-dispatches.js";
 import { claimMilestoneLease } from "../db/milestone-leases.js";
 import { isAutoWorkerLive } from "../db/auto-workers.js";
@@ -1297,25 +1297,33 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         });
       }
 
-      const activeDispatch = getLatestForUnit(decision.unitId);
-      if (activeDispatch && ["claimed", "running"].includes(activeDispatch.status)) {
-        const parsed = parseUnitId(decision.unitId);
-        const latestTaskAttempt = decision.unitType === "execute-task" && parsed.milestone && parsed.slice && parsed.task
-          ? readLatestTaskAttempt({
-              milestoneId: parsed.milestone,
-              sliceId: parsed.slice,
-              taskId: parsed.task,
-            })
-          : null;
-        const activeTaskAttempt = latestTaskAttempt?.coordinationDispatchId === activeDispatch.id
+      const parsed = parseUnitId(decision.unitId);
+      const latestTaskAttempt = decision.unitType === "execute-task" && parsed.milestone && parsed.slice && parsed.task
+        ? readLatestTaskAttempt({
+            milestoneId: parsed.milestone,
+            sliceId: parsed.slice,
+            taskId: parsed.task,
+          })
+        : null;
+      const recovery = latestTaskAttempt
+        ? readTaskRecoveryRoute(latestTaskAttempt.attemptId)
+        : null;
+      const activeDispatch = getRecentDispatchesForUnit(decision.unitId)
+        .find((dispatch) => dispatch.status === "claimed" || dispatch.status === "running");
+      const attemptDispatch = latestTaskAttempt
+        ? getDispatchById(latestTaskAttempt.coordinationDispatchId)
+        : null;
+      const orphanCandidate = activeDispatch
+        ?? (latestTaskAttempt && (latestTaskAttempt.state === "running" || recovery?.action === "abort")
+          ? attemptDispatch
+          : null);
+      if (orphanCandidate) {
+        const activeTaskAttempt = latestTaskAttempt?.coordinationDispatchId === orphanCandidate.id
           ? latestTaskAttempt
           : null;
-        const executorWorkerId = activeTaskAttempt?.workerId ?? activeDispatch.worker_id;
+        const executorWorkerId = activeTaskAttempt?.workerId ?? orphanCandidate.worker_id;
         if (!isAutoWorkerLive(executorWorkerId)) {
           this.clearPendingDispatch();
-          const recovery = activeTaskAttempt
-            ? readTaskRecoveryRoute(activeTaskAttempt.attemptId)
-            : null;
           const recoveryInstruction = recovery?.action === "abort"
             ? ` Resume with gsd_task_recovery_resume using recoveryActionId ${recovery.recoveryActionId}.`
             : activeTaskAttempt?.state === "running"
@@ -1323,7 +1331,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
               : " Inspect /gsd status for the active UnitRun's recovery eligibility.";
           const executionDetail = activeTaskAttempt
             ? `Attempt ${activeTaskAttempt.attemptId} is ${activeTaskAttempt.state}`
-            : `UnitRun ${activeDispatch.id} is ${activeDispatch.status}`;
+            : `UnitRun ${orphanCandidate.id} is ${orphanCandidate.status}`;
           const reason =
             `stale-active ${decision.unitType} ${decision.unitId}: ${executionDetail}, ` +
             `but executor worker ${executorWorkerId} is not live.${recoveryInstruction}`;
@@ -1345,7 +1353,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
             inputPayload: JSON.stringify({
               unitType: decision.unitType,
               unitId: decision.unitId,
-              dispatchId: activeDispatch.id,
+              dispatchId: orphanCandidate.id,
               attemptId: activeTaskAttempt?.attemptId ?? null,
               attemptState: activeTaskAttempt?.state ?? null,
               executorWorkerId,

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -59,6 +59,7 @@ import { getRegisteredToolSnapshot, getToolBaselineSnapshot } from "../auto-mode
 import { deriveState } from "../state.js";
 import { isSkippedForDispatch } from "../status-guards.js";
 import { getErrorMessage } from "../error-utils.js";
+import { parseUnitId } from "../unit-id.js";
 import { logWarning } from "../workflow-logger.js";
 import { normalizeRealPath } from "../paths.js";
 import { preserveProjectionChanges } from "../projection-worker.js";
@@ -84,8 +85,10 @@ import {
   markCanceled as markDispatchCanceled,
   getRecentForUnit as getRecentDispatchesForUnit,
   getActiveForWorker,
+  getLatestForUnit,
 } from "../db/unit-dispatches.js";
 import { claimMilestoneLease } from "../db/milestone-leases.js";
+import { isAutoWorkerLive } from "../db/auto-workers.js";
 import type { IterationRunOutcome } from "./iteration-run.js";
 import {
   activeUnitFromWorker,
@@ -104,6 +107,8 @@ import {
   getAlreadyClosedDispatchReason as getDispatchAlreadyClosedReason,
   shouldBypassAlreadyClosedForVerificationRetry,
 } from "./dispatch.js";
+import { readLatestTaskAttempt } from "../task-execution-domain-operation.js";
+import { readTaskRecoveryRoute } from "../task-recovery-domain-operation.js";
 
 type UokFlags = ReturnType<typeof resolveUokFlags>;
 
@@ -1292,6 +1297,65 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         });
       }
 
+      const activeDispatch = getLatestForUnit(decision.unitId);
+      if (activeDispatch && ["claimed", "running"].includes(activeDispatch.status)) {
+        const parsed = parseUnitId(decision.unitId);
+        const latestTaskAttempt = decision.unitType === "execute-task" && parsed.milestone && parsed.slice && parsed.task
+          ? readLatestTaskAttempt({
+              milestoneId: parsed.milestone,
+              sliceId: parsed.slice,
+              taskId: parsed.task,
+            })
+          : null;
+        const activeTaskAttempt = latestTaskAttempt?.coordinationDispatchId === activeDispatch.id
+          ? latestTaskAttempt
+          : null;
+        const executorWorkerId = activeTaskAttempt?.workerId ?? activeDispatch.worker_id;
+        if (!isAutoWorkerLive(executorWorkerId)) {
+          this.clearPendingDispatch();
+          const recovery = activeTaskAttempt
+            ? readTaskRecoveryRoute(activeTaskAttempt.attemptId)
+            : null;
+          const recoveryInstruction = recovery?.action === "abort"
+            ? ` Resume with gsd_task_recovery_resume using recoveryActionId ${recovery.recoveryActionId}.`
+            : activeTaskAttempt?.state === "running"
+              ? ` Settle the orphaned Attempt with gsd_task_settle using attemptId ${activeTaskAttempt.attemptId}.`
+              : " Inspect /gsd status for the active UnitRun's recovery eligibility.";
+          const executionDetail = activeTaskAttempt
+            ? `Attempt ${activeTaskAttempt.attemptId} is ${activeTaskAttempt.state}`
+            : `UnitRun ${activeDispatch.id} is ${activeDispatch.status}`;
+          const reason =
+            `stale-active ${decision.unitType} ${decision.unitId}: ${executionDetail}, ` +
+            `but executor worker ${executorWorkerId} is not live.${recoveryInstruction}`;
+          const blocked: AutoAdvanceResult = {
+            kind: "blocked",
+            reason,
+            action: "stop",
+            stateSnapshot: reconciliation.stateSnapshot,
+          };
+          this.journalTransition({
+            name: "advance-blocked",
+            reason,
+            unitType: decision.unitType,
+            unitId: decision.unitId,
+          });
+          this.postAdvanceRecord(blocked);
+          return this.withLivenessInput(blocked, {
+            guardId: "orphaned-active-unit",
+            inputPayload: JSON.stringify({
+              unitType: decision.unitType,
+              unitId: decision.unitId,
+              dispatchId: activeDispatch.id,
+              attemptId: activeTaskAttempt?.attemptId ?? null,
+              attemptState: activeTaskAttempt?.state ?? null,
+              executorWorkerId,
+              recoveryActionId: recovery?.recoveryActionId ?? null,
+            }),
+            sanctionedExit: reason,
+          });
+        }
+      }
+
       const existingRun = resolveExistingUnitRun({
         workerId: this.s.workerId,
         unitType: decision.unitType,
@@ -1304,6 +1368,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
           kind: "skipped",
           code: UNIT_ALREADY_ACTIVE_SKIP_CODE,
           reason: UNIT_ALREADY_ACTIVE_SKIP_REASON,
+          stateSnapshot: reconciliation.stateSnapshot,
         };
         this.journalTransition({
           name: "advance-skipped",

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -18,6 +18,7 @@ import { getVisualBriefOutputDir } from "../../../visual-brief/artifact-policy.j
 import { buildVisualBriefPrompt, parseVisualBriefArgs, VISUAL_BRIEF_USAGE } from "../../../visual-brief/prompts.js";
 import { GSD_CORE_IMPLEMENTED_CATALOG } from "../../commands-gsd-core.js";
 import { GSD_CORE_ALIAS_CATALOG } from "../gsd-core-aliases.js";
+import { readCurrentTaskRecoveryRoute } from "../../task-recovery-domain-operation.js";
 
 export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
   const summaryLines = [
@@ -642,6 +643,29 @@ export function formatTextStatus(state: GSDState, basePath?: string): string {
   }
   if (state.blockers.length > 0) {
     lines.push(`Blockers: ${state.blockers.join("; ")}`);
+  }
+  if (state.activeMilestone && state.activeSlice && state.activeTask) {
+    try {
+      const recovery = readCurrentTaskRecoveryRoute({
+        milestoneId: state.activeMilestone.id,
+        sliceId: state.activeSlice.id,
+        taskId: state.activeTask.id,
+      });
+      if (recovery?.action === "abort") {
+        const eligibility = recovery.resumeEligibility;
+        const recoveryStatus = recovery.resumeAuthorized
+          ? "successor Attempt authorized"
+          : eligibility?.eligible
+            ? "resume eligible"
+            : `resume unavailable (${eligibility?.failedGuard ?? "unknown"}: ${eligibility?.detail ?? "not eligible"})`;
+        lines.push(
+          `Task recovery: abort ${recovery.recoveryActionId} — ${recoveryStatus}`,
+        );
+      }
+    } catch {
+      // Status remains available for legacy/incomplete databases that do not
+      // yet have the canonical Task recovery tables.
+    }
   }
   if (state.registry.length > 0) {
     lines.push("");

--- a/src/resources/extensions/gsd/db/auto-workers.ts
+++ b/src/resources/extensions/gsd/db/auto-workers.ts
@@ -251,6 +251,16 @@ function isWorkerProcessAlive(candidate: Pick<AutoWorkerRow, "host" | "pid">): b
   }
 }
 
+/** True when a worker still owns a fresh heartbeat and a live local process. */
+export function isAutoWorkerLive(workerId: string): boolean {
+  const worker = getAutoWorker(workerId);
+  if (!worker || worker.status !== "active") return false;
+  const heartbeatAt = Date.parse(worker.last_heartbeat_at);
+  if (!Number.isFinite(heartbeatAt)) return false;
+  if (heartbeatAt < Date.now() - HEARTBEAT_TTL_SECONDS * 1000) return false;
+  return isWorkerProcessAlive(worker);
+}
+
 /**
  * Phase C pt 2 — find the most recently active worker for a project root
  * whose heartbeat has lapsed (the "previous crashed session" indicator).

--- a/src/resources/extensions/gsd/task-recovery-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-recovery-domain-operation.ts
@@ -646,6 +646,20 @@ export function readTaskRecoveryResumeEligibility(
                AND latest.lifecycle_id = attempt.lifecycle_id
            ) THEN 1 ELSE 0 END AS latest_attempt,
            CASE WHEN EXISTS (
+             SELECT 1 FROM workflow_execution_attempts latest
+             WHERE latest.project_id = attempt.project_id
+               AND latest.lifecycle_id = attempt.lifecycle_id
+               AND latest.attempt_state = 'settled'
+               AND latest.settle_outcome = 'succeeded'
+               AND latest.attempt_number > attempt.attempt_number
+               AND NOT EXISTS (
+                 SELECT 1 FROM workflow_execution_attempts newer
+                 WHERE newer.project_id = latest.project_id
+                   AND newer.lifecycle_id = latest.lifecycle_id
+                   AND newer.attempt_number > latest.attempt_number
+               )
+           ) THEN 1 ELSE 0 END AS latest_attempt_succeeded,
+           CASE WHEN EXISTS (
              SELECT 1 FROM workflow_blockers blocker
              WHERE blocker.project_id = action.project_id
                AND blocker.lifecycle_id = action.lifecycle_id
@@ -713,7 +727,13 @@ export function readTaskRecoveryResumeEligibility(
   if (stored["lifecycle_status"] !== "in_progress") return reject("lifecycle-in-progress", `Task lifecycle is ${String(stored["lifecycle_status"])}`);
   if (stored["attempt_state"] !== "settled") return reject("attempt-settled", `Attempt state is ${String(stored["attempt_state"])}`);
   if (Number(stored["causal_authority"]) !== 1) return reject("causal-authority", "Result no longer owns the current execute/verify failure route");
-  if (Number(stored["latest_attempt"]) !== 1) return reject("latest-attempt", "a newer Task Attempt exists");
+  // #1754 residual databases can contain a settled successful successor that
+  // predates the still-current abort route. Let that durable route be resumed
+  // once; ordinary stale or already-consumed actions still fail this guard.
+  const supersededResidual = Number(stored["latest_attempt_succeeded"]) === 1
+    && Number(stored["has_route_head"]) === 1
+    && Number(stored["already_resumed"]) !== 1;
+  if (Number(stored["latest_attempt"]) !== 1 && !supersededResidual) return reject("latest-attempt", "a newer Task Attempt exists");
   if (Number(stored["has_open_blockers"]) === 1) return reject("open-blockers", "Task lifecycle has an open Blocker");
   if (Number(stored["has_route_head"]) !== 1) return reject("route-head", "Attempt no longer owns the current route Kernel checkpoint");
   if (Number(stored["already_resumed"]) === 1) return reject("already-resumed", "Recovery Action was already resumed");

--- a/src/resources/extensions/gsd/task-recovery-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-recovery-domain-operation.ts
@@ -34,6 +34,7 @@ import {
   isTaskRecoveryResumeAuthorized,
 } from "./db/writers/lifecycle-commands.js";
 import type { ExecutionInvocation } from "./execution-invocation.js";
+import { readLatestTaskAttempt } from "./task-execution-domain-operation.js";
 
 export {
   cancelTask,
@@ -187,6 +188,29 @@ export interface TaskRecoveryRouteSnapshot {
   failureKind: string;
   blocker: TaskRecoveryBlockerSnapshot | null;
   resumeAuthorized: boolean;
+  resumeEligibility?: TaskRecoveryResumeEligibility;
+}
+
+export type TaskRecoveryResumeGuard =
+  | "recovery-action-exists"
+  | "abort-action"
+  | "agent-owned"
+  | "action-blocker"
+  | "lifecycle-in-progress"
+  | "attempt-settled"
+  | "causal-authority"
+  | "latest-attempt"
+  | "open-blockers"
+  | "route-head"
+  | "already-resumed";
+
+export interface TaskRecoveryResumeEligibility {
+  recoveryActionId: string;
+  eligible: boolean;
+  attemptId?: string;
+  resultId?: string;
+  failedGuard?: TaskRecoveryResumeGuard;
+  detail?: string;
 }
 
 function taskRecoveryBlockerSnapshot(
@@ -599,9 +623,51 @@ function loadTaskRecoveryReceipt(
   };
 }
 
-function requireResumableAbortScope(recoveryActionId: string): FailedAttemptScope {
+/**
+ * Diagnose the durable guards for an abort resume without binding the caller
+ * to the session that recorded the abort. Guard order is intentional: callers
+ * get the first actionable failure instead of one opaque SQL miss.
+ */
+export function readTaskRecoveryResumeEligibility(
+  recoveryActionId: string,
+): TaskRecoveryResumeEligibility {
+  const normalizedId = requireNonBlank(recoveryActionId, "recoveryActionId");
   const stored = getDb().prepare(`
-    SELECT observation.attempt_id, observation.result_id
+    SELECT action.action, action.blocker_id,
+           observation.recovery_owner, observation.boundary_stage,
+           observation.attempt_id, observation.result_id,
+           attempt.attempt_state, attempt.attempt_number,
+           result.outcome, lifecycle.lifecycle_status,
+           CASE WHEN ${CURRENT_TASK_RECOVERY_CAUSAL_AUTHORITY_SQL} THEN 1 ELSE 0 END AS causal_authority,
+           CASE WHEN attempt.attempt_number = (
+             SELECT MAX(latest.attempt_number)
+             FROM workflow_execution_attempts latest
+             WHERE latest.project_id = attempt.project_id
+               AND latest.lifecycle_id = attempt.lifecycle_id
+           ) THEN 1 ELSE 0 END AS latest_attempt,
+           CASE WHEN EXISTS (
+             SELECT 1 FROM workflow_blockers blocker
+             WHERE blocker.project_id = action.project_id
+               AND blocker.lifecycle_id = action.lifecycle_id
+               AND blocker.blocker_status = 'open'
+           ) THEN 1 ELSE 0 END AS has_open_blockers,
+           CASE WHEN EXISTS (
+             SELECT 1 FROM workflow_kernel_checkpoints kernel
+             WHERE kernel.project_id = attempt.project_id
+               AND kernel.lifecycle_id = attempt.lifecycle_id
+               AND kernel.attempt_id = attempt.attempt_id
+               AND kernel.next_stage = 'route'
+               AND NOT EXISTS (
+                 SELECT 1 FROM workflow_kernel_checkpoints successor
+                 WHERE successor.previous_kernel_checkpoint_id = kernel.kernel_checkpoint_id
+               )
+           ) THEN 1 ELSE 0 END AS has_route_head,
+           CASE WHEN EXISTS (
+             SELECT 1 FROM workflow_domain_events resumed
+             WHERE resumed.project_id = action.project_id
+               AND resumed.event_type = 'task.recovery.resumed'
+               AND json_extract(resumed.payload_json, '$.recoveryActionId') = action.recovery_action_id
+           ) THEN 1 ELSE 0 END AS already_resumed
     FROM workflow_recovery_actions action
     JOIN workflow_failure_observations observation
       ON observation.project_id = action.project_id
@@ -620,27 +686,48 @@ function requireResumableAbortScope(recoveryActionId: string): FailedAttemptScop
       ON lifecycle.project_id = attempt.project_id
      AND lifecycle.lifecycle_id = attempt.lifecycle_id
     WHERE action.recovery_action_id = :recovery_action_id
-      AND action.action = 'abort'
-      AND action.blocker_id IS NULL
-      AND observation.recovery_owner = 'agent'
-      AND lifecycle.lifecycle_status = 'in_progress'
-      AND attempt.attempt_state = 'settled'
-      AND ${CURRENT_TASK_RECOVERY_CAUSAL_AUTHORITY_SQL}
-      AND NOT EXISTS (
-        SELECT 1 FROM workflow_blockers blocker
-        WHERE blocker.project_id = action.project_id
-          AND blocker.lifecycle_id = action.lifecycle_id
-          AND blocker.blocker_status = 'open'
-      )
-      AND NOT EXISTS (
-        SELECT 1 FROM workflow_domain_events resumed
-        WHERE resumed.project_id = action.project_id
-          AND resumed.event_type = 'task.recovery.resumed'
-          AND json_extract(resumed.payload_json, '$.recoveryActionId') = action.recovery_action_id
-      )
-  `).get({ ":recovery_action_id": recoveryActionId }) as Record<string, unknown> | undefined;
-  if (!stored) throw new Error("Task recovery resume requires the current agent-owned abort");
-  return loadRoutedFailureScope(String(stored["attempt_id"]), String(stored["result_id"]));
+  `).get({ ":recovery_action_id": normalizedId }) as Record<string, unknown> | undefined;
+  if (!stored) {
+    return {
+      recoveryActionId: normalizedId,
+      eligible: false,
+      failedGuard: "recovery-action-exists",
+      detail: "no Recovery Action exists with this recoveryActionId",
+    };
+  }
+
+  const base = {
+    recoveryActionId: normalizedId,
+    attemptId: String(stored["attempt_id"]),
+    resultId: String(stored["result_id"]),
+  };
+  const reject = (failedGuard: TaskRecoveryResumeGuard, detail: string): TaskRecoveryResumeEligibility => ({
+    ...base,
+    eligible: false,
+    failedGuard,
+    detail,
+  });
+  if (stored["action"] !== "abort") return reject("abort-action", `Recovery Action is ${String(stored["action"])}, not abort`);
+  if (stored["recovery_owner"] !== "agent") return reject("agent-owned", `recovery owner is ${String(stored["recovery_owner"])}, not agent`);
+  if (stored["blocker_id"] !== null) return reject("action-blocker", "Recovery Action is linked to a Blocker");
+  if (stored["lifecycle_status"] !== "in_progress") return reject("lifecycle-in-progress", `Task lifecycle is ${String(stored["lifecycle_status"])}`);
+  if (stored["attempt_state"] !== "settled") return reject("attempt-settled", `Attempt state is ${String(stored["attempt_state"])}`);
+  if (Number(stored["causal_authority"]) !== 1) return reject("causal-authority", "Result no longer owns the current execute/verify failure route");
+  if (Number(stored["latest_attempt"]) !== 1) return reject("latest-attempt", "a newer Task Attempt exists");
+  if (Number(stored["has_open_blockers"]) === 1) return reject("open-blockers", "Task lifecycle has an open Blocker");
+  if (Number(stored["has_route_head"]) !== 1) return reject("route-head", "Attempt no longer owns the current route Kernel checkpoint");
+  if (Number(stored["already_resumed"]) === 1) return reject("already-resumed", "Recovery Action was already resumed");
+  return { ...base, eligible: true };
+}
+
+function requireResumableAbortScope(recoveryActionId: string): FailedAttemptScope {
+  const eligibility = readTaskRecoveryResumeEligibility(recoveryActionId);
+  if (!eligibility.eligible || !eligibility.attemptId || !eligibility.resultId) {
+    throw new Error(
+      `Task recovery resume rejected by ${eligibility.failedGuard ?? "unknown"} guard: ${eligibility.detail ?? "not eligible"}`,
+    );
+  }
+  return loadRoutedFailureScope(eligibility.attemptId, eligibility.resultId);
 }
 
 function loadTaskRecoveryResumeReceipt(
@@ -727,14 +814,30 @@ export function readTaskRecoveryRoute(attemptId: string): TaskRecoveryRouteSnaps
   `).get({ ":attempt_id": attemptId }) as Record<string, unknown> | undefined;
   if (!stored) return null;
   const blocker = stored["blocker_id"] ? taskRecoveryBlockerSnapshot(stored) : null;
+  const recoveryActionId = String(stored["recovery_action_id"]);
+  const resumeEligibility = stored["action"] === "abort"
+    ? readTaskRecoveryResumeEligibility(recoveryActionId)
+    : undefined;
   return {
-    recoveryActionId: String(stored["recovery_action_id"]),
+    recoveryActionId,
     action: String(stored["action"]) as RecoveryDecision["action"],
     recoveryOwner: String(stored["recovery_owner"]) as TaskRecoveryRouteSnapshot["recoveryOwner"],
     failureKind: String(stored["failure_kind"]),
     blocker,
     resumeAuthorized: stored["action"] === "abort" && isTaskRecoveryResumeAuthorized(attemptId),
+    ...(resumeEligibility ? { resumeEligibility } : {}),
   };
+}
+
+export function readCurrentTaskRecoveryRoute(task: {
+  milestoneId: string;
+  sliceId: string;
+  taskId: string;
+}): (TaskRecoveryRouteSnapshot & { attemptId: string }) | null {
+  const attempt = readLatestTaskAttempt(task);
+  if (!attempt) return null;
+  const route = readTaskRecoveryRoute(attempt.attemptId);
+  return route ? { attemptId: attempt.attemptId, ...route } : null;
 }
 
 export function readTaskRecoveryBlocker(attemptId: string): TaskRecoveryBlockerSnapshot | null {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -41,10 +41,11 @@ import {
   openDatabase,
 } from "../gsd-db.js";
 import { AutoSession } from "../auto/session.js";
-import { registerAutoWorker } from "../db/auto-workers.js";
+import { markWorkerCrashed, registerAutoWorker } from "../db/auto-workers.js";
 import { claimMilestoneLease, getMilestoneLease, releaseMilestoneLease } from "../db/milestone-leases.js";
 import { recordDispatchClaim, markFailed } from "../db/unit-dispatches.js";
 import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.js";
+import { recordFailureAndSelectRecovery } from "../task-recovery-domain-operation.js";
 import { internalExecutionInvocation } from "../execution-invocation.js";
 import { normalizeRealPath, resolveMilestoneFile } from "../paths.js";
 import { acquireSessionLock, releaseSessionLock } from "../session-lock.js";
@@ -723,14 +724,114 @@ test("idempotency skip fires with its own reason before saturation", async (t) =
   t.after(() => f.cleanup());
 
   const first = await f.orchestrator.advance();
+  assert.equal(first.kind, "advanced");
+  if (first.kind !== "advanced") throw new Error("expected first advance");
+  const workerId = f.session.workerId;
+  const milestoneLeaseToken = f.session.milestoneLeaseToken;
+  assert.ok(workerId);
+  assert.ok(milestoneLeaseToken);
+  claimTaskAttempt({
+    invocation: internalExecutionInvocation("test:orchestrator:live-executor:claim"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId,
+    milestoneLeaseToken,
+    coordinationDispatchId: first.dispatchId,
+  });
   f.session.unitExecutionInFlight = true;
   const second = await f.orchestrator.advance();
 
-  assert.equal(first.kind, "advanced");
   assert.equal(second.kind, "skipped");
   if (second.kind !== "skipped") return;
   assert.equal(second.reason, "idempotent advance: unit already active");
   assert.equal(second.code, "unit-already-active");
+});
+
+test("an active UnitRun with a settled executor Attempt stops with durable recovery guidance", async (t) => {
+  const f = makeFixture();
+  t.after(() => f.cleanup());
+
+  const first = await f.orchestrator.advance();
+  assert.equal(first.kind, "advanced");
+  if (first.kind !== "advanced") throw new Error("expected first advance");
+  const workerId = f.session.workerId;
+  const milestoneLeaseToken = f.session.milestoneLeaseToken;
+  assert.ok(workerId);
+  assert.ok(milestoneLeaseToken);
+
+  const attempt = claimTaskAttempt({
+    invocation: internalExecutionInvocation("test:orchestrator:orphan:claim"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId,
+    milestoneLeaseToken,
+    coordinationDispatchId: first.dispatchId,
+  });
+  const settled = settleTaskAttempt({
+    invocation: internalExecutionInvocation("test:orchestrator:orphan:settle"),
+    attemptId: attempt.attemptId,
+    outcome: "failed",
+    failureClass: "execution",
+    summary: "executor stopped before closeout",
+    output: {},
+  });
+  const recovery = recordFailureAndSelectRecovery({
+    invocation: internalExecutionInvocation("test:orchestrator:orphan:route"),
+    attemptId: attempt.attemptId,
+    resultId: settled.resultId,
+    owner: "agent",
+    classification: { failureKind: "fatal" },
+    summary: "executor stopped before closeout",
+    evidence: { source: "test" },
+    rationale: "preserve a durable resume action",
+  });
+  assert.equal(recovery.action, "abort");
+
+  markWorkerCrashed(workerId);
+  f.session.workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(f.base) });
+  f.session.milestoneLeaseToken = null;
+  f.session.unitExecutionInFlight = false;
+  const result = await f.orchestrator.advance();
+
+  assert.equal(result.kind, "blocked");
+  if (result.kind !== "blocked") throw new Error("expected orphaned active unit to block");
+  assert.equal(result.action, "stop");
+  assert.match(result.reason, /stale-active execute-task M001\/S01\/T01/);
+  assert.match(result.reason, /executor worker .* is not live/);
+  assert.match(result.reason, new RegExp(recovery.recoveryActionId));
+  assert.match(result.reason, /gsd_task_recovery_resume/);
+  assert.ok(f.journalNames().includes("advance-blocked"));
+});
+
+test("an active UnitRun checks its running Attempt worker before idling", async (t) => {
+  const f = makeFixture();
+  t.after(() => f.cleanup());
+
+  const first = await f.orchestrator.advance();
+  assert.equal(first.kind, "advanced");
+  if (first.kind !== "advanced") throw new Error("expected first advance");
+  const workerId = f.session.workerId;
+  const milestoneLeaseToken = f.session.milestoneLeaseToken;
+  assert.ok(workerId);
+  assert.ok(milestoneLeaseToken);
+
+  const attempt = claimTaskAttempt({
+    invocation: internalExecutionInvocation("test:orchestrator:dead-executor:claim"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId,
+    milestoneLeaseToken,
+    coordinationDispatchId: first.dispatchId,
+  });
+  markWorkerCrashed(workerId);
+  f.session.unitExecutionInFlight = true;
+
+  const result = await f.orchestrator.advance();
+
+  assert.equal(result.kind, "blocked");
+  if (result.kind !== "blocked") throw new Error("expected dead executor to block");
+  assert.equal(result.action, "stop");
+  assert.match(result.reason, new RegExp(attempt.attemptId));
+  assert.match(result.reason, /is running/);
+  assert.match(result.reason, /executor worker .* is not live/);
+  assert.match(result.reason, /gsd_task_settle/);
 });
 
 test("completeActiveUnit clears in-flight idempotency and stops stale same-unit advance", async (t) => {

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -476,8 +476,10 @@ describe("prompt-budget: execute-task template", () => {
 
       assert.match(
         prompt,
-        /Task plan not found at dispatch time\. Read `\.gsd\/phases\/01-flat-phase\/01-01-PLAN\.md` before executing\./,
+        /Source: `\.gsd\/phases\/01-flat-phase\/01-01-PLAN\.md`/,
       );
+      assert.match(prompt, /\*\*T01: Flat task\*\*/);
+      assert.doesNotMatch(prompt, /Task plan not found at dispatch time/);
       assert.doesNotMatch(prompt, /\.gsd\/phases\/01-flat-phase\/tasks\/T01-PLAN\.md/);
     } finally {
       cleanup(base);
@@ -649,8 +651,10 @@ describe("prompt-budget: reactive-execute builder", () => {
 
       assert.match(
         prompt,
-        /Task plan not found at dispatch time\. Read `\.gsd\/phases\/01-flat-phase\/01-01-PLAN\.md` before executing\./,
+        /Source: `\.gsd\/phases\/01-flat-phase\/01-01-PLAN\.md`/,
       );
+      assert.match(prompt, /\*\*T01: Flat task\*\*/);
+      assert.doesNotMatch(prompt, /Task plan not found at dispatch time/);
       assert.doesNotMatch(prompt, /\.gsd\/phases\/01-flat-phase\/tasks\/T01-PLAN\.md/);
     } finally {
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/task-recovery-convergence.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-convergence.test.ts
@@ -444,7 +444,7 @@ test("agent recovery exhausts durably, resumes once, then passes host verificati
     recoveryActionId: routed3.recoveryActionId,
     repairSummary: "Attempting to reuse already-consumed authorization.",
     evidence: { verification: "must be rejected" },
-  }), /already been consumed|current (?:agent-owned )?abort|pending recovery/i);
+  }), /latest-attempt guard|already been consumed|current (?:agent-owned )?abort|pending recovery/i);
 
   recordPassingVerdict(basePath, claim4.attemptId, "convergence/verdict/4");
   const published = await publishVerifiedTaskCompletion({

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -1311,7 +1311,7 @@ test("deterministic repair abort resumes after restart and is consumed by one su
     recentDecisions: [],
     blockers: [],
     nextAction: "Resume recovery",
-    registry: [{ id: "M001", title: "Recovery", status: "active", depends: [] }],
+    registry: [{ id: "M001", title: "Recovery", status: "active", dependsOn: [] }],
   } as GSDState, firstFailure.basePath);
   assert.match(status, new RegExp(`Task recovery: abort ${second.recoveryActionId} — resume eligible`));
 

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -26,6 +26,7 @@ import {
   cancelTask,
   grantTaskWaiver,
   readPendingTaskRecoveryContext,
+  readTaskRecoveryResumeEligibility,
   readTaskRecoveryRoute,
   recordFailureAndSelectRecovery,
   recordTaskRequirementDisposition,
@@ -42,6 +43,8 @@ import { buildCustomEngineIterationData } from "../auto/workflow-custom-engine-i
 import { handleReplanTask } from "../tools/replan-task.ts";
 import { resolveDispatch } from "../auto-dispatch.ts";
 import { verifyExpectedArtifact, readTerminalTaskRecoveryAbort } from "../artifact-verification.ts";
+import { formatTextStatus } from "../commands/handlers/core.ts";
+import type { GSDState } from "../types.ts";
 
 const tempDirs = new Set<string>();
 
@@ -1234,7 +1237,7 @@ test("durable budget use survives retries and exhausts to agent abort", async ()
     recoveryActionId: third.recoveryActionId,
     repairSummary: "Try to record a second authorization.",
     evidence: { source: "duplicate" },
-  }), /current agent-owned abort/i);
+  }), /already-resumed guard/i);
 
   const fourthFailure = seedRetryFailure(thirdFailure.attemptId, 4);
   assert.ok(fourthFailure.attemptId);
@@ -1252,13 +1255,13 @@ test("durable budget use survives retries and exhausts to agent abort", async ()
     recoveryActionId: third.recoveryActionId,
     repairSummary: "Try to reuse stale authorization.",
     evidence: { source: "stale" },
-  }), /current agent-owned abort/i);
+  }), /latest-attempt guard/i);
   assert.throws(() => resumeTaskRecovery({
     invocation: invocation("recovery/resume/non-abort"),
     recoveryActionId: first.recoveryActionId,
     repairSummary: "Try to resume a retry action.",
     evidence: { source: "invalid" },
-  }), /current agent-owned abort/i);
+  }), /abort-action guard/i);
 });
 
 test("deterministic repair abort resumes after restart and is consumed by one successor claim", () => {
@@ -1293,17 +1296,41 @@ test("deterministic repair abort resumes after restart and is consumed by one su
   );
   assert.equal(second.action, "abort");
   assert.equal(readTaskRecoveryRoute(secondFailure.attemptId)?.resumeAuthorized, false);
+  assert.deepEqual(readTaskRecoveryResumeEligibility(second.recoveryActionId), {
+    recoveryActionId: second.recoveryActionId,
+    eligible: true,
+    attemptId: secondFailure.attemptId,
+    resultId: secondFailure.resultId,
+  });
+  assert.equal(readTaskRecoveryRoute(secondFailure.attemptId)?.resumeEligibility?.eligible, true);
+  const status = formatTextStatus({
+    activeMilestone: { id: "M001", title: "Recovery" },
+    activeSlice: { id: "S01", title: "Recovery operation" },
+    activeTask: { id: "T01", title: "Recover atomically" },
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "Resume recovery",
+    registry: [{ id: "M001", title: "Recovery", status: "active", depends: [] }],
+  } as GSDState, firstFailure.basePath);
+  assert.match(status, new RegExp(`Task recovery: abort ${second.recoveryActionId} — resume eligible`));
 
   closeDatabase();
   assert.equal(openDatabase(firstFailure.dbPath), true);
+  const replacementInvocation = {
+    ...invocation("recovery/deterministic/resume"),
+    actorId: "replacement-agent-session",
+    traceId: "trace:replacement-agent-session",
+    turnId: "turn:replacement-agent-session",
+  };
   const resumed = resumeTaskRecovery({
-    invocation: invocation("recovery/deterministic/resume"),
+    invocation: replacementInvocation,
     recoveryActionId: second.recoveryActionId,
     repairSummary: "Recreated the missing worktree root and verified GSD can resolve it.",
     evidence: { command: "gsd doctor", exitCode: 0, verdict: "PASS" },
   });
   const replayedResume = resumeTaskRecovery({
-    invocation: invocation("recovery/deterministic/resume"),
+    invocation: replacementInvocation,
     recoveryActionId: second.recoveryActionId,
     repairSummary: "Recreated the missing worktree root and verified GSD can resolve it.",
     evidence: { command: "gsd doctor", exitCode: 0, verdict: "PASS" },
@@ -1348,7 +1375,7 @@ test("deterministic repair abort resumes after restart and is consumed by one su
     recoveryActionId: second.recoveryActionId,
     repairSummary: "Try to reuse a consumed repaired-abort authorization.",
     evidence: { command: "gsd doctor", exitCode: 0, verdict: "PASS" },
-  }), /current agent-owned abort/i);
+  }), /latest-attempt guard/i);
   assert.equal(Number(row(`
     SELECT COUNT(*) AS count
     FROM workflow_execution_attempts

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -32,6 +32,7 @@ import type { UnitGsdToolName } from "../unit-registry.ts";
 import {
   buildExecuteTaskPrompt,
   buildGateEvaluatePrompt,
+  buildReactiveExecutePrompt,
   buildReassessRoadmapPrompt,
   buildWorkflowPreferencesPrompt,
   renderTaskRecoveryDispatchContext,
@@ -590,6 +591,104 @@ test("execute-task prompt injects unresolved blocking rework findings", async (t
   assert.match(prompt, /Compile regression/);
   assert.match(prompt, /pnpm run typecheck:extensions/);
   assert.match(prompt, /reworkResolution/);
+});
+
+test("execute-task prompt resolves an inline slice task without a standalone task plan", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", title: "Inline task", status: "pending" });
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+    [
+      "# S01: First",
+      "",
+      "<tasks>",
+      "- [ ] **T01**: Earlier task",
+      "- [ ] **T02**: Inline task",
+      "  - Files: `src/inline.ts`",
+      "  - Verify: pnpm test inline",
+      "</tasks>",
+      "",
+    ].join("\n"),
+  );
+
+  const prompt = await buildExecuteTaskPrompt("M001", "S01", "First", "T02", "Inline task", base);
+
+  assert.match(prompt, /Source: `\.gsd\/milestones\/M001\/slices\/S01\/S01-PLAN\.md`/);
+  assert.match(prompt, /\*\*T02\*\*: Inline task/);
+  assert.match(prompt, /src\/inline\.ts/);
+  assert.doesNotMatch(prompt, /Task plan not found at dispatch time/);
+  assert.doesNotMatch(prompt, /tasks\/T02-PLAN\.md/);
+});
+
+test("execute-task prompt prefers durable inline task planning state when no task file exists", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  insertTask({
+    id: "T02",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Durable task",
+    status: "pending",
+    planning: {
+      description: "Implement the durable inline contract.",
+      estimate: "1h",
+      files: ["src/durable.ts"],
+      verify: "pnpm test durable",
+      inputs: [],
+      expectedOutput: ["src/durable.ts"],
+      observabilityImpact: "none",
+      fullPlanMd: "# T02: Durable task\n\nImplement the durable inline contract.\n",
+    },
+  });
+
+  const prompt = await buildExecuteTaskPrompt("M001", "S01", "First", "T02", "Durable task", base);
+
+  assert.match(prompt, /Source: durable task planning state for M001\/S01\/T02/);
+  assert.match(prompt, /Implement the durable inline contract/);
+  assert.doesNotMatch(prompt, /Task plan not found at dispatch time/);
+});
+
+test("reactive execute-task dispatch resolves inline slice task plans", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", title: "Inline reactive task", status: "pending" });
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+    [
+      "# S01: First",
+      "",
+      "<tasks>",
+      "- [ ] **T02**: Inline reactive task",
+      "  - Files: `src/reactive-inline.ts`",
+      "  - Verify: pnpm test reactive-inline",
+      "</tasks>",
+      "",
+    ].join("\n"),
+  );
+
+  const prompt = await buildReactiveExecutePrompt(
+    "M001",
+    "Recovery",
+    "S01",
+    "First",
+    ["T02"],
+    base,
+  );
+
+  assert.match(prompt, /Source: `\.gsd\/milestones\/M001\/slices\/S01\/S01-PLAN\.md`/);
+  assert.match(prompt, /src\/reactive-inline\.ts/);
+  assert.doesNotMatch(prompt, /Task plan not found at dispatch time/);
+  assert.doesNotMatch(prompt, /tasks\/T02-PLAN\.md/);
 });
 
 test("execute-task recovery context gives repair, remediation, and replan distinct executor contracts", () => {


### PR DESCRIPTION
## Summary
- Fixed orphan liveness detection, cross-session recovery diagnostics, and inline task-plan dispatch with focused regression coverage.

## Bugs Addressed
- [x] **Orphaned active units bypass liveness checks on idle skips**
- [x] **Task recovery cannot resume eligible aborts across sessions**
- [x] **Task dispatch assumes an inline plan has a standalone task file**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1805
- [#1805 Orphaned active unit starves the liveness backstop (zero-iteration idle sessions) and task recovery is session-locked](https://github.com/open-gsd/gsd-pi/issues/1805)

## User
- @rager306

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1805-orphaned-active-unit-starves-the-livenes-1787093425`