### PR TITLE
fix(issue): Windows v1.16.1: initial worktree projection bootstrap DELETE-locks its own CWD; transient kind is dropped and ADR-047 wedges

### DIFF
--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -9,6 +9,7 @@
 // and lifecycle-interface types remain here.
 
 import type { GSDState } from "../types.js";
+import type { RecoveryFailureKind } from "../recovery-classification.js";
 
 export interface AutoSessionContext {
   basePath: string;
@@ -81,7 +82,12 @@ export type AutoAdvanceResult =
       stateSnapshot?: GSDState;
       terminalOutcome?: AutoTerminalOutcome;
     }
-  | { kind: "paused"; reason: string; backoffMs?: readonly number[] }
+  | {
+      kind: "paused";
+      reason: string;
+      failureKind: RecoveryFailureKind;
+      backoffMs?: readonly number[];
+    }
   | { kind: "error"; reason: string };
 
 export interface AutoOrchestrationModule {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -35,7 +35,6 @@ import {
 } from "./unit-phase.js";
 import { debugLog } from "../debug-logger.js";
 import { markBlockedStopReason } from "../stop-notice.js";
-import { isTransientProjectionLockError } from "../projection-root-errors.js";
 import {
   formatWedgeTripNotice,
   recordNonAdvancingOutcome,
@@ -1436,9 +1435,9 @@ export async function autoLoop(
             s.pendingOrchestrationDispatch = null;
             const pausedMsg = orchestrationResult.reason ?? "orchestration transient pause";
             const backoffMs = orchestrationResult.backoffMs;
-            const projectionLockTransient = isTransientProjectionLockError(pausedMsg)
-              && backoffMs !== undefined
-              && backoffMs.length > 0;
+            const projectionLockTransient =
+              orchestrationResult.failureKind === "projection-lock-transient";
+            const projectionLockBackoffMs = projectionLockTransient ? backoffMs ?? [] : [];
             let pauseAttempt: number;
             if (projectionLockTransient) {
               // Projection-root contention owns a longer class-specific schedule.
@@ -1448,9 +1447,9 @@ export async function autoLoop(
               // unchanged lock error is not evidence of a deterministic wedge.
               consecutiveProjectionLockPauses++;
               pauseAttempt = consecutiveProjectionLockPauses;
-              if (pauseAttempt > backoffMs.length) {
+              if (pauseAttempt > projectionLockBackoffMs.length) {
                 const stopMessage =
-                  `projection root remained busy after ${backoffMs.length} transient retries`;
+                  `projection root remained busy after ${projectionLockBackoffMs.length} transient retries`;
                 ctx.ui.notify(`Auto-mode stopped: ${stopMessage}.`, "error");
                 await deferStopAuto(ctx, pi, markBlockedStopReason(stopMessage));
                 finishTurn("stopped", "execution", pausedMsg, null);
@@ -1512,7 +1511,7 @@ export async function autoLoop(
               "skipped",
               "execution",
               pausedMsg,
-              isTransientProjectionLockError(pausedMsg) ? null : "orchestration-transient-pause",
+              projectionLockTransient ? null : "orchestration-transient-pause",
             );
             continue;
           }

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -19,6 +19,7 @@ import type { GSDState, Phase } from "../types.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
 
 type BlockedAdvanceResult = Extract<AutoAdvanceResult, { kind: "blocked" }>;
+export type AutoAdvanceFailureResult = Extract<AutoAdvanceResult, { kind: "paused" | "error" | "stopped" }>;
 
 import { debugCount, debugLog, debugTime } from "../debug-logger.js";
 import {
@@ -394,6 +395,24 @@ export async function decideOrchestratorDispatch(
     reason: action.matchedRule ?? "dispatch",
     preconditions: [],
   };
+}
+
+export function classifyAutoAdvanceFailure(input: {
+  error: unknown;
+  unitType?: string;
+  unitId?: string;
+}): AutoAdvanceFailureResult {
+  const recovery = classifyFailure(input);
+  if (recovery.action === "retry") {
+    return {
+      kind: "paused",
+      reason: recovery.reason,
+      failureKind: recovery.failureKind,
+      backoffMs: recovery.backoffMs,
+    };
+  }
+  if (recovery.action === "escalate") return { kind: "error", reason: recovery.reason };
+  return { kind: "stopped", reason: recovery.reason };
 }
 
 export class AutoOrchestrator implements AutoOrchestrationModule {
@@ -892,17 +911,6 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       return { ok: false, reason: `${result.kind}: ${result.reason}${repairDetail}` };
     }
     return { ok: true, reason: result.kind };
-  }
-
-  // ── RecoveryAdapter (folded) ─────────────────────────────────────────────
-
-  private classifyAndRecover(input: {
-    error: unknown;
-    unitType?: string;
-    unitId?: string;
-  }): { action: "retry" | "escalate" | "stop"; reason: string; backoffMs?: readonly number[] } {
-    const recovery = classifyFailure(input);
-    return { action: recovery.action, reason: recovery.reason, backoffMs: recovery.backoffMs };
   }
 
   /**
@@ -1461,21 +1469,16 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       this.postAdvanceRecord(advanced);
       return advanced;
     } catch (error) {
-      const recovery = this.classifyAndRecover({
+      let result: AutoAdvanceResult = classifyAutoAdvanceFailure({
         error,
         unitType: activeUnitFromWorker(this.s.workerId)?.unitType,
         unitId: activeUnitFromWorker(this.s.workerId)?.unitId,
       });
-      let result: AutoAdvanceResult;
-      if (recovery.action === "retry") {
-        result = { kind: "paused", reason: recovery.reason, backoffMs: recovery.backoffMs };
-      } else if (recovery.action === "escalate") {
+      if (result.kind === "error") {
         result = this.withLivenessInput(
-          { kind: "error", reason: recovery.reason },
+          result,
           { guardId: "advance-exception" },
         );
-      } else {
-        result = { kind: "stopped", reason: recovery.reason };
       }
 
       if (result.kind === "paused") {
@@ -1497,14 +1500,14 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         : result.kind === "stopped"
           ? "advance-stopped"
           : "advance-error";
-      this.journalTransition({ name: journalName, reason: recovery.reason });
+      this.journalTransition({ name: journalName, reason: result.reason });
 
       if (result.kind === "paused") {
-        this.notifyLifecycle({ name: "pause", detail: recovery.reason });
+        this.notifyLifecycle({ name: "pause", detail: result.reason });
       } else if (result.kind === "stopped") {
-        this.notifyLifecycle({ name: "stopped", detail: recovery.reason });
+        this.notifyLifecycle({ name: "stopped", detail: result.reason });
       } else if (result.kind === "error") {
-        this.notifyLifecycle({ name: "error", detail: recovery.reason });
+        this.notifyLifecycle({ name: "error", detail: result.reason });
       }
       this.postAdvanceRecord(result);
       return result;

--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -2254,7 +2254,25 @@ export function recordManagedProjectionFile(filePath: string): void {
   if (target !== null) recordManagedProjectionPath(target.targetRoot, filePath);
 }
 
-function createInitialProjectionDirectory(directoryPath: string): boolean {
+type InitialProjectionRootHandle = Pick<ProjectionRootIdentityLock, "createDirectory" | "close">;
+
+function openInitialProjectionRoot(projectionRoot: string): ProjectionRootIdentityLock {
+  const projectionStat = lstatSync(projectionRoot, { bigint: true });
+  if (!projectionStat.isDirectory() || projectionStat.isSymbolicLink()) {
+    throw new Error("managed projection root is not identity-stable");
+  }
+  return acquireProjectionRootIdentityLock(
+    realpathSync(projectionRoot),
+    projectionStat.dev.toString(),
+    projectionStat.ino.toString(),
+  );
+}
+
+function createInitialProjectionDirectory(
+  directoryPath: string,
+  nativeLockAvailable: () => boolean = isProjectionRootIdentityLockAvailable,
+  openProjectionRoot: (projectionRoot: string) => InitialProjectionRootHandle = openInitialProjectionRoot,
+): boolean {
   let projectionRoot = resolve(directoryPath);
   while (projectionRoot !== dirname(projectionRoot)
     && basename(projectionRoot).toLocaleLowerCase("en-US") !== ".gsd") {
@@ -2262,7 +2280,7 @@ function createInitialProjectionDirectory(directoryPath: string): boolean {
   }
   if (basename(projectionRoot).toLocaleLowerCase("en-US") !== ".gsd") return false;
   const targetRoot = dirname(projectionRoot);
-  if (!isProjectionRootIdentityLockAvailable()) {
+  if (!nativeLockAvailable()) {
     // Validate the project root before mkdir-ing under it, mirroring the
     // native lock's identity-stable, non-symlink root guard. A missing root
     // is not an error here: the recursive mkdir creates it (fresh worktrees
@@ -2292,17 +2310,28 @@ function createInitialProjectionDirectory(directoryPath: string): boolean {
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
     throw new Error("managed projection project root is not identity-stable");
   }
-  const handle = acquireProjectionRootIdentityLock(
-    realpathSync(targetRoot),
-    rootStat.dev.toString(),
-    rootStat.ino.toString(),
-  );
+  // Bootstrap the projection root before acquiring the native identity lock.
+  // Locking targetRoot here makes a Windows worktree CWD contend with GSD's
+  // own current-directory handle. Once .gsd exists, pinning it gives the same
+  // fail-closed descendant creation without locking the parent worktree.
+  mkdirSync(projectionRoot, { recursive: true });
+  const handle = openManagedProjectionRootWithRetry(() => openProjectionRoot(projectionRoot));
   try {
-    handle.createDirectory(relative(targetRoot, resolve(directoryPath)).replaceAll("\\", "/"));
+    const logicalPath = relative(projectionRoot, resolve(directoryPath)).replaceAll("\\", "/");
+    if (logicalPath.length > 0) handle.createDirectory(logicalPath);
   } finally {
     handle.close();
   }
   return true;
+}
+
+export function _createInitialProjectionDirectoryForTest(
+  directoryPath: string,
+  openProjectionRoot: (
+    projectionRoot: string,
+  ) => Pick<ProjectionRootIdentityLock, "createDirectory" | "close">,
+): boolean {
+  return createInitialProjectionDirectory(directoryPath, () => true, openProjectionRoot);
 }
 
 export function createManagedProjectionDirectorySync(directoryPath: string): boolean {

--- a/src/resources/extensions/gsd/tests/atomic-write.test.ts
+++ b/src/resources/extensions/gsd/tests/atomic-write.test.ts
@@ -338,6 +338,47 @@ test("projection directory fallback rejects a symlinked .gsd projection root", (
   assert.equal(existsSync(join(outside, "phases")), false);
 });
 
+test("initial projection bootstrap locks .gsd when the worktree root is the process CWD", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-dir-cwd-bootstrap-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const moduleUrl = new URL("../managed-projection-history.ts", import.meta.url).href;
+  const loaderPath = new URL("./resolve-ts.mjs", import.meta.url).pathname;
+  const script = `
+    const { _createInitialProjectionDirectoryForTest } = await import(${JSON.stringify(moduleUrl)});
+    const { mkdirSync } = await import("node:fs");
+    const { join, relative } = await import("node:path");
+    const expectedProjectionRoot = join(process.cwd(), ".gsd");
+    let acquiredRoot = null;
+    _createInitialProjectionDirectoryForTest(
+      join(expectedProjectionRoot, "phases", "22-m022"),
+      (projectionRoot) => {
+        acquiredRoot = projectionRoot;
+        return {
+          createDirectory: (logicalPath) => mkdirSync(join(projectionRoot, logicalPath), { recursive: true }),
+          close: () => {},
+        };
+      },
+    );
+    if (relative(expectedProjectionRoot, acquiredRoot) !== "") {
+      throw new Error(\`expected projection lock on \${expectedProjectionRoot}, got \${acquiredRoot}\`);
+    }
+  `;
+
+  const result = spawnSync(process.execPath, [
+    "--import", loaderPath,
+    "--experimental-strip-types",
+    "--input-type=module",
+    "--eval", script,
+  ], {
+    cwd: base,
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(existsSync(join(base, ".gsd", "phases", "22-m022")), true);
+});
+
 test("copyProjectionFileSync fallback rejects a source-parent swap during the proof", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-copy-parent-swap-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -288,7 +288,7 @@ function createLoopTestOrchestration(
         return { kind: "skipped", code: "no-dispatch" as const, reason: "pre-dispatch-skip" };
       }
       if (preDispatchResult.action === "retry") {
-        return { kind: "paused", reason: preDispatchResult.reason };
+        return { kind: "paused", reason: preDispatchResult.reason, failureKind: "runtime-unknown" as const };
       }
 
       const dispatch = await captureAutoSideEffects(() =>
@@ -306,7 +306,7 @@ function createLoopTestOrchestration(
         };
       }
       if (dispatch.result.action === "retry") {
-        return { kind: "paused", reason: dispatch.result.reason };
+        return { kind: "paused", reason: dispatch.result.reason, failureKind: "runtime-unknown" as const };
       }
 
       const data = dispatch.result.data;
@@ -3513,7 +3513,7 @@ test("autoLoop retries next iteration when orchestration reports paused", async 
       advance: async () => {
         advanceCalls++;
         return advanceCalls === 1
-          ? { kind: "paused" as const, reason: "provider transient; retry" }
+          ? { kind: "paused" as const, reason: "provider transient; retry", failureKind: "provider" as const }
           : { kind: "stopped" as const, reason: "done retrying" };
       },
       settle: async () => {},
@@ -5278,7 +5278,11 @@ test("ADR-047 #1655: identical transient pauses trip at the loop outcome boundar
     const session = makeLoopSession({ currentMilestoneId: "M001" });
     session.orchestration = {
       start: async () => ({ kind: "stopped" as const, reason: "unused" }),
-      advance: async () => ({ kind: "paused" as const, reason: "transient: database is locked" }),
+      advance: async () => ({
+        kind: "paused" as const,
+        reason: "transient: database is locked",
+        failureKind: "runtime-unknown" as const,
+      }),
       settle: async () => {},
       completeActiveUnit: async () => {},
       retryActiveUnit: async () => {},
@@ -5336,7 +5340,8 @@ test("#1852: projection-lock transient pauses exhaust their backoff and never we
       advanceCalls++;
       return {
         kind: "paused" as const,
-        reason: "projection root operation failed: file in use (os error 32)",
+        reason: "Projection root busy: native projection root identity locking failed",
+        failureKind: "projection-lock-transient" as const,
         backoffMs: [1, 1, 1],
       };
     },

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1158,7 +1158,7 @@ test("advance() routes a lost-lock error through recovery and journals an outcom
 
 test("projection lock classification survives the paused result boundary", () => {
   const nativeError = new Error("native projection root identity locking failed", {
-    cause: new Error("The process cannot access the file (os error 32)"),
+    cause: new Error("projection root operation failed: The process cannot access the file (os error 32)"),
   });
 
   const result = classifyAutoAdvanceFailure({ error: nativeError });

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  classifyAutoAdvanceFailure,
   createAutoOrchestrator,
   decideOrchestratorDispatch,
   resolveLiveOrchestratorBasePath,
@@ -1137,7 +1138,7 @@ test("advance() routes a lost-lock error through recovery and journals an outcom
   t.after(() => f.cleanup());
 
   // Release the lock so ensureLockOwnership() sees missing-metadata and throws,
-  // exercising the catch → classifyAndRecover → result-mapping branch.
+  // exercising the catch → classifyAutoAdvanceFailure → result-mapping branch.
   releaseSessionLock(f.base);
   // Remove the lockfile artifact so getSessionLockStatus returns !valid.
   try { rmSync(join(f.base, ".gsd", "auto.lock"), { force: true }); } catch { /* */ }
@@ -1153,6 +1154,20 @@ test("advance() routes a lost-lock error through recovery and journals an outcom
     names.includes("advance-paused") || names.includes("advance-stopped") || names.includes("advance-error"),
     "recovery must journal an advance-paused/stopped/error event",
   );
+});
+
+test("projection lock classification survives the paused result boundary", () => {
+  const nativeError = new Error("native projection root identity locking failed", {
+    cause: new Error("The process cannot access the file (os error 32)"),
+  });
+
+  const result = classifyAutoAdvanceFailure({ error: nativeError });
+
+  assert.equal(result.kind, "paused");
+  if (result.kind !== "paused") throw new Error("expected paused projection-lock recovery");
+  assert.equal(result.failureKind, "projection-lock-transient");
+  assert.ok(result.backoffMs && result.backoffMs.length > 0);
+  assert.equal(result.reason, "Projection root busy: native projection root identity locking failed");
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixed Windows projection bootstrap locking and preserved typed transient failures, with focused regression verification.

## Bugs Addressed
- [x] **Initial projection bootstrap locks the worktree CWD on Windows**
- [x] **Paused auto results discard typed projection-lock failures**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1905
- [#1905 Windows v1.16.1: initial worktree projection bootstrap DELETE-locks its own CWD; transient kind is dropped and ADR-047 wedges](https://github.com/open-gsd/gsd-pi/issues/1905)

## User
- @mik888em

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1905-windows-v1-16-1-initial-worktree-project-1787297162`