### PR TITLE
fix(issue): stale projection journal wedges ROADMAP repair without native lock (#1755)

### DIFF
--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -1598,15 +1598,10 @@ function recoverManagedProjectionMutations(
 
 export function loadManagedProjectionPaths(targetRoot: string): string[] {
   if (!isProjectionRootIdentityLockAvailable()) {
-    // Mutation journals can only be recovered through the native identity
-    // lock; fail closed when recovery state exists, otherwise read the
-    // history file directly (same policy as loadUnboundProjectionEvidence).
-    if (existsSync(journalRoot(targetRoot))) {
-      throw new Error("native projection root identity locking is unavailable");
-    }
+    // Journals cannot be replayed without the native identity lock. Skip them
+    // and read history directly so a stale projection-mutations dir cannot
+    // wedge ROADMAP repair forever (#1755).
     const path = historyPath(targetRoot);
-    // Run the read under the write fence so it does not bypass maintenance/
-    // replacement intents, matching the native path and loadUnboundProjectionEvidence.
     return withProjectionMutationSync(path, () => readFallbackManagedProjectionPaths(path));
   }
   const path = historyPath(targetRoot);
@@ -1618,12 +1613,6 @@ export function loadManagedProjectionPaths(targetRoot: string): string[] {
 
 export function loadUnboundProjectionEvidence(targetRoot: string): UnboundProjectionEvidence[] {
   if (!isProjectionRootIdentityLockAvailable()) {
-    const projectionRoot = gsdProjectionRoot(targetRoot);
-    const hasUnsupportedRecoveryState = existsSync(join(projectionRoot, NATIVE_EVIDENCE_LOGICAL_ROOT))
-      || existsSync(journalRoot(targetRoot));
-    if (hasUnsupportedRecoveryState) {
-      throw new Error("native projection root identity locking is unavailable");
-    }
     return withProjectionMutationSync(
       historyPath(targetRoot),
       () => readFallbackUnboundProjectionEvidence(targetRoot),

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -748,27 +748,24 @@ test("loadManagedProjectionPaths returns empty without a history file when the n
   assert.deepEqual(JSON.parse(result.stdout), []);
 });
 
-// The no-native fallback must fail closed when a managed projection mutation
-// journal directory exists: journals can only be recovered through the native
-// identity lock, so reading the history file directly could silently drop
-// pending recovery state. This guards against accidental relaxation of that
-// safety policy back to a plain read.
-test("loadManagedProjectionPaths fails closed with a mutation journal when the native engine is unavailable", (t) => {
-  const base = mkdtempSync(join(tmpdir(), "gsd-history-journal-fail-closed-"));
+test("loadManagedProjectionPaths reads history when a stale mutation journal exists without native lock (#1755)", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-history-journal-fallback-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));
   const migration = join(base, ".gsd", "migration");
-  mkdirSync(migration, { recursive: true });
+  mkdirSync(join(migration, "projection-mutations"), { recursive: true });
   writeFileSync(
     join(migration, "managed-outputs.json"),
     `${JSON.stringify(["phases/01-a/01-PLAN.md"])}\n`,
   );
-  // The presence of the journal directory alone must force fail-closed.
-  mkdirSync(join(migration, "projection-mutations"));
+  writeFileSync(join(migration, "projection-mutations", "dead.json"), "{}\n");
   const moduleUrl = new URL("../managed-projection-history.ts", import.meta.url).href;
   const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
   const script = `
     const { loadManagedProjectionPaths } = await import(${JSON.stringify(moduleUrl)});
-    loadManagedProjectionPaths(process.argv[1]);
+    const paths = loadManagedProjectionPaths(process.argv[1]);
+    if (!paths.includes("phases/01-a/01-PLAN.md")) {
+      throw new Error("expected fallback history paths, got " + JSON.stringify(paths));
+    }
   `;
 
   const result = spawnSync(process.execPath, [
@@ -782,8 +779,7 @@ test("loadManagedProjectionPaths fails closed with a mutation journal when the n
     env: { ...process.env, GSD_NATIVE_DISABLE: "1" },
   });
 
-  assert.notEqual(result.status, 0, "expected the mutation journal to force fail-closed");
-  assert.match(result.stderr, /native projection root identity locking is unavailable/);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
 });
 
 // The native history read opens with AT_SYMLINK_NOFOLLOW, so the plain-fs


### PR DESCRIPTION
## TL;DR

**What:** Do not throw when native projection-root locking is unavailable and a stale mutation journal exists.
**Why:** \`roadmap-missing\` repair could never succeed; resume-wedge retripped forever.
**How:** Fallback reads managed-outputs.json directly and skips journal replay without the native lock.

Closes #1755.