### PR TITLE
fix(issue): Windows: verification gate scores a missing OS command (grep 'is not recognized') as a real failure, not command-not-found -> unbreakable auto-fix loop -> liveness wedge

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -316,11 +316,11 @@ Configure shell commands that run automatically after every task execution:
 verification_commands:
   - npm run lint
   - npm run test
-verification_auto_fix: true    # auto-retry on failure (default)
+verification_auto_fix: true    # auto-retry runnable failures (default)
 verification_max_retries: 2    # max retry attempts (default: 2)
 ```
 
-Failures trigger auto-fix retries — the agent sees the verification output and attempts to fix the issues before advancing. This ensures code quality gates are enforced mechanically, not by LLM compliance.
+Runnable checks that fail are eligible for bounded auto-fix retries — the agent sees the verification output and attempts to fix the issues before advancing. If an executable is missing, including a Windows `is not recognized as an internal or external command` error, GSD classifies the check as `command-not-found`, records its verification evidence as inconclusive, and pauses without consuming an auto-fix retry. Install the executable or update the verification command, then resume auto mode. This ensures code quality gates are enforced mechanically without wasting repair attempts on an environment or configuration problem.
 
 Commands must be directly runnable checks such as `npm run lint`, `npm run test`, or `python3 -m pytest`. GSD supports single shell pipelines with `|`, so commands like `python3 -m pytest | tail -5` are valid. Logical OR fallbacks (`||`) are rejected, and GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution because verification is run as a controlled command list, not as an arbitrary shell program.
 

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -683,13 +683,13 @@ When enabled, auto-mode runs UAT after slice completion. Non-PASS verdicts on cl
 
 ### Verification
 
-Configure shell commands that run automatically after every task execution. Failures trigger auto-fix retries before advancing.
+Configure shell commands that run automatically after every task execution. Runnable failures can trigger auto-fix retries before advancing.
 
 ```yaml
 verification_commands:
   - npm run lint
   - npm run test
-verification_auto_fix: true       # auto-retry on failure (default: true)
+verification_auto_fix: true       # auto-retry runnable failures (default: true)
 verification_max_retries: 2       # max retry attempts (default: 2)
 verification_timeout_ms: 120000   # host verification and verification-oriented gsd_exec default (default: 120000)
 ```
@@ -697,9 +697,11 @@ verification_timeout_ms: 120000   # host verification and verification-oriented 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `verification_commands` | string[] | `[]` | Simple executable commands to run after task execution |
-| `verification_auto_fix` | boolean | `true` | Auto-retry when verification fails |
-| `verification_max_retries` | number | `2` | Maximum auto-fix retry attempts |
+| `verification_auto_fix` | boolean | `true` | Auto-retry runnable verification failures |
+| `verification_max_retries` | number | `2` | Maximum auto-fix retry attempts for runnable failures |
 | `verification_timeout_ms` | number | `120000` | Per-command host-verification timeout in milliseconds and the default timeout for verification-oriented `gsd_exec` workloads. Unset keeps the 120s host-verification default. A timeout is reported as `failureClass: timeout`, never as exit 127. |
+
+If the shell cannot find an executable, GSD classifies the check as `failureClass: command-not-found`. This includes exit code 127, `command not found` output, and Windows `is not recognized as an internal or external command` errors. The check is recorded as `inconclusive` in verification evidence, its failure does not consume `verification_max_retries`, and auto mode pauses for you to install the executable or correct the command before resuming.
 
 Verification commands must be simple executable commands. Shell piping (`|`) is supported, but logical OR (`||`) is rejected. GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program.
 

--- a/docs/zh-CN/user-docs/auto-mode.md
+++ b/docs/zh-CN/user-docs/auto-mode.md
@@ -172,11 +172,11 @@ auto_supervisor:
 verification_commands:
   - npm run lint
   - npm run test
-verification_auto_fix: true    # 默认开启自动重试修复
+verification_auto_fix: true    # 默认对可运行但失败的命令自动重试修复
 verification_max_retries: 2    # 最大重试次数（默认 2）
 ```
 
