### PR TITLE
fix(issue): Add a bounded selective route to discard orphaned milestone reservations (headless + slash)

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -119,6 +119,7 @@ After writing the file, GSD attempts to open it in a browser using the local pla
 | `/gsd reset-slice` | Reopen the full terminal slice and every terminal task in one guarded database operation, preserve prior execution history, then refresh readable status |
 | `/gsd park` | Park a milestone — skip without deleting |
 | `/gsd unpark` | Reactivate a parked milestone |
+| `/gsd discard <milestone-id>` | Confirm and permanently discard one milestone without entering the smart-entry flow |
 | `/gsd rethink` | Conversational project reorganization — reorder, park, discard unadopted work, or add milestones |
 | Discard milestone | Available via `/gsd` wizard → "Milestone actions" → "Discard"; milestones with adopted canonical lifecycle history must be parked instead |
 
@@ -474,6 +475,17 @@ echo "Build a CLI tool" | gsd headless new-milestone --context -
 In JSON output summaries, headless can also return `status: "no-work-deterministic"` for repeatable no-progress tails (for example select → input → cancelled). This status exits with code `1` and suppresses automatic restart loops.
 
 Any `/gsd` subcommand works as a positional argument — `gsd headless status`, `gsd headless doctor`, `gsd headless dispatch execute`, etc.
+
+### `gsd headless discard-milestone`
+
+Deletes one or more DB-only orphan milestone reservations without starting an RPC session or running projection reconciliation. The mandatory `--orphan-only` guard preflights the complete set and refuses if any target has hierarchy or artifact rows, planning content, a disk projection, queue/dependency references, a worktree or milestone branch, or an active lease/dispatch/worker. No target is deleted unless every target passes; successful deletion occurs in one transaction.
+
+```bash
+gsd headless discard-milestone M015 --orphan-only
+gsd headless discard-milestone M015 M016 --orphan-only
+```
+
+The command always writes one structured JSON object with `before` and `after` snapshots. Exit `0` means every requested row was removed and the canonical post-delete query found none; exit `1` is a refusal or error.
 
 ### `gsd headless recover`
 

--- a/src/headless-discard-milestone.ts
+++ b/src/headless-discard-milestone.ts
@@ -1,0 +1,121 @@
+/**
+ * Headless orphan milestone discard — `gsd headless discard-milestone`.
+ *
+ * This path opens only the existing canonical database and invokes the
+ * selective orphan preflight directly. It deliberately does not start an RPC
+ * session or run extension bootstrap/reconciliation.
+ */
+
+import { createJiti } from '@mariozechner/jiti'
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
+import { resolveGsdAgentExtensionsDir, shouldUseAgentExtensionsDir } from './headless-query.js'
+
+const jiti = createJiti(fileURLToPath(import.meta.url), { interopDefault: true, debug: false })
+const agentExtensionsDir = resolveGsdAgentExtensionsDir()
+const { useAgentDir } = shouldUseAgentExtensionsDir({ env: process.env })
+
+function extensionModule(...segments: string[]): string {
+  if (!useAgentDir) return resolveBundledGsdExtensionModule(import.meta.url, segments.join('/'))
+  const requested = join(agentExtensionsDir, ...segments)
+  if (existsSync(requested)) return requested
+  const jsPath = requested.replace(/\.ts$/, '.js')
+  return existsSync(jsPath) ? jsPath : requested
+}
+
+interface DiscardOutput {
+  ok: boolean
+  command: 'discard-milestone'
+  orphanOnly: true
+  before: unknown[]
+  after: unknown[]
+  errors?: string[]
+}
+
+interface DiscardModules {
+  openExistingWorkflowDatabase(basePath: string): { ok: boolean; reason: string; error?: Error }
+  closeWorkflowDatabase(): void
+  discardOrphanMilestoneReservations(basePath: string, ids: readonly string[]): DiscardOutput
+}
+
+async function loadModules(): Promise<DiscardModules> {
+  const workspace = await jiti.import(extensionModule('db-workspace.ts'), {}) as any
+  const discard = await jiti.import(extensionModule('orphan-milestone-discard.ts'), {}) as any
+  return {
+    openExistingWorkflowDatabase: workspace.openExistingWorkflowDatabase,
+    closeWorkflowDatabase: workspace.closeWorkflowDatabase,
+    discardOrphanMilestoneReservations: discard.discardOrphanMilestoneReservations,
+  }
+}
+
+export interface HeadlessDiscardResult {
+  exitCode: number
+  output: DiscardOutput
+}
+
+function refusal(errors: string[]): HeadlessDiscardResult {
+  return {
+    exitCode: 1,
+    output: { ok: false, command: 'discard-milestone', orphanOnly: true, before: [], after: [], errors },
+  }
+}
+
+export function parseDiscardMilestoneArgs(args: readonly string[]): { ids: string[]; errors: string[] } {
+  const errors: string[] = []
+  const orphanOnlyCount = args.filter((arg) => arg === '--orphan-only').length
+  if (orphanOnlyCount !== 1) errors.push('exactly one --orphan-only flag is required')
+  const unknownFlags = args.filter((arg) => arg.startsWith('--') && arg !== '--orphan-only')
+  if (unknownFlags.length > 0) errors.push(`unknown flags: ${unknownFlags.join(', ')}`)
+  const ids = args.filter((arg) => !arg.startsWith('--'))
+  if (ids.length === 0) errors.push('at least one milestone ID is required')
+  return { ids, errors }
+}
+
+export async function runHeadlessDiscardMilestone(
+  basePath: string,
+  args: readonly string[],
+  modules: DiscardModules,
+): Promise<HeadlessDiscardResult> {
+  const parsed = parseDiscardMilestoneArgs(args)
+  if (parsed.errors.length > 0) return refusal(parsed.errors)
+
+  let opened = false
+  try {
+    const openResult = modules.openExistingWorkflowDatabase(basePath)
+    if (!openResult.ok) {
+      return refusal([
+        openResult.reason === 'schema-too-new' && openResult.error
+          ? openResult.error.message
+          : `canonical database unavailable: ${openResult.reason}`,
+      ])
+    }
+    opened = true
+    const output = modules.discardOrphanMilestoneReservations(basePath, parsed.ids)
+    return { exitCode: output.ok ? 0 : 1, output }
+  } catch (error) {
+    return refusal([error instanceof Error ? error.message : String(error)])
+  } finally {
+    if (opened) {
+      try {
+        modules.closeWorkflowDatabase()
+      } catch {
+        // The operation result is authoritative; a close failure must not
+        // replace a committed deletion and its before/after snapshots.
+      }
+    }
+  }
+}
+
+export async function handleDiscardMilestone(basePath: string, args: readonly string[]): Promise<HeadlessDiscardResult> {
+  let result: HeadlessDiscardResult
+  try {
+    result = await runHeadlessDiscardMilestone(basePath, args, await loadModules())
+  } catch (error) {
+    result = refusal([`failed to load discard modules: ${error instanceof Error ? error.message : String(error)}`])
+  }
+  process.stdout.write(`${JSON.stringify(result.output)}\n`)
+  return result
+}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -410,6 +410,14 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     }
   }
 
