### PR TITLE
fix(issue): migration staging resolves to live repo .gsd (#1866)

### DIFF
--- a/src/resources/extensions/gsd/migrate/execution.ts
+++ b/src/resources/extensions/gsd/migrate/execution.ts
@@ -19,7 +19,7 @@ import {
 } from "../legacy-import-application-result.js";
 import { executeLegacyImportRecoveryAction } from "../legacy-import-recovery-action.js";
 import { captureCurrentLegacyImportBaseSnapshot } from "../legacy-import-preview-base.js";
-import { gsdRoot } from "../paths.js";
+import { gsdRoot, MIGRATION_STAGING_DIR_PREFIX } from "../paths.js";
 import { loadManagedProjectionPaths } from "../managed-projection-history.js";
 import { deriveState, invalidateStateCache } from "../state.js";
 import {
@@ -566,7 +566,6 @@ export async function assertMigrationDbReadiness(
   };
 }
 
-const MIGRATION_STAGING_PREFIX = ".gsd-migrate-stage-";
 /**
  * Staging trees younger than this may belong to a concurrent in-flight
  * migration; only older trees are treated as SIGKILL leak remnants.
@@ -575,7 +574,7 @@ const MIGRATION_STAGING_STALE_MS = 60 * 60 * 1000;
 
 export function sweepStaleMigrationStaging(targetRoot: string, now: number = Date.now()): void {
   for (const entry of readdirSync(targetRoot, { withFileTypes: true })) {
-    if (!entry.name.startsWith(MIGRATION_STAGING_PREFIX)) continue;
+    if (!entry.name.startsWith(MIGRATION_STAGING_DIR_PREFIX)) continue;
     if (entry.isSymbolicLink() || !entry.isDirectory()) continue;
     const path = join(targetRoot, entry.name);
     if (now - lstatSync(path).mtimeMs < MIGRATION_STAGING_STALE_MS) continue;
@@ -594,11 +593,11 @@ export async function executeMigrationWrite(
   const projectionRootIdentity = proveMigrationProjectionRoot(targetRoot);
   sweepStaleMigrationStaging(targetRoot);
   pruneMigrationPublications(targetRoot, projectionRootIdentity);
-  const stagingRoot = mkdtempSync(join(targetRoot, ".gsd-migrate-stage-"));
+  const stagingRoot = mkdtempSync(join(targetRoot, MIGRATION_STAGING_DIR_PREFIX));
 
   try {
     const staged = await writeGSDDirectory(project, stagingRoot);
-    const stagedGsd = gsdRoot(stagingRoot);
+    const stagedGsd = join(stagingRoot, ".gsd");
     const requestHash = migrationPublicationRequestHash(sourcePath, stagedGsd);
     const retained = findMigrationPublication(sourcePath, targetRoot, requestHash, projectionRootIdentity);
     if (retained) {

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -557,6 +557,19 @@ function isInsideGsdWorktree(p: string): boolean {
   return name.length > 0;
 }
 
+/** Prefix used by executeMigrationWrite temp dirs (`mkdtempSync(join(targetRoot, prefix))`). */
+export const MIGRATION_STAGING_DIR_PREFIX = ".gsd-migrate-stage-";
+
+/**
+ * Detect a path inside a `.gsd-migrate-stage-*` temp dir.
+ *
+ * Staging lives under the target repo, so the git-root probe would otherwise
+ * resolve to the live repo `.gsd` and write staged projection there (#1866).
+ */
+function isInsideMigrationStaging(p: string): boolean {
+  return p.replaceAll("\\", "/").split("/").some((seg) => seg.startsWith(MIGRATION_STAGING_DIR_PREFIX));
+}
+
 function probeGsdRoot(rawBasePath: string): string {
   const contract = resolveGsdPathContract(rawBasePath);
   if (contract.isWorktree) return contract.projectGsd;
@@ -572,6 +585,10 @@ function probeGsdRoot(rawBasePath: string): string {
   //     state in the wrong location.
   if (isInsideGsdWorktree(rawBasePath)) return local;
 
+  // 1c. Migration staging (#1866) — temp dirs live inside the target repo, so
+  //     git-root / walk-up would return the live `.gsd`. Keep staging local.
+  if (isInsideMigrationStaging(rawBasePath)) return local;
+
   // Resolve symlinks so path comparisons work correctly across platforms
   // (e.g. macOS /var → /private/var). Use rawBasePath as fallback if not resolvable.
   let basePath: string;
@@ -579,6 +596,7 @@ function probeGsdRoot(rawBasePath: string): string {
 
   // Also check the resolved path for the worktree pattern (macOS /tmp → /private/tmp)
   if (basePath !== rawBasePath && isInsideGsdWorktree(basePath)) return local;
+  if (basePath !== rawBasePath && isInsideMigrationStaging(basePath)) return local;
 
   // 2. Git root anchor — used as both probe target and walk-up boundary
   //    Only walk if we're inside a git project — prevents escaping into

--- a/src/resources/extensions/gsd/tests/integration/paths.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/paths.test.ts
@@ -277,4 +277,18 @@ describe('paths', () => {
       cleanup(root);
     }
   });
+
+  test('Case 12: migration staging under a git repo does not resolve to the live .gsd (#1866)', (t) => {
+    const root = tmp();
+    t.after(() => cleanup(root));
+    initGit(root);
+    const liveGsd = join(root, ".gsd");
+    mkdirSync(liveGsd);
+    writeFileSync(join(liveGsd, "PROJECT.md"), "# live\n");
+    const stagingRoot = mkdtempSync(join(root, ".gsd-migrate-stage-"));
+    _clearGsdRootCache();
+    const result = gsdRoot(stagingRoot);
+    assert.deepStrictEqual(result, join(stagingRoot, ".gsd"), "staging probe returns stagingRoot/.gsd");
+    assert.notDeepStrictEqual(result, liveGsd, "staging probe must not return the live git-root .gsd");
+  });
 });

--- a/src/resources/extensions/gsd/tests/paths-migration-staging.test.ts
+++ b/src/resources/extensions/gsd/tests/paths-migration-staging.test.ts
@@ -1,0 +1,25 @@
+// gsd-pi — gsdRoot must not follow git-root from migration staging into the live .gsd (#1866)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, realpathSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+import { gsdRoot, _clearGsdRootCache } from "../paths.ts";
+
+test("gsdRoot on .gsd-migrate-stage-* does not return the live git-root .gsd (#1866)", (t) => {
+  const root = realpathSync.native(mkdtempSync(join(tmpdir(), "gsd-migrate-stage-probe-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  spawnSync("git", ["init"], { cwd: root });
+  spawnSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: root });
+  const liveGsd = join(root, ".gsd");
+  mkdirSync(liveGsd);
+  writeFileSync(join(liveGsd, "PROJECT.md"), "# live\n");
+  const stagingRoot = mkdtempSync(join(root, ".gsd-migrate-stage-"));
+  _clearGsdRootCache();
+  const result = gsdRoot(stagingRoot);
+  assert.equal(result, join(stagingRoot, ".gsd"));
+  assert.notEqual(result, liveGsd);
+});


### PR DESCRIPTION
## TL;DR

**What:** Migration staging now resolves to `stagingRoot/.gsd` instead of the live git-root `.gsd`.
**Why:** `probeGsdRoot` followed git-root from `.gsd-migrate-stage-*` temp dirs, so staged writes and retained-evidence hashes hit the live tree and migration could not complete.
**How:** Skip the git-root / walk-up probe when the path is under `.gsd-migrate-stage-*`, and hash `join(stagingRoot, ".gsd")` directly.

## What

`executeMigrationWrite` stages via `mkdtempSync(join(targetRoot, ".gsd-migrate-stage-"))`. `writeGSDDirectory` then calls `gsdRoot(stagingRoot)`. Because that temp dir sits inside the target repo and does not yet contain `.gsd`, `probeGsdRoot` took the git-root path and returned the live repo `.gsd`.

This change:
- special-cases `.gsd-migrate-stage-*` in `probeGsdRoot` so staging stays at `stagingRoot/.gsd`
- uses `join(stagingRoot, ".gsd")` for the retained-evidence hash instead of re-probing
- shares the staging prefix between `paths.ts` and `execution.ts` so the skip and `mkdtemp` cannot drift

Does not touch `migration-auto-check.ts`.

## Why

With a live `.gsd` already present (including after auto-init), staging wrote into the live tree. The retained-evidence hash then included `gsd.db`, WAL, and notifications, so publication never matched:

```
Migration failed without replacing database authority; any committed Import Application was retained: migration publication retained evidence does not match the reviewed request hash
```

Closes #1866

## How

`isInsideMigrationStaging` treats any path segment starting with `.gsd-migrate-stage-` like the existing worktree guard: return `join(basePath, ".gsd")` and skip git-root / ancestor walk-up. Normal subdirectory probes are unchanged.

A unit test and the paths probe suite both fail if `gsdRoot(stagingRoot)` returns the live git-root `.gsd`.

- [x] `fix` — Bug fix