### PR TITLE
fix(issue): --no-auth LAN error documents env recipes (#1635)

### DIFF
--- a/docs/user-docs/web-interface.md
+++ b/docs/user-docs/web-interface.md
@@ -27,10 +27,22 @@ gsd --web --host 0.0.0.0 --port 8080 --allowed-origins "https://example.com"
 
 **Unauthenticated LAN interlock.** `--no-auth` (or `GSD_WEB_NO_AUTH=1`) disables the built-in bearer token. On a non-loopback bind such as `--host 0.0.0.0`, that would expose terminal and file APIs to anyone who can reach the host. GSD therefore refuses startup unless `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` is also set. Loopback hosts (`127.0.0.1`, `localhost`, `::1`, other `127.x.x.x` addresses) are exempt — `--no-auth` works there without the override.
 
-To deliberately run unauthenticated web mode on a LAN-facing host, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` in the same environment (see [configuration.md](configuration.md) for POSIX, PowerShell, and CMD examples):
+To deliberately run unauthenticated web mode on a LAN-facing host, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` in the same environment. `--no-auth` alone is not enough on a non-loopback bind.
 
 ```bash
+# POSIX shell (bash, zsh)
 GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 gsd --web --host 0.0.0.0 --no-auth
+```
+
+```powershell
+# PowerShell
+$env:GSD_WEB_ALLOW_UNAUTHENTICATED_LAN="1"; gsd --web --host 0.0.0.0 --no-auth
+```
+
+```bat
+REM CMD
+set GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1
+gsd --web --host 0.0.0.0 --no-auth
 ```
 
 This exposes terminal and file APIs to any client that can reach the server unless trusted external access control is already in place. Use the override only behind authentication you control, such as a reverse proxy, VPN, or private network boundary.

--- a/gitbook/reference/cli-flags.md
+++ b/gitbook/reference/cli-flags.md
@@ -65,18 +65,16 @@
 | `--allowed-origins` | (none) | CORS origins |
 | `--no-auth` | disabled | Disable the built-in bearer token gate |
 
-`--no-auth` is refused on non-loopback hosts by default (loopback is exempt). To deliberately combine unauthenticated web mode with a LAN-facing bind such as `--host 0.0.0.0`, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1`; this exposes terminal and file APIs unless trusted external access control is in place.
+`--no-auth` is refused on non-loopback hosts by default (loopback is exempt). `--no-auth` alone is not enough. To deliberately combine unauthenticated web mode with a LAN-facing bind such as `--host 0.0.0.0`, set `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1`; this exposes terminal and file APIs unless trusted external access control is in place.
 
 ```bash
 # POSIX shell (bash, zsh)
-export GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1
-gsd --web --host 0.0.0.0 --no-auth
+GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 gsd --web --host 0.0.0.0 --no-auth
 ```
 
 ```powershell
 # PowerShell
-$env:GSD_WEB_ALLOW_UNAUTHENTICATED_LAN="1"
-gsd --web --host 0.0.0.0 --no-auth
+$env:GSD_WEB_ALLOW_UNAUTHENTICATED_LAN="1"; gsd --web --host 0.0.0.0 --no-auth
 ```
 
 ```bat

--- a/src/tests/integration/web-mode-network-flags.test.ts
+++ b/src/tests/integration/web-mode-network-flags.test.ts
@@ -185,7 +185,8 @@ test('launchWebMode refuses --no-auth on non-loopback host without override', as
   assert.equal(status.ok, false)
   if (status.ok) throw new Error('expected failure')
   assert.match(status.failureReason, /refusing to disable auth/)
-  assert.match(status.failureReason, /GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1/)
+  assert.match(status.failureReason, /GSD_WEB_ALLOW_UNAUTHENTICATED_LAN/)
+  assert.match(status.failureReason, /\$env:GSD_WEB_ALLOW_UNAUTHENTICATED_LAN/)
   assert.match(status.failureReason, /docs\/user-docs\/web-interface\.md/)
 })
 

