### PR TITLE
fix(issue): ScheduleWakeup collides with Claude Code native tool (#1847)

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -115,7 +115,7 @@ Writes outside those allowed paths, unsafe bash commands, and subagent dispatch 
 
 ### ScheduleWakeup Continuations
 
-`ScheduleWakeup` schedules a delayed follow-up prompt. In auto mode, it is used for long external waits inside `execute-task` units and keeps the same unit session alive instead of ending the unit as incomplete. Outside auto mode, it waits for the requested delay and then starts a new triggered turn with the supplied wakeup prompt.
+`gsd_schedule_wakeup` schedules a delayed follow-up prompt. In auto mode, it is used for long external waits inside `execute-task` units and keeps the same unit session alive instead of ending the unit as incomplete. Outside auto mode, it waits for the requested delay and then starts a new triggered turn with the supplied wakeup prompt. Do not use Claude Code's native `ScheduleWakeup` tool for this.
 
 - Use it when a task kicked off external work (for example CI, deploy, or async jobs) and needs a later poll.
 - Include a concrete follow-up prompt that says what to check and what artifact to write when done.

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -132,8 +132,8 @@ export function clearInFlightTools(): void {
  */
 const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Input validation error|Invalid arguments for tool|MCP error -32602|No such tool available|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON|does not provide an export named|Named export .* not found|Cannot find module|ERR_MODULE_NOT_FOUND|ERR_MODULE_NOT_EXPORTED|ERR_PACKAGE_PATH_NOT_EXPORTED/i;
 const DETERMINISTIC_POLICY_ERROR_RE = /(?:^|\b)(?:HARD BLOCK:|Blocked: \/gsd queue is a planning tool|Direct writes to \.gsd\/STATE\.md and \.gsd\/gsd\.db are blocked|This is a mechanical gate)/i;
-const SCHEDULE_WAKEUP_TOOL_NAME = "ScheduleWakeup";
 const SCHEDULE_WAKEUP_CONTINUATION_ERROR = "`prompt` is required when `stop` is not true";
+const SCHEDULE_WAKEUP_TOOL_NAMES = new Set(["ScheduleWakeup", "gsd_schedule_wakeup"]);
 
 /**
  * Matches the runtime's "tool not registered" error. Unlike the deterministic
@@ -159,7 +159,7 @@ export function isToolInvocationError(errorMsg: string): boolean {
  * unrelated tools does not pause auto-mode.
  */
 export function isScheduleWakeupContinuationError(toolName: string, errorMsg: string): boolean {
-  return stripMcpToolPrefix(toolName) === SCHEDULE_WAKEUP_TOOL_NAME
+  return SCHEDULE_WAKEUP_TOOL_NAMES.has(stripMcpToolPrefix(toolName))
     && errorMsg.trim() === SCHEDULE_WAKEUP_CONTINUATION_ERROR;
 }
 

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -204,7 +204,7 @@ export function shouldClearToolInvocationErrorAfterSuccess(
   successfulToolName?: string,
 ): boolean {
   return !isRecordedScheduleWakeupContinuationError(recordedError)
-    || stripMcpToolPrefix(successfulToolName ?? "") === SCHEDULE_WAKEUP_TOOL_NAME;
+    || SCHEDULE_WAKEUP_TOOL_NAMES.has(stripMcpToolPrefix(successfulToolName ?? ""));
 }
 
 /**

--- a/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
+++ b/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
@@ -12,6 +12,10 @@ import { resolveCtxCwd } from "./dynamic-tools.js";
 const MAX_WAKEUP_DELAY_SECONDS = 24 * 60 * 60;
 const INTERACTIVE_WAKEUP_CUSTOM_TYPE = "gsd-schedule-wakeup";
 
+/** GSD-owned name so Claude Code's native `ScheduleWakeup` does not collide (#1847). */
+export const GSD_SCHEDULE_WAKEUP_TOOL_NAME = "gsd_schedule_wakeup";
+export const CLAUDE_CODE_NATIVE_SCHEDULE_WAKEUP_TOOL_NAME = "ScheduleWakeup";
+
 // One pending interactive wakeup per session, keyed by base path — the same
 // scoping auto-mode uses for its wakeup map (see `wakeupKey`). Re-arming cancels
 // only that session's prior timer, so repeated polling never stacks overlapping
@@ -44,13 +48,13 @@ function scheduleInteractiveWakeup(
       )).catch((error) => {
         logWarning(
           "bootstrap",
-          `ScheduleWakeup interactive dispatch failed: ${error instanceof Error ? error.message : String(error)}`,
+          `${GSD_SCHEDULE_WAKEUP_TOOL_NAME} interactive dispatch failed: ${error instanceof Error ? error.message : String(error)}`,
         );
       });
     } catch (error) {
       logWarning(
         "bootstrap",
-        `ScheduleWakeup interactive dispatch failed: ${error instanceof Error ? error.message : String(error)}`,
+        `${GSD_SCHEDULE_WAKEUP_TOOL_NAME} interactive dispatch failed: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }, delaySeconds * 1000);
@@ -74,17 +78,19 @@ export function _resetInteractiveWakeupsForTest(): void {
 
 export function registerScheduleWakeupTool(pi: ExtensionAPI): void {
   pi.registerTool({
-    name: "ScheduleWakeup",
+    name: GSD_SCHEDULE_WAKEUP_TOOL_NAME,
     label: "Schedule Wakeup",
     description:
       "Schedule a delayed continuation turn. In GSD auto-mode, continue the current unit in the same session; " +
-      "outside auto-mode, start a new triggered turn with the supplied wakeup prompt.",
+      "outside auto-mode, start a new triggered turn with the supplied wakeup prompt. " +
+      "Do not call Claude Code's native ScheduleWakeup tool.",
     promptSnippet: "Schedule a wakeup prompt after a delay.",
     promptGuidelines: [
-      "Use ScheduleWakeup at the end of an execute-task turn when waiting for a long external process.",
+      `Use ${GSD_SCHEDULE_WAKEUP_TOOL_NAME} at the end of an execute-task turn when waiting for a long external process.`,
       "Include a prompt that says exactly what external state to check next and what artifact to write when done.",
-      "Re-arm ScheduleWakeup on each polling turn if the external process is still running.",
-      "Outside auto-mode, use ScheduleWakeup when the user asks you to check back or poll later.",
+      `Re-arm ${GSD_SCHEDULE_WAKEUP_TOOL_NAME} on each polling turn if the external process is still running.`,
+      `Outside auto-mode, use ${GSD_SCHEDULE_WAKEUP_TOOL_NAME} when the user asks you to check back or poll later.`,
+      "Never call the native ScheduleWakeup tool; it is not GSD's continuation mechanism.",
     ],
     parameters: Type.Object({
       delaySeconds: Type.Number({

--- a/src/resources/extensions/gsd/tests/schedule-wakeup-tool.test.ts
+++ b/src/resources/extensions/gsd/tests/schedule-wakeup-tool.test.ts
@@ -28,7 +28,7 @@ test("ScheduleWakeup arms an interactive wakeup when auto-mode is inactive", asy
 
   try {
     registerScheduleWakeupTool(pi as any);
-    assert.ok(tool, "ScheduleWakeup tool should be registered");
+    assert.equal(tool.name, "gsd_schedule_wakeup");
 
     const result = await tool.execute(
       "call-1",
@@ -86,7 +86,7 @@ test("ScheduleWakeup re-arm cancels the prior interactive timer instead of stack
 
   try {
     registerScheduleWakeupTool(pi as any);
-    assert.ok(tool, "ScheduleWakeup tool should be registered");
+    assert.equal(tool.name, "gsd_schedule_wakeup");
 
     const ctx = { cwd: process.cwd() };
     await tool.execute(
@@ -133,7 +133,7 @@ test("ScheduleWakeup keeps interactive wakeups isolated per session base path", 
 
   try {
     registerScheduleWakeupTool(pi as any);
-    assert.ok(tool, "ScheduleWakeup tool should be registered");
+    assert.equal(tool.name, "gsd_schedule_wakeup");
 
     // Two concurrent interactive sessions (different cwds) arm wakeups. One
     // session re-arming must not cancel the other session's pending wakeup.

--- a/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
@@ -127,6 +127,10 @@ describe("#2883: isToolInvocationError classification", () => {
       isScheduleWakeupContinuationError("ScheduleWakeup", error),
       true,
     );
+    assert.equal(
+      isScheduleWakeupContinuationError("gsd_schedule_wakeup", error),
+      true,
+    );
     assert.equal(isScheduleWakeupContinuationError("read", error), false);
     assert.equal(
       isScheduleWakeupContinuationError(


### PR DESCRIPTION
## TL;DR

**What:** Rename GSD's wakeup tool to `gsd_schedule_wakeup`.
**Why:** Claude Code's native `ScheduleWakeup` has a different schema and wins on the claude-code engine, so GSD never records the continuation.
**How:** Collision-proof GSD tool name; keep treating native `ScheduleWakeup` validation errors as continuation failures.

## What

- GSD registers `gsd_schedule_wakeup` instead of `ScheduleWakeup`.
- Prompts tell the model not to call the native tool.
- `isScheduleWakeupContinuationError` still matches native `ScheduleWakeup` (and the new name) so a leftover native validation error still pauses instead of looping.

## Why

Closes #1847. Same-name registration let the vendor CLI validate `prompt`/`stop` and either reject or schedule a wakeup inside a session that is about to end.

## How

Rename only the GSD-owned tool. Native Claude Code `ScheduleWakeup` remains a vendor tool.

## Verification

- `schedule-wakeup-tool.test.ts`, `tool-invocation-error-loop-break.test.ts`, `claude-tool-schema-golden.test.ts` — 77 passed