### PR TITLE
fix(issue): ROADMAP render-import grows M### title prefix (#1592)

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -51,6 +51,7 @@ import {
 } from "./paths.js";
 import { saveFile, clearParseCache, registerCacheClearCallback } from "./files.js";
 import { parseProjectionRoadmap } from "./schemas/parsers.js";
+import { stripIdPrefix } from "./strip-id-prefix.js";
 import { invalidateStateCache } from "./state.js";
 import { clearPathCache, milestonesDir, legacyMilestonesDir, isLegacyMilestonesLayout, resolveMilestonePath, relSliceFile, canonicalPhaseDirName } from "./paths.js";
 import { readCompatMarker, writeCompatMarker, computeProjectionSha, deriveCompatProjectionKey } from "./compat/compat-marker.js";
@@ -328,8 +329,9 @@ async function writeAndStore(
 
 function renderRoadmapMarkdown(milestone: MilestoneRow, slices: SliceRow[]): string {
   const lines: string[] = [];
+  const displayTitle = stripIdPrefix(milestone.title || milestone.id, milestone.id);
 
-  lines.push(`# ${milestone.id}: ${milestone.title || milestone.id}`);
+  lines.push(`# ${milestone.id}: ${displayTitle}`);
   lines.push("");
   lines.push(milestone.vision ? `**Vision:** ${milestone.vision}` : "**Vision:**");
   lines.push("");

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -47,6 +47,7 @@ import {
 } from './paths.js';
 import { findMilestoneIds } from './guided-flow.js';
 import { milestoneIdToPhaseNum } from './layout-policy.js';
+import { stripIdPrefix } from './strip-id-prefix.js';
 import { parseProjectionRoadmap as parseRoadmap, parseProjectionPlan as parsePlan } from './schemas/parsers.js';
 import { parseContextDependsOn, parseSummary } from './files.js';
 import { logWarning } from './workflow-logger.js';
@@ -717,7 +718,8 @@ export function migrateHierarchyToDb(
     if (hasRoadmap) {
       roadmapContent = readFileSync(roadmapPath!, 'utf-8');
       roadmap = parseRoadmap(roadmapContent);
-      milestoneTitle = roadmap.title;
+      // #1592: H1 is `${id}: ${title}`; store the title without the id prefix.
+      milestoneTitle = stripIdPrefix(roadmap.title, milestoneId);
     }
 
     // Determine milestone status
@@ -732,7 +734,7 @@ export function migrateHierarchyToDb(
     if (!milestoneTitle && hasContext) {
       const contextContent = readFileSync(contextPath!, 'utf-8');
       const h1Match = contextContent.match(/^#\s+(.+)/m);
-      if (h1Match) milestoneTitle = h1Match[1].trim();
+      if (h1Match) milestoneTitle = stripIdPrefix(h1Match[1].trim(), milestoneId);
     }
 
     // Determine depends_on from CONTEXT frontmatter

--- a/src/resources/extensions/gsd/strip-id-prefix.ts
+++ b/src/resources/extensions/gsd/strip-id-prefix.ts
@@ -1,0 +1,13 @@
+/**
+ * Strip a leading ID prefix (e.g. "M001: " or "S04: ") from a title
+ * to prevent double-prefixing when the renderer adds its own prefix.
+ * Handles repeated prefixes (e.g. "M001: M001: M001: Title" → "Title").
+ */
+export function stripIdPrefix(title: string, id: string): string {
+  const prefix = `${id}: `;
+  let result = title;
+  while (result.startsWith(prefix)) {
+    result = result.slice(prefix.length);
+  }
+  return result.trim() || title;
+}

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -24,6 +24,7 @@ import {
   updateSliceStatus,
   insertGateRow,
   saveGateResult,
+  transaction,
   _getAdapter,
 } from '../gsd-db.ts';
 import {
@@ -41,6 +42,7 @@ import {
   stripProjectionStamp,
 } from '../markdown-renderer.ts';
 import { repairStaleRenders } from '../state-reconciliation/drift/stale-render.ts';
+import { migrateHierarchyToDb } from '../md-importer.ts';
 import {
   parseProjectionRoadmap as parseRoadmap,
   parseProjectionPlan as parsePlan,
@@ -1922,6 +1924,68 @@ test('── markdown-renderer: stamped re-render is byte-stable (no stamp accum
 
     // A freshly rendered projection has no content drift against DB intent.
     assert.deepStrictEqual(detectProjectionDrift(tmpDir), [], 'fresh render has no projection drift');
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
+test('── markdown-renderer: ROADMAP render-import round-trip does not grow M### title prefix (#1592) ──', async () => {
+  // Renderer: a DB title that already carries the id prefix must not double in the H1.
+  const renderDir = makeTmpDir();
+  openDatabase(path.join(renderDir, '.gsd', 'gsd.db'));
+  clearAllCaches();
+  try {
+    insertMilestone({ id: 'M001', title: 'M001: M001: Clean Title', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'First Slice', status: 'complete' });
+    scaffoldDirs(renderDir, 'M001', ['S01']);
+
+    const rendered = await renderRoadmapFromDb(renderDir, 'M001');
+    assert.ok(!('skipped' in rendered), 'prefixed-title milestone still renders');
+    assert.equal(
+      rendered.content.split('\n')[0],
+      '# M001: Clean Title',
+      'render must strip existing M001: prefixes from the H1',
+    );
+  } finally {
+    closeDatabase();
+    cleanupDir(renderDir);
+  }
+
+  // Importer: row-creating imports must not prepend another M001: each cycle.
+  const tmpDir = makeTmpDir();
+  openDatabase(path.join(tmpDir, '.gsd', 'gsd.db'));
+  clearAllCaches();
+  try {
+    insertMilestone({ id: 'M001', title: 'Clean Title', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'First Slice', status: 'complete' });
+    scaffoldDirs(tmpDir, 'M001', ['S01']);
+
+    for (let cycle = 1; cycle <= 3; cycle++) {
+      const rendered = await renderRoadmapFromDb(tmpDir, 'M001');
+      assert.ok(!('skipped' in rendered), `cycle ${cycle}: planned milestone renders`);
+      assert.equal(
+        rendered.content.split('\n')[0],
+        '# M001: Clean Title',
+        `cycle ${cycle}: H1 must stay a single M001: prefix`,
+      );
+
+      const db = _getAdapter()!;
+      transaction(() => {
+        db.exec("DELETE FROM tasks");
+        db.exec("DELETE FROM slices");
+        db.exec("DELETE FROM milestones");
+      });
+      clearAllCaches();
+
+      const counts = migrateHierarchyToDb(tmpDir);
+      assert.equal(counts.milestones, 1, `cycle ${cycle}: import recreates the milestone`);
+      assert.equal(
+        getMilestone('M001')?.title,
+        'Clean Title',
+        `cycle ${cycle}: stored title must not grow an id prefix`,
+      );
+    }
   } finally {
     closeDatabase();
     cleanupDir(tmpDir);

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -28,22 +28,8 @@ import { renderPlanFromDb, renderRoadmapFromDb, writeTaskSummaryProjection } fro
 import { readManifest } from "./workflow-manifest.js";
 import { gsdRoot, resolveMilestoneFile, resolveSliceFile, resolveTaskFile } from "./paths.js";
 import { removeOwnedPlanProjection } from "./projection-cleanup.js";
-
-// ─── Helpers ─────────────────────────────────────────────────────────────
-
-/**
- * Strip a leading ID prefix (e.g. "M001: " or "S04: ") from a title
- * to prevent double-prefixing when the renderer adds its own prefix.
- * Handles repeated prefixes (e.g. "M001: M001: M001: Title" → "Title").
- */
-export function stripIdPrefix(title: string, id: string): string {
-  const prefix = `${id}: `;
-  let result = title;
-  while (result.startsWith(prefix)) {
-    result = result.slice(prefix.length);
-  }
-  return result.trim() || title;
-}
+import { stripIdPrefix } from "./strip-id-prefix.js";
+export { stripIdPrefix };
 
 // ─── PLAN.md Projection ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## TL;DR

**What:** Stop ROADMAP render→import from appending another `M###: ` to the stored milestone title.
**Why:** Row-creating imports (`/gsd recover`, lost-DB rebuild) grew titles unboundedly and churned phase-directory slugs.
**How:** Shared `stripIdPrefix` on ROADMAP H1 render and on markdown import title assignment; both sides strip repeated prefixes.

## What

- Extract `stripIdPrefix` to `strip-id-prefix.ts` so the renderer can use it without importing `workflow-projections`.
- `renderRoadmapMarkdown` writes `# ${id}: ${strippedTitle}` instead of embedding the raw DB title.
- `migrateHierarchyToDb` strips the id prefix from roadmap H1 and CONTEXT H1 before `insertMilestone`.

## Why

Closes #1592. `renderRoadmapMarkdown` emitted the raw DB title and the importer stored the H1 verbatim. `INSERT OR IGNORE` hid this on existing rows; every row-creating import prepended one more `M001: `.

## How

Defense in depth on both sides of the round-trip. Parser `roadmap.title` stays the full H1 (`M001: Title`) so existing parse tests keep their contract; storage and display normalize via `stripIdPrefix`, which already loops repeated prefixes.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern 'ROADMAP render-import round-trip|#1592|byte-identical to the pre-stamp' src/resources/extensions/gsd/tests/markdown-renderer.test.ts` — 2 passed
- importer/parser tests — 36 passed
- `pnpm run verify:fast` — passed