### PR TITLE
fix(issue): Post-unit gates audit stale HEAD and ignore evidence-backed GSD-only task verification

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -78,7 +78,12 @@ import {
 import type { AutoSession, SidecarItem } from "./auto/session.js";
 import { getEvidence, clearEvidenceFromDisk, isExecutionToolName } from "./safety/evidence-collector.js";
 import { removeProjectionFileSync } from "./atomic-write.js";
-import { validateFileChanges, effectiveFileChangeAllowlist } from "./safety/file-change-validator.js";
+import {
+  validateFileChanges,
+  effectiveFileChangeAllowlist,
+  readCommittedHeadSha,
+  type FileChangeAudit,
+} from "./safety/file-change-validator.js";
 import { crossReferenceEvidence, type ClaimedEvidence } from "./safety/evidence-cross-ref.js";
 import { validateContent } from "./safety/content-validator.js";
 import { resolveSafetyHarnessConfig } from "./safety/safety-harness.js";
@@ -791,6 +796,72 @@ export function _hasExecutionToolCallsInSessionForTest(entries: readonly unknown
 
 export function shouldDeferCloseoutGitAction(unitType: string): boolean {
   return unitType === "execute-task";
+}
+
+function reportFileChangeWarnings(
+  ctx: ExtensionContext,
+  audit: FileChangeAudit | null,
+): void {
+  if (!audit || audit.violations.length === 0) return;
+  const warnings = audit.violations.filter(v => v.severity === "warning");
+  for (const v of warnings) {
+    logWarning("safety", `file-change: ${v.file} — ${v.reason}`);
+  }
+  if (warnings.length > 0) {
+    ctx.ui.notify(
+      `Safety: ${warnings.length} unexpected file change(s) outside task plan`,
+      "warning",
+    );
+  }
+}
+
+function runExecuteTaskFileChangeSafety(
+  s: AutoSession,
+  ctx: ExtensionContext,
+  fileChangeAllowlist: string[],
+  headBeforeCloseout: string | null,
+): void {
+  if (s.currentUnit?.type !== "execute-task") return;
+  const { milestone: sMid, slice: sSid, task: sTid } = parseUnitId(s.currentUnit.id);
+  if (!sMid || !sSid || !sTid) return;
+
+  try {
+    const sliceTaskRows = isDbAvailable()
+      ? getSliceTasks(sMid, sSid).filter((t) => isClosedStatus(t.status) || t.id === sTid)
+      : [];
+
+    if (sliceTaskRows.length > 0) {
+      const expectedOutput = getPlannedKeyFiles(
+        sliceTaskRows.map((taskRow) => ({
+          expected_output: taskRow.expected_output,
+          files: taskRow.files,
+        })),
+      );
+      const plannedFiles = getPlannedKeyFiles(
+        sliceTaskRows.map((taskRow) => ({ files: taskRow.files })),
+      );
+      reportFileChangeWarnings(
+        ctx,
+        validateFileChanges(s.basePath, expectedOutput, plannedFiles, fileChangeAllowlist, { headBeforeCloseout }),
+      );
+      return;
+    }
+
+    const taskRow = getTask(sMid, sSid, sTid);
+    if (!taskRow) return;
+    reportFileChangeWarnings(
+      ctx,
+      validateFileChanges(
+        s.basePath,
+        taskRow.expected_output ?? [],
+        taskRow.files ?? [],
+        fileChangeAllowlist,
+        { headBeforeCloseout },
+      ),
+    );
+  } catch (e) {
+    debugLog("postUnit", { phase: "safety-file-change", error: String(e) });
+  }
 }
 
 /** Unit types that only touch `.gsd/` internal state files (no code changes).
@@ -1823,73 +1894,6 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       if (safetyConfig.enabled) {
         const { milestone: sMid, slice: sSid, task: sTid } = parseUnitId(s.currentUnit.id);
 
-        const fileChangeAllowlist = effectiveFileChangeAllowlist(
-          safetyConfig.file_change_allowlist,
-          (prefs?.git as { manage_gitignore?: boolean } | undefined)?.manage_gitignore,
-        );
-
-        // File change validation (execute-task only, after unit execution)
-        if (safetyConfig.file_change_validation && s.currentUnit.type === "execute-task" && sMid && sSid && sTid) {
-          try {
-            const sliceTaskRows = isDbAvailable()
-              ? getSliceTasks(sMid, sSid).filter((t) => isClosedStatus(t.status) || t.id === sTid)
-              : [];
-
-            if (sliceTaskRows.length > 0) {
-              const expectedOutput = getPlannedKeyFiles(
-                sliceTaskRows.map((taskRow) => ({
-                  expected_output: taskRow.expected_output,
-                  files: taskRow.files,
-                })),
-              );
-              const plannedFiles = getPlannedKeyFiles(
-                sliceTaskRows.map((taskRow) => ({
-                  files: taskRow.files,
-                })),
-              );
-              const audit = validateFileChanges(s.basePath, expectedOutput, plannedFiles, fileChangeAllowlist);
-              if (audit && audit.violations.length > 0) {
-                const warnings = audit.violations.filter(v => v.severity === "warning");
-                for (const v of warnings) {
-                  logWarning("safety", `file-change: ${v.file} — ${v.reason}`);
-                }
-                if (warnings.length > 0) {
-                  ctx.ui.notify(
-                    `Safety: ${warnings.length} unexpected file change(s) outside task plan`,
-                    "warning",
-                  );
-                }
-              }
-            } else {
-              const taskRow = getTask(sMid, sSid, sTid);
-              if (taskRow) {
-                const expectedOutput = taskRow.expected_output ?? [];
-                const plannedFiles = taskRow.files ?? [];
-                const audit = validateFileChanges(
-                  s.basePath,
-                  expectedOutput,
-                  plannedFiles,
-                  fileChangeAllowlist,
-                );
-                if (audit && audit.violations.length > 0) {
-                  const warnings = audit.violations.filter(v => v.severity === "warning");
-                  for (const v of warnings) {
-                    logWarning("safety", `file-change: ${v.file} — ${v.reason}`);
-                  }
-                  if (warnings.length > 0) {
-                    ctx.ui.notify(
-                      `Safety: ${warnings.length} unexpected file change(s) outside task plan`,
-                      "warning",
-                    );
-                  }
-                }
-              }
-            }
-          } catch (e) {
-            debugLog("postUnit", { phase: "safety-file-change", error: String(e) });
-          }
-        }
-
         // Evidence cross-reference (execute-task only)
         // Only compare against concrete command evidence persisted by the task
         // completion tool. A prose Verify field can be satisfied later by the
@@ -2641,6 +2645,7 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
   if (s.currentUnit) {
     if (shouldDeferCloseoutGitAction(s.currentUnit.type)) {
+      const headBeforeCloseout = readCommittedHeadSha(s.basePath);
       const gitActionResult = await runCloseoutGitAction(pctx, s.currentUnit, { softFailure: true });
       if (gitActionResult === "dispatched") {
         return "stopped";
@@ -2656,6 +2661,21 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
         }) === "retry"
       ) {
         return "retry";
+      }
+      try {
+        const prefs = loadEffectiveGSDPreferences()?.preferences;
+        const safetyConfig = resolveSafetyHarnessConfig(
+          prefs?.safety_harness as Record<string, unknown> | undefined,
+        );
+        if (safetyConfig.enabled && safetyConfig.file_change_validation) {
+          const fileChangeAllowlist = effectiveFileChangeAllowlist(
+            safetyConfig.file_change_allowlist,
+            (prefs?.git as { manage_gitignore?: boolean } | undefined)?.manage_gitignore,
+          );
+          runExecuteTaskFileChangeSafety(s, ctx, fileChangeAllowlist, headBeforeCloseout);
+        }
+      } catch (e) {
+        debugLog("postUnit", { phase: "safety-file-change", error: String(e) });
       }
     }
 

--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -8,6 +8,10 @@
  * Using diff-tree --root handles initial commits, shallow clones, and merge commits correctly
  * (Bug #4385 — git diff HEAD~1 failed on initial commits).
  *
+ * When the unit created no commit, HEAD is still the previous unit's changeset.
+ * Callers must pass `headBeforeCloseout` so that case returns an empty change set
+ * instead of auditing stale HEAD (#1431).
+ *
  * Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
  */
 
@@ -36,6 +40,17 @@ export interface FileChangeAudit {
   unexpectedFiles: string[];
   missingFiles: string[];
   violations: FileViolation[];
+}
+
+export interface FileChangeAuditOptions {
+  /**
+   * HEAD SHA recorded immediately before the unit's closeout commit.
+   * When current HEAD still equals this SHA, the unit created no commit —
+   * return an empty change set instead of auditing the previous commit (#1431).
+   * Pass null when the baseline is unknown to skip the audit. Omit only for
+   * legacy callers that intentionally audit the current HEAD commit.
+   */
+  headBeforeCloseout?: string | null;
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────────
@@ -67,6 +82,7 @@ export function validateFileChanges(
   expectedOutput: string[],
   plannedFiles: string[],
   fileChangeAllowlist: string[] = [],
+  options?: FileChangeAuditOptions,
 ): FileChangeAudit | null {
   const allExpected = new Set([...expectedOutput, ...plannedFiles]);
 
@@ -74,7 +90,7 @@ export function validateFileChanges(
   if (allExpected.size === 0) return null;
 
   // Get actual changed files from last commit
-  const actualFiles = getChangedFilesFromLastCommit(basePath);
+  const actualFiles = getChangedFilesFromLastCommit(basePath, options?.headBeforeCloseout);
   if (!actualFiles) return null;
 
   const configuredProjectsDir = process.env.GSD_STATE_DIR
@@ -141,8 +157,30 @@ export function validateFileChanges(
 
 // ─── Internals ──────────────────────────────────────────────────────────────
 
-function getChangedFilesFromLastCommit(basePath: string): string[] | null {
+/** Current committed HEAD SHA, or null when HEAD is missing/unborn. */
+export function readCommittedHeadSha(basePath: string): string | null {
   try {
+    const sha = execFileSync(
+      "git",
+      ["rev-parse", "--verify", "HEAD"],
+      { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
+    ).trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+function getChangedFilesFromLastCommit(
+  basePath: string,
+  headBeforeCloseout?: string | null,
+): string[] | null {
+  try {
+    if (headBeforeCloseout === null) return null;
+    if (headBeforeCloseout) {
+      const head = readCommittedHeadSha(basePath);
+      if (!head || head === headBeforeCloseout) return [];
+    }
     const result = execFileSync(
       "git",
       ["diff-tree", "--root", "--no-commit-id", "-r", "--name-only", "HEAD"],

--- a/src/resources/extensions/gsd/tests/file-change-validator.test.ts
+++ b/src/resources/extensions/gsd/tests/file-change-validator.test.ts
@@ -198,6 +198,49 @@ test("validateFileChanges excludes the configured in-repo GSD state directory", 
   assert.deepEqual(audit.actualFiles, ["src/app.ts"]);
 });
 
+test("validateFileChanges does not treat pre-closeout HEAD as this unit's changeset when no commit was created", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  git(base, "init");
+  git(base, "config", "user.email", "test@example.com");
+  git(base, "config", "user.name", "Test User");
+
+  writeFileSync(join(base, "lib.rs"), "fn previous() {}\n");
+  writeFileSync(join(base, "main.rs"), "fn main() {}\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "previous rust refactor");
+  const headBeforeCloseout = git(base, "rev-parse", "HEAD");
+
+  const stale = validateFileChanges(base, ["docs/plan.md"], []);
+  assert.ok(stale, "audit should be produced for stale HEAD");
+  assert.ok(
+    stale.unexpectedFiles.includes("lib.rs") && stale.unexpectedFiles.includes("main.rs"),
+    "without a closeout boundary, previous commit files are treated as this unit's changeset",
+  );
+
+  const audit = validateFileChanges(base, ["docs/plan.md"], [], [], { headBeforeCloseout });
+  assert.ok(audit, "audit should be produced when the unit created no commit");
+  assert.deepEqual(audit.actualFiles, [], "no-commit units have an empty change set");
+  assert.deepEqual(audit.unexpectedFiles, [], "stale HEAD files must not be unexpected");
+
+  mkdirSync(join(base, "docs"));
+  writeFileSync(join(base, "docs", "plan.md"), "synced\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "task planning artifacts");
+
+  const committed = validateFileChanges(base, ["docs/plan.md"], [], [], { headBeforeCloseout });
+  assert.ok(committed, "audit should be produced after the unit commit");
+  assert.deepEqual(committed.actualFiles, ["docs/plan.md"]);
+  assert.deepEqual(committed.unexpectedFiles, [], "this unit's files remain expected");
+
+  assert.equal(
+    validateFileChanges(base, ["docs/plan.md"], [], [], { headBeforeCloseout: null }),
+    null,
+    "an unknown commit boundary must skip validation instead of auditing HEAD",
+  );
+});
+
 test("GSD-managed .gitignore edit swept into a task commit is not flagged", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/verification-evidence.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-evidence.test.ts
@@ -5,7 +5,7 @@
  *   1. writeVerificationJSON writes correct JSON shape (schemaVersion, taskId, timestamp, passed, discoverySource, checks)
  *   2. writeVerificationJSON creates directory if it doesn't exist
  *   3. writeVerificationJSON maps exitCode to verdict correctly (0 = pass, non-zero = fail)
- *   4. writeVerificationJSON excludes stdout/stderr from output
+ *   4. writeVerificationJSON persists bounded stdout/stderr excerpts
  *   5. writeVerificationJSON handles empty checks array
  *   6. writeVerificationJSON accepts optional unitId
  *   7. formatEvidenceTable returns markdown table with correct columns for checks
@@ -79,6 +79,8 @@ test("verification-evidence: writeVerificationJSON writes correct JSON shape", (
     assert.equal(json.checks[0].exitCode, 0);
     assert.equal(json.checks[0].durationMs, 2340);
     assert.equal(json.checks[0].verdict, "pass");
+    assert.equal(json.checks[0].stdoutExcerpt, undefined);
+    assert.equal(json.checks[0].stderrExcerpt, undefined);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
@@ -134,31 +136,51 @@ test("verification-evidence: writeVerificationJSON maps exitCode to verdict corr
   }
 });
 
-test("verification-evidence: writeVerificationJSON excludes stdout/stderr from output", () => {
-  const tmp = makeTempDir("ve-no-stdio");
-  try {
-    const result = makeResult({
-      checks: [
-        {
-          command: "echo hello",
-          exitCode: 0,
-          stdout: "hello\n",
-          stderr: "some warning",
-          durationMs: 50,
-        },
-      ],
-    });
+test("verification-evidence: writeVerificationJSON persists failed-command stdout/stderr excerpts", (t) => {
+  const tmp = makeTempDir("ve-stdio");
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  const result = makeResult({
+    passed: false,
+    checks: [
+      {
+        command: "failing-check",
+        exitCode: 1,
+        stdout: "hello\n",
+        stderr: "some warning",
+        durationMs: 50,
+      },
+    ],
+  });
 
-    writeVerificationJSON(result, tmp, "T01");
+  writeVerificationJSON(result, tmp, "T01");
 
-    const raw = readFileSync(join(tmp, "T01-VERIFY.json"), "utf-8");
-    assert.ok(!raw.includes('"stdout"'), "JSON should not contain stdout key");
-    assert.ok(!raw.includes('"stderr"'), "JSON should not contain stderr key");
-    assert.ok(!raw.includes("hello\\n"), "JSON should not contain stdout value");
-    assert.ok(!raw.includes("some warning"), "JSON should not contain stderr value");
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
-  }
+  const json = JSON.parse(readFileSync(join(tmp, "T01-VERIFY.json"), "utf-8"));
+  assert.equal(json.checks[0].stdoutExcerpt, "hello\n");
+  assert.equal(json.checks[0].stderrExcerpt, "some warning");
+});
+
+test("verification-evidence: writeVerificationJSON bounds output excerpts and keeps failure tail", (t) => {
+  const tmp = makeTempDir("ve-bounded-stdio");
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  const stdout = `stdout-start\n${"A".repeat(10_000)}\nstdout-end`;
+  const stderr = `stderr-start\n${"B".repeat(10_000)}\nstderr-end`;
+  const result = makeResult({
+    passed: false,
+    checks: [{ command: "cargo test", exitCode: 1, stdout, stderr, durationMs: 120_000 }],
+  });
+
+  writeVerificationJSON(result, tmp, "T01");
+
+  const json = JSON.parse(readFileSync(join(tmp, "T01-VERIFY.json"), "utf-8"));
+  const check = json.checks[0];
+  assert.ok(Buffer.byteLength(check.stdoutExcerpt, "utf-8") <= 4 * 1024);
+  assert.ok(Buffer.byteLength(check.stderrExcerpt, "utf-8") <= 4 * 1024);
+  assert.match(check.stdoutExcerpt, /^stdout-start/);
+  assert.match(check.stdoutExcerpt, /…\[truncated\]/);
+  assert.match(check.stdoutExcerpt, /stdout-end$/);
+  assert.match(check.stderrExcerpt, /^stderr-start/);
+  assert.match(check.stderrExcerpt, /…\[truncated\]/);
+  assert.match(check.stderrExcerpt, /stderr-end$/);
 });
 
 test("verification-evidence: writeVerificationJSON handles empty checks array", () => {

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -596,6 +596,22 @@ describe("verification-gate: execution", () => {
     assert.equal(typeof result.timestamp, "number");
   });
 
+  test("passing task evidence prevents unrelated preference verification from failing an artifact task (#1431)", () => {
+    const result = runVerificationGate({
+      cwd: tmp,
+      taskPlanVerify: "Planning artifacts exist and contain all required sections",
+      preferenceCommands: ["node -e 'process.exit(9)'"],
+      taskEvidence: [
+        { command: "gsd_exec node: artifact check", exitCode: 0, verdict: "passed", durationMs: 12 },
+        { command: "gsd_exec node: consolidated artifact verification", exitCode: 0, verdict: "pass", durationMs: 8 },
+      ],
+    });
+
+    assert.equal(result.passed, true);
+    assert.equal(result.discoverySource, "task-plan-prose");
+    assert.deepEqual(result.checks, []);
+  });
+
   test("host verification removes GSD control-plane routing while preserving ordinary environment", () => {
     const routingKeys = [
       "GSD_PROJECT_ROOT",

--- a/src/resources/extensions/gsd/verification-evidence.ts
+++ b/src/resources/extensions/gsd/verification-evidence.ts
@@ -6,7 +6,7 @@
  *   - formatEvidenceTable:   returns a markdown evidence table string
  *
  * JSON schema uses schemaVersion: 1 for forward-compatibility.
- * stdout/stderr are intentionally excluded from the JSON to avoid unbounded file sizes.
+ * Failed-command output is persisted as bounded excerpts for forensics.
  */
 
 import { join } from "node:path";
@@ -20,6 +20,32 @@ export interface EvidenceCheckJSON {
   exitCode: number;
   durationMs: number;
   verdict: "pass" | "fail";
+  stdoutExcerpt?: string;
+  stderrExcerpt?: string;
+}
+
+/** Maximum bytes retained for each stdout/stderr excerpt in VERIFY.json. */
+const MAX_OUTPUT_EXCERPT_BYTES = 4 * 1024;
+const OUTPUT_TRUNCATION_MARKER = "\n…[truncated]\n";
+
+function boundedOutputExcerpt(value: string): string | undefined {
+  if (!value) return undefined;
+  const output = Buffer.from(value, "utf-8");
+  if (output.byteLength <= MAX_OUTPUT_EXCERPT_BYTES) return value;
+
+  const marker = Buffer.from(OUTPUT_TRUNCATION_MARKER, "utf-8");
+  const retainedBytes = MAX_OUTPUT_EXCERPT_BYTES - marker.byteLength;
+  const headBytes = Math.floor(retainedBytes / 2);
+  const tailBytes = retainedBytes - headBytes;
+  let headEnd = headBytes;
+  while (headEnd > 0 && (output[headEnd] & 0xc0) === 0x80) headEnd--;
+  let tailStart = output.byteLength - tailBytes;
+  while (tailStart < output.byteLength && (output[tailStart] & 0xc0) === 0x80) tailStart++;
+  return Buffer.concat([
+    output.subarray(0, headEnd),
+    marker,
+    output.subarray(tailStart),
+  ]).toString("utf-8");
 }
 
 export interface RuntimeErrorJSON {
@@ -102,8 +128,8 @@ export interface EvidenceJSON {
  * Creates the directory with mkdirSync({ recursive: true }) if it doesn't exist.
  * Flat-phase callers can pass sliceId to write S##-T##-VERIFY.json.
  *
- * stdout/stderr are excluded from the JSON — the full output lives in VerificationResult
- * in memory and is logged to stderr during the gate run.
+ * Failed-command stdout/stderr excerpts are bounded per stream so output is
+ * available to forensics without allowing artifacts to grow without limit.
  */
 export function writeVerificationJSON(
   result: VerificationResult,
@@ -122,12 +148,18 @@ export function writeVerificationJSON(
     timestamp: result.timestamp,
     passed: result.passed,
     discoverySource: result.discoverySource,
-    checks: result.checks.map((check) => ({
-      command: check.command,
-      exitCode: check.exitCode,
-      durationMs: check.durationMs,
-      verdict: check.exitCode === 0 ? "pass" : "fail",
-    })),
+    checks: result.checks.map((check) => {
+      const stdoutExcerpt = check.exitCode === 0 ? undefined : boundedOutputExcerpt(check.stdout);
+      const stderrExcerpt = check.exitCode === 0 ? undefined : boundedOutputExcerpt(check.stderr);
+      return {
+        command: check.command,
+        exitCode: check.exitCode,
+        durationMs: check.durationMs,
+        verdict: check.exitCode === 0 ? "pass" : "fail",
+        ...(stdoutExcerpt !== undefined ? { stdoutExcerpt } : {}),
+        ...(stderrExcerpt !== undefined ? { stderrExcerpt } : {}),
+      };
+    }),
     ...(retryAttempt !== undefined ? { retryAttempt } : {}),
     ...(maxRetries !== undefined ? { maxRetries } : {}),
   };

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -146,16 +146,13 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
     }
   }
 
-  // 1b. Prose task verify backed by passing structured task evidence (#1591).
-  // Task-specific evidence must not be silently replaced by unrelated
-  // project-wide preference commands.
-  if (
+  // A prose verification requirement may be satisfied by the structured
+  // evidence staged for this Task. Keep this decision next to preference
+  // fallback below so unrelated project-wide checks cannot replace it (#1431).
+  const taskEvidenceSatisfiesVerify =
     hasTaskPlanProse &&
     !hasUnsafeTaskPlanCommand &&
-    hasQualifyingTaskEvidence(options.taskEvidence)
-  ) {
-    return { commands: [], source: "task-plan-prose" };
-  }
+    hasQualifyingTaskEvidence(options.taskEvidence);
 
   // 2. Preference commands
   if (options.preferenceCommands && options.preferenceCommands.length > 0) {
@@ -163,8 +160,15 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
       .map(c => c.trim())
       .filter(Boolean);
     if (filtered.length > 0) {
+      if (taskEvidenceSatisfiesVerify) {
+        return { commands: [], source: "task-plan-prose" };
+      }
       return { commands: filtered, source: "preference" };
     }
+  }
+
+  if (taskEvidenceSatisfiesVerify) {
+    return { commands: [], source: "task-plan-prose" };
   }
 
   // 3. package.json scripts


### PR DESCRIPTION
## Summary
- Fixed closeout file auditing, evidence-backed task verification, and bounded failure-output persistence with focused regression coverage.

## Bugs Addressed
- [x] **File-change safety audit validates stale HEAD**
- [x] **Verification gate ignores passing task evidence**
- [x] **Verification artifacts omit failure output**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1431
- [#1431 Post-unit gates audit stale HEAD and ignore evidence-backed GSD-only task verification](https://github.com/open-gsd/gsd-pi/issues/1431)

## User
- @mik888em

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1431-post-unit-gates-audit-stale-head-and-ign-1787232110`