### PR TITLE
fix(issue): Post-unit hooks dispatch on verify-staged Tasks before publishVerifiedTaskExecution (Task is not complete loop)

### DIFF
--- a/src/resources/extensions/gsd/auto/finalize.ts
+++ b/src/resources/extensions/gsd/auto/finalize.ts
@@ -99,6 +99,7 @@ export async function runFinalize(
   iterData: IterationData,
   loopState: LoopState,
   sidecarItem?: SidecarItem,
+  publishVerifiedTask?: () => Promise<void>,
 ): Promise<PhaseResult> {
   const { ctx, pi, s, deps } = ic;
   const { pauseAfterUatDispatch } = iterData;
@@ -306,6 +307,22 @@ export async function runFinalize(
         debugLog("autoLoop", { phase: "verification-retry", iteration: ic.iteration });
         clearFinalizingUnit();
         return { action: "continue" };
+      }
+    }
+
+    if (
+      verificationResult === "continue"
+      && iterData.unitType === "execute-task"
+      && publishVerifiedTask
+    ) {
+      try {
+        await publishVerifiedTask();
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        ctx.ui.notify(reason, "error");
+        await deps.stopAuto(ctx, pi, reason);
+        clearFinalizingUnit();
+        return { action: "break", reason };
       }
     }
   }

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -1912,7 +1912,16 @@ export async function autoLoop(
         unitId: iterData.unitId,
       });
       try {
-        finalizeResult = await runFinalize(ic, iterData, loopState, sidecarItem);
+        finalizeResult = await runFinalize(ic, iterData, loopState, sidecarItem, async () => {
+          await (deps.taskPublicationBoundary ?? publishVerifiedTaskExecution)({
+            unitType: unitIterData.unitType,
+            unitId: unitIterData.unitId,
+            workerId: s.workerId,
+            traceId: flowId,
+            turnId,
+            basePath: s.basePath,
+          }, VERIFIED_TASK_PUBLICATION_DEPS);
+        });
       } catch (err) {
         const error = formatDispatchExceptionSummary({ error: err });
         journalReporter.emit("post-unit-finalize-end", {
@@ -1998,33 +2007,6 @@ export async function autoLoop(
         });
         finishTurn("retry", "closeout", finalizeDecision.ledgerErrorSummary, "finalize-retry");
         continue;
-      }
-
-      if (iterData.unitType === "execute-task") {
-        try {
-          await (deps.taskPublicationBoundary ?? publishVerifiedTaskExecution)({
-            unitType: iterData.unitType,
-            unitId: iterData.unitId,
-            workerId: s.workerId,
-            traceId: flowId,
-            turnId,
-            basePath: s.basePath,
-          }, VERIFIED_TASK_PUBLICATION_DEPS);
-        } catch (publishErr) {
-          const publishReason = publishErr instanceof Error ? publishErr.message : String(publishErr);
-          await closeRun("failed", publishReason);
-          ctx.ui.notify(publishReason, "error");
-          finishIncompleteIteration({
-            status: "stopped",
-            reason: publishReason,
-            unitType: iterData.unitType,
-            unitId: iterData.unitId,
-            failureClass: "closeout",
-          });
-          finishTurn("stopped", "closeout", publishReason, "task-publication-failed");
-          await deferStopAuto(ctx, pi, publishReason);
-          break;
-        }
       }
 
       await closeRun("completed", "iteration-complete");

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -174,7 +174,7 @@ export interface RetryTrigger {
 function captureTaskCompletionIdentity(trigger: HookTriggerRef): Pick<
   RetryTrigger,
   "completionOperationId" | "legacyCompletedAt"
-> {
+> | null {
   if (trigger.triggerUnitType !== "execute-task") return {};
   const { milestone, slice, task } = parseUnitId(trigger.triggerUnitId);
   if (!milestone || !slice || !task) {
@@ -210,7 +210,7 @@ function captureTaskCompletionIdentity(trigger: HookTriggerRef): Pick<
     );
   }
   if (!row || row["status"] !== "complete") {
-    throw new Error(`Cannot dispatch execute-task hook for ${trigger.triggerUnitId}: Task is not complete`);
+    return null;
   }
   if (
     row["lifecycle_status"] === "completed"
@@ -387,6 +387,7 @@ export class RuleRegistry {
       triggerUnitType: completedUnitType,
       triggerUnitId: completedUnitId,
     });
+    if (!completionIdentity) return null;
 
     // Build hook queue for this trigger
     this.hookQueue = hooks.map(config => ({
@@ -1288,6 +1289,7 @@ export class RuleRegistry {
       triggerUnitType: unitType,
       triggerUnitId: unitId,
     });
+    if (!completionIdentity) return null;
 
     this.activeHook = {
       hookName: hook.name,

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -3240,10 +3240,13 @@ test("autoLoop calls deriveState → resolveDispatch → runUnit in sequence", a
       deps.callLog.push("resolveDispatch");
       return {
         action: "dispatch" as const,
-        unitType: "plan-slice",
-        unitId: "M001/S01",
+        unitType: "execute-task",
+        unitId: "M001/S01/T01",
         prompt: "do the thing",
       };
+    },
+    taskPublicationBoundary: async () => {
+      deps.callLog.push("publishVerifiedTaskExecution");
     },
     postUnitPostVerification: async () => {
       deps.callLog.push("postUnitPostVerification");
@@ -3270,6 +3273,7 @@ test("autoLoop calls deriveState → resolveDispatch → runUnit in sequence", a
   const dispatchIdx = deps.callLog.indexOf("resolveDispatch");
   const preVerIdx = deps.callLog.indexOf("postUnitPreVerification");
   const verIdx = deps.callLog.indexOf("runPostUnitVerification");
+  const publishIdx = deps.callLog.indexOf("publishVerifiedTaskExecution");
   const postVerIdx = deps.callLog.indexOf("postUnitPostVerification");
 
   assert.ok(deriveIdx >= 0, "deriveState should have been called");
@@ -3286,8 +3290,12 @@ test("autoLoop calls deriveState → resolveDispatch → runUnit in sequence", a
     "runPostUnitVerification should come after pre-verification",
   );
   assert.ok(
-    postVerIdx > verIdx,
-    "postUnitPostVerification should come after verification",
+    publishIdx > verIdx,
+    "verified Task publication should come after verification",
+  );
+  assert.ok(
+    postVerIdx > publishIdx,
+    "postUnitPostVerification should observe the published Task",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/rule-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/rule-registry.test.ts
@@ -23,6 +23,13 @@ import type { UnifiedRule } from "../rule-types.ts";
 import type { DispatchAction, DispatchContext } from "../auto-dispatch.ts";
 import { DISPATCH_RULES, getDispatchRuleNames } from "../auto-dispatch.ts";
 import type { GSDState } from "../types.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../gsd-db.ts";
 
 // ─── Mock Rule Factories ──────────────────────────────────────────────────
 
@@ -415,6 +422,53 @@ describe("RuleRegistry", () => {
     const registry = new RuleRegistry([]);
     const result = registry.evaluatePostUnit("quick-task", "M001/S01/T01", "/tmp/test");
     assert.deepStrictEqual(result, null, "quick-task skipped");
+  });
+
+  test("evaluatePostUnit does not dispatch execute-task hooks before canonical completion", (t) => {
+    const originalGsdHome = process.env.GSD_HOME;
+    const projectRoot = mkdtempSync(join(tmpdir(), "gsd-hook-staged-task-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-hook-home-"));
+
+    t.after(() => {
+      closeDatabase();
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    });
+
+    mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "version: 1",
+        "post_unit_hooks:",
+        "  - name: review-after-task",
+        "    after: [execute-task]",
+        "    prompt: Review {taskId}",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+    process.env.GSD_HOME = tempGsdHome;
+    openDatabase(join(projectRoot, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", status: "active" });
+    insertTask({
+      id: "T01",
+      milestoneId: "M001",
+      sliceId: "S01",
+      title: "Staged Task",
+      status: "pending",
+    });
+
+    const registry = new RuleRegistry([]);
+    assert.equal(
+      registry.evaluatePostUnit("execute-task", "M001/S01/T01", projectRoot),
+      null,
+      "verify-staged Tasks must fail closed without dispatching hooks",
+    );
   });
 
   test("evaluatePreDispatch bypasses hook units", () => {


### PR DESCRIPTION
## Summary
- Published verified Tasks before hook evaluation, added an incomplete-Task guard, and verified with focused tests, build, typecheck, and fast gates.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1850
- [#1850 Post-unit hooks dispatch on verify-staged Tasks before publishVerifiedTaskExecution (Task is not complete loop)](https://github.com/open-gsd/gsd-pi/issues/1850)

## User
- @Jack11111eee

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1850-post-unit-hooks-dispatch-on-verify-stage-1787144795`