### PR TITLE
fix(issue): Branch isolation makes recorded integration branch disappear in unborn repositories

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree-branch-lifecycle.ts
+++ b/src/resources/extensions/gsd/auto-worktree-branch-lifecycle.ts
@@ -10,9 +10,12 @@ import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { debugLog } from "./debug-logger.js";
 import { checkoutBranchWithStashGuard } from "./worktree-git-recovery.js";
 import {
+  nativeAddAll,
   nativeBranchExists,
   nativeBranchForceReset,
+  nativeCheckoutBranch,
   nativeCheckoutNewBranch,
+  nativeCommit,
   nativeDetectMainBranch,
   nativeHasCommittedHead,
   nativeIsAncestor,
@@ -45,6 +48,8 @@ export function _resolveAutoWorktreeStartPoint(
  * Creates `milestone/<MID>` from the integration branch (if it doesn't
  * exist yet) and checks out to it. No worktree directory is created — the
  * project root is the working copy; only HEAD changes.
+ * An unborn repository first receives a baseline commit on its integration
+ * branch so that branch remains available after milestone isolation begins.
  *
  * Uses the same 3-tier integration-branch fallback as createAutoWorktree:
  *   1. META.json recorded integration branch
@@ -56,21 +61,38 @@ export function enterBranchModeForMilestone(
   milestoneId: string,
 ): void {
   const branch = autoWorktreeBranch(milestoneId);
+
+  if (!nativeHasCommittedHead(basePath)) {
+    const currentBranch = runGit(
+      basePath,
+      ["symbolic-ref", "--quiet", "--short", "HEAD"],
+    );
+    const gitMainBranch = loadEffectiveGSDPreferences(basePath)?.preferences?.git?.main_branch;
+    const integrationBranch =
+      readIntegrationBranch(basePath, milestoneId) ??
+      gitMainBranch ??
+      (currentBranch !== branch ? currentBranch : "main");
+
+    if (currentBranch !== integrationBranch) {
+      if (nativeBranchExists(basePath, integrationBranch)) {
+        nativeCheckoutBranch(basePath, integrationBranch);
+      } else {
+        nativeCheckoutNewBranch(basePath, integrationBranch);
+      }
+    }
+    nativeAddAll(basePath);
+    nativeCommit(basePath, "chore: init project", { allowEmpty: true });
+    debugLog("auto-worktree", {
+      action: "establishIntegrationBranch",
+      milestoneId,
+      branch: integrationBranch,
+      repositoryState: "unborn",
+    });
+  }
+
   const branchExists = nativeBranchExists(basePath, branch);
 
   if (!branchExists) {
-    if (!nativeHasCommittedHead(basePath)) {
-      nativeCheckoutNewBranch(basePath, branch);
-      debugLog("auto-worktree", {
-        action: "enterBranchMode",
-        milestoneId,
-        branch,
-        repositoryState: "unborn",
-        created: true,
-      });
-      return;
-    }
-
     // Create the milestone branch from the integration branch start-point.
     const integrationBranch =
       readIntegrationBranch(basePath, milestoneId) ?? undefined;

--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -12,11 +12,12 @@ import { isClosedStatus } from "./status-guards.js";
 import { allWorktreesDirs, createWorktree, listWorktrees, resolveGitDir } from "./worktree-manager.js";
 import { abortAndReset } from "./git-self-heal.js";
 import { RUNTIME_EXCLUSION_PATHS, resolveMilestoneIntegrationBranch, writeIntegrationBranch } from "./git-service.js";
-import { nativeIsRepo, nativeWorktreeList, nativeWorktreeRemove, nativeBranchList, nativeBranchDelete, nativeLsFiles, nativeRmCached, nativeHasChanges, nativeLastCommitEpoch, nativeGetCurrentBranch, nativeAddTracked, nativeCommit } from "./native-git-bridge.js";
+import { nativeIsRepo, nativeWorktreeList, nativeWorktreeRemove, nativeBranchList, nativeBranchDelete, nativeLsFiles, nativeRmCached, nativeHasChanges, nativeLastCommitEpoch, nativeGetCurrentBranch, nativeAddTracked, nativeCommit, nativeIsCurrentUnbornBranch } from "./native-git-bridge.js";
 import { getAllWorktreeHealth } from "./worktree-health.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { listUnmergedGitPaths, probeGitConflictState, reconcileGitConflictsOnSignal } from "./git-conflict-state.js";
 import { resolveWorktreeProjectRoot } from "./worktree-root.js";
+import { enterBranchModeForMilestone } from "./auto-worktree-branch-lifecycle.js";
 
 /**
  * Returns true if the directory contains only doctor artifacts
@@ -485,14 +486,21 @@ export async function checkGitHealth(
       }
 
       if (resolution.status === "missing") {
+        const fixableUnbornBranch =
+          isolationMode === "branch" &&
+          nativeIsCurrentUnbornBranch(basePath, `milestone/${milestone.id}`);
         issues.push({
           severity: "error",
           code: "integration_branch_missing",
           scope: "milestone",
           unitId: milestone.id,
           message: resolution.reason,
-          fixable: false,
+          fixable: fixableUnbornBranch,
         });
+        if (fixableUnbornBranch && shouldFix("integration_branch_missing")) {
+          enterBranchModeForMilestone(basePath, milestone.id);
+          fixesApplied.push(`established integration branch for ${milestone.id}`);
+        }
       }
     }
   } catch {

--- a/src/resources/extensions/gsd/tests/unborn-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/unborn-branch.test.ts
@@ -148,7 +148,7 @@ test("branch isolation preserves the integration ref in an unborn repo", async (
   enterBranchModeForMilestone(dir, "M001");
 
   assert.equal(git(["branch", "--show-current"], dir), "milestone/M001");
-  assert.ok(git(["rev-parse", "--verify", "main^{commit}"]));
+  assert.ok(git(["rev-parse", "--verify", "main^{commit}"], dir));
 
   // Re-entry must remain idempotent after the baseline commit.
   enterBranchModeForMilestone(dir, "M001");

--- a/src/resources/extensions/gsd/tests/unborn-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/unborn-branch.test.ts
@@ -8,7 +8,7 @@
  * verified.
  */
 
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -22,6 +22,13 @@ import {
   nativeDetectMainBranch,
 } from "../native-git-bridge.ts";
 import { enterBranchModeForMilestone } from "../auto-worktree-branch-lifecycle.ts";
+import { preDispatchHealthGate } from "../doctor-proactive.ts";
+import { checkGitHealth } from "../doctor-git-checks.ts";
+import type { DoctorIssue } from "../doctor-types.ts";
+import { captureIntegrationBranch } from "../worktree.ts";
+import { readIntegrationBranch } from "../git-service.ts";
+import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
+import { invalidateStateCache } from "../state.ts";
 
 function git(args: string[], cwd: string): string {
   return execFileSync("git", args, {
@@ -29,6 +36,32 @@ function git(args: string[], cwd: string): string {
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf-8",
   }).trim();
+}
+
+function makeUnbornIsolationFixture(t: TestContext): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-test-")));
+  const gsdHome = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-home-")));
+  const previousCwd = process.cwd();
+  const previousGsdHome = process.env.GSD_HOME;
+  t.after(() => {
+    closeDatabase();
+    invalidateStateCache();
+    process.chdir(previousCwd);
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(gsdHome, { recursive: true, force: true });
+  });
+
+  process.chdir(dir);
+  process.env.GSD_HOME = gsdHome;
+  git(["init", "--initial-branch=main"], dir);
+  git(["config", "user.email", "test@test.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  writeFileSync(join(dir, ".gitignore"), ".gsd/\n");
+  writeFileSync(join(dir, "project.txt"), "project content\n");
+  mkdirSync(join(dir, ".gsd"));
+  return dir;
 }
 
 test("nativeBranchExists: returns true for unborn branch (zero commits)", () => {
@@ -90,10 +123,12 @@ test("native branch lookup falls back when unborn HEAD throws", () => {
   assert.equal(branchExistsIncludingUnborn(false, currentBranch, "milestone/M001"), true);
 });
 
-test("branch mode re-enters a dirty current unborn milestone branch", (t) => {
+test("branch mode re-enters a dirty current milestone branch", (t) => {
   const dir = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-test-")));
   t.after(() => rmSync(dir, { recursive: true, force: true }));
   git(["init"], dir);
+  git(["config", "user.email", "test@test.com"], dir);
+  git(["config", "user.name", "Test"], dir);
 
   enterBranchModeForMilestone(dir, "M001");
   writeFileSync(join(dir, "draft.txt"), "uncommitted work\n");
@@ -103,46 +138,67 @@ test("branch mode re-enters a dirty current unborn milestone branch", (t) => {
   assert.equal(git(["status", "--short", "draft.txt"], dir), "?? draft.txt");
 });
 
-test("branch isolation enters the milestone branch in an unborn repo", () => {
-  const dir = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-test-")));
-  const previousCwd = process.cwd();
-  const previousGsdHome = process.env.GSD_HOME;
-  const gsdHome = realpathSync(mkdtempSync(join(tmpdir(), "unborn-branch-home-")));
-  try {
-    process.chdir(dir);
-    process.env.GSD_HOME = gsdHome;
-    git(["init", "--initial-branch=main"], dir);
-    writeFileSync(join(dir, "project.txt"), "untracked project content\n");
-    mkdirSync(join(dir, ".gsd"));
-    writeFileSync(
-      join(dir, ".gsd", "M001-META.json"),
-      JSON.stringify({ integrationBranch: "main" }),
-    );
+test("branch isolation preserves the integration ref in an unborn repo", async (t) => {
+  const dir = makeUnbornIsolationFixture(t);
 
-    assert.equal(nativeDetectMainBranch(dir), "");
+  assert.equal(nativeDetectMainBranch(dir), "");
+  captureIntegrationBranch(dir, "M001");
+  assert.equal(readIntegrationBranch(dir, "M001"), "main");
 
-    enterBranchModeForMilestone(dir, "M001");
+  enterBranchModeForMilestone(dir, "M001");
 
-    assert.equal(git(["branch", "--show-current"], dir), "milestone/M001");
+  assert.equal(git(["branch", "--show-current"], dir), "milestone/M001");
+  assert.ok(git(["rev-parse", "--verify", "main^{commit}"]));
 
-    // Re-entry while the repo is still unborn must not fail: the milestone
-    // branch has no commit-backed ref yet, so a plain checkout would abort
-    // with "pathspec did not match".
-    enterBranchModeForMilestone(dir, "M001");
+  // Re-entry must remain idempotent after the baseline commit.
+  enterBranchModeForMilestone(dir, "M001");
 
-    assert.equal(git(["branch", "--show-current"], dir), "milestone/M001");
-    assert.equal(
-      git(["status", "--short"], dir),
-      "?? .gsd/\n?? project.txt",
-      "branch creation should preserve untracked project content",
-    );
-  } finally {
-    process.chdir(previousCwd);
-    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
-    else process.env.GSD_HOME = previousGsdHome;
-    rmSync(dir, { recursive: true, force: true });
-    rmSync(gsdHome, { recursive: true, force: true });
-  }
+  assert.equal(git(["branch", "--show-current"], dir), "milestone/M001");
+  assert.equal(
+    git(["status", "--short"], dir),
+    "",
+    "the integration baseline should include existing project content",
+  );
+
+  openDatabase(join(dir, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  invalidateStateCache();
+
+  const health = await preDispatchHealthGate(dir);
+  assert.equal(health.proceed, true, health.reason);
+});
+
+test("doctor repairs a legacy unborn milestone branch with a missing integration ref", async (t) => {
+  const dir = makeUnbornIsolationFixture(t);
+  writeFileSync(
+    join(dir, ".gsd", "M001-META.json"),
+    JSON.stringify({ integrationBranch: "main" }),
+  );
+  git(["checkout", "-b", "milestone/M001"], dir);
+
+  openDatabase(join(dir, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  invalidateStateCache();
+
+  const issues: DoctorIssue[] = [];
+  const fixesApplied: string[] = [];
+  await checkGitHealth(
+    dir,
+    issues,
+    fixesApplied,
+    (code) => code === "integration_branch_missing",
+    "branch",
+  );
+
+  assert.equal(
+    issues.find((issue) => issue.code === "integration_branch_missing")?.fixable,
+    true,
+  );
+  assert.ok(git(["rev-parse", "--verify", "main^{commit}"], dir));
+  assert.equal(git(["branch", "--show-current"], dir), "milestone/M001");
+
+  const health = await preDispatchHealthGate(dir);
+  assert.equal(health.proceed, true, health.reason);
 });
 
 test("nativeDetectMainBranch: still throws for a path that is not a repo", () => {

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -306,7 +306,7 @@ test("enterMilestone retries branch isolation when session is degraded", (t) => 
   assert.equal(s.milestoneLeaseToken, null);
 });
 
-test("enterMilestone enters branch isolation in a zero-commit repository (#1688)", (t) => {
+test("enterMilestone establishes an integration ref before branch isolation in a zero-commit repository", (t) => {
   const previousCwd = process.cwd();
   const base = makeGitRepoBase({ isolation: "branch", unborn: true });
   t.after(() => cleanupRepoBase(base, previousCwd));
@@ -321,9 +321,9 @@ test("enterMilestone enters branch isolation in a zero-commit repository (#1688)
     execFileSync("git", ["branch", "--show-current"], { cwd: base, encoding: "utf8" }).trim(),
     "milestone/M001",
   );
-  assert.throws(
-    () => execFileSync("git", ["rev-parse", "--verify", "HEAD"], { cwd: base, stdio: "pipe" }),
-    "branch entry must not fabricate a commit",
+  assert.ok(
+    execFileSync("git", ["rev-parse", "--verify", "main^{commit}"], { cwd: base, encoding: "utf8" }).trim(),
+    "branch entry must preserve a commit-backed integration branch",
   );
 });
 


### PR DESCRIPTION
## Summary
- Preserved integration refs during unborn-repository branch isolation and added doctor recovery with regression coverage.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1895
- [#1895 Branch isolation makes recorded integration branch disappear in unborn repositories](https://github.com/open-gsd/gsd-pi/issues/1895)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1895-branch-isolation-makes-recorded-integrat-1787233310`