### PR TITLE
fix(issue): phase-dir slug drift and Windows lock rmSync no-op (#1526)

### DIFF
--- a/src/resources/extensions/gsd/atomic-write.ts
+++ b/src/resources/extensions/gsd/atomic-write.ts
@@ -15,6 +15,15 @@ import {
 } from "./managed-projection-history.js";
 import { classifyGsdLogicalPath } from "./projection-path-policy.js";
 import { preserveManagedProjectionBeforeMutation } from "./projection-mutation-guard.js";
+import { LAYOUT_SEGMENTS } from "./layout-policy.js";
+import {
+  canonicalPhaseDirName,
+  clearPathCache,
+  gsdProjectionRoot,
+  isLegacyMilestonesLayout,
+  legacyMilestonesDir,
+  resolveMilestonePath,
+} from "./paths.js";
 export { removeLegacyProjectionTreeSync };
 
 const TRANSIENT_LOCK_ERROR_CODES = new Set(["EBUSY", "EPERM", "EACCES"]);
@@ -615,4 +624,38 @@ export function createProjectionDirectorySync(directoryPath: string): void {
       mkdirSync(directoryPath, { recursive: true });
     }
   });
+}
+
+/**
+ * Rename an existing same-milestone phase directory to the title-derived
+ * canonical name. Discuss/plan title changes otherwise leave files under the
+ * old slug while writers and the artifacts table point at the new one (#1526).
+ */
+export function relocatePhaseDirToCanonical(
+  basePath: string,
+  milestoneId: string,
+  title?: string,
+): string {
+  const dest = join(
+    gsdProjectionRoot(basePath),
+    LAYOUT_SEGMENTS.level1,
+    canonicalPhaseDirName(milestoneId, title),
+  );
+  const existing = resolveMilestonePath(basePath, milestoneId);
+  if (!existing) return dest;
+  const legacyBase = legacyMilestonesDir(basePath);
+  const isLegacy = existing.startsWith(legacyBase + "/") || existing.startsWith(legacyBase + "\\")
+    || isLegacyMilestonesLayout(basePath);
+  if (isLegacy) return existing;
+  const existingName = existing.split(/[/\\]/).pop()!;
+  const destName = dest.split(/[/\\]/).pop()!;
+  if (existingName === destName) return existing;
+  if (existsSync(dest)) return dest;
+  try {
+    renameSync(existing, dest);
+    clearPathCache();
+    return dest;
+  } catch {
+    return existing;
+  }
 }

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -1,4 +1,5 @@
 import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
+import { removeDirectoryVerified } from "./verified-rmdir.js";
 import { basename, dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
@@ -196,10 +197,9 @@ export async function checkRuntimeHealth(
             fixable: true,
           });
           if (shouldFix("stranded_lock_directory")) {
-            try {
-              rmSync(lockDir, { recursive: true, force: true });
+            if (removeDirectoryVerified(lockDir)) {
               fixesApplied.push(`removed stranded lock directory ${lockDir}`);
-            } catch {
+            } else {
               fixesApplied.push(`failed to remove stranded lock directory ${lockDir}`);
             }
           }

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -10,7 +10,7 @@
 // parseRoadmap(), parsePlan(), parseSummary() in files.ts.
 
 import { readFileSync, existsSync, mkdirSync, statSync } from "node:fs";
-import { createProjectionDirectorySync, removeProjectionFileSync } from "./atomic-write.js";
+import { createProjectionDirectorySync, relocatePhaseDirToCanonical, removeProjectionFileSync } from "./atomic-write.js";
 import { logWarning } from "./workflow-logger.js";
 import { isClosedStatus, isHiddenFromRoadmap, toStatus } from "./status-guards.js";
 import { isCanonicalStagedTaskSummaryState } from "./task-summary-projection-policy.js";
@@ -719,6 +719,9 @@ export async function renderRoadmapFromDb(
     return { skipped: "unplanned-milestone" };
   }
 
+  if (milestone.title) {
+    relocatePhaseDirToCanonical(basePath, milestoneId, milestone.title);
+  }
   const absPath = targetMilestoneFile(basePath, milestoneId, "ROADMAP", milestone.title);
   const artifactPath = toArtifactPath(absPath, basePath);
   const content = renderRoadmapMarkdown(milestone, slices);

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -17,12 +17,13 @@
  */
 
 import { createRequire } from "node:module";
-import { existsSync, readFileSync, readdirSync, mkdirSync, unlinkSync, rmSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, mkdirSync, unlinkSync, statSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { gsdRoot, normalizeRealPath } from "./paths.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { markWorkerStoppingByPid } from "./db/auto-workers.js";
 import { logWarning } from "./workflow-logger.js";
+import { removeDirectoryVerified } from "./verified-rmdir.js";
 
 const _require = createRequire(import.meta.url);
 
@@ -161,7 +162,7 @@ export function cleanupStrayLockFiles(basePath: string): void {
           try {
             const stat = statSync(fullPath);
             if (stat.isDirectory()) {
-              rmSync(fullPath, { recursive: true, force: true });
+              removeDirectoryVerified(fullPath);
             }
           } catch { /* best-effort */ }
         }
@@ -197,7 +198,7 @@ function ensureExitHandler(_gsdDir: string): void {
       } catch { /* best-effort */ }
       try {
         const lockDir = join(dir + ".lock");
-        if (ownsRegisteredLock && existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+        if (ownsRegisteredLock && existsSync(lockDir)) removeDirectoryVerified(lockDir);
       } catch { /* best-effort */ }
     }
   });
