### PR TITLE
fix(baseline): make per-invariant timeout overridable via GSD_BASELINE_INVARIANT_TIMEOUT_MS

### DIFF
--- a/docs/dev/refactor-baseline-runbook.md
+++ b/docs/dev/refactor-baseline-runbook.md
@@ -116,6 +116,15 @@ Together they cover the real SQLite fixture, contradictory projections, the
 one-shot fault controller, and the production fault-boundary matrix. Each row
 reports its verdict, duration, and exact rerunnable command.
 
+Each invariant runs under a per-invariant hang watchdog (60s by default). On a
+slower machine the `fault-boundary-matrix` invariant can exceed that and is
+reported as a timeout; raise the watchdog with
+`GSD_BASELINE_INVARIANT_TIMEOUT_MS` (milliseconds), for example:
+
+```bash
+GSD_BASELINE_INVARIANT_TIMEOUT_MS=120000 pnpm run baseline:workflow-authority
+```
+
 Capture the machine-readable report outside the repository:
 
 ```bash

--- a/scripts/workflow-authority-baseline.mjs
+++ b/scripts/workflow-authority-baseline.mjs
@@ -62,6 +62,18 @@ function commandForInvariant(invariant) {
   };
 }
 
+// Per-invariant hang watchdog. The default is the historical 60s; slower
+// machines can raise it via the env var (fault-boundary-matrix alone has been
+// measured at 67-85s). Four invariants run sequentially, so 4 x this value must
+// stay under BASELINE_SPAWN_TIMEOUT_MS in src/tests/workflow-authority-baseline.test.ts,
+// which wraps the whole CLI run.
+export const INVARIANT_TIMEOUT_ENV = "GSD_BASELINE_INVARIANT_TIMEOUT_MS";
+const DEFAULT_INVARIANT_TIMEOUT_MS = 60_000;
+
+export function invariantTimeoutMs(env = process.env) {
+  return Number(env[INVARIANT_TIMEOUT_ENV]) || DEFAULT_INVARIANT_TIMEOUT_MS;
+}
+
 export function runInvariant(
   invariant,
   {
@@ -72,17 +84,20 @@ export function runInvariant(
   const command = commandForInvariant(invariant);
   const childEnv = { ...process.env };
   delete childEnv.NODE_TEST_CONTEXT;
+  const timeout = invariantTimeoutMs();
   const startedAt = now();
   const child = spawnSyncImpl(command.executable, command.args, {
     cwd: REPO_ROOT,
     encoding: "utf8",
     env: childEnv,
     maxBuffer: 50 * 1024 * 1024,
-    timeout: 60_000,
+    timeout,
   });
   const durationMs = Math.max(0, Math.round(now() - startedAt));
   const exitCode = Number.isInteger(child.status) ? child.status : null;
-  const error = child.error?.message ?? null;
+  const error = child.error?.code === "ETIMEDOUT"
+    ? `invariant "${invariant.id}" timed out after ${timeout}ms; raise ${INVARIANT_TIMEOUT_ENV} to allow more time on slower machines`
+    : (child.error?.message ?? null);
 
   return {
     id: invariant.id,

--- a/src/tests/workflow-authority-baseline.test.ts
+++ b/src/tests/workflow-authority-baseline.test.ts
@@ -83,6 +83,30 @@ test("workflow authority baseline preserves the first failing child status", () 
   assert.match(baseline.renderWorkflowAuthoritySummary(report), /projection-conflict.*FAIL.*node/s);
 });
 
+test("workflow authority baseline per-invariant timeout honors GSD_BASELINE_INVARIANT_TIMEOUT_MS", (t) => {
+  const original = process.env.GSD_BASELINE_INVARIANT_TIMEOUT_MS;
+  t.after(() => {
+    if (original === undefined) delete process.env.GSD_BASELINE_INVARIANT_TIMEOUT_MS;
+    else process.env.GSD_BASELINE_INVARIANT_TIMEOUT_MS = original;
+  });
+  process.env.GSD_BASELINE_INVARIANT_TIMEOUT_MS = "90000";
+
+  const timeouts: number[] = [];
+  const report = baseline.runWorkflowAuthorityBaseline({
+    now: () => 0,
+    spawnSyncImpl: (_executable: string, _args: string[], options: { timeout: number }) => {
+      timeouts.push(options.timeout);
+      const error = Object.assign(new Error("spawnSync node ETIMEDOUT"), { code: "ETIMEDOUT" });
+      return { status: null, signal: "SIGTERM", stdout: "", stderr: "", error };
+    },
+  });
+
+  assert.deepEqual(timeouts, [90000, 90000, 90000, 90000]);
+  assert.equal(report.verdict, "fail");
+  assert.match(report.invariants[0].error, /timed out after 90000ms/);
+  assert.match(report.invariants[0].error, /GSD_BASELINE_INVARIANT_TIMEOUT_MS/);
+});
+
 test(
   "workflow authority baseline controlled sabotage exits nonzero",
   { timeout: BASELINE_TEST_TIMEOUT_MS },


### PR DESCRIPTION
## TL;DR

**What:** `scripts/workflow-authority-baseline.mjs` reads the per-invariant spawn timeout from `GSD_BASELINE_INVARIANT_TIMEOUT_MS` (default unchanged at 60s) and reports ETIMEDOUT as a named timeout.
**Why:** The `fault-boundary-matrix` invariant takes 67-85s on slower machines, so the fixed 60s watchdog scores a passing invariant as a fail and turns `verify:merge` red locally.
**How:** `Number(process.env.GSD_BASELINE_INVARIANT_TIMEOUT_MS) || 60_000`, plus a clearer error string when `child.error.code === "ETIMEDOUT"`.

## What

- `scripts/workflow-authority-baseline.mjs`: new `invariantTimeoutMs()` / `INVARIANT_TIMEOUT_ENV`; `runInvariant` uses it for `spawnSync`'s `timeout` and, on ETIMEDOUT, sets `error` to `invariant "<id>" timed out after <n>ms; raise GSD_BASELINE_INVARIANT_TIMEOUT_MS ...`. A comment documents that 4 x the per-invariant value must stay under `BASELINE_SPAWN_TIMEOUT_MS` (255s) in `src/tests/workflow-authority-baseline.test.ts`, which wraps the whole CLI run. That outer constant is left as is.
- `src/tests/workflow-authority-baseline.test.ts`: one mocked test (existing `spawnSyncImpl` seam) asserting the env value reaches `spawnSync`'s `timeout` for all four invariants and that an ETIMEDOUT result produces the named-timeout error.
- `docs/dev/refactor-baseline-runbook.md`: documents the env var under the workflow authority gate.

## Why

A machine-speed watchdog was being treated as a correctness signal. No new number is chosen: the default is the historical 60s and the override is an operator choice.

Closes #1926

## How

Verified with `pnpm run test:compile` then `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/tests/workflow-authority-baseline.test.js`: 5/5 pass (including the two real CLI runs). Root `tsc --noEmit --incremental false` clean for the touched files.

- [x] `fix` — Bug fix
