### PR TITLE
fix(issue): Re-entrant session lock acquisition releases ownership and wedges auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1071,9 +1071,16 @@ export async function bootstrapAutoSession(
     return false;
   }
 
-  function releaseLockAndReturn(): false {
+  const ownsSessionLockAcquisition = lockResult.reentrant !== true;
+
+  function releaseLockAcquisition(): void {
+    if (!ownsSessionLockAcquisition) return;
     releaseSessionLock(base);
     clearLock(base);
+  }
+
+  function releaseLockAndReturn(): false {
+    releaseLockAcquisition();
     return false;
   }
 
@@ -1220,6 +1227,16 @@ export async function bootstrapAutoSession(
     }
     // Ensure symlink exists (handles fresh projects and post-migration)
     ensureGsdSymlink(base);
+
+    // Acquisition starts before migration so bootstrap is serialized. Once
+    // .gsd points at external state, hand ownership to that physical target
+    // before any later process can observe or contend on the new path.
+    const migratedLockResult = acquireSessionLock(base);
+    if (!migratedLockResult.acquired) {
+      ctx.ui.notify(migratedLockResult.reason, "error");
+      return releaseLockAndReturn();
+    }
+
     openWorkflowDatabase(base);
 
     // Ensure .gitignore has baseline patterns.
@@ -2062,8 +2079,7 @@ export async function bootstrapAutoSession(
 
     return true;
   } catch (err) {
-    releaseSessionLock(base);
-    clearLock(base);
+    releaseLockAcquisition();
     throw err;
   }
 }

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -38,7 +38,7 @@ export interface SessionLockData {
 }
 
 export type SessionLockResult =
-  | { acquired: true }
+  | { acquired: true; reentrant?: true }
   | { acquired: false; reason: string; existingPid?: number };
 
 export type SessionLockFailureReason =
@@ -65,6 +65,8 @@ interface ProperLockfileApi {
     },
   ): () => void;
 }
+
+let _properLockfileOverride: ProperLockfileApi | undefined;
 
 // ─── Module State ───────────────────────────────────────────────────────────
 
