### PR TITLE
fix(issue): quick has no non-interactive entry point, and 'gsd quick <task>' silently launches the console instead of erroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ Then use slash commands inside the GSD session:
 /gsd status
 ```
 
+For automation, quick tasks also have a non-interactive entry point with a
+structured result and meaningful exit code:
+
+```bash
+gsd quick --output-format json "Describe the task"
+```
+
 ## What GSD Pi Does
 
 - Plans work into milestones, slices, and tasks.

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -422,6 +422,7 @@ The following commands are sent directly in your **Telegram chat** to a configur
 | `gsd remove <source>` | Remove a previously installed extension |
 | `gsd list` | List installed extensions |
 | `gsd graph <subcommand>` | Build, query, status, or diff the project knowledge graph built from `.gsd/` artifacts |
+| `gsd quick <task>` | Execute a quick task without a TUI (alias for `gsd headless quick <task>`) |
 | `gsd headless --json` | Structured JSONL event stream to stdout for scripting, CI, and troubleshooting (alias: `--output-format stream-json`) |
 | `gsd headless new-milestone` | Create a new milestone from a context file (headless — no TUI required) |
 
@@ -435,6 +436,9 @@ gsd headless
 
 # Run a single unit
 gsd headless next
+
+# Execute a quick task and return task, branch, artifact, commit, and exit details
+gsd quick --output-format json "fix the login button on mobile"
 
 # Instant JSON snapshot — no LLM, ~50ms
 gsd headless query

--- a/gsd-orchestrator/references/commands.md
+++ b/gsd-orchestrator/references/commands.md
@@ -47,6 +47,20 @@ Step mode — execute exactly one unit (task/slice/milestone step), then exit. R
 gsd headless --output-format json next
 ```
 
+### `quick <task>`
+
+Execute a lightweight task with GSD branch, artifact, and commit guarantees. The
+short form `gsd quick` is an alias for the headless command.
+
+```bash
+gsd quick --output-format json "fix the login button on mobile"
+gsd headless --output-format json quick "update the setup instructions"
+```
+
+The JSON result includes `task`, `branch`, `artifacts`, and `commits`. Quick
+tasks are not automatically retried because replaying a repository mutation
+could duplicate work.
+
 ### `new-milestone`
 
 Create a milestone from a specification document.

--- a/gsd-orchestrator/references/json-result.md
+++ b/gsd-orchestrator/references/json-result.md
@@ -17,6 +17,9 @@ echo "$RESULT" | jq '.nextAction'
 
 **Important:** Progress text goes to stderr. The JSON result goes to stdout. Redirect stderr to `/dev/null` when parsing stdout.
 
+With `--json` or `--output-format stream-json`, the final JSONL record has
+`type: "headless_result"` and carries the same fields after the streamed events.
+
 ## Field Reference
 
 ### Top-Level Fields
@@ -33,6 +36,8 @@ echo "$RESULT" | jq '.nextAction'
 | `milestone` | `string \| undefined` | Active milestone ID (e.g. `"M001"`). |
 | `phase` | `string \| undefined` | Current GSD phase at session end (e.g. `"executing"`, `"blocked"`, `"complete"`). |
 | `nextAction` | `string \| undefined` | Recommended next action from the state machine (e.g. `"dispatch"`, `"complete"`). |
+| `task` | `{ number, slug, description } \| undefined` | Quick-task identity for `quick` runs. |
+| `branch` | `string \| undefined` | Branch used to execute a quick task. |
 | `artifacts` | `string[] \| undefined` | Paths to artifacts created or modified during the session. |
 | `commits` | `string[] \| undefined` | Git commit SHAs created during the session. |
 
@@ -117,6 +122,13 @@ echo "$RESULT" | jq -r '.artifacts[]?'
 
 # List commits made
 echo "$RESULT" | jq -r '.commits[]?'
+```
+
+### Quick Task Result
+
+```bash
+RESULT=$(gsd quick --output-format json "fix typo" 2>/dev/null)
+echo "$RESULT" | jq '{task, branch, artifacts, commits, exitCode}'
 ```
 
 ## Example Result

--- a/mintlify-docs/guides/commands.mdx
+++ b/mintlify-docs/guides/commands.mdx
@@ -161,6 +161,7 @@ In terminals without Kitty keyboard protocol support (macOS Terminal.app, JetBra
 | `gsd sessions` | Interactive session picker |
 | `gsd config` | Set up global API keys |
 | `gsd update` | Update GSD to the latest version |
+| `gsd quick <task>` | Execute a quick task without a TUI |
 
 ## Headless mode
 
@@ -169,6 +170,7 @@ In terminals without Kitty keyboard protocol support (macOS Terminal.app, JetBra
 ```bash
 gsd headless              # run auto mode
 gsd headless next         # run a single unit
+gsd quick --output-format json "fix typo"  # structured quick-task result
 gsd headless query        # instant JSON snapshot (~50ms, no LLM)
 gsd headless recover      # print the sealed recovery Preview for approval
 gsd headless --timeout 600000 auto   # with timeout

