### PR TITLE
fix(issue): phase-dir slug drift and lock rmSync no-op (#1526)

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -2,6 +2,7 @@ import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, rmSync,
 import { basename, dirname, join } from "node:path";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
+import { removeLockDirectory } from "./session-lock.js";
 import { cleanNumberedGsdVariants } from "./repo-identity.js";
 import { milestonesDir, gsdRoot, resolveGsdRootFile, milestoneDirExists } from "./paths.js";
 import { deriveState, isGhostMilestone, isReusableGhostMilestone } from "./state.js";
@@ -197,10 +198,13 @@ export async function checkRuntimeHealth(
           });
           if (shouldFix("stranded_lock_directory")) {
             try {
-              rmSync(lockDir, { recursive: true, force: true });
+              removeLockDirectory(lockDir);
               fixesApplied.push(`removed stranded lock directory ${lockDir}`);
-            } catch {
-              fixesApplied.push(`failed to remove stranded lock directory ${lockDir}`);
+            } catch (error) {
+              fixesApplied.push(
+                `failed to remove stranded lock directory ${lockDir}` +
+                  ` (${error instanceof Error ? error.message : String(error)})`,
+              );
             }
           }
         }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -16,7 +16,8 @@
 // The separate `.gsd/unit-claims.db` (unit-ownership.ts) is an intentionally
 // independent store and is excluded from this invariant.
 import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { renamePhaseDirOnTitleChange } from "./phase-dir-rename.js";
 import type { Decision, Requirement, GateRow, GateId, GateScope, GateStatus, GateVerdict } from "./types.js";
 import { GSDError, GSD_STALE_STATE } from "./errors.js";
 import { getGateIdsForTurn, type OwnerTurn } from "./gate-registry.js";
@@ -48,7 +49,7 @@ import { rowToSlice, rowToTask, type SliceRow, type TaskRow } from "./db-task-sl
 // primitives now live in the engine; re-export the full public surface so
 // existing `from "./gsd-db.js"` imports keep working.
 export * from "./db/engine.js";
-import { immediateTransaction, transaction, getDb, getDbOrNull } from "./db/engine.js";
+import { immediateTransaction, transaction, getDb, getDbOrNull, getDbPath } from "./db/engine.js";
 import { assertNoAdoptedLifecycleHistory } from "./db/writers/import-restore.js";
 
 // ─── Single Writer Layer re-exports ──────────────────────────────────────