@@ -122,6 +124,10 @@ function lockPath(basePath: string): string {
   // If we have a snapshotted path from acquisition, use it for consistency
   if (_snapshotLockPath) return _snapshotLockPath;
   return join(gsdRoot(basePath), effectiveLockFile());
+}
+
+function canonicalLockTarget(basePath: string): string {
+  return normalizeRealPath(effectiveLockTarget(gsdRoot(basePath)));
 }
 
 export interface LockDirectoryFs {
@@ -289,13 +295,51 @@ function createLockCompromisedHandler(lockFilePath: string): () => void {
 /**
  * Assign module-level lock state after a successful lock acquisition.
  */
-function assignLockState(basePath: string, release: () => void, lockFilePath: string): void {
+function assignLockState(lockTarget: string, release: () => void, lockFilePath: string): void {
   _releaseFunction = release;
-  _lockedPath = basePath;
+  _lockedPath = lockTarget;
   _lockPid = process.pid;
   _lockCompromised = false;
   _lockAcquiredAt = Date.now();
   _snapshotLockPath = lockFilePath;
+}
+
+/**
+ * Replace a compromised lock without running stale-lock cleanup. A successful
+ * exclusive lockSync is the proof that the previous OS lock is no longer held.
+ */
+function recoverCompromisedLock(
+  basePath: string,
+  lockFilePath: string,
+  lockData: SessionLockData,
+): boolean {
+  let lockfile: ProperLockfileApi;
+  try {
+    lockfile = _properLockfileOverride ?? _require("proper-lockfile") as ProperLockfileApi;
+  } catch {
+    return false;
+  }
+
+  const lockTarget = canonicalLockTarget(basePath);
+  try {
+    const release = lockfile.lockSync(lockTarget, {
+      realpath: false,
+      stale: 1_800_000,
+      update: 10_000,
+      onCompromised: createLockCompromisedHandler(lockFilePath),
+    });
+    try {
+      atomicWriteSync(lockFilePath, JSON.stringify(lockData, null, 2));
+    } catch {
+      try { release(); } catch { /* best-effort */ }
+      return false;
+    }
+    assignLockState(lockTarget, release, lockFilePath);
+    ensureExitHandler(lockTarget);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────────
@@ -312,18 +356,24 @@ function assignLockState(basePath: string, release: () => void, lockFilePath: st
 export function acquireSessionLock(basePath: string): SessionLockResult {
   const lp = lockPath(basePath);
 
-  // Re-entrant acquire on the same path: release our current OS lock first so
-  // proper-lockfile clears its update timer before we acquire a fresh lock.
-  if (_releaseFunction && _lockedPath === basePath) {
-    try { _releaseFunction(); } catch { /* may already be released */ }
-    _releaseFunction = null;
-    _lockedPath = null;
-    _lockPid = 0;
-    _lockCompromised = false;
-  }
-
-  // Ensure the directory exists
+  // Ensure the directory exists before canonicalizing the lock target.
   mkdirSync(dirname(lp), { recursive: true });
+
+  const lockTarget = canonicalLockTarget(basePath);
+  const lockData: SessionLockData = {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    unitType: "starting",
+    unitId: "bootstrap",
+    unitStartedAt: new Date().toISOString(),
+  };
+
+  // A healthy same-process re-entry already owns the OS lock. Keep that lock
+  // continuously held and only refresh its informational metadata.
+  if (_releaseFunction && !_lockCompromised && _lockedPath === lockTarget) {
+    atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
+    return { acquired: true, reentrant: true };
+  }
 
   // Clean up numbered lock file variants from cloud sync conflicts (#1315)
   cleanupStrayLockFiles(basePath);
@@ -335,25 +385,13 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     markWorkerStoppingByPid(normalizeRealPath(basePath), existingPreflight.pid);
   }
 
-  // Write our lock data first (the content is informational; the OS lock is the real guard)
-  const lockData: SessionLockData = {
-    pid: process.pid,
-    startedAt: new Date().toISOString(),
-    unitType: "starting",
-    unitId: "bootstrap",
-    unitStartedAt: new Date().toISOString(),
-  };
-
   let lockfile: ProperLockfileApi;
   try {
-    lockfile = _require("proper-lockfile") as ProperLockfileApi;
+    lockfile = _properLockfileOverride ?? _require("proper-lockfile") as ProperLockfileApi;
   } catch {
     // proper-lockfile not available — fall back to PID-based check
     return acquireFallbackLock(basePath, lp, lockData);
   }
-
-  const gsdDir = gsdRoot(basePath);
-  const lockTarget = effectiveLockTarget(gsdDir);
 
   // #3218: Pre-flight stale lock cleanup — if the .lock/ directory exists but
   // no auto.lock metadata is present (or the PID is dead), remove the lock
@@ -392,7 +430,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
       onCompromised: createLockCompromisedHandler(lp),
     });
 
-    assignLockState(basePath, release, lp);
+    assignLockState(lockTarget, release, lp);
 
     // Safety net: clean up lock dir on process exit if _releaseFunction
     // wasn't called (e.g., normal exit after clean completion) (#1245).
@@ -425,7 +463,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
           update: 10_000,
           onCompromised: createLockCompromisedHandler(lp),
         });
-        assignLockState(basePath, release, lp);
+        assignLockState(lockTarget, release, lp);
 
         // Safety net — uses centralized handler to avoid double-registration
         ensureExitHandler(lockTarget);
@@ -460,8 +498,17 @@ function acquireFallbackLock(
   lp: string,
   lockData: SessionLockData,
 ): SessionLockResult {
+  const lockTarget = canonicalLockTarget(basePath);
   // Check if an existing lock is held by a live process
   const existing = readExistingLockData(lp);
+  if (
+    _lockedPath === lockTarget &&
+    _lockPid === process.pid &&
+    existing?.pid === process.pid
+  ) {
+    atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
+    return { acquired: true, reentrant: true };
+  }
   if (existing && existing.pid !== process.pid) {
     if (isPidAlive(existing.pid)) {
       return {
@@ -475,7 +522,7 @@ function acquireFallbackLock(
 
   // Write our lock data
   atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
-  _lockedPath = basePath;
+  _lockedPath = lockTarget;
   _lockPid = process.pid;
 
   return { acquired: true };
@@ -491,7 +538,7 @@ export function updateSessionLock(
   unitId: string,
   sessionFile?: string,
 ): void {
-  if (_lockedPath !== basePath && _lockedPath !== null) return;
+  if (_lockedPath !== canonicalLockTarget(basePath) && _lockedPath !== null) return;
 
   const lp = lockPath(basePath);
   try {
@@ -528,15 +575,9 @@ export function getSessionLockStatus(basePath: string): SessionLockStatus {
     // Retry reads to tolerate transient filesystem hiccups (#2324).
     const existing = readExistingLockDataWithRetry(lp);
     if (existing && existing.pid === process.pid) {
-      // Lock file still ours — try to re-acquire the OS lock
-      try {
-        const result = acquireSessionLock(basePath);
-        if (result.acquired) {
-          logWarning("session", "Lock recovered after onCompromised — lock file PID matched, re-acquired.");
-          return { valid: true, recovered: true };
-        }
-      } catch {
-        // Re-acquisition failed — fall through to return false
+      if (recoverCompromisedLock(basePath, lp, existing)) {
+        logWarning("session", "Lock recovered after onCompromised — lock file PID matched, re-acquired.");
+        return { valid: true, recovered: true };
       }
     }
     return {
@@ -548,7 +589,7 @@ export function getSessionLockStatus(basePath: string): SessionLockStatus {
   }
 
   // If we have an OS-level lock, we're still the owner
-  if (_releaseFunction && _lockedPath === basePath) {
+  if (_releaseFunction && _lockedPath === canonicalLockTarget(basePath)) {
     return { valid: true };
   }
 
@@ -702,7 +743,7 @@ export function removeStaleSessionLock(basePath: string): boolean {
  * Returns true if we currently hold a session lock for the given path.
  */
 export function isSessionLockHeld(basePath: string): boolean {
-  return _lockedPath === basePath && _lockPid === process.pid;
+  return _lockedPath === canonicalLockTarget(basePath) && _lockPid === process.pid;
 }
 
 /**
@@ -711,6 +752,13 @@ export function isSessionLockHeld(basePath: string): boolean {
  */
 export function _getRegisteredLockDirs(): string[] {
   return [..._lockDirRegistry];
+}
+
+/** Override proper-lockfile for deterministic lock lifecycle tests. */
+export function _setProperLockfileForTests(lockfile: ProperLockfileApi | undefined): () => void {
+  const previous = _properLockfileOverride;
+  _properLockfileOverride = lockfile;
+  return () => { _properLockfileOverride = previous; };
 }
 
 // ─── Internal Helpers ───────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -73,8 +73,11 @@ let _properLockfileOverride: ProperLockfileApi | undefined;
 /** Release function from proper-lockfile — calling it releases the OS lock. */
 let _releaseFunction: (() => void) | null = null;
 
-/** The path we currently hold a lock on. */
+/** The physical target we currently hold an OS lock on. */
 let _lockedPath: string | null = null;
+
+/** Canonical project/process lock identity, stable across .gsd migration. */
+let _lockedOwner: string | null = null;
 
 /** Our PID at lock acquisition time. */
 let _lockPid: number = 0;
@@ -128,6 +131,10 @@ function lockPath(basePath: string): string {
 
 function canonicalLockTarget(basePath: string): string {
   return normalizeRealPath(effectiveLockTarget(gsdRoot(basePath)));
+}
+
+function canonicalLockOwner(basePath: string): string {
+  return `${normalizeRealPath(basePath)}\0${effectiveLockFile()}`;
 }
 
 export interface LockDirectoryFs {
@@ -295,8 +302,14 @@ function createLockCompromisedHandler(lockFilePath: string): () => void {
 /**
  * Assign module-level lock state after a successful lock acquisition.
  */
-function assignLockState(lockTarget: string, release: () => void, lockFilePath: string): void {
+function assignLockState(
+  lockOwner: string,
+  lockTarget: string,
+  release: () => void,
+  lockFilePath: string,
+): void {
   _releaseFunction = release;
+  _lockedOwner = lockOwner;
   _lockedPath = lockTarget;
   _lockPid = process.pid;
   _lockCompromised = false;
@@ -334,7 +347,7 @@ function recoverCompromisedLock(
       try { release(); } catch { /* best-effort */ }
       return false;
     }
-    assignLockState(lockTarget, release, lockFilePath);
+    assignLockState(canonicalLockOwner(basePath), lockTarget, release, lockFilePath);
     ensureExitHandler(lockTarget);
     return true;
   } catch {
@@ -360,6 +373,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
   mkdirSync(dirname(lp), { recursive: true });
 
   const lockTarget = canonicalLockTarget(basePath);
+  const lockOwner = canonicalLockOwner(basePath);
   const lockData: SessionLockData = {
     pid: process.pid,
     startedAt: new Date().toISOString(),
@@ -370,9 +384,50 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
 
   // A healthy same-process re-entry already owns the OS lock. Keep that lock
   // continuously held and only refresh its informational metadata.
-  if (_releaseFunction && !_lockCompromised && _lockedPath === lockTarget) {
-    atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
-    return { acquired: true, reentrant: true };
+  if (_releaseFunction && !_lockCompromised && _lockedOwner === lockOwner) {
+    if (_lockedPath === lockTarget) {
+      atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
+      return { acquired: true, reentrant: true };
+    }
+
+    // External-state migration can replace <project>/.gsd with a symlink while
+    // bootstrap already owns the original target. Acquire the new physical
+    // target before releasing the old one so exclusion remains continuous.
+    let lockfile: ProperLockfileApi;
+    try {
+      lockfile = _properLockfileOverride ?? _require("proper-lockfile") as ProperLockfileApi;
+    } catch {
+      _lockedPath = lockTarget;
+      atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
+      return { acquired: true, reentrant: true };
+    }
+
+    try {
+      mkdirSync(lockTarget, { recursive: true });
+      const previousRelease = _releaseFunction;
+      const release = lockfile.lockSync(lockTarget, {
+        realpath: false,
+        stale: 1_800_000,
+        update: 10_000,
+        onCompromised: createLockCompromisedHandler(lp),
+      });
+      try {
+        atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
+      } catch (error) {
+        try { release(); } catch { /* best-effort */ }
+        throw error;
+      }
+      assignLockState(lockOwner, lockTarget, release, lp);
+      ensureExitHandler(lockTarget);
+      try { previousRelease(); } catch { /* best-effort: new target is already held */ }
+      return { acquired: true, reentrant: true };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      return {
+        acquired: false,
+        reason: `Could not transfer session lock after state-path migration: ${detail}`,
+      };
+    }
   }
 
   // Clean up numbered lock file variants from cloud sync conflicts (#1315)
@@ -430,7 +485,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
       onCompromised: createLockCompromisedHandler(lp),
     });
 
-    assignLockState(lockTarget, release, lp);
+    assignLockState(lockOwner, lockTarget, release, lp);
 
     // Safety net: clean up lock dir on process exit if _releaseFunction
     // wasn't called (e.g., normal exit after clean completion) (#1245).
@@ -463,7 +518,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
           update: 10_000,
           onCompromised: createLockCompromisedHandler(lp),
         });
-        assignLockState(lockTarget, release, lp);
+        assignLockState(lockOwner, lockTarget, release, lp);
 
         // Safety net — uses centralized handler to avoid double-registration
         ensureExitHandler(lockTarget);
@@ -499,13 +554,15 @@ function acquireFallbackLock(
   lockData: SessionLockData,
 ): SessionLockResult {
   const lockTarget = canonicalLockTarget(basePath);
+  const lockOwner = canonicalLockOwner(basePath);
   // Check if an existing lock is held by a live process
   const existing = readExistingLockData(lp);
   if (
-    _lockedPath === lockTarget &&
+    _lockedOwner === lockOwner &&
     _lockPid === process.pid &&
     existing?.pid === process.pid
   ) {
+    _lockedPath = lockTarget;
     atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
     return { acquired: true, reentrant: true };
   }
@@ -522,6 +579,7 @@ function acquireFallbackLock(
 
   // Write our lock data
   atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
+  _lockedOwner = lockOwner;
   _lockedPath = lockTarget;
   _lockPid = process.pid;
 
@@ -538,7 +596,7 @@ export function updateSessionLock(
   unitId: string,
   sessionFile?: string,
 ): void {
-  if (_lockedPath !== canonicalLockTarget(basePath) && _lockedPath !== null) return;
+  if (_lockedOwner !== canonicalLockOwner(basePath) && _lockedOwner !== null) return;
 
   const lp = lockPath(basePath);
   try {
@@ -589,7 +647,11 @@ export function getSessionLockStatus(basePath: string): SessionLockStatus {
   }
 
   // If we have an OS-level lock, we're still the owner
-  if (_releaseFunction && _lockedPath === canonicalLockTarget(basePath)) {
+  if (
+    _releaseFunction &&
+    _lockedOwner === canonicalLockOwner(basePath) &&
+    _lockedPath === canonicalLockTarget(basePath)
+  ) {
     return { valid: true };
   }
 
@@ -681,6 +743,7 @@ export function releaseSessionLock(basePath: string): void {
   cleanupStrayLockFiles(basePath);
 
   _lockedPath = null;
+  _lockedOwner = null;
   _lockPid = 0;
   _lockCompromised = false;
   _lockAcquiredAt = 0;
@@ -743,7 +806,11 @@ export function removeStaleSessionLock(basePath: string): boolean {
  * Returns true if we currently hold a session lock for the given path.
  */
 export function isSessionLockHeld(basePath: string): boolean {
-  return _lockedPath === canonicalLockTarget(basePath) && _lockPid === process.pid;
+  return (
+    _lockedOwner === canonicalLockOwner(basePath) &&
+    _lockedPath === canonicalLockTarget(basePath) &&
+    _lockPid === process.pid
+  );
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -9,6 +9,12 @@ import { join } from "node:path";
 
 import { bootstrapAutoSession } from "../auto-start.ts";
 import { AutoSession } from "../auto/session.ts";
+import {
+  acquireSessionLock,
+  isSessionLockHeld,
+  releaseSessionLock,
+  validateSessionLock,
+} from "../session-lock.ts";
 import type { InterruptedSessionAssessment } from "../interrupted-session.ts";
 import {
   closeDatabase,
@@ -268,6 +274,53 @@ test("fresh bootstrap clears isolation degradation from a prior auto run (#1689)
 
   assert.equal(ready, false, "the system temp root should stop bootstrap at directory validation");
   assert.equal(s.isolationDegraded, false, "fresh bootstrap must not inherit degradation");
+});
+
+test("re-entrant bootstrap failure preserves the outer session lock", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-reentrant-bootstrap-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  const previousProjectId = process.env.GSD_PROJECT_ID;
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    assert.deepEqual(acquireSessionLock(base), { acquired: true });
+    process.env.GSD_PROJECT_ID = "invalid project id";
+
+    const ready = await bootstrapAutoSession(
+      new AutoSession(),
+      makeCtx(notifications) as any,
+      { getThinkingLevel: () => "medium" } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({} as any),
+      },
+      {} as InterruptedSessionAssessment,
+    );
+
+    assert.equal(ready, false);
+    assert.match(notifications.at(-1)?.message ?? "", /GSD_PROJECT_ID/);
+    assert.equal(
+      isSessionLockHeld(base),
+      true,
+      "failed inner bootstrap must not release outer ownership",
+    );
+    assert.equal(
+      validateSessionLock(base),
+      true,
+      "outer lock remains valid after inner bootstrap aborts",
+    );
+  } finally {
+    if (previousProjectId === undefined) delete process.env.GSD_PROJECT_ID;
+    else process.env.GSD_PROJECT_ID = previousProjectId;
+    releaseSessionLock(base);
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 test("bootstrap aborts before starting next milestone when completed orphan merge fails", async () => {

--- a/src/resources/extensions/gsd/tests/session-lock-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/session-lock-regression.test.ts
@@ -7,12 +7,13 @@
  *   #1251  Same root cause as #1245
  *
  * Tests the acquire → validate → release lifecycle and edge cases
- * without requiring concurrent processes.
+ * including cross-process exclusion during re-entrant acquisition.
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import {
@@ -23,6 +24,7 @@ import {
   readSessionLockData,
   updateSessionLock,
   isSessionLockHeld,
+  _setProperLockfileForTests,
 } from '../session-lock.ts';
 import { gsdRoot } from '../paths.ts';
 import { openDatabase, closeDatabase, _getAdapter } from "../gsd-db.ts";
@@ -337,7 +339,7 @@ describe('session-lock-regression', async () => {
       assert.ok(r1.acquired, 'first acquisition succeeds');
 
       const r2 = acquireSessionLock(base);
-      assert.ok(r2.acquired, 're-entrant acquisition succeeds');
+      assert.deepStrictEqual(r2, { acquired: true, reentrant: true }, 're-entrant acquisition succeeds');
 
       const valid = validateSessionLock(base);
       assert.ok(valid, 're-entrant acquisition does not corrupt validation state');
@@ -347,6 +349,31 @@ describe('session-lock-regression', async () => {
       rmSync(base, { recursive: true, force: true });
     }
   }
+
+  // ─── 9b. Equivalent path spellings share re-entrant ownership ─────────
+  test('canonical lock target identifies re-entry', (t) => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-session-lock-'));
+    mkdirSync(join(base, '.gsd'), { recursive: true });
+    t.after(() => {
+      try { releaseSessionLock(base); } catch { /* best-effort */ }
+      rmSync(base, { recursive: true, force: true });
+    });
+
+    assert.ok(acquireSessionLock(base).acquired, 'first acquisition succeeds');
+    updateSessionLock(base, 'execute-task', 'M001/S01/T01');
+
+    const equivalentBase = `${base}${sep}.`;
+    const result = acquireSessionLock(equivalentBase);
+    assert.deepStrictEqual(
+      result,
+      { acquired: true, reentrant: true },
+      'realpath-equivalent base path is treated as re-entrant',
+    );
+    assert.deepStrictEqual(readSessionLockData(base)?.unitId, 'bootstrap', 'metadata is refreshed atomically');
+    assert.ok(isSessionLockHeld(equivalentBase), 'canonical alias reports held ownership');
+
+    releaseSessionLock(equivalentBase);
+  });
 
   // ─── 10. Re-entrant acquisition refreshes lock artifacts ──────────────
   console.log('\n=== 10. re-entrant acquire refreshes lock artifacts ===');
@@ -376,4 +403,186 @@ describe('session-lock-regression', async () => {
       rmSync(base, { recursive: true, force: true });
     }
   }
+
+
+  test('healthy re-entry excludes a concurrent process until explicit release', {
+    skip: !properLockfileAvailable,
+  }, async (t) => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-session-lock-concurrency-'));
+    mkdirSync(join(base, '.gsd'), { recursive: true });
+    const target = gsdRoot(base);
+    assert.ok(acquireSessionLock(base).acquired, 'process A acquires the lock');
+
+    const contenderScript = String.raw`
+      const lockfile = require('proper-lockfile');
+      const target = process.argv[1];
+      let release = null;
+      let running = true;
+      let reportedBlocked = false;
+      process.stdout.write('ready\n');
+      function attempt() {
+        if (!running || release) return;
+        try {
+          release = lockfile.lockSync(target, { realpath: false, stale: 1800000, update: 10000 });
+          process.stdout.write('acquired\n');
+        } catch {
+          if (!reportedBlocked) {
+            reportedBlocked = true;
+            process.stdout.write('blocked\n');
+          }
+          setImmediate(attempt);
+        }
+      }
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', (command) => {
+        if (command.includes('pause')) {
+          running = false;
+          process.stdout.write('paused\n');
+        }
+        if (command.includes('resume') && !release) {
+          running = true;
+          setImmediate(attempt);
+        }
+        if (command.includes('stop')) {
+          running = false;
+          try { if (release) release(); } catch {}
+          process.exit(0);
+        }
+      });
+      setImmediate(attempt);
+    `;
+    const child = spawn(process.execPath, ['-e', contenderScript, target], {
+      cwd: process.cwd(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let output = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => { output += chunk.toString(); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+    const waitForOutput = (value: string, timeoutMs = 3_000): Promise<void> => new Promise((resolve, reject) => {
+      const interval = setInterval(() => {
+        if (output.includes(value)) {
+          clearTimeout(timeout);
+          clearInterval(interval);
+          resolve();
+        }
+      }, 10);
+      const timeout = setTimeout(() => {
+        clearInterval(interval);
+        reject(new Error(
+          `Timed out waiting for contender output ${JSON.stringify(value)}; `
+          + `stdout=${JSON.stringify(output)} stderr=${JSON.stringify(stderr)}`,
+        ));
+      }, timeoutMs);
+      if (output.includes(value)) {
+        clearTimeout(timeout);
+        clearInterval(interval);
+        resolve();
+      }
+    });
+
+    t.after(async () => {
+      if (child.exitCode === null && child.signalCode === null) {
+        await new Promise<void>((resolve, reject) => {
+          const forceExit = setTimeout(() => { child.kill(); }, 500);
+          const giveUp = setTimeout(() => reject(new Error('contender process did not exit')), 1_500);
+          child.once('close', () => {
+            clearTimeout(forceExit);
+            clearTimeout(giveUp);
+            resolve();
+          });
+          try { child.stdin.end('stop'); } catch { child.kill(); }
+        });
+      }
+      try { releaseSessionLock(base); } catch { /* best-effort */ }
+      rmSync(base, { recursive: true, force: true });
+    });
+
+    await waitForOutput('ready\n');
+    await waitForOutput('blocked\n');
+
+    for (let attempt = 0; attempt < 100; attempt++) {
+      assert.deepStrictEqual(
+        acquireSessionLock(base),
+        { acquired: true, reentrant: true },
+        `process A keeps ownership during re-entry ${attempt + 1}`,
+      );
+    }
+    child.stdin.write('pause\n');
+    await waitForOutput('paused\n');
+    assert.doesNotMatch(output, /acquired/, 'process B cannot acquire during process A re-entry');
+
+    releaseSessionLock(base);
+    child.stdin.write('resume\n');
+    await waitForOutput('acquired\n');
+    assert.match(output, /acquired/, 'process B acquires only after process A explicitly releases');
+  });
+
+  test('getSessionLockStatus re-acquires only after onCompromised drops ownership', (t) => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-session-lock-recovery-'));
+    mkdirSync(join(base, '.gsd'), { recursive: true });
+    let held = false;
+    let lockCalls = 0;
+    let compromised: (() => void) | undefined;
+    let lockFile = '';
+    let removeMetadataOnBlockedAttempt = false;
+    const fakeLockfile = {
+      lockSync: (_path, options) => {
+        if (held) {
+          if (removeMetadataOnBlockedAttempt && lockFile) unlinkSync(lockFile);
+          throw new Error('already locked');
+        }
+        held = true;
+        lockCalls++;
+        compromised = options?.onCompromised;
+        return () => { held = false; };
+      },
+    } satisfies NonNullable<Parameters<typeof _setProperLockfileForTests>[0]>;
+    const realDateNow = Date.now;
+    let restoreLockfile = (): void => {};
+    t.after(() => {
+      Date.now = realDateNow;
+      try { releaseSessionLock(base); } catch { /* best-effort */ }
+      restoreLockfile();
+      rmSync(base, { recursive: true, force: true });
+    });
+
+    restoreLockfile = _setProperLockfileForTests(fakeLockfile);
+    assert.ok(acquireSessionLock(base).acquired, 'initial fake OS lock acquired');
+    lockFile = join(gsdRoot(base), 'auto.lock');
+    const lockDir = gsdRoot(base) + '.lock';
+    mkdirSync(lockDir, { recursive: true });
+    const metadata = readFileSync(lockFile, 'utf8');
+
+    Date.now = () => realDateNow() + 1_800_001;
+    unlinkSync(lockFile);
+    compromised?.();
+    writeFileSync(lockFile, metadata);
+    Date.now = realDateNow;
+
+    removeMetadataOnBlockedAttempt = true;
+    assert.deepStrictEqual(
+      getSessionLockStatus(base),
+      {
+        valid: false,
+        failureReason: 'compromised',
+        existingPid: process.pid,
+        expectedPid: process.pid,
+      },
+      'recovery does not replace a lock that is still held',
+    );
+    assert.deepStrictEqual(lockCalls, 1, 'held lock prevents replacement acquisition');
+    assert.ok(existsSync(lockDir), 'compromised recovery never removes the held lock directory');
+
+    writeFileSync(lockFile, metadata);
+    removeMetadataOnBlockedAttempt = false;
+    held = false;
+    assert.deepStrictEqual(
+      getSessionLockStatus(base),
+      { valid: true, recovered: true },
+      'status validation re-acquires after compromised ownership is gone',
+    );
+    assert.deepStrictEqual(lockCalls, 2, 'recovery performs one replacement acquisition');
+  });
 });

--- a/src/resources/extensions/gsd/tests/session-lock-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/session-lock-regression.test.ts
@@ -10,7 +10,17 @@
  * including cross-process exclusion during re-entrant acquisition.
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { join, sep } from 'node:path';
@@ -373,6 +383,47 @@ describe('session-lock-regression', async () => {
     assert.ok(isSessionLockHeld(equivalentBase), 'canonical alias reports held ownership');
 
     releaseSessionLock(equivalentBase);
+  });
+
+  test('re-entry hands ownership to a migrated external-state lock target', (t) => {
+    const root = mkdtempSync(join(tmpdir(), 'gsd-session-lock-migration-'));
+    const base = join(root, 'project');
+    const externalGsd = join(root, 'external-state');
+    mkdirSync(join(base, '.gsd'), { recursive: true });
+    t.after(() => {
+      try { releaseSessionLock(base); } catch { /* best-effort */ }
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    assert.ok(acquireSessionLock(base).acquired, 'initial in-project lock acquired');
+    const originalLockDir = join(base, '.gsd.lock');
+    assert.ok(existsSync(originalLockDir), 'original physical target is locked');
+
+    renameSync(join(base, '.gsd'), externalGsd);
+    symlinkSync(
+      externalGsd,
+      join(base, '.gsd'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+
+    assert.deepStrictEqual(
+      acquireSessionLock(base),
+      { acquired: true, reentrant: true },
+      'same owner transfers the lock after external-state migration',
+    );
+    assert.equal(
+      existsSync(originalLockDir),
+      false,
+      'old physical target is released after handoff',
+    );
+    assert.ok(existsSync(`${externalGsd}.lock`), 'new external-state target is locked');
+
+    unlinkSync(join(externalGsd, 'auto.lock'));
+    assert.deepStrictEqual(
+      getSessionLockStatus(base),
+      { valid: true },
+      'OS ownership remains authoritative after metadata cleanup',
+    );
   });
 
   // ─── 10. Re-entrant acquisition refreshes lock artifacts ──────────────


### PR DESCRIPTION
## Summary
- Fixed atomic re-entrant session locking with canonical ownership and regression coverage; static verification passed.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1896
- [#1896 Re-entrant session lock acquisition releases ownership and wedges auto-mode](https://github.com/open-gsd/gsd-pi/issues/1896)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1896-re-entrant-session-lock-acquisition-rele-1787234750`