### PR TITLE
fix(issue): background Agent subagents killed 600s after turn (#1855)

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -2137,6 +2137,31 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
 	});
 }
 
+/** CLI print-mode drain kills leftover background Agent tasks after this many ms. */
+export const CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV = "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS";
+/** `0` waits indefinitely. Operators override by setting the env var. */
+const DEFAULT_CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS = "0";
+const CLAUDE_CODE_PRINT_WIND_DOWN_RE =
+	/Background tasks still running after|print wind-down|CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS/i;
+
+/** `"0"` disables the CLI's 600s post-result background-task kill. */
+function withClaudeCodePrintBgWaitCeiling(
+	sourceEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+	const env = { ...sourceEnv };
+	if (!env[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV]?.trim()) {
+		env[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV] = DEFAULT_CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS;
+	}
+	return env;
+}
+
+/** Surface print wind-down / termination lines the SDK otherwise discards. */
+function logClaudeCodeSdkStderr(data: unknown): void {
+	const text = String(data);
+	if (!CLAUDE_CODE_PRINT_WIND_DOWN_RE.test(text)) return;
+	console.warn(`[claude-code] ${text.trimEnd()}`);
+}
+
 /**
  * Build the options object passed to the Claude Agent SDK's `query()` call.
  *
@@ -2147,6 +2172,9 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
  * {@link resolveClaudePermissionMode} so interactive runs don't silently
  * bypass the SDK's permission gate. Callers that want the old always-bypass
  * behaviour pass `permissionMode: "bypassPermissions"` explicitly.
+ *
+ * Long-lived sessions default `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` to `"0"`
+ * unless already set, and attach an stderr sink for print wind-down warnings.
  */
 export function buildSdkOptions(
 	modelId: string,
@@ -2154,7 +2182,7 @@ export function buildSdkOptions(
 	overrides?: { permissionMode?: "bypassPermissions" | "acceptEdits" | "default" | "plan" },
 	extraOptions: Record<string, unknown> & { reasoning?: ThinkingLevel; gsdPhase?: string } = {},
 ): Record<string, unknown> {
-	const { reasoning, cwd, gsdPhase, ...sdkExtraOptions } = extraOptions;
+	const { reasoning, cwd, gsdPhase, env: extraEnv, stderr: extraStderr, ...sdkExtraOptions } = extraOptions;
 	const sdkCwd = typeof cwd === "string" && cwd.trim().length > 0 ? cwd : process.cwd();
 	// Claude Code runs in the milestone worktree for file/shell work, but workflow MCP
 	// config (.mcp.json) and server discovery live at the project root.
@@ -2351,6 +2379,10 @@ export function buildSdkOptions(
 		...(thinkingConfig ?? {}),
 		...(effort ? { effort } : {}),
 		...sdkExtraOptions,
+		env: withClaudeCodePrintBgWaitCeiling(
+			isRecord(extraEnv) ? { ...process.env, ...extraEnv as NodeJS.ProcessEnv } : process.env,
+		),
+		stderr: typeof extraStderr === "function" ? extraStderr : logClaudeCodeSdkStderr,
 	};
 }
 
@@ -2450,7 +2482,9 @@ function injectMilestoneStatusObservationToken(
 	workflowServerName: string | undefined,
 	token: string | null,
 ): void {
-	const childEnv = { ...process.env };
+	const childEnv = withClaudeCodePrintBgWaitCeiling(
+		isRecord(sdkOptions.env) ? sdkOptions.env as NodeJS.ProcessEnv : process.env,
+	);
 	delete childEnv[MILESTONE_STATUS_OBSERVATION_TOKEN_ENV];
 	if (token) childEnv[MILESTONE_STATUS_OBSERVATION_TOKEN_ENV] = token;
 	sdkOptions.env = childEnv;

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -21,6 +21,7 @@ import {
 	buildPromptFromContext,
 	buildSdkQueryPrompt,
 	buildSdkOptions,
+	CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV,
 	resolveClaudeCodeCwd,
 	createClaudeCodeCanUseToolHandler,
 	buildBashPermissionPattern,
@@ -1525,6 +1526,96 @@ describe("claude-code-cli — Claude Fable 5 Opus-tier support", () => {
 		const options = buildSdkOptions("claude-haiku-4-5", "test prompt", undefined, { reasoning: "xhigh" });
 		assert.equal(options.effort, "high", "xhigh must clamp to high for non-Opus-tier models");
 		assert.deepEqual(options.betas, [], "Haiku must not enable the 1M-context beta");
+	});
+});
+
+describe("stream-adapter — print bg wait ceiling (#1855)", () => {
+	function withCeilingEnv(value: string | undefined): () => void {
+		const previous = process.env[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV];
+		if (value === undefined) {
+			delete process.env[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV];
+		} else {
+			process.env[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV] = value;
+		}
+		return () => {
+			if (previous === undefined) {
+				delete process.env[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV];
+			} else {
+				process.env[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV] = previous;
+			}
+		};
+	}
+
+	test("buildSdkOptions includes CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 unless already set", () => {
+		const restore = withCeilingEnv(undefined);
+		try {
+			const options = buildSdkOptions("claude-sonnet-4-20250514", "test prompt");
+			const env = options.env as NodeJS.ProcessEnv | undefined;
+			assert.equal(env?.[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV], "0");
+			assert.equal(typeof options.stderr, "function");
+		} finally {
+			restore();
+		}
+	});
+
+	test("buildSdkOptions preserves an existing CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS", () => {
+		const restore = withCeilingEnv("20000");
+		try {
+			const options = buildSdkOptions("claude-sonnet-4-20250514", "test prompt");
+			const env = options.env as NodeJS.ProcessEnv | undefined;
+			assert.equal(env?.[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV], "20000");
+		} finally {
+			restore();
+		}
+	});
+
+	test("buildSdkOptions stderr sink logs the CLI print wind-down warning", () => {
+		const options = buildSdkOptions("claude-sonnet-4-20250514", "test prompt");
+		const stderr = options.stderr as (data: unknown) => void;
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args.map(String).join(" "));
+		};
+		try {
+			stderr("Background tasks still running after 600s; terminating.\nSet CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 to wait indefinitely.\n");
+			stderr("unrelated cli chatter\n");
+			assert.equal(warnings.length, 1);
+			assert.match(warnings[0]!, /\[claude-code\].*Background tasks still running after 600s/);
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+
+	test("query options keep the print bg wait ceiling after observation-token injection", async () => {
+		const restore = withCeilingEnv(undefined);
+		const cwd = mkdtempSync(join(tmpdir(), "claude-sdk-bg-wait-"));
+		let capturedEnv: NodeJS.ProcessEnv | undefined;
+		let capturedStderr: unknown;
+		try {
+			const stream = streamViaClaudeCode(
+				{ id: "claude-sonnet-4-6" } as any,
+				{ messages: [{ role: "user", content: "Continue." } as Message] },
+				{
+					cwd,
+					_skipWorkflowMcpPreflightForTest: true,
+					async *_sdkQueryForTest(args: {
+						prompt: string | AsyncIterable<unknown>;
+						options?: Record<string, unknown>;
+					}) {
+						capturedEnv = args.options?.env as NodeJS.ProcessEnv | undefined;
+						capturedStderr = args.options?.stderr;
+						yield makeSdkSuccessResult("finished");
+					},
+				} as any,
+			);
+			await stream.result();
+			assert.equal(capturedEnv?.[CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS_ENV], "0");
+			assert.equal(typeof capturedStderr, "function");
+		} finally {
+			restore();
+			rmSync(cwd, { recursive: true, force: true });
+		}
 	});
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Stop Claude Code SDK sessions from killing background Agent subagents 600s after the turn result.
**Why:** `query()` inherited the CLI `--print` wind-down ceiling and discarded the stderr warning that explained the kill.
**How:** Default `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` unless already set, and log print wind-down lines via an SDK `stderr` sink.

## What

In `claude-code-cli/stream-adapter.ts`:
- `buildSdkOptions` now passes `env` with `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` set to `"0"` unless the process (or extra) env already has a value.
- `query()` gets an `stderr` sink that `console.warn`s CLI print wind-down / termination lines.
- Observation-token env injection preserves that ceiling instead of replacing env from a raw `process.env` clone.

## Why

Closes #1855. Long-lived GSD sessions leave background Agent subagents running after the turn `result`. The CLI print-mode drain then swept them at 600s, labelled the death "stopped by user", and the SDK dropped stderr so the real reason was invisible.

## How

`"0"` is the CLI's documented indefinite wait. Operators can restore a finite ceiling by setting the env var. Deliberate aborts still go through `options.signal`.

## Verification

- `src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts` — 213 passed, including `buildSdkOptions includes CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 unless already set`

## Change type

- [x] `fix` — Bug fix