### PR TITLE
fix(issue): [Bug]: checkTmuxKeyboardSetup emits false positive warning when tmux show times out or returns undefined

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-startup.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-startup.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { checkTmuxKeyboardSetup } from "./interactive-startup.js";
+
+const originalTmux = process.env.TMUX;
+const originalPath = process.env.PATH;
+
+afterEach(() => {
+	if (originalTmux === undefined) delete process.env.TMUX;
+	else process.env.TMUX = originalTmux;
+
+	if (originalPath === undefined) delete process.env.PATH;
+	else process.env.PATH = originalPath;
+});
+
+test("checkTmuxKeyboardSetup does not warn when the tmux query is inconclusive", async () => {
+	process.env.TMUX = "test-session";
+	process.env.PATH = "";
+
+	assert.equal(await checkTmuxKeyboardSetup(), undefined);
+});

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-startup.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-startup.ts
@@ -85,7 +85,7 @@ export async function checkTmuxKeyboardSetup(): Promise<string | undefined> {
 		runTmuxShow("extended-keys-format"),
 	]);
 
-	if (extendedKeys !== "on" && extendedKeys !== "always") {
+	if (extendedKeys === "off") {
 		return "tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.";
 	}
 


### PR DESCRIPTION
## Summary
- Fixed false tmux warnings for inconclusive queries and verified the regression test passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1930
- [#1930 [Bug]: checkTmuxKeyboardSetup emits false positive warning when tmux show times out or returns undefined](https://github.com/open-gsd/gsd-pi/issues/1930)

## User
- @denniyahh

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1930-bug-checktmuxkeyboardsetup-emits-false-p-1787354707`