### PR TITLE
fix(issue): stopAuto silently quarantines dirty worktree (#1492)

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -2,7 +2,7 @@
 // File Purpose: Worktree Lifecycle Module — typed-result contract tests for enterMilestone (ADR-016).
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -575,6 +575,48 @@ test("exitMilestone forwards preserveWorktree to teardown on non-merge exit", ()
 
   assert.deepEqual(result, { ok: true, merged: false, codeFilesChanged: false });
   assert.deepEqual(capturedOpts, { preserveBranch: true, preserveWorktree: true });
+});
+
+test("exitMilestone leaves a dirty worktree intact when auto-commit fails (#1492)", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase({ isolation: "worktree" });
+  t.after(() => cleanupRepoBase(base, previousCwd));
+
+  const s = makeSession({ basePath: base, originalBasePath: base });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(
+    s,
+    makeDeps({
+      isInAutoWorktree: () => true,
+      autoCommitCurrentBranch: () => {
+        throw new Error("gitleaks blocked");
+      },
+      teardownAutoWorktree: undefined,
+    }),
+  );
+
+  const entered = lifecycle.enterMilestone("M001", ctx);
+  assert.equal(entered.ok, true, `expected enter ok:true, got: ${JSON.stringify(entered)}`);
+  if (!entered.ok) return;
+  const wtPath = entered.path;
+  writeFileSync(join(wtPath, "uncommitted.ts"), "export const x = 1;\n");
+
+  const result = lifecycle.exitMilestone(
+    "M001",
+    { merge: false, preserveBranch: true },
+    ctx,
+  );
+
+  assert.deepEqual(result, { ok: true, merged: false, codeFilesChanged: false });
+  assert.equal(existsSync(wtPath), true, "dirty worktree must remain on disk");
+  assert.equal(existsSync(join(wtPath, "uncommitted.ts")), true);
+  assert.equal(existsSync(join(base, ".gsd", "quarantine", "worktrees")), false);
+  assert.ok(
+    ctx.messages.some(
+      (m) => m.level === "error" && m.msg.includes(wtPath) && m.msg.includes("left intact"),
+    ),
+    `expected error notify naming the worktree path, got: ${JSON.stringify(ctx.messages)}`,
+  );
 });
 
 // ─── Queries (issue #5587) ────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/worktree-teardown-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-teardown-safety.test.ts
@@ -29,6 +29,7 @@ import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
 
 import { createWorktree, removeWorktree, worktreePath, isInsideWorktreesDir } from "../worktree-manager.ts";
+import { _resetLogs, peekLogs } from "../workflow-logger.ts";
 import { createTestContext } from "./test-helpers.ts";
 
 const { assertEq, assertTrue, report } = createTestContext();
