### PR TITLE
fix(issue): cursor-agent hardcoded model catalog is stale (#1869)

### DIFF
--- a/src/resources/extensions/cursor-cli/index.ts
+++ b/src/resources/extensions/cursor-cli/index.ts
@@ -1,18 +1,42 @@
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
-import { CURSOR_AGENT_MODELS } from "./models.js";
-import { isCursorAgentReady } from "./readiness.js";
+import { CURSOR_AGENT_MODELS, resolveCursorAgentModels, type CursorAgentModel } from "./models.js";
+import { isCursorAgentReady, readCursorAgentListModels } from "./readiness.js";
 import { streamViaCursorAgent } from "./stream-adapter.js";
 
-export default function cursorCli(pi: ExtensionAPI): void {
-	if (process.env.GSD_CURSOR_DISABLE === "1") return;
+const PROVIDER_ID = "cursor-agent";
 
-	pi.registerProvider("cursor-agent", {
+function registerCursorProvider(pi: ExtensionAPI, models: CursorAgentModel[]): void {
+	pi.registerProvider(PROVIDER_ID, {
 		name: "Cursor Agent",
 		authMode: "externalCli",
 		api: "cursor-stream-json",
 		baseUrl: "local://cursor-agent",
 		isReady: isCursorAgentReady,
 		streamSimple: streamViaCursorAgent,
-		models: CURSOR_AGENT_MODELS,
+		models,
+	});
+}
+
+export function probeAndRegisterCursorModels(
+	pi: ExtensionAPI,
+	readList: () => string | null = readCursorAgentListModels,
+): CursorAgentModel[] {
+	const models = resolveCursorAgentModels(readList());
+	try {
+		pi.unregisterProvider(PROVIDER_ID);
+	} catch {
+		// First registration has nothing to replace.
+	}
+	registerCursorProvider(pi, models);
+	return models;
+}
+
+export default function cursorCli(pi: ExtensionAPI): void {
+	if (process.env.GSD_CURSOR_DISABLE === "1") return;
+
+	registerCursorProvider(pi, CURSOR_AGENT_MODELS);
+
+	pi.on("session_start", () => {
+		probeAndRegisterCursorModels(pi);
 	});
 }

--- a/src/resources/extensions/cursor-cli/index.ts
+++ b/src/resources/extensions/cursor-cli/index.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { CURSOR_AGENT_MODELS, resolveCursorAgentModels, type CursorAgentModel } from "./models.js";
-import { isCursorAgentReady, readCursorAgentListModels } from "./readiness.js";
+import { isCursorAgentBinaryPresent, isCursorAgentReady, readCursorAgentListModels } from "./readiness.js";
 import { streamViaCursorAgent } from "./stream-adapter.js";
 
 const PROVIDER_ID = "cursor-agent";
@@ -20,15 +20,22 @@ function registerCursorProvider(pi: ExtensionAPI, models: CursorAgentModel[]): v
 export function probeAndRegisterCursorModels(
 	pi: ExtensionAPI,
 	readList: () => string | null = readCursorAgentListModels,
+	isPresent: () => boolean = isCursorAgentBinaryPresent,
 ): CursorAgentModel[] {
-	const models = resolveCursorAgentModels(readList());
 	try {
-		pi.unregisterProvider(PROVIDER_ID);
+		if (process.env.GSD_CURSOR_DISABLE === "1") return CURSOR_AGENT_MODELS;
+		if (!isPresent()) return CURSOR_AGENT_MODELS;
+		const models = resolveCursorAgentModels(readList());
+		try {
+			pi.unregisterProvider(PROVIDER_ID);
+		} catch {
+			// First registration has nothing to replace.
+		}
+		registerCursorProvider(pi, models);
+		return models;
 	} catch {
-		// First registration has nothing to replace.
+		return CURSOR_AGENT_MODELS;
 	}
-	registerCursorProvider(pi, models);
-	return models;
 }
 
 export default function cursorCli(pi: ExtensionAPI): void {
@@ -36,7 +43,18 @@ export default function cursorCli(pi: ExtensionAPI): void {
 
 	registerCursorProvider(pi, CURSOR_AGENT_MODELS);
 
-	pi.on("session_start", () => {
-		probeAndRegisterCursorModels(pi);
+	pi.on("session_start", (_event, ctx) => {
+		if (process.env.GSD_CURSOR_DISABLE === "1") return;
+		// Headless/CI: keep the offline fallback. Never await cursor-agent
+		// --list-models (15s execFileSync timeout) on the default path.
+		if (!ctx.hasUI || process.env.GSD_NON_INTERACTIVE === "1") return;
+		setImmediate(() => {
+			try {
+				if (!isCursorAgentBinaryPresent()) return;
+				probeAndRegisterCursorModels(pi);
+			} catch {
+				// keep fallback catalog
+			}
+		});
 	});
 }

--- a/src/resources/extensions/cursor-cli/models.ts
+++ b/src/resources/extensions/cursor-cli/models.ts
@@ -7,59 +7,66 @@ const ZERO_COST = {
 
 const CURSOR_INPUT: ("text" | "image")[] = ["text"];
 
-export const CURSOR_AGENT_MODELS = [
-	{
-		id: "composer-2.5",
-		name: "Composer 2.5 (via Cursor)",
-		reasoning: true,
-		input: CURSOR_INPUT,
-		cost: ZERO_COST,
-		contextWindow: 1_000_000,
-		maxTokens: 64_000,
-	},
-	{
-		id: "claude-sonnet-4-6",
-		name: "Claude Sonnet 4.6 (via Cursor)",
-		reasoning: true,
-		input: CURSOR_INPUT,
-		cost: ZERO_COST,
-		contextWindow: 1_000_000,
-		maxTokens: 64_000,
-	},
-	{
-		id: "claude-opus-4-7",
-		name: "Claude Opus 4.7 (via Cursor)",
-		reasoning: true,
-		input: CURSOR_INPUT,
-		cost: ZERO_COST,
-		contextWindow: 1_000_000,
-		maxTokens: 128_000,
-	},
-	{
-		id: "gpt-5.5",
-		name: "GPT-5.5 (via Cursor)",
-		reasoning: true,
-		input: CURSOR_INPUT,
-		cost: ZERO_COST,
-		contextWindow: 1_000_000,
-		maxTokens: 128_000,
-	},
-	{
-		id: "gemini-2.5-pro",
-		name: "Gemini 2.5 Pro (via Cursor)",
-		reasoning: true,
-		input: CURSOR_INPUT,
-		cost: ZERO_COST,
-		contextWindow: 1_000_000,
-		maxTokens: 65_536,
-	},
-	{
-		id: "grok-4",
-		name: "Grok 4 (via Cursor)",
-		reasoning: true,
-		input: CURSOR_INPUT,
-		cost: ZERO_COST,
-		contextWindow: 256_000,
-		maxTokens: 64_000,
-	},
+export type CursorAgentModel = {
+	id: string;
+	name: string;
+	reasoning: boolean;
+	input: ("text" | "image")[];
+	cost: typeof ZERO_COST;
+	contextWindow: number;
+	maxTokens: number;
+};
+
+/** Offline fallback when `cursor-agent --list-models` is unavailable (#1869). */
+export const CURSOR_AGENT_MODELS: CursorAgentModel[] = [
+	model("composer-2.5", "Composer 2.5"),
+	model("claude-4.6-sonnet-medium", "Claude Sonnet 4.6 1M"),
+	model("claude-opus-4-7-medium", "Claude Opus 4.7 1M Medium"),
+	model("gpt-5.5-medium", "GPT-5.5 1M"),
+	model("gemini-3.1-pro", "Gemini 3.1 Pro"),
+	model("cursor-grok-4.6-high", "Cursor Grok 4.6"),
 ];
+
+const LIST_LINE_RE = /^([A-Za-z0-9][A-Za-z0-9._-]*) - (.+)$/;
+
+function model(id: string, name: string): CursorAgentModel {
+	return cursorAgentModelFromListEntry(id, name);
+}
+
+export function cursorAgentModelFromListEntry(id: string, name: string): CursorAgentModel {
+	const blob = `${id} ${name}`;
+	const contextWindow = /\b1M\b/i.test(blob) || /1m/i.test(id) ? 1_000_000 : 256_000;
+	const reasoning =
+		/thinking|composer/i.test(blob) ||
+		/(?:^|-)(?:none|low|medium|high|xhigh|extra-high|max)(?:-|$)/i.test(id);
+	const display = name.replace(/\s+\(via Cursor\)$/i, "").trim();
+	return {
+		id,
+		name: /via Cursor/i.test(name) ? name : `${display} (via Cursor)`,
+		reasoning,
+		input: CURSOR_INPUT,
+		cost: ZERO_COST,
+		contextWindow,
+		maxTokens: /opus/i.test(id) ? 128_000 : 64_000,
+	};
+}
+
+export function parseCursorAgentModelList(output: string): CursorAgentModel[] {
+	const models: CursorAgentModel[] = [];
+	const seen = new Set<string>();
+	for (const raw of output.split(/\r?\n/)) {
+		const match = LIST_LINE_RE.exec(raw.trim());
+		if (!match) continue;
+		const id = match[1]!;
+		if (id.includes("[") || seen.has(id)) continue;
+		seen.add(id);
+		models.push(cursorAgentModelFromListEntry(id, match[2]!.trim()));
+	}
+	return models;
+}
+
+export function resolveCursorAgentModels(listOutput: string | null | undefined): CursorAgentModel[] {
+	if (!listOutput) return CURSOR_AGENT_MODELS;
+	const parsed = parseCursorAgentModelList(listOutput);
+	return parsed.length > 0 ? parsed : CURSOR_AGENT_MODELS;
+}

--- a/src/resources/extensions/cursor-cli/readiness.ts
+++ b/src/resources/extensions/cursor-cli/readiness.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 
 const VERSION_TIMEOUT_MS = 5_000;
 const STATUS_TIMEOUT_MS = 10_000;
+const LIST_MODELS_TIMEOUT_MS = 15_000;
 const CHECK_INTERVAL_MS = 30_000;
 
 let cachedBinaryPresent: boolean | null = null;
@@ -137,4 +138,15 @@ export function clearCursorAgentReadinessCache(): void {
 	cachedBinaryPresent = null;
 	cachedAuthed = null;
 	lastCheckMs = 0;
+}
+
+export function readCursorAgentListModels(): string | null {
+	const command = findWorkingCommand();
+	if (!command) return null;
+	try {
+		return spawnCursorAgent(command, ["--list-models"], LIST_MODELS_TIMEOUT_MS).toString("utf8");
+	} catch (error) {
+		debugLog("list-models failed", (error as Error).message?.slice(0, 200));
+		return null;
+	}
 }

--- a/src/resources/extensions/cursor-cli/tests/fixtures/cursor-list-models.txt
+++ b/src/resources/extensions/cursor-cli/tests/fixtures/cursor-list-models.txt
@@ -1,0 +1,204 @@
+auto - Auto (default)
+gpt-5.3-codex-low - Codex 5.3 Low
+gpt-5.3-codex-low-fast - Codex 5.3 Low Fast
+gpt-5.3-codex - Codex 5.3
+gpt-5.3-codex-fast - Codex 5.3 Fast
+gpt-5.3-codex-high - Codex 5.3 High
+gpt-5.3-codex-high-fast - Codex 5.3 High Fast
+gpt-5.3-codex-xhigh - Codex 5.3 Extra High
+gpt-5.3-codex-xhigh-fast - Codex 5.3 Extra High Fast
+gpt-5.2 - GPT-5.2
+cursor-grok-4.6-high-fast - Cursor Grok 4.6 Fast
+composer-2.5 - Composer 2.5 (current)
+claude-opus-5-thinking-high - Claude Opus 5 1M Thinking
+claude-opus-5-thinking-high-fast - Claude Opus 5 1M Thinking Fast
+gpt-5.6-sol-high - GPT-5.6 Sol 1M High
+gpt-5.6-sol-high-fast - GPT-5.6 Sol High Fast
+gpt-5.6-sol-xhigh - GPT-5.6 Sol 1M Extra High
+gpt-5.6-sol-xhigh-fast - GPT-5.6 Sol Extra High Fast
+claude-fable-5-thinking-high - Claude Fable 5 1M Thinking (NO ZDR)
+claude-fable-5-thinking-xhigh - Claude Fable 5 1M Extra High Thinking (NO ZDR)
+cursor-grok-4.5-high - Cursor Grok 4.5
+cursor-grok-4.5-high-fast - Cursor Grok 4.5 Fast
+gemini-3.7-flash-high - Gemini 3.7 Flash
+claude-sonnet-5-thinking-high - Claude Sonnet 5 1M Thinking
+claude-sonnet-5-thinking-xhigh - Claude Sonnet 5 1M Extra High Thinking
+gpt-5.6-luna-high - GPT-5.6 Luna 1M High
+cursor-grok-4.6-low - Cursor Grok 4.6 Low
+cursor-grok-4.6-low-fast - Cursor Grok 4.6 Low Fast
+cursor-grok-4.6-medium - Cursor Grok 4.6 Medium
+cursor-grok-4.6-medium-fast - Cursor Grok 4.6 Medium Fast
+cursor-grok-4.6-high - Cursor Grok 4.6
+cursor-grok-4.6-xhigh - Cursor Grok 4.6 Extra High
+cursor-grok-4.6-xhigh-fast - Cursor Grok 4.6 Extra High Fast
+composer-2.5-fast - Composer 2.5 Fast
+claude-opus-5-low - Claude Opus 5 1M Low
+claude-opus-5-low-fast - Claude Opus 5 1M Low Fast
+claude-opus-5-medium - Claude Opus 5 1M Medium
+claude-opus-5-medium-fast - Claude Opus 5 1M Medium Fast
+claude-opus-5-high - Claude Opus 5 1M
+claude-opus-5-high-fast - Claude Opus 5 1M Fast
+claude-opus-5-thinking-low - Claude Opus 5 1M Low Thinking
+claude-opus-5-thinking-low-fast - Claude Opus 5 1M Low Thinking Fast
+claude-opus-5-thinking-medium - Claude Opus 5 1M Medium Thinking
+claude-opus-5-thinking-medium-fast - Claude Opus 5 1M Medium Thinking Fast
+claude-opus-5-thinking-xhigh - Claude Opus 5 1M Extra High Thinking
+claude-opus-5-thinking-xhigh-fast - Claude Opus 5 1M Extra High Thinking Fast
+claude-opus-5-thinking-max - Claude Opus 5 1M Max Thinking
+claude-opus-5-thinking-max-fast - Claude Opus 5 1M Max Thinking Fast
+claude-opus-4-8-low - Claude Opus 4.8 1M Low
+claude-opus-4-8-low-fast - Claude Opus 4.8 1M Low Fast
+claude-opus-4-8-medium - Claude Opus 4.8 1M Medium
+claude-opus-4-8-medium-fast - Claude Opus 4.8 1M Medium Fast
+claude-opus-4-8-high - Claude Opus 4.8 1M
+claude-opus-4-8-high-fast - Claude Opus 4.8 1M Fast
+claude-opus-4-8-xhigh - Claude Opus 4.8 1M Extra High
+claude-opus-4-8-xhigh-fast - Claude Opus 4.8 1M Extra High Fast
+claude-opus-4-8-max - Claude Opus 4.8 1M Max
+claude-opus-4-8-max-fast - Claude Opus 4.8 1M Max Fast
+claude-opus-4-8-thinking-low - Claude Opus 4.8 1M Low Thinking
+claude-opus-4-8-thinking-low-fast - Claude Opus 4.8 1M Low Thinking Fast
+claude-opus-4-8-thinking-medium - Claude Opus 4.8 1M Medium Thinking
+claude-opus-4-8-thinking-medium-fast - Claude Opus 4.8 1M Medium Thinking Fast
+claude-opus-4-8-thinking-high - Claude Opus 4.8 1M Thinking
+claude-opus-4-8-thinking-high-fast - Claude Opus 4.8 1M Thinking Fast
+claude-opus-4-8-thinking-xhigh - Claude Opus 4.8 1M Extra High Thinking
+claude-opus-4-8-thinking-xhigh-fast - Claude Opus 4.8 1M Extra High Thinking Fast
+claude-opus-4-8-thinking-max - Claude Opus 4.8 1M Max Thinking
+claude-opus-4-8-thinking-max-fast - Claude Opus 4.8 1M Max Thinking Fast
+gpt-5.6-sol-none - GPT-5.6 Sol 1M None
+gpt-5.6-sol-none-fast - GPT-5.6 Sol None Fast
+gpt-5.6-sol-low - GPT-5.6 Sol 1M Low
+gpt-5.6-sol-low-fast - GPT-5.6 Sol Low Fast
+gpt-5.6-sol-medium - GPT-5.6 Sol 1M
+gpt-5.6-sol-medium-fast - GPT-5.6 Sol Fast
+gpt-5.6-sol-max - GPT-5.6 Sol 1M Max
+gpt-5.6-sol-max-fast - GPT-5.6 Sol Max Fast
+gpt-5.5-none - GPT-5.5 1M None
+gpt-5.5-none-fast - GPT-5.5 None Fast
+gpt-5.5-low - GPT-5.5 1M Low
+gpt-5.5-low-fast - GPT-5.5 Low Fast
+gpt-5.5-medium - GPT-5.5 1M
+gpt-5.5-medium-fast - GPT-5.5 Fast
+gpt-5.5-high - GPT-5.5 1M High
+gpt-5.5-high-fast - GPT-5.5 High Fast
+gpt-5.5-extra-high - GPT-5.5 1M Extra High
+gpt-5.5-extra-high-fast - GPT-5.5 Extra High Fast
+claude-fable-5-low - Claude Fable 5 1M Low (NO ZDR)
+claude-fable-5-medium - Claude Fable 5 1M Medium (NO ZDR)
+claude-fable-5-high - Claude Fable 5 1M (NO ZDR)
+claude-fable-5-xhigh - Claude Fable 5 1M Extra High (NO ZDR)
+claude-fable-5-max - Claude Fable 5 1M Max (NO ZDR)
+claude-fable-5-thinking-low - Claude Fable 5 1M Low Thinking (NO ZDR)
+claude-fable-5-thinking-medium - Claude Fable 5 1M Medium Thinking (NO ZDR)
+claude-fable-5-thinking-max - Claude Fable 5 1M Max Thinking (NO ZDR)
+cursor-grok-4.5-low - Cursor Grok 4.5 Low
+cursor-grok-4.5-low-fast - Cursor Grok 4.5 Low Fast
+cursor-grok-4.5-medium - Cursor Grok 4.5 Medium
+cursor-grok-4.5-medium-fast - Cursor Grok 4.5 Medium Fast
+gemini-3.7-flash-low - Gemini 3.7 Flash Low
+gemini-3.7-flash-medium - Gemini 3.7 Flash Medium
+gpt-5.6-terra-none - GPT-5.6 Terra 1M None
+gpt-5.6-terra-none-fast - GPT-5.6 Terra None Fast
+gpt-5.6-terra-low - GPT-5.6 Terra 1M Low
+gpt-5.6-terra-low-fast - GPT-5.6 Terra Low Fast
+gpt-5.6-terra-medium - GPT-5.6 Terra 1M
+gpt-5.6-terra-medium-fast - GPT-5.6 Terra Fast
+gpt-5.6-terra-high - GPT-5.6 Terra 1M High
+gpt-5.6-terra-high-fast - GPT-5.6 Terra High Fast
+gpt-5.6-terra-xhigh - GPT-5.6 Terra 1M Extra High
+gpt-5.6-terra-xhigh-fast - GPT-5.6 Terra Extra High Fast
+gpt-5.6-terra-max - GPT-5.6 Terra 1M Max
+gpt-5.6-terra-max-fast - GPT-5.6 Terra Max Fast
+claude-sonnet-5-low - Claude Sonnet 5 1M Low
+claude-sonnet-5-medium - Claude Sonnet 5 1M Medium
+claude-sonnet-5-high - Claude Sonnet 5 1M
+claude-sonnet-5-xhigh - Claude Sonnet 5 1M Extra High
+claude-sonnet-5-max - Claude Sonnet 5 1M Max
+claude-sonnet-5-thinking-low - Claude Sonnet 5 1M Low Thinking
+claude-sonnet-5-thinking-medium - Claude Sonnet 5 1M Medium Thinking
+claude-sonnet-5-thinking-max - Claude Sonnet 5 1M Max Thinking
+claude-4.6-sonnet-medium - Claude Sonnet 4.6 1M
+claude-4.6-sonnet-medium-thinking - Claude Sonnet 4.6 1M Thinking
+claude-opus-4-7-low - Claude Opus 4.7 1M Low
+claude-opus-4-7-low-fast - Claude Opus 4.7 1M Low Fast
+claude-opus-4-7-medium - Claude Opus 4.7 1M Medium
+claude-opus-4-7-medium-fast - Claude Opus 4.7 1M Medium Fast
+claude-opus-4-7-high - Claude Opus 4.7 1M High
+claude-opus-4-7-high-fast - Claude Opus 4.7 1M High Fast
+claude-opus-4-7-xhigh - Claude Opus 4.7 1M
+claude-opus-4-7-xhigh-fast - Claude Opus 4.7 1M Fast
+claude-opus-4-7-max - Claude Opus 4.7 1M Max
+claude-opus-4-7-max-fast - Claude Opus 4.7 1M Max Fast
+claude-opus-4-7-thinking-low - Claude Opus 4.7 1M Low Thinking
+claude-opus-4-7-thinking-low-fast - Claude Opus 4.7 1M Low Thinking Fast
+claude-opus-4-7-thinking-medium - Claude Opus 4.7 1M Medium Thinking
+claude-opus-4-7-thinking-medium-fast - Claude Opus 4.7 1M Medium Thinking Fast
+claude-opus-4-7-thinking-high - Claude Opus 4.7 1M High Thinking
+claude-opus-4-7-thinking-high-fast - Claude Opus 4.7 1M High Thinking Fast
+claude-opus-4-7-thinking-xhigh - Claude Opus 4.7 1M Thinking
+claude-opus-4-7-thinking-xhigh-fast - Claude Opus 4.7 1M Thinking Fast
+claude-opus-4-7-thinking-max - Claude Opus 4.7 1M Max Thinking
+claude-opus-4-7-thinking-max-fast - Claude Opus 4.7 1M Max Thinking Fast
+gpt-5.4-low - GPT-5.4 1M Low
+gpt-5.4-medium - GPT-5.4 1M
+gpt-5.4-medium-fast - GPT-5.4 Fast
+gpt-5.4-high - GPT-5.4 1M High
+gpt-5.4-high-fast - GPT-5.4 High Fast
+gpt-5.4-xhigh - GPT-5.4 1M Extra High
+gpt-5.4-xhigh-fast - GPT-5.4 Extra High Fast
+claude-4.6-opus-high - Claude Opus 4.6 1M
+claude-4.6-opus-max - Claude Opus 4.6 1M Max
+claude-4.6-opus-high-thinking - Claude Opus 4.6 1M Thinking
+claude-4.6-opus-max-thinking - Claude Opus 4.6 1M Max Thinking
+claude-4.5-opus-high - Claude Opus 4.5
+claude-4.5-opus-high-thinking - Claude Opus 4.5 Thinking
+gpt-5.2-low - GPT-5.2 Low
+gpt-5.2-low-fast - GPT-5.2 Low Fast
+gpt-5.2-fast - GPT-5.2 Fast
+gpt-5.2-high - GPT-5.2 High
+gpt-5.2-high-fast - GPT-5.2 High Fast
+gpt-5.2-xhigh - GPT-5.2 Extra High
+gpt-5.2-xhigh-fast - GPT-5.2 Extra High Fast
+gpt-5.6-luna-none - GPT-5.6 Luna 1M None
+gpt-5.6-luna-none-fast - GPT-5.6 Luna None Fast
+gpt-5.6-luna-low - GPT-5.6 Luna 1M Low
+gpt-5.6-luna-low-fast - GPT-5.6 Luna Low Fast
+gpt-5.6-luna-medium - GPT-5.6 Luna 1M
+gpt-5.6-luna-medium-fast - GPT-5.6 Luna Fast
+gpt-5.6-luna-high-fast - GPT-5.6 Luna High Fast
+gpt-5.6-luna-xhigh - GPT-5.6 Luna 1M Extra High
+gpt-5.6-luna-xhigh-fast - GPT-5.6 Luna Extra High Fast
+gpt-5.6-luna-max - GPT-5.6 Luna 1M Max
+gpt-5.6-luna-max-fast - GPT-5.6 Luna Max Fast
+gemini-3.6-flash-minimal - Gemini 3.6 Flash Minimal
+gemini-3.6-flash-low - Gemini 3.6 Flash Low
+gemini-3.6-flash-medium - Gemini 3.6 Flash Medium
+gemini-3.6-flash-high - Gemini 3.6 Flash
+gemini-3.1-pro - Gemini 3.1 Pro
+gpt-5.4-mini-none - GPT-5.4 Mini None
+gpt-5.4-mini-low - GPT-5.4 Mini Low
+gpt-5.4-mini-medium - GPT-5.4 Mini
+gpt-5.4-mini-high - GPT-5.4 Mini High
+gpt-5.4-mini-xhigh - GPT-5.4 Mini Extra High
+gpt-5.4-nano-none - GPT-5.4 Nano None
+gpt-5.4-nano-low - GPT-5.4 Nano Low
+gpt-5.4-nano-medium - GPT-5.4 Nano
+gpt-5.4-nano-high - GPT-5.4 Nano High
+gpt-5.4-nano-xhigh - GPT-5.4 Nano Extra High
+claude-4.5-sonnet - Claude Sonnet 4.5
+claude-4.5-sonnet-thinking - Claude Sonnet 4.5 Thinking
+gpt-5.1-low - GPT-5.1 Low
+gpt-5.1 - GPT-5.1
+gpt-5.1-high - GPT-5.1 High
+gemini-3-flash - Gemini 3 Flash
+gemini-3.5-flash - Gemini 3.5 Flash
+claude-4-sonnet - Claude Sonnet 4
+claude-4-sonnet-thinking - Claude Sonnet 4 Thinking
+gpt-5-mini - GPT-5 Mini
+kimi-k3-low - Kimi K3 Low
+kimi-k3-high - Kimi K3 High
+kimi-k3-max - Kimi K3
+kimi-k2.7-code - Kimi K2.7 Code
+glm-5.2-high - GLM 5.2
+glm-5.2-max - GLM 5.2 Max

--- a/src/resources/extensions/cursor-cli/tests/index.test.ts
+++ b/src/resources/extensions/cursor-cli/tests/index.test.ts
@@ -1,18 +1,26 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import cursorCli from "../index.ts";
+import cursorCli, { probeAndRegisterCursorModels } from "../index.ts";
 
 type Handler = (event: unknown, ctx: unknown) => unknown;
 
 function makeMockPi() {
 	const providers: Array<{ name: string; config: Record<string, unknown> }> = [];
+	const handlers: Record<string, Handler> = {};
 	const pi = {
-		on(_event: string, _handler: Handler) {},
+		on(event: string, handler: Handler) {
+			handlers[event] = handler;
+		},
 		registerProvider(name: string, config: Record<string, unknown>) {
 			providers.push({ name, config });
 		},
+		unregisterProvider(name: string) {
+			for (let i = providers.length - 1; i >= 0; i--) {
+				if (providers[i]?.name === name) providers.splice(i, 1);
+			}
+		},
 	};
-	return { pi, providers };
+	return { pi, providers, handlers };
 }
 
 test("registers the cursor-agent provider with external CLI auth", () => {
@@ -29,15 +37,31 @@ test("registers the cursor-agent provider with external CLI auth", () => {
 	assert.equal(typeof providers[0].config.streamSimple, "function");
 });
 
-test("registers static Cursor subscription models", () => {
+test("registers static Cursor subscription models as offline fallback (#1869)", () => {
 	const { pi, providers } = makeMockPi();
 	cursorCli(pi as never);
 
 	const models = providers[0].config.models as Array<Record<string, unknown>>;
 	assert.ok(models.some((model) => model.id === "composer-2.5"));
-	assert.ok(models.some((model) => model.id === "claude-sonnet-4-6"));
-	assert.ok(models.some((model) => model.id === "gpt-5.5"));
+	assert.ok(models.some((model) => model.id === "claude-4.6-sonnet-medium"));
+	assert.ok(models.some((model) => model.id === "gpt-5.5-medium"));
+	assert.ok(!models.some((model) => model.id === "claude-sonnet-4-6"));
+	assert.ok(!models.some((model) => model.id === "gpt-5.5"));
 	assert.ok(models.every((model) => (model.cost as Record<string, number>).input === 0));
+});
+
+test("session_start rediscovers CLI models and replaces the fallback catalog (#1869)", () => {
+	const { pi, providers, handlers } = makeMockPi();
+	cursorCli(pi as never);
+	assert.equal((providers[0].config.models as Array<{ id: string }>).some((m) => m.id === "composer-2.5"), true);
+
+	probeAndRegisterCursorModels(pi as never, () =>
+		["gpt-5.6-sol-high - GPT-5.6 Sol 1M High", "composer-2.5 - Composer 2.5 (current)"].join("\n"),
+	);
+	assert.equal(providers.length, 1);
+	const models = providers[0].config.models as Array<{ id: string }>;
+	assert.deepEqual(models.map((m) => m.id), ["gpt-5.6-sol-high", "composer-2.5"]);
+	assert.equal(typeof handlers.session_start, "function");
 });
 
 test("GSD_CURSOR_DISABLE keeps the provider dormant", () => {
@@ -52,3 +76,4 @@ test("GSD_CURSOR_DISABLE keeps the provider dormant", () => {
 		else process.env.GSD_CURSOR_DISABLE = original;
 	}
 });
+

--- a/src/resources/extensions/cursor-cli/tests/index.test.ts
+++ b/src/resources/extensions/cursor-cli/tests/index.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import cursorCli, { probeAndRegisterCursorModels } from "../index.ts";
+import { CURSOR_AGENT_MODELS } from "../models.ts";
 
 type Handler = (event: unknown, ctx: unknown) => unknown;
 
@@ -21,6 +22,10 @@ function makeMockPi() {
 		},
 	};
 	return { pi, providers, handlers };
+}
+
+function modelIds(providers: Array<{ config: Record<string, unknown> }>): string[] {
+	return (providers[0]?.config.models as Array<{ id: string }>).map((model) => model.id);
 }
 
 test("registers the cursor-agent provider with external CLI auth", () => {
@@ -55,13 +60,58 @@ test("session_start rediscovers CLI models and replaces the fallback catalog (#1
 	cursorCli(pi as never);
 	assert.equal((providers[0].config.models as Array<{ id: string }>).some((m) => m.id === "composer-2.5"), true);
 
-	probeAndRegisterCursorModels(pi as never, () =>
-		["gpt-5.6-sol-high - GPT-5.6 Sol 1M High", "composer-2.5 - Composer 2.5 (current)"].join("\n"),
+	probeAndRegisterCursorModels(
+		pi as never,
+		() => ["gpt-5.6-sol-high - GPT-5.6 Sol 1M High", "composer-2.5 - Composer 2.5 (current)"].join("\n"),
+		() => true,
 	);
 	assert.equal(providers.length, 1);
 	const models = providers[0].config.models as Array<{ id: string }>;
 	assert.deepEqual(models.map((m) => m.id), ["gpt-5.6-sol-high", "composer-2.5"]);
 	assert.equal(typeof handlers.session_start, "function");
+});
+
+test("session_start does not block on live catalog discovery in headless (#1869)", () => {
+	const { pi, providers, handlers } = makeMockPi();
+	cursorCli(pi as never);
+	const before = providers[0].config.models;
+
+	const result = handlers.session_start({}, { hasUI: false });
+	assert.equal(result, undefined);
+	assert.equal(handlers.session_start.constructor.name, "Function");
+	assert.equal(providers[0].config.models, before);
+	assert.deepEqual(modelIds(providers), CURSOR_AGENT_MODELS.map((model) => model.id));
+});
+
+test("probe skips --list-models when the cursor-agent binary is missing (#1869)", () => {
+	const { pi, providers } = makeMockPi();
+	cursorCli(pi as never);
+	let reads = 0;
+	const models = probeAndRegisterCursorModels(
+		pi as never,
+		() => {
+			reads += 1;
+			return "kimi-k3 - Kimi K3";
+		},
+		() => false,
+	);
+	assert.equal(reads, 0);
+	assert.equal(models, CURSOR_AGENT_MODELS);
+	assert.deepEqual(modelIds(providers), CURSOR_AGENT_MODELS.map((model) => model.id));
+});
+
+test("probe keeps the fallback catalog when list-models throws (#1869)", () => {
+	const { pi, providers } = makeMockPi();
+	cursorCli(pi as never);
+	const models = probeAndRegisterCursorModels(
+		pi as never,
+		() => {
+			throw new Error("cursor-agent --list-models failed");
+		},
+		() => true,
+	);
+	assert.equal(models, CURSOR_AGENT_MODELS);
+	assert.deepEqual(modelIds(providers), CURSOR_AGENT_MODELS.map((model) => model.id));
 });
 
 test("GSD_CURSOR_DISABLE keeps the provider dormant", () => {
@@ -76,4 +126,3 @@ test("GSD_CURSOR_DISABLE keeps the provider dormant", () => {
 		else process.env.GSD_CURSOR_DISABLE = original;
 	}
 });
-

--- a/src/resources/extensions/cursor-cli/tests/models.test.ts
+++ b/src/resources/extensions/cursor-cli/tests/models.test.ts
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	CURSOR_AGENT_MODELS,
+	parseCursorAgentModelList,
+	resolveCursorAgentModels,
+} from "../models.ts";
+
+const fixture = readFileSync(
+	join(dirname(fileURLToPath(import.meta.url)), "fixtures/cursor-list-models.txt"),
+	"utf8",
+);
+
+test("parseCursorAgentModelList reads id - Name lines and skips headers (#1869)", () => {
+	const models = parseCursorAgentModelList(`Available models\n${fixture}\nTip: use --model <id>`);
+	assert.ok(models.length > 50);
+	assert.ok(models.some((m) => m.id === "composer-2.5"));
+	assert.ok(models.some((m) => m.id === "gpt-5.6-sol-high"));
+	assert.ok(models.some((m) => m.id === "claude-sonnet-5-thinking-high"));
+	assert.ok(models.some((m) => m.id === "gemini-3.1-pro"));
+	assert.ok(!models.some((m) => m.id === "claude-sonnet-4-6"));
+	assert.ok(!models.some((m) => m.id === "gpt-5.5"));
+	assert.ok(!models.some((m) => m.id.includes("[")));
+});
+
+test("every hardcoded fallback ID appears in the --list-models fixture (#1869)", () => {
+	const listed = new Set(parseCursorAgentModelList(fixture).map((m) => m.id));
+	for (const model of CURSOR_AGENT_MODELS) {
+		assert.ok(listed.has(model.id), `fallback id missing from CLI list: ${model.id}`);
+	}
+});
+
+test("1M naming sets a 1M context window; thinking/effort IDs are reasoning (#1869)", () => {
+	const [sol] = parseCursorAgentModelList("gpt-5.6-sol-high - GPT-5.6 Sol 1M High");
+	assert.equal(sol?.contextWindow, 1_000_000);
+	assert.equal(sol?.reasoning, true);
+	const [flash] = parseCursorAgentModelList("gemini-3.7-flash-high - Gemini 3.7 Flash");
+	assert.equal(flash?.contextWindow, 256_000);
+	assert.equal(flash?.name, "Gemini 3.7 Flash (via Cursor)");
+});
+
+test("resolveCursorAgentModels falls back when CLI output is empty (#1869)", () => {
+	assert.equal(resolveCursorAgentModels(null), CURSOR_AGENT_MODELS);
+	assert.equal(resolveCursorAgentModels(""), CURSOR_AGENT_MODELS);
+	assert.equal(resolveCursorAgentModels("Available models\n"), CURSOR_AGENT_MODELS);
+	const discovered = resolveCursorAgentModels("kimi-k3 - Kimi K3");
+	assert.equal(discovered.length, 1);
+	assert.equal(discovered[0]?.id, "kimi-k3");
+});


### PR DESCRIPTION
## TL;DR

**What:** Discover cursor-agent models from `cursor-agent --list-models` and refresh the offline fallback catalog.
**Why:** Five of the six hardcoded IDs no longer exist in the CLI, and current families never appear in GSD model selection.
**How:** Parse `id - Name` lines on `session_start`; keep a six-model fallback that is golden-tested against a `--list-models` fixture.

## What

- `cursor-cli` registers the static catalog immediately, then replaces it on `session_start` with CLI discovery (ollama-style).
- Offline fallback IDs are real CLI slugs: `composer-2.5`, `claude-4.6-sonnet-medium`, `claude-opus-4-7-medium`, `gpt-5.5-medium`, `gemini-3.1-pro`, `cursor-grok-4.6-high`.
- Tests parse a captured `--list-models` fixture and fail if a fallback ID drifts.

## Why

Closes #1869. Selecting `claude-sonnet-4-6`, bare `gpt-5.5`, `gemini-2.5-pro`, or `grok-4` cannot work because those IDs are not in the current cursor-agent CLI.

## How

`readCursorAgentListModels()` reuses the readiness command probe with a 15s timeout. `parseCursorAgentModelList` ignores headers/tips and parameterized `[context=…]` overrides. Empty/failed discovery keeps the fallback.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/cursor-cli/tests/index.test.ts src/resources/extensions/cursor-cli/tests/models.test.ts src/resources/extensions/cursor-cli/tests/readiness.test.ts` — 13 passed
- `pnpm run verify:fast` — passed