-一旦失败，agent 会看到 verification 输出并尝试自动修复后重试，再决定是否继续。这意味着代码质量门禁是靠机制强制执行，而不是靠 LLM“自觉遵守”。
+对于能够运行但检查失败的命令，agent 会看到 verification 输出，并在有限次数内尝试自动修复后重试。如果缺少可执行文件（包括 Windows 的 `is not recognized as an internal or external command` 错误），GSD 会将该检查归类为 `command-not-found`，在 verification evidence 中记为 `inconclusive`，并暂停自动模式且不消耗自动修复重试次数。安装缺失的可执行文件或修改 verification 命令后，再恢复自动模式。这意味着代码质量门禁由机制强制执行，同时不会把修复次数浪费在环境或配置问题上。
 
 ### Slice 讨论门
 

--- a/docs/zh-CN/user-docs/configuration.md
+++ b/docs/zh-CN/user-docs/configuration.md
@@ -369,21 +369,23 @@ uat_dispatch: true
 
 ### Verification
 
-配置在每次 task 执行后自动运行的 shell 命令。若失败，会先尝试自动修复重试，再决定是否继续。
+配置在每次 task 执行后自动运行的 shell 命令。对于能够运行但检查失败的命令，可以先尝试自动修复重试，再决定是否继续。
 
 ```yaml
 verification_commands:
   - npm run lint
   - npm run test
-verification_auto_fix: true       # 失败时自动重试修复（默认：true）
+verification_auto_fix: true       # 可运行但失败时自动重试修复（默认：true）
 verification_max_retries: 2       # 最大重试次数（默认：2）
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `verification_commands` | string[] | `[]` | task 执行后要运行的 shell 命令 |
-| `verification_auto_fix` | boolean | `true` | verification 失败时是否自动重试 |
-| `verification_max_retries` | number | `2` | 自动修复重试的最大次数 |
+| `verification_auto_fix` | boolean | `true` | 可运行的 verification 命令失败时是否自动重试 |
+| `verification_max_retries` | number | `2` | 对可运行但失败的命令自动修复重试的最大次数 |
+
+如果 shell 找不到可执行文件，GSD 会将该检查归类为 `failureClass: command-not-found`。这包括退出码 127、`command not found` 输出，以及 Windows 的 `is not recognized as an internal or external command` 错误。该检查会在 verification evidence 中记为 `inconclusive`，不会消耗 `verification_max_retries`，并会暂停自动模式，等待你安装缺失的可执行文件或修正命令后再恢复。
 
 <a id="url-blocking-fetch_page"></a>
 ### URL Blocking（`fetch_page`）

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -175,12 +175,14 @@ Shell commands that run after every task execution:
 verification_commands:
   - npm run lint
   - npm run test
-verification_auto_fix: true       # auto-retry on failure (default)
+verification_auto_fix: true       # auto-retry runnable failures (default)
 verification_max_retries: 2       # max attempts (default: 2)
 verification_timeout_ms: 120000   # host verification and verification-oriented gsd_exec default (default: 120000)
 ```
 
 `verification_timeout_ms` also supplies the default timeout for verification-oriented `gsd_exec` workloads such as builds, tests, linting, type checks, and verification commands. An explicit `context_mode.exec_timeout_ms` takes precedence; unrelated `gsd_exec` workloads keep the sandbox's 30-second default when `context_mode.exec_timeout_ms` is unset.
+
+Auto-fix retries apply to runnable checks that fail. A missing executable—including exit code 127, `command not found`, or the Windows `is not recognized as an internal or external command` error—is classified as `command-not-found` and recorded as inconclusive verification evidence. Auto mode pauses for manual correction without consuming `verification_max_retries`; install the executable or update the command, then resume.
 
 Verification commands must be simple executable commands. Shell piping (`|`) is supported, but logical OR (`||`) is rejected. GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program.
 

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -229,11 +229,11 @@ Configure shell commands that run automatically after every task:
 verification_commands:
   - npm run lint
   - npm run test
-verification_auto_fix: true    # auto-retry on failure
+verification_auto_fix: true    # auto-retry runnable failures
 verification_max_retries: 2    # max retry attempts
 ```
 
-If verification fails, the failed host Technical Verdict is recorded against the Attempt and the AI sees the output before a bounded retry. The task does not publish completion or unlock downstream work until host verification records a passing verdict for the same source revision.
+If a runnable verification check fails, the failed host Technical Verdict is recorded against the Attempt and the AI sees the output before a bounded retry. If an executable is missing, including when Windows reports that it `is not recognized as an internal or external command`, GSD instead classifies the check as `command-not-found`, records its verification evidence as inconclusive, and pauses without consuming an auto-fix retry. Install the executable or update the verification command before resuming. The task does not publish completion or unlock downstream work until host verification records a passing verdict for the same source revision.
 
 Commands must be directly runnable checks such as `npm run lint`, `npm run test`, or `python3 -m pytest`. GSD supports single shell pipelines with `|`, so commands like `python3 -m pytest | tail -5` are valid. Logical OR fallbacks (`||`) are rejected, and GSD also rejects redirects (`>` and `<`), semicolons, backticks, and command substitution because verification is run as a controlled command list, not as an arbitrary shell program.
 

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -988,6 +988,7 @@ export async function runPostUnitVerification(
     }
 
     const verdict = decideVerificationVerdict(s.currentUnit.type, result);
+    const unrunnableCheck = result.checks.find((check) => check.failureClass === "command-not-found");
     if (!verdict.passed) {
       result.passed = false;
     }
@@ -998,15 +999,19 @@ export async function runPostUnitVerification(
         id: "verification-gate",
         type: "verification",
         execute: async () => ({
-          outcome: result.passed ? "pass" : "fail",
-          failureClass: result.runtimeErrors?.some((e) => e.blocking)
+          outcome: unrunnableCheck ? "manual-attention" : result.passed ? "pass" : "fail",
+          failureClass: unrunnableCheck
+            ? "manual-attention"
+            : result.runtimeErrors?.some((e) => e.blocking)
             ? "execution"
             : "verification",
           rationale: result.passed
             ? "verification checks passed"
-            : verdict.reason === "no-host-checks"
-              ? "no runnable host-owned verification checks discovered"
-              : "verification checks failed",
+            : unrunnableCheck
+              ? verdict.failureContext
+              : verdict.reason === "no-host-checks"
+                ? "no runnable host-owned verification checks discovered"
+                : "verification checks failed",
           findings: result.passed
             ? ""
             : verdict.failureContext || formatFailureContext(result),
@@ -1031,6 +1036,8 @@ export async function runPostUnitVerification(
       const total = result.checks.length;
       if (result.passed) {
         ctx.ui.notify(formatPostUnitStatusCard("✓ Verification Gate", `${passCount}/${total} checks passed`));
+      } else if (unrunnableCheck) {
+        ctx.ui.notify(formatPostUnitStatusCard("⚠ Verification Gate", verdict.failureContext), "warning");
       } else {
         const failures = result.checks.filter((c) => c.exitCode !== 0);
         const failNames = failures.map((f) => f.command).join(", ");
@@ -1248,11 +1255,12 @@ export async function runPostUnitVerification(
       !sourceError &&
       !postExecInfrastructureError &&
       (result.passed || browserUatContinuation);
-    const hostTechnicalVerdict: RecordTaskTechnicalVerdictInput["verdict"] = sourceError || postExecInfrastructureError
-      ? "inconclusive"
-      : hostTechnicalPassed
-        ? "pass"
-        : "fail";
+    const hostTechnicalVerdict: RecordTaskTechnicalVerdictInput["verdict"] =
+      unrunnableCheck || sourceError || postExecInfrastructureError
+        ? "inconclusive"
+        : hostTechnicalPassed
+          ? "pass"
+          : "fail";
     let durableRecovery: "retry" | "abort" | null = null;
     if (mid && sid && tid) {
       let rationale = verdict.failureContext || postExecFailureSummary || formatFailureContext(result) ||
@@ -1266,42 +1274,44 @@ export async function runPostUnitVerification(
           ? "Canonical executor Result succeeded; browser-facing behavior continues to automated slice UAT."
           : "All host-owned technical verification checks passed.";
       }
-      canonicalVerdictWriteStarted = true;
-      const recordedVerdict = recordHostTechnicalVerdict({
-        context: vctx,
-        attempt: latestAttempt,
-        result,
-        verdict: hostTechnicalVerdict,
-        rationale,
-        ...(sourceBeforeResult.ok ? { sourceBefore: sourceBeforeResult.snapshot } : {}),
-        ...(sourceAfterResult.ok ? { sourceAfter: sourceAfterResult.snapshot } : {}),
-        ...(sourceError ? { sourceError } : {}),
-      });
-      canonicalVerdictWriteStarted = false;
-      if (hostTechnicalVerdict !== "pass") {
-        const failingCheck = result.checks.find((check) => check.failureClass === "timeout")
-          ?? result.checks.find((check) => check.exitCode !== 0);
-        durableRecovery = routeHostTechnicalFailure(taskAuthority, latestAttempt, {
-          verdictId: recordedVerdict.verdictId,
-          evidenceId: recordedVerdict.evidenceId,
+      if (!unrunnableCheck) {
+        canonicalVerdictWriteStarted = true;
+        const recordedVerdict = recordHostTechnicalVerdict({
+          context: vctx,
+          attempt: latestAttempt,
+          result,
           verdict: hostTechnicalVerdict,
-          rationale: describeHostVerificationRationale({
+          rationale,
+          ...(sourceBeforeResult.ok ? { sourceBefore: sourceBeforeResult.snapshot } : {}),
+          ...(sourceAfterResult.ok ? { sourceAfter: sourceAfterResult.snapshot } : {}),
+          ...(sourceError ? { sourceError } : {}),
+        });
+        canonicalVerdictWriteStarted = false;
+        if (hostTechnicalVerdict !== "pass") {
+          const failingCheck = result.checks.find((check) => check.failureClass === "timeout")
+            ?? result.checks.find((check) => check.exitCode !== 0);
+          durableRecovery = routeHostTechnicalFailure(taskAuthority, latestAttempt, {
+            verdictId: recordedVerdict.verdictId,
+            evidenceId: recordedVerdict.evidenceId,
             verdict: hostTechnicalVerdict,
-            checkName: failingCheck?.command ?? "host-verification",
-            observed: failingCheck?.failureClass === "timeout"
-              ? `timeout after ${failingCheck.durationMs}ms (exit ${failingCheck.exitCode})`
-              : failingCheck
-                ? `exit ${failingCheck.exitCode}`
-                : rationale,
-            expected: "exit 0 / pass",
-            evidenceRef: `db://host-verification/${latestAttempt.attemptId} (verdict ${recordedVerdict.verdictId})`,
-            nextAction: hostTechnicalVerdict === "inconclusive"
-              ? "To become conclusive, restore a stable source snapshot and matching evidence, then resume."
-              : failingCheck?.failureClass === "timeout"
-                ? "Raise verification_timeout_ms if this command is expected to run longer."
-                : undefined,
-          }),
-        }, "verification-failed", recordAbort);
+            rationale: describeHostVerificationRationale({
+              verdict: hostTechnicalVerdict,
+              checkName: failingCheck?.command ?? "host-verification",
+              observed: failingCheck?.failureClass === "timeout"
+                ? `timeout after ${failingCheck.durationMs}ms (exit ${failingCheck.exitCode})`
+                : failingCheck
+                  ? `exit ${failingCheck.exitCode}`
+                  : rationale,
+              expected: "exit 0 / pass",
+              evidenceRef: `db://host-verification/${latestAttempt.attemptId} (verdict ${recordedVerdict.verdictId})`,
+              nextAction: hostTechnicalVerdict === "inconclusive"
+                ? "To become conclusive, restore a stable source snapshot and matching evidence, then resume."
+                : failingCheck?.failureClass === "timeout"
+                  ? "Raise verification_timeout_ms if this command is expected to run longer."
+                  : undefined,
+            }),
+          }, "verification-failed", recordAbort);
+        }
       }
 
       try {
@@ -1322,6 +1332,7 @@ export async function runPostUnitVerification(
             const nextAttempt = attempt + 1;
             const includeRetryMetadata =
               !result.passed &&
+              !unrunnableCheck &&
               !browserUatContinuation &&
               autoFixEnabled &&
               nextAttempt <= maxRetries;
@@ -1375,7 +1386,19 @@ export async function runPostUnitVerification(
     }
 
     // ── Auto-fix retry logic ──
-    if (hostTechnicalPassed) {
+    if (unrunnableCheck) {
+      s.verificationRetryCount.delete(retryKey);
+      s.verificationRetryFailureHashes.delete(retryKey);
+      s.pendingVerificationRetry = null;
+      process.stderr.write(
+        `${verdict.failureContext}. Install the command or update the verify command, then resume.\n`,
+      );
+      await pauseAuto(ctx, pi, {
+        message: verdict.failureContext,
+        category: "unknown",
+      });
+      return "pause";
+    } else if (hostTechnicalPassed) {
       s.verificationRetryCount.delete(retryKey);
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -317,11 +317,13 @@ In `"parent"` mode, slice/task `targetRepositories` default to the declared chil
   - Values must match declared repository IDs or the implicit `project`; omitted plan/task `targetRepositories` defaults to `["project"]`.
   - `/gsd codebase` is workspace-aware in parent mode with declared child repositories: generated `.gsd/CODEBASE.md` uses workspace-relative paths, groups files under `## [repo-id]` headings, and refreshes when repository registry metadata changes.
 
-- `verification_commands`: string[] — shell commands to run as host-owned verification after task execution (e.g., `["npm test", "npm run lint"]`). Commands run in order; if any fails, GSD records a failing Technical Verdict for the task Attempt and routes the task to retry or pause instead of publishing completion.
+- `verification_commands`: string[] — shell commands to run as host-owned verification after task execution (e.g., `["npm test", "npm run lint"]`). Commands run in order; if a runnable command fails, GSD records a failing Technical Verdict for the task Attempt and routes the task to retry or pause instead of publishing completion. A missing executable is handled as inconclusive evidence as described below.
 
-- `verification_auto_fix`: boolean — when `true`, automatically attempt to fix verification failures instead of just reporting them. Default: `true`; set to `false` to pause on the first failed or inconclusive host verdict.
+- `verification_auto_fix`: boolean — when `true`, automatically attempt to fix runnable verification failures instead of just reporting them. Default: `true`; set to `false` to pause on the first failed or inconclusive host verdict. This setting does not make a missing executable retryable.
 
-- `verification_max_retries`: number — maximum number of fix-and-retry cycles for verification failures. Default: `2`.
+- `verification_max_retries`: number — maximum number of fix-and-retry cycles for runnable verification failures. Default: `2`.
+
+  If the shell cannot find an executable, GSD classifies the check as `command-not-found`. This includes exit code 127, `command not found` output, and Windows `is not recognized as an internal or external command` errors. The check is recorded as `inconclusive` in verification evidence, auto-fix retry state is cleared without consuming this limit, and auto mode pauses so you can install the executable or correct the verification command before resuming.
 
 - `per_unit_cost_cap_usd`: number — per-unit retry cost ceiling in USD for verification retries. Must be a positive finite number when set; invalid values are rejected during preference validation. Default: `5.0`. During auto-verification and artifact-retry flows, auto-mode pauses when the current unit reaches this cap or when current unit cost spikes to at least `3.0x` the rolling average.
 
@@ -336,9 +338,10 @@ In `"parent"` mode, slice/task `targetRepositories` default to the declared chil
   ```
 
   These settings control how verification is attempted; they do not grant
-  lifecycle authority. Failures are repaired and retried within the configured
-  limits. A pause should mean the agent exhausted its available repair path,
-  needs external access or a dependency, or genuinely needs a user decision.
+  lifecycle authority. Runnable failures are repaired and retried within the
+  configured limits. A missing executable pauses immediately for manual
+  correction; other pauses should mean the agent exhausted its available repair
+  path, needs external access or a dependency, or genuinely needs a user decision.
   No preference or Markdown UAT result can bypass canonical Task proof or
   complete a Slice.
 
@@ -870,7 +873,7 @@ verification_max_retries: 2
 ---
 ```
 
-Runs test, lint, and typecheck after each task. On failure, auto-fix is attempted up to 2 times before reporting the issue.
+Runs test, lint, and typecheck after each task. Runnable failures receive up to 2 auto-fix attempts. A missing executable is recorded as inconclusive and pauses auto mode without consuming those attempts.
 
 ## Experimental Features Example
 

--- a/src/resources/extensions/gsd/tests/auto-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-verification.test.ts
@@ -41,6 +41,69 @@ test("post-unit verification continues when no host-owned verification is needed
 	assert.equal(paused, false);
 });
 
+test("missing host command pauses without recording an auto-fix retry (#1943)", async () => {
+	let paused = false;
+	let recordedVerdict = false;
+	let routedFailure = false;
+	const retryKey = "execute-task:M001/S01/T01";
+	const session = {
+		basePath: process.cwd(),
+		canonicalProjectRoot: process.cwd(),
+		currentUnit: { type: "execute-task", id: "M001/S01/T01" },
+		lastTaskRecoveryAbortId: null,
+		pendingVerificationRetry: { unitId: "stale", failureContext: "stale", attempt: 1 },
+		verificationRetryCount: new Map([[retryKey, 1]]),
+		verificationRetryFailureHashes: new Map([[retryKey, "stale"]]),
+	};
+	const result = await runPostUnitVerification({
+		s: session,
+		ctx: { ui: { notify() {} } },
+		pi: {},
+		taskAuthority: {
+			readLatestTaskAttempt: () => ({
+				attemptId: "attempt-1",
+				resultId: "result-1",
+				state: "settled",
+				outcome: "succeeded",
+				nextStage: "verify",
+			}),
+			readTaskTechnicalVerdict: () => null,
+			recordTaskTechnicalVerdict: () => {
+				recordedVerdict = true;
+				throw new Error("must not record a requirement verdict");
+			},
+			invalidateTaskTechnicalPass: () => { throw new Error("must not invalidate"); },
+			routeTaskFailure: () => {
+				routedFailure = true;
+				throw new Error("must not enter auto-fix recovery");
+			},
+		},
+		runVerificationGate: () => ({
+			passed: false,
+			checks: [{
+				command: "grep -q expected app.css",
+				exitCode: 1,
+				stdout: "",
+				stderr: "'grep' is not recognized as an internal or external command",
+				durationMs: 10,
+				failureClass: "command-not-found",
+			}],
+			discoverySource: "task-plan",
+			timestamp: Date.now(),
+		}),
+	} as never, async () => {
+		paused = true;
+	});
+
+	assert.equal(result, "pause");
+	assert.equal(paused, true);
+	assert.equal(recordedVerdict, false);
+	assert.equal(routedFailure, false);
+	assert.equal(session.verificationRetryCount.has(retryKey), false);
+	assert.equal(session.verificationRetryFailureHashes.has(retryKey), false);
+	assert.equal(session.pendingVerificationRetry, null);
+});
+
 test("built-in verification retries a replayed authorized abort", () => {
 	const outcome = _routeHostTechnicalFailureForTest({
 		routeTaskFailure: () => ({

--- a/src/resources/extensions/gsd/tests/verification-evidence.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-evidence.test.ts
@@ -159,6 +159,28 @@ test("verification-evidence: writeVerificationJSON persists failed-command stdou
   assert.equal(json.checks[0].stderrExcerpt, "some warning");
 });
 
+test("verification-evidence: writeVerificationJSON persists infrastructure failure class (#1943)", (t) => {
+  const tmp = makeTempDir("ve-failure-class");
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  const result = makeResult({
+    passed: false,
+    checks: [{
+      command: "grep -q expected app.css",
+      exitCode: 1,
+      stdout: "",
+      stderr: "'grep' is not recognized as an internal or external command",
+      durationMs: 50,
+      failureClass: "command-not-found",
+    }],
+  });
+
+  writeVerificationJSON(result, tmp, "T01");
+
+  const json = JSON.parse(readFileSync(join(tmp, "T01-VERIFY.json"), "utf-8"));
+  assert.equal(json.checks[0].failureClass, "command-not-found");
+  assert.equal(json.checks[0].verdict, "inconclusive");
+});
+
 test("verification-evidence: writeVerificationJSON bounds output excerpts and keeps failure tail", (t) => {
   const tmp = makeTempDir("ve-bounded-stdio");
   t.after(() => rmSync(tmp, { recursive: true, force: true }));

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -704,15 +704,31 @@ describe("verification-gate: execution", () => {
     assert.equal(result.discoverySource, "none");
   });
 
-  test("command not found → exit code 127", () => {
-    const result = runVerificationGate({
+  test("command not found → inconclusive infrastructure failure", () => {
+    const result = withRtkDisabled(() => runVerificationGate({
       cwd: tmp,
       preferenceCommands: ["__nonexistent_command_xyz_42__"],
-    });
+    }));
     assert.equal(result.passed, false);
     assert.equal(result.checks.length, 1);
-    assert.ok(result.checks[0].exitCode !== 0, "should have non-zero exit code");
+    assert.notEqual(result.checks[0].exitCode, 0);
+    assert.equal(result.checks[0].failureClass, "command-not-found");
     assert.ok(result.checks[0].durationMs >= 0);
+  });
+
+  test("Windows cmd missing-command stderr is classified despite exit code 1 (#1943)", () => {
+    writeFileSync(
+      join(tmp, "windows-command-not-found.cjs"),
+      `process.stderr.write("'grep' is not recognized as an internal or external command"); process.exit(1);\n`,
+    );
+    const result = withRtkDisabled(() => runVerificationGate({
+      cwd: tmp,
+      preferenceCommands: ["node windows-command-not-found.cjs"],
+    }));
+
+    assert.equal(result.passed, false);
+    assert.equal(result.checks[0]?.exitCode, 1);
+    assert.equal(result.checks[0]?.failureClass, "command-not-found");
   });
 
   test("no DEP0190 deprecation warning when running commands", () => {
@@ -1085,15 +1101,15 @@ test("runVerificationGate: timeout is failureClass timeout, not exit 127 (#1759)
   assert.match(result.checks[0]?.stderr ?? "", /verification_timeout_ms/);
 });
 
-test("runVerificationGate: missing binary is still exit 127 (#1759)", () => {
+test("runVerificationGate: missing binary is classified separately from timeout (#1759, #1943)", () => {
   const dir = makeTempDir("gsd-verify-enoent");
   const result = withRtkDisabled(() => runVerificationGate({
     cwd: dir,
     preferenceCommands: ["__gsd_missing_binary_1783__"],
   }));
   assert.equal(result.passed, false);
-  assert.equal(result.checks[0]?.exitCode, 127);
-  assert.equal(result.checks[0]?.failureClass, undefined);
+  assert.notEqual(result.checks[0]?.exitCode, 0);
+  assert.equal(result.checks[0]?.failureClass, "command-not-found");
 });
 
 test("validatePreferences: verification_timeout_ms override and default (#1759)", () => {

--- a/src/resources/extensions/gsd/tests/verification-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-verdict.test.ts
@@ -69,6 +69,30 @@ test("execute-task command failure remains retryable verification failure", () =
   assert.equal(verdict.retryable, true);
 });
 
+test("missing verification command pauses for the operator instead of retrying the task (#1943)", () => {
+  const verdict = decideVerificationVerdict(
+    "execute-task",
+    makeResult({
+      passed: false,
+      discoverySource: "task-plan",
+      checks: [{
+        command: "grep -q expected app.css",
+        exitCode: 1,
+        stdout: "",
+        stderr: "'grep' is not recognized as an internal or external command",
+        durationMs: 10,
+        failureClass: "command-not-found",
+      }],
+    }),
+  );
+
+  assert.equal(verdict.passed, false);
+  assert.equal(verdict.reason, "command-not-found");
+  assert.equal(verdict.retryable, false);
+  assert.match(verdict.failureContext, /Verify command not runnable on this platform/);
+  assert.match(verdict.failureContext, /grep -q expected app\.css/);
+});
+
 test("blocking runtime errors provide failure context when host checks pass", () => {
   const verdict = decideVerificationVerdict(
     "execute-task",

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -89,8 +89,8 @@ export interface VerificationCheck {
   stdout: string;
   stderr: string;
   durationMs: number;
-  /** Distinct from exit 127: a spawn timeout, never command-not-found (#1759). */
-  failureClass?: "timeout";
+  /** Infrastructure failure that prevented the command from producing a requirement verdict. */
+  failureClass?: "timeout" | "command-not-found";
 }
 
 /** A runtime error captured from bg-shell processes or browser console */

--- a/src/resources/extensions/gsd/verification-evidence.ts
+++ b/src/resources/extensions/gsd/verification-evidence.ts
@@ -19,7 +19,8 @@ export interface EvidenceCheckJSON {
   command: string;
   exitCode: number;
   durationMs: number;
-  verdict: "pass" | "fail";
+  verdict: "pass" | "fail" | "inconclusive";
+  failureClass?: "timeout" | "command-not-found";
   stdoutExcerpt?: string;
   stderrExcerpt?: string;
 }
@@ -155,7 +156,12 @@ export function writeVerificationJSON(
         command: check.command,
         exitCode: check.exitCode,
         durationMs: check.durationMs,
-        verdict: check.exitCode === 0 ? "pass" : "fail",
+        verdict: check.failureClass === "command-not-found"
+          ? "inconclusive"
+          : check.exitCode === 0
+            ? "pass"
+            : "fail",
+        ...(check.failureClass ? { failureClass: check.failureClass } : {}),
         ...(stdoutExcerpt !== undefined ? { stdoutExcerpt } : {}),
         ...(stderrExcerpt !== undefined ? { stderrExcerpt } : {}),
       };

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -816,6 +816,12 @@ function isCommandNotFound(error: NodeJS.ErrnoException): boolean {
   return /enoent|not found/i.test(error.message);
 }
 
+function isShellCommandNotFound(exitCode: number, stderr: string): boolean {
+  return exitCode === 127
+    || /command not found/i.test(stderr)
+    || /is not recognized as an internal or external command/i.test(stderr);
+}
+
 /**
  * Run the verification gate: discover commands, execute each via spawnSync,
  * and return a structured result.
@@ -901,6 +907,7 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
         );
       } else if (isCommandNotFound(spawnError)) {
         exitCode = 127;
+        failureClass = "command-not-found";
         stderr = truncate(
           capturedStderr + "\n" + spawnError.message,
           MAX_OUTPUT_BYTES,
@@ -916,6 +923,9 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
       // status is null when killed by signal — treat as failure
       exitCode = result.status ?? 1;
       stderr = capturedStderr;
+      if (isShellCommandNotFound(exitCode, stderr)) {
+        failureClass = "command-not-found";
+      }
     }
 
     const warning = countSearchWarning(command, exitCode);

--- a/src/resources/extensions/gsd/verification-verdict.ts
+++ b/src/resources/extensions/gsd/verification-verdict.ts
@@ -6,6 +6,7 @@ import type { VerificationResult as VerificationGateResult } from "./types.js";
 export type VerificationVerdictReason =
   | "passed"
   | "no-host-checks"
+  | "command-not-found"
   | "checks-failed";
 
 export interface VerificationVerdict {
@@ -39,6 +40,16 @@ export function decideVerificationVerdict(
   unitType: string,
   result: VerificationGateResult,
 ): VerificationVerdict {
+  const unrunnableCheck = result.checks.find((check) => check.failureClass === "command-not-found");
+  if (unrunnableCheck) {
+    return {
+      passed: false,
+      reason: "command-not-found",
+      retryable: false,
+      failureContext: `Verify command not runnable on this platform: \`${unrunnableCheck.command}\``,
+    };
+  }
+
   if (!result.passed) {
     const failureContext = (result.runtimeErrors ?? [])
       .filter((error) => error.blocking)


### PR DESCRIPTION
## Summary
- Classified missing verification commands as inconclusive and paused auto-mode without retries, with focused checks passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1943
- [#1943 Windows: verification gate scores a missing OS command (grep 'is not recognized') as a real failure, not command-not-found -> unbreakable auto-fix loop -> liveness wedge](https://github.com/open-gsd/gsd-pi/issues/1943)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1943-windows-verification-gate-scores-a-missi-1787476628`