### PR TITLE
fix(ci): land production npm releases through RELEASE_PAT

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -740,35 +740,46 @@ jobs:
           RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: git push origin "v${RELEASE_VERSION}"
 
-      - name: Push release commit to main
+      # GitHub Release before the merge-queue PR: a PR-create failure must not
+      # leave npm + tag published with no GitHub Release (v1.16.1).
+      - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
+        run: |
+          if gh release view "v${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "GitHub release v${RELEASE_VERSION} already exists."
+            exit 0
+          fi
+          gh release create "v${RELEASE_VERSION}" \
+            --title "v${RELEASE_VERSION}" \
+            --notes-file release-metadata/release-notes.md \
+            --latest
+
+      - name: Push release commit to main
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
         run: |
           if git push origin main; then
             echo "Release commit pushed to main."
             exit 0
           fi
-          # main enforces a merge queue plus required checks and the Actions
-          # token is not on the ruleset bypass list, so a direct push is
-          # rejected. The tag and npm are already consistent, so land the
-          # version bump through the queue instead of failing the release.
+          # main enforces a merge queue plus required checks and is not on the
+          # ruleset bypass list. GITHUB_TOKEN cannot create PRs unless the repo
+          # setting "Allow GitHub Actions to create and approve pull requests"
+          # is on (it is not). RELEASE_PAT can, same as the back-merge step.
           BRANCH="release/v${RELEASE_VERSION}"
           git push origin "HEAD:refs/heads/${BRANCH}"
-          gh pr create --base main --head "${BRANCH}" \
-            --title "release: v${RELEASE_VERSION}" \
-            --body "Version bump for v${RELEASE_VERSION}. Direct push to main was rejected by branch rules, so the release commit lands through the merge queue. npm, the \`v${RELEASE_VERSION}\` tag and the GitHub release are already published."
+          EXISTING=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number // empty')
+          if [ -n "${EXISTING}" ]; then
+            echo "PR #${EXISTING} for ${BRANCH} already exists."
+          else
+            gh pr create --base main --head "${BRANCH}" \
+              --title "release: v${RELEASE_VERSION}" \
+              --body "Version bump for v${RELEASE_VERSION}. Direct push to main was rejected by branch rules, so the release commit lands through the merge queue. npm, the \`v${RELEASE_VERSION}\` tag and the GitHub release are already published."
+          fi
           echo "::warning::Direct push to main was rejected; the v${RELEASE_VERSION} version bump is waiting in branch ${BRANCH} and must be merged."
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_VERSION: ${{ needs.prod-release-plan.outputs.version }}
-        run: |
-          gh release create "v${RELEASE_VERSION}" \
-            --title "v${RELEASE_VERSION}" \
-            --notes-file release-metadata/release-notes.md \
-            --latest
 
       - name: Post to Discord
         env:

--- a/docs/dev/ci-cd-pipeline.md
+++ b/docs/dev/ci-cd-pipeline.md
@@ -96,6 +96,7 @@ docker run --rm -v $(pwd):/workspace ghcr.io/open-gsd/gsd-pi:<version> --version
 - **Concurrent-publish guard** — every `npm publish` step treats "cannot publish over the previously published version" as an idempotent skip, but only after re-reading the dist-tag; if the tag does not point at the expected version the job fails loudly
 - **dist-tag mutation is not automated** — npm trusted publishing authenticates `npm publish`, not dist-tag moves. When a version already exists and the tag points elsewhere, the workflow stops and prints the manual escape hatch: `npm dist-tag add @opengsd/gsd-pi@<version> <channel>`
 - **Security hardening** — `${{ }}` expressions are passed through `env:` variables rather than interpolated directly into `run:` blocks, to prevent command injection vectors
+- **Merge-queue PR uses `RELEASE_PAT`** — `GITHUB_TOKEN` cannot create PRs on this repo. The GitHub Release is created after the tag and before that PR so a PR-create failure cannot leave npm published with no GitHub Release
 
 ### CI job tiers
 
@@ -203,7 +204,7 @@ For `@dev` or `@next`, roll back the same way (`npm dist-tag add`) or re-run **N
 | Environment: `next` | No protection rules (used by `channel=next`) |
 | Environment: `prod` | Required reviewers: maintainers — this is the approval gate for `@latest` |
 | Secret: `NPM_TOKEN` | Not required for trusted publishing; set for token-fallback bootstrap/manual native publishes (`publish_auth=token`) |
-| Secret: `RELEASE_PAT` | Prod release checkout — needed to push the release commit and tag |
+| Secret: `RELEASE_PAT` | Prod release checkout, tag push, and the merge-queue version-bump PR when branch rules reject a direct push to `main`. `GITHUB_TOKEN` cannot create PRs on this repo. |
 | Secret: `ANTHROPIC_API_KEY` | Prod environment only (non-blocking live LLM tests) |
 | Secret: `OPENAI_API_KEY` | Prod environment only (non-blocking live LLM tests) |
 | Secret: `DISCORD_CHANGELOG_WEBHOOK` | Optional — release announcement; the step tolerates a missing webhook |


### PR DESCRIPTION
## Summary

Production NPM Publish for v1.16.1 published to npm and pushed the tag, then failed creating the version-bump PR:

```
GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

Cause: the merge-queue fallback used `GITHUB_TOKEN`. This repo does not allow Actions to create PRs. The same job already uses `RELEASE_PAT` for checkout and the back-merge PR.

## Changes

- Use `RELEASE_PAT` for the merge-queue version-bump PR
- Create the GitHub Release after the tag and before that PR, so a PR-create failure cannot leave npm published with no GitHub Release
- Skip GitHub Release and PR create when they already exist

v1.16.1 itself is already published: npm `@latest`, tag, GitHub Release, and version-bump PR https://github.com/open-gsd/gsd-pi/pull/1903

## Related

- Failed run: https://github.com/open-gsd/gsd-pi/actions/runs/32430953544