### PR TITLE
fix(issue): discoverCommands splits quoted multi-line verify commands (#1798)

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -22,7 +22,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { discoverCommands, runVerificationGate, runVerificationGateForTargets, formatFailureContext, captureRuntimeErrors, runDependencyAudit, isLikelyCommand, validateVerificationCommand } from "../verification-gate.ts";
+import { discoverCommands, runVerificationGate, runVerificationGateForTargets, formatFailureContext, captureRuntimeErrors, runDependencyAudit, isLikelyCommand, validateVerificationCommand, splitUnquotedLines } from "../verification-gate.ts";
 import type { CaptureRuntimeErrorsOptions, DependencyAuditOptions } from "../verification-gate.ts";
 import { validatePreferences } from "../preferences.ts";
 
@@ -1153,6 +1153,27 @@ test("discoverCommands: #1671 reporter line is not executed; #1724 rg line is", 
   const rg = discoverCommands({ cwd: rgDir, taskPlanVerify: ISSUE_1724_RG });
   assert.deepEqual(rg.commands, [ISSUE_1724_RG]);
   assert.equal(rg.source, "task-plan");
+});
+
+const ISSUE_1798_VERIFY = `grep -q '"version": "1.0.0"' manifest.json && node --input-type=module --eval "import fs from 'node:fs'
+const m = JSON.parse(fs.readFileSync('manifest.json','utf8'))
+if (m.priority !== 100) throw new Error('priority')
+console.log('OK')" && npm run typecheck`;
+
+test("splitUnquotedLines keeps newlines inside quotes (#1798)", () => {
+  assert.deepEqual(splitUnquotedLines("npm test\nnpm run lint"), ["npm test", "npm run lint"]);
+  const lines = splitUnquotedLines(ISSUE_1798_VERIFY);
+  assert.equal(lines.length, 1, "quoted --eval body must stay one command");
+  assert.match(lines[0] ?? "", /npm run typecheck$/);
+});
+
+test("discoverCommands: quoted multi-line --eval stays one command (#1798)", () => {
+  const dir = makeTempDir("gsd-verify-1798");
+  const found = discoverCommands({ cwd: dir, taskPlanVerify: ISSUE_1798_VERIFY });
+  assert.equal(found.source, "task-plan");
+  assert.equal(found.commands.length, 1);
+  assert.match(found.commands[0] ?? "", /node --input-type=module --eval/);
+  assert.match(found.commands[0] ?? "", /npm run typecheck$/);
 });
 
 // ─── Additional Preference Validation Tests (T02) ──────────────────────────

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -120,10 +120,7 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
   // 1. Task plan verify field (commands are untrusted — sanitize)
   if (taskPlanVerify) {
     const commands: string[] = [];
-    const candidates = taskPlanVerify
-      .split(/\r?\n/)
-      .map(c => c.trim())
-      .filter(Boolean);
+    const candidates = splitUnquotedLines(taskPlanVerify);
     for (const candidate of candidates) {
       const normalized = candidate.replace(INTERPRETER_PREFIX_RE, "").trim();
       const validation = validateVerificationCommand(normalized);
@@ -398,6 +395,48 @@ function hasUnsafeShellSyntax(cmd: string): boolean {
  * Split a candidate string on unquoted `;` into individual statements.
  * Used to re-classify prose-vs-command for candidates rejected as unsafe.
  */
+/** Split verify text on newlines that are not inside quotes (#1798). */
+export function splitUnquotedLines(text: string): string[] {
+  const lines: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && !inSingle) {
+      current += ch;
+      escaped = true;
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      current += ch;
+      continue;
+    }
+    if (ch === "\"" && !inSingle) {
+      inDouble = !inDouble;
+      current += ch;
+      continue;
+    }
+    if (ch === "\n" && !inSingle && !inDouble) {
+      if (current.endsWith("\r")) current = current.slice(0, -1);
+      lines.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  lines.push(current);
+  return lines.map(s => s.trim()).filter(Boolean);
+}
+
 function splitUnquotedStatements(cmd: string): string[] {
   const statements: string[] = [];
   let current = "";


### PR DESCRIPTION
## TL;DR

**What:** Quote-aware newline split for task-plan Verify commands.
**Why:** `discoverCommands` shredded a valid `node --eval \"...\"` command at every newline inside the quoted JS.
**How:** `splitUnquotedLines` tracks single/double quotes the same way `splitUnquotedStatements` already tracks `;`.

## What

`verification-gate.ts` no longer uses naive `split(/\\r?\\n/)` on the verify field.

## Why

Closes #1798.

## Verification

- `verification-gate.test.ts` including `#1798` cases — 130 passed