+  // Selective DB-only orphan cleanup: direct one-shot path with no RPC child,
+  // extension bootstrap, or projection reconciliation.
+  if (options.command === 'discard-milestone') {
+    const { handleDiscardMilestone } = await import('./headless-discard-milestone.js')
+    const result = await handleDiscardMilestone(process.cwd(), options.commandArgs)
+    process.exit(result.exitCode)
+  }
+
   // Recover: apply a verified legacy import and assess or execute its recovery
   // action, with no RPC child needed. This is the one mutating headless
   // subcommand, for CI and automation without an interactive TTY-bound runtime.

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -17,7 +17,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|rebuild|db|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|usage|context|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
+  "GSD — Git Ship Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|report|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|closeout|rebuild|db|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|memory|new-milestone|new-project|parallel|cmux|park|unpark|discard|init|setup|onboarding|inspect|extensions|update|upgrade|fast|mcp|rethink|workflow|codebase|notifications|ship|do|usage|context|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -80,6 +80,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "cmux", desc: "Manage cmux integration (status, sidebar, notifications, splits)" },
   { cmd: "park", desc: "Park a milestone — skip without deleting" },
   { cmd: "unpark", desc: "Reactivate a parked milestone" },
+  { cmd: "discard", desc: "Permanently discard one milestone (with confirmation)" },
   { cmd: "update", desc: "Update GSD to the latest version" },
   { cmd: "upgrade", desc: "Alias for update; installs the latest @opengsd package" },
   { cmd: "start", desc: "Start a workflow template (bugfix, spike, feature, etc.)" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -117,6 +117,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd rethink        Conversational project reorganization — reorder, park, discard, add milestones",
     "  /gsd park [id]      Park a milestone — skip without deleting  [reason]",
     "  /gsd unpark [id]    Reactivate a parked milestone",
+    "  /gsd discard <id>   Permanently discard one milestone (with confirmation)",
     "",
     "PROJECT KNOWLEDGE",
     "  /gsd knowledge <type> <text>   Add a rule to KNOWLEDGE.md or capture a pattern/lesson to memories",

--- a/src/resources/extensions/gsd/commands/handlers/workflow.ts
+++ b/src/resources/extensions/gsd/commands/handlers/workflow.ts
@@ -9,7 +9,7 @@ import { showDiscuss, showHeadlessMilestoneCreation, showQueue } from "../../gui
 import { handleStart, handleTemplates, dispatchMarkdownPhasePlugin } from "../../commands-workflow-templates.js";
 import { gsdRoot } from "../../paths.js";
 import { deriveState } from "../../state.js";
-import { isParked, parkMilestone, unparkMilestone } from "../../milestone-actions.js";
+import { discardMilestone, isParked, parkMilestone, unparkMilestone } from "../../milestone-actions.js";
 import { loadEffectiveGSDPreferences } from "../../preferences.js";
 import { setPlanningDepth } from "../../planning-depth.js";
 import { nextMilestoneId, normalizeDiscussTarget } from "../../milestone-ids.js";
@@ -32,6 +32,7 @@ import {
   type WorkflowPlugin,
 } from "../../workflow-plugins.js";
 import { dispatchOneshot } from "../../workflow-dispatch.js";
+import { showConfirm } from "../../../shared/tui.js";
 import {
   fetchWorkflowSource,
   globalInstallDir,
@@ -677,6 +678,31 @@ export async function handleWorkflowCommand(trimmed: string, ctx: ExtensionComma
     const success = unparkMilestone(basePath, targetId);
     ctx.ui.notify(
       success ? `Unparked ${targetId}. It will resume its normal position in the queue.` : `Could not unpark ${targetId} — milestone not found or not parked.`,
+      success ? "info" : "warning",
+    );
+    return true;
+  }
+  if (trimmed === "discard" || trimmed.startsWith("discard ")) {
+    if (requireNotAutoActive("/gsd discard", ctx)) return true;
+    const args = trimmed.replace(/^discard\s*/, "").trim().split(/\s+/).filter(Boolean);
+    if (args.length !== 1) {
+      ctx.ui.notify("Usage: /gsd discard <milestone-id>", "warning");
+      return true;
+    }
+    const targetId = args[0]!;
+    const confirmed = await showConfirm(ctx, {
+      title: "Discard milestone?",
+      message: `This will permanently delete ${targetId} and all its contents.`,
+      confirmLabel: "Discard",
+      declineLabel: "Cancel",
+    });
+    if (!confirmed) {
+      ctx.ui.notify(`Discard of ${targetId} cancelled.`, "info");
+      return true;
+    }
+    const success = discardMilestone(projectRoot(), targetId);
+    ctx.ui.notify(
+      success ? `Discarded ${targetId}.` : `Could not discard ${targetId} — milestone not found.`,
       success ? "info" : "warning",
     );
     return true;

--- a/src/resources/extensions/gsd/db/writers/orphan-milestone-discard.ts
+++ b/src/resources/extensions/gsd/db/writers/orphan-milestone-discard.ts
@@ -1,0 +1,197 @@
+// Project/App: gsd-pi
+// File Purpose: Atomic fail-closed deletion of DB-only milestone reservations.
+
+import { getDbOrNull, immediateTransaction, readTransaction } from "../engine.js";
+import { GSDError, GSD_STALE_STATE } from "../../errors.js";
+
+export interface OrphanMilestoneDbSnapshot {
+  id: string;
+  dbRow: boolean;
+  status?: string;
+  planningFields: string[];
+  relatedRows: Record<string, number>;
+  dependentMilestones: string[];
+}
+
+export type OrphanMilestoneDbDiscardResult =
+  | { ok: true; before: OrphanMilestoneDbSnapshot[]; after: OrphanMilestoneDbSnapshot[] }
+  | { ok: false; before: OrphanMilestoneDbSnapshot[]; after: OrphanMilestoneDbSnapshot[]; errors: string[] };
+
+const CONTENT_COLUMNS = [
+  "vision",
+  "success_criteria",
+  "key_risks",
+  "proof_strategy",
+  "verification_contract",
+  "verification_integration",
+  "verification_operational",
+  "verification_uat",
+  "definition_of_done",
+  "requirement_coverage",
+  "boundary_map_markdown",
+] as const;
+
+const AUXILIARY_ACTIVE_SURFACES = [
+  {
+    table: "milestone_leases",
+    where: `milestone_id = :id AND (
+      datetime(expires_at) IS NULL
+      OR status NOT IN ('held', 'expired', 'released')
+      OR (status = 'held' AND datetime(expires_at) >= datetime('now'))
+    )`,
+  },
+  { table: "runtime_kv", where: "scope = 'milestone' AND scope_id = :id" },
+  { table: "cancellation_requests", where: "scope = 'milestone' AND scope_id = :id AND status NOT IN ('acked', 'completed', 'cancelled')" },
+  { table: "liveness_block_signatures", where: "unit_id = :id" },
+  { table: "liveness_wedge_records", where: "unit_id = :id AND acknowledged_at IS NULL" },
+  { table: "turn_git_transactions", where: "unit_id = :id AND status NOT IN ('complete', 'completed', 'cancelled')" },
+  {
+    table: "command_queue",
+    where: "completed_at IS NULL AND json_valid(args_json) AND EXISTS (SELECT 1 FROM json_tree(args_json) WHERE value = :id)",
+  },
+] as const;
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function hasContent(value: unknown): boolean {
+  if (value === null || value === undefined || value === "") return false;
+  if (typeof value !== "string") return true;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return Array.isArray(parsed) ? parsed.length > 0 : parsed !== null;
+  } catch {
+    return true;
+  }
+}
+
+function tablesWithMilestoneId(): string[] {
+  const db = getDbOrNull()!;
+  return db.prepare(
+    `SELECT schema_table.name AS name
+       FROM sqlite_schema AS schema_table
+      WHERE schema_table.type = 'table'
+        AND schema_table.name NOT LIKE 'sqlite_%'
+        AND schema_table.name != 'milestones'
+        AND schema_table.name != 'milestone_leases'
+        AND EXISTS (
+          SELECT 1 FROM pragma_table_info(schema_table.name) AS column_info
+           WHERE column_info.name = 'milestone_id'
+        )
+      ORDER BY schema_table.name`,
+  ).all().map((row) => String(row["name"]));
+}
+
+function inspect(ids: readonly string[]): OrphanMilestoneDbSnapshot[] {
+  const db = getDbOrNull()!;
+  const tables = tablesWithMilestoneId();
+  const allMilestones = db.prepare("SELECT id, depends_on FROM milestones ORDER BY id").all();
+  const malformedPendingCommands = Number(db.prepare(
+    `SELECT COUNT(*) AS count
+       FROM command_queue
+      WHERE completed_at IS NULL
+        AND CASE
+          WHEN json_valid(args_json) THEN json_type(args_json) != 'object'
+          ELSE 1
+        END`,
+  ).get()?.["count"] ?? 0);
+
+  return ids.map((id) => {
+    const row = db.prepare("SELECT * FROM milestones WHERE id = :id").get({ ":id": id });
+    const planningFields: string[] = row
+      ? CONTENT_COLUMNS.filter((column) => hasContent(row[column]))
+      : [];
+    if (row && Number(row["sequence"] ?? 0) !== 0) planningFields.push("sequence");
+    const relatedRows: Record<string, number> = {};
+    if (malformedPendingCommands > 0) relatedRows.command_queue_malformed = malformedPendingCommands;
+    for (const table of tables) {
+      const countRow = db.prepare(
+        `SELECT COUNT(*) AS count FROM ${quoteIdentifier(table)} WHERE milestone_id = :id`,
+      ).get({ ":id": id });
+      const count = Number(countRow?.["count"] ?? 0);
+      if (count > 0) relatedRows[table] = count;
+    }
+    for (const surface of AUXILIARY_ACTIVE_SURFACES) {
+      const count = Number(db.prepare(
+        `SELECT COUNT(*) AS count FROM ${surface.table} WHERE ${surface.where}`,
+      ).get({ ":id": id })?.["count"] ?? 0);
+      if (count > 0) relatedRows[surface.table] = count;
+    }
+
+    const dependentMilestones = allMilestones.flatMap((candidate) => {
+      if (String(candidate["id"]) === id) return [];
+      try {
+        const dependencies = JSON.parse(String(candidate["depends_on"] || "[]")) as unknown;
+        return Array.isArray(dependencies) && dependencies.includes(id) ? [String(candidate["id"])] : [];
+      } catch {
+        return [String(candidate["id"])];
+      }
+    });
+
+    return {
+      id,
+      dbRow: row !== undefined,
+      ...(row ? { status: String(row["status"] ?? "") } : {}),
+      planningFields,
+      relatedRows,
+      dependentMilestones,
+    };
+  });
+}
+
+function refusalErrors(snapshots: readonly OrphanMilestoneDbSnapshot[], targetIds: ReadonlySet<string>): string[] {
+  const errors: string[] = [];
+  for (const snapshot of snapshots) {
+    if (!snapshot.dbRow) {
+      errors.push(`${snapshot.id}: milestone DB row does not exist`);
+      continue;
+    }
+    if (snapshot.planningFields.length > 0) {
+      errors.push(`${snapshot.id}: planning content exists in ${snapshot.planningFields.join(", ")}`);
+    }
+    for (const [table, count] of Object.entries(snapshot.relatedRows)) {
+      errors.push(`${snapshot.id}: ${table} contains ${count} related row${count === 1 ? "" : "s"}`);
+    }
+    for (const dependent of snapshot.dependentMilestones) {
+      if (!targetIds.has(dependent)) errors.push(`${dependent} depends on ${snapshot.id}`);
+    }
+  }
+  return errors;
+}
+
+export function preflightOrphanMilestoneRows(ids: readonly string[]): {
+  before: OrphanMilestoneDbSnapshot[];
+  errors: string[];
+} {
+  if (!getDbOrNull()) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  return readTransaction(() => {
+    const before = inspect(ids);
+    return { before, errors: refusalErrors(before, new Set(ids)) };
+  });
+}
+
+/**
+ * Preflight every ID against the same reserved-writer snapshot, then delete the
+ * complete set in one transaction. Expected refusals return without mutation;
+ * unexpected SQL or verification failures throw and roll back.
+ */
+export function discardOrphanMilestoneRows(ids: readonly string[]): OrphanMilestoneDbDiscardResult {
+  if (!getDbOrNull()) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  return immediateTransaction(() => {
+    const before = inspect(ids);
+    const errors = refusalErrors(before, new Set(ids));
+    if (errors.length > 0) return { ok: false, before, after: before, errors };
+
+    const placeholders = ids.map(() => "?").join(",");
+    getDbOrNull()!.prepare(`DELETE FROM milestone_leases WHERE milestone_id IN (${placeholders})`).run(...ids);
+    getDbOrNull()!.prepare(`DELETE FROM milestones WHERE id IN (${placeholders})`).run(...ids);
+    const after = inspect(ids);
+    if (after.some((snapshot) => snapshot.dbRow)) {
+      throw new GSDError(GSD_STALE_STATE, "orphan milestone discard verification failed; transaction rolled back");
+    }
+    return { ok: true, before, after };
+  });
+}

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -61,6 +61,7 @@ export * from "./db/writers/import-restore.js";
 export * from "./db/writers/lifecycle-commands.js";
 export * from "./db/writers/projection-kind-remediation.js";
 export * from "./db/writers/liveness-backstop.js";
+export * from "./db/writers/orphan-milestone-discard.js";
 export { executeDomainOperation } from "./db/domain-operation.js";
 export type {
   DomainJsonValue,

--- a/src/resources/extensions/gsd/orphan-milestone-discard.ts
+++ b/src/resources/extensions/gsd/orphan-milestone-discard.ts
@@ -1,0 +1,265 @@
+// Project/App: gsd-pi
+// File Purpose: Bounded filesystem/Git/DB preflight for orphan milestone discard.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import { invalidateAllCaches } from "./cache.js";
+import {
+  discardOrphanMilestoneRows,
+  preflightOrphanMilestoneRows,
+  type OrphanMilestoneDbSnapshot,
+} from "./db/writers/orphan-milestone-discard.js";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
+import { MILESTONE_ID_RE } from "./milestone-ids.js";
+import { gsdRoot, milestoneDirExists } from "./paths.js";
+import { isSessionStale, type SessionStatus } from "./session-status-io.js";
+import { worktreesDirs } from "./worktree-placement.js";
+import { resolveWorktreeProjectRoot } from "./worktree-root.js";
+
+export interface OrphanMilestoneSnapshot extends OrphanMilestoneDbSnapshot {
+  diskProjection: boolean | null;
+  worktrees: string[] | null;
+  milestoneBranch: boolean | null;
+  queueOrderReference: boolean | null;
+  activeWorkers: Array<{ pid: number; state: string }> | null;
+  inspectionErrors: string[];
+  orphan: boolean;
+}
+
+export type OrphanMilestoneDiscardResult =
+  | { ok: true; command: "discard-milestone"; orphanOnly: true; before: OrphanMilestoneSnapshot[]; after: OrphanMilestoneSnapshot[] }
+  | { ok: false; command: "discard-milestone"; orphanOnly: true; before: OrphanMilestoneSnapshot[]; after: OrphanMilestoneSnapshot[]; errors: string[] };
+
+interface ExternalState {
+  worktrees: Array<{ path: string; branch: string }>;
+  branches: string[];
+  queueOrder: string[];
+  workerStatuses: SessionStatus[];
+  physicalWorktrees: Map<string, string[]>;
+}
+
+function gitOutput(basePath: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: basePath,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+    env: GIT_NO_PROMPT_ENV,
+  }).trim();
+}
+
+function loadQueueOrderStrict(basePath: string): string[] {
+  const path = join(gsdRoot(basePath), "QUEUE-ORDER.json");
+  if (!existsSync(path)) return [];
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (!parsed || typeof parsed !== "object" || !("order" in parsed)
+    || !Array.isArray(parsed.order) || !parsed.order.every((id) => typeof id === "string")) {
+    throw new Error("QUEUE-ORDER.json is malformed");
+  }
+  return parsed.order;
+}
+
+function isSessionStatus(value: unknown): value is SessionStatus {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<SessionStatus>;
+  const currentUnitValid = candidate.currentUnit === null || (
+    !!candidate.currentUnit
+    && typeof candidate.currentUnit.type === "string"
+    && typeof candidate.currentUnit.id === "string"
+    && typeof candidate.currentUnit.startedAt === "number"
+  );
+  return typeof candidate.milestoneId === "string"
+    && typeof candidate.pid === "number"
+    && ["running", "paused", "stopped", "error"].includes(String(candidate.state))
+    && currentUnitValid
+    && typeof candidate.completedUnits === "number"
+    && typeof candidate.cost === "number"
+    && typeof candidate.lastHeartbeat === "number"
+    && typeof candidate.startedAt === "number"
+    && typeof candidate.worktreePath === "string";
+}
+
+function loadWorkerStatusesStrict(basePath: string): SessionStatus[] {
+  const dir = join(gsdRoot(basePath), "parallel");
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((entry) => entry.endsWith(".status.json")).map((entry) => {
+    const parsed = JSON.parse(readFileSync(join(dir, entry), "utf8")) as unknown;
+    if (!isSessionStatus(parsed)) throw new Error(`${entry} is malformed`);
+    const fileMilestoneId = entry.slice(0, -".status.json".length);
+    if (parsed.milestoneId !== fileMilestoneId) throw new Error(`${entry} has a mismatched milestone ID`);
+    return parsed;
+  });
+}
+
+function inspectExternalState(basePath: string, ids: readonly string[]): ExternalState {
+  const worktreeOutput = gitOutput(basePath, ["worktree", "list", "--porcelain"]);
+  const worktrees = worktreeOutput.split("\n\n").filter(Boolean).map((block) => {
+    const lines = block.split("\n");
+    const path = lines.find((line) => line.startsWith("worktree "))?.slice("worktree ".length);
+    if (!path) throw new Error("git worktree output is malformed");
+    const branch = lines.find((line) => line.startsWith("branch refs/heads/"))
+      ?.slice("branch refs/heads/".length) ?? "";
+    return { path, branch };
+  });
+  const branches = gitOutput(basePath, ["branch", "--format=%(refname:short)", "--list"])
+    .split("\n").filter(Boolean);
+  const physicalWorktrees = new Map<string, string[]>();
+  const containers = worktreesDirs(basePath);
+  for (const id of ids) {
+    const paths: string[] = [];
+    for (const container of containers) {
+      const candidate = join(container, id);
+      try {
+        lstatSync(candidate);
+        paths.push(candidate);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    }
+    physicalWorktrees.set(id, paths);
+  }
+  return {
+    worktrees,
+    branches,
+    queueOrder: loadQueueOrderStrict(basePath),
+    workerStatuses: loadWorkerStatusesStrict(basePath),
+    physicalWorktrees,
+  };
+}
+
+function addExternalState(
+  basePath: string,
+  snapshots: readonly OrphanMilestoneDbSnapshot[],
+  targetIds: ReadonlySet<string>,
+  externalState: ExternalState | null,
+  inspectionErrors: string[] = [],
+): OrphanMilestoneSnapshot[] {
+  return snapshots.map((snapshot) => {
+    const branch = `milestone/${snapshot.id}`;
+    const matchingWorktrees = externalState
+      ? [...new Set([
+        ...externalState.worktrees
+          .filter((worktree) => worktree.branch === branch || basename(worktree.path) === snapshot.id)
+          .map((worktree) => worktree.path),
+        ...(externalState.physicalWorktrees.get(snapshot.id) ?? []),
+      ])]
+      : null;
+    const diskProjection = inspectionErrors.length === 0 ? milestoneDirExists(basePath, snapshot.id) : null;
+    const milestoneBranch = externalState?.branches.includes(branch) ?? null;
+    const queueOrderReference = externalState?.queueOrder.includes(snapshot.id) ?? null;
+    const activeWorkers = externalState?.workerStatuses
+      .filter((status) => status.milestoneId === snapshot.id
+        && (status.state === "running" || status.state === "paused")
+        && !isSessionStale(status))
+      .map((status) => ({ pid: status.pid, state: status.state })) ?? null;
+    const orphan = snapshot.dbRow
+      && snapshot.planningFields.length === 0
+      && Object.keys(snapshot.relatedRows).length === 0
+      && snapshot.dependentMilestones.every((dependent) => targetIds.has(dependent))
+      && diskProjection === false
+      && matchingWorktrees?.length === 0
+      && milestoneBranch === false
+      && queueOrderReference === false
+      && activeWorkers?.length === 0
+      && inspectionErrors.length === 0;
+    return {
+      ...snapshot,
+      diskProjection,
+      worktrees: matchingWorktrees,
+      milestoneBranch,
+      queueOrderReference,
+      activeWorkers,
+      inspectionErrors,
+      orphan,
+    };
+  });
+}
+
+function mergeAfterSnapshots(
+  before: readonly OrphanMilestoneSnapshot[],
+  afterDb: readonly OrphanMilestoneDbSnapshot[],
+): OrphanMilestoneSnapshot[] {
+  const beforeById = new Map(before.map((snapshot) => [snapshot.id, snapshot]));
+  return afterDb.map((snapshot) => ({
+    ...beforeById.get(snapshot.id)!,
+    ...snapshot,
+    orphan: false,
+  }));
+}
+
+export function discardOrphanMilestoneReservations(
+  basePath: string,
+  ids: readonly string[],
+): OrphanMilestoneDiscardResult {
+  const errors: string[] = [];
+  if (ids.length === 0) errors.push("at least one milestone ID is required");
+  const duplicateIds = [...new Set(ids.filter((id, index) => ids.indexOf(id) !== index))];
+  if (duplicateIds.length > 0) errors.push(`duplicate milestone IDs: ${duplicateIds.join(", ")}`);
+  const invalidIds = ids.filter((id) => !MILESTONE_ID_RE.test(id));
+  if (invalidIds.length > 0) errors.push(`invalid milestone IDs: ${invalidIds.join(", ")}`);
+  if (errors.length > 0) {
+    return { ok: false, command: "discard-milestone", orphanOnly: true, before: [], after: [], errors };
+  }
+
+  const projectRoot = resolveWorktreeProjectRoot(basePath);
+  const targetIds = new Set(ids);
+  const dbPreflight = preflightOrphanMilestoneRows(ids);
+  let externalState: ExternalState | null = null;
+  let inspectionErrors: string[] = [];
+  try {
+    externalState = inspectExternalState(projectRoot, ids);
+  } catch (error) {
+    inspectionErrors = [`external preflight failed: ${error instanceof Error ? error.message : String(error)}`];
+  }
+  const before = addExternalState(projectRoot, dbPreflight.before, targetIds, externalState, inspectionErrors);
+  const externalErrors = before.flatMap((snapshot) => [
+    ...(snapshot.diskProjection ? [`${snapshot.id}: disk projection exists`] : []),
+    ...(snapshot.worktrees && snapshot.worktrees.length > 0 ? [`${snapshot.id}: worktree exists at ${snapshot.worktrees.join(", ")}`] : []),
+    ...(snapshot.milestoneBranch ? [`${snapshot.id}: milestone branch exists`] : []),
+    ...(snapshot.queueOrderReference ? [`${snapshot.id}: queue order reference exists`] : []),
+    ...(snapshot.activeWorkers && snapshot.activeWorkers.length > 0 ? [`${snapshot.id}: active worker exists`] : []),
+  ]);
+
+  if (inspectionErrors.length > 0 || externalErrors.length > 0) {
+    return {
+      ok: false,
+      command: "discard-milestone",
+      orphanOnly: true,
+      before,
+      after: before,
+      errors: [...dbPreflight.errors, ...inspectionErrors, ...externalErrors],
+    };
+  }
+  if (dbPreflight.errors.length > 0) {
+    return {
+      ok: false,
+      command: "discard-milestone",
+      orphanOnly: true,
+      before,
+      after: before,
+      errors: dbPreflight.errors,
+    };
+  }
+
+  // Re-preflight under the reserved writer transaction immediately before the
+  // set deletion, closing the gap after the filesystem/Git checks.
+  const dbResult = discardOrphanMilestoneRows(ids);
+  if (!dbResult.ok) {
+    return {
+      ...dbResult,
+      command: "discard-milestone",
+      orphanOnly: true,
+      before: addExternalState(projectRoot, dbResult.before, targetIds, externalState),
+      after: addExternalState(projectRoot, dbResult.after, targetIds, externalState),
+    };
+  }
+  invalidateAllCaches();
+  return {
+    ok: true,
+    command: "discard-milestone",
+    orphanOnly: true,
+    before,
+    after: mergeAfterSnapshots(before, dbResult.after),
+  };
+}

--- a/src/resources/extensions/gsd/skills/gsd-headless/references/commands.md
+++ b/src/resources/extensions/gsd/skills/gsd-headless/references/commands.md
@@ -15,6 +15,7 @@ Session startup flags such as `--model ID` and `--thinking LEVEL` can be supplie
 | `new-milestone` | Create milestone from specification (requires `--context`) |
 | `dispatch <phase>` | Force-dispatch: research, plan, execute, complete, reassess, uat, replan |
 | `discuss` | Start guided milestone/slice discussion |
+| `discard-milestone <ids...> --orphan-only` | Atomically discard DB-only orphan reservations after fail-closed preflight; emits before/after JSON |
 
 ## State Inspection
 

--- a/src/resources/extensions/gsd/tests/discard-command.test.ts
+++ b/src/resources/extensions/gsd/tests/discard-command.test.ts
@@ -1,0 +1,71 @@
+// Project/App: gsd-pi
+// File Purpose: Direct confirmed /gsd discard routing contract.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { handleWorkflowCommand } from "../commands/handlers/workflow.ts";
+import { withCommandCwd } from "../commands/context.ts";
+import { closeDatabase, getMilestone, insertMilestone, openDatabase } from "../gsd-db.ts";
+
+test("/gsd discard confirms and calls the primitive directly", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-discard-command-"));
+  const notifications: string[] = [];
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd: base, stdio: "ignore" });
+  writeFileSync(join(base, "README.md"), "# Test\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "test: initialize fixture"], { cwd: base, stdio: "ignore" });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", status: "queued" });
+
+  const ctx = {
+    cwd: base,
+    hasUI: true,
+    ui: {
+      custom: async () => true,
+      notify: (message: string) => notifications.push(message),
+    },
+  };
+  const handled = await withCommandCwd(base, () => handleWorkflowCommand("discard M001", ctx as any, {} as any));
+
+  assert.equal(handled, true);
+  assert.equal(getMilestone("M001"), null);
+  assert.ok(notifications.includes("Discarded M001."));
+});
+
+test("/gsd discard leaves the milestone when confirmation is declined", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-discard-command-cancel-"));
+  const notifications: string[] = [];
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", status: "queued" });
+
+  const ctx = {
+    cwd: base,
+    hasUI: true,
+    ui: {
+      custom: async () => false,
+      notify: (message: string) => notifications.push(message),
+    },
+  };
+  const handled = await withCommandCwd(base, () => handleWorkflowCommand("discard M001", ctx as any, {} as any));
+
+  assert.equal(handled, true);
+  assert.notEqual(getMilestone("M001"), null);
+  assert.ok(notifications.includes("Discard of M001 cancelled."));
+});

