### PR TITLE
fix(issue): [Bug]: validate-milestone recovery tells validator to write VALIDATION.md instead of calling gsd_validate_milestone

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -325,7 +325,7 @@ export function diagnoseExpectedArtifact(
     case "run-uat":
       return `${relSliceFile(base, mid, sid!, "ASSESSMENT")} (UAT assessment result)`;
     case "validate-milestone":
-      return `${relMilestoneFile(base, mid, "VALIDATION")} (milestone validation report)`;
+      return `a canonical validation result persisted via gsd_validate_milestone (projected to ${relMilestoneFile(base, mid, "VALIDATION")})`;
     case "complete-milestone":
       return `${relMilestoneFile(base, mid, "SUMMARY")} (milestone summary)`;
     default:

--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -237,26 +237,36 @@ export async function recoverTimedOutUnit(
       harnessAbort: undefined,
     });
 
-    const steeringLines = isEscalation
+    const steeringLines = unitType === "validate-milestone"
       ? [
-          `**FINAL ${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — last chance before skip.**`,
-          `You are still executing ${unitType} ${unitId}.`,
-          `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts} — next failure skips this unit.`,
-          `Expected durable output: ${expected}.`,
-          "You MUST write the artifact file NOW, even if incomplete.",
-          "Write whatever you have — partial research, preliminary findings, best-effort analysis.",
-          "A partial artifact is infinitely better than no artifact.",
-          "If you are truly blocked, write the file with a BLOCKER section explaining why.",
-        ]
-      : [
-          `**${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — stay in auto-mode.**`,
+          `**${isEscalation ? "FINAL " : ""}${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — persist the canonical validation now.**`,
           `You are still executing ${unitType} ${unitId}.`,
           `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
-          `Expected durable output: ${expected}.`,
-          "Stop broad exploration.",
-          "Write the required artifact now.",
-          "If blocked, write the partial artifact and explicitly record the blocker instead of going silent.",
-        ];
+          "Finish reviewer aggregation and synthesize the verdict from the reviewers' findings.",
+          "Call `gsd_validate_milestone` with the complete validation result.",
+          "Do not manually write VALIDATION.md; it is a projection rendered by the canonical persistence operation.",
+          "If canonical persistence cannot be completed, stop and leave the unit fail-closed.",
+        ]
+      : isEscalation
+        ? [
+            `**FINAL ${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — last chance before skip.**`,
+            `You are still executing ${unitType} ${unitId}.`,
+            `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts} — next failure skips this unit.`,
+            `Expected durable output: ${expected}.`,
+            "You MUST write the artifact file NOW, even if incomplete.",
+            "Write whatever you have — partial research, preliminary findings, best-effort analysis.",
+            "A partial artifact is infinitely better than no artifact.",
+            "If you are truly blocked, write the file with a BLOCKER section explaining why.",
+          ]
+        : [
+            `**${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — stay in auto-mode.**`,
+            `You are still executing ${unitType} ${unitId}.`,
+            `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
+            `Expected durable output: ${expected}.`,
+            "Stop broad exploration.",
+            "Write the required artifact now.",
+            "If blocked, write the partial artifact and explicitly record the blocker instead of going silent.",
+          ];
 
     const recoveryTrigger = getInFlightToolCount() === 0;
     if (recoveryTrigger) {
@@ -270,8 +280,11 @@ export async function recoverTimedOutUnit(
       },
       { triggerTurn: recoveryTrigger, deliverAs: "steer" },
     );
+    const recoveryTarget = unitType === "validate-milestone"
+      ? "finish reviewer aggregation and call gsd_validate_milestone"
+      : `produce ${expected}`;
     ctx.ui.notify(
-      `${reason === "idle" ? "Idle" : "Timeout"} recovery: steering ${unitType} ${unitId} to produce ${expected} (attempt ${attemptNumber}, session ${recoveryAttempts + 1}/${maxRecoveryAttempts}).`,
+      `${reason === "idle" ? "Idle" : "Timeout"} recovery: steering ${unitType} ${unitId} to ${recoveryTarget} (attempt ${attemptNumber}, session ${recoveryAttempts + 1}/${maxRecoveryAttempts}).`,
       "warning",
     );
     return "recovered";

--- a/src/resources/extensions/gsd/tests/validate-milestone-timeout-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-timeout-recovery.test.ts
@@ -1,0 +1,72 @@
+// Project/App: gsd-pi
+// File Purpose: Regression coverage for validate-milestone timeout recovery steering (#1919).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { diagnoseExpectedArtifact } from "../auto-recovery.ts";
+import { recoverTimedOutUnit, type RecoveryContext } from "../auto-timeout-recovery.ts";
+
+function recoveryContext(base: string, startedAt: number): RecoveryContext {
+  return {
+    basePath: base,
+    verbose: false,
+    currentUnitStartedAt: startedAt,
+    unitRecoveryCount: new Map(),
+  };
+}
+
+function recordingHarness() {
+  const messages: Array<{ content?: string }> = [];
+  const notifications: string[] = [];
+  return {
+    ctx: { ui: { notify: (message: string) => notifications.push(message) } } as any,
+    pi: { sendMessage: (message: { content?: string }) => messages.push(message) } as any,
+    messages,
+    notifications,
+  };
+}
+
+test("validate-milestone expected artifact describes canonical persistence, not a hand-written file", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-validate-timeout-recovery-"));
+  try {
+    const expected = diagnoseExpectedArtifact("validate-milestone", "M001", base) ?? "";
+    assert.match(expected, /gsd_validate_milestone/);
+    assert.match(expected, /projected to .*VALIDATION\.md/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("validate-milestone recovery steers to gsd_validate_milestone instead of writing VALIDATION.md", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-validate-timeout-recovery-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  try {
+    const harness = recordingHarness();
+    const result = await recoverTimedOutUnit(
+      harness.ctx,
+      harness.pi,
+      "validate-milestone",
+      "M001",
+      "idle",
+      recoveryContext(base, Date.now()),
+    );
+
+    assert.equal(result, "recovered");
+    assert.equal(harness.messages.length, 1);
+    const steering = harness.messages[0].content ?? "";
+    assert.match(steering, /finish reviewer aggregation/i);
+    assert.match(steering, /call `gsd_validate_milestone`/i);
+    assert.match(steering, /do not manually write VALIDATION\.md/i);
+    assert.doesNotMatch(steering, /write the (?:required )?artifact/i);
+    assert.ok(
+      harness.notifications.every((message) => !/produce .*VALIDATION\.md/i.test(message)),
+      "recovery notification must not direct validation toward the projected artifact",
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Fixed validate-milestone recovery to require canonical persistence and added regression coverage; static checks passed while test execution was dependency-blocked.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1919
- [#1919 [Bug]: validate-milestone recovery tells validator to write VALIDATION.md instead of calling gsd_validate_milestone](https://github.com/open-gsd/gsd-pi/issues/1919)

## User
- @FrancioG

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1919-bug-validate-milestone-recovery-tells-va-1787326748`