### PR TITLE
fix(issue): Depth verification ignores answers[id].answers result shape

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -818,23 +818,42 @@ function isContextDraftSummarySave(toolName: string, input: unknown): boolean {
 }
 
 /**
- * External engines (claude-code-cli) deliver ask_user_questions results as
- * relayed MCP tool results: the structured round payload arrives in
- * `result.structuredContent`, not in pi-native `event.details`. Without this
- * fallback, applyAskUserQuestionsGateResult sees no response for an answered
- * gate question and lands in the "waiting" branch — leaving a re-armed gate
- * permanently pending and the discuss→auto handoff blocked.
+ * Normalize supported ask_user_questions result shapes before gate handling.
+ * Some providers return top-level `answers` whose entries use `answers`, while
+ * native results use `response.answers` entries with `selected`. External
+ * engines may also relay either shape through `result.structuredContent`.
  */
-function resolveAskUserQuestionsGateDetails(event: { details?: unknown; result?: unknown }): any {
-  const hasRoundShape = (value: any): boolean =>
-    !!value && typeof value === "object" &&
-    (value.cancelled !== undefined || value.timed_out !== undefined || value.response !== undefined);
+function normalizeAskUserQuestionsAnswer(answer: any): any {
+  if (!answer || typeof answer !== "object" || answer.selected !== undefined) return answer;
+  return answer.answers !== undefined ? { ...answer, selected: answer.answers } : answer;
+}
 
-  const details = event.details as any;
-  if (hasRoundShape(details)) return details;
+function normalizeAskUserQuestionsRound(value: unknown): any | null {
+  if (!value || typeof value !== "object") return null;
+  const round = value as any;
+  const response = round.response ??
+    (round.answers !== undefined ? { answers: round.answers } : undefined);
+  if (!response && round.cancelled === undefined && round.timed_out === undefined) return null;
+  if (!response) return round;
+
+  return {
+    ...round,
+    response: {
+      ...response,
+      answers: Object.fromEntries(
+        Object.entries(response.answers ?? {}).map(
+          ([id, answer]) => [id, normalizeAskUserQuestionsAnswer(answer)],
+        ),
+      ),
+    },
+  };
+}
+
+function resolveAskUserQuestionsGateDetails(event: { details?: unknown; result?: unknown }): any {
+  const details = normalizeAskUserQuestionsRound(event.details);
+  if (details) return details;
   const structured = (event.result as { structuredContent?: unknown } | undefined)?.structuredContent;
-  if (hasRoundShape(structured)) return structured;
-  return details ?? {};
+  return normalizeAskUserQuestionsRound(structured) ?? {};
 }
 
 type StructuredQuestion = {

--- a/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
@@ -1186,6 +1186,66 @@ test("tool_result verifies the gate from result.structuredContent when event.det
   assert.ok(loadWriteGateSnapshot(dir).verifiedDepthMilestones.includes("M002"));
 });
 
+test("tool_result normalizes provider answers shape before verifying a depth gate (#1894)", async (t) => {
+  const dir = makeTempDir("provider-answers");
+  resetWriteGateState(dir);
+  t.after(() => {
+    resetWriteGateState(dir);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const { handlers, pi } = makeHookHarness();
+  registerHooks(pi, []);
+  const ctx = { cwd: dir, ui: { notify: () => undefined } } as any;
+  const questionId = "depth_verification_M001-sdflkr";
+  const questions = [{
+    id: questionId,
+    options: [
+      { label: "Confirm M001 (Recommended)" },
+      { label: "Not quite — let me clarify" },
+    ],
+  }];
+
+  setPendingGate(questionId, dir);
+
+  for (const handler of handlers.get("tool_result") ?? []) {
+    await handler({
+      toolCallId: "t-depth",
+      toolName: "ask_user_questions",
+      input: { questions },
+      details: {
+        answers: {
+          [questionId]: { answers: ["Confirm M001 (Recommended)"] },
+        },
+      },
+    }, ctx);
+  }
+
+  assert.equal(getPendingGate(dir), null, "provider-shaped confirmation must clear the pending gate");
+  assert.ok(
+    loadWriteGateSnapshot(dir).verifiedDepthMilestones.includes("M001-sdflkr"),
+    "provider-shaped confirmation must persist milestone depth verification",
+  );
+  assert.equal(
+    shouldBlockContextArtifactSave("CONTEXT", "M001-sdflkr", null, dir).block,
+    false,
+    "provider-shaped confirmation must unlock the matching milestone context",
+  );
+
+  let contextBlock: { block?: boolean } | undefined;
+  for (const handler of handlers.get("tool_call") ?? []) {
+    contextBlock = await handler({
+      toolName: "gsd_summary_save",
+      input: {
+        milestone_id: "M001-sdflkr",
+        artifact_type: "CONTEXT",
+        content: "# M001 Context\n",
+      },
+    }, ctx);
+  }
+  assert.notEqual(contextBlock?.block, true, "the subsequent milestone CONTEXT save must be permitted");
+});
+
 test("tool_result without details or structured content leaves the gate pending without crashing", async (t) => {
   const dir = makeTempDir("no-details");
   resetWriteGateState(dir);


### PR DESCRIPTION
## Summary
- Normalized provider-shaped depth answers and added regression coverage; available checks passed.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1894
- [#1894 Depth verification ignores answers[id].answers result shape](https://github.com/open-gsd/gsd-pi/issues/1894)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1894-depth-verification-ignores-answers-id-an-1787318842`