### PR TITLE
fix(dispatch-guard): do not block dispatch on an earlier placeholder milestone with no slice rows

### DIFF
--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -95,6 +95,9 @@ export function getPriorSliceCompletionBlocker(
 
     const slices = getMilestoneSliceSummaries(mid);
     if (slices.length === 0) {
+      // An earlier milestone with no slice rows is a placeholder; it cannot
+      // have incomplete slices, so it never gates the target milestone.
+      if (mid !== targetMid) continue;
       return `Cannot dispatch ${unitType} ${unitId}: milestone ${mid} has no slice rows in the workflow DB.`;
     }
 

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -88,6 +88,24 @@ test("dispatch guard fails closed on missing legacy DB routing rows", (t) => {
   );
 });
 
+test("dispatch guard skips an earlier placeholder milestone with no slice rows (#1947)", (t) => {
+  const repo = setupRepo();
+  t.after(() => teardownRepo(repo));
+
+  insertMilestone({ id: "M001", title: "Placeholder", status: "queued" });
+  insertMilestone({ id: "M002", title: "Current", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M002", title: "Target", status: "pending", depends: [] });
+
+  assert.equal(getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M002/S01"), null);
+  assert.equal(getPriorSliceCompletionBlocker(repo, "main", "research-slice", "M002/parallel-research"), null);
+
+  // The target milestone itself having no slice rows still fails closed.
+  assert.match(
+    getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M001/S01") ?? "",
+    /milestone M001 has no slice rows in the workflow DB/i,
+  );
+});
+
 test("dispatch guard fails closed when a declared dependency row is missing", (t) => {
   const repo = setupRepo();
   t.after(() => teardownRepo(repo));


### PR DESCRIPTION
## TL;DR

**What:** `getPriorSliceCompletionBlocker` no longer fails closed when an *earlier* milestone in the workflow-DB ordering has zero slice rows.
**Why:** A placeholder milestone (e.g. `queued`, empty) blocked every dispatch of the active milestone with `milestone <M> has no slice rows in the workflow DB.`, so the identical signature recurred and ADR-047 tripped a `prior-slice-completion` wedge (#1947 seed defect).
**How:** Skip earlier milestones with no slice rows; keep the hard block when the target milestone itself has none. One regression test.

## What

- `src/resources/extensions/gsd/dispatch-guard.ts`: in `getPriorSliceCompletionBlocker`, an earlier milestone (`mid !== targetMid`) with zero slice rows is treated like a skipped milestone (`continue`). The "no slice rows" blocker still fires for the target milestone.
- `src/resources/extensions/gsd/tests/dispatch-guard.test.ts`: new test — earlier empty `queued` milestone does not block `plan-slice` or the `parallel-research` sentinel; an empty target milestone still fails closed.

## Why

Refs #1947

A milestone with no slice rows cannot have incomplete slices, so it cannot gate later milestones. Failing closed on it made auto-mode unusable for any project with an empty placeholder milestone earlier in the DB ordering.

The second half of #1947 (the `prior-slice-completion` wedge being unacknowledgeable via `/gsd auto --resume-wedge` because `recheckWedge()` has no branch for that guard) is addressed by #1946, not here. This PR removes the condition that creates the wedge in the first place.

## How

- Guard change is three lines; no change to same-milestone, dependency, or `GSD_MILESTONE_LOCK` behaviour.
- Verified: `pnpm run test:compile`, then `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/dispatch-guard.test.js dist-test/src/resources/extensions/gsd/tests/dispatch-guard-closed-status.test.js` → 28 pass, 0 fail. `pnpm run typecheck:extensions` clean.
