### PR TITLE
fix(issue): Bug: gsd_task_complete verificationEvidence validation fails when passed as JSON string

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -1553,7 +1553,7 @@ describe("workflow MCP tools", () => {
     }
   });
 
-  it("gsd_task_complete accepts step-mode evidence when verification summary is omitted", async () => {
+  it("gsd_task_complete accepts JSON-stringified evidence when verification summary is omitted", async () => {
     const base = makeTmpBase();
     try {
       mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
@@ -1575,9 +1575,9 @@ describe("workflow MCP tools", () => {
         milestoneId: "M001",
         oneLiner: "Completed task",
         narrative: "Did the work",
-        verificationEvidence: [
+        verificationEvidence: JSON.stringify([
           { command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 },
-        ],
+        ]),
       }, {
         requestId: "rpc-task-complete",
         _meta: { "claudecode/toolUseId": "toolu_task_complete" },

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1883,6 +1883,18 @@ const verificationEvidenceItemSchema = z.preprocess(
   }),
 );
 
+const verificationEvidenceSchema = z.preprocess(
+  (value) => {
+    if (typeof value !== "string") return value;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  },
+  z.array(verificationEvidenceItemSchema),
+);
+
 const nonEmptyString = (field: string) =>
   z.string().trim().min(1, `${field} must be a non-empty string`);
 
@@ -2405,7 +2417,7 @@ const taskCompleteParams = {
       "When true, the recommendation is recorded as the default, but auto-mode still pauses until the user resolves via /gsd escalate resolve.",
     ),
   }).optional().describe("ADR-011 Phase 2: optional escalation payload. Only honored when phases.mid_execution_escalation is true."),
-  verificationEvidence: z.array(verificationEvidenceItemSchema).optional().describe("Verification evidence entries"),
+  verificationEvidence: verificationEvidenceSchema.optional().describe("Verification evidence entries, or that array encoded as JSON"),
   reworkResolution: z.array(z.object({
     findingId: nonEmptyString("findingId"),
     status: z.enum(["resolved", "deferred-with-override"]),

--- a/packages/pi-ai/src/utils/normalize-tool-arguments.ts
+++ b/packages/pi-ai/src/utils/normalize-tool-arguments.ts
@@ -137,6 +137,10 @@ export function normalizeToolArguments(toolName: string, args: unknown): unknown
 		normalizeJsonStringCollections(args, ["tasks", "chain"]);
 	}
 
+	if (canonical === "gsd_task_complete" || canonical === "gsd_complete_task") {
+		normalizeJsonStringCollections(args, ["verificationEvidence"]);
+	}
+
 	return args;
 }
 

--- a/packages/pi-ai/src/utils/tests/normalize-tool-arguments.test.ts
+++ b/packages/pi-ai/src/utils/tests/normalize-tool-arguments.test.ts
@@ -166,6 +166,31 @@ describe("validateToolArguments integration", () => {
 		assert.equal(validated.path, "README.md");
 	});
 
+	test("accepts gsd_task_complete calls with JSON-stringified verificationEvidence", () => {
+		const evidence = [{ command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 }];
+		const tool = {
+			name: "gsd_task_complete",
+			description: "complete task",
+			parameters: Type.Object({
+				verificationEvidence: Type.Array(
+					Type.Object({
+						command: Type.String(),
+						exitCode: Type.Number(),
+						verdict: Type.String(),
+						durationMs: Type.Number(),
+					}),
+				),
+			}),
+		};
+		const validated = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "complete-task-1",
+			name: "gsd_task_complete",
+			arguments: { verificationEvidence: JSON.stringify(evidence) },
+		});
+		assert.deepEqual(validated.verificationEvidence, evidence);
+	});
+
 	test("accepts Edit calls that use Cursor-style old_string/new_string", () => {
 		const tool = {
 			name: "edit",


### PR DESCRIPTION
## Summary
- Fixed JSON-stringified verification evidence handling and verified normalization, syntax, and diff integrity.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1848
- [#1848 Bug: gsd_task_complete verificationEvidence validation fails when passed as JSON string](https://github.com/open-gsd/gsd-pi/issues/1848)

## User
- @ventus78

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1848-bug-gsd-task-complete-verificationeviden-1787125471`