### PR TITLE
fix(issue): [Bug]: auto-mode escape-path violation — resumed-once task-recovery abort re-settled with dead worker names an already-consumed recoveryActionId as its only exit; transient Codex usage_limit_reached escalated to terminal abort (1.16.1)

### DIFF
--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -104,15 +104,27 @@ Auto mode persists worker state, unit-dispatch state, and paused-session metadat
 
 ### Provider error recovery
 
-| Error type   | Examples                      | Action                                      |
-| ------------ | ----------------------------- | ------------------------------------------- |
-| Rate limit   | 429, "too many requests"      | Auto-resume after retry-after header or 60s |
-| Server error | 500, 502, 503, "overloaded"   | Auto-resume after 30s                       |
-| Permanent    | "unauthorized", "invalid key" | Pause indefinitely (requires manual resume) |
+| Error type          | Examples                                          | Action                                                                 |
+| ------------------- | ------------------------------------------------- | ---------------------------------------------------------------------- |
+| Rate or usage limit | 429, "too many requests", Codex `usage_limit_reached` | Try a fallback model; otherwise enter cooldown and retry the same unit |
+| Server error        | 500, 502, 503, "overloaded"                       | Auto-resume after 30s                                                  |
+| Permanent           | "unauthorized", "invalid key"                    | Pause indefinitely (requires manual resume)                            |
+
+For a transient Codex usage-limit error with no available model fallback, auto mode stays active instead of pausing the session. It waits for the provider's retry hint plus a small buffer when the hint is at most 60 seconds, or 35 seconds when no usable hint is available, then retries from the current checkpoint. The cooldown budget allows five consecutive retries. If the limit is still exhausted on the next attempt, auto mode stops and records a crash note when possible; run `/gsd auto` after capacity returns to resume from the last checkpoint.
 
 ### Stuck detection
 
 A sliding-window analysis detects stuck loops — catching cycles like A→B→A→B as well as single-unit repeats. On detection, GSD retries once with a diagnostic prompt. If it fails again, auto mode stops with the exact file it expected.
+
+### Liveness wedge recovery
+
+When the same non-advancing guard recurs with unchanged inputs, the liveness backstop stops auto mode and reports a wedge ID, the originating guard, and a sanctioned recovery action. Fix the reported blocker first, then acknowledge that exact wedge and request re-entry:
+
+```
+/gsd auto --resume-wedge <wedge-id>
+```
+
+Plain `/gsd auto` cannot resume an open wedge, and a different wedge ID is refused. GSD also refuses acknowledgment when no wedge is open, the workflow database or auto orchestration is unavailable, the originating guard has no read-only recheck, or that recheck shows the blocker is unchanged. A successful recheck acknowledges the wedge and resets only its block-signature counter before auto mode continues.
 
 ### Artifact verification retries
 
@@ -190,7 +202,8 @@ Set `reactive_execution.enabled: true` explicitly to use the earlier two-ready-t
   </Step>
   <Step title="Resume">
     ``` /gsd auto ``` Auto mode reads DB-backed runtime state and picks up where
-    it left off.
+    it left off. A liveness wedge is the exception: resolve its blocker and use
+    ``` /gsd auto --resume-wedge <wedge-id> ``` with the exact reported ID.
   </Step>
   <Step title="Stop">
     ``` /gsd stop ``` Stops auto mode gracefully. Can be run from a different

--- a/mintlify-docs/guides/commands.mdx
+++ b/mintlify-docs/guides/commands.mdx
@@ -10,6 +10,7 @@ description: "Every GSD command, keyboard shortcut, and CLI flag."
 | `/gsd` | Step mode — execute one unit at a time, pause between each |
 | `/gsd next` | Explicit step mode (same as `/gsd`) |
 | `/gsd auto` | Autonomous mode — research, plan, execute, commit, repeat |
+| `/gsd auto --resume-wedge <wedge-id>` | Resume a reported liveness wedge after its originating guard clears; the exact open wedge ID is required |
 | `/gsd quick [--discuss] [--research] [--validate] [--full] <task>` | Execute a quick task with GSD guarantees; optionally add discussion, research, plan checking, and post-execution verification (`--full` enables all three stages) |
 | `/gsd stop` | Stop auto mode gracefully |
 | `/gsd pause` | Pause auto mode (preserves state, `/gsd auto` to resume) |

