### PR TITLE
fix(issue): mcp_call never sends request _meta (#1792)

### DIFF
--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -588,11 +588,18 @@ export default function (pi: ExtensionAPI) {
 			),
 		}),
 
-		async execute(_id, params, signal, _onUpdate, ctx) {
+		async execute(toolCallId, params, signal, _onUpdate, ctx) {
 			try {
 				const client = await getOrConnect(params.server, signal, ctx);
 				const result = await client.callTool(
-					{ name: params.tool, arguments: params.args ?? {} },
+					{
+						name: params.tool,
+						arguments: params.args ?? {},
+						_meta: {
+							"claudecode/toolUseId": toolCallId,
+							"io.opengsd/idempotency-key": `pi:${toolCallId}`,
+						},
+					},
 					undefined,
 					{ signal, timeout: 60000 },
 				);

--- a/src/resources/extensions/mcp-client/tests/mcp-call-meta.test.ts
+++ b/src/resources/extensions/mcp-client/tests/mcp-call-meta.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression test for #1792 — mcp_call must attach replay-stable request _meta
+ * on CallTool so servers that require io.opengsd/idempotency-key or
+ * claudecode/toolUseId can accept mutations.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import mcpClientExtension, { _resetMcpClientStateForTest } from "../index.js";
+
+function createMockPi(): { pi: unknown; tools: Map<string, any> } {
+	const tools = new Map<string, any>();
+	return {
+		tools,
+		pi: {
+			on() {},
+			registerTool(tool: any) {
+				tools.set(tool.name, tool);
+			},
+		},
+	};
+}
+
+test("mcp_call CallTool request params include replay-stable _meta (#1792)", async () => {
+	const previousGsdHome = process.env.GSD_HOME;
+	const originalCwd = process.cwd();
+	const projectDir = mkdtempSync(join(tmpdir(), "mcp-call-meta-project-"));
+	const gsdHomeDir = mkdtempSync(join(tmpdir(), "mcp-call-meta-home-"));
+
+	try {
+		process.env.GSD_HOME = gsdHomeDir;
+		process.chdir(projectDir);
+		mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+
+		const require = createRequire(import.meta.url);
+		const mcpModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/mcp.js")).href;
+		const stdioModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/stdio.js")).href;
+		const serverPath = join(projectDir, "echo-meta-mcp-server.mjs");
+		writeFileSync(
+			serverPath,
+			[
+				`const { McpServer } = await import(${JSON.stringify(mcpModuleUrl)});`,
+				`const { StdioServerTransport } = await import(${JSON.stringify(stdioModuleUrl)});`,
+				'const server = new McpServer({ name: "echo-meta", version: "1.0.0" }, { capabilities: { tools: {} } });',
+				'server.tool("echo_meta", "Echo request _meta", {}, async (_args, extra) => ({',
+				'  content: [{ type: "text", text: JSON.stringify(extra?._meta ?? null) }],',
+				"}));",
+				"await server.connect(new StdioServerTransport());",
+			].join("\n"),
+			"utf-8",
+		);
+		writeFileSync(
+			join(projectDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					"echo-meta": { command: process.execPath, args: [serverPath] },
+				},
+			}),
+			"utf-8",
+		);
+
+		const { pi, tools } = createMockPi();
+		mcpClientExtension(pi as any);
+		const mcpCall = tools.get("mcp_call");
+		assert.ok(mcpCall, "mcp_call must be registered");
+
+		const ctx = {
+			hasUI: true,
+			ui: {
+				confirm: async () => true,
+			},
+		};
+		const toolCallId = "tool-call-1792";
+		const result = await mcpCall.execute(
+			toolCallId,
+			{ server: "echo-meta", tool: "echo_meta", args: {} },
+			new AbortController().signal,
+			() => {},
+			ctx,
+		);
+
+		const meta = JSON.parse(result.content[0]?.text ?? "");
+		assert.notEqual(meta, null);
+		assert.equal(typeof meta, "object");
+		assert.equal(meta["claudecode/toolUseId"], toolCallId);
+		assert.equal(meta["io.opengsd/idempotency-key"], `pi:${toolCallId}`);
+	} finally {
+		await _resetMcpClientStateForTest();
+		process.chdir(originalCwd);
+		if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+		else process.env.GSD_HOME = previousGsdHome;
+		rmSync(projectDir, { recursive: true, force: true });
+		rmSync(gsdHomeDir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## TL;DR

**What:** `mcp_call` now attaches replay-stable CallTool request `_meta`.
**Why:** gsd-workflow write tools reject mutations unless `_meta` includes `io.opengsd/idempotency-key` or `claudecode/toolUseId`.
**How:** Derive `_meta` from the tool call id and send it as a sibling of `arguments`, not inside `args`.

## What

The built-in MCP client `mcp_call` tool built CallTool params with only `name` and `arguments`. MCP servers that require replay-stable request metadata never received `_meta`, so every gsd-workflow write tool failed before doing work.

This change:
- Sets `_meta["claudecode/toolUseId"]` to the `mcp_call` tool call id
- Sets `_meta["io.opengsd/idempotency-key"]` to `pi:<toolCallId>` so retries of the same logical call stay stable
- Adds a stdio MCP server test that echoes `extra._meta` and asserts both keys are present on the request

## Why

Closes #1792

Putting `_meta` inside `args` does not work: the SDK exposes `request.params._meta`, and server-side schemas strip argument-level `_meta`. Claude Code clients already inject `claudecode/toolUseId`; pi did not.

## How

In `mcp_call` execute, `client.callTool` now sends:

```ts
_meta: {
  "claudecode/toolUseId": toolCallId,
  "io.opengsd/idempotency-key": `pi:${toolCallId}`,
}
```

No new `mcp_call` input field. Transport metadata is generated from the invocation identity.

### Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes