### PR TITLE
fix(issue): schema overload has no retry for rotating fields (#1715)

### DIFF
--- a/packages/pi-agent-core/src/schema-overload-convergence.ts
+++ b/packages/pi-agent-core/src/schema-overload-convergence.ts
@@ -24,6 +24,13 @@ export function isConvergingValidationFieldSet(previous: readonly string[], curr
   return current.every((field) => prev.has(field));
 }
 
+/** True when current fields are nonempty and not a subset of previous (rotating / different missing fields). */
+export function isRotatingValidationFieldSet(previous: readonly string[], current: readonly string[]): boolean {
+  if (current.length === 0) return false;
+  const prev = new Set(previous);
+  return current.some((field) => !prev.has(field));
+}
+
 export function decideSchemaOverloadBreaker(input: {
   consecutive: number;
   cap: number;
@@ -32,11 +39,13 @@ export function decideSchemaOverloadBreaker(input: {
   narrowedRetryGranted: boolean;
 }): { trip: boolean; grantNarrowedRetry: boolean } {
   if (input.consecutive < input.cap) return { trip: false, grantNarrowedRetry: false };
-  if (
-    !input.narrowedRetryGranted
-    && isConvergingValidationFieldSet(input.previousFields, input.currentFields)
-  ) {
-    return { trip: false, grantNarrowedRetry: true };
+  if (!input.narrowedRetryGranted) {
+    if (isConvergingValidationFieldSet(input.previousFields, input.currentFields)) {
+      return { trip: false, grantNarrowedRetry: true };
+    }
+    if (isRotatingValidationFieldSet(input.previousFields, input.currentFields)) {
+      return { trip: false, grantNarrowedRetry: true };
+    }
   }
   return { trip: true, grantNarrowedRetry: false };
 }

--- a/packages/pi-agent-core/test/schema-overload-convergence.test.ts
+++ b/packages/pi-agent-core/test/schema-overload-convergence.test.ts
@@ -4,6 +4,7 @@ import {
 	decideSchemaOverloadBreaker,
 	extractValidationErrorFields,
 	isConvergingValidationFieldSet,
+	isRotatingValidationFieldSet,
 	narrowedSchemaRetryInstruction,
 } from "../src/schema-overload-convergence.js";
 
@@ -29,6 +30,15 @@ describe("schema-overload convergence", () => {
 		expect(isConvergingValidationFieldSet(["/a"], ["/a", "/b"])).toBe(false);
 	});
 
+	it("treats a nonempty non-subset field set as rotating", () => {
+		expect(isRotatingValidationFieldSet(["/a", "/b"], ["/a", "/c"])).toBe(true);
+		expect(isRotatingValidationFieldSet(["/modified"], ["/sliceId"])).toBe(true);
+		expect(isRotatingValidationFieldSet(["/a"], ["/a", "/b"])).toBe(true);
+		expect(isRotatingValidationFieldSet(["/a", "/b"], ["/a", "/b"])).toBe(false);
+		expect(isRotatingValidationFieldSet(["/a", "/b"], ["/a"])).toBe(false);
+		expect(isRotatingValidationFieldSet(["/a", "/b"], [])).toBe(false);
+	});
+
 	it("grants one narrowed retry when errors shrink at the cap", () => {
 		expect(
 			decideSchemaOverloadBreaker({
@@ -36,6 +46,18 @@ describe("schema-overload convergence", () => {
 				cap,
 				previousFields: ["/a", "/b"],
 				currentFields: ["/a"],
+				narrowedRetryGranted: false,
+			}),
+		).toEqual({ trip: false, grantNarrowedRetry: true });
+	});
+
+	it("grants one narrowed retry when missing fields rotate at the cap", () => {
+		expect(
+			decideSchemaOverloadBreaker({
+				consecutive: cap,
+				cap,
+				previousFields: ["/modified"],
+				currentFields: ["/sliceId"],
 				narrowedRetryGranted: false,
 			}),
 		).toEqual({ trip: false, grantNarrowedRetry: true });
@@ -53,6 +75,18 @@ describe("schema-overload convergence", () => {
 		).toEqual({ trip: true, grantNarrowedRetry: false });
 	});
 
+	it("trips at the cap when current fields are empty", () => {
+		expect(
+			decideSchemaOverloadBreaker({
+				consecutive: cap,
+				cap,
+				previousFields: ["/a"],
+				currentFields: [],
+				narrowedRetryGranted: false,
+			}),
+		).toEqual({ trip: true, grantNarrowedRetry: false });
+	});
+
 	it("trips after the narrowed retry even if still shrinking", () => {
 		expect(
 			decideSchemaOverloadBreaker({
@@ -60,6 +94,18 @@ describe("schema-overload convergence", () => {
 				cap,
 				previousFields: ["/a", "/b"],
 				currentFields: ["/a"],
+				narrowedRetryGranted: true,
+			}),
+		).toEqual({ trip: true, grantNarrowedRetry: false });
+	});
+
+	it("trips after the rotating retry even if fields still rotate", () => {
+		expect(
+			decideSchemaOverloadBreaker({
+				consecutive: cap,
+				cap,
+				previousFields: ["/modified"],
+				currentFields: ["/sliceId"],
 				narrowedRetryGranted: true,
 			}),
 		).toEqual({ trip: true, grantNarrowedRetry: false });


### PR DESCRIPTION
## TL;DR

**What:** Grant one extra narrowed schema-overload retry when missing fields rotate instead of shrink.
**Why:** Consecutive validation errors that swap fields still tripped the cap after the shrink-only retry path.
**How:** Treat a nonempty field set that is not a subset of the previous set as rotating; grant one retry, then trip. Keep the existing shrink path.

## What

`decideSchemaOverloadBreaker` already granted one narrowed retry when the invalid-field set shrank. Rotating or different missing fields still tripped immediately at the cap.

This adds `isRotatingValidationFieldSet` and grants that same one-shot retry when current fields are nonempty and not a subset of the previous set. Identical repeating fields and empty field sets still trip. A second failure after the grant still trips.

## Why

Closes #1715. Large structured tool payloads (e.g. `gsd_reassess_roadmap`) often re-serialize the whole object on each retry, so the model can fix one missing field and drop another. That is recoverable serialization noise, not a stuck loop.

## How

Keep the existing proper-subset shrink path. Add a rotating path: current fields nonempty and at least one field not in the previous set. Both share `narrowedRetryGranted`, so only one extra retry is ever granted.

## Change type

- [x] `fix` — Bug fix

## Verification

- `pnpm --filter @gsd/pi-agent-core exec vitest --run test/schema-overload-convergence.test.ts` — 10 passed