### PR TITLE
fix(issue): complete-slice cannot settle Waiver rejections (#1796)

### DIFF
--- a/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
+++ b/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
@@ -365,6 +365,8 @@ test("buildMinimalAutoGsdToolSet includes closeout tool for complete-slice", () 
     "gsd_task_reopen",
     "gsd_replan_slice",
     "gsd_slice_complete",
+    "gsd_slice_reopen",
+    "gsd_journal_query",
     "gsd_complete_slice",
     "memory_query",
     "capture_thought",
@@ -372,11 +374,13 @@ test("buildMinimalAutoGsdToolSet includes closeout tool for complete-slice", () 
   ], "complete-slice");
 
   assert.ok(result.includes("gsd_slice_complete"));
+  assert.ok(result.includes("gsd_slice_reopen"));
   assert.ok(result.includes("gsd_task_reopen"));
+  assert.ok(result.includes("gsd_task_complete"));
+  assert.ok(result.includes("gsd_journal_query"));
   assert.ok(result.includes("gsd_replan_slice"));
   assert.ok(result.includes("subagent"));
   assert.ok(result.includes("gsd_capture_thought"));
-  assert.ok(!result.includes("gsd_task_complete"));
   assert.ok(!result.includes("gsd_complete_slice"));
 });
 
@@ -385,8 +389,11 @@ test("buildMinimalAutoGsdToolSet preserves workflow MCP-namespaced closeout tool
     "bash",
     "read",
     "mcp__gsd-workflow__gsd_task_reopen",
+    "mcp__gsd-workflow__gsd_task_complete",
     "mcp__gsd-workflow__gsd_replan_slice",
     "mcp__gsd-workflow__gsd_slice_complete",
+    "mcp__gsd-workflow__gsd_slice_reopen",
+    "mcp__gsd-workflow__gsd_journal_query",
     "mcp__gsd-workflow__gsd_complete_slice",
     "mcp__gsd-workflow__gsd_exec",
     "mcp__gsd-workflow__memory_query",
@@ -395,8 +402,11 @@ test("buildMinimalAutoGsdToolSet preserves workflow MCP-namespaced closeout tool
   ], "complete-slice");
 
   assert.ok(result.includes("mcp__gsd-workflow__gsd_task_reopen"));
+  assert.ok(result.includes("mcp__gsd-workflow__gsd_task_complete"));
   assert.ok(result.includes("mcp__gsd-workflow__gsd_replan_slice"));
   assert.ok(result.includes("mcp__gsd-workflow__gsd_slice_complete"));
+  assert.ok(result.includes("mcp__gsd-workflow__gsd_slice_reopen"));
+  assert.ok(result.includes("mcp__gsd-workflow__gsd_journal_query"));
   assert.ok(!result.includes("mcp__gsd-workflow__gsd_complete_slice"));
   assert.ok(result.includes("mcp__gsd-workflow__gsd_exec"));
   assert.ok(result.includes("mcp__gsd-workflow__memory_query"));

--- a/src/resources/extensions/gsd/tests/unit-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-registry.test.ts
@@ -25,6 +25,7 @@ import {
   UNIT_TOOL_CONTRACTS,
   getUnitToolSurfaceContract,
 } from "../unit-tool-contracts.ts";
+import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.ts";
 import { UNIT_MANIFESTS } from "../unit-context-manifest.ts";
 import { phaseChainForUnit } from "../preferences-models.ts";
 
@@ -244,4 +245,25 @@ test("every registry row is reachable through the descriptor accessor", () => {
     assert.equal(getUnitPhaseChain(unitType), descriptor.phaseChain);
   }
   assert.equal(getUnitDescriptor("no-such-unit"), undefined);
+});
+
+test("complete-slice can settle Waiver rejections without SUMMARY fallback (#1796)", () => {
+  const completeSlice = getUnitToolSurfaceContract("complete-slice")?.allowedGsdTools ?? [];
+  const executeTask = getUnitToolSurfaceContract("execute-task")?.allowedGsdTools ?? [];
+  const waiverSettlementTools = ["gsd_slice_reopen", "gsd_task_complete", "gsd_journal_query"] as const;
+
+  for (const tool of waiverSettlementTools) {
+    assert.ok(
+      completeSlice.includes(tool),
+      `complete-slice allowedGsdTools must include ${tool}`,
+    );
+    assert.equal(
+      shouldBlockAutoUnitToolCall("complete-slice", tool).block,
+      false,
+      `complete-slice must not HARD BLOCK ${tool}`,
+    );
+  }
+
+  assert.ok(!executeTask.includes("gsd_slice_reopen"), "execute-task must not gain gsd_slice_reopen");
+  assert.ok(!executeTask.includes("gsd_journal_query"), "execute-task must not gain gsd_journal_query");
 });

--- a/src/resources/extensions/gsd/unit-registry.ts
+++ b/src/resources/extensions/gsd/unit-registry.ts
@@ -284,11 +284,14 @@ export const UNIT_REGISTRY = {
     toolContract: {
       allowedGsdTools: [
         "gsd_milestone_status",
+        "gsd_journal_query",
         "gsd_exec",
         "gsd_exec_search",
         "gsd_resume",
         "gsd_slice_complete",
+        "gsd_slice_reopen",
         "gsd_task_reopen",
+        "gsd_task_complete",
         "gsd_replan_slice",
         "gsd_replan_task",
         "gsd_rework_brief_save",


### PR DESCRIPTION
## TL;DR

**What:** `complete-slice` can now call `gsd_slice_reopen`, `gsd_task_complete`, and `gsd_journal_query`.
**Why:** A cancelled task without Waiver made `gsd_slice_complete` fail, and the unit could not settle in-phase, so it wrote SUMMARY and wedged on `artifact-db-status-divergence`.
**How:** Add those in-phase tools to `complete-slice.allowedGsdTools`. Leave `execute-task` unchanged.

## What

`complete-slice` was missing the lifecycle tools needed after `gsd_slice_complete` rejected a cancelled task that lacked a Waiver:

- `gsd_slice_reopen` — reopen a blocked slice
- `gsd_task_complete` — re-close a task after `gsd_task_reopen` (already allowed); without this, reopen leaves the task non-terminal and slice complete still fails
- `gsd_journal_query` — inspect Waiver / lifecycle state (read-only)

Those calls were HARD BLOCKed, so the agent fell back to `gsd_summary_save` and created artifact/DB divergence.

`execute-task` is not widened.

## Why

Closes #1796

A recoverable `gsd_slice_complete` lifecycle rejection must be settleable in the complete-slice unit. Otherwise the only remaining write is SUMMARY, which the reconciliation guard treats as stale drift and auto-mode wedges.

## How

Add the three tools to `complete-slice.allowedGsdTools` in the unit registry. They stay optional recovery tools (not `requiredWorkflowTools`). The derived tool-scope table, HARD BLOCK gate, and Tool Surface advertisement follow that list automatically.

A unit-registry test asserts `complete-slice.allowedGsdTools` includes the new tools, that they are not HARD BLOCKed, and that `execute-task` does not gain `gsd_slice_reopen` or `gsd_journal_query`.

## Change type

- [x] `fix` — Bug fix