### PR TITLE
fix(issue): scanDbHierarchy counts skipped slices omitted from ROADMAP (#1860)

### DIFF
--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -15,6 +15,7 @@ import {
   resolveMilestoneFile,
   resolveSliceFile,
 } from "./paths.js";
+import { isHiddenFromRoadmap } from "./status-guards.js";
 
 export interface HierarchyCounts {
   milestones: number;
@@ -235,11 +236,17 @@ export function scanDbHierarchy(): HierarchyScan {
 
   for (const milestone of milestones) {
     scan.milestones.add(milestone.id);
-    const slices = getMilestoneSlices(milestone.id);
+    // Match renderRoadmapFromDb so skipped slices/tasks omitted from ROADMAP/PLAN
+    // are not counted as markdown-hierarchy drift (#1860).
+    const slices = getMilestoneSlices(milestone.id).filter(
+      (slice) => !isHiddenFromRoadmap(slice.status),
+    );
     scan.counts.slices += slices.length;
     for (const slice of slices) {
       scan.slices.add(`${milestone.id}/${slice.id}`);
-      const tasks = getSliceTasks(milestone.id, slice.id);
+      const tasks = getSliceTasks(milestone.id, slice.id).filter(
+        (task) => !isHiddenFromRoadmap(task.status),
+      );
       scan.counts.tasks += tasks.length;
       for (const task of tasks) {
         scan.tasks.add(`${milestone.id}/${slice.id}/${task.id}`);

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -178,6 +178,76 @@ test("migration auto-check ignores unplanned DB milestones deliberately omitted 
   assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 1 });
 });
 
+test("migration auto-check omits skipped slices and tasks that ROADMAP/PLAN omit (#1860)", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory({ projectContent: "# P\n", decisionsContent: "", requirements: [], milestones: [] }, base);
+    assert.equal(await ensureDbOpen(base), true);
+
+    insertMilestone({
+      id: "M001",
+      title: "Planned Milestone",
+      status: "active",
+      planning: { vision: "Keep planned work visible." },
+    });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Visible slice",
+      status: "complete",
+      risk: "low",
+      depends: [],
+      demo: "Visible work ships.",
+      sequence: 1,
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Visible task",
+      status: "complete",
+    });
+    // Skipped T02 is omitted from PLAN; skipped S02 (and its tasks) is omitted
+    // from ROADMAP. Rebuild reproduces that projection; the DB scan must match.
+    insertTask({
+      id: "T02",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Skipped task",
+      status: "skipped",
+    });
+    insertSlice({
+      id: "S02",
+      milestoneId: "M001",
+      title: "Skipped slice",
+      status: "skipped",
+      risk: "low",
+      depends: [],
+      demo: "",
+      sequence: 2,
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S02",
+      milestoneId: "M001",
+      title: "Hidden by skipped slice",
+      status: "complete",
+    });
+
+    const { rebuildMarkdownProjectionsFromDb } = await import("../commands-maintenance.ts");
+    const rebuild = await rebuildMarkdownProjectionsFromDb(base);
+    assert.ok(rebuild.rendered > 0, "expected ROADMAP/PLAN projections to render");
+
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
+    assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("migration auto-check flags a populated DB with missing markdown and points at rebuild (not recover)", async () => {
   const base = makeBase();
   try {


### PR DESCRIPTION
## TL;DR

**What:** `scanDbHierarchy` now omits skipped slices and skipped tasks, matching `renderRoadmapFromDb`.
**Why:** The ROADMAP renderer drops skipped rows while the hierarchy scanner counted them, so `checkMarkdownHierarchyAgainstDb` stayed on `recovery-required` forever.
**How:** Filter both slices and tasks with the existing `isHiddenFromRoadmap` predicate.

## What

`renderRoadmapFromDb` already filters skipped slices with `isHiddenFromRoadmap`. PLAN rendering omits skipped tasks. `scanDbHierarchy` counted every slice and task, so a planned milestone with a skipped slice (or a skipped task in a visible slice) could never reach `in-sync`.

`rebuildMarkdownProjectionsFromDb` re-renders through the same filter, so auto-rebuild reproduced the omission and left the drift verdict unchanged.

This PR applies that same predicate in `scanDbHierarchy` only. The `scanMarkdownHierarchy` path is left alone to keep the conflict surface with #1868 small.

## Why

Skipped rows are omitted from ROADMAP/PLAN by design. Counting them on the DB side made the markdown-hierarchy check report permanent drift, with no user-side repair: hand-adding the omitted rows is reverted as external-markdown-edit, and rebuild writes the same omission again.

Closes #1860

## How

- Import `isHiddenFromRoadmap` from `status-guards`.
- Skip hidden slices before counting or walking tasks (so a skipped slice also drops its tasks, matching ROADMAP-driven markdown scanning).
- Skip hidden tasks in visible slices, matching PLAN omission.
- Add a regression test that rebuilds projections for a planned milestone with one skipped slice and one skipped task, then asserts `in-sync` at 1/1/1.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None. Hierarchy counts used by recover/migration verification now match projected markdown, which is the intended parity contract.