--- a/src/resources/extensions/gsd/artifact-verification.ts
+++ b/src/resources/extensions/gsd/artifact-verification.ts
@@ -83,7 +83,8 @@ export function readExecuteTaskArtifactReadiness(
  * superseded Attempt remains operative when newer Attempts carry no agent abort
  * of their own (#1754 residual). Ineligible actions are historical evidence,
  * not sanctioned exits; consumed actions in particular must never advertise a
- * resume command that deterministically rejects (#1944).
+ * resume command that deterministically rejects (#1944). A newer agent-owned
+ * non-abort route supersedes any older abort (#1908).
  */
 export function readTerminalTaskRecoveryAbort(
   milestoneId: string,
@@ -93,7 +94,9 @@ export function readTerminalTaskRecoveryAbort(
   for (const attemptId of readTaskRecoveryAttemptIds({ milestoneId, sliceId, taskId })) {
     const route = readTaskRecoveryRoute(attemptId);
     if (!route || route.recoveryOwner !== "agent") continue;
-    if (route.action !== "abort") continue;
+    // The newest agent-owned route is authoritative: a non-abort action
+    // (retry/repair/remediate) on a newer Attempt supersedes any older abort.
+    if (route.action !== "abort") return null;
     const eligibility = readTaskRecoveryResumeEligibility(route.recoveryActionId);
     if (!eligibility.eligible) continue;
     return route.resumeAuthorized ? null : { recoveryActionId: route.recoveryActionId };

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -670,6 +670,41 @@ export async function autoLoop(
     const finishIncompleteIteration = (details: Record<string, unknown>): void => {
       emitIterationEnd(details);
     };
+    const waitForCredentialCooldown = async (
+      retryAfterMs: number | undefined,
+      errorMessage = "credential-cooldown",
+    ): Promise<"retry" | "stop"> => {
+      await closeRun("canceled", "credential-cooldown");
+      consecutiveCooldowns++;
+      const cooldownDecision = decideCooldownRecovery({
+        consecutiveCooldowns,
+        maxCooldownRetries: MAX_COOLDOWN_RETRIES,
+        retryAfterMs,
+        fallbackWaitMs: COOLDOWN_FALLBACK_WAIT_MS,
+      });
+      debugLog("autoLoop", {
+        phase: "cooldown-wait",
+        iteration,
+        consecutiveCooldowns,
+        retryAfterMs,
+      });
+      if (cooldownDecision.action === "stop") {
+        const crashNotePath = persistCrashNote(s, "cooldown-exhausted", errorMessage, observedUnitType, observedUnitId);
+        ctx.ui.notify(
+          `${cooldownDecision.notifyMessage}${crashNotePath ? ` Crash note: ${crashNotePath}` : ""} Run /gsd auto to resume from the last checkpoint.`,
+          "error",
+        );
+        finishIncompleteIteration({ status: "stopped", reason: "credential-cooldown-exhausted" });
+        finishTurn("stopped", "timeout", errorMessage, "credential-cooldown-exhausted");
+        await deferStopAuto(ctx, pi, cooldownDecision.stopMessage);
+        return "stop";
+      }
+      ctx.ui.notify(cooldownDecision.notifyMessage, "warning");
+      await new Promise(resolve => setTimeout(resolve, cooldownDecision.waitMs));
+      finishIncompleteIteration({ status: "retry", reason: "cooldown-retry" });
+      finishTurn("retry", "timeout", errorMessage, "credential-cooldown");
+      return "retry";
+    };
 
     // ── Shared adjudication boundary (ADR-047) ──────────────────────────────
     // The try opens BEFORE the preflight exits (max-iteration, memory pressure,
@@ -1016,6 +1051,11 @@ export async function autoLoop(
           break;
         }
         if (unitPhaseResult.action === "retry") {
+          if (unitPhaseResult.reason === "credential-cooldown") {
+            const cooldown = await waitForCredentialCooldown(unitPhaseResult.data?.retryAfterMs);
+            if (cooldown === "stop") break;
+            continue;
+          }
           customDispatchSettled = settleDispatchIfNeeded(customDispatchSettled, () =>
             settleDispatchFailed(customDispatchId, unitPhaseResult.reason, {
               markFailed: markDispatchFailed,
@@ -1911,6 +1951,11 @@ export async function autoLoop(
         break;
       }
       if (unitPhaseResult.action === "retry") {
+        if (unitPhaseResult.reason === "credential-cooldown") {
+          const cooldown = await waitForCredentialCooldown(unitPhaseResult.data?.retryAfterMs);
+          if (cooldown === "stop") break;
+          continue;
+        }
         const retryStopReason = await closeRun("retry", unitPhaseResult.reason);
         if (retryStopReason) {
           finishRetryCloseoutStop(retryStopReason);
@@ -2129,40 +2174,9 @@ export async function autoLoop(
       // consecutive failure — but cap retries so we don't spin for hours
       // on persistent quota exhaustion.
       if (isTransientCooldownError(loopErr)) {
-        consecutiveCooldowns++;
         const retryAfterMs = getCooldownRetryAfterMs(loopErr);
-        const cooldownDecision = decideCooldownRecovery({
-          consecutiveCooldowns,
-          maxCooldownRetries: MAX_COOLDOWN_RETRIES,
-          retryAfterMs,
-          fallbackWaitMs: COOLDOWN_FALLBACK_WAIT_MS,
-        });
-        debugLog("autoLoop", {
-          phase: "cooldown-wait",
-          iteration,
-          consecutiveCooldowns,
-          retryAfterMs,
-          error: msg,
-        });
-
-        if (cooldownDecision.action === "stop") {
-          const crashNotePath = persistCrashNote(s, "cooldown-exhausted", msg, observedUnitType, observedUnitId);
-          ctx.ui.notify(
-            `${cooldownDecision.notifyMessage}${crashNotePath ? ` Crash note: ${crashNotePath}` : ""} Run /gsd auto to resume from the last checkpoint.`,
-            "error",
-          );
-          finishTurn("stopped", "timeout", msg, "credential-cooldown-exhausted");
-          await deferStopAuto(ctx, pi, cooldownDecision.stopMessage);
-          break;
-        }
-
-        ctx.ui.notify(cooldownDecision.notifyMessage, "warning");
-        await new Promise(resolve => setTimeout(resolve, cooldownDecision.waitMs));
-        finishTurn("retry", "timeout", msg, "credential-cooldown");
-        finishIncompleteIteration({
-          status: "retry",
-          reason: "cooldown-retry",
-        });
+        const cooldown = await waitForCredentialCooldown(retryAfterMs, msg);
+        if (cooldown === "stop") break;
         continue; // Retry iteration without incrementing consecutiveErrors
       }
 

--- a/src/resources/extensions/gsd/auto/unit-phase.ts
+++ b/src/resources/extensions/gsd/auto/unit-phase.ts
@@ -172,7 +172,7 @@ export async function runUnitPhase(
   iterData: IterationData,
   loopState: LoopState,
   sidecarItem?: SidecarItem,
-): Promise<PhaseResult<{ unitStartedAt?: number; requestDispatchedAt?: number }>> {
+): Promise<PhaseResult<{ unitStartedAt?: number; requestDispatchedAt?: number; retryAfterMs?: number }>> {
   const { ctx, pi, s, deps, prefs } = ic;
   const { unitType, unitId, prompt, state, mid } = iterData;
 

--- a/src/resources/extensions/gsd/auto/unit-phase.ts
+++ b/src/resources/extensions/gsd/auto/unit-phase.ts
@@ -656,6 +656,25 @@ export async function runUnitPhase(
     }
 
     const errorCategory = unitResult.errorContext?.category;
+    if (
+      errorCategory === "provider" &&
+      unitResult.errorContext?.isTransient === true &&
+      typeof unitResult.errorContext.retryAfterMs === "number" &&
+      unitResult.errorContext.retryAfterMs > 0
+    ) {
+      await emitCancelledUnitEnd(ic, unitType, unitId, unitStartSeq, unitResult.errorContext);
+      debugLog("autoLoop", {
+        phase: "provider-credential-cooldown",
+        unitType,
+        unitId,
+        retryAfterMs: unitResult.errorContext.retryAfterMs,
+      });
+      return {
+        action: "retry",
+        reason: "credential-cooldown",
+        data: { retryAfterMs: unitResult.errorContext.retryAfterMs },
+      };
+    }
     // Provider-error pause: agent_end recovery normally pauses before this
     // branch. Provider readiness failures happen before dispatch, so pause here
     // if nothing upstream already did.

--- a/src/resources/extensions/gsd/auto/workflow-unit-dispatch.ts
+++ b/src/resources/extensions/gsd/auto/workflow-unit-dispatch.ts
@@ -18,6 +18,7 @@ export type DispatchContract = "legacy-direct" | "uok-scheduler";
 export type UnitPhaseResult = PhaseResult<{
   unitStartedAt?: number;
   requestDispatchedAt?: number;
+  retryAfterMs?: number;
 }>;
 
 export interface UnitDispatchScheduler {

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -914,8 +914,9 @@ export async function handleAgentEnd(
     }
 
     // --- Transient fallback: pause with auto-resume ---
+    // (rate-limit already returned above, so this is never a rate-limit pause)
     if (isTransient(cls)) {
-      await pauseTransientWithBackoff(cls, pi, ctx, errorDetail, cls.kind === "rate-limit");
+      await pauseTransientWithBackoff(cls, pi, ctx, errorDetail, false);
       return;
     }
 

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -900,6 +900,19 @@ export async function handleAgentEnd(
       }
     }
 
+    // Auto-mode owns bounded credential cooldowns at the loop boundary. Keep
+    // the Task Attempt on its transient retry route instead of pausing the
+    // session here, which can later be mistaken for a crashed executor.
+    if (cls.kind === "rate-limit") {
+      resolveAgentEndCancelled({
+        message: `Provider error${errorDetail}`,
+        category: "provider",
+        isTransient: true,
+        retryAfterMs: cls.retryAfterMs,
+      });
+      return;
+    }
+
     // --- Transient fallback: pause with auto-resume ---
     if (isTransient(cls)) {
       await pauseTransientWithBackoff(cls, pi, ctx, errorDetail, cls.kind === "rate-limit");

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -6159,7 +6159,7 @@ test("runUnitPhase remembers aborted milestone closeout for same-unit resume", a
   assert.equal(runtime?.lastProgressKind, "unit-aborted-pause");
 });
 
-test("runUnitPhase schedules default auto-resume for transient provider cancellations", async (t) => {
+test("runUnitPhase routes transient usage-limit cancellations through credential cooldown", async (t) => {
   _resetPendingResolve();
 
   const basePath = makeLoopTestBase("gsd-provider-resume-");
@@ -6198,9 +6198,10 @@ test("runUnitPhase schedules default auto-resume for transient provider cancella
       ...makeMockPi(),
       sendMessage: () => {
         queueMicrotask(() => resolveAgentEndCancelled({
-          message: "provider temporarily overloaded",
+          message: "Provider error: Codex usage_limit_reached: The usage limit has been reached",
           category: "provider",
           isTransient: true,
+          retryAfterMs: 30_000,
         }));
       },
     } as any;
@@ -6240,17 +6241,14 @@ test("runUnitPhase schedules default auto-resume for transient provider cancella
       { consecutiveFinalizeTimeouts: 0 },
     );
 
-    assert.equal(result.action, "break");
-    assert.equal((result as any).reason, "provider-pause");
-    assert.equal(deps.callLog.includes("pauseAuto"), true);
-    assert.ok(
-      timers.some((timer) => timer.delay === 30_000),
-      "transient provider pauses must schedule the default auto-resume delay",
-    );
-    assert.ok(
-      notifications.some((entry) => entry.message.includes("Auto-resuming in 30s")),
-      "default transient provider pause should announce the delayed resume",
-    );
+    assert.deepEqual(result, {
+      action: "retry",
+      reason: "credential-cooldown",
+      data: { retryAfterMs: 30_000 },
+    });
+    assert.equal(deps.callLog.includes("pauseAuto"), false);
+    assert.equal(timers.length, 0, "the auto loop owns the bounded cooldown wait");
+    assert.equal(notifications.length, 0);
   } finally {
     globalThis.setTimeout = originalSetTimeout;
   }

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -6247,8 +6247,8 @@ test("runUnitPhase routes transient usage-limit cancellations through credential
       data: { retryAfterMs: 30_000 },
     });
     assert.equal(deps.callLog.includes("pauseAuto"), false);
-    assert.equal(timers.length, 0, "the auto loop owns the bounded cooldown wait");
-    assert.equal(notifications.length, 0);
+    assert.equal(timers.some((timer) => timer.delay === 30_000), false, "the auto loop owns the bounded cooldown wait");
+    assert.equal(notifications.some((n) => /pausing|provider error/i.test(n.message)), false, "no provider pause is announced for a bounded cooldown");
   } finally {
     globalThis.setTimeout = originalSetTimeout;
   }

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -29,6 +29,7 @@ import {
   _zeroToolPseudoToolCallSnippetForTest,
 } from "../auto/unit-phase.ts";
 import { autoSession } from "../auto-runtime-state.ts";
+import { _resetPendingResolve, _setCurrentResolve } from "../auto/resolve.ts";
 import { getNextFallbackModel } from "../preferences.ts";
 import { clearGuidedUnitContext, getGuidedUnitContext, setGuidedUnitContext } from "../guided-unit-context.ts";
 import { initNotificationStore, readNotifications, _resetNotificationStore } from "../notification-store.ts";
@@ -666,6 +667,53 @@ test("rate-limit agent_end walks past unavailable fallback models before pausing
     process.chdir(originalCwd);
     clearTemporaryModelBlocksForTest();
     autoSession.reset();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("usage-limit agent_end resolves a credential-cooldown cancellation without pausing auto-mode", async () => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-usage-limit-cooldown-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+
+  try {
+    process.chdir(base);
+    autoSession.reset();
+    autoSession.active = true;
+    autoSession.basePath = base;
+    autoSession.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+    const resultPromise = new Promise<any>((resolve) => _setCurrentResolve(resolve));
+
+    await handleAgentEnd({
+      setModel: async () => false,
+    } as any, {
+      messages: [{
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "Codex usage_limit_reached: The usage limit has been reached",
+        retryAfterMs: 30_000,
+      }],
+    } as any, {
+      model: { provider: "openai-codex", id: "gpt-5.5" },
+      modelRegistry: { getAvailable: () => [] },
+      ui: { notify: () => {} },
+    } as any);
+
+    const result = await resultPromise;
+    assert.equal(autoSession.active, true, "provider recovery must leave loop-owned cooldown active");
+    assert.deepEqual(result, {
+      status: "cancelled",
+      errorContext: {
+        message: "Provider error: Codex usage_limit_reached: The usage limit has been reached",
+        category: "provider",
+        isTransient: true,
+        retryAfterMs: 30_000,
+      },
+    });
+  } finally {
+    _resetPendingResolve();
+    autoSession.reset();
+    process.chdir(originalCwd);
     rmSync(base, { recursive: true, force: true });
   }
 });

--- a/src/resources/extensions/gsd/tests/rate-limit-model-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/rate-limit-model-fallback.test.ts
@@ -46,22 +46,26 @@ test("rate-limit errors are NOT short-circuited to pause before model fallback",
   );
 });
 
-test("rate-limit errors fall through to pause if no fallback model is available", () => {
+test("rate-limit errors hand the bounded cooldown to the auto loop if no fallback model is available", () => {
   const src = getRecoverySource();
 
-  // After the fallback block, the transient fallback pause must still fire for rate-limit.
-  // The isTransient check covers rate-limit (verified by error-classifier tests).
-  // Verify pauseTransientWithBackoff is called with isRateLimit derived from cls.kind.
   assert.ok(
     src.includes('cls.kind === "rate-limit"'),
-    'agent-end-recovery.ts must reference cls.kind === "rate-limit" for fallback and pause paths (#2770)',
+    'agent-end-recovery.ts must reference cls.kind === "rate-limit" for the fallback path (#2770)',
   );
 
-  // The transient fallback pause must pass the isRateLimit flag correctly.
-  const pauseCallRe = /pauseTransientWithBackoff\([^)]*cls\.kind\s*===\s*"rate-limit"/;
+  // After the fallback block, a rate-limit resolves the unit as a transient
+  // cancellation carrying retryAfterMs so the auto loop owns the cooldown
+  // (#1908) instead of pausing the session here.
+  const cooldownHandoffRe = /if\s*\(\s*cls\.kind\s*===\s*"rate-limit"\s*\)\s*\{[^}]*resolveAgentEndCancelled\([^)]*isTransient:\s*true[^)]*retryAfterMs:\s*cls\.retryAfterMs/;
+  const handoff = cooldownHandoffRe.exec(src);
   assert.ok(
-    pauseCallRe.test(src),
-    'pauseTransientWithBackoff must receive isRateLimit based on cls.kind === "rate-limit" (#2770)',
+    handoff,
+    'rate-limit must resolve the unit as a transient cancellation with retryAfterMs before the transient pause (#1908)',
+  );
+  assert.ok(
+    handoff.index > src.indexOf("tryProviderModelFallback("),
+    "the rate-limit cooldown handoff must come after the model fallback attempt (#2770)",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -1639,6 +1639,187 @@ test("a terminal abort on a superseded Attempt stops dispatch and resumes (#1754
   );
 });
 
+test("a newer agent-owned non-abort route supersedes an older terminal abort (#1908)", () => {
+  const firstFailure = seedFailedAttempt();
+  const route = (
+    key: string,
+    failure: { attemptId: string; resultId: string },
+    summary: string,
+  ) =>
+    recordFailureAndSelectRecovery({
+      invocation: invocation(key),
+      ...failure,
+      owner: "agent",
+      classification: { failureKind: "worktree-invalid" },
+      summary,
+      evidence: { source: "executor", diagnostic: summary },
+      rationale: "repair the deterministic worktree fault",
+    });
+
+  route("recovery/superseded-remediate/1", firstFailure, "Worktree root was missing before the repair.");
+  const secondDispatchId = insertClaimedDispatch(2);
+  const secondClaim = claimTaskAttempt({
+    invocation: invocation("fixture/claim/2"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+    coordinationDispatchId: secondDispatchId,
+    retryOfAttemptId: firstFailure.attemptId,
+  });
+
+  const secondSettlement = settleTaskAttempt({
+    invocation: invocation("fixture/settle/2"),
+    attemptId: secondClaim.attemptId,
+    outcome: "interrupted",
+    failureClass: "stale-worker",
+    summary: "Replaced stale Task Attempt after milestone lease takeover",
+    output: {},
+  });
+  const aborted = route(
+    "recovery/superseded-remediate/2",
+    { attemptId: secondClaim.attemptId, resultId: secondSettlement.resultId },
+    "Worktree root was still missing after the repair attempt.",
+  );
+  assert.equal(aborted.action, "abort");
+
+  // A successor Attempt supersedes the aborted one. Current claim rules
+  // refuse to build on an unresumed abort, but pre-fix production minted
+  // exactly this state (#1754), so the residual is seeded the way those DBs
+  // carry it: a settled superseding Attempt whose claim predates any resume.
+  // The claim-authority and settled-shape triggers reject that insert today,
+  // so they are dropped for the seed, matching the fixture-surgery pattern
+  // used for immutable domain events above.
+  const thirdDispatchId = insertClaimedDispatch(3);
+  db().exec(`
+    DROP TRIGGER trg_workflow_attempt_route_authority_v39;
+    DROP TRIGGER trg_workflow_attempt_settlement_insert_shape_v36;
+    DROP TRIGGER trg_workflow_kernel_checkpoint_chain;
+    DROP TRIGGER trg_workflow_kernel_checkpoint_attempt_claim;
+  `);
+  const secondOperation = row(`
+    SELECT project_id, settle_operation_id, settle_project_revision, settle_authority_epoch
+    FROM workflow_execution_attempts WHERE attempt_id = :attempt_id
+  `, { ":attempt_id": secondClaim.attemptId });
+  db().prepare(`
+    INSERT INTO workflow_execution_attempts (
+      attempt_id, project_id, lifecycle_id, attempt_number, retry_of_attempt_id,
+      attempt_state, coordination_dispatch_id, worker_id, milestone_lease_token,
+      claimed_at, started_at, ended_at, claim_operation_id,
+      claim_project_revision, claim_authority_epoch, settle_outcome,
+      settle_operation_id, settle_project_revision, settle_authority_epoch
+    ) VALUES (
+      'attempt-superseding', :project_id, :lifecycle_id, 3, :retry_of,
+      'settled', :dispatch_id, 'worker-1', 7,
+      '2026-07-13T00:03:00.000Z', '2026-07-13T00:03:00.000Z', '2026-07-13T00:04:00.000Z',
+      :operation_id, :project_revision, :authority_epoch,
+      'succeeded', :operation_id, :project_revision, :authority_epoch
+    )
+  `).run({
+    ":project_id": secondOperation.project_id,
+    ":lifecycle_id": firstFailure.lifecycleId,
+    ":retry_of": secondClaim.attemptId,
+    ":dispatch_id": thirdDispatchId,
+    ":operation_id": secondOperation.settle_operation_id,
+    ":project_revision": secondOperation.settle_project_revision,
+    ":authority_epoch": secondOperation.settle_authority_epoch,
+  });
+  const routeHead = row(`
+    SELECT kernel_checkpoint_id, sequence
+    FROM workflow_kernel_checkpoints
+    WHERE lifecycle_id = :lifecycle_id
+    ORDER BY sequence DESC LIMIT 1
+  `, { ":lifecycle_id": firstFailure.lifecycleId });
+  db().prepare(`
+    INSERT INTO workflow_attempt_results (
+      result_id, project_id, lifecycle_id, attempt_id, outcome,
+      failure_class, summary, output_json, created_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES (
+      'result-superseding', :project_id, :lifecycle_id, 'attempt-superseding',
+      'succeeded', 'none', 'Superseding execution succeeded', '{}',
+      '2026-07-13T00:04:00.000Z', :operation_id, :project_revision, :authority_epoch
+    )
+  `).run({
+    ":project_id": secondOperation.project_id,
+    ":lifecycle_id": firstFailure.lifecycleId,
+    ":operation_id": secondOperation.settle_operation_id,
+    ":project_revision": secondOperation.settle_project_revision,
+    ":authority_epoch": secondOperation.settle_authority_epoch,
+  });
+  db().prepare(`
+    INSERT INTO workflow_kernel_checkpoints (
+      kernel_checkpoint_id, project_id, lifecycle_id, attempt_id,
+      next_stage, sequence, previous_kernel_checkpoint_id, created_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES
+      ('kernel-superseding-execute', :project_id, :lifecycle_id, 'attempt-superseding',
+       'execute', :execute_sequence, :route_head, '2026-07-13T00:03:00.000Z',
+       :operation_id, :project_revision, :authority_epoch),
+      ('kernel-superseding-verify', :project_id, :lifecycle_id, 'attempt-superseding',
+       'verify', :verify_sequence, 'kernel-superseding-execute', '2026-07-13T00:04:00.000Z',
+       :operation_id, :project_revision, :authority_epoch)
+  `).run({
+    ":project_id": secondOperation.project_id,
+    ":lifecycle_id": firstFailure.lifecycleId,
+    ":execute_sequence": Number(routeHead.sequence) + 1,
+    ":verify_sequence": Number(routeHead.sequence) + 2,
+    ":route_head": routeHead.kernel_checkpoint_id,
+    ":operation_id": secondOperation.settle_operation_id,
+    ":project_revision": secondOperation.settle_project_revision,
+    ":authority_epoch": secondOperation.settle_authority_epoch,
+  });
+  assert.equal(
+    row("SELECT attempt_id AS id FROM workflow_execution_attempts ORDER BY attempt_number DESC LIMIT 1").id,
+    "attempt-superseding",
+    "the aborted Attempt is superseded by a newer Attempt",
+  );
+
+  // Residual shape (#1754): the older abort is still the advertised exit.
+  assert.equal(
+    readTerminalTaskRecoveryAbort("M001", "S01", "T01")?.recoveryActionId,
+    aborted.recoveryActionId,
+  );
+
+  // The superseding Attempt succeeded, failed host verification, and recorded
+  // its own newer agent-owned `remediate` route. That route is the Task's
+  // current recovery decision; the stale abort must not be re-advertised as
+  // the only exit (#1908).
+  recordTaskTechnicalVerdict({
+    invocation: invocation("recovery/superseded-remediate/verdict"),
+    attemptId: "attempt-superseding",
+    testedSourceRevision: "git:superseding",
+    verdict: "fail",
+    rationale: "Host verification failed after the superseding execution.",
+    evidence: {
+      evidenceClass: "command",
+      commandOrTool: "python3 -m pytest",
+      workingDirectory: firstFailure.basePath,
+      startedAt: "2026-07-13T00:05:00.000Z",
+      endedAt: "2026-07-13T00:05:01.000Z",
+      exitCode: 1,
+      observation: "failed",
+      durableOutputRef: "db://host-verification/superseding",
+      environment: { runner: "node-test", platform: "test" },
+    },
+  });
+  const remediate = recordFailureAndSelectRecovery({
+    invocation: invocation("recovery/superseded-remediate/3"),
+    attemptId: "attempt-superseding",
+    resultId: "result-superseding",
+    owner: "agent",
+    classification: { failureKind: "verification-failed" },
+    summary: "Host verification failed after the superseding execution.",
+    evidence: { command: "python3 -m pytest", exitCode: 1, verdict: "FAIL" },
+    rationale: "remediate the failed host verification",
+  });
+  assert.equal(remediate.action, "remediate");
+  assert.equal(
+    readTerminalTaskRecoveryAbort("M001", "S01", "T01"),
+    null,
+    "a newer agent-owned non-abort route supersedes the older abort",
+  );
+});
+
 test("ineligible recovery history is not advertised when an Attempt leaves the live lifecycle join", () => {
   const firstFailure = seedFailedAttempt();
   const aborted = recordFailureAndSelectRecovery({


### PR DESCRIPTION
## TL;DR
**What:** Let a newer agent-owned non-abort recovery route supersede a stale terminal abort, and route transient provider usage-limit errors through the auto-loop credential cooldown instead of the task-recovery-abort ladder.
**Why:** Closes #1908 — auto-mode advertised `gsd_task_recovery_resume <id>` for an abort that was already superseded, and a transient `Codex usage_limit_reached` was escalated into a terminal abort.
**How:** One-line supersession in `readTerminalTaskRecoveryAbort`; rate-limit hand-off to the loop-owned cooldown in `agent-end-recovery.ts` / `unit-phase.ts` / `loop.ts`.

## What
- `artifact-verification.ts` — `readTerminalTaskRecoveryAbort`: `if (route.action !== "abort") return null;` (was `continue`). The newest agent-owned route is authoritative; a newer retry/repair/remediate route supersedes any older abort. Main's resume-eligibility gate (#1946) stays in place right after it.
- `bootstrap/agent-end-recovery.ts` — after model fallback fails, a rate-limit resolves the unit as a transient cancellation carrying `retryAfterMs` instead of pausing the session.
- `auto/unit-phase.ts`, `auto/loop.ts`, `auto/workflow-unit-dispatch.ts` — `credential-cooldown` retry path consumes `retryAfterMs` and retries the same unit after the bounded cooldown.
- Docs: provider-error recovery table and `/gsd auto --resume-wedge` reference.
- Tests: #1908 supersession case in `task-recovery-domain-operation.test.ts` (red on `continue`, green on `return null`); cooldown tests in `auto-loop.test.ts` / `provider-errors.test.ts`; `rate-limit-model-fallback.test.ts` contract updated to the cooldown hand-off.

## Superseded by #1946 / #1942
The original bug-1 (consumed-abort `isConsumedTaskRecoveryAbort`) and bug-3 (wedge-acknowledgment recheck) hunks were dropped from this PR: main now covers them via `readTaskRecoveryResumeEligibility` gating in `readTerminalTaskRecoveryAbort` (#1946) and `recheckWedge` / `acknowledgeWedge(recheck)` (#1942). This PR was rebuilt on top of main with only its unique contributions.

## Why
Closes #1908

## How
See **What**. Verified standalone: task-recovery-domain-operation, auto-task-execution-cutover, auto-orchestrator, auto-loop, auto-liveness-backstop-1655, provider-errors, agent-end-retry, rate-limit-model-fallback, task-recovery-convergence; `typecheck:extensions` clean.
