### PR TITLE
fix(issue): [Bug]: post-execution import check cannot resolve `.d.ts` targets — `resolveImportPath` omits the extension, blocking task completion on committed generated declaration files (1.16.1)

### DIFF
--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -210,8 +210,8 @@ export function extractRelativeImports(
  *   1. Imports carrying an explicit extension are checked as-is (handles assets
  *      like .css/.scss/images/fonts and .json, not just code extensions).
  *   2. TypeScript ESM convention where .js imports resolve to .ts files.
- *   3. Extensionless imports resolved against .ts/.tsx/.js/.jsx/.mjs/.cjs.
- *   4. Directory imports resolved against index.{ts,tsx,js,jsx,mjs,cjs}.
+ *   3. Extensionless imports resolved against .ts/.d.ts/.tsx/.js/.jsx/.mjs/.cjs.
+ *   4. Directory imports resolved against index.{ts,d.ts,tsx,js,jsx,mjs,cjs}.
  */
 export function resolveImportPath(
   importPath: string,
@@ -219,7 +219,7 @@ export function resolveImportPath(
   basePath: string
 ): { exists: boolean; resolvedPath: string | null } {
   const sourceDir = dirname(resolve(basePath, sourceFile));
-  const extensions = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+  const extensions = [".ts", ".d.ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
 
   // If the import already has an explicit extension, check it as-is first.
   // This correctly resolves asset imports like .css, .scss, images, fonts

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -241,6 +241,23 @@ describe("resolveImportPath", () => {
     }
   });
 
+  test("resolves declaration files and declaration directory indexes", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-dts-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src", "generated"), { recursive: true });
+    mkdirSync(join(dir, "src", "types"), { recursive: true });
+    writeFileSync(join(dir, "src", "generated", "schema.d.ts"), "export interface Schema {}\n");
+    writeFileSync(join(dir, "src", "types", "index.d.ts"), "export interface Types {}\n");
+
+    const fileResult = resolveImportPath("./generated/schema", "src/index.ts", dir);
+    assert.ok(fileResult.exists);
+    assert.ok(fileResult.resolvedPath?.endsWith("schema.d.ts"));
+
+    const indexResult = resolveImportPath("./types", "src/index.ts", dir);
+    assert.ok(indexResult.exists);
+    assert.ok(indexResult.resolvedPath?.endsWith("index.d.ts"));
+  });
+
   test("resolves parent directory imports", () => {
     tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Added `.d.ts` import resolution with regression tests covering direct and index declarations.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1936
- [#1936 [Bug]: post-execution import check cannot resolve `.d.ts` targets — `resolveImportPath` omits the extension, blocking task completion on committed generated declaration files (1.16.1)](https://github.com/open-gsd/gsd-pi/issues/1936)

## User
- @sandersietses

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1936-bug-post-execution-import-check-cannot-r-1787463546`