--- a/src/resources/extensions/gsd/tests/orphan-milestone-discard.test.ts
+++ b/src/resources/extensions/gsd/tests/orphan-milestone-discard.test.ts
@@ -1,0 +1,193 @@
+// Project/App: gsd-pi
+// File Purpose: Contract tests for bounded, atomic orphan milestone reservation discard.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, test } from "node:test";
+
+import {
+  closeDatabase,
+  getDbOrNull,
+  getMilestone,
+  insertMilestone,
+  insertSlice,
+  openDatabase,
+} from "../gsd-db.ts";
+import { discardOrphanMilestoneReservations } from "../orphan-milestone-discard.ts";
+
+let base = "";
+
+function makeBase(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-orphan-discard-"));
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: dir, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd: dir, stdio: "ignore" });
+  writeFileSync(join(dir, "README.md"), "# Test\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: dir, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "test: initialize fixture"], { cwd: dir, stdio: "ignore" });
+  openDatabase(join(dir, ".gsd", "gsd.db"));
+  return dir;
+}
+
+afterEach(() => {
+  closeDatabase();
+  if (base) rmSync(base, { recursive: true, force: true });
+  base = "";
+});
+
+describe("discardOrphanMilestoneReservations", () => {
+  test("preflights and deletes every orphan target in one bounded operation", () => {
+    base = makeBase();
+    insertMilestone({ id: "M001", title: "M001", status: "queued" });
+    insertMilestone({ id: "M002", status: "active" });
+
+    const result = discardOrphanMilestoneReservations(base, ["M001", "M002"]);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.before.map((entry) => entry.id), ["M001", "M002"]);
+    assert.ok(result.before.every((entry) => entry.dbRow && entry.orphan));
+    assert.ok(result.after.every((entry) => !entry.dbRow));
+    assert.equal(getMilestone("M001"), null);
+    assert.equal(getMilestone("M002"), null);
+  });
+
+  test("refuses the entire set when any target owns hierarchy rows", () => {
+    base = makeBase();
+    insertMilestone({ id: "M001", status: "queued" });
+    insertMilestone({ id: "M002", status: "queued" });
+    insertSlice({ milestoneId: "M002", id: "S01", title: "Started", status: "pending" });
+
+    const result = discardOrphanMilestoneReservations(base, ["M001", "M002"]);
+
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /M002.*slices/i);
+    assert.ok(getMilestone("M001"), "the clean target must not be partially deleted");
+    assert.ok(getMilestone("M002"), "the rejected target must remain");
+  });
+
+  test("refuses dependent milestone references", () => {
+    base = makeBase();
+    insertMilestone({ id: "M001", status: "queued" });
+    insertMilestone({ id: "M002", status: "queued", depends_on: ["M001"] });
+
+    const result = discardOrphanMilestoneReservations(base, ["M001"]);
+
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /M002.*depends on M001/i);
+    assert.ok(getMilestone("M001"));
+  });
+
+  test("refuses disk projections, worktrees, and milestone branches", () => {
+    base = makeBase();
+    insertMilestone({ id: "M001", status: "queued" });
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+    mkdirSync(join(base, ".gsd-worktrees", "M001"), { recursive: true });
+    execFileSync("git", ["branch", "milestone/M001"], { cwd: base, stdio: "ignore" });
+
+    const result = discardOrphanMilestoneReservations(base, ["M001"]);
+
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /disk projection/i);
+    assert.match(result.errors.join("\n"), /worktree exists/i);
+    assert.match(result.errors.join("\n"), /milestone branch/i);
+    assert.ok(getMilestone("M001"));
+  });
+
+  test("refuses queue references and live worker status files", () => {
+    base = makeBase();
+    insertMilestone({ id: "M001", status: "queued" });
+    writeFileSync(join(base, ".gsd", "QUEUE-ORDER.json"), JSON.stringify({
+      order: ["M001"],
+      updatedAt: new Date().toISOString(),
+    }), "utf8");
+    mkdirSync(join(base, ".gsd", "parallel"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "parallel", "M001.status.json"), JSON.stringify({
+      milestoneId: "M001",
+      pid: process.pid,
+      state: "running",
+      currentUnit: null,
+      completedUnits: 0,
+      cost: 0,
+      lastHeartbeat: Date.now(),
+      startedAt: Date.now(),
+      worktreePath: "",
+    }), "utf8");
+
+    const result = discardOrphanMilestoneReservations(base, ["M001"]);
+
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /queue order reference/i);
+    assert.match(result.errors.join("\n"), /active worker/i);
+    assert.ok(getMilestone("M001"));
+  });
+
+  test("fails closed when an external state file is malformed", () => {
+    base = makeBase();
+    insertMilestone({ id: "M001", status: "queued" });
+    writeFileSync(join(base, ".gsd", "QUEUE-ORDER.json"), "not json", "utf8");
+
+    const result = discardOrphanMilestoneReservations(base, ["M001"]);
+
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /external preflight failed/i);
+    assert.ok(getMilestone("M001"));
+  });
+
+  test("fails closed when a pending command has malformed arguments", () => {
+    base = makeBase();
+    insertMilestone({ id: "M001", status: "queued" });
+    getDbOrNull()!.prepare(
+      "INSERT INTO command_queue(command, args_json, enqueued_at) VALUES ('run', 'not json', 'now')",
+    ).run();
+
+    const result = discardOrphanMilestoneReservations(base, ["M001"]);
+
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /command_queue_malformed/i);
+    assert.ok(getMilestone("M001"));
+  });
+
+  test("refuses an active lease but removes an expired lease with its reservation", () => {
+    base = makeBase();
+    insertMilestone({ id: "M001", status: "queued" });
+    const db = getDbOrNull()!;
+    db.prepare(`INSERT INTO workers (
+      worker_id, host, pid, started_at, version, last_heartbeat_at, status, project_root_realpath
+    ) VALUES ('worker-1', 'local', 1, 'now', 'test', 'now', 'active', :root)`).run({ ":root": base });
+    db.prepare(`INSERT INTO milestone_leases (
+      milestone_id, worker_id, fencing_token, acquired_at, expires_at, status
+    ) VALUES ('M001', 'worker-1', 1, 'now', '2999-01-01T00:00:00.000Z', 'held')`).run();
+
+    const held = discardOrphanMilestoneReservations(base, ["M001"]);
+    assert.equal(held.ok, false);
+    assert.match(held.errors.join("\n"), /milestone_leases/i);
+    assert.ok(getMilestone("M001"));
+
+    db.prepare("UPDATE milestone_leases SET expires_at = 'not a date'").run();
+    const malformed = discardOrphanMilestoneReservations(base, ["M001"]);
+    assert.equal(malformed.ok, false);
+    assert.match(malformed.errors.join("\n"), /milestone_leases/i);
+    assert.ok(getMilestone("M001"));
+
+    db.prepare("UPDATE milestone_leases SET status = 'expired', expires_at = '2000-01-01T00:00:00.000Z'").run();
+    const expired = discardOrphanMilestoneReservations(base, ["M001"]);
+    assert.equal(expired.ok, true);
+    assert.equal(getMilestone("M001"), null);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM milestone_leases").get()?.["count"], 0);
+  });
+
+  test("refuses missing, duplicate, and invalid IDs before mutation", () => {
+    base = makeBase();
+    insertMilestone({ id: "M001", status: "queued" });
+
+    for (const ids of [["M001", "M001"], ["M001", "not-an-id"], ["M001", "M002"]]) {
+      const result = discardOrphanMilestoneReservations(base, ids);
+      assert.equal(result.ok, false);
+      assert.ok(getMilestone("M001"));
+    }
+  });
+});