--- a/src/cli-web-branch.ts
+++ b/src/cli-web-branch.ts
@@ -54,6 +54,7 @@ const PASSTHROUGH_SUBCOMMANDS = new Set([
   'list',
   'read',
   'remove',
+  'quick',
   'sessions',
   'update',
   'upgrade',
@@ -157,7 +158,7 @@ export function parseCliArgs(argv: string[]): CliFlags {
   return flags
 }
 
-export function buildHeadlessAutoArgs(flags: Pick<CliFlags, 'messages' | 'model' | 'thinking'>): string[] {
+export function buildHeadlessCommandArgs(flags: Pick<CliFlags, 'messages' | 'model' | 'thinking'>): string[] {
   const args: string[] = []
   if (flags.model) args.push('--model', flags.model)
   if (flags.thinking) args.push('--thinking', flags.thinking)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ import { validateConfiguredModel } from './startup-model-validation.js'
 import { migrateAnthropicDefaultToClaudeCode, migrateGeminiCliDefaultToAntigravity } from './provider-migrations.js'
 import { applyModelOverride } from './cli-model-override.js'
 import {
-  buildHeadlessAutoArgs,
+  buildHeadlessCommandArgs,
   parseCliArgs,
   runWebCliBranch,
   migrateLegacyFlatSessions,
@@ -382,6 +382,7 @@ const subcommandsExemptFromEarlyTtyCheck = new Set([
   'headless',
   'hermes',
   'read',
+  'quick',
   'install',
   'list',
   'remove',
@@ -536,12 +537,20 @@ if (cliFlags.messages[0] === 'headless') {
   process.exit(process.exitCode ?? 1)
 }
 
+// `gsd quick <task>` — first-class non-interactive shorthand for
+// `gsd headless quick <task>`. Always route through headless, even when a TTY
+// is attached, so task arguments can never fall through to the empty composer.
+if (cliFlags.messages[0] === 'quick') {
+  initResources(agentDir)
+  await runHeadlessCommand(buildHeadlessCommandArgs(cliFlags))
+}
+
 /**
  * Run a headless command by invoking the headless entrypoint with a synthetic
- * argv. Shared by the `auto` shorthand (#2732) and the auto-piped-stdout
- * redirect so they use the same bootstrap + dynamic-import dance.
+ * argv. Shared by CLI shorthands so they use the same bootstrap and dynamic
+ * import path as `gsd headless`.
  */
-async function runHeadlessFromAuto(headlessArgs: string[]): Promise<never> {
+async function runHeadlessCommand(headlessArgs: string[]): Promise<never> {
   await ensureRtkBootstrap()
   const { runHeadless, parseHeadlessArgs } = await import('./headless.js')
   const argv = [process.argv[0], process.argv[1], 'headless', ...headlessArgs]
@@ -581,7 +590,7 @@ async function probeDeferredProvidersForListModels(modelRegistry: ModelRegistryI
 // `gsd headless auto [args...]` (#2732). Keep terminal TTY launches in the
 // interactive path so Warp/iTerm/Terminal retain foreground ownership.
 if (shouldRedirectAutoToHeadless(cliFlags.messages[0], process.stdin.isTTY, process.stdout.isTTY)) {
-  await runHeadlessFromAuto(buildHeadlessAutoArgs(cliFlags))
+  await runHeadlessCommand(buildHeadlessCommandArgs(cliFlags))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/headless-quick-result.ts
+++ b/src/headless-quick-result.ts
@@ -1,0 +1,142 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { basename, resolve } from 'node:path'
+
+import type { HeadlessJsonResult } from './headless-types.js'
+
+export interface QuickTaskMetadata {
+  task: NonNullable<HeadlessJsonResult['task']>
+  branch: string
+  artifact: string
+}
+
+export interface QuickTaskGitState {
+  head?: string
+  worktreeStatus?: string
+}
+
+export interface QuickTaskResultDetails {
+  task: NonNullable<HeadlessJsonResult['task']>
+  branch: string
+  artifacts: string[]
+  commits: string[]
+}
+
+export interface CollectedQuickTaskResult {
+  ok: boolean
+  details: QuickTaskResultDetails
+  error?: string
+}
+
+function runGit(cwd: string, args: string[]): string | undefined {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return undefined
+  }
+}
+
+export function captureQuickTaskGitState(cwd: string): QuickTaskGitState {
+  return {
+    head: runGit(cwd, ['rev-parse', 'HEAD']) || undefined,
+    worktreeStatus: runGit(cwd, ['status', '--porcelain=v1', '--untracked-files=all']),
+  }
+}
+
+export function parseQuickTaskNotification(message: string): QuickTaskMetadata | undefined {
+  const match = message.match(/^Quick task (\d+): ([\s\S]+)\nDirectory: ([^\n]+)\nBranch: ([^\n]+)$/)
+  if (!match) return undefined
+
+  const number = Number.parseInt(match[1], 10)
+  const taskDir = match[3]
+  const dirName = basename(taskDir)
+  const prefix = `${number}-`
+  if (!Number.isSafeInteger(number) || !dirName.startsWith(prefix)) return undefined
+
+  return {
+    task: {
+      number,
+      description: match[2],
+      slug: dirName.slice(prefix.length),
+    },
+    branch: match[4],
+    artifact: `${taskDir}/${number}-SUMMARY.md`,
+  }
+}
+
+export function collectQuickTaskResult(
+  cwd: string,
+  before: QuickTaskGitState,
+  metadata: QuickTaskMetadata,
+): CollectedQuickTaskResult {
+  const head = runGit(cwd, ['rev-parse', 'HEAD'])
+  let commits: string[] = []
+  if (before.head && head && before.head !== head) {
+    const revisionList = runGit(cwd, ['rev-list', '--reverse', `${before.head}..${head}`])
+    commits = revisionList ? revisionList.split(/\r?\n/).filter(Boolean) : []
+  }
+
+  const isIsolatedQuick = metadata.branch.startsWith('gsd/quick/')
+  const expectedCommitSubject = `quick(Q${metadata.task.number}): ${metadata.task.slug}`
+  const headSubject = isIsolatedQuick && head
+    ? runGit(cwd, ['show', '-s', '--format=%s', head])
+    : undefined
+
+  // Branch-isolated quick tasks squash to one deterministic closeout commit.
+  // Report that resulting commit rather than any pre-branch dirty-state commit
+  // that may also have been created after the initial snapshot.
+  if (isIsolatedQuick && head && headSubject === expectedCommitSubject) {
+    commits = [head]
+  }
+
+  const details: QuickTaskResultDetails = {
+    task: metadata.task,
+    branch: metadata.branch,
+    artifacts: [metadata.artifact],
+    commits,
+  }
+
+  if (!existsSync(resolve(cwd, metadata.artifact))) {
+    return {
+      ok: false,
+      details,
+      error: `Quick task ${metadata.task.number} did not produce its summary artifact: ${metadata.artifact}`,
+    }
+  }
+
+  const currentBranch = runGit(cwd, ['branch', '--show-current'])
+  if (isIsolatedQuick && currentBranch === metadata.branch) {
+    return {
+      ok: false,
+      details,
+      error: `Quick task ${metadata.task.number} did not return from branch ${metadata.branch}`,
+    }
+  }
+
+  if (isIsolatedQuick) {
+    if (headSubject !== expectedCommitSubject) {
+      return {
+        ok: false,
+        details,
+        error: `Quick task ${metadata.task.number} did not produce its merged quick-task commit`,
+      }
+    }
+  }
+
+  if (!isIsolatedQuick) {
+    const worktreeStatus = runGit(cwd, ['status', '--porcelain=v1', '--untracked-files=all'])
+    if (worktreeStatus !== before.worktreeStatus) {
+      return {
+        ok: false,
+        details,
+        error: `Quick task ${metadata.task.number} left repository changes uncommitted`,
+      }
+    }
+  }
+
+  return { ok: true, details }
+}

--- a/src/headless-types.ts
+++ b/src/headless-types.ts
@@ -34,6 +34,12 @@ export interface HeadlessJsonResult {
   milestone?: string
   phase?: string
   nextAction?: string
+  task?: {
+    number: number
+    slug: string
+    description: string
+  }
+  branch?: string
   artifacts?: string[]
   commits?: string[]
 }

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -44,6 +44,12 @@ import {
 
 import type { OutputFormat, HeadlessJsonResult } from './headless-types.js'
 import { VALID_OUTPUT_FORMATS } from './headless-types.js'
+import {
+  captureQuickTaskGitState,
+  collectQuickTaskResult,
+  parseQuickTaskNotification,
+} from './headless-quick-result.js'
+import type { QuickTaskMetadata, QuickTaskResultDetails } from './headless-quick-result.js'
 
 import {
   handleExtensionUIRequest,
@@ -279,6 +285,29 @@ export function parseHeadlessArgs(argv: string[]): HeadlessOptions {
 // ---------------------------------------------------------------------------
 
 export async function runHeadless(options: HeadlessOptions): Promise<void> {
+  if (options.command === 'quick' && options.commandArgs.join(' ').trim().length === 0) {
+    process.stderr.write('[headless] Error: quick requires a task description.\n')
+    process.stderr.write('[headless] Usage: gsd headless quick "<task description>"\n')
+    if (options.outputFormat === 'json') {
+      const result: HeadlessJsonResult = {
+        status: 'error',
+        exitCode: EXIT_ERROR,
+        duration: 0,
+        cost: {
+          total: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+        },
+        toolCalls: 0,
+        events: 0,
+      }
+      process.stdout.write(JSON.stringify(result) + '\n')
+    }
+    process.exit(EXIT_ERROR)
+  }
+
   const maxRestarts = options.maxRestarts ?? 3
   let restartCount = 0
 
@@ -287,6 +316,12 @@ export async function runHeadless(options: HeadlessOptions): Promise<void> {
 
     // Success or blocked — exit normally
     if (result.exitCode === EXIT_SUCCESS || result.exitCode === EXIT_BLOCKED) {
+      process.exit(result.exitCode)
+    }
+
+    // A quick task mutates the repository and must never be replayed after a
+    // failed result: retrying could create a second task/branch/commit.
+    if (options.command === 'quick') {
       process.exit(result.exitCode)
     }
 
@@ -317,6 +352,8 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   let interrupted = false
   const startTime = Date.now()
   const isNewMilestone = options.command === 'new-milestone'
+  const isQuickTask = options.command === 'quick'
+  const quickTaskGitState = isQuickTask ? captureQuickTaskGitState(process.cwd()) : undefined
 
   // new-milestone involves codebase investigation + artifact writing — needs more time
   if (isNewMilestone && options.timeout === 300_000) {
@@ -493,6 +530,8 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   let cumulativeCacheReadTokens = 0
   let cumulativeCacheWriteTokens = 0
   let lastSessionId: string | undefined
+  let quickTaskMetadata: QuickTaskMetadata | undefined
+  let quickTaskDetails: QuickTaskResultDetails | undefined
 
   // Verbose text-mode state
   const toolStartTimes = new Map<string, number>()
@@ -502,13 +541,11 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   let inTextBlock = false
   let inThinkingBlock = false
 
-  // Emit HeadlessJsonResult to stdout for --output-format json batch mode
-  function emitBatchJsonResult(): void {
-    if (options.outputFormat !== 'json') return
+  function buildStructuredResult(): HeadlessJsonResult {
     const duration = Date.now() - startTime
     const finalStatus = classifyHeadlessFinalStatus({ blocked, exitCode, totalEvents, recentEvents })
     const status: HeadlessJsonResult['status'] = finalStatus === 'complete' ? 'success' : finalStatus
-    const result: HeadlessJsonResult = {
+    return {
       status,
       exitCode,
       sessionId: lastSessionId,
@@ -522,8 +559,22 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
       },
       toolCalls: toolCallCount,
       events: totalEvents,
+      task: quickTaskDetails?.task ?? quickTaskMetadata?.task,
+      branch: quickTaskDetails?.branch ?? quickTaskMetadata?.branch,
+      artifacts: quickTaskDetails?.artifacts ?? (quickTaskMetadata ? [quickTaskMetadata.artifact] : undefined),
+      commits: quickTaskDetails?.commits,
     }
-    process.stdout.write(JSON.stringify(result) + '\n')
+  }
+
+  // Batch JSON emits one object; stream-json emits the same terminal result as
+  // a typed JSONL event after the raw RPC event stream.
+  function emitStructuredResult(): void {
+    const result = buildStructuredResult()
+    if (options.outputFormat === 'json') {
+      process.stdout.write(JSON.stringify(result) + '\n')
+    } else if (options.outputFormat === 'stream-json') {
+      process.stdout.write(JSON.stringify({ type: 'headless_result', ...result }) + '\n')
+    }
   }
 
   function trackEvent(event: Record<string, unknown>): void {
@@ -616,6 +667,9 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     trackEvent(eventObj)
 
     const eventType = String(eventObj.type ?? '')
+    if (isQuickTask && !quickTaskMetadata && eventType === 'extension_ui_request' && eventObj.method === 'notify') {
+      quickTaskMetadata = parseQuickTaskNotification(String(eventObj.message ?? ''))
+    }
     if (eventType === 'tool_execution_start') {
       const toolCallId = String(eventObj.toolCallId ?? eventObj.id ?? '')
       if (toolCallId && isInteractiveHeadlessTool(String(eventObj.toolName ?? ''))) {
@@ -870,7 +924,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     }
 
     // Quick commands: resolve on first agent_end
-    if (eventObj.type === 'agent_end' && isQuickCommand(options.command, options.commandArgs) && !completed) {
+    if (eventObj.type === 'agent_end' && (isQuickTask || isQuickCommand(options.command, options.commandArgs)) && !completed) {
       completed = true
       resolveCompletion()
       return
@@ -900,10 +954,8 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     })
     if (timeoutTimer) clearTimeout(timeoutTimer)
     if (idleTimer) clearTimeout(idleTimer)
-    // Emit batch JSON result if in json mode before exiting
-    if (options.outputFormat === 'json') {
-      emitBatchJsonResult()
-    }
+    // Preserve a terminal machine-readable result for both JSON output modes.
+    emitStructuredResult()
     process.exit(exitCode)
   }
   // Use prependListener so our handler runs before pi-coding-agent's
@@ -1084,6 +1136,20 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   await client.stop()
 
+  if (isQuickTask) {
+    if (!quickTaskMetadata || !quickTaskGitState) {
+      if (exitCode !== EXIT_BLOCKED) exitCode = EXIT_ERROR
+      process.stderr.write('[headless] Error: Quick task did not start; no task metadata was reported.\n')
+    } else {
+      const quickResult = collectQuickTaskResult(process.cwd(), quickTaskGitState, quickTaskMetadata)
+      quickTaskDetails = quickResult.details
+      if (!quickResult.ok) {
+        if (exitCode !== EXIT_BLOCKED) exitCode = EXIT_ERROR
+        process.stderr.write(`[headless] Error: ${quickResult.error}\n`)
+      }
+    }
+  }
+
   // Summary
   const duration = ((Date.now() - startTime) / 1000).toFixed(1)
   const status = classifyHeadlessFinalStatus({ blocked, exitCode, totalEvents, recentEvents })
@@ -1119,7 +1185,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   }
 
   // Emit structured JSON result in batch mode
-  emitBatchJsonResult()
+  emitStructuredResult()
 
   return { exitCode, interrupted, totalEvents, toolCallCount, recentEvents: [...recentEvents], status }
 }

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -171,6 +171,20 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     '  gsd read memory --json --project ~/code/myapp --query auth',
   ].join('\n'),
 
+  quick: [
+    'Usage: gsd quick [headless flags] <task description>',
+    '',
+    'Execute a quick task without the TUI. This is an alias for:',
+    '  gsd headless quick <task description>',
+    '',
+    'Use --output-format json for a structured result containing the task',
+    'number, slug, branch, summary artifact, resulting commit SHAs, and exit code.',
+    '',
+    'Examples:',
+    '  gsd quick "fix the login button on mobile"',
+    '  gsd quick --output-format json "update the setup instructions"',
+  ].join('\n'),
+
   headless: [
     'Usage: gsd headless [flags] [command] [args...]',
     '',
@@ -192,6 +206,7 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     'Commands:',
     '  auto                 Run all queued units continuously (default)',
     '  next                 Run one unit',
+    '  quick <task>         Execute a quick task with atomic commits and a summary artifact',
     '  status               Show progress dashboard',
     '  new-milestone        Create a milestone from a specification document',
     '  query                JSON snapshot: state + next dispatch + costs (no LLM)',
@@ -205,11 +220,12 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     'Output formats:',
     '  text         Human-readable progress on stderr (default)',
     '  json         Collect events silently, emit structured HeadlessJsonResult on stdout at exit',
-    '  stream-json  Stream JSONL events to stdout in real time (same as --json)',
+    '  stream-json  Stream JSONL events, ending with a headless_result event (same as --json)',
     '',
     'Examples:',
     '  gsd headless                                    Run /gsd auto',
     '  gsd headless next                               Run one unit',
+    '  gsd headless --output-format json quick "fix typo"  Run a quick task with a structured result',
     '  gsd headless --output-format json auto           Structured JSON result on stdout',
     '  gsd headless --json status                      Machine-readable JSONL stream',
     '  gsd headless --timeout 60000                    With 1-minute timeout',
@@ -264,6 +280,7 @@ export function printHelp(version: string): void {
   process.stdout.write('  sessions                 List and resume a past session\n')
   process.stdout.write('  worktree <cmd>           Manage worktrees (list, merge, clean, remove)\n')
   process.stdout.write('  auto [args]              Run auto-mode without TUI (pipeable)\n')
+  process.stdout.write('  quick <task>             Execute a quick task without TUI\n')
   process.stdout.write('  headless [cmd] [args]    Run /gsd commands without TUI (default: auto)\n')
   process.stdout.write('  graph <subcommand>       Manage knowledge graph (build, query, status, diff)\n')
   process.stdout.write('  hermes install           Install the Hermes Agent plugin\n')

--- a/src/tests/auto-mode-piped.test.ts
+++ b/src/tests/auto-mode-piped.test.ts
@@ -23,11 +23,11 @@ test('routes `gsd auto` with piped stdin to headless mode', () => {
   assert.equal(shouldRedirectAutoToHeadless('auto', false, true), true)
 })
 
-test('src/cli.ts routes `gsd auto` with piped stdout through the headless entrypoint', () => {
+test('src/cli.ts routes `gsd auto` and `gsd quick` through the headless entrypoint', (t) => {
   const tempDir = mkdtempSync(join(tmpdir(), 'gsd-auto-cli-route-'))
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }))
   const loaderPath = join(tempDir, 'stub-loader.mjs')
-  try {
-    writeFileSync(loaderPath, `
+  writeFileSync(loaderPath, `
 import { existsSync } from 'node:fs'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -80,6 +80,16 @@ const modules = new Map([
     passthrough.red = passthrough
     export default passthrough
   \`],
+  ['stub:resource-loader', \`
+    export const bareResourceLoaderOptions = () => ({})
+    export const buildResourceLoader = async () => ({})
+    export const getNewerManagedResourceVersion = () => undefined
+    export const initResources = () => {}
+  \`],
+  ['stub:onboarding', \`
+    export const runOnboarding = async () => {}
+    export const shouldRunOnboarding = async () => false
+  \`],
   ['stub:headless', \`
     export function parseHeadlessArgs(argv) {
       process.stderr.write('AUTO_REDIRECT_ARGV ' + JSON.stringify(argv) + '\\\\n')
@@ -97,6 +107,12 @@ export async function resolve(specifier, context, nextResolve) {
   if (specifier.startsWith('@gsd/pi-ai')) return { url: 'stub:pi-ai', shortCircuit: true }
   if (specifier.startsWith('@gsd/pi-tui')) return { url: 'stub:pi-tui', shortCircuit: true }
   if (specifier === 'chalk') return { url: 'stub:chalk', shortCircuit: true }
+  if (specifier === './resource-loader.js' && context.parentURL?.endsWith('/src/cli.ts')) {
+    return { url: 'stub:resource-loader', shortCircuit: true }
+  }
+  if (specifier === './onboarding.js' && context.parentURL?.endsWith('/src/cli.ts')) {
+    return { url: 'stub:onboarding', shortCircuit: true }
+  }
   if (specifier === './headless.js' && context.parentURL?.endsWith('/src/cli.ts')) {
     return { url: 'stub:headless', shortCircuit: true }
   }
@@ -118,45 +134,78 @@ export async function load(url, context, nextLoad) {
 }
 `)
 
-    const registerLoader = `
+  const registerLoader = `
       import { register } from 'node:module'
       import { pathToFileURL } from 'node:url'
       Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true })
       Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: false })
       register(${JSON.stringify(pathToFileURL(loaderPath).href)}, pathToFileURL('./'))
-    `
-    const result = spawnSync(process.execPath, [
-      '--import',
-      `data:text/javascript,${encodeURIComponent(registerLoader)}`,
-      '--experimental-strip-types',
-      join(process.cwd(), 'src', 'cli.ts'),
-      'auto',
-      '--model',
-      'test-model',
-    ], {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        GSD_HOME: join(tempDir, 'home'),
-        GSD_RTK_DISABLED: '1',
-      },
-      encoding: 'utf8',
-      input: '',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    })
+  `
+  const result = spawnSync(process.execPath, [
+    '--import',
+    `data:text/javascript,${encodeURIComponent(registerLoader)}`,
+    '--experimental-strip-types',
+    join(process.cwd(), 'src', 'cli.ts'),
+    'auto',
+    '--model',
+    'test-model',
+  ], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      GSD_HOME: join(tempDir, 'home'),
+      GSD_RTK_DISABLED: '1',
+    },
+    encoding: 'utf8',
+    input: '',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
 
-    assert.equal(result.status, 0, result.stderr)
-    const markerLine = result.stderr
-      .split(/\r?\n/)
-      .find((line) => line.startsWith('AUTO_REDIRECT_ARGV '))
-    assert.ok(markerLine, result.stderr)
+  assert.equal(result.status, 0, result.stderr)
+  const markerLine = result.stderr
+    .split(/\r?\n/)
+    .find((line) => line.startsWith('AUTO_REDIRECT_ARGV '))
+  assert.ok(markerLine, result.stderr)
 
-    const headlessArgv = JSON.parse(markerLine.slice('AUTO_REDIRECT_ARGV '.length)) as string[]
-    assert.deepEqual(headlessArgv.slice(2), ['headless', '--model', 'test-model', 'auto'])
-    assert.match(result.stderr, /AUTO_REDIRECT_RUN /)
-  } finally {
-    rmSync(tempDir, { recursive: true, force: true })
-  }
+  const headlessArgv = JSON.parse(markerLine.slice('AUTO_REDIRECT_ARGV '.length)) as string[]
+  assert.deepEqual(headlessArgv.slice(2), ['headless', '--model', 'test-model', 'auto'])
+  assert.match(result.stderr, /AUTO_REDIRECT_RUN /)
+
+  const quickRegisterLoader = registerLoader.replace(
+    "Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: false })",
+    "Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })",
+  )
+  const quickResult = spawnSync(process.execPath, [
+    '--import',
+    `data:text/javascript,${encodeURIComponent(quickRegisterLoader)}`,
+    '--experimental-strip-types',
+    join(process.cwd(), 'src', 'cli.ts'),
+    'quick',
+    '--output-format',
+    'json',
+    'fix the login button',
+  ], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      GSD_HOME: join(tempDir, 'quick-home'),
+      GSD_RTK_DISABLED: '1',
+    },
+    encoding: 'utf8',
+    input: '',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+
+  assert.equal(quickResult.status, 0, quickResult.stderr)
+  const quickMarkerLine = quickResult.stderr
+    .split(/\r?\n/)
+    .find((line) => line.startsWith('AUTO_REDIRECT_ARGV '))
+  assert.ok(quickMarkerLine, quickResult.stderr)
+  const quickHeadlessArgv = JSON.parse(quickMarkerLine.slice('AUTO_REDIRECT_ARGV '.length)) as string[]
+  assert.deepEqual(
+    quickHeadlessArgv.slice(2),
+    ['headless', 'quick', '--output-format', 'json', 'fix the login button'],
+  )
 })
 
 test('keeps terminal `gsd auto` on the interactive path', () => {

--- a/src/tests/headless-cli-surface.test.ts
+++ b/src/tests/headless-cli-surface.test.ts
@@ -306,11 +306,15 @@ test('HeadlessJsonResult accepts optional fields', () => {
     milestone: 'M001',
     phase: 'planning',
     nextAction: 'fix blocker',
+    task: { number: 7, slug: 'fix-login', description: 'fix login' },
+    branch: 'gsd/quick/7-fix-login',
     artifacts: ['ROADMAP.md'],
     commits: ['abc1234'],
   }
   assert.equal(result.sessionId, 'sess-abc')
   assert.equal(result.milestone, 'M001')
+  assert.equal(result.task?.number, 7)
+  assert.equal(result.branch, 'gsd/quick/7-fix-login')
   assert.deepEqual(result.artifacts, ['ROADMAP.md'])
   assert.deepEqual(result.commits, ['abc1234'])
 })

--- a/src/tests/headless-quick-result.test.ts
+++ b/src/tests/headless-quick-result.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  captureQuickTaskGitState,
+  collectQuickTaskResult,
+  parseQuickTaskNotification,
+} from '../headless-quick-result.ts'
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+test('parseQuickTaskNotification extracts task, branch, and artifact metadata', () => {
+  assert.deepEqual(
+    parseQuickTaskNotification(
+      'Quick task 12: fix the login button\n' +
+      'Directory: .gsd/quick/12-fix-the-login-button\n' +
+      'Branch: gsd/quick/12-fix-the-login-button',
+    ),
+    {
+      task: { number: 12, description: 'fix the login button', slug: 'fix-the-login-button' },
+      branch: 'gsd/quick/12-fix-the-login-button',
+      artifact: '.gsd/quick/12-fix-the-login-button/12-SUMMARY.md',
+    },
+  )
+})
+
+test('collectQuickTaskResult reports the resulting commits and artifact', (t) => {
+  const repo = mkdtempSync(join(tmpdir(), 'gsd-headless-quick-result-'))
+  t.after(() => rmSync(repo, { recursive: true, force: true }))
+  git(repo, 'init', '-b', 'main')
+  git(repo, 'config', 'user.email', 'test@example.com')
+  git(repo, 'config', 'user.name', 'Test User')
+  writeFileSync(join(repo, 'README.md'), 'base\n')
+  git(repo, 'add', 'README.md')
+  git(repo, 'commit', '-m', 'chore: initial')
+
+  const before = captureQuickTaskGitState(repo)
+  const artifact = '.gsd/quick/1-fix-typo/1-SUMMARY.md'
+  mkdirSync(join(repo, '.gsd', 'quick', '1-fix-typo'), { recursive: true })
+  writeFileSync(join(repo, artifact), '# Summary\n')
+  writeFileSync(join(repo, 'fix.txt'), 'fixed\n')
+  git(repo, 'add', '.gsd/quick/1-fix-typo/1-SUMMARY.md', 'fix.txt')
+  git(repo, 'commit', '-m', 'quick(Q1): fix-typo')
+
+  const result = collectQuickTaskResult(repo, before, {
+    task: { number: 1, description: 'fix typo', slug: 'fix-typo' },
+    branch: 'gsd/quick/1-fix-typo',
+    artifact,
+  })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.details.task.number, 1)
+  assert.equal(result.details.branch, 'gsd/quick/1-fix-typo')
+  assert.deepEqual(result.details.artifacts, [artifact])
+  assert.deepEqual(result.details.commits, [git(repo, 'rev-parse', 'HEAD')])
+})
+
+test('collectQuickTaskResult fails when the summary artifact is missing', (t) => {
+  const repo = mkdtempSync(join(tmpdir(), 'gsd-headless-quick-missing-'))
+  t.after(() => rmSync(repo, { recursive: true, force: true }))
+  git(repo, 'init', '-b', 'main')
+  git(repo, 'config', 'user.email', 'test@example.com')
+  git(repo, 'config', 'user.name', 'Test User')
+  writeFileSync(join(repo, 'README.md'), 'base\n')
+  git(repo, 'add', 'README.md')
+  git(repo, 'commit', '-m', 'chore: initial')
+
+  const result = collectQuickTaskResult(repo, captureQuickTaskGitState(repo), {
+    task: { number: 1, description: 'fix typo', slug: 'fix-typo' },
+    branch: 'gsd/quick/1-fix-typo',
+    artifact: '.gsd/quick/1-fix-typo/1-SUMMARY.md',
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.error ?? '', /did not produce its summary artifact/)
+})
+
+test('collectQuickTaskResult fails when an isolated quick branch was not merged', (t) => {
+  const repo = mkdtempSync(join(tmpdir(), 'gsd-headless-quick-unmerged-'))
+  t.after(() => rmSync(repo, { recursive: true, force: true }))
+  git(repo, 'init', '-b', 'main')
+  git(repo, 'config', 'user.email', 'test@example.com')
+  git(repo, 'config', 'user.name', 'Test User')
+  writeFileSync(join(repo, 'README.md'), 'base\n')
+  git(repo, 'add', 'README.md')
+  git(repo, 'commit', '-m', 'chore: initial')
+
+  const artifact = '.gsd/quick/1-fix-typo/1-SUMMARY.md'
+  mkdirSync(join(repo, '.gsd', 'quick', '1-fix-typo'), { recursive: true })
+  writeFileSync(join(repo, artifact), '# Summary\n')
+  const result = collectQuickTaskResult(repo, captureQuickTaskGitState(repo), {
+    task: { number: 1, description: 'fix typo', slug: 'fix-typo' },
+    branch: 'gsd/quick/1-fix-typo',
+    artifact,
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.error ?? '', /did not produce its merged quick-task commit/)
+})
+
+test('collectQuickTaskResult fails when branchless execution leaves new changes uncommitted', (t) => {
+  const repo = mkdtempSync(join(tmpdir(), 'gsd-headless-quick-dirty-'))
+  t.after(() => rmSync(repo, { recursive: true, force: true }))
+  git(repo, 'init', '-b', 'main')
+  git(repo, 'config', 'user.email', 'test@example.com')
+  git(repo, 'config', 'user.name', 'Test User')
+  writeFileSync(join(repo, 'README.md'), 'base\n')
+  writeFileSync(join(repo, '.gitignore'), '.gsd/\n')
+  git(repo, 'add', 'README.md', '.gitignore')
+  git(repo, 'commit', '-m', 'chore: initial')
+
+  const before = captureQuickTaskGitState(repo)
+  const artifact = '.gsd/quick/1-fix-typo/1-SUMMARY.md'
+  mkdirSync(join(repo, '.gsd', 'quick', '1-fix-typo'), { recursive: true })
+  writeFileSync(join(repo, artifact), '# Summary\n')
+  writeFileSync(join(repo, 'committed.txt'), 'committed\n')
+  git(repo, 'add', 'committed.txt')
+  git(repo, 'commit', '-m', 'fix: partial quick task')
+  writeFileSync(join(repo, 'fix.txt'), 'not committed\n')
+  const result = collectQuickTaskResult(repo, before, {
+    task: { number: 1, description: 'fix typo', slug: 'fix-typo' },
+    branch: 'main',
+    artifact,
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.error ?? '', /left repository changes uncommitted/)
+})

--- a/src/tests/parse-cli-args.test.ts
+++ b/src/tests/parse-cli-args.test.ts
@@ -3,7 +3,7 @@
 
 import test, { describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildHeadlessAutoArgs, parseCliArgs } from '../cli-web-branch.ts'
+import { buildHeadlessCommandArgs, parseCliArgs } from '../cli-web-branch.ts'
 
 function parse(...args: string[]) {
   return parseCliArgs(['node', 'gsd', ...args])
@@ -25,14 +25,14 @@ describe('parseCliArgs — modes', () => {
   })
 })
 
-describe('buildHeadlessAutoArgs', () => {
+describe('buildHeadlessCommandArgs', () => {
   test('preserves auto positional args without a model override', () => {
-    const args = buildHeadlessAutoArgs({ messages: ['auto', 'next'] })
+    const args = buildHeadlessCommandArgs({ messages: ['auto', 'next'] })
     assert.deepEqual(args, ['auto', 'next'])
   })
 
   test('forwards --model before auto positional args', () => {
-    const args = buildHeadlessAutoArgs({
+    const args = buildHeadlessCommandArgs({
       model: 'claude-code/sonnet',
       messages: ['auto', 'next'],
     })
@@ -40,7 +40,7 @@ describe('buildHeadlessAutoArgs', () => {
   })
 
   test('forwards --thinking before auto positional args', () => {
-    const args = buildHeadlessAutoArgs({
+    const args = buildHeadlessCommandArgs({
       thinking: 'medium',
       messages: ['auto', 'next'],
     })
@@ -128,6 +128,11 @@ describe('parseCliArgs — short flags and basic options', () => {
     assert.deepEqual(flags.messages, ['headless', '--bare', 'auto'])
   })
 
+  test('quick task text and headless output flags pass through together', () => {
+    const flags = parse('quick', '--output-format', 'json', 'fix the login button')
+    assert.deepEqual(flags.messages, ['quick', '--output-format', 'json', 'fix the login button'])
+  })
+
   test('--bare is accepted at top level (the RPC child argv from headless/MCP forwarding)', () => {
     // headless.ts and the MCP/daemon session managers spawn the RPC child as
     // `node cli.js --mode rpc ... --bare`; that argv hits this parser directly.
@@ -140,12 +145,12 @@ describe('parseCliArgs — short flags and basic options', () => {
     assert.equal(parse('-p').bare, undefined)
   })
 
-  test('`auto` does not pass through: --model/--thinking are parsed so buildHeadlessAutoArgs can reorder them', () => {
+  test('`auto` does not pass through: --model/--thinking are parsed so buildHeadlessCommandArgs can reorder them', () => {
     const flags = parse('auto', '--model', 'test-model', '--thinking', 'medium')
     assert.deepEqual(flags.messages, ['auto'])
     assert.equal(flags.model, 'test-model')
     assert.equal(flags.thinking, 'medium')
-    assert.deepEqual(buildHeadlessAutoArgs(flags), ['--model', 'test-model', '--thinking', 'medium', 'auto'])
+    assert.deepEqual(buildHeadlessCommandArgs(flags), ['--model', 'test-model', '--thinking', 'medium', 'auto'])
   })
 })
 

--- a/src/tests/provider-help-text.test.ts
+++ b/src/tests/provider-help-text.test.ts
@@ -31,6 +31,16 @@ describe("help-text branding", () => {
     assert.ok(text.includes("--no-auth"), "help should list web no-auth mode");
     assert.ok(text.includes("external access control"), "help should warn about external access control");
   });
+
+  it("main and subcommand help document non-interactive quick tasks", () => {
+    const main = captureStdout(() => printHelp("1.2.3"));
+    const quick = captureStdout(() => printSubcommandHelp("quick", "1.2.3"));
+    const headless = captureStdout(() => printSubcommandHelp("headless", "1.2.3"));
+    assert.ok(main.includes("quick <task>"));
+    assert.ok(quick.includes("gsd headless quick"));
+    assert.ok(quick.includes("--output-format json"));
+    assert.ok(headless.includes("quick <task>"));
+  });
 });
 
 describe("help-text provider references", () => {


### PR DESCRIPTION
## Summary
- Added direct and headless quick-task execution with structured results, verified by 60 focused tests and syntax checks.

## Bugs Addressed
- [x] **CLI silently ignores `quick` and its task arguments**
- [x] **Quick tasks have no non-interactive entry point**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1554
- [#1554 quick has no non-interactive entry point, and 'gsd quick <task>' silently launches the console instead of erroring](https://github.com/open-gsd/gsd-pi/issues/1554)

## User
- @proofoftom

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1554-quick-has-no-non-interactive-entry-point-1787319344`