@@ -353,6 +354,9 @@ export function insertMilestone(m: {
 
 export function upsertMilestonePlanning(milestoneId: string, planning: Partial<MilestonePlanningRecord> & { title?: string; status?: string; depends_on?: string[] }): void {
   if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const previousTitle = (getDbOrNull()!.prepare(
+    "SELECT title FROM milestones WHERE id = :id",
+  ).get({ ":id": milestoneId }) as { title?: string } | undefined)?.title;
   transaction(() => {
     if (planning.status !== undefined && planning.status !== "") {
       applyStatusTransition({
@@ -397,6 +401,15 @@ export function upsertMilestonePlanning(milestoneId: string, planning: Partial<M
     const finalTitle = planning.title?.trim();
     if (finalTitle) reconcileMilestonePhaseArtifactPaths(milestoneId, finalTitle);
   });
+  const finalTitle = planning.title?.trim();
+  const dbPath = getDbPath();
+  if (finalTitle && dbPath && dbPath !== ":memory:") {
+    try {
+      renamePhaseDirOnTitleChange(dirname(dirname(dbPath)), milestoneId, previousTitle, finalTitle);
+    } catch (error) {
+      logWarning("db", `phase dir rename after title update failed: ${(error as Error).message}`);
+    }
+  }
 }
 
 export function insertSlice(s: {

--- a/src/resources/extensions/gsd/phase-dir-rename.ts
+++ b/src/resources/extensions/gsd/phase-dir-rename.ts
@@ -1,0 +1,47 @@
+// Project/App: gsd-pi
+// File Purpose: Rename the on-disk phase directory when a milestone title changes.
+
+import { existsSync, renameSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import {
+  canonicalPhaseDirName,
+  clearPathCache,
+  isLegacyMilestonesLayout,
+  milestonesDir,
+  resolveMilestonePath,
+} from "./paths.js";
+
+/**
+ * Move `phases/NN-old-slug` → `phases/NN-canonical` after a title change.
+ * No-op when the old dir is missing, the new dir already exists, names match,
+ * or the project is still on the legacy milestones/ layout. (#1526)
+ */
+export function renamePhaseDirOnTitleChange(
+  basePath: string,
+  milestoneId: string,
+  previousTitle: string | undefined,
+  nextTitle: string,
+): boolean {
+  if (!nextTitle.trim()) return false;
+  if (isLegacyMilestonesLayout(basePath)) return false;
+
+  const nextName = canonicalPhaseDirName(milestoneId, nextTitle);
+  const phasesDir = milestonesDir(basePath);
+  const nextPath = join(phasesDir, nextName);
+  if (existsSync(nextPath)) return false;
+
+  const existingPath = resolveMilestonePath(basePath, milestoneId);
+  const predictedOldPath = join(
+    phasesDir,
+    canonicalPhaseDirName(milestoneId, previousTitle || milestoneId),
+  );
+  const fromPath = existingPath && existsSync(existingPath) ? existingPath : predictedOldPath;
+
+  if (!existsSync(fromPath)) return false;
+  if (basename(fromPath) === nextName) return false;
+
+  renameSync(fromPath, nextPath);
+  clearPathCache();
+  return true;
+}

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -125,7 +125,7 @@ function lockPath(basePath: string): string {
 }
 
 export interface LockDirectoryFs {
-  rmSync(path: string, options: { recursive: boolean; force: boolean }): void;
+  rmSync(path: string, options: { recursive: boolean; force: true }): void;
   rmdirSync(path: string): void;
   existsSync(path: string): boolean;
 }

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -17,7 +17,7 @@
  */
 
 import { createRequire } from "node:module";
-import { existsSync, readFileSync, readdirSync, mkdirSync, unlinkSync, rmSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, mkdirSync, unlinkSync, rmSync, rmdirSync, statSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { gsdRoot, normalizeRealPath } from "./paths.js";
 import { atomicWriteSync } from "./atomic-write.js";
@@ -124,6 +124,49 @@ function lockPath(basePath: string): string {
   return join(gsdRoot(basePath), effectiveLockFile());
 }
 
+export interface LockDirectoryFs {
+  rmSync(path: string, options: { recursive: boolean; force: boolean }): void;
+  rmdirSync(path: string): void;
+  existsSync(path: string): boolean;
+}
+
+const defaultLockDirectoryFs: LockDirectoryFs = { rmSync, rmdirSync, existsSync };
+
+/**
+ * Remove a proper-lockfile directory. Node `fs.rmSync({ recursive: true })` can
+ * return without throwing while leaving the directory in place on Windows when
+ * the absolute path contains non-ASCII characters. After rmSync, verify with
+ * existsSync and fall back to rmdirSync; if the path still exists, throw with
+ * the path so callers cannot treat a no-op as success. (#1526)
+ */
+export function removeLockDirectory(
+  lockDir: string,
+  fsOps: LockDirectoryFs = defaultLockDirectoryFs,
+): void {
+  if (!fsOps.existsSync(lockDir)) return;
+  try {
+    fsOps.rmSync(lockDir, { recursive: true, force: true });
+  } catch {
+    // rmSync may throw or silently no-op; rmdirSync is the known-working fallback.
+  }
+  if (!fsOps.existsSync(lockDir)) return;
+  try {
+    fsOps.rmdirSync(lockDir);
+  } catch (error) {
+    throw new Error(
+      `Session lock directory still exists after rmSync/rmdirSync: ${lockDir}` +
+        ` (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+  if (fsOps.existsSync(lockDir)) {
+    throw new Error(
+      `Session lock directory still exists after rmSync/rmdirSync: ${lockDir}. ` +
+        `Node fs.rmSync can no-op on Windows paths with non-ASCII characters. ` +
+        `Remove it manually: rmdir "${lockDir}"`,
+    );
+  }
+}
+
 // ─── Stray Lock Cleanup ─────────────────────────────────────────────────────
 
 /**
@@ -161,7 +204,7 @@ export function cleanupStrayLockFiles(basePath: string): void {
           try {
             const stat = statSync(fullPath);
             if (stat.isDirectory()) {
-              rmSync(fullPath, { recursive: true, force: true });
+              try { removeLockDirectory(fullPath); } catch { /* best-effort stray cleanup */ }
             }
           } catch { /* best-effort */ }
         }
@@ -197,8 +240,8 @@ function ensureExitHandler(_gsdDir: string): void {
       } catch { /* best-effort */ }
       try {
         const lockDir = join(dir + ".lock");
-        if (ownsRegisteredLock && existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
-      } catch { /* best-effort */ }
+        if (ownsRegisteredLock) removeLockDirectory(lockDir);
+      } catch { /* best-effort on process exit */ }
     }
   });
 }
@@ -323,7 +366,14 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     if (deadPid) markWorkerStoppingByPid(normalizeRealPath(basePath), deadPid);
     const isOrphan = !existingData || !!deadPid;
     if (isOrphan) {
-      try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+      try {
+        removeLockDirectory(lockDir);
+      } catch (error) {
+        return {
+          acquired: false,
+          reason: error instanceof Error ? error.message : String(error),
+        };
+      }
       try { if (existsSync(lp)) unlinkSync(lp); } catch { /* best-effort */ }
     }
   }
@@ -365,7 +415,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     if (!existingData || (existingPid && !isPidAlive(existingPid))) {
       try {
         const lockDir = join(lockTarget + ".lock");
-        if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+        removeLockDirectory(lockDir);
         if (existsSync(lp)) unlinkSync(lp);
 
         // Retry acquisition after cleanup
@@ -382,7 +432,10 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
 
         atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
         return { acquired: true };
-      } catch {
+      } catch (retryErr) {
+        if (retryErr instanceof Error && retryErr.message.includes("Session lock directory still exists")) {
+          return { acquired: false, reason: retryErr.message };
+        }
         // Retry also failed — fall through to the error path
       }
     }
@@ -556,11 +609,8 @@ export function releaseSessionLock(basePath: string): void {
   // In parallel worker mode, this is .gsd/parallel/<MID>.lock/ (#2184).
   const gsdDir = gsdRoot(basePath);
   const lockTarget = effectiveLockTarget(gsdDir);
-  try {
-    const lockDir = join(lockTarget + ".lock");
-    if (ownsPrimaryLock && existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
-  } catch {
-    // Non-fatal
+  if (ownsPrimaryLock) {
+    removeLockDirectory(join(lockTarget + ".lock"));
   }
   // Also clean the per-milestone parallel directory itself if it exists
   if (ownsPrimaryLock && lockTarget !== gsdDir) {
@@ -581,8 +631,8 @@ export function releaseSessionLock(basePath: string): void {
     } catch { /* best-effort */ }
     try {
       const lockDir = join(dir + ".lock");
-      if (ownsRegisteredLock && existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
-    } catch { /* best-effort */ }
+      if (ownsRegisteredLock) removeLockDirectory(lockDir);
+    } catch { /* best-effort registry cleanup */ }
   }
   _lockDirRegistry.clear();
 
@@ -634,12 +684,8 @@ export function removeStaleSessionLock(basePath: string): boolean {
 
   let removed = false;
   if (existsSync(lockDir)) {
-    try {
-      rmSync(lockDir, { recursive: true, force: true });
-      removed = true;
-    } catch {
-      /* best-effort */
-    }
+    removeLockDirectory(lockDir);
+    removed = true;
   }
   if (existsSync(lp)) {
     try {

--- a/src/resources/extensions/gsd/tests/phase-dir-rename.test.ts
+++ b/src/resources/extensions/gsd/tests/phase-dir-rename.test.ts
@@ -1,0 +1,107 @@
+// Regression tests for #1526: phase-dir slug drift when a milestone title changes.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { renamePhaseDirOnTitleChange } from "../phase-dir-rename.ts";
+import { canonicalPhaseDirName } from "../paths.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  openDatabase,
+  upsertMilestonePlanning,
+} from "../gsd-db.ts";
+
+function makeProject(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-phase-dir-rename-"));
+  mkdirSync(join(base, ".gsd", "phases"), { recursive: true });
+  return base;
+}
+
+test("renamePhaseDirOnTitleChange moves the old slug dir to the canonical name (#1526)", () => {
+  const base = makeProject();
+  try {
+    const oldName = canonicalPhaseDirName("M001", "New milestone M001");
+    const newName = canonicalPhaseDirName("M001", "Lokably brand foundation and welcome page rebuild");
+    const oldDir = join(base, ".gsd", "phases", oldName);
+    const newDir = join(base, ".gsd", "phases", newName);
+    mkdirSync(oldDir, { recursive: true });
+    writeFileSync(join(oldDir, "01-CONTEXT.md"), "# New milestone M001\n");
+
+    assert.equal(renamePhaseDirOnTitleChange(base, "M001", "New milestone M001", "Lokably brand foundation and welcome page rebuild"), true);
+    assert.equal(existsSync(oldDir), false, "old slug dir should be gone");
+    assert.equal(existsSync(newDir), true, "canonical slug dir should exist");
+    assert.equal(readFileSync(join(newDir, "01-CONTEXT.md"), "utf8"), "# New milestone M001\n");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("renamePhaseDirOnTitleChange is a no-op when the new dir already exists", () => {
+  const base = makeProject();
+  try {
+    const oldName = canonicalPhaseDirName("M001", "Old title");
+    const newName = canonicalPhaseDirName("M001", "New title");
+    const oldDir = join(base, ".gsd", "phases", oldName);
+    const newDir = join(base, ".gsd", "phases", newName);
+    mkdirSync(oldDir, { recursive: true });
+    mkdirSync(newDir, { recursive: true });
+    writeFileSync(join(oldDir, "old.md"), "old");
+    writeFileSync(join(newDir, "new.md"), "new");
+
+    assert.equal(renamePhaseDirOnTitleChange(base, "M001", "Old title", "New title"), false);
+    assert.equal(existsSync(oldDir), true, "old dir must be left in place");
+    assert.equal(existsSync(join(newDir, "new.md")), true);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("renamePhaseDirOnTitleChange is a no-op when the old dir is missing", () => {
+  const base = makeProject();
+  try {
+    assert.equal(renamePhaseDirOnTitleChange(base, "M001", "Old title", "New title"), false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("renamePhaseDirOnTitleChange is a no-op when the slug does not change", () => {
+  const base = makeProject();
+  try {
+    const name = canonicalPhaseDirName("M001", "Foundation");
+    const dir = join(base, ".gsd", "phases", name);
+    mkdirSync(dir, { recursive: true });
+    assert.equal(renamePhaseDirOnTitleChange(base, "M001", "Foundation", "foundation"), false);
+    assert.equal(existsSync(dir), true);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("upsertMilestonePlanning renames the on-disk phase dir when the title changes (#1526)", () => {
+  const base = makeProject();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "New milestone M001", status: "active" });
+
+    const oldName = canonicalPhaseDirName("M001", "New milestone M001");
+    const newName = canonicalPhaseDirName("M001", "Lokably brand foundation");
+    const oldDir = join(base, ".gsd", "phases", oldName);
+    const newDir = join(base, ".gsd", "phases", newName);
+    mkdirSync(oldDir, { recursive: true });
+    writeFileSync(join(oldDir, "01-ROADMAP.md"), "# Placeholder\n");
+
+    upsertMilestonePlanning("M001", { title: "Lokably brand foundation" });
+
+    assert.equal(existsSync(oldDir), false, "placeholder slug dir should be renamed");
+    assert.equal(existsSync(newDir), true, "canonical slug dir should exist after title update");
+    assert.equal(readFileSync(join(newDir, "01-ROADMAP.md"), "utf8"), "# Placeholder\n");
+  } finally {
+    try { closeDatabase(); } catch { /* already closed */ }
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/plan-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone.test.ts
@@ -23,6 +23,11 @@ import {
 import { handlePlanMilestone as handlePlanMilestoneWithInvocation } from '../tools/plan-milestone.ts';
 import { internalPlanningInvocation } from '../planning-invocation.ts';
 import { parseProjectionRoadmap as parseRoadmap } from '../schemas/parsers.ts';
+import { canonicalPhaseDirName } from '../paths.ts';
+
+function expectedRoadmapPath(base: string, title: string, milestoneId = 'M001'): string {
+  return join(base, '.gsd', 'phases', canonicalPhaseDirName(milestoneId, title), '01-ROADMAP.md');
+}
 
 function handlePlanMilestone(
   params: Parameters<typeof handlePlanMilestoneWithInvocation>[0],
@@ -151,7 +156,7 @@ test('handlePlanMilestone writes milestone and slice planning state and renders 
     assert.equal(slices[0]?.goal, 'Wire the handler.');
     assert.equal(slices[1]?.depends[0], 'S01');
 
-    const roadmapPath = join(base, '.gsd', 'phases', '01-test', '01-ROADMAP.md');
+    const roadmapPath = expectedRoadmapPath(base, 'DB-backed planning');
     assert.ok(existsSync(roadmapPath), 'roadmap should be rendered to disk');
     const roadmap = readFileSync(roadmapPath, 'utf-8');
     assert.match(roadmap, /# M001: DB-backed planning/);
@@ -236,16 +241,16 @@ test('handlePlanMilestone clears parse-visible roadmap state after successful re
   openDatabase(dbPath);
 
   try {
-    const roadmapPath = join(base, '.gsd', 'phases', '01-test', '01-ROADMAP.md');
-    writeFileSync(roadmapPath, '# M001: Cached roadmap\n\n**Vision:** old value\n\n## Slices\n\n', 'utf-8');
+    const cachedPath = join(base, '.gsd', 'phases', '01-test', '01-ROADMAP.md');
+    writeFileSync(cachedPath, '# M001: Cached roadmap\n\n**Vision:** old value\n\n## Slices\n\n', 'utf-8');
 
-    const cachedBefore = parseRoadmap(readFileSync(roadmapPath, 'utf-8'));
+    const cachedBefore = parseRoadmap(readFileSync(cachedPath, 'utf-8'));
     assert.equal(cachedBefore.vision, 'old value');
 
     const result = await handlePlanMilestone(validParams(), base);
     assert.ok(!('error' in result));
 
-    const contentAfter = readFileSync(roadmapPath, 'utf-8');
+    const contentAfter = readFileSync(expectedRoadmapPath(base, 'DB-backed planning'), 'utf-8');
     assert.match(contentAfter, /Make planning write through the database\./);
     assert.match(contentAfter, /S01/);
     assert.match(contentAfter, /S02/);

--- a/src/resources/extensions/gsd/tests/planning-domain-operations.test.ts
+++ b/src/resources/extensions/gsd/tests/planning-domain-operations.test.ts
@@ -18,6 +18,7 @@ import {
   insertTask,
   openDatabase,
 } from "../gsd-db.ts";
+import { canonicalPhaseDirName } from "../paths.ts";
 import { executeDomainOperation } from "../db/domain-operation.ts";
 import {
   adoptOrTransitionLifecycle,
@@ -332,7 +333,7 @@ test("fresh milestone planning keeps its public response and atomically adopts r
 
   assert.deepEqual(result, {
     milestoneId: "M001",
-    roadmapPath: join(base, ".gsd", "phases", "01-test", "01-ROADMAP.md"),
+    roadmapPath: join(base, ".gsd", "phases", canonicalPhaseDirName("M001", "Atomic planning"), "01-ROADMAP.md"),
   });
   assert.deepEqual(rows(`
     SELECT item_kind, milestone_id, slice_id, lifecycle_status, state_version

--- a/src/resources/extensions/gsd/tests/session-lock-rmsync.test.ts
+++ b/src/resources/extensions/gsd/tests/session-lock-rmsync.test.ts
@@ -1,0 +1,88 @@
+// Regression tests for #1526: rmSync no-op on lock directories must not be silent.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { removeLockDirectory, removeStaleSessionLock } from "../session-lock.ts";
+import { gsdRoot } from "../paths.ts";
+
+test("removeLockDirectory removes an empty lock directory", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-lock-rm-"));
+  try {
+    const lockDir = join(base, ".gsd.lock");
+    mkdirSync(lockDir, { recursive: true });
+    removeLockDirectory(lockDir);
+    assert.equal(existsSync(lockDir), false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("removeLockDirectory removes a lock directory that still has contents", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-lock-rm-"));
+  try {
+    const lockDir = join(base, ".gsd.lock");
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, "marker"), "held");
+    removeLockDirectory(lockDir);
+    assert.equal(existsSync(lockDir), false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("removeLockDirectory falls back to rmdirSync when rmSync no-ops (#1526)", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-lock-rm-"));
+  try {
+    const lockDir = join(base, ".gsd.lock");
+    mkdirSync(lockDir, { recursive: true });
+    let rmdirCalled = false;
+    removeLockDirectory(lockDir, {
+      rmSync() {
+        /* simulate Windows non-ASCII rmSync no-op */
+      },
+      rmdirSync(path) {
+        rmdirCalled = true;
+        rmSync(path, { recursive: true, force: true });
+      },
+      existsSync,
+    });
+    assert.equal(rmdirCalled, true, "rmdirSync fallback must run after rmSync no-op");
+    assert.equal(existsSync(lockDir), false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("removeLockDirectory throws with the path when the directory still exists (#1526)", () => {
+  const lockDir = "/tmp/gsd-lock-still-here.lock";
+  assert.throws(
+    () => removeLockDirectory(lockDir, {
+      rmSync() { /* no-op */ },
+      rmdirSync() { /* no-op */ },
+      existsSync() { return true; },
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /still exists after rmSync\/rmdirSync/);
+      assert.match(error.message, new RegExp(lockDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+      return true;
+    },
+  );
+});
+
+test("removeStaleSessionLock removes an orphaned lock directory", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-stale-lock-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  try {
+    const lockDir = gsdRoot(base) + ".lock";
+    mkdirSync(lockDir, { recursive: true });
+    assert.equal(removeStaleSessionLock(base), true);
+    assert.equal(existsSync(lockDir), false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Rename the on-disk phase directory when a milestone title changes, and fail loudly if session-lock directory removal no-ops.
**Why:** Title-derived phase slugs drifted off disk, and Windows `fs.rmSync({ recursive: true })` can leave `.gsd.lock/` in place on non-ASCII paths, stranding auto-mode.
**How:** A small rename helper on title update; session-lock cleanup verifies `rmSync` with `existsSync`, falls back to `rmdirSync`, and throws with the path.

## What

- On `upsertMilestonePlanning` title updates, rename `phases/NN-old-slug` to the canonical phase dir when the old dir exists and the new one does not.
- Session-lock cleanup now goes through `removeLockDirectory`: `rmSync`, then `rmdirSync` if the path still exists, then a loud error that includes the path.
- Doctor stranded-lock heal uses the same helper.

Does not move `canonicalPhaseDirName` into `layout-policy.ts` (that is #1581 / PR #1880).

## Why

Closes #1526

Discuss created `phases/NN-<placeholder-slug>/`. After `plan-milestone` set the real title, the DB projected a different dir that did not exist. Combined with a silent `rmSync` no-op on Windows non-ASCII paths, `/gsd` crashed and re-stranded `.gsd.lock/` on every launch.

## How

- `renamePhaseDirOnTitleChange` uses existing `canonicalPhaseDirName` and only `renameSync`s when the destination is absent.
- `removeLockDirectory` is the single lock-dir removal path in `session-lock.ts`. Acquisition surfaces the persist error instead of the generic stuck-lock message.

## Change type

- [x] `fix` — Bug fix