### PR TITLE
fix(issue): [Bug]: slice-prefixed task ids make parseProjectionPlan return zero tasks — startup auto-rebuild never converges (1.16.0)

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -148,6 +148,11 @@ export {
 import { logWarning } from "./workflow-logger.js";
 import { deleteRuntimeKv } from "./db/runtime-kv.js";
 import { PAUSED_SESSION_KV_KEY } from "./interrupted-session.js";
+import {
+  clearMarkdownAutoRebuildBackoff,
+  recordMarkdownAutoRebuildFailure,
+  shouldAttemptMarkdownAutoRebuild,
+} from "./markdown-auto-rebuild-backoff.js";
 import { buildWorkflowDispatchContent } from "./workflow-protocol.js";
 import { isFullGsdToolSurfaceRequested, restoreGsdWorkflowTools, scopeGsdWorkflowToolsForDispatch } from "./bootstrap/register-hooks.js";
 import {
@@ -2054,41 +2059,55 @@ export async function showSmartEntry(
       const result = await checkMarkdownHierarchyAgainstDb(basePath);
       if (result.action === "recovery-required") {
         if (result.recoveryCommand === "/gsd rebuild markdown") {
-          try {
-            const { rebuildMarkdownProjectionsFromDb } = await import("./commands-maintenance.js");
-            const rebuild = await rebuildMarkdownProjectionsFromDb(basePath);
-            const after = await checkMarkdownHierarchyAgainstDb(basePath);
-            if (after.action === "none") {
+          if (shouldAttemptMarkdownAutoRebuild(result)) {
+            try {
+              const { rebuildMarkdownProjectionsFromDb } = await import("./commands-maintenance.js");
+              const rebuild = await rebuildMarkdownProjectionsFromDb(basePath);
+              const after = await checkMarkdownHierarchyAgainstDb(basePath);
+              if (after.action === "none") {
+                clearMarkdownAutoRebuildBackoff();
+                ctx.ui.notify(
+                  `Self-heal: rebuilt markdown projections from the authoritative DB ` +
+                    `(${rebuild.rendered} rendered${rebuild.errors.length > 0 ? `, ${rebuild.errors.length} error(s)` : ""}).`,
+                  rebuild.errors.length > 0 ? "warning" : "info",
+                );
+              } else {
+                if (after.recoveryCommand === "/gsd rebuild markdown") {
+                  recordMarkdownAutoRebuildFailure(after);
+                } else {
+                  clearMarkdownAutoRebuildBackoff();
+                }
+                ctx.ui.notify(
+                  (after.message ?? "Markdown planning artifacts still diverge from the DB after auto-rebuild.") +
+                    (rebuild.errors.length > 0
+                      ? `\nAuto-rebuild had ${rebuild.errors.length} projection error(s).`
+                      : "") +
+                    "\nAutomatic rebuild is paused until this drift changes. Run `/gsd rebuild markdown` after review.",
+                  "warning",
+                );
+              }
+            } catch (rebuildErr) {
+              const rebuildMessage = rebuildErr instanceof Error ? rebuildErr.message : String(rebuildErr);
+              logWarning("guided", `markdown auto-rebuild failed: ${rebuildMessage}`, { file: "guided-flow.ts" });
+              recordMarkdownAutoRebuildFailure(result);
               ctx.ui.notify(
-                `Self-heal: rebuilt markdown projections from the authoritative DB ` +
-                  `(${rebuild.rendered} rendered${rebuild.errors.length > 0 ? `, ${rebuild.errors.length} error(s)` : ""}).`,
-                rebuild.errors.length > 0 ? "warning" : "info",
-              );
-            } else {
-              ctx.ui.notify(
-                (result.message ?? "Markdown planning artifacts still diverge from the DB after auto-rebuild.") +
-                  (rebuild.errors.length > 0
-                    ? `\nAuto-rebuild had ${rebuild.errors.length} projection error(s). Run \`/gsd rebuild markdown\` after review.`
-                    : ""),
+                (result.message ??
+                  `Markdown planning artifacts do not match the authoritative DB. Run \`${result.recoveryCommand ?? "/gsd rebuild markdown"}\` to re-project from the DB.`) +
+                  "\nAutomatic rebuild is paused until this drift changes.",
                 "warning",
               );
             }
-          } catch (rebuildErr) {
-            const rebuildMessage = rebuildErr instanceof Error ? rebuildErr.message : String(rebuildErr);
-            logWarning("guided", `markdown auto-rebuild failed: ${rebuildMessage}`, { file: "guided-flow.ts" });
-            ctx.ui.notify(
-              result.message ??
-                `Markdown planning artifacts do not match the authoritative DB. Run \`${result.recoveryCommand ?? "/gsd rebuild markdown"}\` to re-project from the DB.`,
-              "warning",
-            );
           }
         } else {
+          clearMarkdownAutoRebuildBackoff();
           ctx.ui.notify(
             result.message ??
               `Markdown planning artifacts do not match the authoritative DB. Run \`${result.recoveryCommand ?? "/gsd recover"}\` to preview an explicit markdown import.`,
             "warning",
           );
         }
+      } else {
+        clearMarkdownAutoRebuildBackoff();
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/resources/extensions/gsd/markdown-auto-rebuild-backoff.ts
+++ b/src/resources/extensions/gsd/markdown-auto-rebuild-backoff.ts
@@ -1,0 +1,41 @@
+import { deleteRuntimeKv, getRuntimeKv, setRuntimeKv } from "./db/runtime-kv.js";
+import type { MigrationAutoCheckResult } from "./migration-auto-check.js";
+
+const MARKDOWN_AUTO_REBUILD_BACKOFF_KEY = "markdown_auto_rebuild_nonconvergent";
+
+interface MarkdownAutoRebuildBackoff {
+  signature: string;
+}
+
+function recoverySignature(result: MigrationAutoCheckResult): string {
+  return JSON.stringify({
+    recoveryFingerprint: result.recoveryFingerprint ?? null,
+    reason: result.reason,
+    recoveryCommand: result.recoveryCommand ?? null,
+    markdown: result.markdown,
+    beforeDb: result.beforeDb,
+  });
+}
+
+/** Return false after the same recovery verdict already survived an auto-rebuild. */
+export function shouldAttemptMarkdownAutoRebuild(result: MigrationAutoCheckResult): boolean {
+  const backoff = getRuntimeKv<MarkdownAutoRebuildBackoff>(
+    "global",
+    "",
+    MARKDOWN_AUTO_REBUILD_BACKOFF_KEY,
+  );
+  return backoff?.signature !== recoverySignature(result);
+}
+
+/** Persist a non-convergent verdict so later launches do not repeat the rebuild. */
+export function recordMarkdownAutoRebuildFailure(result: MigrationAutoCheckResult): void {
+  setRuntimeKv("global", "", MARKDOWN_AUTO_REBUILD_BACKOFF_KEY, {
+    signature: recoverySignature(result),
+  } satisfies MarkdownAutoRebuildBackoff);
+}
+
+/** Clear backoff as soon as the hierarchy converges or the recovery direction changes. */
+export function clearMarkdownAutoRebuildBackoff(): void {
+  if (getRuntimeKv("global", "", MARKDOWN_AUTO_REBUILD_BACKOFF_KEY) === null) return;
+  deleteRuntimeKv("global", "", MARKDOWN_AUTO_REBUILD_BACKOFF_KEY);
+}

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
@@ -29,6 +30,7 @@ export interface MigrationAutoCheckResult {
   afterDb: HierarchyCounts;
   recoveryCommand?: string;
   message?: string;
+  recoveryFingerprint?: string;
 }
 
 interface HierarchyScan {
@@ -88,6 +90,23 @@ function scanHasExtraIdentities(a: HierarchyScan, b: HierarchyScan): boolean {
     hasExtra(a.slices, b.slices) ||
     hasExtra(a.tasks, b.tasks)
   );
+}
+
+function recoveryFingerprint(markdownScan: HierarchyScan, dbScan: HierarchyScan): string {
+  const sorted = (values: ReadonlySet<string>): string[] => [...values].sort();
+  const identities = {
+    markdown: {
+      milestones: sorted(markdownScan.milestones),
+      slices: sorted(markdownScan.slices),
+      tasks: sorted(markdownScan.tasks),
+    },
+    db: {
+      milestones: sorted(dbScan.milestones),
+      slices: sorted(dbScan.slices),
+      tasks: sorted(dbScan.tasks),
+    },
+  };
+  return createHash("sha256").update(JSON.stringify(identities)).digest("hex");
 }
 
 function excludeUnplannedMilestonesFromDbScan(
@@ -305,6 +324,7 @@ export async function checkMarkdownHierarchyAgainstDb(
   // Reserve explicit legacy import for a lost or corrupt DB whose intended
   // source is markdown.
   const dbHasExtra = scanHasExtraIdentities(dbScan, markdownScan);
+  const driftFingerprint = recoveryFingerprint(markdownScan, dbScan);
 
   const countsLine =
     `Markdown planning artifacts (${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T) ` +
@@ -320,6 +340,7 @@ export async function checkMarkdownHierarchyAgainstDb(
       beforeDb,
       afterDb: beforeDb,
       recoveryCommand: "/gsd rebuild markdown",
+      recoveryFingerprint: driftFingerprint,
       message:
         countsLine +
         "The DB holds rows the markdown lacks, so the markdown projection is stale. " +
@@ -338,6 +359,7 @@ export async function checkMarkdownHierarchyAgainstDb(
     beforeDb,
     afterDb: beforeDb,
     recoveryCommand: "/gsd recover",
+    recoveryFingerprint: driftFingerprint,
     message:
       countsLine +
       "Runtime startup will not import markdown automatically; run `/gsd recover` and approve its exact Preview hash if markdown should repopulate the database.",

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -237,7 +237,11 @@ export function buildTaskFileName(taskId: string, suffix: string): string {
  * ("S06", "T03", "SUMMARY") → "S06-T03-SUMMARY.md"
  */
 export function buildFlatTaskFileName(sliceId: string, taskId: string, suffix: string): string {
-  return `${sliceId}-${taskId}-${suffix}.md`;
+  const redundantPrefix = `${sliceId}-`;
+  const bareTaskId = taskId.toUpperCase().startsWith(redundantPrefix.toUpperCase())
+    ? taskId.slice(redundantPrefix.length)
+    : taskId;
+  return `${sliceId}-${bareTaskId}-${suffix}.md`;
 }
 
 /**

--- a/src/resources/extensions/gsd/schemas/parsers.ts
+++ b/src/resources/extensions/gsd/schemas/parsers.ts
@@ -524,7 +524,14 @@ function _parsePlanImpl(content: string): SlicePlan {
   const [, body] = splitFrontmatter(content);
   // Try native parser first for better performance
   const nativeResult = nativeParsePlanFile(body);
-  if (nativeResult) {
+  const taskCheckboxCount = body.match(/^\s*-\s+\[[ xX]\]\s+\*\*/gm)?.length ?? 0;
+  const nativeTasksAreComplete = nativeResult?.tasks.every((task) => task.id.trim().length > 0) ?? false;
+  // Older native engines do not understand flat-phase <tasks> entries. A
+  // zero-task, partial, or empty-id native result is therefore not authoritative
+  // when the source visibly contains task checkboxes; fall through to JS.
+  if (nativeResult && (taskCheckboxCount === 0 || (
+    nativeResult.tasks.length === taskCheckboxCount && nativeTasksAreComplete
+  ))) {
     stopTimer({ native: true });
     return {
       id: nativeResult.id,
@@ -582,11 +589,11 @@ function _parsePlanImpl(content: string): SlicePlan {
       // Match both formats:
       //   Legacy:  - [x] **T01: Title** `est:30m`
       //   Flat-phase: - [x] **T01**: Title _(30m)_
-      const cbMatch = line.match(/^-\s+\[([ xX])\]\s+\*\*([\w.]+):\s+(.+?)\*\*\s*(.*)/)
-        || line.match(/^-\s+\[([ xX])\]\s+\*\*([\w.]+)\*\*:\s+(.+?)\s*(?:_\(([^)]*)\)_\s*)?$/);
+      const cbMatch = line.match(/^-\s+\[([ xX])\]\s+\*\*((?:S\d+-)?[\w.]+):\s+(.+?)\*\*\s*(.*)/)
+        || line.match(/^-\s+\[([ xX])\]\s+\*\*((?:S\d+-)?[\w.]+)\*\*:\s+(.+?)\s*(?:_\(([^)]*)\)_\s*)?$/);
       // Heading-style: ### T01 -- Title, ### T01: Title, ### T01 — Title
       const hdMatch = !cbMatch
-        ? line.match(/^#{2,4}\s+([A-Z]+\d+(?:\.[A-Z]+\d+)*)\s*(?:--|—|:)\s*(.+)/)
+        ? line.match(/^#{2,4}\s+((?:S\d+-)?[A-Z]+\d+(?:\.[A-Z]+\d+)*)\s*(?:--|—|:)\s*(.+)/)
         : null;
       if (cbMatch || hdMatch) {
         const taskId = cbMatch ? cbMatch[2] : hdMatch![1];

--- a/src/resources/extensions/gsd/tests/integration/paths.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/paths.test.ts
@@ -8,6 +8,7 @@ import { spawnSync } from "node:child_process";
 import {
   gsdProjectionRoot,
   gsdRoot,
+  buildFlatTaskFileName,
   milestonesDir,
   resolveGsdPathContract,
   resolveSliceFile,
@@ -32,6 +33,11 @@ function initGit(dir: string): void {
 }
 
 describe('paths', () => {
+  test('flat task artifacts do not duplicate a redundant slice prefix', () => {
+    assert.equal(buildFlatTaskFileName('S05', 'S05-T01', 'SUMMARY'), 'S05-T01-SUMMARY.md');
+    assert.equal(buildFlatTaskFileName('S05', 'T01', 'SUMMARY'), 'S05-T01-SUMMARY.md');
+  });
+
   test('Case 1: .gsd exists at basePath — fast path', () => {
     const root = tmp();
     try {

--- a/src/resources/extensions/gsd/tests/markdown-auto-rebuild-backoff.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-auto-rebuild-backoff.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { closeDatabase, openDatabase } from "../gsd-db.ts";
+import {
+  clearMarkdownAutoRebuildBackoff,
+  recordMarkdownAutoRebuildFailure,
+  shouldAttemptMarkdownAutoRebuild,
+} from "../markdown-auto-rebuild-backoff.ts";
+import type { MigrationAutoCheckResult } from "../migration-auto-check.ts";
+
+function recoveryResult(tasks: number, recoveryFingerprint = `fingerprint-${tasks}`): MigrationAutoCheckResult {
+  return {
+    action: "recovery-required",
+    reason: "count-mismatch",
+    markdown: { milestones: 1, slices: 1, tasks },
+    beforeDb: { milestones: 1, slices: 1, tasks: tasks + 1 },
+    afterDb: { milestones: 1, slices: 1, tasks: tasks + 1 },
+    recoveryCommand: "/gsd rebuild markdown",
+    recoveryFingerprint,
+  };
+}
+
+test("unchanged non-convergent recovery verdict persists an auto-rebuild backoff", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-markdown-rebuild-backoff-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    const verdict = recoveryResult(0);
+
+    assert.equal(shouldAttemptMarkdownAutoRebuild(verdict), true);
+    recordMarkdownAutoRebuildFailure(verdict);
+    assert.equal(shouldAttemptMarkdownAutoRebuild(verdict), false);
+
+    closeDatabase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    assert.equal(shouldAttemptMarkdownAutoRebuild(verdict), false, "backoff survives process-style DB reopen");
+    assert.equal(shouldAttemptMarkdownAutoRebuild(recoveryResult(1)), true, "changed drift gets one new attempt");
+    assert.equal(
+      shouldAttemptMarkdownAutoRebuild(recoveryResult(0, "changed-identity")),
+      true,
+      "identity drift with unchanged counts gets one new attempt",
+    );
+
+    clearMarkdownAutoRebuildBackoff();
+    assert.equal(shouldAttemptMarkdownAutoRebuild(verdict), true);
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -227,6 +227,7 @@ test("migration auto-check detects identity drift even when counts match", async
     // The DB holds S99 (which markdown lacks), so recover would DELETE it. Even
     // at equal counts the safe recommendation must be rebuild, not recover.
     assert.equal(result.recoveryCommand, "/gsd rebuild markdown");
+    assert.match(result.recoveryFingerprint ?? "", /^[a-f0-9]{64}$/);
     assert.match(result.message ?? "", /Do NOT run/);
   } finally {
     cleanup(base);
@@ -579,6 +580,46 @@ test("rebuildMarkdownProjectionsFromDb realigns markdown when DB holds extra row
     assert.equal(after.reason, "in-sync");
     assert.deepEqual(after.markdown, { milestones: 1, slices: 2, tasks: 2 });
     assert.deepEqual(after.beforeDb, { milestones: 1, slices: 2, tasks: 2 });
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("slice-prefixed DB task ids converge after markdown projection rebuild", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory({ projectContent: "# P\n", decisionsContent: "", requirements: [], milestones: [] }, base);
+    assert.equal(await ensureDbOpen(base), true);
+    insertMilestone({ id: "M016", title: "Prefixed tasks", status: "active" });
+    insertSlice({
+      id: "S05",
+      milestoneId: "M016",
+      title: "Account state",
+      status: "pending",
+      risk: "medium",
+      depends: [],
+      demo: "Account state is visible",
+      sequence: 1,
+    });
+    insertTask({
+      id: "S05-T01",
+      sliceId: "S05",
+      milestoneId: "M016",
+      title: "Account State Panel",
+      status: "pending",
+      sequence: 1,
+    });
+
+    const before = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(before.recoveryCommand, "/gsd rebuild markdown");
+
+    const { rebuildMarkdownProjectionsFromDb } = await import("../commands-maintenance.ts");
+    await rebuildMarkdownProjectionsFromDb(base);
+
+    const after = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(after.action, "none");
+    assert.equal(after.reason, "in-sync");
+    assert.deepEqual(after.markdown, { milestones: 1, slices: 1, tasks: 1 });
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/parsers.test.ts
+++ b/src/resources/extensions/gsd/tests/parsers.test.ts
@@ -302,6 +302,28 @@ skills_used:
   assert.ok(p.filesLikelyTouched[0].includes('tests/parsers.test.ts'), 'first file');
 });
 
+test('parsePlan: accepts slice-prefixed task ids in flat-phase task blocks', () => {
+  const content = `# S05: Prefixed task ids
+
+**Goal:** Keep legacy DB identities visible in markdown scans.
+
+<tasks>
+- [x] **S05-T01**: Account State Panel _(medium)_
+  - Files: \`src/account-state.ts\`
+  - Verify: pnpm test
+</tasks>
+`;
+
+  const p = parsePlan(content);
+
+  assert.equal(p.tasks.length, 1);
+  assert.equal(p.tasks[0].id, 'S05-T01');
+  assert.equal(p.tasks[0].title, 'Account State Panel');
+  assert.equal(p.tasks[0].done, true);
+  assert.deepEqual(p.tasks[0].files, ['src/account-state.ts']);
+  assert.equal(p.tasks[0].verify, 'pnpm test');
+});
+
 test('parseTaskPlanFile: defaults missing frontmatter fields', () => {
   const content = `# T01: Minimal task plan
 


### PR DESCRIPTION
## Summary
- Fixed prefixed task projection convergence and persistent startup rebuild loops with focused regression coverage.

## Bugs Addressed
- [x] **Slice-prefixed task IDs break PLAN parsing and artifact paths**
- [x] **Persistent recovery-required verdict triggers rebuild on every launch**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1859
- [#1859 [Bug]: slice-prefixed task ids make parseProjectionPlan return zero tasks — startup auto-rebuild never converges (1.16.0)](https://github.com/open-gsd/gsd-pi/issues/1859)

## User
- @jg-main

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1859-bug-slice-prefixed-task-ids-make-parsepr-1787158716`