@@ -323,7 +324,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     if (deadPid) markWorkerStoppingByPid(normalizeRealPath(basePath), deadPid);
     const isOrphan = !existingData || !!deadPid;
     if (isOrphan) {
-      try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+      try { removeDirectoryVerified(lockDir); } catch { /* best-effort */ }
       try { if (existsSync(lp)) unlinkSync(lp); } catch { /* best-effort */ }
     }
   }
@@ -365,7 +366,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     if (!existingData || (existingPid && !isPidAlive(existingPid))) {
       try {
         const lockDir = join(lockTarget + ".lock");
-        if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+        if (existsSync(lockDir)) removeDirectoryVerified(lockDir);
         if (existsSync(lp)) unlinkSync(lp);
 
         // Retry acquisition after cleanup
@@ -389,9 +390,12 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
 
     // #3218: Provide actionable workaround when lock recovery fails
     const lockDirPath = lockTarget + ".lock";
+    const stuckDir = existsSync(lockDirPath);
     const reason = existingPid
       ? `Another auto-mode session (PID ${existingPid}) appears to be running.\nRun \`/gsd stop\` for graceful shutdown, or choose "Force start" from \`/gsd auto\` to terminate it.`
-      : `Another auto-mode session lock is stuck on this project.\nRun: rm -rf "${lockDirPath}" && rm -f "${lp}"`;
+      : stuckDir
+        ? `Another auto-mode session lock is stuck on this project.\nAutomatic removal of "${lockDirPath}" failed. On Windows, recursive delete can silently no-op when the path contains non-ASCII characters — move the project to an ASCII-only path or delete the directory from a shell:\n  rmdir /s /q "${lockDirPath}" && del "${lp}"`
+        : `Another auto-mode session lock is stuck on this project.\nRun: rm -rf "${lockDirPath}" && rm -f "${lp}"`;
 
     return { acquired: false, reason, existingPid };
   }
@@ -558,14 +562,14 @@ export function releaseSessionLock(basePath: string): void {
   const lockTarget = effectiveLockTarget(gsdDir);
   try {
     const lockDir = join(lockTarget + ".lock");
-    if (ownsPrimaryLock && existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+    if (ownsPrimaryLock && existsSync(lockDir)) removeDirectoryVerified(lockDir);
   } catch {
     // Non-fatal
   }
   // Also clean the per-milestone parallel directory itself if it exists
   if (ownsPrimaryLock && lockTarget !== gsdDir) {
     try {
-      if (existsSync(lockTarget)) rmSync(lockTarget, { recursive: true, force: true });
+      if (existsSync(lockTarget)) removeDirectoryVerified(lockTarget);
     } catch {
       // Non-fatal
     }
@@ -581,7 +585,7 @@ export function releaseSessionLock(basePath: string): void {
     } catch { /* best-effort */ }
     try {
       const lockDir = join(dir + ".lock");
-      if (ownsRegisteredLock && existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+      if (ownsRegisteredLock && existsSync(lockDir)) removeDirectoryVerified(lockDir);
     } catch { /* best-effort */ }
   }
   _lockDirRegistry.clear();
@@ -635,8 +639,7 @@ export function removeStaleSessionLock(basePath: string): boolean {
   let removed = false;
   if (existsSync(lockDir)) {
     try {
-      rmSync(lockDir, { recursive: true, force: true });
-      removed = true;
+      removed = removeDirectoryVerified(lockDir);
     } catch {
       /* best-effort */
     }

--- a/src/resources/extensions/gsd/tests/phase-dir-title-rename.test.ts
+++ b/src/resources/extensions/gsd/tests/phase-dir-title-rename.test.ts
@@ -1,0 +1,35 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { relocatePhaseDirToCanonical } from "../atomic-write.ts";
+import { targetMilestoneFile } from "../paths.ts";
+
+test("relocatePhaseDirToCanonical renames the discuss slug when the title changes (#1526)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-phase-rename-"));
+  const oldDir = join(base, ".gsd", "phases", "01-new-milestone-m001");
+  mkdirSync(oldDir, { recursive: true });
+  writeFileSync(join(oldDir, "01-CONTEXT.md"), "# New milestone M001\n");
+
+  const dest = relocatePhaseDirToCanonical(base, "M001", "Web API");
+  assert.match(dest, /[/\\]01-web-api$/);
+  assert.equal(existsSync(oldDir), false);
+  assert.equal(existsSync(join(dest, "01-CONTEXT.md")), true);
+  assert.equal(readFileSync(join(dest, "01-CONTEXT.md"), "utf8"), "# New milestone M001\n");
+  rmSync(base, { recursive: true, force: true });
+});
+
+test("targetMilestoneFile writes into the renamed canonical phase dir (#1526)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-phase-target-"));
+  const oldDir = join(base, ".gsd", "phases", "01-new-milestone-m001");
+  mkdirSync(oldDir, { recursive: true });
+  writeFileSync(join(oldDir, "01-ROADMAP.md"), "# leftover\n");
+
+  relocatePhaseDirToCanonical(base, "M001", "Web API");
+  const path = targetMilestoneFile(base, "M001", "ROADMAP", "Web API");
+  assert.match(path.replace(/\\/g, "/"), /\/01-web-api\/01-ROADMAP\.md$/);
+  assert.equal(existsSync(oldDir), false);
+  assert.equal(existsSync(path), true);
+  rmSync(base, { recursive: true, force: true });
+});

