### PR TITLE
fix(issue): no sanctioned task lifecycle reconcile after repair (#1749)

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2456,6 +2456,9 @@ const taskSettleParams = {
   taskId: nonEmptyString("taskId").describe("Task ID (e.g. T01)"),
   reason: nonEmptyString("reason").describe("Operator rationale recorded on the settled Attempt Result"),
   apply: z.boolean().optional().describe("Actually settle; omit or false for a dry run that changes nothing"),
+  reconcileLifecycle: z.boolean().optional().describe(
+    "After settling (or if already interrupted), adopt ready/completed to match tasks.status without deleting SUMMARYs",
+  ),
 };
 const taskSettleSchema = z.object(taskSettleParams);
 
@@ -3482,7 +3485,7 @@ export function registerWorkflowTools(
 
   server.tool(
     "gsd_task_settle",
-    "Operator tool: settle a Task's orphaned running Attempt as interrupted. Dry-run by default — prints the exact rows it would change; mutation requires apply: true.",
+    "Operator tool: settle a Task's orphaned running Attempt as interrupted. Dry-run by default — prints the exact rows it would change; mutation requires apply: true. Optional reconcileLifecycle adopts ready/completed to match tasks.status without deleting SUMMARYs.",
     taskSettleParams,
     async (args: Record<string, unknown>, extra?: WorkflowMcpRequestExtra) => {
       const parsed = parseWorkflowArgs(taskSettleSchema, args);

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -2588,6 +2588,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 			"Run without apply first and read the planned rows before mutating.",
 			"Only settles while the Attempt's own milestone lease is still held; a cross-process orphan whose lease is gone belongs to the next auto session's replacement-lease interrupt.",
 			"A second apply is a no-op — the tool is idempotent.",
+			"reconcileLifecycle adopts ready/completed to match tasks.status after the interrupted Attempt without deleting SUMMARYs.",
 		],
 		parameters: Type.Object(
 			{
@@ -2601,6 +2602,12 @@ export function registerDbTools(pi: ExtensionAPI): void {
 				apply: Type.Optional(
 					Type.Boolean({
 						description: "Actually settle. Omit or false for a dry run that changes nothing.",
+					}),
+				),
+				reconcileLifecycle: Type.Optional(
+					Type.Boolean({
+						description:
+							"After settling (or if already interrupted), adopt ready/completed to match tasks.status without deleting SUMMARYs.",
 					}),
 				),
 			},

--- a/src/resources/extensions/gsd/commands-task-settle.ts
+++ b/src/resources/extensions/gsd/commands-task-settle.ts
@@ -8,11 +8,18 @@ import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 import { applyTaskSettle, planTaskSettle, type TaskSettleTask } from "./task-settle.js";
 import type { ExecutionInvocation } from "./execution-invocation.js";
 
-function parseTaskSettleArgs(args: string): { task: TaskSettleTask; reason: string; apply: boolean } | null {
+function parseTaskSettleArgs(args: string): {
+  task: TaskSettleTask;
+  reason: string;
+  apply: boolean;
+  reconcileLifecycle: boolean;
+} | null {
   const apply = /(?:^|\s)--apply(?:\s|$)/.test(args);
+  const reconcileLifecycle = /(?:^|\s)--reconcile-lifecycle(?:\s|$)/.test(args);
   const reasonMatch = args.match(/--reason\s+"([^"]+)"|--reason\s+'([^']+)'|--reason\s+(\S+)/);
   const positional = args
     .replace(/--apply/g, "")
+    .replace(/--reconcile-lifecycle/g, "")
     .replace(/--reason\s+"[^"]*"|\s--reason\s+'[^']*'|--reason\s+\S+/g, "")
     .trim()
     .split(/\s+/)
@@ -25,6 +32,7 @@ function parseTaskSettleArgs(args: string): { task: TaskSettleTask; reason: stri
     task: { milestoneId: parts[0], sliceId: parts[1], taskId: parts[2] },
     reason,
     apply,
+    reconcileLifecycle,
   };
 }
 
@@ -46,8 +54,8 @@ export async function handleTaskSettle(
   const parsed = parseTaskSettleArgs(args);
   if (!parsed) {
     ctx.ui.notify(
-      'Usage: /gsd task settle <M001/S01/T01> --reason "why this Attempt is being settled" [--apply]\n' +
-      "Dry-run by default: prints the exact Attempt row it would change. --apply performs the settle.",
+      'Usage: /gsd task settle <M001/S01/T01> --reason "why this Attempt is being settled" [--apply] [--reconcile-lifecycle]\n' +
+      "Dry-run by default: prints the exact Attempt and optional lifecycle rows it would change. --apply performs the settle.",
       "warning",
     );
     return;
@@ -58,15 +66,21 @@ export async function handleTaskSettle(
   }
   const unit = `${parsed.task.milestoneId}/${parsed.task.sliceId}/${parsed.task.taskId}`;
   try {
+    const settleOptions = { reconcileLifecycle: parsed.reconcileLifecycle };
     if (!parsed.apply) {
-      const plan = planTaskSettle(parsed.task, parsed.reason);
-      if (plan.rows.length === 0) {
+      const plan = planTaskSettle(parsed.task, parsed.reason, settleOptions);
+      if (plan.rows.length === 0 && plan.lifecycleRows.length === 0) {
         ctx.ui.notify(`gsd task settle (dry run): ${unit} has no running Attempt — nothing to do.`, "info");
         return;
       }
-      const lines = plan.rows.map(
-        (row) => `  attempt ${row.attemptId}: ${row.currentStatus} → ${row.targetStatus} — ${row.rationale}`,
-      );
+      const lines = [
+        ...plan.rows.map(
+          (row) => `  attempt ${row.attemptId}: ${row.currentStatus} → ${row.targetStatus} — ${row.rationale}`,
+        ),
+        ...plan.lifecycleRows.map(
+          (row) => `  lifecycle ${row.currentStatus} → ${row.targetStatus} — ${row.rationale}`,
+        ),
+      ];
       ctx.ui.notify(
         `gsd task settle (dry run) — no changes made:\n${lines.join("\n")}\nRe-run with --apply to settle.`,
         "info",
@@ -77,15 +91,21 @@ export async function handleTaskSettle(
       invocation: cliInvocation(),
       task: parsed.task,
       reason: parsed.reason,
+      ...settleOptions,
     });
-    if (!result.settled) {
+    if (!result.settled && !result.reconciled) {
       ctx.ui.notify(`gsd task settle: ${unit} has no running Attempt — nothing to do.`, "info");
       return;
     }
-    ctx.ui.notify(
-      `Settled Attempt ${result.rows[0].attemptId} as interrupted (${unit}).`,
-      "info",
-    );
+    const parts: string[] = [];
+    if (result.settled) {
+      parts.push(`Settled Attempt ${result.rows[0].attemptId} as interrupted (${unit}).`);
+    }
+    if (result.reconciled) {
+      const target = result.lifecycleRows[result.lifecycleRows.length - 1]?.targetStatus;
+      parts.push(`Reconciled lifecycle to ${target} (${unit}) without deleting SUMMARYs.`);
+    }
+    ctx.ui.notify(parts.join(" "), "info");
   } catch (error) {
     ctx.ui.notify(`gsd task settle: ${error instanceof Error ? error.message : String(error)}`, "error");
   }

--- a/src/resources/extensions/gsd/commands-task-settle.ts
+++ b/src/resources/extensions/gsd/commands-task-settle.ts
@@ -80,6 +80,7 @@ export async function handleTaskSettle(
         ...plan.lifecycleRows.map(
           (row) => `  lifecycle ${row.currentStatus} → ${row.targetStatus} — ${row.rationale}`,
         ),
+        ...(plan.proof ? [`  proof: ${plan.proof.note}`] : []),
       ];
       ctx.ui.notify(
         `gsd task settle (dry run) — no changes made:\n${lines.join("\n")}\nRe-run with --apply to settle.`,

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -162,7 +162,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd rebuild database  Reserved for DB-native rebuilds; does not import markdown",
     "  /gsd recover           Preview an evidence-bound DB import after loss/corruption",
     "  /gsd db restore-backup List or restore a verified pre-migration database backup (destructive)",
-    "  /gsd task settle  Settle an orphaned running task Attempt (dry-run first)  <M001/S01/T01> --reason \"...\" [--apply]",
+    "  /gsd task settle  Settle an orphaned running task Attempt (dry-run first)  <M001/S01/T01> --reason \"...\" [--apply] [--reconcile-lifecycle]",
     "  /gsd worktree       Manage worktrees from the TUI  [list|merge|clean|remove]",
     "  /gsd migrate        Migrate .planning/ (v1) to DB-backed .gsd/ with backup + audit",
     "  /gsd remote         Control remote auto-mode  [slack|discord|status|disconnect]",

--- a/src/resources/extensions/gsd/task-settle.ts
+++ b/src/resources/extensions/gsd/task-settle.ts
@@ -38,10 +38,16 @@ export interface TaskLifecycleReconcileRow {
   rationale: string;
 }
 
+export interface TaskSettleProof {
+  attemptId: string | null;
+  note: string;
+}
+
 export interface TaskSettlePlan {
   task: TaskSettleTask;
   rows: TaskSettleRow[];
   lifecycleRows: TaskLifecycleReconcileRow[];
+  proof: TaskSettleProof | null;
 }
 
 export interface TaskSettleOptions {
@@ -155,6 +161,69 @@ function readTaskLifecycleState(task: TaskSettleTask): TaskLifecycleState {
     lifecycleStatus: state["lifecycle_status"]
       ? String(state["lifecycle_status"]) as CanonicalLifecycleStatus
       : null,
+  };
+}
+
+function readPassingProofAttempt(task: TaskSettleTask): string | null {
+  const row = getDb().prepare(`
+    SELECT attempt.attempt_id
+    FROM workflow_item_lifecycles lifecycle
+    JOIN workflow_execution_attempts attempt
+      ON attempt.lifecycle_id = lifecycle.lifecycle_id
+     AND attempt.project_id = lifecycle.project_id
+     AND attempt.attempt_state = 'settled'
+    JOIN workflow_attempt_results result
+      ON result.attempt_id = attempt.attempt_id
+     AND result.lifecycle_id = lifecycle.lifecycle_id
+     AND result.outcome = 'succeeded'
+    JOIN workflow_acceptance_criteria criterion
+      ON criterion.lifecycle_id = lifecycle.lifecycle_id
+     AND criterion.criterion_key = 'host-technical-verification'
+     AND NOT EXISTS (
+       SELECT 1 FROM workflow_acceptance_criteria successor
+       WHERE successor.supersedes_criterion_id = criterion.criterion_id
+     )
+    JOIN workflow_technical_verdicts verdict
+      ON verdict.criterion_id = criterion.criterion_id
+     AND verdict.attempt_id = attempt.attempt_id
+     AND verdict.verdict = 'pass'
+     AND NOT EXISTS (
+       SELECT 1 FROM workflow_technical_verdicts successor
+       WHERE successor.supersedes_verdict_id = verdict.verdict_id
+     )
+    JOIN workflow_verification_evidence evidence
+      ON evidence.verdict_id = verdict.verdict_id
+     AND evidence.attempt_id = attempt.attempt_id
+     AND evidence.observation = 'passed'
+    WHERE lifecycle.item_kind = 'task'
+      AND lifecycle.milestone_id = :milestone_id
+      AND lifecycle.slice_id = :slice_id
+      AND lifecycle.task_id = :task_id
+    ORDER BY attempt.attempt_number DESC
+    LIMIT 1
+  `).get({
+    ":milestone_id": task.milestoneId,
+    ":slice_id": task.sliceId,
+    ":task_id": task.taskId,
+  }) as { attempt_id?: string } | undefined;
+  return row?.attempt_id ? String(row.attempt_id) : null;
+}
+
+function planCompletionProof(
+  task: TaskSettleTask,
+  lifecycleRows: TaskLifecycleReconcileRow[],
+): TaskSettleProof | null {
+  if (!lifecycleRows.some((row) => row.targetStatus === "completed")) return null;
+  const attemptId = readPassingProofAttempt(task);
+  if (attemptId) {
+    return {
+      attemptId,
+      note: `current passing Technical Verdict is on Attempt ${attemptId}`,
+    };
+  }
+  return {
+    attemptId: null,
+    note: "no current passing Technical Verdict — gsd_slice_complete will still refuse until one is recorded",
   };
 }
 
@@ -290,7 +359,8 @@ export function planTaskSettle(
   const lifecycleRows = options.reconcileLifecycle
     ? planLifecycleReconcile(task, reason, attempt !== null)
     : [];
-  if (!attempt) return { task, rows: [], lifecycleRows };
+  const proof = planCompletionProof(task, lifecycleRows);
+  if (!attempt) return { task, rows: [], lifecycleRows, proof };
   const leaseHeld = readLeaseHeld(attempt, task.milestoneId);
   const rationale = leaseHeld
     ? reason
@@ -305,6 +375,7 @@ export function planTaskSettle(
       leaseHeld,
     }],
     lifecycleRows,
+    proof,
   };
 }
 
@@ -357,10 +428,12 @@ export function applyTaskSettle(input: {
     resultId = settlement.resultId;
   }
   let lifecycleRows = plan.lifecycleRows;
+  let proof = plan.proof;
   let reconciled = false;
   if (input.reconcileLifecycle) {
     const after = planTaskSettle(input.task, input.reason, { reconcileLifecycle: true });
     lifecycleRows = after.lifecycleRows;
+    proof = after.proof;
     if (lifecycleRows.length > 0) {
       applyLifecycleReconcile(input.invocation, input.task, input.reason, lifecycleRows);
       reconciled = true;
@@ -369,6 +442,7 @@ export function applyTaskSettle(input: {
   return {
     ...plan,
     lifecycleRows,
+    proof,
     settled,
     reconciled,
     ...(resultId ? { resultId } : {}),

--- a/src/resources/extensions/gsd/task-settle.ts
+++ b/src/resources/extensions/gsd/task-settle.ts
@@ -1,10 +1,22 @@
 // Project/App: gsd-pi
 // File Purpose: Operator Task settle — human-gated, dry-run-first reconciliation
-// of a running Task Attempt whose executor is gone (#1749).
+// of a running Task Attempt whose executor is gone, plus optional lifecycle
+// adopt after an interrupted Attempt (#1749).
 
+import { executeDomainOperation } from "./db/domain-operation.js";
 import { getDb } from "./db/engine.js";
+import { normalizeLegacyLifecycleStatus } from "./db/lifecycle-shadow-comparison.js";
+import {
+  adoptOrTransitionLifecycle,
+  readDomainOperationFence,
+  type CanonicalLifecycleStatus,
+} from "./db/writers/lifecycle-commands.js";
 import type { ExecutionInvocation } from "./execution-invocation.js";
-import { settleTaskAttempt } from "./task-execution-domain-operation.js";
+import { TASK_LIFECYCLE_PROJECTION_KIND } from "./projection-identity.js";
+import {
+  readLatestTaskAttempt,
+  settleTaskAttempt,
+} from "./task-execution-domain-operation.js";
 
 export interface TaskSettleTask {
   milestoneId: string;
@@ -20,15 +32,35 @@ export interface TaskSettleRow {
   leaseHeld: boolean;
 }
 
+export interface TaskLifecycleReconcileRow {
+  currentStatus: string;
+  targetStatus: "paused" | "ready" | "completed";
+  rationale: string;
+}
+
 export interface TaskSettlePlan {
   task: TaskSettleTask;
   rows: TaskSettleRow[];
+  lifecycleRows: TaskLifecycleReconcileRow[];
+}
+
+export interface TaskSettleOptions {
+  reconcileLifecycle?: boolean;
 }
 
 interface RunningAttemptRow {
   attempt_id: string;
   worker_id: string | null;
   milestone_lease_token: number | null;
+}
+
+interface TaskLifecycleState {
+  legacyStatus: string;
+  lifecycleStatus: CanonicalLifecycleStatus | null;
+}
+
+function unitId(task: TaskSettleTask): string {
+  return `${task.milestoneId}/${task.sliceId}/${task.taskId}`;
 }
 
 function readRunningAttempts(task: TaskSettleTask): RunningAttemptRow[] {
@@ -98,13 +130,167 @@ function requireSingleRunningAttempt(task: TaskSettleTask): RunningAttemptRow | 
   return running[0];
 }
 
+function readTaskLifecycleState(task: TaskSettleTask): TaskLifecycleState {
+  const state = getDb().prepare(`
+    SELECT task.status AS task_status, lifecycle.lifecycle_status
+    FROM tasks task
+    LEFT JOIN workflow_item_lifecycles lifecycle
+      ON lifecycle.item_kind = 'task'
+     AND lifecycle.milestone_id = task.milestone_id
+     AND lifecycle.slice_id = task.slice_id
+     AND lifecycle.task_id = task.id
+    WHERE task.milestone_id = :milestone_id
+      AND task.slice_id = :slice_id
+      AND task.id = :task_id
+  `).get({
+    ":milestone_id": task.milestoneId,
+    ":slice_id": task.sliceId,
+    ":task_id": task.taskId,
+  }) as Record<string, unknown> | undefined;
+  if (!state) {
+    throw new Error(`gsd_task_settle: unknown Task ${unitId(task)}`);
+  }
+  return {
+    legacyStatus: String(state["task_status"]),
+    lifecycleStatus: state["lifecycle_status"]
+      ? String(state["lifecycle_status"]) as CanonicalLifecycleStatus
+      : null,
+  };
+}
+
+function targetCanonicalStatus(legacyStatus: string): "ready" | "completed" {
+  const normalized = normalizeLegacyLifecycleStatus(legacyStatus);
+  if (normalized === "pending") return "ready";
+  if (normalized === "completed") return "completed";
+  throw new Error(
+    `gsd_task_settle: reconcileLifecycle only repairs a pending/complete mismatch ` +
+    `after an interrupted Attempt; tasks.status is ${legacyStatus}`,
+  );
+}
+
+function lifecycleTransitionSteps(
+  from: CanonicalLifecycleStatus,
+  to: "ready" | "completed",
+): Array<"paused" | "ready" | "completed"> {
+  if (from === to) return [];
+  if (to === "ready") {
+    if (from === "in_progress") return ["paused", "ready"];
+    if (from === "paused") return ["ready"];
+  } else if (from === "in_progress") {
+    return ["completed"];
+  }
+  throw new Error(
+    `gsd_task_settle: cannot reconcile lifecycle ${from} → ${to} after an interrupted Attempt`,
+  );
+}
+
+function planLifecycleReconcile(
+  task: TaskSettleTask,
+  reason: string,
+  hasRunningAttempt: boolean,
+): TaskLifecycleReconcileRow[] {
+  const latest = readLatestTaskAttempt(task);
+  if (!hasRunningAttempt && latest?.outcome !== "interrupted") {
+    throw new Error(
+      "gsd_task_settle: reconcileLifecycle requires an interrupted Attempt " +
+      "(settle the running Attempt first)",
+    );
+  }
+  const state = readTaskLifecycleState(task);
+  const target = targetCanonicalStatus(state.legacyStatus);
+  const fromStatus = state.lifecycleStatus;
+  if (fromStatus === null) {
+    throw new Error(`gsd_task_settle: Task ${unitId(task)} has no canonical lifecycle to reconcile`);
+  }
+  if (fromStatus === target) return [];
+  const steps = lifecycleTransitionSteps(fromStatus, target);
+  const rows: TaskLifecycleReconcileRow[] = [];
+  let current: CanonicalLifecycleStatus = fromStatus;
+  for (const next of steps) {
+    rows.push({
+      currentStatus: current,
+      targetStatus: next,
+      rationale:
+        `${reason} (adopt ${target} to match tasks.status=${state.legacyStatus}; ` +
+        "SUMMARY projections are left in place)",
+    });
+    current = next;
+  }
+  return rows;
+}
+
+function applyLifecycleReconcile(
+  invocation: ExecutionInvocation,
+  task: TaskSettleTask,
+  reason: string,
+  rows: TaskLifecycleReconcileRow[],
+): void {
+  const entityId = unitId(task);
+  for (const step of rows) {
+    const idempotencyKey = `${invocation.idempotencyKey}:lifecycle:${step.targetStatus}`;
+    const fence = readDomainOperationFence(idempotencyKey);
+    executeDomainOperation({
+      operationType: "task.lifecycle.reconcile",
+      idempotencyKey,
+      expectedRevision: fence.revision,
+      expectedAuthorityEpoch: fence.authorityEpoch,
+      actorType: invocation.actorType,
+      ...(invocation.actorId ? { actorId: invocation.actorId } : {}),
+      sourceTransport: invocation.sourceTransport,
+      ...(invocation.traceId ? { traceId: invocation.traceId } : {}),
+      ...(invocation.turnId ? { turnId: invocation.turnId } : {}),
+      payload: {
+        milestoneId: task.milestoneId,
+        sliceId: task.sliceId,
+        taskId: task.taskId,
+        from: step.currentStatus,
+        to: step.targetStatus,
+        reason,
+      },
+    }, (context) => {
+      adoptOrTransitionLifecycle(context, {
+        itemKind: "task",
+        milestoneId: task.milestoneId,
+        sliceId: task.sliceId,
+        taskId: task.taskId,
+        lifecycleStatus: step.targetStatus,
+      });
+      return {
+        events: [{
+          eventType: "task.lifecycle.reconciled",
+          entityType: "task",
+          entityId,
+          payload: {
+            from: step.currentStatus,
+            to: step.targetStatus,
+            reason,
+          },
+          destinations: ["projection"],
+        }],
+        projections: [{
+          projectionKey: `lifecycle/${entityId}`.toLowerCase(),
+          projectionKind: TASK_LIFECYCLE_PROJECTION_KIND,
+          rendererVersion: "1",
+        }],
+      };
+    });
+  }
+}
+
 /**
- * Read-only settle plan: the exact Attempt rows an apply would change. Zero
- * rows means the Task has no running Attempt — an apply is a no-op.
+ * Read-only settle plan: the exact Attempt and optional lifecycle rows an
+ * apply would change. Zero rows of both kinds means an apply is a no-op.
  */
-export function planTaskSettle(task: TaskSettleTask, reason: string): TaskSettlePlan {
+export function planTaskSettle(
+  task: TaskSettleTask,
+  reason: string,
+  options: TaskSettleOptions = {},
+): TaskSettlePlan {
   const attempt = requireSingleRunningAttempt(task);
-  if (!attempt) return { task, rows: [] };
+  const lifecycleRows = options.reconcileLifecycle
+    ? planLifecycleReconcile(task, reason, attempt !== null)
+    : [];
+  if (!attempt) return { task, rows: [], lifecycleRows };
   const leaseHeld = readLeaseHeld(attempt, task.milestoneId);
   const rationale = leaseHeld
     ? reason
@@ -118,6 +304,7 @@ export function planTaskSettle(task: TaskSettleTask, reason: string): TaskSettle
       rationale,
       leaseHeld,
     }],
+    lifecycleRows,
   };
 }
 
@@ -127,35 +314,63 @@ export function planTaskSettle(task: TaskSettleTask, reason: string): TaskSettle
  * milestone lease, so a plain attempt.settle is legal (V47 dispatch-scope
  * rule). A cross-process orphan whose lease is already gone belongs to the
  * replacement-lease interrupt path (#1748) — the next auto session settles it.
+ *
+ * Optional `reconcileLifecycle` then adopts ready/completed to match
+ * tasks.status after that interrupted Attempt, without reopening or deleting
+ * SUMMARY projections (#1749).
  */
 export function applyTaskSettle(input: {
   invocation: ExecutionInvocation;
   task: TaskSettleTask;
   reason: string;
-}): TaskSettlePlan & { settled: boolean; resultId?: string } {
-  const plan = planTaskSettle(input.task, input.reason);
-  if (plan.rows.length === 0) return { ...plan, settled: false };
-  const row = plan.rows[0];
-  if (!row.leaseHeld) {
-    throw new Error(
-      `gsd_task_settle: Attempt ${row.attemptId} was claimed under a milestone lease that is ` +
-      "no longer held, so this operator settle is not authorized. Start `/gsd auto` — the next " +
-      "session takes over the lease and interrupts the orphaned Attempt via the replacement-lease path.",
-    );
-  }
-  const settlement = settleTaskAttempt({
-    invocation: input.invocation,
-    attemptId: row.attemptId,
-    outcome: "interrupted",
-    failureClass: "operator-settle",
-    summary: input.reason,
-    output: {
-      operator: true,
-      milestoneId: input.task.milestoneId,
-      sliceId: input.task.sliceId,
-      taskId: input.task.taskId,
-      reason: input.reason,
-    },
+  reconcileLifecycle?: boolean;
+}): TaskSettlePlan & { settled: boolean; reconciled: boolean; resultId?: string } {
+  const plan = planTaskSettle(input.task, input.reason, {
+    reconcileLifecycle: input.reconcileLifecycle,
   });
-  return { ...plan, settled: true, resultId: settlement.resultId };
+  let settled = false;
+  let resultId: string | undefined;
+  if (plan.rows.length > 0) {
+    const row = plan.rows[0];
+    if (!row.leaseHeld) {
+      throw new Error(
+        `gsd_task_settle: Attempt ${row.attemptId} was claimed under a milestone lease that is ` +
+        "no longer held, so this operator settle is not authorized. Start `/gsd auto` — the next " +
+        "session takes over the lease and interrupts the orphaned Attempt via the replacement-lease path.",
+      );
+    }
+    const settlement = settleTaskAttempt({
+      invocation: input.invocation,
+      attemptId: row.attemptId,
+      outcome: "interrupted",
+      failureClass: "operator-settle",
+      summary: input.reason,
+      output: {
+        operator: true,
+        milestoneId: input.task.milestoneId,
+        sliceId: input.task.sliceId,
+        taskId: input.task.taskId,
+        reason: input.reason,
+      },
+    });
+    settled = true;
+    resultId = settlement.resultId;
+  }
+  let lifecycleRows = plan.lifecycleRows;
+  let reconciled = false;
+  if (input.reconcileLifecycle) {
+    const after = planTaskSettle(input.task, input.reason, { reconcileLifecycle: true });
+    lifecycleRows = after.lifecycleRows;
+    if (lifecycleRows.length > 0) {
+      applyLifecycleReconcile(input.invocation, input.task, input.reason, lifecycleRows);
+      reconciled = true;
+    }
+  }
+  return {
+    ...plan,
+    lifecycleRows,
+    settled,
+    reconciled,
+    ...(resultId ? { resultId } : {}),
+  };
 }

--- a/src/resources/extensions/gsd/tests/task-settle.test.ts
+++ b/src/resources/extensions/gsd/tests/task-settle.test.ts
@@ -340,4 +340,24 @@ test("reconcileLifecycle adopts completed for complete after interrupt without d
   assert.equal(row("SELECT status FROM tasks WHERE id = 'T01'").status, "complete");
   assert.equal(existsSync(summaryPath), true);
   assert.equal(readFileSync(summaryPath, "utf8"), "# Completed repair SUMMARY");
+  assert.equal(applied.proof?.attemptId ?? null, null);
+  assert.match(
+    applied.proof?.note ?? "",
+    /no current passing Technical Verdict/,
+  );
+});
+
+test("reconcileLifecycle reports when completed repair still lacks passing proof (#1749)", () => {
+  const { dispatchId } = seedRunningAttempt();
+  orphanClaimedAttempt(dispatchId);
+  db().prepare(`
+    UPDATE tasks SET status = 'complete' WHERE milestone_id = 'M001' AND slice_id = 'S01' AND id = 'T01'
+  `).run();
+
+  const plan = planTaskSettle(TASK, "operator repair", { reconcileLifecycle: true });
+  assert.equal(plan.proof?.attemptId ?? null, null);
+  assert.match(
+    plan.proof?.note ?? "",
+    /gsd_slice_complete will still refuse/,
+  );
 });

--- a/src/resources/extensions/gsd/tests/task-settle.test.ts
+++ b/src/resources/extensions/gsd/tests/task-settle.test.ts
@@ -3,7 +3,7 @@
 // idempotent, never-guessing Task Attempt settlement (#1749).
 
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
@@ -47,7 +47,7 @@ function invocation(key: string): ExecutionInvocation {
 
 const TASK = { milestoneId: "M001", sliceId: "S01", taskId: "T01" };
 
-function seedRunningAttempt(): { attemptId: string; dispatchId: number } {
+function seedRunningAttempt(): { attemptId: string; dispatchId: number; dir: string } {
   const dir = mkdtempSync(join(tmpdir(), "gsd-task-settle-"));
   tempDirs.add(dir);
   assert.equal(openDatabase(join(dir, "gsd.db")), true);
@@ -121,7 +121,7 @@ function seedRunningAttempt(): { attemptId: string; dispatchId: number } {
     milestoneLeaseToken: 7,
     coordinationDispatchId: dispatchId,
   });
-  return { attemptId: claim.attemptId, dispatchId };
+  return { attemptId: claim.attemptId, dispatchId, dir };
 }
 
 function orphanClaimedAttempt(dispatchId: number): void {
@@ -168,11 +168,21 @@ test("apply settles the orphaned Attempt and a second apply is a no-op", () => {
     reason: "operator repair after manual investigation",
   });
   assert.equal(applied.settled, true);
+  assert.equal(applied.reconciled, false);
   assert.equal(applied.rows[0].attemptId, attemptId);
   const settled = readTaskAttempt(attemptId);
   assert.equal(settled?.state, "settled");
   assert.equal(settled?.outcome, "interrupted");
   assert.equal(settled?.resultFailureClass, "operator-settle");
+  assert.equal(
+    row(`
+      SELECT lifecycle_status AS status
+      FROM workflow_item_lifecycles
+      WHERE item_kind = 'task' AND task_id = 'T01'
+    `).status,
+    "in_progress",
+    "settle without reconcileLifecycle must not adopt canonical status",
+  );
 
   const again = applyTaskSettle({
     invocation: invocation("settle/apply/2"),
@@ -237,4 +247,97 @@ test("apply refuses when the Attempt's lease is no longer held", () => {
     "running",
     "the refused apply leaves the Attempt untouched",
   );
+});
+
+function taskLifecycleStatus(): string {
+  return String(row(`
+    SELECT lifecycle_status AS status
+    FROM workflow_item_lifecycles
+    WHERE item_kind = 'task' AND task_id = 'T01'
+  `).status);
+}
+
+function restoreSummary(dir: string, body: string, status: "pending" | "complete"): string {
+  const summaryPath = join(dir, "T01-SUMMARY.md");
+  writeFileSync(summaryPath, body);
+  db().prepare(`
+    UPDATE tasks SET status = :status, full_summary_md = :body
+    WHERE milestone_id = 'M001' AND slice_id = 'S01' AND id = 'T01'
+  `).run({ ":status": status, ":body": body });
+  return summaryPath;
+}
+
+test("reconcileLifecycle adopts ready for pending after interrupt without deleting SUMMARYs", () => {
+  const { dispatchId, dir } = seedRunningAttempt();
+  orphanClaimedAttempt(dispatchId);
+
+  const dryRun = planTaskSettle(TASK, "operator repair", { reconcileLifecycle: true });
+  assert.equal(dryRun.rows.length, 1);
+  assert.deepEqual(
+    dryRun.lifecycleRows.map((row) => `${row.currentStatus}->${row.targetStatus}`),
+    ["in_progress->paused", "paused->ready"],
+  );
+  assert.equal(taskLifecycleStatus(), "in_progress", "dry-run must not adopt lifecycle");
+
+  const settled = applyTaskSettle({
+    invocation: invocation("settle/reconcile/pending/settle"),
+    task: TASK,
+    reason: "operator repair",
+  });
+  assert.equal(settled.settled, true);
+  const summaryPath = restoreSummary(dir, "# Pending repair SUMMARY", "pending");
+
+  const planned = planTaskSettle(TASK, "operator repair", { reconcileLifecycle: true });
+  assert.equal(planned.rows.length, 0);
+  assert.deepEqual(
+    planned.lifecycleRows.map((row) => `${row.currentStatus}->${row.targetStatus}`),
+    ["in_progress->paused", "paused->ready"],
+  );
+
+  const applied = applyTaskSettle({
+    invocation: invocation("settle/reconcile/pending"),
+    task: TASK,
+    reason: "operator repair",
+    reconcileLifecycle: true,
+  });
+  assert.equal(applied.settled, false);
+  assert.equal(applied.reconciled, true);
+  assert.equal(taskLifecycleStatus(), "ready");
+  assert.equal(row("SELECT status FROM tasks WHERE id = 'T01'").status, "pending");
+  assert.equal(row("SELECT full_summary_md AS body FROM tasks WHERE id = 'T01'").body, "# Pending repair SUMMARY");
+  assert.equal(existsSync(summaryPath), true);
+  assert.equal(readFileSync(summaryPath, "utf8"), "# Pending repair SUMMARY");
+
+  const again = applyTaskSettle({
+    invocation: invocation("settle/reconcile/pending/2"),
+    task: TASK,
+    reason: "operator repair",
+    reconcileLifecycle: true,
+  });
+  assert.equal(again.settled, false);
+  assert.equal(again.reconciled, false);
+  assert.equal(taskLifecycleStatus(), "ready");
+});
+
+test("reconcileLifecycle adopts completed for complete after interrupt without deleting SUMMARYs", () => {
+  const { dispatchId, dir } = seedRunningAttempt();
+  orphanClaimedAttempt(dispatchId);
+  const summaryPath = restoreSummary(dir, "# Completed repair SUMMARY", "complete");
+
+  const applied = applyTaskSettle({
+    invocation: invocation("settle/reconcile/complete"),
+    task: TASK,
+    reason: "operator repair",
+    reconcileLifecycle: true,
+  });
+  assert.equal(applied.settled, true);
+  assert.equal(applied.reconciled, true);
+  assert.deepEqual(
+    applied.lifecycleRows.map((row) => `${row.currentStatus}->${row.targetStatus}`),
+    ["in_progress->completed"],
+  );
+  assert.equal(taskLifecycleStatus(), "completed");
+  assert.equal(row("SELECT status FROM tasks WHERE id = 'T01'").status, "complete");
+  assert.equal(existsSync(summaryPath), true);
+  assert.equal(readFileSync(summaryPath, "utf8"), "# Completed repair SUMMARY");
 });

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -826,6 +826,7 @@ export interface TaskSettleExecutorParams {
   taskId: string;
   reason: string;
   apply?: boolean;
+  reconcileLifecycle?: boolean;
 }
 export type ReopenSliceExecutorParams = ReopenSliceParams;
 export type SkipSliceExecutorParams = SkipSliceParams;
@@ -1146,44 +1147,75 @@ export async function executeTaskSettle(
     taskId: params.taskId,
   };
   const unit = `${task.milestoneId}/${task.sliceId}/${task.taskId}`;
+  const settleOptions = { reconcileLifecycle: params.reconcileLifecycle === true };
   try {
     if (!params.apply) {
-      const plan = planTaskSettle(task, params.reason);
-      if (plan.rows.length === 0) {
+      const plan = planTaskSettle(task, params.reason, settleOptions);
+      if (plan.rows.length === 0 && plan.lifecycleRows.length === 0) {
         return {
           content: [{ type: "text", text: `gsd_task_settle (dry run): ${unit} has no running Attempt — nothing to do.` }],
-          details: { operation: "task_settle", dryRun: true, rows: [] },
+          details: { operation: "task_settle", dryRun: true, rows: [], lifecycleRows: [] },
         };
       }
-      const lines = plan.rows.map(
-        (row) => `  attempt ${row.attemptId}: ${row.currentStatus} → ${row.targetStatus} — ${row.rationale}`,
-      );
+      const lines = [
+        ...plan.rows.map(
+          (row) => `  attempt ${row.attemptId}: ${row.currentStatus} → ${row.targetStatus} — ${row.rationale}`,
+        ),
+        ...plan.lifecycleRows.map(
+          (row) => `  lifecycle ${row.currentStatus} → ${row.targetStatus} — ${row.rationale}`,
+        ),
+      ];
       return {
         content: [{
           type: "text",
           text: `gsd_task_settle (dry run) — no changes made:\n${lines.join("\n")}\nRe-run with apply: true to settle.`,
         }],
-        details: { operation: "task_settle", dryRun: true, rows: plan.rows },
+        details: {
+          operation: "task_settle",
+          dryRun: true,
+          rows: plan.rows,
+          lifecycleRows: plan.lifecycleRows,
+        },
       };
     }
-    const result = applyTaskSettle({ invocation, task, reason: params.reason });
-    if (!result.settled) {
+    const result = applyTaskSettle({
+      invocation,
+      task,
+      reason: params.reason,
+      ...settleOptions,
+    });
+    if (!result.settled && !result.reconciled) {
       return {
         content: [{ type: "text", text: `gsd_task_settle: ${unit} has no running Attempt — nothing to do.` }],
-        details: { operation: "task_settle", dryRun: false, rows: [], settled: false },
+        details: {
+          operation: "task_settle",
+          dryRun: false,
+          rows: [],
+          lifecycleRows: [],
+          settled: false,
+          reconciled: false,
+        },
       };
     }
+    const parts: string[] = [];
+    if (result.settled) {
+      parts.push(`Settled Attempt ${result.rows[0].attemptId} as interrupted (${unit}).`);
+    }
+    if (result.reconciled) {
+      const target = result.lifecycleRows[result.lifecycleRows.length - 1]?.targetStatus;
+      parts.push(`Reconciled lifecycle to ${target} (${unit}) without deleting SUMMARYs.`);
+    }
     return {
-      content: [{
-        type: "text",
-        text: `Settled Attempt ${result.rows[0].attemptId} as interrupted (${unit}).`,
-      }],
+      content: [{ type: "text", text: parts.join(" ") }],
       details: {
         operation: "task_settle",
         dryRun: false,
-        settled: true,
-        attemptId: result.rows[0].attemptId,
-        resultId: result.resultId,
+        settled: result.settled,
+        reconciled: result.reconciled,
+        ...(result.settled
+          ? { attemptId: result.rows[0].attemptId, resultId: result.resultId }
+          : {}),
+        lifecycleRows: result.lifecycleRows,
       },
     };
   } catch (err) {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -1164,6 +1164,7 @@ export async function executeTaskSettle(
         ...plan.lifecycleRows.map(
           (row) => `  lifecycle ${row.currentStatus} → ${row.targetStatus} — ${row.rationale}`,
         ),
+        ...(plan.proof ? [`  proof: ${plan.proof.note}`] : []),
       ];
       return {
         content: [{
@@ -1204,6 +1205,9 @@ export async function executeTaskSettle(
     if (result.reconciled) {
       const target = result.lifecycleRows[result.lifecycleRows.length - 1]?.targetStatus;
       parts.push(`Reconciled lifecycle to ${target} (${unit}) without deleting SUMMARYs.`);
+    }
+    if (result.proof) {
+      parts.push(result.proof.note);
     }
     return {
       content: [{ type: "text", text: parts.join(" ") }],


### PR DESCRIPTION
## TL;DR

**What:** Optional `reconcileLifecycle` on `gsd_task_settle` adopts ready/completed canonical status to match `tasks.status` after an interrupted Attempt.
**Why:** After settling an orphaned Attempt there was no sanctioned way to align `workflow_item_lifecycles.lifecycle_status` without `gsd_task_reopen` deleting SUMMARYs.
**How:** Extend the existing operator settle tool instead of adding a new tool or a doctor `--fix` settle path.

## What

`gsd_task_settle` still settles the one running Attempt as `interrupted`. With `reconcileLifecycle: true` (CLI `--reconcile-lifecycle`) it then adopts:

- `tasks.status` pending → canonical `ready` (`in_progress` → `paused` → `ready`)
- `tasks.status` complete → canonical `completed` (`in_progress` → `completed`)

Uses `TASK_LIFECYCLE_PROJECTION_KIND`. Does not call `gsd_task_reopen`, does not reset `tasks.status`, and does not delete SUMMARY files.

Wired through MCP, Pi, and `/gsd task settle`.

## Why

Closes #1749. After `gsd_task_settle`, lifecycle stayed `in_progress` while `tasks.status` was already correct. The closest built-in, `gsd_task_reopen`, deletes SUMMARYs and resets the task to pending.

## How

- Dry-run prints Attempt rows and planned lifecycle steps; `apply: true` mutates.
- Reconcile is valid after the Attempt is interrupted (settle first, or already interrupted).
- A second apply is a no-op.
- Tests cover pending → ready, complete → completed, and SUMMARY preservation.

## Change type

- [x] `fix` — Bug fix