@@ -141,6 +142,7 @@ describe("worktree-teardown-safety", () => {
     writeFileSync(join(wt.path, "generated-feature.ts"), "export const answer = 42;\n");
     writeFileSync(join(wt.path, "README.md"), "# changed in worktree\n");
 
+    _resetLogs();
     removeWorktree(tempDir, "dirty-wt", { deleteBranch: false });
 
     assertTrue(!existsSync(wt.path), "original dirty worktree path removed after quarantine");
@@ -148,6 +150,13 @@ describe("worktree-teardown-safety", () => {
     const entries = readdirSync(quarantineRoot).filter((entry) => entry.startsWith("dirty-wt-"));
     assertEq(entries.length, 1, "dirty worktree snapshot quarantined");
     const quarantineDir = join(quarantineRoot, entries[0]!);
+    const quarantineNotice = peekLogs().find(
+      (entry) => entry.severity === "error" && entry.message.includes(quarantineDir),
+    );
+    assertTrue(
+      Boolean(quarantineNotice),
+      "quarantine path is surfaced as an error notification",
+    );
     assertEq(
       readFileSync(join(quarantineDir, "generated-feature.ts"), "utf-8"),
       "export const answer = 42;\n",

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -83,6 +83,7 @@ import {
 } from "./auto-worktree-entry.js";
 import { getAutoWorktreePath } from "./auto-worktree-path-resolution.js";
 import { teardownAutoWorktree } from "./auto-worktree-teardown.js";
+import { inspectUncommittedWorktreeState } from "./worktree-manager.js";
 import { resolveRoadmapForMilestoneMerge } from "./milestone-merge-roadmap.js";
 import type { MilestoneMergeTransactionRunner } from "./milestone-merge-transaction.js";
 
@@ -1708,14 +1709,33 @@ export class WorktreeLifecycle {
     try {
       autoCommitLifecycleBranch(this.deps, this.s.basePath, "stop", milestoneId);
     } catch (err) {
+      const errorText = err instanceof Error ? err.message : String(err);
       debugLog("WorktreeLifecycle", {
         action: "exitMilestone",
         milestoneId,
         phase: "auto-commit-failed",
-        error: err instanceof Error ? err.message : String(err),
+        error: errorText,
       });
+      const worktreePath = this.s.basePath;
+      if (inspectUncommittedWorktreeState(worktreePath).dirty) {
+        ctx.notify(
+          `Auto-commit before exiting ${milestoneId} failed: ${errorText}. ` +
+            `Worktree is still dirty and was left intact at ${worktreePath}. ` +
+            `It was not torn down or quarantined. Fix the commit in that worktree, then stop again.`,
+          "error",
+        );
+        this.restoreToProjectRoot();
+        debugLog("WorktreeLifecycle", {
+          action: "exitMilestone",
+          milestoneId,
+          result: "dirty-worktree-preserved",
+          worktreePath,
+          basePath: this.s.basePath,
+        });
+        return;
+      }
       ctx.notify(
-        `Auto-commit before exiting ${milestoneId} failed: ${err instanceof Error ? err.message : String(err)}. Branch ${lifecycleAutoWorktreeBranch(this.deps, milestoneId)} is preserved for recovery.`,
+        `Auto-commit before exiting ${milestoneId} failed: ${errorText}. Branch ${lifecycleAutoWorktreeBranch(this.deps, milestoneId)} is preserved for recovery.`,
         "warning",
       );
     }

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -23,7 +23,7 @@ import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, re
 import { execFileSync } from "node:child_process";
 import { join, resolve, sep } from "node:path";
 import { GSDError, GSD_PARSE_ERROR, GSD_STALE_STATE, GSD_LOCK_HELD, GSD_GIT_ERROR, GSD_MERGE_CONFLICT } from "./errors.js";
-import { logWarning } from "./workflow-logger.js";
+import { logError, logWarning } from "./workflow-logger.js";
 import {
   nativeBranchList,
   nativeBranchDelete,
@@ -227,7 +227,7 @@ function isRegisteredGitWorktreeAtPath(basePath: string, wtPath: string): boolea
   }
 }
 
-function inspectUncommittedWorktreeState(wtPath: string): { dirty: boolean; status: string } {
+export function inspectUncommittedWorktreeState(wtPath: string): { dirty: boolean; status: string } {
   try {
     const status = execFileSync(
       "git",
@@ -326,9 +326,11 @@ function quarantineDirtyWorktree(
     );
   }
 
-  logWarning(
-    "reconcile",
-    `Quarantined dirty worktree ${name} at ${quarantinePath} before removal. Branch ${branch} was preserved.`,
+  logError(
+    "worktree",
+    `Quarantined dirty worktree ${name} at ${quarantinePath} before removal. ` +
+      `Branch ${branch} was preserved. Recover by checking out ${branch} and copying files from ${quarantinePath} ` +
+      `(exclude .git, .gsd, and .gsd-quarantine.json).`,
     { worktree: name, path: quarantinePath, branch },
   );
   return quarantinePath;


### PR DESCRIPTION
## TL;DR

**What:** Stop-time auto-commit failure no longer destroys a dirty milestone worktree, and quarantine now names the rescue path.
**Why:** `/gsd stop` was silently quarantining uncommitted work behind a logWarning, then the write guard blocked recovery.
**How:** Skip teardown when auto-commit fails and the tree is still dirty; promote the quarantine notice to an error that includes the path.

## What

- `WorktreeLifecycle._exitWithoutMerge` inspects the worktree after a failed stop-time auto-commit. If it is still dirty, it notifies with the live worktree path and returns without teardown.
- `quarantineDirtyWorktree` now `logError`s the quarantine path and recovery steps so other removal paths still surface where the files went.

## Why

Closes #1492.

When stop-time `autoCommitLifecycleBranch` failed, teardown still ran. Dirty files were moved to `.gsd/quarantine/worktrees/` with only a `logWarning`, so the worktree appeared to vanish. This PR keeps the worktree intact in that case.

Write-guard recovery messaging is out of scope here.

## How

- Failed auto-commit + dirty tree: `ctx.notify(..., "error")` with the worktree path, `restoreToProjectRoot()`, skip `teardownAutoWorktree`.
- Failed auto-commit + clean tree: existing branch-preserved warning and teardown.
- Quarantine (other callers): error-level log that names the quarantine path.

## Change type

- [x] `fix` — Bug fix