### PR TITLE
fix(issue): Migration import deadlocks: transformer synthesizes dual task claims and no supported path records preview resolutions

### DIFF
--- a/src/resources/extensions/gsd/db-workspace.ts
+++ b/src/resources/extensions/gsd/db-workspace.ts
@@ -52,8 +52,11 @@ import {
 import {
   createLegacyImportPreview,
   hashLegacyImportValue,
+  revalidateLegacyImportPreview,
+  resolveLegacyImportPreview,
   type LegacyImportPreviewArtifact,
   type LegacyImportPreviewCreateInput,
+  type LegacyImportPreviewResolutionChoice,
 } from "./legacy-import-preview.js";
 import { drillLegacyImportBackupRestore } from "./legacy-import-restore-drill.js";
 import { inspectSqliteReadOnlySnapshot } from "./sqlite-readonly.js";
@@ -387,10 +390,7 @@ function countRecoverRows(database: DbAdapter, table: "milestones" | "slices" | 
   return Number(database.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()?.["count"] ?? 0);
 }
 
-function prepareVerifiedImportPreview(
-  basePath: string,
-  previewInput: LegacyImportPreviewCreateInput,
-): Pick<PreparedVerifiedRecoverApplication, "basePath" | "previewInput" | "preview"> {
+function requireVerifiedImportDatabase(basePath: string): void {
   const location = resolveWorkflowDatabaseLocation(basePath);
   const databasePath = getWorkflowDatabasePath();
   const canonicalDatabasePath = realpathSync(location.projectDb);
@@ -404,36 +404,49 @@ function prepareVerifiedImportPreview(
   if (databasePath !== canonicalDatabasePath && !openDatabase(canonicalDatabasePath)) {
     throw new Error("verified import could not reopen the canonical project database path");
   }
+}
 
+function prepareVerifiedImportPreview(
+  basePath: string,
+  previewInput: LegacyImportPreviewCreateInput,
+): Pick<PreparedVerifiedRecoverApplication, "basePath" | "previewInput" | "preview"> {
+  requireVerifiedImportDatabase(basePath);
   return { basePath, previewInput, preview: createLegacyImportPreview(previewInput) };
 }
 
-function prepareVerifiedImportEvidence(
+function revalidateVerifiedImportPreview(
   basePath: string,
   previewInput: LegacyImportPreviewCreateInput,
+  expected: LegacyImportPreviewArtifact,
+): LegacyImportPreviewArtifact {
+  requireVerifiedImportDatabase(basePath);
+  return revalidateLegacyImportPreview(previewInput, expected);
+}
+
+function prepareVerifiedImportEvidence(
+  evidence: Pick<PreparedVerifiedRecoverApplication, "basePath" | "previewInput" | "preview">,
   label: string,
 ): {
   previewInput: LegacyImportPreviewCreateInput;
   preview: LegacyImportPreviewArtifact;
   backup: LegacyImportVerifiedBackup;
 } {
-  const evidence = prepareVerifiedImportPreview(basePath, previewInput);
-  const location = resolveWorkflowDatabaseLocation(basePath);
+  const location = resolveWorkflowDatabaseLocation(evidence.basePath);
   const base = captureCurrentLegacyImportBaseSnapshot();
   const destinationDirectory = join(location.projectGsd, "backups");
   mkdirSync(destinationDirectory, { recursive: true });
   const backup = prepareLegacyImportBackup({
     preview: evidence.preview,
     base,
-    roots: previewInput.roots,
-    ...(previewInput.bundledDefinitionNames === undefined
+    roots: evidence.previewInput.roots,
+    ...(evidence.previewInput.bundledDefinitionNames === undefined
       ? {}
-      : { bundledDefinitionNames: previewInput.bundledDefinitionNames }),
+      : { bundledDefinitionNames: evidence.previewInput.bundledDefinitionNames }),
     destination_directory: destinationDirectory,
     label,
   });
   drillLegacyImportBackupRestore({ backup, preview: evidence.preview, base });
-  return { previewInput, preview: evidence.preview, backup };
+  return { previewInput: evidence.previewInput, preview: evidence.preview, backup };
 }
 
 function recoverAuthorizationText(preview: LegacyImportPreviewArtifact): string {
@@ -490,9 +503,20 @@ export function prepareVerifiedRecoverApplication(basePath: string): PreparedVer
   return prepareVerifiedRecoverEvidence(basePath);
 }
 
+export function resolvePreparedVerifiedRecoverApplication(
+  evidence: Readonly<PreparedVerifiedRecoverApplication>,
+  choices: readonly LegacyImportPreviewResolutionChoice[],
+): PreparedVerifiedRecoverApplication {
+  const preview = resolveLegacyImportPreview(evidence.preview, choices);
+  return { ...evidence, preview, authorizationText: recoverAuthorizationText(preview) };
+}
+
 export function prepareVerifiedRecoverBackup(basePath: string): LegacyImportVerifiedBackup {
   const evidence = prepareVerifiedRecoverEvidence(basePath);
-  return prepareVerifiedImportEvidence(basePath, evidence.previewInput, "pre-recover").backup;
+  return prepareVerifiedImportEvidence(
+    prepareVerifiedImportPreview(basePath, evidence.previewInput),
+    "pre-recover",
+  ).backup;
 }
 
 function requireApprovedRecoverPreview(
@@ -509,11 +533,27 @@ export function applyPreparedVerifiedRecoverApplication(
   approvedPreviewHash: string,
 ): VerifiedRecoverApplicationResult {
   requireApprovedRecoverPreview(evidence.preview, approvedPreviewHash);
-  const current = prepareVerifiedImportPreview(evidence.basePath, evidence.previewInput);
-  requireApprovedRecoverPreview(current.preview, approvedPreviewHash);
-  const prepared = prepareVerifiedImportEvidence(evidence.basePath, evidence.previewInput, "pre-recover");
+  const current = revalidateVerifiedImportPreview(
+    evidence.basePath,
+    evidence.previewInput,
+    evidence.preview,
+  );
+  requireApprovedRecoverPreview(current, approvedPreviewHash);
+  const backupPreview = revalidateVerifiedImportPreview(
+    evidence.basePath,
+    evidence.previewInput,
+    evidence.preview,
+  );
+  const prepared = prepareVerifiedImportEvidence(
+    { ...evidence, preview: backupPreview },
+    "pre-recover",
+  );
   requireApprovedRecoverPreview(prepared.preview, approvedPreviewHash);
-  const finalPreview = prepareVerifiedImportPreview(evidence.basePath, evidence.previewInput).preview;
+  const finalPreview = revalidateVerifiedImportPreview(
+    evidence.basePath,
+    evidence.previewInput,
+    evidence.preview,
+  );
   requireApprovedRecoverPreview(finalPreview, approvedPreviewHash);
   const receipt = applyLegacyImport({
     invocation: {
@@ -955,7 +995,22 @@ export function applyVerifiedMigrationApplication(
         presence: "required",
       }],
     };
-    const evidence = prepareVerifiedImportEvidence(basePath, previewInput, "pre-migrate-import");
+    const created = prepareVerifiedImportPreview(basePath, previewInput);
+    const preservable = new Set(created.preview.preview.diagnoses
+      .filter((diagnosis) => diagnosis.code === "ambiguous-task-membership")
+      .map((diagnosis) => diagnosis.diagnosis_id));
+    const resolved = resolveLegacyImportPreview(
+      created.preview,
+      created.preview.preview.resolutions.flatMap((resolution) => (
+        resolution.disposition === "requires-user" && preservable.has(resolution.diagnosis_id)
+          ? [{ diagnosis_id: resolution.diagnosis_id, disposition: "preserved" as const }]
+          : []
+      )),
+    );
+    const evidence = prepareVerifiedImportEvidence(
+      { ...created, preview: resolved },
+      "pre-migrate-import",
+    );
     beforeApply?.({
       previewId: evidence.preview.preview.preview_id,
       previewHash: evidence.preview.preview_hash,

--- a/src/resources/extensions/gsd/legacy-import-preview.ts
+++ b/src/resources/extensions/gsd/legacy-import-preview.ts
@@ -77,16 +77,17 @@ export interface LegacyImportPreviewCreateInput {
 export type LegacyImportPreviewErrorCode =
   | "LEGACY_IMPORT_PREVIEW_BASE_CHANGED"
   | "LEGACY_IMPORT_PREVIEW_EXPECTED_INVALID"
+  | "LEGACY_IMPORT_PREVIEW_RESOLUTION_INVALID"
   | "LEGACY_IMPORT_PREVIEW_CHANGED";
 
 export class LegacyImportPreviewError extends Error {
-  readonly stage: "create" | "revalidate";
+  readonly stage: "create" | "resolve" | "revalidate";
   readonly code: LegacyImportPreviewErrorCode;
   readonly retryable: boolean;
   readonly context: Readonly<Record<string, LegacyImportValue>>;
 
   constructor(
-    stage: "create" | "revalidate",
+    stage: "create" | "resolve" | "revalidate",
     code: LegacyImportPreviewErrorCode,
     message: string,
     retryable: boolean,
@@ -622,12 +623,107 @@ function validateExpectedPreview(expected: unknown): asserts expected is LegacyI
   );
 }
 
+export interface LegacyImportPreviewResolutionChoice {
+  diagnosis_id: string;
+  disposition: "preserved";
+}
+
+/** Record reviewed choices on an immutable sealed Preview and seal the result. */
+export function resolveLegacyImportPreview(
+  expected: LegacyImportPreviewArtifact,
+  choices: readonly LegacyImportPreviewResolutionChoice[],
+): LegacyImportPreviewArtifact {
+  let artifact: LegacyImportPreviewArtifact;
+  let selected: readonly LegacyImportPreviewResolutionChoice[];
+  try {
+    artifact = structuredClone(expected);
+    selected = structuredClone(choices);
+  } catch {
+    throw new LegacyImportPreviewError(
+      "resolve",
+      "LEGACY_IMPORT_PREVIEW_RESOLUTION_INVALID",
+      "legacy import Preview resolutions could not be detached",
+      false,
+    );
+  }
+  if (!isValidLegacyImportPreviewArtifact(artifact) || !Array.isArray(selected)) {
+    throw new LegacyImportPreviewError(
+      "resolve",
+      "LEGACY_IMPORT_PREVIEW_RESOLUTION_INVALID",
+      "legacy import Preview resolutions require a valid sealed Preview",
+      false,
+    );
+  }
+
+  const byDiagnosis = new Map(artifact.preview.resolutions.map((resolution) => (
+    [resolution.diagnosis_id, resolution] as const
+  )));
+  const updates = new Map<string, LegacyImportPreviewResolution>();
+  for (const choice of selected) {
+    if (
+      !hasExactKeys(choice, ["diagnosis_id", "disposition"])
+      || !isCanonicalHash(choice.diagnosis_id)
+      || choice.disposition !== "preserved"
+      || updates.has(choice.diagnosis_id)
+    ) {
+      throw new LegacyImportPreviewError(
+        "resolve",
+        "LEGACY_IMPORT_PREVIEW_RESOLUTION_INVALID",
+        "legacy import Preview contains an invalid or duplicate resolution choice",
+        false,
+      );
+    }
+    const current = byDiagnosis.get(choice.diagnosis_id);
+    if (current?.disposition !== "requires-user") {
+      throw new LegacyImportPreviewError(
+        "resolve",
+        "LEGACY_IMPORT_PREVIEW_RESOLUTION_INVALID",
+        "legacy import Preview resolution choice does not identify a user-required diagnosis",
+        false,
+      );
+    }
+    updates.set(choice.diagnosis_id, {
+      diagnosis_id: choice.diagnosis_id,
+      disposition: choice.disposition,
+      ...(current.target === undefined ? {} : { target: current.target }),
+    });
+  }
+
+  const resolutions = artifact.preview.resolutions.map((resolution) => (
+    updates.get(resolution.diagnosis_id) ?? resolution
+  ));
+  const preview: LegacyImportPreviewEnvelope = {
+    ...artifact.preview,
+    counts: {
+      ...artifact.preview.counts,
+      unresolved: resolutions.filter((resolution) => (
+        resolution.disposition === "requires-user" || resolution.disposition === "unsupported"
+      )).length,
+    },
+    resolutions,
+  };
+  return deepFreeze({ preview, preview_hash: hashLegacyImportValue(preview) });
+}
+
 export function revalidateLegacyImportPreview(
   input: LegacyImportPreviewCreateInput,
   expected: LegacyImportPreviewArtifact,
 ): LegacyImportPreviewArtifact {
   validateExpectedPreview(expected);
-  const observed = createLegacyImportPreview(input);
+  const created = createLegacyImportPreview(input);
+  const createdResolutions = new Map(created.preview.resolutions.map((resolution) => (
+    [resolution.diagnosis_id, resolution] as const
+  )));
+  const choices = expected.preview.resolutions.flatMap((resolution) => {
+    const createdResolution = createdResolutions.get(resolution.diagnosis_id);
+    return createdResolution?.disposition === "requires-user"
+      && resolution.disposition === "preserved"
+      ? [{ diagnosis_id: resolution.diagnosis_id, disposition: "preserved" as const }]
+      : [];
+  });
+  const observed = choices.length === 0
+    ? created
+    : resolveLegacyImportPreview(created, choices);
   if (observed.preview_hash !== expected.preview_hash) {
     throw new LegacyImportPreviewError(
       "revalidate",

--- a/src/resources/extensions/gsd/migrate/writer.ts
+++ b/src/resources/extensions/gsd/migrate/writer.ts
@@ -153,7 +153,7 @@ export function formatRoadmap(milestone: GSDMilestone): string {
 
 /**
  * Format a slice's PLAN.md (S01-PLAN.md).
- * Output must parse correctly through parsePlan().
+ * Task claims live only in the individual T##-PLAN.md files written below.
  */
 export function formatPlan(slice: GSDSlice): string {
   const lines: string[] = [];
@@ -167,18 +167,6 @@ export function formatPlan(slice: GSDSlice): string {
   lines.push('## Must-Haves');
   lines.push('');
   // No must-haves in migrated data — empty section
-  lines.push('');
-
-  lines.push('## Tasks');
-  lines.push('');
-  for (const task of slice.tasks) {
-    const check = task.done ? 'x' : ' ';
-    const estPart = task.estimate ? ` \`est:${task.estimate}\`` : '';
-    lines.push(`- [${check}] **${task.id}: ${task.title}**${estPart}`);
-    if (task.description) {
-      lines.push(`  - ${task.description}`);
-    }
-  }
   lines.push('');
 
   lines.push('## Files Likely Touched');
@@ -282,6 +270,7 @@ export function formatTaskPlan(task: GSDTask, sliceId: string, milestoneId: stri
   lines.push(`# ${task.id}: ${task.title}`);
   lines.push('');
   lines.push(`**Slice:** ${sliceId} — **Milestone:** ${milestoneId}`);
+  lines.push(`Status: ${task.done ? 'complete' : 'pending'}`);
   lines.push('');
   lines.push('## Description');
   lines.push('');

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -14,6 +14,9 @@ import { findMilestoneIds } from "./milestone-ids.js";
 import {
   resolveMilestoneFile,
   resolveSliceFile,
+  resolveTaskFiles,
+  resolveTasksDir,
+  taskIdFromTaskFileName,
 } from "./paths.js";
 
 export interface HierarchyCounts {
@@ -217,9 +220,17 @@ export function scanMarkdownHierarchy(basePath: string): HierarchyScan {
       const planPath = resolveSliceFile(basePath, milestoneId, slice.id, "PLAN");
       if (!planPath || !existsSync(planPath)) continue;
       const plan = parsePlan(readFileSync(planPath, "utf-8"));
-      scan.counts.tasks += plan.tasks.length;
-      for (const task of plan.tasks) {
-        scan.tasks.add(`${milestoneId}/${slice.id}/${task.id}`);
+      const taskIds = new Set(plan.tasks.map((task) => task.id));
+      const tasksDir = resolveTasksDir(basePath, milestoneId, slice.id);
+      if (tasksDir !== null) {
+        for (const fileName of resolveTaskFiles(tasksDir, "PLAN")) {
+          const taskId = taskIdFromTaskFileName(fileName, "PLAN");
+          if (taskId !== null) taskIds.add(taskId);
+        }
+      }
+      scan.counts.tasks += taskIds.size;
+      for (const taskId of taskIds) {
+        scan.tasks.add(`${milestoneId}/${slice.id}/${taskId}`);
       }
     }
   }

--- a/src/resources/extensions/gsd/tests/gsd-recover.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-recover.test.ts
@@ -38,6 +38,7 @@ import {
   openWorkflowDatabase,
   persistVerifiedRecoverRestoreApproval,
   prepareVerifiedRecoverApplication,
+  resolvePreparedVerifiedRecoverApplication,
 } from '../db-workspace.ts';
 import { executeLegacyImportRecoveryAction } from '../legacy-import-recovery-action.ts';
 import { _restoreLegacyImportLiveForTest } from '../legacy-import-live-restore.ts';
@@ -609,6 +610,34 @@ describe('gsd-recover', async () => {
       );
       assert.equal(existsSync(join(base, '.gsd', 'backups')), false, 'stale approval fails before backup preparation');
       assert.equal(getMilestone('M001'), null, 'stale approval cannot import changed markdown');
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('prepared recover applies a sealed preservation resolution for mixed-content sources', () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_M001);
+      writeFile(base, 'milestones/M001/slices/S01/S01-RESEARCH.md', '# Research\n\nRetain these notes.\n');
+      openDatabase(join(base, '.gsd', 'gsd.db'));
+
+      const pending = prepareVerifiedRecoverApplication(base);
+      const diagnosis = pending.preview.preview.diagnoses.find((entry) => (
+        entry.code === 'ambiguous-task-membership'
+      ));
+      assert.ok(diagnosis);
+      const resolved = resolvePreparedVerifiedRecoverApplication(pending, [{
+        diagnosis_id: diagnosis.diagnosis_id,
+        disposition: 'preserved',
+      }]);
+
+      assert.equal(pending.preview.preview.counts.unresolved, 1);
+      assert.equal(resolved.preview.preview.counts.unresolved, 0);
+      const result = applyPreparedVerifiedRecoverApplication(resolved, resolved.preview.preview_hash);
+      assert.equal(result.preview.preview_hash, resolved.preview.preview_hash);
+      assert.ok(getMilestone('M001'));
     } finally {
       closeDatabase();
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/legacy-import-preview.test.ts
+++ b/src/resources/extensions/gsd/tests/legacy-import-preview.test.ts
@@ -25,6 +25,7 @@ import {
   type LegacyImportBaseSnapshotSource,
 } from "../legacy-import-preview-base.ts";
 import { classifyLegacyImportChanges } from "../legacy-import-preview-classifier.ts";
+import { compileLegacyImportApplicationPlan } from "../legacy-import-application-plan.ts";
 import {
   collectLegacyImportDatabaseTargetEvidence,
 } from "../legacy-import-preview-database-target.ts";
@@ -46,6 +47,7 @@ import {
   hashLegacyImportValue,
   isValidLegacyImportPreviewArtifact,
   LegacyImportPreviewError,
+  resolveLegacyImportPreview,
   revalidateLegacyImportPreview,
   sealLegacyImportPreview,
   type LegacyImportPreviewArtifact,
@@ -1203,6 +1205,86 @@ test("legacy public Preview composes and revalidates one deterministic read-only
   } finally {
     closeDatabase();
   }
+});
+
+test("legacy public Preview records and revalidates a required preservation resolution", (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "gsd-preview-resolution-"));
+  t.after(() => {
+    closeDatabase();
+    rmSync(directory, { recursive: true, force: true });
+  });
+  const gsdRoot = join(directory, ".gsd");
+  const milestone = join(gsdRoot, "milestones", "M001");
+  const slice = join(milestone, "slices", "S01");
+  mkdirSync(slice, { recursive: true });
+  writeFileSync(join(milestone, "M001-ROADMAP.md"), [
+    "# M001: Migration",
+    "",
+    "## Slices",
+    "",
+    "- [ ] **S01: Mixed content** `risk:low` `depends:[]`",
+  ].join("\n"));
+  writeFileSync(join(slice, "S01-RESEARCH.md"), "# Research\n\nPreserve these notes.\n");
+  assert.equal(openDatabase(join(directory, "canonical.db")), true);
+  const input: LegacyImportPreviewCreateInput = {
+    roots: [{
+      id: "mixed-content-gsd",
+      kind: "project",
+      physical_path: gsdRoot,
+      logical_path: ".gsd",
+      presence: "required",
+    }],
+  };
+
+  const pending = createLegacyImportPreview(input);
+  const diagnosis = pending.preview.diagnoses.find((entry) => (
+    entry.code === "ambiguous-task-membership"
+  ));
+  assert.ok(diagnosis);
+  const resolved = resolveLegacyImportPreview(pending, [{
+    diagnosis_id: diagnosis.diagnosis_id,
+    disposition: "preserved",
+  }]);
+
+  assert.equal(pending.preview.counts.unresolved, 1, "the original sealed Preview remains unchanged");
+  assert.equal(resolved.preview.counts.unresolved, 0);
+  assert.equal(resolved.preview.preview_id, pending.preview.preview_id);
+  assert.notEqual(resolved.preview_hash, pending.preview_hash);
+  assert.equal(
+    resolved.preview.resolutions.find((entry) => entry.diagnosis_id === diagnosis.diagnosis_id)?.disposition,
+    "preserved",
+  );
+  assert.doesNotThrow(() => compileLegacyImportApplicationPlan(resolved));
+  assert.deepEqual(revalidateLegacyImportPreview(input, resolved), resolved);
+  const assertInvalidResolution = (operation: () => unknown): void => {
+    assert.throws(operation, (error) => {
+      assert.ok(error instanceof LegacyImportPreviewError);
+      assert.equal(error.stage, "resolve");
+      assert.equal(error.code, "LEGACY_IMPORT_PREVIEW_RESOLUTION_INVALID");
+      return true;
+    });
+  };
+  assertInvalidResolution(() => resolveLegacyImportPreview(pending, [
+    { diagnosis_id: diagnosis.diagnosis_id, disposition: "preserved" },
+    { diagnosis_id: diagnosis.diagnosis_id, disposition: "preserved" },
+  ]));
+  assertInvalidResolution(() => resolveLegacyImportPreview(pending, [{
+    diagnosis_id: diagnosis.diagnosis_id,
+    disposition: "mapped",
+  // Exercise the runtime contract with a disposition intentionally excluded from the public choice type.
+  }] as never));
+  assertInvalidResolution(() => resolveLegacyImportPreview(pending, [{
+    diagnosis_id: `sha256:${"2".repeat(64)}` as LegacyImportSha256,
+    disposition: "preserved",
+  }]));
+  assertInvalidResolution(() => resolveLegacyImportPreview(resolved, [{
+    diagnosis_id: diagnosis.diagnosis_id,
+    disposition: "preserved",
+  }]));
+  assertInvalidResolution(() => resolveLegacyImportPreview(
+    { ...pending, preview_hash: ONE_HASH },
+    [],
+  ));
 });
 
 test("legacy public Preview leaves an anchor-incomplete v44 database supplemental-only", (t) => {

--- a/src/resources/extensions/gsd/tests/migrate-safety-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-safety-audit.test.ts
@@ -68,7 +68,7 @@ import {
 } from "../managed-projection-history.ts";
 import { renderAllFromDb, renderMilestoneArtifactsFromDb, renderRoadmapFromDb } from "../markdown-renderer.ts";
 import { gsdRoot } from "../paths.ts";
-import { _getAdapter, closeDatabase, getArtifact, getMilestone, insertArtifact, insertMilestone, openDatabase } from "../gsd-db.ts";
+import { _getAdapter, closeDatabase, getArtifact, getMilestone, getSliceTasks, insertArtifact, insertMilestone, openDatabase } from "../gsd-db.ts";
 import { _setDomainOperationFaultForTest, executeDomainOperation } from "../db/domain-operation.ts";
 import { hashLegacyImportValue } from "../legacy-import-preview.ts";
 import type { GSDProject } from "../migrate/types.ts";
@@ -539,6 +539,8 @@ test("completed milestone artifacts retain exact canonical bytes", async () => {
     const planning = createPlanningSource(base);
     const project = projectFixture();
     project.milestones[0]!.slices[0]!.done = true;
+    project.milestones[0]!.slices[0]!.tasks[0]!.done = true;
+    project.milestones[0]!.slices[0]!.research = "# Slice Research\n\nRetain these mixed-content notes.\n";
     const result = await executeMigrationWrite(planning, base, project, generatePreview(project));
     const expected = [
       "milestones/M001/M001-VALIDATION.md",
@@ -551,6 +553,11 @@ test("completed milestone artifacts retain exact canonical bytes", async () => {
         readFileSync(join(base, ".gsd", logicalPath), "utf8"),
       );
     }
+    assert.equal(getSliceTasks("M001", "S01")[0]?.status, "complete");
+    assert.equal(
+      getArtifact(".gsd/milestones/M001/slices/S01/S01-RESEARCH.md")?.full_content,
+      project.milestones[0]!.slices[0]!.research,
+    );
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/migrate-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-writer.test.ts
@@ -152,7 +152,7 @@ test('Scenario A: Roadmap round-trip with 2 slices (1 done, 1 not)', () => {
   assert.deepStrictEqual(parsed.boundaryMap.length, 0, 'roadmap: boundaryMap empty');
 });
 
-test('Scenario B: Plan round-trip with 3 tasks (mixed done)', () => {
+test('Scenario B: Slice plan leaves task claims to the individual task plans', () => {
   const slice = makeSlice({
     id: 'S01',
     title: 'Auth System',
@@ -172,20 +172,11 @@ test('Scenario B: Plan round-trip with 3 tasks (mixed done)', () => {
   assert.deepStrictEqual(parsed.title, 'Auth System', 'plan: title');
   assert.deepStrictEqual(parsed.goal, 'Working authentication system', 'plan: goal');
   assert.deepStrictEqual(parsed.demo, 'Login works with valid credentials', 'plan: demo');
-  assert.deepStrictEqual(parsed.tasks.length, 3, 'plan: tasks count');
-
-  assert.deepStrictEqual(parsed.tasks[0].id, 'T01', 'plan: T01 id');
-  assert.deepStrictEqual(parsed.tasks[0].title, 'Setup Models', 'plan: T01 title');
-  assert.deepStrictEqual(parsed.tasks[0].done, true, 'plan: T01 done');
-  assert.deepStrictEqual(parsed.tasks[0].estimate, '15m', 'plan: T01 estimate');
-
-  assert.deepStrictEqual(parsed.tasks[1].id, 'T02', 'plan: T02 id');
-  assert.deepStrictEqual(parsed.tasks[1].done, false, 'plan: T02 done');
-  assert.deepStrictEqual(parsed.tasks[1].estimate, '30m', 'plan: T02 estimate');
-
-  assert.deepStrictEqual(parsed.tasks[2].id, 'T03', 'plan: T03 id');
-  assert.deepStrictEqual(parsed.tasks[2].done, true, 'plan: T03 done');
-  assert.deepStrictEqual(parsed.tasks[2].estimate, '20m', 'plan: T03 estimate');
+  assert.deepStrictEqual(parsed.tasks, [], 'plan: task claims are not duplicated');
+  assert.match(
+    formatTaskPlan(slice.tasks[0]!, slice.id, 'M001'),
+    /^# T01: Setup Models$[\s\S]*^Status: complete$/m,
+  );
 });
 
 test('Scenario C: Slice summary round-trip with full data', () => {
@@ -347,15 +338,17 @@ test('F13: formatState produces valid content', () => {
   assert.ok(output.includes('1/2'), 'edge: state shows slice progress');
 });
 
-test('F14: Task with no estimate → no est backtick in plan', () => {
+test('F14: Task metadata remains in its task plan when the estimate is empty', () => {
   const slice = makeSlice({
     tasks: [makeTask({ id: 'T01', title: 'Quick Fix', estimate: '' })],
   });
   const output = formatPlan(slice);
   const parsed = parsePlan(output);
-  assert.deepStrictEqual(parsed.tasks[0].id, 'T01', 'edge: task no estimate id');
-  assert.deepStrictEqual(parsed.tasks[0].estimate, '', 'edge: task no estimate empty');
+  assert.deepStrictEqual(parsed.tasks, [], 'edge: slice plan has no duplicate task claim');
+  assert.match(
+    formatTaskPlan(slice.tasks[0]!, slice.id, 'M001'),
+    /^# T01: Quick Fix$[\s\S]*^Status: pending$/m,
+  );
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-


### PR DESCRIPTION
## Summary
- Removed duplicate migration task claims, added applicable sealed preview resolutions, and verified both fixes with focused tests and fast gates.

## Bugs Addressed
- [x] **Migration writer synthesizes conflicting duplicate task claims**
- [x] **Migration preview has no supported way to record required resolutions**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1867
- [#1867 Migration import deadlocks: transformer synthesizes dual task claims and no supported path records preview resolutions](https://github.com/open-gsd/gsd-pi/issues/1867)

## User
- @denniyahh

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1867-migration-import-deadlocks-transformer-s-1787191069`