### PR TITLE
fix(issue): plan-slice assigns execute-task-illegal lifecycle tools (#1530)

### DIFF
--- a/src/resources/extensions/gsd/execute-task-plan-tool-guard.ts
+++ b/src/resources/extensions/gsd/execute-task-plan-tool-guard.ts
@@ -1,0 +1,114 @@
+// Reject plan-slice/plan-task work that execute-task cannot call.
+
+import { FRAMEWORK_METADATA_DIRS } from "./paths.js";
+import {
+  EXECUTE_TASK_UNIT_TYPES,
+  KNOWN_UNIT_TYPES,
+} from "./unit-registry.js";
+import { getUnitToolSurfaceContract } from "./unit-tool-contracts.js";
+import { canonicalWorkflowSurfaceToolName } from "./workflow-tool-surface.js";
+
+const EXECUTE_TASK_UNIT_TYPE = "execute-task";
+const GSD_TOOL_NAME_RE = /\b(?:mcp__[a-z0-9_-]+__)?gsd_[a-z0-9_]+/gi;
+/** Lifecycle tools execute-task cannot call. Mentions of planner tools like gsd_plan_task are not task requirements. */
+const EXECUTE_TASK_ILLEGAL_LIFECYCLE_TOOLS = new Set([
+  "gsd_requirement_update",
+  "gsd_milestone_status",
+]);
+const REQUIREMENTS_BASENAME_RE = /^REQUIREMENTS\.md$/i;
+const ROADMAP_BASENAME_RE = /^ROADMAP\.md$/i;
+const MILESTONE_METADATA_BASENAME_RE = /^(PROJECT|CONTEXT)\.md$/i;
+const MILESTONE_ARTIFACT_BASENAME_RE = /^M\d+-(ROADMAP|CONTEXT|PROJECT)\.md$/i;
+
+export interface ExecuteTaskPlanToolFields {
+  description: string;
+  files: readonly string[];
+}
+
+function allowedExecuteTaskTools(): Set<string> | null {
+  const allowed = getUnitToolSurfaceContract(EXECUTE_TASK_UNIT_TYPE)?.allowedGsdTools;
+  if (!allowed) return null;
+  return new Set(allowed);
+}
+
+function ownerUnitsForTool(tool: string): string[] {
+  return KNOWN_UNIT_TYPES.filter((unitType) => {
+    if (EXECUTE_TASK_UNIT_TYPES.has(unitType)) return false;
+    const allowed = getUnitToolSurfaceContract(unitType)?.allowedGsdTools ?? [];
+    return (allowed as readonly string[]).includes(tool);
+  });
+}
+
+function extractNamedGsdTools(text: string): string[] {
+  const found = new Set<string>();
+  for (const match of text.matchAll(GSD_TOOL_NAME_RE)) {
+    const canonical = canonicalWorkflowSurfaceToolName(match[0]);
+    if (canonical.startsWith("gsd_")) found.add(canonical);
+  }
+  return [...found];
+}
+
+function normalizePlannedPath(file: string): string {
+  return file.trim().replace(/\\/g, "/");
+}
+
+function isFrameworkMetadataPath(normalized: string): boolean {
+  return FRAMEWORK_METADATA_DIRS.some((dir) =>
+    normalized.split("/").some((segment) => segment.toLowerCase() === dir),
+  );
+}
+
+function toolsImpliedByPlannedFile(file: string): string[] {
+  const normalized = normalizePlannedPath(file);
+  if (!normalized) return [];
+  const basename = normalized.split("/").pop() ?? "";
+  if (REQUIREMENTS_BASENAME_RE.test(basename)) return ["gsd_requirement_update"];
+  if (ROADMAP_BASENAME_RE.test(basename)) return ["gsd_milestone_status"];
+  if (MILESTONE_ARTIFACT_BASENAME_RE.test(basename)) return ["gsd_milestone_status"];
+  if (isFrameworkMetadataPath(normalized) && MILESTONE_METADATA_BASENAME_RE.test(basename)) {
+    return ["gsd_milestone_status"];
+  }
+  return [];
+}
+
+function collectRequiredTools(task: ExecuteTaskPlanToolFields): string[] {
+  const required = new Set<string>();
+  const consider = (name: string) => {
+    if (EXECUTE_TASK_ILLEGAL_LIFECYCLE_TOOLS.has(name)) required.add(name);
+  };
+  for (const name of extractNamedGsdTools(task.description)) consider(name);
+  for (const file of task.files) {
+    for (const name of extractNamedGsdTools(file)) consider(name);
+    for (const implied of toolsImpliedByPlannedFile(file)) consider(implied);
+  }
+  return [...required];
+}
+
+function formatIllegalTool(tool: string): string {
+  const owners = ownerUnitsForTool(tool);
+  if (owners.length === 0) {
+    return `${tool} (no owning unit — remove this mutation from the execute-task plan)`;
+  }
+  return `${tool} (owned by ${owners.join(", ")})`;
+}
+
+/**
+ * Planner-visible error when a planned task needs lifecycle tools execute-task cannot call.
+ * Fail closed for requirement/milestone mutations named in files or description.
+ */
+export function executeTaskIllegalPlanToolsError(
+  task: ExecuteTaskPlanToolFields,
+  label: string,
+): string | null {
+  const required = collectRequiredTools(task);
+  if (required.length === 0) return null;
+
+  const allowed = allowedExecuteTaskTools();
+  const illegal = allowed
+    ? required.filter((tool) => !allowed.has(tool)).sort()
+    : [...required].sort();
+  if (illegal.length === 0) return null;
+
+  const details = illegal.map(formatIllegalTool).join("; ");
+  return `${label} requires tools execute-task cannot call: ${details}`;
+}

--- a/src/resources/extensions/gsd/tests/execute-task-plan-tool-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/execute-task-plan-tool-guard.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { executeTaskIllegalPlanToolsError } from "../execute-task-plan-tool-guard.ts";
+import { getUnitToolSurfaceContract } from "../unit-tool-contracts.ts";
+
+function task(overrides: {
+  description?: string;
+  files?: string[];
+} = {}) {
+  return {
+    description: overrides.description ?? "Implement the handler and add tests.",
+    files: overrides.files ?? ["src/handler.ts"],
+  };
+}
+
+test("ordinary execute-task plans are not blocked", () => {
+  assert.equal(executeTaskIllegalPlanToolsError(task(), "tasks[0]"), null);
+  assert.equal(
+    executeTaskIllegalPlanToolsError(
+      task({ description: "Run checks with gsd_exec, then call gsd_task_complete." }),
+      "tasks[0]",
+    ),
+    null,
+  );
+  assert.equal(
+    executeTaskIllegalPlanToolsError(
+      task({ description: "Implement the first task added through gsd_plan_task." }),
+      "tasks[0]",
+    ),
+    null,
+  );
+});
+
+test("plan-slice rejects tasks that name execute-task-illegal lifecycle tools (#1530)", () => {
+  const requirementError = executeTaskIllegalPlanToolsError(
+    task({
+      description: "Terminalize R001 with gsd_requirement_update after evidence lands.",
+    }),
+    "tasks[0]",
+  );
+  assert.match(requirementError ?? "", /tasks\[0\] requires tools execute-task cannot call/);
+  assert.match(requirementError ?? "", /gsd_requirement_update/);
+  assert.match(requirementError ?? "", /complete-slice/);
+  assert.equal(
+    getUnitToolSurfaceContract("execute-task")?.allowedGsdTools.includes("gsd_requirement_update"),
+    false,
+  );
+
+  const aliasError = executeTaskIllegalPlanToolsError(
+    task({ description: "Call gsd_update_requirement for R001." }),
+    "tasks[0]",
+  );
+  assert.match(aliasError ?? "", /gsd_requirement_update/);
+
+  const statusError = executeTaskIllegalPlanToolsError(
+    task({ description: "Reconcile stale success criteria via gsd_milestone_status." }),
+    "tasks[0]",
+  );
+  assert.match(statusError ?? "", /gsd_milestone_status/);
+  assert.match(statusError ?? "", /reassess-roadmap|complete-slice|plan-slice/);
+});
+
+test("plan-slice rejects files that require requirement or milestone metadata writes (#1530)", () => {
+  const requirementsFile = executeTaskIllegalPlanToolsError(
+    task({ files: [".gsd/REQUIREMENTS.md"] }),
+    "tasks[0]",
+  );
+  assert.match(requirementsFile ?? "", /gsd_requirement_update/);
+
+  const roadmapFile = executeTaskIllegalPlanToolsError(
+    task({ files: ["ROADMAP.md"] }),
+    "tasks[0]",
+  );
+  assert.match(roadmapFile ?? "", /gsd_milestone_status/);
+
+  const projectFile = executeTaskIllegalPlanToolsError(
+    task({ files: [".gsd/PROJECT.md"] }),
+    "tasks[0]",
+  );
+  assert.match(projectFile ?? "", /gsd_milestone_status/);
+});

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -776,6 +776,32 @@ test('handlePlanTask materializes the slice PLAN.md and clears the sketch flag o
   }
 });
 