--- a/src/resources/extensions/gsd/tests/verified-rmdir.test.ts
+++ b/src/resources/extensions/gsd/tests/verified-rmdir.test.ts
@@ -1,0 +1,48 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  existsSync,
+  rmSync,
+  rmdirSync,
+  readdirSync,
+  unlinkSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { removeDirectoryVerified, type VerifiedRmdirIo } from "../verified-rmdir.ts";
+
+test("removeDirectoryVerified deletes a nested directory (#1526)", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-verified-rm-"));
+  const dir = join(root, "lock");
+  mkdirSync(join(dir, "nested"), { recursive: true });
+  writeFileSync(join(dir, "nested", "marker"), "x");
+  assert.equal(removeDirectoryVerified(dir), true);
+  assert.equal(existsSync(dir), false);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("removeDirectoryVerified falls back to rmdir when recursive rm is a no-op (#1526)", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-verified-rm-noop-"));
+  const dir = join(root, ".gsd.lock");
+  mkdirSync(join(dir, "nested"), { recursive: true });
+  writeFileSync(join(dir, "nested", "marker"), "x");
+
+  const io: VerifiedRmdirIo = {
+    existsSync,
+    rmSync: () => {
+      // Windows Node 24 non-ASCII path: recursive rm returns without deleting.
+    },
+    rmdirSync,
+    readdirSync,
+    unlinkSync,
+    statSync,
+  };
+
+  assert.equal(removeDirectoryVerified(dir, io), true);
+  assert.equal(existsSync(dir), false);
+  rmSync(root, { recursive: true, force: true });
+});