--- a/src/tests/headless-discard-milestone.test.ts
+++ b/src/tests/headless-discard-milestone.test.ts
@@ -1,0 +1,75 @@
+// Project/App: gsd-pi
+// File Purpose: Headless discard argument and structured-result contracts.
+
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import {
+  parseDiscardMilestoneArgs,
+  runHeadlessDiscardMilestone,
+} from '../headless-discard-milestone.ts'
+
+describe('headless discard-milestone', () => {
+  test('requires the explicit orphan-only safety flag and at least one ID', () => {
+    assert.deepEqual(parseDiscardMilestoneArgs(['M001']), {
+      ids: ['M001'],
+      errors: ['exactly one --orphan-only flag is required'],
+    })
+    assert.deepEqual(parseDiscardMilestoneArgs(['--orphan-only']), {
+      ids: [],
+      errors: ['at least one milestone ID is required'],
+    })
+  })
+
+  test('preserves all positional IDs for one atomic extension call', async () => {
+    let receivedIds: readonly string[] = []
+    let closeCalls = 0
+    const result = await runHeadlessDiscardMilestone('/project', [
+      'M001',
+      'M002',
+      '--orphan-only',
+    ], {
+      openExistingWorkflowDatabase: () => ({ ok: true, reason: 'opened-existing' }),
+      closeWorkflowDatabase: () => {
+        closeCalls++
+        throw new Error('synthetic close failure')
+      },
+      discardOrphanMilestoneReservations: (_basePath, ids) => {
+        receivedIds = ids
+        return {
+          ok: true,
+          command: 'discard-milestone',
+          orphanOnly: true,
+          before: [{ id: 'M001' }, { id: 'M002' }],
+          after: [{ id: 'M001', dbRow: false }, { id: 'M002', dbRow: false }],
+        }
+      },
+    })
+
+    assert.equal(result.exitCode, 0)
+    assert.deepEqual(receivedIds, ['M001', 'M002'])
+    assert.equal(closeCalls, 1)
+    assert.equal(result.output.ok, true)
+    assert.equal(result.output.before.length, 2)
+    assert.equal(result.output.after.length, 2)
+  })
+
+  test('reports a structured refusal without creating a missing database', async () => {
+    let discardCalls = 0
+    const result = await runHeadlessDiscardMilestone('/project', ['M001', '--orphan-only'], {
+      openExistingWorkflowDatabase: () => ({ ok: false, reason: 'missing-database' }),
+      closeWorkflowDatabase: () => {},
+      discardOrphanMilestoneReservations: () => {
+        discardCalls++
+        throw new Error('must not run')
+      },
+    })
+
+    assert.equal(result.exitCode, 1)
+    assert.equal(result.output.ok, false)
+    assert.deepEqual(result.output.before, [])
+    assert.deepEqual(result.output.after, [])
+    assert.match(result.output.errors?.[0] ?? '', /missing-database/)
+    assert.equal(discardCalls, 0)
+  })
+})


### PR DESCRIPTION
## Summary
- Added bounded headless and slash orphan milestone discard routes with fail-closed atomic verification.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1548
- [#1548 Add a bounded selective route to discard orphaned milestone reservations (headless + slash)](https://github.com/open-gsd/gsd-pi/issues/1548)

## User
- @proofoftom

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1548-add-a-bounded-selective-route-to-discard-1787344979`