### PR TITLE
fix(issue): [Bug]: provider usage_limit_reached during execute-task closeout strands a running Attempt with a dead lease; no in-context recovery can complete or settle it

### DIFF
--- a/src/resources/extensions/gsd/auto/unit-phase.ts
+++ b/src/resources/extensions/gsd/auto/unit-phase.ts
@@ -596,7 +596,27 @@ export async function runUnitPhase(
     sessionFile,
   );
 
-  if (unitResult.status === "cancelled") {
+  // The provider can fail after gsd_task_complete atomically staged success.
+  // In that case execution is already durable and the canonical Attempt is at
+  // `verify`; continue closeout instead of dispatching the implementation again.
+  const resumeDurableTaskCloseout =
+    unitResult.status === "cancelled" &&
+    unitResult.errorContext?.category === "provider" &&
+    unitResult.errorContext.isTransient === true &&
+    isTaskExecutionReadyForHostVerification(unitType, unitId);
+  if (resumeDurableTaskCloseout) {
+    debugLog("autoLoop", {
+      phase: "provider-error-after-durable-task-completion",
+      unitType,
+      unitId,
+    });
+    ctx.ui.notify(
+      `Provider failed after ${unitType} ${unitId} durably recorded completion; resuming at host verification.`,
+      "warning",
+    );
+  }
+
+  if (unitResult.status === "cancelled" && !resumeDurableTaskCloseout) {
     if (_isPauseOriginCancelledResult(s.paused, unitResult.errorContext)) {
       if (!pausedBeforeRun) {
         const pauseContext = {
@@ -954,9 +974,11 @@ export async function runUnitPhase(
   }
 
   const unitEndStatus =
-    !artifactVerified && unitResult.status === "completed"
-      ? "no-artifact"
-      : unitResult.status;
+    resumeDurableTaskCloseout
+      ? "completed"
+      : !artifactVerified && unitResult.status === "completed"
+        ? "no-artifact"
+        : unitResult.status;
   deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: ic.nextSeq(), eventType: "unit-end", data: { unitType, unitId, status: unitEndStatus, artifactVerified, ...(unitResult.errorContext ? { errorContext: unitResult.errorContext } : {}) }, causedBy: { flowId: ic.flowId, seq: unitStartSeq } });
 
   // ── Safety harness: checkpoint cleanup or rollback ──

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -32,6 +32,7 @@ import {
   resolveAgentEndCancelled,
 } from "../auto/resolve.js";
 import { shouldIgnoreAgentEndForActiveUnit } from "../auto/unit-runner-events.js";
+import { isTaskExecutionReadyForHostVerification } from "../auto/task-execution-cutover.js";
 import { resolveModelId } from "../auto-model-selection.js";
 import { resolveProjectRoot } from "../worktree.js";
 import { clearDiscussionFlowState } from "./write-gate.js";
@@ -691,6 +692,25 @@ export async function handleAgentEnd(
 
     // ── 1. Classify, preserving non-empty errorMessage precedence ──────
     const cls = classifyError(rawErrorMsg || displayMsg, explicitRetryAfterMs);
+
+    // The provider can fail after gsd_task_complete has durably moved the
+    // canonical Attempt to `verify`. Resolve the in-flight unit without
+    // pausing so unit-phase can finish host verification and publication.
+    const currentUnit = getAutoDashboardData().currentUnit;
+    if (
+      isTransient(cls) &&
+      currentUnit &&
+      isTaskExecutionReadyForHostVerification(currentUnit.type, currentUnit.id)
+    ) {
+      resetRetryState(retryState);
+      resolveAgentEndCancelled({
+        message: displayMsg || rawErrorMsg || "Transient provider error after durable Task completion",
+        category: "provider",
+        isTransient: true,
+        retryAfterMs: "retryAfterMs" in cls ? cls.retryAfterMs : undefined,
+      });
+      return;
+    }
 
     // ── 1a. Unsupported-model: provider rejected this model for the current
     //        account/plan at request time (#4513).  Persist a block so the

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -2623,7 +2623,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 			"Settle an orphaned running Task Attempt (dry-run first, apply: true to mutate)",
 		promptGuidelines: [
 			"Run without apply first and read the planned rows before mutating.",
-			"Only settles while the Attempt's own milestone lease is still held; a cross-process orphan whose lease is gone belongs to the next auto session's replacement-lease interrupt.",
+			"Settles under the Attempt's held lease, or safely reclaims an expired/released lease when its worker is no longer live; never steals a live peer's lease.",
 			"A second apply is a no-op — the tool is idempotent.",
 			"reconcileLifecycle adopts ready/completed to match tasks.status after the interrupted Attempt without deleting SUMMARYs.",
 		],

--- a/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
+++ b/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
@@ -158,7 +158,20 @@ export function resolveTaskCompletionAuthority(
              WHERE attempt.lifecycle_id = lifecycle.lifecycle_id
                AND attempt.project_id = lifecycle.project_id
                AND attempt.attempt_state = 'running'
-           ) AS has_running_attempt
+           ) AS has_running_attempt,
+           EXISTS (
+             SELECT 1
+             FROM workflow_execution_attempts attempt
+             JOIN milestone_leases lease
+               ON lease.milestone_id = lifecycle.milestone_id
+              AND lease.worker_id = attempt.worker_id
+              AND lease.fencing_token = attempt.milestone_lease_token
+              AND lease.status = 'held'
+              AND lease.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+             WHERE attempt.lifecycle_id = lifecycle.lifecycle_id
+               AND attempt.project_id = lifecycle.project_id
+               AND attempt.attempt_state = 'running'
+           ) AS has_held_running_attempt
     FROM workflow_item_lifecycles lifecycle
     WHERE lifecycle.item_kind = 'task'
       AND lifecycle.milestone_id = :milestone_id
@@ -176,8 +189,18 @@ export function resolveTaskCompletionAuthority(
     }
     return "legacy";
   }
-  if (Number(lifecycle["has_running_attempt"]) === 1) return "canonical";
-  throw new Error("Canonical Task completion requires a running or replay-matched Attempt");
+  if (Number(lifecycle["has_held_running_attempt"]) === 1) return "canonical";
+  if (Number(lifecycle["has_running_attempt"]) === 1) {
+    throw new Error(
+      "Canonical Task completion found an orphaned running Attempt whose milestone lease is no " +
+      "longer held. Dry-run gsd_task_settle and apply it only if the lease is reported " +
+      "reclaimable; otherwise re-enter `/gsd auto` to recover under the current lease.",
+    );
+  }
+  throw new Error(
+    "Canonical Task completion has no running Attempt to close. Re-enter `/gsd auto` to resume " +
+    "the Task from its durable checkpoint.",
+  );
 }
 
 function runningAttemptId(task: TaskCompletionIdentity): string {

--- a/src/resources/extensions/gsd/task-settle.ts
+++ b/src/resources/extensions/gsd/task-settle.ts
@@ -5,6 +5,12 @@
 
 import { executeDomainOperation } from "./db/domain-operation.js";
 import { getDb } from "./db/engine.js";
+import { isAutoWorkerLive } from "./db/auto-workers.js";
+import {
+  claimMilestoneLease,
+  getMilestoneLease,
+  releaseMilestoneLease,
+} from "./db/milestone-leases.js";
 import { normalizeLegacyLifecycleStatus } from "./db/lifecycle-shadow-comparison.js";
 import {
   adoptOrTransitionLifecycle,
@@ -105,6 +111,30 @@ function readLeaseHeld(row: RunningAttemptRow, milestoneId: string): boolean {
     ":fencing_token": row.milestone_lease_token,
   });
   return lease !== undefined;
+}
+
+function canReclaimLease(row: RunningAttemptRow, milestoneId: string): boolean {
+  if (!row.worker_id || row.milestone_lease_token === null) return false;
+  if (isAutoWorkerLive(row.worker_id)) return false;
+  const lease = getMilestoneLease(milestoneId);
+  if (!lease || lease.fencing_token < row.milestone_lease_token) return false;
+  return lease.status !== "held" || Date.parse(lease.expires_at) <= Date.now();
+}
+
+function claimRecoveryLease(
+  row: RunningAttemptRow,
+  milestoneId: string,
+): { workerId: string; milestoneLeaseToken: number } | null {
+  if (!canReclaimLease(row, milestoneId) || !row.worker_id || row.milestone_lease_token === null) {
+    return null;
+  }
+  const claimed = claimMilestoneLease(row.worker_id, milestoneId);
+  if (!claimed.ok) return null;
+  if (claimed.token <= row.milestone_lease_token) {
+    releaseMilestoneLease(row.worker_id, milestoneId, claimed.token);
+    return null;
+  }
+  return { workerId: row.worker_id, milestoneLeaseToken: claimed.token };
 }
 
 function requireSingleRunningAttempt(task: TaskSettleTask): RunningAttemptRow | null {
@@ -364,7 +394,11 @@ export function planTaskSettle(
   const leaseHeld = readLeaseHeld(attempt, task.milestoneId);
   const rationale = leaseHeld
     ? reason
-    : `${reason} (warning: the Attempt's milestone lease is no longer held — apply will refuse)`;
+    : canReclaimLease(attempt, task.milestoneId)
+      ? `${reason} (the orphaned Attempt's worker is gone and its milestone lease is ` +
+        "expired or released — apply will reclaim it with a newer fencing token)"
+      : `${reason} (warning: the Attempt's milestone lease is no longer held, but a live ` +
+        "worker or replacement lease prevents safe recovery — apply will refuse)";
   return {
     task,
     rows: [{
@@ -380,11 +414,11 @@ export function planTaskSettle(
 }
 
 /**
- * Settle the Task's one running Attempt as `interrupted`. Only the own-lease
- * path is authorized: the worker that claimed the Attempt still holds its
- * milestone lease, so a plain attempt.settle is legal (V47 dispatch-scope
- * rule). A cross-process orphan whose lease is already gone belongs to the
- * replacement-lease interrupt path (#1748) — the next auto session settles it.
+ * Settle the Task's one running Attempt as `interrupted`. The own-lease path
+ * uses a plain attempt.settle (V47 dispatch-scope rule). If the owner is no
+ * longer live and its lease is expired or released, the operator reclaims the
+ * lease with a newer fencing token and uses attempt.interrupt (#1907). A live
+ * owner or replacement lease remains fail-closed.
  *
  * Optional `reconcileLifecycle` then adopts ready/completed to match
  * tasks.status after that interrupted Attempt, without reopening or deleting
@@ -403,29 +437,50 @@ export function applyTaskSettle(input: {
   let resultId: string | undefined;
   if (plan.rows.length > 0) {
     const row = plan.rows[0];
-    if (!row.leaseHeld) {
+    const attempt = requireSingleRunningAttempt(input.task);
+    if (!attempt || attempt.attempt_id !== row.attemptId) {
+      throw new Error("gsd_task_settle: running Attempt changed after the dry-run plan; retry the operation");
+    }
+    const recovery = row.leaseHeld
+      ? null
+      : claimRecoveryLease(attempt, input.task.milestoneId);
+    if (!row.leaseHeld && !recovery) {
       throw new Error(
         `gsd_task_settle: Attempt ${row.attemptId} was claimed under a milestone lease that is ` +
-        "no longer held, so this operator settle is not authorized. Start `/gsd auto` — the next " +
-        "session takes over the lease and interrupts the orphaned Attempt via the replacement-lease path.",
+        "no longer held, but a live worker or replacement lease prevents safe recovery. " +
+        "Re-enter `/gsd auto` to recover under the current replacement lease.",
       );
     }
-    const settlement = settleTaskAttempt({
-      invocation: input.invocation,
-      attemptId: row.attemptId,
-      outcome: "interrupted",
-      failureClass: "operator-settle",
-      summary: input.reason,
-      output: {
-        operator: true,
-        milestoneId: input.task.milestoneId,
-        sliceId: input.task.sliceId,
-        taskId: input.task.taskId,
-        reason: input.reason,
-      },
-    });
-    settled = true;
-    resultId = settlement.resultId;
+    try {
+      const settlement = settleTaskAttempt({
+        invocation: input.invocation,
+        attemptId: row.attemptId,
+        outcome: "interrupted",
+        failureClass: "operator-settle",
+        summary: input.reason,
+        output: {
+          operator: true,
+          milestoneId: input.task.milestoneId,
+          sliceId: input.task.sliceId,
+          taskId: input.task.taskId,
+          reason: input.reason,
+        },
+        ...(recovery ? { recovery: {
+          workerId: recovery.workerId,
+          milestoneLeaseToken: recovery.milestoneLeaseToken,
+        } } : {}),
+      });
+      settled = true;
+      resultId = settlement.resultId;
+    } finally {
+      if (recovery) {
+        releaseMilestoneLease(
+          recovery.workerId,
+          input.task.milestoneId,
+          recovery.milestoneLeaseToken,
+        );
+      }
+    }
   }
   let lifecycleRows = plan.lifecycleRows;
   let proof = plan.proof;

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2512,8 +2512,6 @@ test("autoLoop resumes canonical closeout when a transient provider error follow
 
   const originalCwd = process.cwd();
   const ctx = makeMockCtx();
-  ctx.model = { provider: "openai-codex", id: "gpt-5.6-sol" };
-  ctx.modelRegistry = { getAvailable: () => [] };
   ctx.ui.setStatus = () => {};
   ctx.ui.setWidget = () => {};
   ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -65,6 +65,7 @@ import {
 import { recordFailureAndSelectRecovery } from "../task-recovery-domain-operation.js";
 import { handleReplanTask } from "../tools/replan-task.js";
 import { appendCapture, markCaptureResolved } from "../captures.js";
+import { autoSession } from "../auto-runtime-state.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -2506,10 +2507,13 @@ test("custom-engine recovery fails loudly when dispatch terminalization cannot b
   }
 });
 
-test("autoLoop publishes a canonical Task only after host verification without legacy dispatch re-settlement", async () => {
+test("autoLoop resumes canonical closeout when a transient provider error follows durable Task completion (#1907)", async () => {
   _resetPendingResolve();
 
+  const originalCwd = process.cwd();
   const ctx = makeMockCtx();
+  ctx.model = { provider: "openai-codex", id: "gpt-5.6-sol" };
+  ctx.modelRegistry = { getAvailable: () => [] };
   ctx.ui.setStatus = () => {};
   ctx.ui.setWidget = () => {};
   ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
@@ -2585,7 +2589,28 @@ test("autoLoop publishes a canonical Task only after host verification without l
     });
     assert.equal(getTask("M001", "S01", "T01")?.status, "in_progress");
 
-    resolveAgentEnd(makeEvent());
+    autoSession.reset();
+    autoSession.active = true;
+    autoSession.basePath = basePath;
+    autoSession.originalBasePath = basePath;
+    autoSession.currentUnit = {
+      type: "execute-task",
+      id: "M001/S01/T01",
+      startedAt: Date.now(),
+    };
+    const { handleAgentEnd } = await import("../bootstrap/agent-end-recovery.js");
+    process.chdir(basePath);
+    try {
+      await handleAgentEnd(pi, {
+        messages: [{
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "Provider error: Codex usage_limit_reached: The usage limit has been reached",
+        }],
+      } as AgentEndEvent, ctx);
+    } finally {
+      process.chdir(originalCwd);
+    }
     await loopPromise;
 
     const attempt = readLatestTaskAttempt({ milestoneId: "M001", sliceId: "S01", taskId: "T01" });
@@ -2599,8 +2624,14 @@ test("autoLoop publishes a canonical Task only after host verification without l
     assert.equal(attempt.state, "settled");
     assert.equal(attempt.outcome, "succeeded");
     assert.equal(attempt.nextStage, "settled");
+    assert.equal(pi.calls.length, 1, "the completed executor is not re-dispatched");
+    assert.equal(deps.callLog.includes("pauseAuto"), false, "durable closeout bypasses provider pause");
+    assert.equal(autoSession.active, true, "provider handling does not pause the active auto session");
+    assert.equal(autoSession.paused, false, "provider handling leaves no stale paused state");
     assert.equal(getLatestForUnit("M001/S01/T01")?.status, "completed");
   } finally {
+    process.chdir(originalCwd);
+    autoSession.reset();
     try { closeDatabase(); } catch { /* noop */ }
     rmSync(basePath, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/task-settle.test.ts
+++ b/src/resources/extensions/gsd/tests/task-settle.test.ts
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
 
@@ -16,6 +16,7 @@ import {
 } from "../db/writers/lifecycle-commands.ts";
 import { claimTaskAttempt, readTaskAttempt } from "../task-execution-domain-operation.ts";
 import { applyTaskSettle, planTaskSettle } from "../task-settle.ts";
+import { resolveTaskCompletionAuthority } from "../task-completion-compatibility-adapter.ts";
 import type { ExecutionInvocation } from "../execution-invocation.ts";
 
 const tempDirs = new Set<string>();
@@ -225,27 +226,128 @@ test("a typo'd task id errors without writes", () => {
   );
 });
 
-test("apply refuses when the Attempt's lease is no longer held", () => {
+test("apply reclaims an expired lease and interrupts its orphaned Attempt (#1907)", () => {
+  const { attemptId, dispatchId } = seedRunningAttempt();
+  orphanClaimedAttempt(dispatchId);
+  db().exec(`
+    UPDATE milestone_leases
+    SET status = 'held', expires_at = '2000-01-01T00:00:00.000Z'
+    WHERE milestone_id = 'M001'
+  `);
+
+  const plan = planTaskSettle(TASK, "operator repair");
+  assert.equal(plan.rows[0].leaseHeld, false);
+  assert.match(plan.rows[0].rationale, /orphaned.*apply will reclaim/i);
+  assert.throws(
+    () => resolveTaskCompletionAuthority(TASK, "completion/orphaned"),
+    /orphaned running Attempt.*gsd_task_settle.*reclaimable.*\/gsd auto/s,
+  );
+
+  const applied = applyTaskSettle({
+    invocation: invocation("settle/apply/released"),
+    task: TASK,
+    reason: "operator repair",
+  });
+  assert.equal(applied.settled, true);
+  assert.equal(readTaskAttempt(attemptId)?.state, "settled");
+  assert.deepEqual(
+    row(`
+      SELECT recovery_worker_id AS worker, recovery_milestone_lease_token AS token
+      FROM workflow_execution_attempts WHERE attempt_id = '${attemptId}'
+    `),
+    { worker: "worker-1", token: 8 },
+  );
+  assert.equal(row("SELECT status FROM milestone_leases WHERE milestone_id = 'M001'").status, "released");
+  assert.throws(
+    () => resolveTaskCompletionAuthority(TASK, "completion/no-running"),
+    /no running Attempt.*\/gsd auto/s,
+  );
+});
+
+test("apply reclaims a released lease and interrupts its orphaned Attempt (#1907)", () => {
   const { attemptId, dispatchId } = seedRunningAttempt();
   orphanClaimedAttempt(dispatchId);
   db().exec("UPDATE milestone_leases SET status = 'released' WHERE milestone_id = 'M001'");
 
   const plan = planTaskSettle(TASK, "operator repair");
   assert.equal(plan.rows[0].leaseHeld, false);
-  assert.match(plan.rows[0].rationale, /no longer held/);
+  assert.match(plan.rows[0].rationale, /orphaned.*apply will reclaim/i);
 
+  const applied = applyTaskSettle({
+    invocation: invocation("settle/apply/released"),
+    task: TASK,
+    reason: "operator repair",
+  });
+  assert.equal(applied.settled, true);
+  assert.equal(readTaskAttempt(attemptId)?.state, "settled");
+  assert.equal(row("SELECT status FROM milestone_leases WHERE milestone_id = 'M001'").status, "released");
+});
+
+test("apply refuses an expired lease while its original worker is live (#1907)", () => {
+  const { attemptId, dispatchId } = seedRunningAttempt();
+  orphanClaimedAttempt(dispatchId);
+  db().prepare(`
+    UPDATE workers
+    SET host = :host, pid = :pid, last_heartbeat_at = :heartbeat
+    WHERE worker_id = 'worker-1'
+  `).run({
+    ":host": hostname(),
+    ":pid": process.pid,
+    ":heartbeat": new Date().toISOString(),
+  });
+  db().exec(`
+    UPDATE milestone_leases
+    SET status = 'held', expires_at = '2000-01-01T00:00:00.000Z'
+    WHERE milestone_id = 'M001'
+  `);
+
+  const plan = planTaskSettle(TASK, "operator repair");
+  assert.equal(plan.rows[0].leaseHeld, false);
+  assert.match(plan.rows[0].rationale, /apply will refuse/i);
   assert.throws(
     () => applyTaskSettle({
-      invocation: invocation("settle/apply/released"),
+      invocation: invocation("settle/apply/live-owner"),
       task: TASK,
       reason: "operator repair",
     }),
-    /no longer held.*not authorized|replacement-lease/s,
+    /live worker or replacement lease.*\/gsd auto/s,
+  );
+  assert.equal(readTaskAttempt(attemptId)?.state, "running");
+});
+
+test("apply refuses to steal a live replacement lease (#1907)", () => {
+  const { attemptId, dispatchId } = seedRunningAttempt();
+  orphanClaimedAttempt(dispatchId);
+  db().exec(`
+    INSERT INTO workers (
+      worker_id, host, pid, started_at, version, last_heartbeat_at, status,
+      project_root_realpath
+    ) VALUES (
+      'worker-2', 'test-host', 2, '2026-07-13T00:05:00.000Z', 'test',
+      '2099-07-13T00:05:00.000Z', 'active', '/tmp/project'
+    );
+    UPDATE milestone_leases
+    SET worker_id = 'worker-2', fencing_token = 8, status = 'held',
+        expires_at = '2099-07-13T00:06:00.000Z'
+    WHERE milestone_id = 'M001';
+  `);
+
+  const plan = planTaskSettle(TASK, "operator repair");
+  assert.equal(plan.rows[0].leaseHeld, false);
+  assert.match(plan.rows[0].rationale, /apply will refuse/i);
+
+  assert.throws(
+    () => applyTaskSettle({
+      invocation: invocation("settle/apply/live-replacement"),
+      task: TASK,
+      reason: "operator repair",
+    }),
+    /live worker or replacement lease.*\/gsd auto/s,
   );
   assert.equal(
     readTaskAttempt(attemptId)?.state,
     "running",
-    "the refused apply leaves the Attempt untouched",
+    "the live peer's Attempt remains untouched",
   );
 });
 


### PR DESCRIPTION
## Summary
- Fixed orphaned task recovery and durable closeout resumption, with affected tests passing before the final dependency-blocked rerun.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1907
- [#1907 [Bug]: provider usage_limit_reached during execute-task closeout strands a running Attempt with a dead lease; no in-context recovery can complete or settle it](https://github.com/open-gsd/gsd-pi/issues/1907)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1907-bug-provider-usage-limit-reached-during--1787318705`