### PR TITLE
fix(issue): [Bug]: Windows verification stuck-loop — forward-slash pnpm.cmd path breaks cmd.exe + 30s exec default timeout kills next build

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -691,7 +691,7 @@ verification_commands:
   - npm run test
 verification_auto_fix: true       # auto-retry on failure (default: true)
 verification_max_retries: 2       # max retry attempts (default: 2)
-verification_timeout_ms: 120000   # per-command spawn timeout (default: 120000)
+verification_timeout_ms: 120000   # host verification and verification-oriented gsd_exec default (default: 120000)
 ```
 
 | Field | Type | Default | Description |
@@ -699,9 +699,11 @@ verification_timeout_ms: 120000   # per-command spawn timeout (default: 120000)
 | `verification_commands` | string[] | `[]` | Simple executable commands to run after task execution |
 | `verification_auto_fix` | boolean | `true` | Auto-retry when verification fails |
 | `verification_max_retries` | number | `2` | Maximum auto-fix retry attempts |
-| `verification_timeout_ms` | number | `120000` | Per-command host-verification timeout in milliseconds. Unset keeps the 120s default. A timeout is reported as `failureClass: timeout`, never as exit 127. |
+| `verification_timeout_ms` | number | `120000` | Per-command host-verification timeout in milliseconds and the default timeout for verification-oriented `gsd_exec` workloads. Unset keeps the 120s host-verification default. A timeout is reported as `failureClass: timeout`, never as exit 127. |
 
 Verification commands must be simple executable commands. Shell piping (`|`) is supported, but logical OR (`||`) is rejected. GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program.
+
+For `gsd_exec`, verification-oriented workloads include builds, tests, linting, type checks, and verification commands. An explicit `context_mode.exec_timeout_ms` takes precedence over `verification_timeout_ms`; unrelated `gsd_exec` workloads keep the sandbox's 30-second default when `context_mode.exec_timeout_ms` is unset.
 
 For task-level `verify` commands (`taskPlanVerify`), GSD splits checks on newlines. `&&` chains stay within a single shell invocation, so commands such as `cd path && npm test` preserve directory context.
 

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -177,8 +177,10 @@ verification_commands:
   - npm run test
 verification_auto_fix: true       # auto-retry on failure (default)
 verification_max_retries: 2       # max attempts (default: 2)
-verification_timeout_ms: 120000   # per-command spawn timeout (default: 120000)
+verification_timeout_ms: 120000   # host verification and verification-oriented gsd_exec default (default: 120000)
 ```
+
+`verification_timeout_ms` also supplies the default timeout for verification-oriented `gsd_exec` workloads such as builds, tests, linting, type checks, and verification commands. An explicit `context_mode.exec_timeout_ms` takes precedence; unrelated `gsd_exec` workloads keep the sandbox's 30-second default when `context_mode.exec_timeout_ms` is unset.
 
 Verification commands must be simple executable commands. Shell piping (`|`) is supported, but logical OR (`||`) is rejected. GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program.
 

--- a/src/resources/extensions/gsd/package-manager.ts
+++ b/src/resources/extensions/gsd/package-manager.ts
@@ -9,6 +9,39 @@ import { join } from "node:path";
 export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
 
 /**
+ * Make a relative package-manager executable path safe for cmd.exe.
+ *
+ * cmd.exe does not reliably treat `app/pnpm.cmd` as a path in command
+ * position. Keep Unix commands untouched, but on Windows emit the native,
+ * explicitly-relative form (`.\\app\\pnpm.cmd`).
+ */
+export function normalizeWindowsPackageManagerCommand(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32") return command;
+
+  const match = command.match(/^(\s*)(?:(["'])(.*?)\2|(\S+))(.*)$/s);
+  if (!match) return command;
+
+  const executable = match[3] ?? match[4] ?? "";
+  if (!executable.includes("/") || !/(?:^|[\\/])(?:npm|pnpm|yarn|bun)(?:\.cmd|\.bat|\.exe)?$/i.test(executable)) {
+    return command;
+  }
+
+  let nativeExecutable = executable.replaceAll("/", "\\");
+  const isExplicitPath =
+    nativeExecutable.startsWith(".\\") ||
+    nativeExecutable.startsWith("..\\") ||
+    nativeExecutable.startsWith("\\") ||
+    /^[A-Za-z]:\\/.test(nativeExecutable);
+  if (!isExplicitPath) nativeExecutable = `.\\${nativeExecutable}`;
+
+  const quote = match[2] ?? "";
+  return `${match[1]}${quote}${nativeExecutable}${quote}${match[5]}`;
+}
+
+/**
  * Detect the package manager used by a project.
  *
  * Detection order (first match wins):

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -553,7 +553,7 @@ export interface GSDPreferences {
   verification_commands?: string[];
   verification_auto_fix?: boolean;
   verification_max_retries?: number;
-  /** Per-command host-verification spawn timeout in ms. Unset uses 120000. */
+  /** Per-command host-verification and verification-oriented gsd_exec timeout in ms. Unset host verification uses 120000. */
   verification_timeout_ms?: number;
   per_unit_cost_cap_usd?: number;
   /** Multiplier over the rolling per-unit cost average that triggers a cost-spike pause. Default: 3.0. The `burn-max` token profile ignores this and never pauses on spikes. */

--- a/src/resources/extensions/gsd/tests/exec-tool.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-tool.test.ts
@@ -74,6 +74,70 @@ test("executeGsdExec passes AbortSignal into sandbox options", async () => {
   assert.equal(capturedSignal, controller.signal);
 });
 
+test("executeGsdExec uses verification_timeout_ms as its configured default", async () => {
+  let capturedDefaultTimeout: number | undefined;
+
+  const result = await executeGsdExec(
+    { runtime: "bash", script: "pnpm verify:pr" },
+    {
+      baseDir: "/tmp/gsd-exec-verification-timeout-test",
+      preferences: {
+        context_mode: { enabled: true },
+        verification_timeout_ms: 180_000,
+      },
+      run: async (request, opts: ExecSandboxOptions) => {
+        capturedDefaultTimeout = opts.default_timeout_ms;
+        return makeExecResult(request);
+      },
+    },
+  );
+
+  assert.equal(result.isError, false);
+  assert.equal(capturedDefaultTimeout, 180_000);
+});
+
+test("executeGsdExec keeps the explicit context-mode timeout ahead of verification timeout", async () => {
+  let capturedDefaultTimeout: number | undefined;
+
+  await executeGsdExec(
+    { runtime: "bash", script: "pnpm test" },
+    {
+      baseDir: "/tmp/gsd-exec-explicit-timeout-test",
+      preferences: {
+        context_mode: { enabled: true, exec_timeout_ms: 45_000 },
+        verification_timeout_ms: 180_000,
+      },
+      run: async (request, opts: ExecSandboxOptions) => {
+        capturedDefaultTimeout = opts.default_timeout_ms;
+        return makeExecResult(request);
+      },
+    },
+  );
+
+  assert.equal(capturedDefaultTimeout, 45_000);
+});
+
+test("executeGsdExec keeps the sandbox default for unrelated workloads", async () => {
+  let capturedDefaultTimeout: number | undefined;
+
+  await executeGsdExec(
+    { runtime: "bash", script: "rg -n TODO src" },
+    {
+      baseDir: "/tmp/gsd-exec-unrelated-timeout-test",
+      preferences: {
+        context_mode: { enabled: true },
+        verification_timeout_ms: 180_000,
+      },
+      run: async (request, opts: ExecSandboxOptions) => {
+        capturedDefaultTimeout = opts.default_timeout_ms;
+        return makeExecResult(request);
+      },
+    },
+  );
+
+  assert.equal(capturedDefaultTimeout, 30_000);
+});
+
 test("gsd_exec surfaces aborted child termination distinctly from a clean exit", async () => {
   const result = await executeGsdExec(
     { runtime: "bash", script: "trap 'exit 0' TERM; sleep 60" },

--- a/src/resources/extensions/gsd/tests/package-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/package-manager.test.ts
@@ -7,7 +7,11 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { detectPackageManager, buildScriptCommand } from "../package-manager.js";
+import {
+  detectPackageManager,
+  buildScriptCommand,
+  normalizeWindowsPackageManagerCommand,
+} from "../package-manager.js";
 
 describe("package-manager: detectPackageManager", () => {
   let tmp: string;
@@ -125,5 +129,29 @@ describe("package-manager: buildScriptCommand", () => {
 
   test("bun build → bun run build (explicit run)", () => {
     assert.equal(buildScriptCommand("bun", "build"), "bun run build");
+  });
+});
+
+describe("package-manager: normalizeWindowsPackageManagerCommand", () => {
+  test("makes a forward-slash relative pnpm.cmd path native and explicitly relative", () => {
+    assert.equal(
+      normalizeWindowsPackageManagerCommand("app/pnpm.cmd --dir app test", "win32"),
+      ".\\app\\pnpm.cmd --dir app test",
+    );
+  });
+
+  test("preserves non-Windows commands", () => {
+    assert.equal(
+      normalizeWindowsPackageManagerCommand("app/pnpm.cmd --dir app test", "linux"),
+      "app/pnpm.cmd --dir app test",
+    );
+  });
+
+  test("preserves bare and already-native Windows package-manager commands", () => {
+    assert.equal(normalizeWindowsPackageManagerCommand("pnpm test", "win32"), "pnpm test");
+    assert.equal(
+      normalizeWindowsPackageManagerCommand(".\\app\\pnpm.cmd --dir app test", "win32"),
+      ".\\app\\pnpm.cmd --dir app test",
+    );
   });
 });

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -8,7 +8,11 @@ import {
   type ExecSandboxRequest,
   type ExecSandboxResult,
 } from "../exec-sandbox.js";
-import { isContextModeEnabled, type ContextModeConfig } from "../preferences-types.js";
+import {
+  isContextModeEnabled,
+  type ContextModeConfig,
+  type GSDPreferences,
+} from "../preferences-types.js";
 import { bashReferencesProjectRootOutsideWorktree } from "../worktree-shell-guard.js";
 import { contextModeDisabledResult, type ToolExecutionResult } from "./context-mode-tool-result.js";
 
@@ -25,7 +29,7 @@ export interface ExecToolParams {
 
 export interface ExecToolDeps {
   baseDir: string;
-  preferences: { context_mode?: ContextModeConfig } | null;
+  preferences: Pick<GSDPreferences, "context_mode" | "verification_timeout_ms"> | null;
   /** Optional override for testing. */
   run?: (req: ExecSandboxRequest, opts: ExecSandboxOptions) => Promise<ExecSandboxResult>;
   env?: NodeJS.ProcessEnv;
@@ -76,6 +80,7 @@ export function buildExecOptions(
   baseDir: string,
   cfg: ContextModeConfig | undefined,
   extras?: Pick<ExecSandboxOptions, "env" | "now" | "generateId" | "signal">,
+  verificationTimeoutMs?: number,
 ): ExecSandboxOptions {
   const allowlist = Array.isArray(cfg?.exec_env_allowlist) ? cfg!.exec_env_allowlist! : EXEC_DEFAULTS.envAllowlist;
   const stdoutCap = clampNumber(
@@ -85,7 +90,7 @@ export function buildExecOptions(
     16_777_216,
   );
   const defaultTimeout = clampNumber(
-    cfg?.exec_timeout_ms,
+    cfg?.exec_timeout_ms ?? verificationTimeoutMs,
     EXEC_DEFAULTS.defaultTimeoutMs,
     1_000,
     EXEC_DEFAULTS.clampTimeoutMs,
@@ -151,6 +156,25 @@ function normalizeScript(params: ExecToolParams): string | ToolExecutionResult {
   return paramError("script is required and must be a non-empty string");
 }
 
+function isVerificationWorkload(params: ExecToolParams, script: string): boolean {
+  if (typeof params.purpose === "string" && /\b(?:build|test|verify|verification|lint|typecheck)\b/i.test(params.purpose)) {
+    return true;
+  }
+
+  return script.split(/&&|\|\||[;|\n]/).some((statement) => {
+    const invocation = statement.trim().match(/^(?:["']([^"']+)["']|(\S+))(?:\s+([\s\S]*))?$/);
+    if (!invocation) return false;
+    const executable = (invocation[1] ?? invocation[2] ?? "").split(/[\\/]/).pop()?.toLowerCase() ?? "";
+    const args = invocation[3] ?? "";
+
+    if (/^(?:npm|pnpm|yarn|bun)(?:\.(?:cmd|bat|exe))?$/.test(executable)) {
+      return /\b(?:build|test|lint|typecheck|check|verify|verification)\b/i.test(args);
+    }
+    if (executable === "node" || executable === "node.exe") return /(?:^|\s)--test(?:\s|$)/.test(args);
+    return /^(?:next|eslint|tsc|vitest|jest|pytest)(?:\.(?:cmd|bat|exe))?$/.test(executable);
+  });
+}
+
 function normalizeRequiredString(value: unknown, field: string): string | ToolExecutionResult {
   if (typeof value !== "string" || value.trim().length === 0) {
     return paramError(`${field} is required and must be a non-empty string`);
@@ -211,6 +235,7 @@ export async function executeGsdExec(
     deps.baseDir,
     deps.preferences?.context_mode,
     { env: deps.env, now: deps.now, generateId: deps.generateId, signal: deps.signal },
+    isVerificationWorkload(params, script) ? deps.preferences?.verification_timeout_ms : undefined,
   );
   const run = deps.run ?? runExecSandbox;
 

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -27,7 +27,11 @@ import {
   isWorkflowToolSurfaceName,
   stripMcpToolPrefix,
 } from "./workflow-tool-surface.js";
-import { detectPackageManager, buildScriptCommand } from "./package-manager.js";
+import {
+  detectPackageManager,
+  buildScriptCommand,
+  normalizeWindowsPackageManagerCommand,
+} from "./package-manager.js";
 
 /** Maximum bytes of stdout/stderr to retain per command (10 KB). */
 const MAX_OUTPUT_BYTES = 10 * 1024;
@@ -843,7 +847,9 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
 
   for (const command of commands) {
     const start = Date.now();
-    const rewrittenCommand = normalizePythonCommand(rewriteCommandWithRtk(command), options.cwd);
+    const rewrittenCommand = normalizeWindowsPackageManagerCommand(
+      normalizePythonCommand(rewriteCommandWithRtk(command), options.cwd),
+    );
     // Pass the command string as an argument to the shell explicitly
     // to avoid Node.js DEP0190 (spawnSync with shell: true and no args).
     const shellBin = process.platform === "win32" ? "cmd" : "sh";


### PR DESCRIPTION
## Summary
- Fixed Windows verification command paths and routed configured verification timeouts to build and verification exec workloads.

## Bugs Addressed
- [x] **Windows cmd.exe cannot execute forward-slash package-manager path**
- [x] **Default 30-second exec timeout kills valid verification builds**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1910
- [#1910 [Bug]: Windows verification stuck-loop — forward-slash pnpm.cmd path breaks cmd.exe + 30s exec default timeout kills next build](https://github.com/open-gsd/gsd-pi/issues/1910)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1910-bug-windows-verification-stuck-loop-forw-1787318665`