### PR TITLE
fix(issue): Bug: gsd_task_complete knownIssues validation rejects LLM {"item": "..."} wrapper — wedges task as orphaned-active-unit (1.16.x)

### DIFF
--- a/packages/pi-ai/src/utils/normalize-tool-arguments.ts
+++ b/packages/pi-ai/src/utils/normalize-tool-arguments.ts
@@ -51,6 +51,15 @@ function normalizeJsonStringCollections(args: Record<string, unknown>, keys: rea
 	}
 }
 
+function normalizeItemWrappedStrings(args: Record<string, unknown>, keys: readonly string[]): void {
+	for (const key of keys) {
+		const value = args[key];
+		if (isRecord(value) && typeof value.item === "string") {
+			args[key] = value.item;
+		}
+	}
+}
+
 function normalizeEditEntry(entry: unknown): void {
 	if (!isRecord(entry)) return;
 	if (typeof entry.oldText !== "string" && typeof entry.old_string === "string") {
@@ -139,6 +148,14 @@ export function normalizeToolArguments(toolName: string, args: unknown): unknown
 
 	if (canonical === "gsd_task_complete" || canonical === "gsd_complete_task") {
 		normalizeJsonStringCollections(args, ["verificationEvidence"]);
+		normalizeItemWrappedStrings(args, [
+			"verification",
+			"deviations",
+			"knownIssues",
+			"failureModes",
+			"loadProfile",
+			"negativeTests",
+		]);
 	}
 
 	return args;

--- a/packages/pi-ai/src/utils/tests/normalize-tool-arguments.test.ts
+++ b/packages/pi-ai/src/utils/tests/normalize-tool-arguments.test.ts
@@ -191,6 +191,43 @@ describe("validateToolArguments integration", () => {
 		assert.deepEqual(validated.verificationEvidence, evidence);
 	});
 
+	test("accepts item-wrapped string fields for gsd_task_complete", () => {
+		const tool = {
+			name: "gsd_task_complete",
+			description: "complete task",
+			parameters: Type.Object({
+				verification: Type.Optional(Type.String()),
+				deviations: Type.Optional(Type.String()),
+				knownIssues: Type.Optional(Type.String()),
+				failureModes: Type.Optional(Type.String()),
+				loadProfile: Type.Optional(Type.String()),
+				negativeTests: Type.Optional(Type.String()),
+			}),
+		};
+		const validated = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "complete-task-2",
+			name: "gsd_task_complete",
+			arguments: {
+				verification: { item: "npm test passed" },
+				deviations: { item: "None." },
+				knownIssues: { item: "Scenario 3b out-of-scope" },
+				failureModes: { item: "Dependency outage" },
+				loadProfile: { item: "Ten requests per second" },
+				negativeTests: { item: "Malformed input rejected" },
+			},
+		});
+
+		assert.deepEqual(validated, {
+			verification: "npm test passed",
+			deviations: "None.",
+			knownIssues: "Scenario 3b out-of-scope",
+			failureModes: "Dependency outage",
+			loadProfile: "Ten requests per second",
+			negativeTests: "Malformed input rejected",
+		});
+	});
+
 	test("accepts Edit calls that use Cursor-style old_string/new_string", () => {
 		const tool = {
 			name: "edit",


### PR DESCRIPTION
## Summary
- Added pre-validation unwrapping for malformed task-completion string fields with regression coverage and focused offline verification.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1928
- [#1928 Bug: gsd_task_complete knownIssues validation rejects LLM {"item": "..."} wrapper — wedges task as orphaned-active-unit (1.16.x)](https://github.com/open-gsd/gsd-pi/issues/1928)

## User
- @efrembaraldo

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1928-bug-gsd-task-complete-knownissues-valida-1787352069`