### PR TITLE
fix(issue): post-unit gates audit stale HEAD (#1431)

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -78,7 +78,12 @@ import {
 import type { AutoSession, SidecarItem } from "./auto/session.js";
 import { getEvidence, clearEvidenceFromDisk, isExecutionToolName } from "./safety/evidence-collector.js";
 import { removeProjectionFileSync } from "./atomic-write.js";
-import { validateFileChanges, effectiveFileChangeAllowlist } from "./safety/file-change-validator.js";
+import {
+  validateFileChanges,
+  effectiveFileChangeAllowlist,
+  readCommittedHeadSha,
+  type FileChangeAudit,
+} from "./safety/file-change-validator.js";
 import { crossReferenceEvidence, type ClaimedEvidence } from "./safety/evidence-cross-ref.js";
 import { validateContent } from "./safety/content-validator.js";
 import { resolveSafetyHarnessConfig } from "./safety/safety-harness.js";
@@ -791,6 +796,71 @@ export function _hasExecutionToolCallsInSessionForTest(entries: readonly unknown
 
 export function shouldDeferCloseoutGitAction(unitType: string): boolean {
   return unitType === "execute-task";
+}
+
+function reportFileChangeWarnings(
+  ctx: ExtensionContext,
+  audit: FileChangeAudit | null,
+): void {
+  if (!audit || audit.violations.length === 0) return;
+  const warnings = audit.violations.filter(v => v.severity === "warning");
+  for (const v of warnings) {
+    logWarning("safety", `file-change: ${v.file} — ${v.reason}`);
+  }
+  if (warnings.length > 0) {
+    ctx.ui.notify(
+      `Safety: ${warnings.length} unexpected file change(s) outside task plan`,
+      "warning",
+    );
+  }
+}
+
+function runExecuteTaskFileChangeSafety(
+  s: AutoSession,
+  ctx: ExtensionContext,
+  fileChangeAllowlist: string[],
+  preUnitHead: string | null,
+): void {
+  if (s.currentUnit?.type !== "execute-task") return;
+  const { milestone: sMid, slice: sSid, task: sTid } = parseUnitId(s.currentUnit.id);
+  if (!sMid || !sSid || !sTid) return;
+  try {
+    const sliceTaskRows = isDbAvailable()
+      ? getSliceTasks(sMid, sSid).filter((t) => isClosedStatus(t.status) || t.id === sTid)
+      : [];
+    if (sliceTaskRows.length > 0) {
+      const expectedOutput = getPlannedKeyFiles(
+        sliceTaskRows.map((taskRow) => ({
+          expected_output: taskRow.expected_output,
+          files: taskRow.files,
+        })),
+      );
+      const plannedFiles = getPlannedKeyFiles(
+        sliceTaskRows.map((taskRow) => ({
+          files: taskRow.files,
+        })),
+      );
+      reportFileChangeWarnings(
+        ctx,
+        validateFileChanges(s.basePath, expectedOutput, plannedFiles, fileChangeAllowlist, { preUnitHead }),
+      );
+      return;
+    }
+    const taskRow = getTask(sMid, sSid, sTid);
+    if (!taskRow) return;
+    reportFileChangeWarnings(
+      ctx,
+      validateFileChanges(
+        s.basePath,
+        taskRow.expected_output ?? [],
+        taskRow.files ?? [],
+        fileChangeAllowlist,
+        { preUnitHead },
+      ),
+    );
+  } catch (e) {
+    debugLog("postUnit", { phase: "safety-file-change", error: String(e) });
+  }
 }
 
 /** Unit types that only touch `.gsd/` internal state files (no code changes).
@@ -1823,73 +1893,6 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       if (safetyConfig.enabled) {
         const { milestone: sMid, slice: sSid, task: sTid } = parseUnitId(s.currentUnit.id);
 
-        const fileChangeAllowlist = effectiveFileChangeAllowlist(
-          safetyConfig.file_change_allowlist,
-          (prefs?.git as { manage_gitignore?: boolean } | undefined)?.manage_gitignore,
-        );
-
-        // File change validation (execute-task only, after unit execution)
-        if (safetyConfig.file_change_validation && s.currentUnit.type === "execute-task" && sMid && sSid && sTid) {
-          try {
-            const sliceTaskRows = isDbAvailable()
-              ? getSliceTasks(sMid, sSid).filter((t) => isClosedStatus(t.status) || t.id === sTid)
-              : [];
-
-            if (sliceTaskRows.length > 0) {
-              const expectedOutput = getPlannedKeyFiles(
-                sliceTaskRows.map((taskRow) => ({
-                  expected_output: taskRow.expected_output,
-                  files: taskRow.files,
-                })),
-              );
-              const plannedFiles = getPlannedKeyFiles(
-                sliceTaskRows.map((taskRow) => ({
-                  files: taskRow.files,
-                })),
-              );
-              const audit = validateFileChanges(s.basePath, expectedOutput, plannedFiles, fileChangeAllowlist);
-              if (audit && audit.violations.length > 0) {
-                const warnings = audit.violations.filter(v => v.severity === "warning");
-                for (const v of warnings) {
-                  logWarning("safety", `file-change: ${v.file} — ${v.reason}`);
-                }
-                if (warnings.length > 0) {
-                  ctx.ui.notify(
-                    `Safety: ${warnings.length} unexpected file change(s) outside task plan`,
-                    "warning",
-                  );
-                }
-              }
-            } else {
-              const taskRow = getTask(sMid, sSid, sTid);
-              if (taskRow) {
-                const expectedOutput = taskRow.expected_output ?? [];
-                const plannedFiles = taskRow.files ?? [];
-                const audit = validateFileChanges(
-                  s.basePath,
-                  expectedOutput,
-                  plannedFiles,
-                  fileChangeAllowlist,
-                );
-                if (audit && audit.violations.length > 0) {
-                  const warnings = audit.violations.filter(v => v.severity === "warning");
-                  for (const v of warnings) {
-                    logWarning("safety", `file-change: ${v.file} — ${v.reason}`);
-                  }
-                  if (warnings.length > 0) {
-                    ctx.ui.notify(
-                      `Safety: ${warnings.length} unexpected file change(s) outside task plan`,
-                      "warning",
-                    );
-                  }
-                }
-              }
-            }
-          } catch (e) {
-            debugLog("postUnit", { phase: "safety-file-change", error: String(e) });
-          }
-        }
-
         // Evidence cross-reference (execute-task only)
         // Only compare against concrete command evidence persisted by the task
         // completion tool. A prose Verify field can be satisfied later by the
@@ -2641,6 +2644,7 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
   if (s.currentUnit) {
     if (shouldDeferCloseoutGitAction(s.currentUnit.type)) {
+      const preUnitHead = readCommittedHeadSha(s.basePath);
       const gitActionResult = await runCloseoutGitAction(pctx, s.currentUnit, { softFailure: true });
       if (gitActionResult === "dispatched") {
         return "stopped";
@@ -2656,6 +2660,21 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
         }) === "retry"
       ) {
         return "retry";
+      }
+      try {
+        const prefs = loadEffectiveGSDPreferences()?.preferences;
+        const safetyConfig = resolveSafetyHarnessConfig(
+          prefs?.safety_harness as Record<string, unknown> | undefined,
+        );
+        if (safetyConfig.enabled && safetyConfig.file_change_validation) {
+          const fileChangeAllowlist = effectiveFileChangeAllowlist(
+            safetyConfig.file_change_allowlist,
+            (prefs?.git as { manage_gitignore?: boolean } | undefined)?.manage_gitignore,
+          );
+          runExecuteTaskFileChangeSafety(s, ctx, fileChangeAllowlist, preUnitHead);
+        }
+      } catch (e) {
+        debugLog("postUnit", { phase: "safety-file-change", error: String(e) });
       }
     }
 

--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -8,6 +8,10 @@
  * Using diff-tree --root handles initial commits, shallow clones, and merge commits correctly
  * (Bug #4385 — git diff HEAD~1 failed on initial commits).
  *
+ * When the unit created no commit, HEAD is still the previous unit's changeset.
+ * Callers must pass `preUnitHead` so that case returns an empty change set
+ * instead of auditing stale HEAD (#1431).
+ *
  * Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
  */
 
@@ -36,6 +40,16 @@ export interface FileChangeAudit {
   unexpectedFiles: string[];
   missingFiles: string[];
   violations: FileViolation[];
+}
+
+export interface FileChangeAuditOptions {
+  /**
+   * HEAD SHA recorded before this unit's commit.
+   * When current HEAD still equals this SHA, the unit created no commit —
+   * return an empty change set instead of auditing the previous commit (#1431).
+   * Omit or pass null when the baseline is unknown; then HEAD is audited as before.
+   */
+  preUnitHead?: string | null;
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────────
@@ -67,6 +81,7 @@ export function validateFileChanges(
   expectedOutput: string[],
   plannedFiles: string[],
   fileChangeAllowlist: string[] = [],
+  options?: FileChangeAuditOptions,
 ): FileChangeAudit | null {
   const allExpected = new Set([...expectedOutput, ...plannedFiles]);
 
@@ -74,7 +89,7 @@ export function validateFileChanges(
   if (allExpected.size === 0) return null;
 
   // Get actual changed files from last commit
-  const actualFiles = getChangedFilesFromLastCommit(basePath);
+  const actualFiles = getChangedFilesFromLastCommit(basePath, options?.preUnitHead);
   if (!actualFiles) return null;
 
   const configuredProjectsDir = process.env.GSD_STATE_DIR
@@ -141,8 +156,31 @@ export function validateFileChanges(
 
 // ─── Internals ──────────────────────────────────────────────────────────────
 
-function getChangedFilesFromLastCommit(basePath: string): string[] | null {
+/**
+ * Current committed HEAD SHA, or null when HEAD is missing/unborn.
+ */
+export function readCommittedHeadSha(basePath: string): string | null {
   try {
+    const sha = execFileSync(
+      "git",
+      ["rev-parse", "--verify", "HEAD"],
+      { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
+    ).trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+function getChangedFilesFromLastCommit(
+  basePath: string,
+  preUnitHead?: string | null,
+): string[] | null {
+  try {
+    if (preUnitHead) {
+      const head = readCommittedHeadSha(basePath);
+      if (!head || head === preUnitHead) return [];
+    }
     const result = execFileSync(
       "git",
       ["diff-tree", "--root", "--no-commit-id", "-r", "--name-only", "HEAD"],

--- a/src/resources/extensions/gsd/tests/file-change-validator.test.ts
+++ b/src/resources/extensions/gsd/tests/file-change-validator.test.ts
@@ -198,6 +198,43 @@ test("validateFileChanges excludes the configured in-repo GSD state directory", 
   assert.deepEqual(audit.actualFiles, ["src/app.ts"]);
 });
 
+test("validateFileChanges does not treat pre-unit HEAD as this unit's changeset when no commit was created", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  git(base, "init");
+  git(base, "config", "user.email", "test@example.com");
+  git(base, "config", "user.name", "Test User");
+
+  writeFileSync(join(base, "lib.rs"), "fn previous() {}\n");
+  writeFileSync(join(base, "main.rs"), "fn main() {}\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "previous rust refactor");
+  const preUnitHead = git(base, "rev-parse", "HEAD");
+
+  const stale = validateFileChanges(base, ["docs/plan.md"], []);
+  assert.ok(stale, "audit should be produced for stale HEAD");
+  assert.ok(
+    stale.unexpectedFiles.includes("lib.rs") && stale.unexpectedFiles.includes("main.rs"),
+    "without preUnitHead, previous commit files are treated as this unit's changeset",
+  );
+
+  const audit = validateFileChanges(base, ["docs/plan.md"], [], [], { preUnitHead });
+  assert.ok(audit, "audit should be produced when the unit created no commit");
+  assert.deepEqual(audit.actualFiles, [], "no-commit units have an empty change set");
+  assert.deepEqual(audit.unexpectedFiles, [], "stale HEAD files must not be unexpected");
+
+  mkdirSync(join(base, "docs"));
+  writeFileSync(join(base, "docs", "plan.md"), "synced\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "task planning artifacts");
+
+  const committed = validateFileChanges(base, ["docs/plan.md"], [], [], { preUnitHead });
+  assert.ok(committed, "audit should be produced after the unit commit");
+  assert.deepEqual(committed.actualFiles, ["docs/plan.md"]);
+  assert.deepEqual(committed.unexpectedFiles, [], "this unit's files remain expected");
+});
+
 test("GSD-managed .gitignore edit swept into a task commit is not flagged", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## TL;DR

**What:** Post-unit file-change safety no longer reports the previous commit's files as unexpected when the current unit created no commit.
**Why:** Execute-task closeout git is deferred, so `git diff-tree HEAD` was auditing stale pre-unit HEAD and warning on files the unit never changed.
**How:** Record HEAD before deferred closeout git and pass it to the validator; if HEAD did not move, use an empty change set.

## What

- `validateFileChanges` accepts `preUnitHead`. When current HEAD still equals that SHA, `getChangedFilesFromLastCommit` returns `[]` instead of `diff-tree HEAD`.
- Execute-task file-change safety runs after deferred closeout git, so a real unit commit is still audited.
- Adds a regression test for a GSD-only/no-commit unit whose expected files do not match the previous commit.

## Why

Remaining gap on #1431: file-change safety treated pre-unit HEAD as this unit's changeset when the unit made no commit, producing `Safety: N unexpected file change(s) outside task plan`. Prose verify plus task evidence already beats preference commands.

Closes #1431

## How

Capture HEAD immediately before `runCloseoutGitAction` for execute-task units. After git, pass that SHA into `validateFileChanges`. No commit → empty actual files → no unexpected-file warnings from the previous commit. A commit that moves HEAD is still audited with `diff-tree HEAD`.

### Change type

- [x] `fix` — Bug fix