### PR TITLE
fix(auto): verify reassess-roadmap against the milestone-scoped ROADMAP-ASSESSMENT.md

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -216,7 +216,9 @@ export function resolveExpectedArtifactPath(
       return resolveSliceArtifactPath(base, mid, sid!, "PLAN");
     }
     case "reassess-roadmap": {
-      return resolveSliceArtifactPath(base, mid, sid!, "ASSESSMENT");
+      // gsd_reassess_roadmap writes the milestone-scoped <NN>-ROADMAP-ASSESSMENT.md
+      // (resolveRoadmapAssessmentProjectionPath), not a slice-scoped ASSESSMENT.
+      return resolveMilestoneArtifactPath(base, mid, "ROADMAP-ASSESSMENT");
     }
     case "run-uat": {
       return resolveSliceArtifactPath(base, mid, sid!, "ASSESSMENT");
@@ -321,7 +323,7 @@ export function diagnoseExpectedArtifact(
     case "rewrite-docs":
       return "Active overrides resolved in .gsd/OVERRIDES.md + plan documents updated";
     case "reassess-roadmap":
-      return `${relSliceFile(base, mid, sid!, "ASSESSMENT")} (roadmap reassessment)`;
+      return `${relMilestoneFile(base, mid, "ROADMAP-ASSESSMENT")} (roadmap reassessment)`;
     case "run-uat":
       return `${relSliceFile(base, mid, sid!, "ASSESSMENT")} (UAT assessment result)`;
     case "validate-milestone":

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -882,7 +882,7 @@ import {
   type AutoOutcomeSurfaceSnapshot,
 } from "./auto-dashboard.js";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
-import { join, relative } from "node:path";
+import { basename, join, relative } from "node:path";
 import { _resetHasChangesCache } from "./native-git-bridge.js";
 import { autoCommitCurrentBranch } from "./worktree.js";
 
@@ -972,9 +972,9 @@ export function detectRogueFileWrites(
       rogues.push({ path: replanPath, unitType, unitId });
     }
   } else if (unitType === "reassess-roadmap") {
-    if (!mid || !sid) return [];
+    if (!mid) return [];
 
-    const assessPath = resolveSliceFile(basePath, mid, sid, "ASSESSMENT");
+    const assessPath = resolveMilestoneFile(basePath, mid, "ROADMAP-ASSESSMENT");
     if (!assessPath || !existsSync(assessPath)) return [];
 
     // Assessment file exists on disk — check if DB knows about it via the artifacts table
@@ -982,7 +982,7 @@ export function detectRogueFileWrites(
     if (adapter) {
       const row = adapter.prepare(
         `SELECT 1 FROM artifacts WHERE path LIKE :pattern AND artifact_type = 'ASSESSMENT' LIMIT 1`,
-      ).get({ ":pattern": `%${sid}-ASSESSMENT.md` });
+      ).get({ ":pattern": `%${basename(assessPath)}` });
       if (!row) {
         rogues.push({ path: assessPath, unitType, unitId });
       }

--- a/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-artifact-paths.test.ts
@@ -624,3 +624,32 @@ test("resolveExistingSliceResearchPath returns absolute path when RESEARCH exist
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+// ── #1933: reassess-roadmap verifies the milestone-scoped ROADMAP-ASSESSMENT ──
+//
+// gsd_reassess_roadmap writes <NN>-ROADMAP-ASSESSMENT.md (milestone-scoped).
+// The verifier used to expect the slice-scoped <NN>-<SS>-ASSESSMENT.md, so the
+// unit could never finalize and looped on "expected artifact not found".
+
+test("reassess-roadmap expects the milestone-scoped ROADMAP-ASSESSMENT file (#1933)", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-reassess-artifact-")));
+  try {
+    const phaseDir = join(root, ".gsd", "phases", "01-m001");
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(join(phaseDir, "01-ROADMAP.md"), "# M001 roadmap\n");
+    writeFileSync(join(phaseDir, "01-ROADMAP-ASSESSMENT.md"), "# M001 Roadmap Assessment\n");
+
+    _clearGsdRootCache();
+    clearPathCache();
+
+    assert.equal(
+      resolveExpectedArtifactPath("reassess-roadmap", "M001/S01", root),
+      join(phaseDir, "01-ROADMAP-ASSESSMENT.md"),
+      "reassess-roadmap must verify the file gsd_reassess_roadmap writes, not a slice-scoped ASSESSMENT",
+    );
+  } finally {
+    _clearGsdRootCache();
+    clearPathCache();
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR
- **What:** Point the auto-mode verifier for `reassess-roadmap` at the file the tool actually writes (`<NN>-ROADMAP-ASSESSMENT.md`) instead of the slice-scoped `<NN>-<SS>-ASSESSMENT.md`.
- **Why:** The writer and verifier disagreed on the path, so the unit could never finalize and retried forever.
- **How:** Switch the three verifier sites to the milestone-scoped resolver; add a regression test.

## What
- `auto-artifact-paths.ts`: `resolveExpectedArtifactPath` and `diagnoseExpectedArtifact` use `ROADMAP-ASSESSMENT` (milestone-scoped) for `reassess-roadmap`.
- `auto-post-unit.ts`: the rogue-artifact probe checks the milestone `ROADMAP-ASSESSMENT` file and matches its basename in the `artifacts` table.
- `tests/auto-artifact-paths.test.ts`: new case asserting `reassess-roadmap` resolves to `01-ROADMAP-ASSESSMENT.md`.

## Why
`gsd_reassess_roadmap` writes via `resolveRoadmapAssessmentProjectionPath` (milestone-scoped), and `reassess-handler.test.ts` already asserts `ROADMAP-ASSESSMENT.md`. The verifier expected a slice-scoped ASSESSMENT that nothing writes, producing a deterministic "expected artifact not found" finalize-retry wedge.

Closes #1933

## How
- `pnpm run test:compile`; `auto-artifact-paths`, `rogue-file-detection`, `reassess-handler` test files: 43 pass, 0 fail.
- `pnpm run typecheck:extensions` clean.
