### PR TITLE
fix(remote-questions): add GSD_DISABLE_REMOTE_QUESTIONS guard and isolate ask-user tests

### DIFF
--- a/docs/user-docs/remote-questions.md
+++ b/docs/user-docs/remote-questions.md
@@ -75,6 +75,13 @@ remote_questions:
   poll_interval_seconds: 5  # 2-30, default 5
 ```
 
+### Temporarily disabling remote dispatch
+
+Set `GSD_DISABLE_REMOTE_QUESTIONS=1` to make GSD treat remote questions as
+unconfigured for that process, without editing preferences or unsetting bot
+tokens. Questions then go only to the local UI. The repository's own test
+suite sets this so fixture questions never reach a real channel.
+
 ## How It Works
 
 1. GSD encounters a decision point during auto-mode

--- a/src/resources/extensions/remote-questions/config.ts
+++ b/src/resources/extensions/remote-questions/config.ts
@@ -74,7 +74,20 @@ function hydrateRemoteTokensFromAuth(): void {
   }
 }
 
+/**
+ * Hard off-switch for remote dispatch. Set to "1" to make every channel look
+ * unconfigured regardless of preferences, auth.json, or bot-token env vars.
+ * Test suites set this so fixture questions never reach an operator's real
+ * Slack/Discord/Telegram channel (#1923).
+ */
+export const REMOTE_QUESTIONS_DISABLE_ENV = "GSD_DISABLE_REMOTE_QUESTIONS";
+
+export function isRemoteQuestionsDisabled(): boolean {
+  return process.env[REMOTE_QUESTIONS_DISABLE_ENV] === "1";
+}
+
 export function resolveRemoteConfig(): ResolvedConfig | null {
+  if (isRemoteQuestionsDisabled()) return null;
   hydrateRemoteTokensFromAuth();
   const prefs = loadEffectiveGSDPreferences();
   const rq: RemoteQuestionsConfig | undefined = prefs?.preferences.remote_questions;
@@ -101,6 +114,7 @@ export function resolveRemoteConfig(): ResolvedConfig | null {
 }
 
 export function getRemoteConfigStatus(): string {
+  if (isRemoteQuestionsDisabled()) return `Remote questions: disabled by ${REMOTE_QUESTIONS_DISABLE_ENV}=1`;
   hydrateRemoteTokensFromAuth();
   const prefs = loadEffectiveGSDPreferences();
   const rq: RemoteQuestionsConfig | undefined = prefs?.preferences.remote_questions;

--- a/src/resources/extensions/shared/tests/ask-user-freetext.test.ts
+++ b/src/resources/extensions/shared/tests/ask-user-freetext.test.ts
@@ -12,11 +12,22 @@
 
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// #1923: execute() consults the operator's real Remote Questions config. Without
+// this guard, fixture questions are posted to a configured Slack/Discord/Telegram
+// channel on every test run.
+process.env.GSD_DISABLE_REMOTE_QUESTIONS = "1";
 
 // The ask-user-questions extension registers a tool via pi.registerTool().
 // We capture that registration and call execute() directly with a mock context.
 import AskUserQuestions from "../../ask-user-questions.js";
 import { resetAskUserQuestionsCache } from "../../ask-user-questions.js";
+import { isRemoteConfigured } from "../../remote-questions/manager.js";
+import { resolveRemoteConfig } from "../../remote-questions/config.js";
+import { clearGSDPreferencesCache, getGlobalGSDPreferencesPath } from "../../gsd/preferences.js";
 
 interface CapturedTool {
 	name: string;
@@ -157,5 +168,55 @@ describe("ask-user-questions RPC fallback free-text", () => {
 		assert.ok(text, "result should have text content");
 		const parsed = JSON.parse(text);
 		assert.deepStrictEqual(parsed.answers.q1.answers, ["None of the above"]);
+	});
+});
+
+describe("ask-user-questions remote isolation (#1923)", () => {
+	it("GSD_DISABLE_REMOTE_QUESTIONS=1 keeps execute() on the local path even when a channel is configured", async (t) => {
+		const originalGsdHome = process.env.GSD_HOME;
+		const originalToken = process.env.TELEGRAM_BOT_TOKEN;
+		const tempGsdHome = mkdtempSync(join(tmpdir(), "ask-user-remote-isolation-"));
+		t.after(() => {
+			process.env.GSD_DISABLE_REMOTE_QUESTIONS = "1";
+			if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+			else process.env.GSD_HOME = originalGsdHome;
+			if (originalToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
+			else process.env.TELEGRAM_BOT_TOKEN = originalToken;
+			clearGSDPreferencesCache();
+			rmSync(tempGsdHome, { recursive: true, force: true });
+		});
+
+		// Hermetic "operator has Remote Questions configured" state.
+		process.env.GSD_HOME = tempGsdHome;
+		process.env.TELEGRAM_BOT_TOKEN = "test-token-never-used";
+		mkdirSync(tempGsdHome, { recursive: true });
+		writeFileSync(
+			getGlobalGSDPreferencesPath(),
+			"---\nversion: 1\nremote_questions:\n  channel: telegram\n  channel_id: \"123456789\"\n---\n",
+			"utf-8",
+		);
+		clearGSDPreferencesCache();
+
+		// Sanity: without the guard this machine state WOULD dispatch remotely.
+		delete process.env.GSD_DISABLE_REMOTE_QUESTIONS;
+		assert.ok(resolveRemoteConfig(), "fixture must look like a configured channel without the guard");
+
+		// With the guard, the manager sees no remote channel at all.
+		process.env.GSD_DISABLE_REMOTE_QUESTIONS = "1";
+		assert.equal(isRemoteConfigured(), false);
+
+		// execute() therefore resolves purely through the mock local UI.
+		resetAskUserQuestionsCache();
+		const tool = captureTool();
+		const { ctx, selectCalls } = makeMockCtx({ selectReturns: ["Option A"] });
+		const result = await tool.execute(
+			"call-4",
+			{ questions: [makeQuestion("q1", ["Option A", "Option B"])] },
+			undefined,
+			undefined,
+			ctx,
+		);
+		assert.equal(selectCalls.length, 1);
+		assert.deepStrictEqual(JSON.parse(result.content[0].text).answers.q1.answers, ["Option A"]);
 	});
 });


### PR DESCRIPTION
## TL;DR

**What:** Add a `GSD_DISABLE_REMOTE_QUESTIONS=1` off-switch in `resolveRemoteConfig()` and set it in the ask-user test file.
**Why:** `execute()` in `ask-user-questions.ts` consults the operator's real Remote Questions config, so running the tests on a configured machine posted fixture questions to a real Telegram/Discord/Slack channel.
**How:** Env guard that cannot depend on the operator's machine state, plus one hermetic test showing a configured channel is ignored under the guard.

## What

- `src/resources/extensions/remote-questions/config.ts`: `REMOTE_QUESTIONS_DISABLE_ENV` / `isRemoteQuestionsDisabled()`; `resolveRemoteConfig()` returns `null` and `getRemoteConfigStatus()` reports "disabled by GSD_DISABLE_REMOTE_QUESTIONS=1" when set. Every caller (`isRemoteConfigured`, `tryRemoteQuestions`, notify, auto-mode command polling, register-hooks) goes through `resolveRemoteConfig`, so the guard covers all dispatch paths.
- `src/resources/extensions/shared/tests/ask-user-freetext.test.ts`: sets the guard at module load; new test builds a hermetic configured state (`GSD_HOME` temp dir with `remote_questions` prefs + `TELEGRAM_BOT_TOKEN`), asserts `resolveRemoteConfig()` is non-null without the guard, `isRemoteConfigured()` is `false` with it, and `execute()` resolves through the mock local UI only.
- `docs/user-docs/remote-questions.md`: documents the env var.

`ask-user-questions-dedup.test.ts` and `-render.test.ts` do not call `execute()`, so they are untouched.

## Why

There was no test seam between `execute()` and the remote manager; the routing raced remote dispatch against the mock UI, the mock won instantly, and the posted message was never withdrawn (issue #1923). The repo has no existing repo-wide test-mode env (`NODE_TEST_CONTEXT` is only ever deleted in scripts, never read by source), so a dedicated, explicit guard was added rather than inferring test mode.

Closes #1923

## How

Verified with `pnpm run test:compile` then:
- `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/shared/tests/ask-user-freetext.test.js` — 4/4 pass
- remote-questions tests (command-polling, remote-answer-normalization, telegram-commands) — 23/23 pass
- `pnpm run typecheck:extensions` clean; root `tsc --noEmit --incremental false` clean for touched files.

The race-design change suggested in the issue (do not dispatch remote until local fails) is out of scope for this PR.

- [x] `fix` — Bug fix