--- a/src/web-mode.ts
+++ b/src/web-mode.ts
@@ -402,6 +402,17 @@ function isWebNoAuthEnabled(env: NodeJS.ProcessEnv): boolean {
   return env.GSD_WEB_NO_AUTH === '1'
 }
 
+function unauthenticatedLanRefusalReason(host: string): string {
+  return [
+    `refusing to disable auth on non-loopback host ${host}: this exposes terminal and file APIs to the network. Bind to 127.0.0.1, keep token auth on, or set GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 to override. --no-auth alone is not enough.`,
+    'Unix: GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 gsd --web --host 0.0.0.0 --no-auth',
+    'PowerShell: $env:GSD_WEB_ALLOW_UNAUTHENTICATED_LAN="1"; gsd --web --host 0.0.0.0 --no-auth',
+    'CMD: set GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1',
+    '     gsd --web --host 0.0.0.0 --no-auth',
+    'See docs/user-docs/web-interface.md.',
+  ].join('\n')
+}
+
 function isLoopbackHost(host: string): boolean {
   const h = host.trim().toLowerCase()
   return h === '127.0.0.1' || h === 'localhost' || h === '::1' || h === '[::1]' || (isIP(h) === 4 && h.startsWith('127.'))
@@ -655,7 +666,7 @@ export async function launchWebMode(
       hostKind: 'unresolved',
       hostPath: null,
       hostRoot: null,
-      failureReason: `refusing to disable auth on non-loopback host ${host}: this exposes terminal and file APIs to the network. Bind to 127.0.0.1, keep token auth on, or set GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 to override. See docs/user-docs/web-interface.md.`,
+      failureReason: unauthenticatedLanRefusalReason(host),
       candidates: [],
     }
     emitLaunchStatus(stderr, failure)


### PR DESCRIPTION
## Linked issue

Closes #1635

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** The `--no-auth` LAN refusal error now includes Unix, PowerShell, and CMD env recipes, and the same recipes are in the web-interface and CLI-flag docs.
**Why:** `--no-auth` on a non-loopback bind still requires `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1`, but Windows users could not tell how to set that second key.
**How:** Keep the two-key interlock; document copy-paste recipes in the CLI error and in docs.

## What

`--no-auth` (or `GSD_WEB_NO_AUTH=1`) on a non-loopback host is still refused unless `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` is also set. This PR does not weaken that interlock.

The refusal error now includes per-OS recipes:

- Unix: `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1 gsd --web --host 0.0.0.0 --no-auth`
- PowerShell: `$env:GSD_WEB_ALLOW_UNAUTHENTICATED_LAN="1"; gsd --web --host 0.0.0.0 --no-auth`
- CMD: `set GSD_WEB_ALLOW_UNAUTHENTICATED_LAN=1` then `gsd --web --host 0.0.0.0 --no-auth`

The same recipes are in `docs/user-docs/web-interface.md` and `gitbook/reference/cli-flags.md`.

## Why

Issue #1635 asked whether `--no-auth` should imply unauthenticated LAN, and asked for Windows/Unix env recipes. `--no-auth` alone must not expose LAN; the second env key stays required. The missing piece was copy-paste documentation in the error and docs.

## How

- `unauthenticatedLanRefusalReason()` builds the refusal text with Unix, PowerShell, and CMD recipes.
- Docs show the same recipes next to the interlock explanation.
- The existing refusal test now asserts the error includes `GSD_WEB_ALLOW_UNAUTHENTICATED_LAN` and a PowerShell `$env:` example.

## Change type

- [x] `fix` — Bug fix

## Scope

CLI web-mode launch + user docs.

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] New/updated tests included
- [x] Manual testing — ran `src/tests/integration/web-mode-network-flags.test.ts` (18 pass) and `pnpm run verify:fast`
- [ ] CI passes

## AI disclosure

- [ ] This PR includes AI-assisted code