### PR TITLE
fix(issue): gsd_milestone_reopen has no partial mode (#1854)

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2475,6 +2475,7 @@ const milestoneReopenParams = {
   reason: z.string().optional().describe("Why the milestone is being reopened"),
   actorName: z.string().optional().describe("Caller-provided actor identity for audit trail"),
   triggerReason: z.string().optional().describe("Caller-provided reason this action was triggered"),
+  keepCompleted: z.boolean().optional().describe("When true, unlock the milestone without resetting completed slices/tasks or deleting their SUMMARY projections. Default false (full cascade reset)."),
 };
 const milestoneReopenSchema = z.object(milestoneReopenParams);
 
@@ -3528,7 +3529,7 @@ export function registerWorkflowTools(
 
   server.tool(
     "gsd_milestone_reopen",
-    "Reopen a terminal Milestone hierarchy atomically while preserving immutable history, then refresh readable projections.",
+    "Reopen a terminal Milestone hierarchy atomically while preserving immutable history, then refresh readable projections. Pass keepCompleted=true to unlock the milestone without resetting completed slices/tasks or deleting their SUMMARYs.",
     milestoneReopenParams,
     async (args: Record<string, unknown>, extra?: WorkflowMcpRequestExtra) => {
       const parsed = parseWorkflowArgs(milestoneReopenSchema, args);
@@ -3543,7 +3544,7 @@ export function registerWorkflowTools(
 
   server.tool(
     "gsd_reopen_milestone",
-    "Alias for gsd_milestone_reopen. Reopen a terminal Milestone hierarchy atomically, then refresh readable projections.",
+    "Alias for gsd_milestone_reopen. Reopen a terminal Milestone hierarchy atomically, then refresh readable projections. Pass keepCompleted=true to unlock without resetting completed work.",
     milestoneReopenParams,
     async (args: Record<string, unknown>, extra?: WorkflowMcpRequestExtra) => {
       logAliasUsage("gsd_reopen_milestone", "gsd_milestone_reopen");

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -2706,12 +2706,13 @@ export function registerDbTools(pi: ExtensionAPI): void {
 		name: "gsd_milestone_reopen",
 		label: "Reopen Milestone",
 		description:
-			"Reopen a terminal Milestone and its completed work in one revision- and Authority-Epoch-fenced SQLite operation while preserving immutable history, then remove stale readable summaries.",
+			"Reopen a terminal Milestone and its completed work in one revision- and Authority-Epoch-fenced SQLite operation while preserving immutable history, then remove stale readable summaries. Pass keepCompleted=true to unlock the milestone without resetting completed slices/tasks or deleting their SUMMARYs.",
 		promptSnippet:
 			"Reopen a terminal GSD Milestone atomically, then refresh readable projections",
 		promptGuidelines: [
 			"Use gsd_milestone_reopen when a terminal Milestone needs to be re-done (e.g. validation failure surfaced after closure).",
-			"All terminal slices and tasks reopen together — no partial reopen — while prior Attempts and evidence remain immutable.",
+			"Default is a full cascade: all terminal slices and tasks reopen together while prior Attempts and evidence remain immutable.",
+			"Pass keepCompleted=true to unlock the milestone for new work without resetting completed slices/tasks or deleting their SUMMARY projections.",
 			"Will fail if the Milestone is not currently terminal — there is nothing to reopen.",
 			"Exact invocation replays report duplicate; historical replays report superseded and cannot remove newer projections.",
 			"Use the canonical name gsd_milestone_reopen; gsd_reopen_milestone is only an alias.",
@@ -2722,6 +2723,12 @@ export function registerDbTools(pi: ExtensionAPI): void {
 				Type.String({
 					description:
 						"Why the milestone is being reopened (recorded in the audit trail)",
+				}),
+			),
+			keepCompleted: Type.Optional(
+				Type.Boolean({
+					description:
+						"When true, unlock the milestone without resetting completed slices/tasks or deleting their SUMMARY projections. Default false.",
 				}),
 			),
 			// Single-writer v3 audit trail (Stream 2): caller-provided actor identity + causation.

--- a/src/resources/extensions/gsd/db/writers/cascades.ts
+++ b/src/resources/extensions/gsd/db/writers/cascades.ts
@@ -85,11 +85,16 @@ export type ReopenMilestoneOutcome =
   | { ok: false; reason: "milestone-not-closed"; status: string };
 
 /**
- * Reopen a closed milestone: milestone → "active", every slice → "in_progress",
- * every task → "pending", completion timestamps cleared, in one commit. Folds
- * the hand-rolled transaction-plus-cascade previously in tools/reopen-milestone.ts.
+ * Reopen a closed milestone: milestone → "active", completion timestamp
+ * cleared. The default cascade also sets every slice → "in_progress" and every
+ * task → "pending". Pass keepCompleted to unlock the milestone without
+ * resetting already-finished descendants. Folds the hand-rolled
+ * transaction-plus-cascade previously in tools/reopen-milestone.ts.
  */
-export function reopenMilestoneCascade(milestoneId: string): ReopenMilestoneOutcome {
+export function reopenMilestoneCascade(
+  milestoneId: string,
+  keepCompleted = false,
+): ReopenMilestoneOutcome {
   requireDb();
   let outcome: ReopenMilestoneOutcome = { ok: true, slicesReset: 0, tasksReset: 0 };
   transaction(() => {
@@ -106,11 +111,15 @@ export function reopenMilestoneCascade(milestoneId: string): ReopenMilestoneOutc
     }
     if (!isClosedStatus(milestone.status)) { outcome = { ok: false, reason: "milestone-not-closed", status: milestone.status }; return; }
 
-    const slices = getMilestoneSlices(milestoneId);
-
     getDbOrNull()!.prepare(
       `UPDATE milestones SET status = 'active', completed_at = NULL WHERE id = :mid`,
     ).run({ ":mid": milestoneId });
+    if (keepCompleted) {
+      outcome = { ok: true, slicesReset: 0, tasksReset: 0 };
+      return;
+    }
+
+    const slices = getMilestoneSlices(milestoneId);
     getDbOrNull()!.prepare(
       `UPDATE slices SET status = 'in_progress', completed_at = NULL WHERE milestone_id = :mid`,
     ).run({ ":mid": milestoneId });

--- a/src/resources/extensions/gsd/db/writers/milestone-lifecycle.ts
+++ b/src/resources/extensions/gsd/db/writers/milestone-lifecycle.ts
@@ -57,6 +57,7 @@ export interface MilestoneCompletionHierarchyResult {
 export interface MilestoneReopenHierarchyInput {
   milestoneId: string;
   reason: string;
+  keepCompleted?: boolean;
 }
 
 export interface MilestoneReopenHierarchyResult {
@@ -649,13 +650,13 @@ export function reopenMilestoneHierarchy(
   requireNoActiveAttempts(milestoneId);
   requireNoProgressedDependentMilestones(context, milestoneId);
 
-  const waiverResult = revokeCancellationWaivers(
-    context,
-    milestoneId,
-    reason,
-    reopenedAt,
-  );
+  const keepCompleted = input.keepCompleted === true;
+  const waiverResult = keepCompleted
+    ? { revokedWaiverIds: [] as string[], supersedingDispositionIds: [] as string[] }
+    : revokeCancellationWaivers(context, milestoneId, reason, reopenedAt);
   const reopenedTaskIds: string[] = [];
+  const reopenedSliceIds: string[] = [];
+  if (!keepCompleted) {
   for (const task of tasks) {
     const taskId = task.taskId!;
     adoptOrTransitionLifecycle(context, {
@@ -685,7 +686,6 @@ export function reopenMilestoneHierarchy(
     reopenedTaskIds.push(`${task.sliceId}/${taskId}`);
   }
 
-  const reopenedSliceIds: string[] = [];
   for (const slice of slices) {
     const sliceId = slice.sliceId!;
     adoptOrTransitionLifecycle(context, {
@@ -712,6 +712,7 @@ export function reopenMilestoneHierarchy(
     }
     ensurePendingSliceQ8(context, { milestoneId, sliceId });
     reopenedSliceIds.push(sliceId);
+  }
   }
 
   const milestoneLifecycle = adoptOrTransitionLifecycle(context, {

--- a/src/resources/extensions/gsd/milestone-lifecycle-domain-operation.ts
+++ b/src/resources/extensions/gsd/milestone-lifecycle-domain-operation.ts
@@ -426,18 +426,21 @@ export function reopenMilestone(input: {
   milestoneId: string;
   reason: string;
   audit?: MilestoneCompletionAudit;
+  keepCompleted?: boolean;
 }): MilestoneReopenReceipt {
   const milestoneId = requiredText(input.milestoneId, "milestoneId");
   const reason = requiredText(input.reason, "reason");
   const audit = normalizedAudit(input.audit);
+  const keepCompleted = input.keepCompleted === true;
   const operation = executeDomainOperation(
     operationRequest("milestone.reopen", input.invocation, {
       milestoneId,
       reason,
       audit,
+      ...(keepCompleted ? { keepCompleted: true } : {}),
     }),
     (context) => {
-      const result = reopenMilestoneHierarchy(context, { milestoneId, reason });
+      const result = reopenMilestoneHierarchy(context, { milestoneId, reason, keepCompleted });
       return {
         events: [{
           eventType: "milestone.reopened",

--- a/src/resources/extensions/gsd/tests/milestone-reopen-keep-completed.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-reopen-keep-completed.test.ts
@@ -1,0 +1,137 @@
+// Project/App: gsd-pi
+// File Purpose: keepCompleted reopen unlocks a closed milestone without
+// wiping completed task timestamps or SUMMARY projections (#1854).
+
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { clearParseCache } from "../files.ts";
+import {
+  _getAdapter,
+  closeDatabase,
+  getMilestone,
+  getSlice,
+  getTask,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+  reopenMilestoneCascade,
+} from "../gsd-db.ts";
+import { clearPathCache, targetTaskFile } from "../paths.ts";
+import { isClosedStatus } from "../status-guards.ts";
+import { handleReopenMilestone } from "../tools/reopen-milestone.ts";
+
+const COMPLETED_AT = "2026-08-06T12:00:00.000Z";
+const SUMMARY_BODY = "Completed work from August 6. Do not delete.\n";
+
+function db() {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  return adapter;
+}
+
+function seedClosedMilestone(): { base: string; summaryPath: string } {
+  const base = mkdtempSync(join(tmpdir(), "gsd-milestone-reopen-keep-completed-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  insertMilestone({ id: "M001", title: "Partial reopen", status: "complete" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Finished slice", status: "complete" });
+  insertTask({
+    id: "T01",
+    milestoneId: "M001",
+    sliceId: "S01",
+    title: "Finished task",
+    status: "complete",
+    fullSummaryMd: SUMMARY_BODY,
+  });
+  db().exec(`
+    UPDATE milestones SET completed_at = '${COMPLETED_AT}' WHERE id = 'M001';
+    UPDATE slices SET completed_at = '${COMPLETED_AT}' WHERE milestone_id = 'M001' AND id = 'S01';
+    UPDATE tasks SET completed_at = '${COMPLETED_AT}' WHERE milestone_id = 'M001' AND slice_id = 'S01' AND id = 'T01';
+  `);
+  const summaryPath = targetTaskFile(base, "M001", "S01", "T01", "SUMMARY", "Partial reopen");
+  mkdirSync(dirname(summaryPath), { recursive: true });
+  writeFileSync(summaryPath, SUMMARY_BODY);
+  return { base, summaryPath };
+}
+
+function cleanup(base: string): void {
+  clearPathCache();
+  clearParseCache();
+  closeDatabase();
+  rmSync(base, { recursive: true, force: true });
+}
+
+test("keepCompleted cascade unlocks the milestone without resetting completed tasks", (t) => {
+  const { base } = seedClosedMilestone();
+  t.after(() => cleanup(base));
+
+  const outcome = reopenMilestoneCascade("M001", true);
+  assert.deepEqual(outcome, { ok: true, slicesReset: 0, tasksReset: 0 });
+
+  const milestone = getMilestone("M001");
+  assert.ok(milestone);
+  assert.equal(isClosedStatus(milestone.status), false);
+  assert.equal(milestone.completed_at, null);
+
+  const task = getTask("M001", "S01", "T01");
+  assert.ok(task);
+  assert.equal(task.status, "complete");
+  assert.equal(task.completed_at, COMPLETED_AT);
+
+  const slice = getSlice("M001", "S01");
+  assert.ok(slice);
+  assert.equal(slice.status, "complete");
+  assert.equal(slice.completed_at, COMPLETED_AT);
+});
+
+test("keepCompleted handler preserves task completed_at and SUMMARY files", async (t) => {
+  const { base, summaryPath } = seedClosedMilestone();
+  t.after(() => cleanup(base));
+
+  const result = await handleReopenMilestone({
+    milestoneId: "M001",
+    reason: "Add one more slice without discarding finished work.",
+    keepCompleted: true,
+  }, base);
+
+  assert.ok(!("error" in result), `reopen failed: ${"error" in result ? result.error : ""}`);
+  assert.equal(result.slicesReset, 0);
+  assert.equal(result.tasksReset, 0);
+
+  const milestone = getMilestone("M001");
+  assert.ok(milestone);
+  assert.equal(isClosedStatus(milestone.status), false);
+  assert.equal(milestone.completed_at, null);
+
+  const task = getTask("M001", "S01", "T01");
+  assert.ok(task);
+  assert.equal(task.status, "complete");
+  assert.equal(task.completed_at, COMPLETED_AT);
+  assert.equal(existsSync(summaryPath), true, summaryPath);
+  assert.match(readFileSync(summaryPath, "utf8"), new RegExp(COMPLETED_AT));
+});
+
+test("omitted keepCompleted still resets completed tasks and deletes SUMMARYs", async (t) => {
+  const { base, summaryPath } = seedClosedMilestone();
+  t.after(() => cleanup(base));
+
+  const result = await handleReopenMilestone({
+    milestoneId: "M001",
+    reason: "Full redo remains the default.",
+  }, base);
+
+  assert.ok(!("error" in result), `reopen failed: ${"error" in result ? result.error : ""}`);
+  assert.equal(result.slicesReset, 1);
+  assert.equal(result.tasksReset, 1);
+
+  const task = getTask("M001", "S01", "T01");
+  assert.ok(task);
+  assert.equal(task.status, "pending");
+  assert.equal(task.completed_at, null);
+  assert.equal(existsSync(summaryPath), false, summaryPath);
+});

--- a/src/resources/extensions/gsd/tools/reopen-milestone.ts
+++ b/src/resources/extensions/gsd/tools/reopen-milestone.ts
@@ -53,6 +53,8 @@ export interface ReopenMilestoneParams {
   actorName?: string;
   /** Optional caller-provided reason this action was triggered */
   triggerReason?: string;
+  /** Unlock the milestone without resetting completed slices/tasks or deleting their SUMMARYs. */
+  keepCompleted?: boolean;
 }
 
 export interface ReopenMilestoneResult {
@@ -99,6 +101,7 @@ export async function handleReopenMilestone(
         invocation,
         milestoneId: params.milestoneId,
         reason: params.reason?.trim() || "Full Milestone redo requested",
+        keepCompleted: params.keepCompleted === true,
         audit: {
           ...(params.actorName ? { actorName: params.actorName } : {}),
           ...(params.triggerReason ? { triggerReason: params.triggerReason } : {}),
@@ -110,7 +113,7 @@ export async function handleReopenMilestone(
       return { error: error instanceof Error ? error.message : String(error) };
     }
   } else {
-    const outcome = reopenMilestoneCascade(params.milestoneId);
+    const outcome = reopenMilestoneCascade(params.milestoneId, params.keepCompleted === true);
     if (!outcome.ok) {
       switch (outcome.reason) {
         case "milestone-not-found":
@@ -168,6 +171,7 @@ export async function handleReopenMilestone(
         }
       }
 
+      if (params.keepCompleted !== true) {
       cleanup: for (const slice of slices) {
         if (superseded) break;
         const sliceDir = resolveSlicePath(basePath, params.milestoneId, slice.id);
@@ -216,6 +220,7 @@ export async function handleReopenMilestone(
             }
           }
         }
+      }
       }
     } catch (err) {
       projectionStale = true;


### PR DESCRIPTION
## TL;DR

**What:** Add optional `keepCompleted` to `gsd_milestone_reopen` so a closed milestone can be unlocked without wiping finished work.
**Why:** The only reopen path today resets every slice/task, nulls `completed_at`, and deletes every per-task SUMMARY just to add one more slice.
**How:** Default stays the current full cascade; `keepCompleted: true` reopens only the milestone and leaves completed descendants and their SUMMARYs intact.

## What

`gsd_milestone_reopen` now accepts optional `keepCompleted` (default `false`).

When `keepCompleted` is true:
- the milestone is set back to `active` with `completed_at` cleared
- completed slices/tasks keep their status and `completed_at`
- per-slice/per-task SUMMARY projections are not deleted

When omitted or false, behavior is unchanged: full cascade reset plus SUMMARY cleanup.

## Why

Unlocking a closed milestone to plan one new slice currently discards the record of already-finished work. That is the common case, and the cost only shows up after the tool has already run.

Closes #1854

## How

- MCP and in-process tool schemas expose optional `keepCompleted`
- `reopenMilestoneCascade` skips descendant UPDATEs when the flag is true
- adopted reopen skips descendant lifecycle resets and waiver revocation when the flag is true
- handler cleanup still removes the milestone SUMMARY, but not completed slice/task SUMMARYs

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes