### PR TITLE
fix(issue): Windows: verification gate mangles nested-quote verify commands (cmd /c without windowsVerbatimArguments) -> deterministic host/agent divergence -> unbreakable finalize-break wedge

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -993,6 +993,20 @@ export async function runPostUnitVerification(
       result.passed = false;
     }
 
+    if (verdict.reason === "execution-fault") {
+      s.verificationRetryCount.delete(retryKey);
+      s.verificationRetryFailureHashes.delete(retryKey);
+      s.pendingVerificationRetry = null;
+      const message = `Verification gate execution fault: ${verdict.failureContext}`;
+      ctx.ui.notify(message, "error");
+      process.stderr.write(`verification-gate: pausing — ${verdict.failureContext}\n`);
+      await pauseAuto(ctx, pi, {
+        message,
+        category: "unknown",
+      });
+      return "pause";
+    }
+
     if (uokFlags.gates) {
       const gateRunner = new UokGateRunner();
       gateRunner.register({

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -525,6 +525,45 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.equal(s.pendingVerificationRetry, null);
   });
 
+  test("shell parse execution fault pauses without consuming a verification retry", async () => {
+    createBasicTask();
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+    const vctx = makeVerificationContext(s, ctx, pi);
+    const recordTaskTechnicalVerdict = mock.fn(() => verdictReceipt("fail"));
+    const routeTaskFailure = mock.fn(() => recoveryReceipt("remediate"));
+    vctx.runVerificationGate = () => ({
+      passed: false,
+      checks: [{
+        command: `node -e '"const'`,
+        exitCode: 1,
+        stdout: "",
+        stderr: "[eval]:1\nUnterminated string constant\nSyntaxError: Invalid or unexpected token",
+        durationMs: 10,
+        failureClass: "shell-parse",
+      }],
+      discoverySource: "preference",
+      timestamp: Date.now(),
+    });
+    vctx.taskAuthority = {
+      ...vctx.taskAuthority!,
+      recordTaskTechnicalVerdict,
+      routeTaskFailure,
+    };
+
+    const result = await runPostUnitVerification(vctx, pauseAutoMock);
+
+    assert.equal(result, "pause");
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+    assert.match(pauseAutoMock.mock.calls[0]?.arguments[2]?.message ?? "", /shell could not parse/i);
+    assert.equal(recordTaskTechnicalVerdict.mock.callCount(), 0);
+    assert.equal(routeTaskFailure.mock.callCount(), 0);
+    assert.equal(s.verificationRetryCount.has("execute-task:M001/S01/T01"), false);
+    assert.equal(s.pendingVerificationRetry, null);
+  });
+
   test("source drift records an inconclusive verdict and routes to retry", async () => {
     const driftPath = join(tempDir, "drift-during-verification.txt");
     createBasicTask(`node -e "require('node:fs').writeFileSync('${driftPath}', 'changed')"`);

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -529,7 +529,7 @@ describe("Post-execution blocking failure retry bypass", () => {
     createBasicTask();
     const ctx = makeMockCtx();
     const pi = makeMockPi();
-    const pauseAutoMock = mock.fn(async () => {});
+    const pauseAutoMock = mock.fn(async (_ctx?: unknown, _pi?: unknown, _errorContext?: { message: string }) => {});
     const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
     const vctx = makeVerificationContext(s, ctx, pi);
     const recordTaskTechnicalVerdict = mock.fn(() => verdictReceipt("fail"));

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -596,6 +596,32 @@ describe("verification-gate: execution", () => {
     assert.equal(typeof result.timestamp, "number");
   });
 
+  test("executes nested-quote node -e commands without mangling (#1939)", () => {
+    writeFileSync(join(tmp, "nested-quote-probe.txt"), "ready\n");
+    const command = String.raw`node -e "const fs=require('node:fs'); if (!fs.readFileSync(\"nested-quote-probe.txt\", 'utf8').includes(\"ready\")) process.exit(2)"`;
+
+    const result = withRtkDisabled(() => runVerificationGate({
+      cwd: tmp,
+      preferenceCommands: [command],
+    }));
+
+    assert.equal(result.passed, true, result.checks[0]?.stderr);
+    assert.equal(result.checks[0]?.exitCode, 0);
+  });
+
+  test("shell parser failures are tagged as execution faults (#1939)", () => {
+    const result = withRtkDisabled(() => runVerificationGate({
+      cwd: tmp,
+      preferenceCommands: [`node -e '\"const'`],
+    }));
+
+    assert.equal(result.passed, false);
+    assert.equal(result.checks[0]?.exitCode, 1);
+    assert.equal(result.checks[0]?.stdout, "");
+    assert.match(result.checks[0]?.stderr ?? "", /Unterminated string constant/);
+    assert.equal(result.checks[0]?.failureClass, "shell-parse");
+  });
+
   test("passing task evidence prevents unrelated preference verification from failing an artifact task (#1431)", () => {
     const result = runVerificationGate({
       cwd: tmp,

--- a/src/resources/extensions/gsd/tests/verification-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-verdict.test.ts
@@ -93,6 +93,32 @@ test("missing verification command pauses for the operator instead of retrying t
   assert.match(verdict.failureContext, /grep -q expected app\.css/);
 });
 
+test("shell parse failure is a non-retryable execution fault", () => {
+  const verdict = decideVerificationVerdict(
+    "execute-task",
+    makeResult({
+      passed: false,
+      discoverySource: "preference",
+      checks: [
+        {
+          command: `node -e '"const'`,
+          exitCode: 1,
+          stdout: "",
+          stderr: "[eval]:1\nUnterminated string constant\nSyntaxError: Invalid or unexpected token",
+          durationMs: 10,
+          failureClass: "shell-parse",
+        },
+      ],
+    }),
+  );
+
+  assert.equal(verdict.passed, false);
+  assert.equal(verdict.reason, "execution-fault");
+  assert.equal(verdict.retryable, false);
+  assert.match(verdict.failureContext, /shell could not parse/i);
+  assert.match(verdict.failureContext, /node -e/);
+});
+
 test("blocking runtime errors provide failure context when host checks pass", () => {
   const verdict = decideVerificationVerdict(
     "execute-task",

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -89,8 +89,8 @@ export interface VerificationCheck {
   stdout: string;
   stderr: string;
   durationMs: number;
-  /** Infrastructure failure that prevented the command from producing a requirement verdict. */
-  failureClass?: "timeout" | "command-not-found";
+  /** Infrastructure/execution faults that prevented the command from producing a requirement verdict. */
+  failureClass?: "timeout" | "command-not-found" | "shell-parse";
 }
 
 /** A runtime error captured from bg-shell processes or browser console */

--- a/src/resources/extensions/gsd/verification-evidence.ts
+++ b/src/resources/extensions/gsd/verification-evidence.ts
@@ -20,7 +20,7 @@ export interface EvidenceCheckJSON {
   exitCode: number;
   durationMs: number;
   verdict: "pass" | "fail" | "inconclusive";
-  failureClass?: "timeout" | "command-not-found";
+  failureClass?: "timeout" | "command-not-found" | "shell-parse";
   stdoutExcerpt?: string;
   stderrExcerpt?: string;
 }
@@ -156,7 +156,7 @@ export function writeVerificationJSON(
         command: check.command,
         exitCode: check.exitCode,
         durationMs: check.durationMs,
-        verdict: check.failureClass === "command-not-found"
+        verdict: check.failureClass === "command-not-found" || check.failureClass === "shell-parse"
           ? "inconclusive"
           : check.exitCode === 0
             ? "pass"

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -822,6 +822,15 @@ function isShellCommandNotFound(exitCode: number, stderr: string): boolean {
     || /is not recognized as an internal or external command/i.test(stderr);
 }
 
+function isShellParseFailure(exitCode: number, stdout: string, stderr: string): boolean {
+  if (exitCode !== 1 || stdout.trim() !== "") return false;
+  return /unterminated string constant/i.test(stderr)
+    || /syntax error: unterminated quoted string/i.test(stderr)
+    || /unexpected eof while looking for matching/i.test(stderr)
+    || /syntax error near unexpected token/i.test(stderr)
+    || /was unexpected at this time/i.test(stderr);
+}
+
 /**
  * Run the verification gate: discover commands, execute each via spawnSync,
  * and return a structured result.
@@ -858,9 +867,10 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
     );
     // Pass the command string as an argument to the shell explicitly
     // to avoid Node.js DEP0190 (spawnSync with shell: true and no args).
-    const shellBin = process.platform === "win32" ? "cmd" : "sh";
-    const shellArgs = process.platform === "win32"
-      ? ["/c", rewrittenCommand]
+    const isWindows = process.platform === "win32";
+    const shellBin = isWindows ? "cmd" : "sh";
+    const shellArgs = isWindows
+      ? ["/d", "/s", "/c", rewrittenCommand]
       : [
           "-c",
           "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c \"$1\" verification-gate; fi\nexec sh -c \"$1\" verification-gate",
@@ -881,6 +891,7 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
         env: verificationChildEnvironment(options.cwd),
         stdio: ["ignore", stdoutFd, stderrFd],
         timeout: options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
+        windowsVerbatimArguments: isWindows,
       });
       stdout = readBoundedCommandOutput(stdoutPath);
       capturedStderr = readBoundedCommandOutput(stderrPath);
@@ -926,6 +937,10 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
       if (isShellCommandNotFound(exitCode, stderr)) {
         failureClass = "command-not-found";
       }
+    }
+
+    if (!failureClass && isShellParseFailure(exitCode, stdout, stderr)) {
+      failureClass = "shell-parse";
     }
 
     const warning = countSearchWarning(command, exitCode);

--- a/src/resources/extensions/gsd/verification-verdict.ts
+++ b/src/resources/extensions/gsd/verification-verdict.ts
@@ -7,6 +7,7 @@ export type VerificationVerdictReason =
   | "passed"
   | "no-host-checks"
   | "command-not-found"
+  | "execution-fault"
   | "checks-failed";
 
 export interface VerificationVerdict {
@@ -47,6 +48,16 @@ export function decideVerificationVerdict(
       reason: "command-not-found",
       retryable: false,
       failureContext: `Verify command not runnable on this platform: \`${unrunnableCheck.command}\``,
+    };
+  }
+
+  const shellParseFailure = result.checks.find((check) => check.failureClass === "shell-parse");
+  if (shellParseFailure) {
+    return {
+      passed: false,
+      reason: "execution-fault",
+      retryable: false,
+      failureContext: `The verification shell could not parse command: ${shellParseFailure.command}. ${shellParseFailure.stderr}`.trim(),
     };
   }
 


### PR DESCRIPTION
## Summary
- Fixed Windows command quoting and prevented shell parse faults from creating verification retry wedges.

## Bugs Addressed
- [x] **Windows verification gate corrupts commands with nested quotes**
- [x] **Shell parse failures are misclassified as verification failures**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1939
- [#1939 Windows: verification gate mangles nested-quote verify commands (cmd /c without windowsVerbatimArguments) -> deterministic host/agent divergence -> unbreakable finalize-break wedge](https://github.com/open-gsd/gsd-pi/issues/1939)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1939-windows-verification-gate-mangles-nested-1787470034`