+test('handlePlanSlice rejects tasks that require execute-task-illegal lifecycle tools (#1530)', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    const result = await handlePlanSlice({
+      ...validParams(),
+      tasks: [
+        {
+          ...validParams().tasks[0],
+          description: 'Terminalize R001 with gsd_requirement_update and reconcile milestone metadata via gsd_milestone_status.',
+        },
+      ],
+    }, base);
+
+    assert.ok('error' in result);
+    assert.match(result.error, /validation failed: tasks\[0\] requires tools execute-task cannot call/);
+    assert.match(result.error, /gsd_requirement_update/);
+    assert.match(result.error, /gsd_milestone_status/);
+    assert.equal(getSliceTasks('M001', 'S02').length, 0, 'illegal lifecycle work must not persist as execute-task');
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanSlice explains string task IO fields must be arrays', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -41,6 +41,7 @@ import {
   type PlanningInvocation,
 } from "../planning-invocation.js";
 import { ensurePendingSliceQ8 } from "../db/writers/slice-companion-state.js";
+import { executeTaskIllegalPlanToolsError } from "../execute-task-plan-tool-guard.js";
 
 
 export interface PlanSliceTaskInput {
@@ -137,6 +138,12 @@ function validateTasks(value: unknown): PlanSliceTaskInput[] | undefined {
       `tasks[${index}].targetRepositories`,
       targetRepositories,
     );
+
+    const illegalToolsError = executeTaskIllegalPlanToolsError(
+      { description, files: validatedFiles },
+      `tasks[${index}]`,
+    );
+    if (illegalToolsError) throw new Error(illegalToolsError);
 
     return {
       taskId,

--- a/src/resources/extensions/gsd/tools/plan-task.ts
+++ b/src/resources/extensions/gsd/tools/plan-task.ts
@@ -37,6 +37,7 @@ import {
   planningOperationPayload,
 } from "../planning-domain-operation.js";
 import type { PlanningInvocation } from "../planning-invocation.js";
+import { executeTaskIllegalPlanToolsError } from "../execute-task-plan-tool-guard.js";
 
 export interface PlanTaskParams {
   milestoneId: string;
@@ -141,9 +142,16 @@ function validateParams(params: PlanTaskParams): PlanTaskParams {
     throw new Error("observabilityImpact must be a non-empty string when provided");
   }
 
+  const files = validateStringArray(params.files, "files");
+  const illegalToolsError = executeTaskIllegalPlanToolsError(
+    { description: params.description, files },
+    `task ${params.taskId}`,
+  );
+  if (illegalToolsError) throw new Error(illegalToolsError);
+
   return {
     ...params,
-    files: validateStringArray(params.files, "files"),
+    files,
     inputs: validateStringArray(params.inputs, "inputs"),
     expectedOutput: validateStringArray(params.expectedOutput, "expectedOutput"),
     ...(params.targetRepositories !== undefined


### PR DESCRIPTION
## TL;DR

**What:** Plan-slice/plan-task now reject tasks that require lifecycle tools execute-task cannot call.
**Why:** Those plans reached execute-task, hit a hard tool-contract block, and could loop on reopen.
**How:** Fail closed at planning validation with a planner-visible error naming the illegal tool and owning unit.

## What

`gsd_plan_slice` and `gsd_plan_task` validate each task's `files` and `description` before persist. If the task names or implies `gsd_requirement_update` or `gsd_milestone_status` (including requirement/milestone metadata files), planning returns a validation error and does not write task rows.

Ordinary code tasks and descriptions that merely mention planner tools such as `gsd_plan_task` still persist.

## Why

Closes #1530

`execute-task` has a narrow tool contract. Plan-slice could still assign requirement terminalization or milestone-metadata work to a normal task. Execution then hard-blocked on `gsd_requirement_update` / `gsd_milestone_status` instead of failing at plan time.

## How

- Scan task `description` and `files` for those lifecycle tools (canonical names, aliases, MCP-prefixed names).
- Infer the same tools from requirement/milestone metadata paths (`REQUIREMENTS.md`, `ROADMAP.md`, `.gsd/PROJECT.md`, `M###-ROADMAP.md`).
- Compare against `execute-task` `allowedGsdTools` and fail closed with a planner-visible error that names an owning unit (`complete-slice`, `reassess-roadmap`, …).

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes