### PR TITLE
fix(issue): gsd quick lacks the right-sizing flags gsd-core has (--research/--validate/--discuss/--full)

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -8,7 +8,7 @@
 | `/gsd next` | Explicit step mode (same as `/gsd`) |
 | `/gsd auto` | Autonomous mode — research, plan, execute, commit, repeat |
 | `/gsd auto --resume-wedge <id>` | Acknowledge the named liveness wedge and re-enter auto mode after applying its sanctioned recovery |
-| `/gsd quick` | Execute a quick task with GSD guarantees (atomic commits, state tracking) without full planning overhead |
+| `/gsd quick [--discuss] [--research] [--validate] [--full] <task>` | Execute a quick task with GSD guarantees; optionally add discussion, research, plan checking, and post-execution verification (`--full` enables all three stages) |
 | `/gsd do <text>` | Route freeform text to the right GSD command |
 | `/gsd stop` | Stop auto mode gracefully |
 | `/gsd pause` | Pause auto-mode (preserves state, `/gsd auto` to resume) |
@@ -53,6 +53,8 @@
 | `/gsd help` | Categorized command reference with descriptions for all GSD subcommands |
 
 `/gsd discuss` supports optional direct targets: `/gsd discuss M014`, `/gsd discuss M014/S03`, `/gsd discuss --milestone M014`, and `/gsd discuss --slice M014/S03`.
+
+Quick-task right-sizing flags are composable. Use `--discuss` to surface design choices before planning, `--research` to investigate approaches first, and `--validate` to add plan checking and independent post-execution verification. Passing all three is equivalent to `--full`; passing none preserves the lightweight quick-task flow.
 
 ## Visual Briefs
 

--- a/mintlify-docs/guides/commands.mdx
+++ b/mintlify-docs/guides/commands.mdx
@@ -10,7 +10,7 @@ description: "Every GSD command, keyboard shortcut, and CLI flag."
 | `/gsd` | Step mode — execute one unit at a time, pause between each |
 | `/gsd next` | Explicit step mode (same as `/gsd`) |
 | `/gsd auto` | Autonomous mode — research, plan, execute, commit, repeat |
-| `/gsd quick` | Execute a quick task with GSD guarantees without full planning overhead |
+| `/gsd quick [--discuss] [--research] [--validate] [--full] <task>` | Execute a quick task with GSD guarantees; optionally add discussion, research, plan checking, and post-execution verification (`--full` enables all three stages) |
 | `/gsd stop` | Stop auto mode gracefully |
 | `/gsd pause` | Pause auto mode (preserves state, `/gsd auto` to resume) |
 | `/gsd steer` | Hard-steer plan documents during execution |
@@ -42,6 +42,8 @@ description: "Every GSD command, keyboard shortcut, and CLI flag."
 | `/gsd logs` | Browse activity logs, debug logs, and metrics |
 | `/gsd remote` | Control remote auto-mode |
 | `/gsd help` | Categorized command reference |
+
+Quick-task right-sizing flags are composable. Use `--discuss` to surface design choices before planning, `--research` to investigate approaches first, and `--validate` to add plan checking and independent post-execution verification. Passing all three is equivalent to `--full`; passing none preserves the lightweight quick-task flow.
 
 ## Configuration and diagnostics
 

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -121,6 +121,12 @@ const NESTED_COMPLETIONS: CompletionMap = {
     { cmd: "--dry-run", desc: "Preview next step without executing" },
     { cmd: "--debug", desc: "Enable debug logging" },
   ],
+  quick: [
+    { cmd: "--discuss", desc: "Surface design choices before planning" },
+    { cmd: "--research", desc: "Investigate approaches before planning" },
+    { cmd: "--validate", desc: "Check the plan and verify the result" },
+    { cmd: "--full", desc: "Enable discussion, research, and validation" },
+  ],
   widget: [
     { cmd: "full", desc: "Full widget display" },
     { cmd: "small", desc: "Compact widget display" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -84,7 +84,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd discuss        Start guided milestone/slice discussion",
     "  /gsd new-milestone  Create milestone from headless context (used by gsd headless)",
     "  /gsd new-project    Bootstrap a new project (use --deep for staged project-level discovery)",
-    "  /gsd quick          Execute a quick task without full planning overhead",
+    "  /gsd quick          Quick task  [--discuss] [--research] [--validate] [--full]",
     "  /gsd dispatch       Dispatch a specific phase directly  [research|plan|execute|complete|validate|reassess|uat|replan]",
     "  /gsd verdict <v>    Override unadopted compatibility validation  [pass|needs-attention|needs-remediation] [--milestone Mxxx] [--rationale \"...\"]",
     "  /gsd parallel       Parallel milestone orchestration  [start|status|stop|pause|resume|merge|watch]",

--- a/src/resources/extensions/gsd/prompts/quick-task.md
+++ b/src/resources/extensions/gsd/prompts/quick-task.md
@@ -5,6 +5,8 @@ You are executing a GSD quick task — a lightweight, focused unit of work outsi
 **Task directory:** `{{taskDir}}`
 **Branch:** `{{branch}}`
 
+{{qualityInstructions}}
+
 ## Instructions
 
 1. Read the task description above carefully. This is a focused, self-contained task.

--- a/src/resources/extensions/gsd/quick.ts
+++ b/src/resources/extensions/gsd/quick.ts
@@ -30,6 +30,82 @@ interface QuickReturnState {
   description: string;
 }
 
+export interface QuickOptions {
+  description: string;
+  discuss: boolean;
+  research: boolean;
+  validate: boolean;
+  full: boolean;
+}
+
+const QUICK_FLAG_RE = /(^|\s)--(discuss|research|validate|full)(?=\s|$)/g;
+
+/** Parse composable right-sizing flags without including them in the task description. */
+export function parseQuickArgs(raw: string): QuickOptions {
+  const explicitFull = /(^|\s)--full(?=\s|$)/.test(raw);
+  const discuss = explicitFull || /(^|\s)--discuss(?=\s|$)/.test(raw);
+  const research = explicitFull || /(^|\s)--research(?=\s|$)/.test(raw);
+  const validate = explicitFull || /(^|\s)--validate(?=\s|$)/.test(raw);
+  const description = raw.replace(QUICK_FLAG_RE, " ").replace(/\s+/g, " ").trim();
+
+  return {
+    description,
+    discuss,
+    research,
+    validate,
+    full: explicitFull || (discuss && research && validate),
+  };
+}
+
+/** Build the optional pipeline instructions injected into the quick-task prompt. */
+export function buildQuickQualityInstructions(
+  options: QuickOptions,
+  taskDir: string,
+  taskNum: number,
+): string {
+  if (!options.discuss && !options.research && !options.validate) return "";
+
+  const planPath = `${taskDir}/${taskNum}-PLAN.md`;
+  const lines = [
+    "## Right-sized quality pipeline",
+    "",
+    "Complete the enabled pre-execution stages before editing, then complete any post-execution stage before writing the summary.",
+  ];
+
+  if (options.discuss) {
+    lines.push(
+      "",
+      "### Discussion",
+      "Before planning, identify material ambiguities or design choices. Ask focused questions and wait for the user's answers when a choice could change the outcome; otherwise state the assumptions you will use.",
+    );
+  }
+
+  if (options.research) {
+    lines.push(
+      "",
+      "### Research",
+      `Before planning, use a scout subagent to investigate relevant code, implementation approaches, and pitfalls. Summarize the findings and chosen approach in \`${taskDir}/${taskNum}-RESEARCH.md\`.`,
+    );
+  }
+
+  lines.push(
+    "",
+    "### Plan",
+    `Write a concise implementation plan with verification steps to \`${planPath}\` before editing.`,
+  );
+
+  if (options.validate) {
+    lines.push(
+      "Use a reviewer subagent to check that plan for correctness, completeness, scope, and test coverage. Address its findings before execution.",
+      "",
+      "### Post-execution verification",
+      "After implementation, use a tester or reviewer subagent to verify the finished work independently. Fix any findings and rerun the relevant checks before writing the quick-task summary.",
+    );
+  }
+
+  return lines.join("\n");
+}
+
 let pendingQuickReturn: QuickReturnState | null = null;
 const pendingQuickReturnMisses = new Map<string, string>();
 
@@ -342,11 +418,12 @@ export async function handleQuick(
     return;
   }
 
-  // Parse description from args
-  let description = args.trim();
+  // Parse description and optional right-sizing flags from args
+  const quickOptions = parseQuickArgs(args);
+  const { description } = quickOptions;
   if (!description) {
     ctx.ui.notify(
-      "Usage: /gsd quick <task description>\n\nExample: /gsd quick fix login button not responding on mobile",
+      "Usage: /gsd quick [--discuss] [--research] [--validate] [--full] <task description>\n\nExample: /gsd quick --validate fix login button not responding on mobile",
       "info",
     );
     return;
@@ -421,6 +498,7 @@ export async function handleQuick(
   const summaryPath = `${taskDirRel}/${taskNum}-SUMMARY.md`;
   const prompt = loadPrompt("quick-task", {
     description,
+    qualityInstructions: buildQuickQualityInstructions(quickOptions, taskDirRel, taskNum),
     taskDir: taskDirRel,
     branch: actualBranch,
     summaryPath,

--- a/src/resources/extensions/gsd/tests/catalog.test.ts
+++ b/src/resources/extensions/gsd/tests/catalog.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { getGsdArgumentCompletions } from "../commands/catalog.ts";
+
+test("quick command completion surfaces every right-sizing flag", () => {
+  const labels = getGsdArgumentCompletions("quick ").map((completion) => completion.label);
+
+  assert.deepEqual(labels, ["--discuss", "--research", "--validate", "--full"]);
+});

--- a/src/resources/extensions/gsd/tests/quick.test.ts
+++ b/src/resources/extensions/gsd/tests/quick.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { buildQuickQualityInstructions, parseQuickArgs } from "../quick.ts";
+
+describe("quick task right-sizing flags", () => {
+  test("preserves the lightweight default", () => {
+    const options = parseQuickArgs("fix the typo");
+
+    assert.deepEqual(options, {
+      description: "fix the typo",
+      discuss: false,
+      research: false,
+      validate: false,
+      full: false,
+    });
+    assert.equal(buildQuickQualityInstructions(options, ".gsd/quick/1-fix-the-typo", 1), "");
+  });
+
+  test("strips and composes granular flags", () => {
+    const options = parseQuickArgs("--validate fix auth --discuss --research");
+
+    assert.equal(options.description, "fix auth");
+    assert.equal(options.discuss, true);
+    assert.equal(options.research, true);
+    assert.equal(options.validate, true);
+    assert.equal(options.full, true);
+  });
+
+  test("--full enables every optional stage", () => {
+    const options = parseQuickArgs("critical auth fix --full");
+    const instructions = buildQuickQualityInstructions(options, ".gsd/quick/2-critical-auth-fix", 2);
+
+    assert.equal(options.description, "critical auth fix");
+    assert.equal(options.discuss, true);
+    assert.equal(options.research, true);
+    assert.equal(options.validate, true);
+    assert.equal(options.full, true);
+    assert.match(instructions, /### Discussion/);
+    assert.match(instructions, /### Research/);
+    assert.match(instructions, /reviewer subagent to check that plan/);
+    assert.match(instructions, /### Post-execution verification/);
+  });
+
+  test("only emits instructions for enabled optional stages", () => {
+    const options = parseQuickArgs("--research compare cache clients");
+    const instructions = buildQuickQualityInstructions(options, ".gsd/quick/3-cache", 3);
+
+    assert.match(instructions, /### Research/);
+    assert.match(instructions, /### Plan/);
+    assert.doesNotMatch(instructions, /### Discussion/);
+    assert.doesNotMatch(instructions, /Post-execution verification/);
+  });
+});

--- a/web/components/gsd/remaining-command-panels.tsx
+++ b/web/components/gsd/remaining-command-panels.tsx
@@ -164,7 +164,7 @@ export function QuickPanel() {
         <div className="space-y-2">
           <h4 className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Usage</h4>
           <div className="rounded-md border border-border/50 bg-background/50 px-3 py-2 font-mono text-[11px] text-foreground/80">
-            /gsd quick &lt;description&gt;
+            /gsd quick [--discuss] [--research] [--validate] [--full] &lt;description&gt;
           </div>
         </div>
 
@@ -187,7 +187,8 @@ export function QuickPanel() {
 
         <div className="rounded-md border border-info/15 bg-info/5 px-3 py-2 text-[11px] text-info/90">
           Quick tasks run as standalone units — they don&apos;t affect milestone progress, slices, or the plan. Use them
-          for work that should happen now without ceremony.
+          for work that should happen now without ceremony. Add <code>--discuss</code>, <code>--research</code>, or
+          <code>--validate</code> when a task needs more rigor; <code>--full</code> enables all three.
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Added composable quick-task rigor flags with documented behavior and passing focused tests and fast gates.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1553
- [#1553 gsd quick lacks the right-sizing flags gsd-core has (--research/--validate/--discuss/--full)](https://github.com/open-gsd/gsd-pi/issues/1553)

## User
- @proofoftom

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1553-gsd-quick-lacks-the-right-sizing-flags-g-1787319323`