### PR TITLE
fix(issue): verify:merge fails on a fresh checkout without native test addon (#1582)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,14 @@ CI is tiered to match local scripts. See [Test confidence stack](docs/dev/test-c
 ```bash
 pnpm run verify:fast    # ~1–3 min: same scans as CI fast-gates (secrets, docs injection, skill refs)
 pnpm run verify:pr      # ~5–15 min: fast inner loop — build:core → typecheck:extensions → test:unit
-pnpm run verify:merge   # ~20–40 min: CI PR blocking parity (build, all test jobs, validate-pack)
+pnpm run verify:merge   # ~20–40 min: CI PR blocking parity (native test addon, build, all test jobs, validate-pack)
 pnpm run verify:full    # Alias for verify:merge
 pnpm run audit:test-confidence   # Inventory report: runners, tiers, thin areas
 ```
 
 Run `verify:fast` on every push. While iterating, `verify:pr` is enough for a quick check. **Before requesting review** on a PR that touches `src/`, `packages/`, or tests, run **`verify:merge`** — a passing `verify:pr` alone does not match what CI requires to merge.
+
+`verify:merge` builds the native engine with `pnpm run build:native:test` (needs Rust/`rustc`) and copies `native/addon/*.node` into `dist-test/native/addon/` with `GSD_NATIVE_PREFER_LOCAL=1`, matching CI. Without that, compiled unit tests fail on a fresh checkout because the published `@opengsd/engine-*` binary can lag N-API exports such as `ProjectionRootIdentityLock`.
 
 If `verify:pr` fails after running tests (e.g. `Cannot find module '@gsd/*'` errors), run `pnpm install --frozen-lockfile` first to restore workspace symlinks, then try again.
 

--- a/docs/dev/test-confidence-stack.md
+++ b/docs/dev/test-confidence-stack.md
@@ -64,7 +64,7 @@ When `heavy-code-changed=true`, CI runs the Linux build and test stack in one jo
 Native package tests are skipped in the main Linux package-test step unless native/portability paths changed; otherwise a full Rust native rebuild can dominate unrelated CI runs.
 Compiled package tests use Node's `--test-force-exit` so leaked handles in one package do not idle until the CI watchdog fires after all assertions pass.
 
-Local parity: **`npm run verify:merge`** (runs the same npm scripts sequentially, including `verify:extension-coverage`).
+Local parity: **`npm run verify:merge`** (runs the same npm scripts sequentially, including `verify:extension-coverage`). It also builds `pnpm run build:native:test` and stages `dist-test/native/addon/` with `GSD_NATIVE_PREFER_LOCAL=1`, matching the CI `build` job. Requires a local Rust toolchain.
 
 `verify:fast` also runs:
 

--- a/scripts/__tests__/audit-test-confidence.test.mjs
+++ b/scripts/__tests__/audit-test-confidence.test.mjs
@@ -11,6 +11,13 @@ test("verify:merge and verify:full alias stay aligned with CI PR blocking parity
   assert.match(pkg.scripts["audit:test-confidence"], /audit-test-confidence\.mjs/);
 });
 
+test("verify:merge stages the native test addon like CI (#1582)", () => {
+  const script = readFileSync("scripts/verify-merge.sh", "utf8");
+  assert.match(script, /build:native:test/);
+  assert.match(script, /dist-test\/native\/addon/);
+  assert.match(script, /GSD_NATIVE_PREFER_LOCAL=1/);
+});
+
 test("audit:test-confidence --strict passes when tier map is intact", async () => {
   const { spawnSync } = await import("node:child_process");
   const result = spawnSync(process.execPath, ["scripts/audit-test-confidence.mjs", "--strict"], {

--- a/scripts/verify-merge.sh
+++ b/scripts/verify-merge.sh
@@ -8,6 +8,15 @@ cd "$ROOT"
 
 echo "── verify:merge (CI PR blocking parity) ──"
 
+echo "── native addon from source (test-fault-injection) ──"
+if ! command -v rustc >/dev/null 2>&1; then
+  echo "verify:merge needs Rust to build the local native engine (pnpm run build:native:test)."
+  echo "CI does this before unit tests so ProjectionRootIdentityLock matches this commit."
+  echo "Install rustup, then re-run. See CONTRIBUTING.md (Native engine version lockstep)."
+  exit 1
+fi
+pnpm run build:native:test
+
 echo "── build:core ──"
 pnpm run build:core
 
@@ -28,7 +37,11 @@ echo "── verify:extension-coverage ──"
 pnpm run verify:extension-coverage
 
 echo "── test:unit ──"
-pnpm run test:unit
+pnpm run test:compile
+mkdir -p dist-test/native/addon
+cp native/addon/*.node dist-test/native/addon/
+export GSD_NATIVE_PREFER_LOCAL=1
+pnpm run test:unit:compiled
 
 echo "── test:packages ──"
 pnpm run test:packages


### PR DESCRIPTION
## TL;DR

**What:** \`verify:merge\` builds and stages the native test addon the same way CI does.
**Why:** Fresh checkouts fail ~140 unit tests because published engine binaries lag N-API exports.
**How:** \`pnpm run build:native:test\`, copy into \`dist-test/native/addon/\`, \`GSD_NATIVE_PREFER_LOCAL=1\`. Requires Rust.

Closes #1582.