--- a/src/resources/extensions/gsd/verified-rmdir.ts
+++ b/src/resources/extensions/gsd/verified-rmdir.ts
@@ -1,0 +1,80 @@
+import {
+  existsSync,
+  readdirSync,
+  rmdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+
+export type VerifiedRmdirIo = {
+  existsSync: typeof existsSync;
+  rmSync: typeof rmSync;
+  rmdirSync: typeof rmdirSync;
+  readdirSync: typeof readdirSync;
+  unlinkSync: typeof unlinkSync;
+  statSync: typeof statSync;
+};
+
+const DEFAULT_IO: VerifiedRmdirIo = {
+  existsSync,
+  rmSync,
+  rmdirSync,
+  readdirSync,
+  unlinkSync,
+  statSync,
+};
+
+/**
+ * Remove a directory and verify it is gone.
+ *
+ * On Windows + Node 24, `rmSync({ recursive: true })` can return without
+ * throwing while leaving the directory in place when the path contains
+ * non-ASCII characters (#1526). `rmdirSync` on an emptied directory still
+ * works, so fall back to a walk + rmdir when the recursive rm is a no-op.
+ */
+export function removeDirectoryVerified(dir: string, io: VerifiedRmdirIo = DEFAULT_IO): boolean {
+  if (!io.existsSync(dir)) return true;
+  try {
+    io.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Fall through to rmdir walk.
+  }
+  if (!io.existsSync(dir)) return true;
+  try {
+    removeTreeWithRmdir(dir, io);
+  } catch {
+    // Caller inspects existsSync.
+  }
+  return !io.existsSync(dir);
+}
+
+function removeTreeWithRmdir(dir: string, io: VerifiedRmdirIo): void {
+  let names: string[] = [];
+  try {
+    names = io.readdirSync(dir);
+  } catch {
+    io.rmdirSync(dir);
+    return;
+  }
+  for (const name of names) {
+    const full = join(dir, name);
+    let isDir = false;
+    try {
+      isDir = io.statSync(full).isDirectory();
+    } catch {
+      isDir = false;
+    }
+    if (isDir) {
+      removeTreeWithRmdir(full, io);
+    } else {
+      try {
+        io.unlinkSync(full);
+      } catch {
+        // Keep draining siblings.
+      }
+    }
+  }
+  io.rmdirSync(dir);
+}


### PR DESCRIPTION
## TL;DR

**What:** Rename the phase directory when a milestone title changes, and verify session-lock directory removal.
**Why:** Title changes left files under the old slug while DB/writers pointed at the new one; Windows recursive `rmSync` can silently no-op on non-ASCII paths and strand `.gsd.lock`.
**How:** Relocate the on-disk phase dir through the projection write boundary; fall back to walk+`rmdirSync` when recursive rm leaves the lock dir.

## What

- `relocatePhaseDirToCanonical` (atomic-write) renames `phases/NN-old-slug` to `phases/NN-new-title-slug` before ROADMAP render.
- `removeDirectoryVerified` tries `rmSync({recursive:true})`, then empties and `rmdirSync` if the directory still exists.
- Session lock acquire/release/stale cleanup and doctor stranded-lock heal use the verified remover.
- Stuck-lock error mentions the Windows non-ASCII recursive-rm failure and `rmdir /s /q`.

## Why

Closes #1526. Discuss created the phase dir under a placeholder title; `plan-milestone` updated the title and artifact paths without moving the directory. A later bootstrap crash then stranded `.gsd.lock` because `rmSync` returned success while the directory remained.

## How

Path builders stay read-only. The rename lives on the managed projection write boundary so title-derived writes land in the same directory as the files. Lock removal checks `existsSync` after delete instead of treating a silent no-op as success.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/verified-rmdir.test.ts src/resources/extensions/gsd/tests/phase-dir-title-rename.test.ts src/resources/extensions/gsd/tests/flat-phase-validation-path.test.ts src/resources/extensions/gsd/tests/stale-lockfile-recovery.test.ts` — 13 passed
- `bash scripts/ci-fast-gates.sh` — passed