### PR TITLE
fix(issue): team-suffix milestone ids create divergent phase dirs (#1581)

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -87,10 +87,8 @@ import { applyStatusTransition } from "./db/writers/status.js";
 export { projectCanonicalStatusToLegacy } from "./db/writers/status.js";
 import {
   LAYOUT_SEGMENTS,
-  derivePhaseSlug,
+  canonicalPhaseDirName,
   milestoneIdToPhaseNum,
-  milestoneIdUniqueSuffix,
-  phaseDirName,
 } from "./layout-policy.js";
 
 export function insertDecision(d: Omit<Decision, "seq">): void {
@@ -231,17 +229,10 @@ export function insertArtifact(a: {
   }));
 }
 
-function canonicalPhaseDirNameForDb(milestoneId: string, title: string): string {
-  const phaseNum = milestoneIdToPhaseNum(milestoneId);
-  const slug = derivePhaseSlug(title || milestoneId);
-  const suffix = milestoneIdUniqueSuffix(milestoneId);
-  return phaseDirName(phaseNum, suffix ? `${suffix}-${slug}` : slug);
-}
-
 function reconcileMilestonePhaseArtifactPaths(milestoneId: string, title: string): void {
   const db = getDbOrNull()!;
   const phaseNumPrefix = String(milestoneIdToPhaseNum(milestoneId)).padStart(2, "0");
-  const canonicalDir = canonicalPhaseDirNameForDb(milestoneId, title);
+  const canonicalDir = canonicalPhaseDirName(milestoneId, title);
   const staleRows = db.prepare(
     `SELECT path
        FROM artifacts

--- a/src/resources/extensions/gsd/layout-policy.ts
+++ b/src/resources/extensions/gsd/layout-policy.ts
@@ -53,10 +53,12 @@ export function milestoneIdToPhaseNum(milestoneId: string): number {
   return m ? Number.parseInt(m[1]!, 10) : 1;
 }
 
+const TEAM_MILESTONE_ID_RE = /^M(\d{3})(?:-([a-z0-9]{6}))?$/i;
+const LEADING_MILESTONE_ID_TOKENS = /^(?:M\d{3}(?:-[a-z0-9]{6})?(?:[\s:_-]+|$))+/i;
+
 /** Team-mode suffix from milestone ids like M001-abc123. */
 export function milestoneIdUniqueSuffix(milestoneId: string): string | undefined {
-  const m = milestoneId.match(/^M(\d{3})(?:-([a-z0-9]{6}))?$/);
-  return m?.[2];
+  return milestoneId.match(TEAM_MILESTONE_ID_RE)?.[2]?.toLowerCase();
 }
 
 /**
@@ -76,11 +78,31 @@ export function sliceIdToPlanNum(sliceId: string): number {
  * same title on every run, or the directory churns on every projection.
  */
 export function derivePhaseSlug(title: string): string {
-  const slug = title
+  const trimmed = title.trim();
+  const withoutIds = trimmed.replace(LEADING_MILESTONE_ID_TOKENS, "").trim();
+  const source = withoutIds || trimmed;
+  const slug = source
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 40)
     .replace(/-+$/g, "");
   return slug || "phase";
+}
+
+/**
+ * Canonical flat-phase directory name for a milestone.
+ * Team-suffix ids contribute the suffix once; title text that already
+ * contains the milestone id is not baked into the slug a second time.
+ */
+export function canonicalPhaseDirName(milestoneId: string, title?: string): string {
+  const phaseNum = milestoneIdToPhaseNum(milestoneId);
+  const suffix = milestoneIdUniqueSuffix(milestoneId);
+  const idSlug = derivePhaseSlug(milestoneId);
+  const slug = derivePhaseSlug(title || milestoneId);
+  const rest = slug === idSlug ? "" : slug;
+  if (suffix) {
+    return phaseDirName(phaseNum, rest ? `${suffix}-${rest}` : suffix);
+  }
+  return phaseDirName(phaseNum, rest || idSlug);
 }

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -20,13 +20,15 @@ import { gsdHome } from "./gsd-home.js";
 import { findWorktreeSegment, isGsdWorktreePath, resolveExternalStateProjectGsdFromWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
 import {
   LAYOUT_SEGMENTS,
-  phaseDirName,
   planFileName,
   milestoneIdToPhaseNum,
   milestoneIdUniqueSuffix,
   sliceIdToPlanNum,
-  derivePhaseSlug,
+  canonicalPhaseDirName,
 } from "./layout-policy.js";
+
+export { canonicalPhaseDirName };
+
 // ─── Directory Listing Cache ──────────────────────────────────────────────────
 
 const dirEntryCache = new Map<string, Dirent[]>();
@@ -806,21 +808,6 @@ function resolvePhaseDir(basePath: string, milestoneId: string): string | null {
     }
   }
   return null;
-}
-
-/**
- * Derive the canonical phase dir name for a milestone when it doesn't exist yet.
- * Used by the renderer to create new phase dirs, and by ensurePreconditions to
- * scaffold the correct NN-slug directory on disk before the first render.
- */
-export function canonicalPhaseDirName(milestoneId: string, title?: string): string {
-  const phaseNum = milestoneIdToPhaseNum(milestoneId);
-  const slug = derivePhaseSlug(title || milestoneId);
-  const suffix = milestoneIdUniqueSuffix(milestoneId);
-  if (suffix) {
-    return phaseDirName(phaseNum, `${suffix}-${slug}`);
-  }
-  return phaseDirName(phaseNum, slug);
 }
 
 export function resolveRuntimeFile(basePath: string): string {

--- a/src/resources/extensions/gsd/tests/layout-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/layout-policy.test.ts
@@ -10,8 +10,10 @@ import {
   planFileName,
   dbPath,
   milestoneIdToPhaseNum,
+  milestoneIdUniqueSuffix,
   sliceIdToPlanNum,
   derivePhaseSlug,
+  canonicalPhaseDirName,
 } from "../layout-policy.ts";
 
 test("LAYOUT_ROOT is .gsd", () => {
@@ -61,4 +63,52 @@ test("derivePhaseSlug is stable and deterministic", () => {
 test("derivePhaseSlug falls back when title is empty or punctuation-only", () => {
   assert.equal(derivePhaseSlug(""), "phase");
   assert.equal(derivePhaseSlug("---"), "phase");
+});
+
+test("milestoneIdUniqueSuffix extracts the team suffix", () => {
+  assert.equal(milestoneIdUniqueSuffix("M001-abc123"), "abc123");
+  assert.equal(milestoneIdUniqueSuffix("M009-obg27g"), "obg27g");
+  assert.equal(milestoneIdUniqueSuffix("M001"), undefined);
+  assert.equal(milestoneIdUniqueSuffix("M012"), undefined);
+});
+
+test("milestoneIdUniqueSuffix is case-insensitive like milestoneIdToPhaseNum (#1581)", () => {
+  assert.equal(milestoneIdUniqueSuffix("m009-obg27g"), "obg27g");
+  assert.equal(milestoneIdUniqueSuffix("M009-OBG27G"), "obg27g");
+  assert.equal(milestoneIdToPhaseNum("m009-obg27g"), 9);
+  assert.equal(milestoneIdUniqueSuffix("m001"), undefined);
+});
+
+test("derivePhaseSlug strips leading milestone id tokens from concatenated titles (#1581)", () => {
+  assert.equal(derivePhaseSlug("M009-obg27g Web API"), "web-api");
+  assert.equal(derivePhaseSlug("m009-obg27g M009-obg27g Web API"), "web-api");
+  assert.equal(derivePhaseSlug("M001 Foundation"), "foundation");
+});
+
+test("derivePhaseSlug keeps an id-only title as the slug placeholder", () => {
+  assert.equal(derivePhaseSlug("M001"), "m001");
+  assert.equal(derivePhaseSlug("M009-obg27g"), "m009-obg27g");
+});
+
+test("canonicalPhaseDirName keeps unsuffixed id-only names as NN-mNNN", () => {
+  assert.equal(canonicalPhaseDirName("M001"), "01-m001");
+  assert.equal(canonicalPhaseDirName("M001", "Foundation"), "01-foundation");
+});
+
+test("canonicalPhaseDirName does not bake a team-suffix id into the slug twice (#1581)", () => {
+  assert.equal(canonicalPhaseDirName("M009-obg27g", "Web API"), "09-obg27g-web-api");
+  assert.equal(canonicalPhaseDirName("M009-obg27g", "M009-obg27g Web API"), "09-obg27g-web-api");
+  assert.equal(canonicalPhaseDirName("M009-obg27g", "M009-obg27g"), "09-obg27g");
+  assert.equal(canonicalPhaseDirName("M009-obg27g"), "09-obg27g");
+});
+
+test("canonicalPhaseDirName matches lowercase team-suffix ids to one spelling (#1581)", () => {
+  assert.equal(
+    canonicalPhaseDirName("m009-obg27g", "M009-obg27g Web API"),
+    "09-obg27g-web-api",
+  );
+  assert.equal(
+    canonicalPhaseDirName("m009", "m009-obg27g M009-obg27g Web API"),
+    "09-web-api",
+  );
 });


### PR DESCRIPTION
## TL;DR

**What:** Team-suffix milestone ids now resolve to one canonical phase directory spelling.
**Why:** A case-sensitive suffix regex plus title-in-slug concat created two dirs per milestone on Linux.
**How:** Make the suffix regex case-insensitive and stop baking the milestone id into the phase slug twice.

## What

`layout-policy.ts` is the single source of truth for canonical phase dir names:

- `milestoneIdUniqueSuffix` now matches `/i` (same as `milestoneIdToPhaseNum`) and lowercases the captured suffix.
- `derivePhaseSlug` strips leading milestone-id tokens from concatenated titles (`M009-obg27g Web API` → `web-api`).
- `canonicalPhaseDirName` lives in layout-policy: team suffix is prepended once; id-only titles do not add a second copy of the id.
- `paths.ts` re-exports it; `gsd-db.ts` uses the same helper instead of a duplicate.

Out of scope: #1526 (rename the on-disk dir when the title later changes), insert-site `title === id` rejection, and doctor duplicate-phase-number checks.

## Why

Closes #1581

On Linux, team-mode ids such as `M009-obg27g` produced two coexisting phase dirs, e.g. `09-obg27g-m009-obg27g-web-api` and `09-m009-obg27g-m009-obg27g-web-api`. Lowercased ids missed the suffix regex, and titles that already contained the id were slugged again after the suffix prefix.

## How

- Case-insensitive team-suffix parse so `m009-obg27g` yields suffix `obg27g`.
- Strip leading `MNNN` / `MNNN-xxxxxx` tokens from titles before slugging.
- If the remaining slug is just the milestone id, use the team suffix alone (`09-obg27g`) rather than `09-obg27g-m009-obg27g`.
- Unsuffixed id-only names stay `01-m001`.

Existing sibling-dir resolution still finds older spellings; this PR does not rename on-disk dirs when the title changes (#1526).

## Change type

- [x] `fix` — Bug fix