### PR TITLE
fix(issue): boot sweep deletes user-created extensions (#1853)

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -681,21 +681,12 @@ function pruneRemovedBundledExtensions(
   }
 
   if (manifest?.installedExtensionDirs) {
-    // Manifest-based: remove previously-installed subdirectory extensions that are no longer bundled
+    // Manifest-based: remove previously-installed subdirectory extensions that are no longer bundled.
+    // Do not sweep unknown directories — those are user-created (#1853).
     for (const prevDir of manifest.installedExtensionDirs) {
       removeDirIfStale(prevDir)
     }
   }
-
-  // Sweep-based: also remove any installed extension subdirectory not in the current bundle,
-  // even if it was never tracked in the manifest (e.g. installed by a pre-manifest version).
-  try {
-    if (existsSync(extensionsDir)) {
-      for (const e of readdirSync(extensionsDir, { withFileTypes: true })) {
-        if (e.isDirectory()) removeDirIfStale(e.name)
-      }
-    }
-  } catch { /* non-fatal */ }
 
   // Always remove known stale files regardless of manifest state.
   // These were installed by pre-manifest versions so they may not appear in

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -796,6 +796,11 @@ test("pruneRemovedBundledExtensions removes stale subdirectory extensions not in
       "manifest should contain installedExtensionDirs array",
     );
 
+    // Treat mcporter as a previously bundled dir so prune is manifest-based (#1853).
+    if (!manifest.installedExtensionDirs.includes("mcporter")) {
+      manifest.installedExtensionDirs = [...manifest.installedExtensionDirs, "mcporter"];
+    }
+
     // Bump the manifest version to force a re-sync (simulates upgrading GSD).
     manifest.gsdVersion = "0.0.0-force-resync";
     manifest.contentHash = "0000000000000000";
@@ -808,6 +813,37 @@ test("pruneRemovedBundledExtensions removes stale subdirectory extensions not in
       existsSync(staleExtDir),
       false,
       "stale subdirectory extension (mcporter/) should be pruned after upgrade",
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("pruneRemovedBundledExtensions preserves user-created extension directories (#1853)", async () => {
+  const { initResources } = await import("../resource-loader.ts");
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-user-ext-"));
+  const fakeAgentDir = join(tmp, "agent");
+
+  try {
+    initResources(fakeAgentDir, join(tmp, "skills"));
+
+    const userExtDir = join(fakeAgentDir, "extensions", "my-local-ext");
+    mkdirSync(userExtDir, { recursive: true });
+    writeFileSync(join(userExtDir, "index.js"), "export default function (pi) {}\n");
+
+    const manifestPath = join(fakeAgentDir, "managed-resources.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    assert.ok(!manifest.installedExtensionDirs?.includes("my-local-ext"));
+    manifest.gsdVersion = "0.0.0-force-resync";
+    manifest.contentHash = "0000000000000000";
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    initResources(fakeAgentDir, join(tmp, "skills"));
+
+    assert.equal(existsSync(userExtDir), true, "user-created extension must survive boot prune");
+    assert.equal(
+      readFileSync(join(userExtDir, "index.js"), "utf-8"),
+      "export default function (pi) {}\n",
     );
   } finally {
     rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## TL;DR

**What:** Stop `initResources()` from deleting user-created `~/.gsd/agent/extensions/*` directories.
**Why:** The boot prune swept every dir not in the current bundle, contradicting `syncResourceDir`'s preserve-user-dirs contract.
**How:** Prune only dirs listed in `installedExtensionDirs` that left the bundle.

## What

`pruneRemovedBundledExtensions` no longer walks every installed subdirectory. Previously bundled extensions that were removed still get deleted via the manifest list.

## Why

Closes #1853. `mkdir ~/.gsd/agent/extensions/my-local-ext` then `gsd` deleted the directory on every boot, including hash-match fast path.

## How

Keep the manifest-based prune. Drop the catch-all sweep.

## Verification

- `src/tests/resource-loader.test.ts` including `preserves user-created extension directories (#1853)` — 24 passed