### PR TITLE
fix(issue): [Bug]: auto-mode deadlock — dispatch-rule-stop fails closed on a superseded attempt's consumed abort while every sanctioned recovery lever is circularly blocked

### DIFF
--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -68,8 +68,8 @@ export function readExecuteTaskArtifactReadiness(
 }
 
 /**
- * The recovery action id when any Task Attempt already settled on an
- * agent-owned `abort` that is not resume-authorized.
+ * The recovery action id when the newest agent-owned `abort` is not
+ * resume-authorized.
  *
  * `readExecuteTaskArtifactReadiness` reports "route" for *any* settled Attempt
  * parked at the route stage — including one whose agent-owned recovery already
@@ -79,8 +79,9 @@ export function readExecuteTaskArtifactReadiness(
  * refuse instead of clearing the dispatch ring and re-dispatching.
  *
  * Detection is not limited to the latest Attempt: a terminal abort on a
- * superseded Attempt is just as operative, and the latest Attempt carrying no
- * route of its own must not hide it (#1754 residual).
+ * superseded Attempt remains operative when newer Attempts carry no agent abort
+ * of their own (#1754 residual). A newer resume-authorized abort does supersede
+ * older aborts whose authorization was consumed by that newer Attempt (#1861).
  */
 export function readTerminalTaskRecoveryAbort(
   milestoneId: string,
@@ -90,8 +91,8 @@ export function readTerminalTaskRecoveryAbort(
   for (const attemptId of readTaskRecoveryAttemptIds({ milestoneId, sliceId, taskId })) {
     const route = readTaskRecoveryRoute(attemptId);
     if (!route || route.recoveryOwner !== "agent") continue;
-    if (route.action !== "abort" || route.resumeAuthorized) continue;
-    return { recoveryActionId: route.recoveryActionId };
+    if (route.action !== "abort") continue;
+    return route.resumeAuthorized ? null : { recoveryActionId: route.recoveryActionId };
   }
   return null;
 }

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -1385,6 +1385,53 @@ test("deterministic repair abort resumes after restart and is consumed by one su
   `, { ":attempt_id": secondFailure.attemptId }).count), 1);
 });
 
+test("latest resumed abort supersedes an ancestor whose authorization was consumed", () => {
+  const firstFailure = seedFailedAttempt();
+  const route = (
+    key: string,
+    failure: { attemptId: string; resultId: string },
+  ) => recordFailureAndSelectRecovery({
+    invocation: invocation(key),
+    ...failure,
+    owner: "agent",
+    classification: { failureKind: "verification-failed" },
+    summary: "Host verification still fails after remediation.",
+    evidence: { command: "python3 -m pytest", exitCode: 1, verdict: "FAIL" },
+    rationale: "remediate the failed host verification",
+  });
+
+  route("recovery/repeated-verify/1", firstFailure);
+  const secondFailure = seedRetryFailure(firstFailure.attemptId, 2);
+  route("recovery/repeated-verify/2", secondFailure);
+  const thirdFailure = seedRetryFailure(secondFailure.attemptId, 3);
+  const ancestorAbort = route("recovery/repeated-verify/3", thirdFailure);
+  assert.equal(ancestorAbort.action, "abort");
+  resumeTaskRecovery({
+    invocation: invocation("recovery/repeated-verify/resume-ancestor"),
+    recoveryActionId: ancestorAbort.recoveryActionId,
+    repairSummary: "Applied and checked the first verification repair.",
+    evidence: { command: "python3 -m pytest", exitCode: 0, verdict: "PASS" },
+  });
+
+  const latestFailure = seedRetryFailure(thirdFailure.attemptId, 4);
+  const latestAbort = route("recovery/repeated-verify/4", latestFailure);
+  assert.equal(latestAbort.action, "abort");
+  resumeTaskRecovery({
+    invocation: invocation("recovery/repeated-verify/resume-latest"),
+    recoveryActionId: latestAbort.recoveryActionId,
+    repairSummary: "Applied and checked the second verification repair.",
+    evidence: { command: "python3 -m pytest", exitCode: 0, verdict: "PASS" },
+  });
+
+  assert.equal(readTaskRecoveryRoute(thirdFailure.attemptId)?.resumeAuthorized, false);
+  assert.equal(readTaskRecoveryRoute(latestFailure.attemptId)?.resumeAuthorized, true);
+  assert.equal(
+    readTerminalTaskRecoveryAbort("M001", "S01", "T01"),
+    null,
+    "the latest unconsumed resume authorization must allow its successor dispatch",
+  );
+});
+
 test("a terminal abort on a superseded Attempt stops dispatch and resumes (#1754 residual)", () => {
   const firstFailure = seedFailedAttempt();
   const route = (

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -762,6 +762,26 @@ describe("verification-gate: execution", () => {
     assert.ok(result.checks[2].stdout.includes("third"));
   });
 
+  test("large failure output preserves the exit code and trailing test summary", () => {
+    const scriptPath = join(tmp, "large-failure.cjs");
+    writeFileSync(scriptPath, [
+      'process.stdout.write("failure details\\n");',
+      'process.stdout.write("x".repeat(2 * 1024 * 1024));',
+      'process.stdout.write("\\n=== short test summary info ===\\nFAILED tests/test_example.py::test_failure\\n");',
+      "process.exitCode = 1;",
+    ].join("\n"));
+
+    const result = withRtkDisabled(() => runVerificationGate({
+      cwd: tmp,
+      preferenceCommands: [`${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)}`],
+    }));
+
+    assert.equal(result.passed, false);
+    assert.equal(result.checks[0].exitCode, 1);
+    assert.match(result.checks[0].stdout, /FAILED tests\/test_example\.py::test_failure/);
+    assert.doesNotMatch(result.checks[0].stderr, /ENOBUFS/);
+  });
+
 test("gate execution uses cwd for spawnSync", () => {
     // pwd should report the temp dir
     const result = runVerificationGate({

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -3,9 +3,21 @@
 // Discovery order (D003): task plan verify → preference → package.json scripts.
 // First non-empty source wins.
 
-import { spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { existsSync, readFileSync, readdirSync, type Dirent } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  rmSync,
+  type Dirent,
+} from "node:fs";
 import { join, basename, delimiter } from "node:path";
+import { tmpdir } from "node:os";
 import type { AuditWarning, RuntimeError, VerificationCheck, VerificationResult } from "./types.js";
 import { DEFAULT_COMMAND_TIMEOUT_MS } from "./constants.js";
 import { rewriteCommandWithRtk } from "../shared/rtk.js";
@@ -27,6 +39,26 @@ function truncate(value: string | null | undefined, maxBytes: number): string {
   // Slice conservatively then trim to last full character
   const buf = Buffer.from(value, "utf-8").subarray(0, maxBytes);
   return buf.toString("utf-8") + "\n…[truncated]";
+}
+
+function readBoundedCommandOutput(path: string): string {
+  const fd = openSync(path, "r");
+  try {
+    const size = fstatSync(fd).size;
+    if (size <= MAX_OUTPUT_BYTES) return readFileSync(path, "utf-8");
+
+    const marker = Buffer.from("\n…[truncated]\n", "utf-8");
+    const retainedBytes = MAX_OUTPUT_BYTES - marker.byteLength;
+    const headBytes = Math.floor(retainedBytes / 2);
+    const tailBytes = retainedBytes - headBytes;
+    const head = Buffer.allocUnsafe(headBytes);
+    const tail = Buffer.allocUnsafe(tailBytes);
+    readSync(fd, head, 0, headBytes, 0);
+    readSync(fd, tail, 0, tailBytes, size - tailBytes);
+    return Buffer.concat([head, marker, tail]).toString("utf-8");
+  } finally {
+    closeSync(fd);
+  }
 }
 
 // ─── Command Discovery ──────────────────────────────────────────────────────
@@ -724,7 +756,7 @@ function mergeDiscoverySource(
 }
 
 function isSpawnTimeout(
-  result: SpawnSyncReturns<string>,
+  result: { signal: NodeJS.Signals | null },
   error: NodeJS.ErrnoException & { killed?: boolean },
 ): boolean {
   if (error.code === "ETIMEDOUT") return true;
@@ -780,13 +812,28 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
           "verification-gate",
           rewrittenCommand,
         ];
-    const result: SpawnSyncReturns<string> = spawnSync(shellBin, shellArgs, {
-      cwd: options.cwd,
-      env: verificationChildEnvironment(options.cwd),
-      stdio: "pipe",
-      encoding: "utf-8",
-      timeout: options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
-    });
+    const outputDir = mkdtempSync(join(tmpdir(), "gsd-verification-"));
+    const stdoutPath = join(outputDir, "stdout");
+    const stderrPath = join(outputDir, "stderr");
+    const stdoutFd = openSync(stdoutPath, "w");
+    const stderrFd = openSync(stderrPath, "w");
+    let result: ReturnType<typeof spawnSync>;
+    let stdout: string;
+    let capturedStderr: string;
+    try {
+      result = spawnSync(shellBin, shellArgs, {
+        cwd: options.cwd,
+        env: verificationChildEnvironment(options.cwd),
+        stdio: ["ignore", stdoutFd, stderrFd],
+        timeout: options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
+      });
+      stdout = readBoundedCommandOutput(stdoutPath);
+      capturedStderr = readBoundedCommandOutput(stderrPath);
+    } finally {
+      closeSync(stdoutFd);
+      closeSync(stderrFd);
+      rmSync(outputDir, { recursive: true, force: true });
+    }
     const durationMs = Date.now() - start;
 
     let exitCode: number;
@@ -800,26 +847,26 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
         exitCode = 124;
         failureClass = "timeout";
         stderr = truncate(
-          `${result.stderr || ""}\ntimed out after ${limitMs}ms. Raise verification_timeout_ms if this command is expected to run longer.`.trim(),
+          `${capturedStderr}\ntimed out after ${limitMs}ms. Raise verification_timeout_ms if this command is expected to run longer.`.trim(),
           MAX_OUTPUT_BYTES,
         );
       } else if (isCommandNotFound(spawnError)) {
         exitCode = 127;
         stderr = truncate(
-          (result.stderr || "") + "\n" + spawnError.message,
+          capturedStderr + "\n" + spawnError.message,
           MAX_OUTPUT_BYTES,
         );
       } else {
         exitCode = result.status ?? 1;
         stderr = truncate(
-          (result.stderr || "") + "\n" + spawnError.message,
+          capturedStderr + "\n" + spawnError.message,
           MAX_OUTPUT_BYTES,
         );
       }
     } else {
       // status is null when killed by signal — treat as failure
       exitCode = result.status ?? 1;
-      stderr = truncate(result.stderr, MAX_OUTPUT_BYTES);
+      stderr = capturedStderr;
     }
 
     const warning = countSearchWarning(command, exitCode);
@@ -827,7 +874,7 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
     checks.push({
       command,
       exitCode,
-      stdout: truncate(result.stdout, MAX_OUTPUT_BYTES),
+      stdout,
       stderr: truncate(appendStderrWarning(stderr, warning), MAX_OUTPUT_BYTES),
       durationMs,
       ...(failureClass ? { failureClass } : {}),


### PR DESCRIPTION
## Summary
- Fixed superseded-abort dispatch deadlocks and large pytest output handling with focused regression coverage.

## Bugs Addressed
- [x] **Superseded recovery abort permanently blocks task dispatch**
- [x] **Pytest output overflow masks failures as spawnSync ENOBUFS**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1861
- [#1861 [Bug]: auto-mode deadlock — dispatch-rule-stop fails closed on a superseded attempt's consumed abort while every sanctioned recovery lever is circularly blocked](https://github.com/open-gsd/gsd-pi/issues/1861)

## User
- @gioco

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1861-bug-auto-mode-deadlock-dispatch-rule-sto-1787160754`