### PR TITLE
fix(gsd): void stale abort route on task reopen so recovery levers stay live (#1948)

### DIFF
--- a/src/resources/extensions/gsd/auto/task-execution-cutover.ts
+++ b/src/resources/extensions/gsd/auto/task-execution-cutover.ts
@@ -12,6 +12,7 @@ import type {
 import {
   isTaskAttemptAwaitingVerification,
   readLatestTaskAttempt,
+  readTaskLifecycleStatus,
 } from "../task-execution-domain-operation.js";
 import type {
   RouteFailureInput,
@@ -112,6 +113,8 @@ function routeStoredTechnicalFailure(
 
 export interface VerifiedTaskPublicationDeps {
   readLatestTaskAttempt(task: ClaimTaskAttemptInput["task"]): TaskExecutionAttemptSnapshot | null;
+  /** Canonical lifecycle status; defaults to the database reader. */
+  readTaskLifecycleStatus?(task: ClaimTaskAttemptInput["task"]): string | null;
   publishVerifiedTaskCompletion(input: PublishVerifiedTaskCompletionInput): Promise<unknown>;
 }
 
@@ -490,7 +493,10 @@ export async function runWithTaskExecutionAttempt(
       }
     } else if (predecessor) {
       const terminalRecovery = deps.readTaskRecoveryRoute(predecessor.attemptId);
+      // Only a live route head carries an operative abort; a lineage closed by
+      // task reopen is history and must not advertise a dead resume (#1948).
       if (
+        predecessor.nextStage === "route" &&
         terminalRecovery?.recoveryOwner === "agent" &&
         terminalRecovery.action === "abort" &&
         !terminalRecovery.resumeAuthorized
@@ -598,8 +604,12 @@ export async function publishVerifiedTaskExecution(
   }
   const task = parseTaskIdentity(input.unitId);
   const attempt = deps.readLatestTaskAttempt(task);
+  // A reopened Task voids its prior lineage to `settled` without publishing
+  // (#1948); its `ready` lifecycle has nothing to replay. A committed
+  // publication whose projection failed stays replayable (lifecycle completed).
   const publicationReplayCandidate = attempt?.state === "settled" &&
-    attempt.outcome === "succeeded" && attempt.nextStage === "settled";
+    attempt.outcome === "succeeded" && attempt.nextStage === "settled" &&
+    (deps.readTaskLifecycleStatus ?? readTaskLifecycleStatus)(task) !== "ready";
   const resolvedHumanReviewCandidate = attempt?.state === "settled" &&
     attempt.outcome === "succeeded" && attempt.nextStage === "route";
   if (!isTaskAttemptAwaitingVerification(attempt) &&

--- a/src/resources/extensions/gsd/task-execution-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-execution-domain-operation.ts
@@ -379,6 +379,25 @@ export function readLatestTaskAttempt(
   return snapshot(row);
 }
 
+/** Canonical lifecycle status for the Task, or null when no lifecycle exists. */
+export function readTaskLifecycleStatus(
+  task: ClaimTaskAttemptInput["task"],
+): string | null {
+  const row = getDb().prepare(`
+    SELECT lifecycle_status
+    FROM workflow_item_lifecycles
+    WHERE item_kind = 'task'
+      AND milestone_id = :milestone_id
+      AND slice_id = :slice_id
+      AND task_id = :task_id
+  `).get({
+    ":milestone_id": task.milestoneId,
+    ":slice_id": task.sliceId,
+    ":task_id": task.taskId,
+  }) as { lifecycle_status: string } | undefined;
+  return row ? String(row.lifecycle_status) : null;
+}
+
 /**
  * Every Task Attempt id for the lifecycle, newest first. Recovery scans must
  * consider superseded Attempts, not just the latest (#1754 residual).

--- a/src/resources/extensions/gsd/task-lifecycle-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-lifecycle-domain-operation.ts
@@ -4,6 +4,7 @@
 import {
   executeDomainOperation,
   type DomainJsonValue,
+  type DomainOperationContext,
   type DomainOperationMutation,
   type DomainOperationRequest,
   type DomainOperationResult,
@@ -316,6 +317,43 @@ function loadReceipt(
   };
 }
 
+/**
+ * A reopened lifecycle has no operative Attempt route head (#1948). A terminal
+ * lifecycle can still carry a settled Attempt parked at `route` with an
+ * agent-owned abort that was never resumed; reopen discards that lineage by
+ * closing the Kernel head (`route -> closeout -> settled`) so the next claim is
+ * a fresh Attempt and no guard advertises a resume the lifecycle can no longer
+ * satisfy.
+ */
+function voidStaleRouteHead(
+  context: Readonly<DomainOperationContext>,
+  lifecycleId: string,
+): void {
+  const head = getDb().prepare(`
+    SELECT head.kernel_checkpoint_id, head.attempt_id, head.next_stage
+    FROM workflow_kernel_checkpoints head
+    WHERE head.project_id = :project_id AND head.lifecycle_id = :lifecycle_id
+      AND NOT EXISTS (
+        SELECT 1 FROM workflow_kernel_checkpoints successor
+        WHERE successor.previous_kernel_checkpoint_id = head.kernel_checkpoint_id
+      )
+  `).get({ ":project_id": context.projectId, ":lifecycle_id": lifecycleId }) as
+    { kernel_checkpoint_id: string; attempt_id: string; next_stage: string } | undefined;
+  if (head?.next_stage !== "route") return;
+  const closeout = appendKernelCheckpoint(context, {
+    lifecycleId,
+    attemptId: head.attempt_id,
+    nextStage: "closeout",
+    previousKernelCheckpointId: head.kernel_checkpoint_id,
+  });
+  appendKernelCheckpoint(context, {
+    lifecycleId,
+    attemptId: head.attempt_id,
+    nextStage: "settled",
+    previousKernelCheckpointId: closeout.kernelCheckpointId,
+  });
+}
+
 export function reopenTask(input: {
   invocation: ExecutionInvocation;
   task: TaskLifecycleIdentity;
@@ -339,6 +377,7 @@ export function reopenTask(input: {
     if (state.lifecycleId && currentRunningAttempt(state.lifecycleId)) {
       throw new Error("Task reopen cannot target a running Attempt");
     }
+    if (state.lifecycleId) voidStaleRouteHead(context, state.lifecycleId);
     const lifecycle = adoptOrTransitionLifecycle(context, {
       itemKind: "task",
       milestoneId: state.milestoneId,

--- a/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
@@ -28,9 +28,11 @@ import {
   settleTaskAttempt,
 } from "../task-execution-domain-operation.js";
 import {
+  readTaskRecoveryResumeEligibility,
   readTaskRecoveryRoute,
   recordFailureAndSelectRecovery,
 } from "../task-recovery-domain-operation.js";
+import { reopenTask } from "../task-lifecycle-domain-operation.js";
 import {
   readTaskTechnicalVerdict,
   recordTaskTechnicalVerdict,
@@ -168,6 +170,7 @@ interface CutoverSubject {
     input: Pick<CutoverInput, "unitType" | "unitId" | "workerId" | "traceId" | "turnId"> & { basePath: string },
     deps: {
       readLatestTaskAttempt(task: TaskIdentity): AttemptSnapshot | null;
+      readTaskLifecycleStatus?(task: TaskIdentity): string | null;
       publishVerifiedTaskCompletion(input: {
         invocation: {
           idempotencyKey: string;
@@ -461,6 +464,97 @@ function canonicalDeps(): CutoverDeps {
     },
   } as CutoverDeps;
 }
+
+test("a Task reopened over a stale agent abort dispatches a fresh Attempt (#1948)", async () => {
+  const { runWithTaskExecutionAttempt } = await subject();
+  const firstDispatchId = seedCanonicalTask();
+  const task = { milestoneId: "M001", sliceId: "S01", taskId: "T01" };
+
+  const first = claimTaskAttempt({
+    invocation: { idempotencyKey: "reopen/claim/1", sourceTransport: "internal", actorType: "agent" },
+    task,
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+    coordinationDispatchId: firstDispatchId,
+  });
+  const settled = settleTaskAttempt({
+    invocation: { idempotencyKey: "reopen/settle/1", sourceTransport: "internal", actorType: "agent" },
+    attemptId: first.attemptId,
+    outcome: "failed",
+    failureClass: "verification",
+    summary: "closeout verification failed",
+    output: {},
+  });
+  const abort = recordFailureAndSelectRecovery({
+    invocation: { idempotencyKey: "reopen/route/1", sourceTransport: "internal", actorType: "agent" },
+    attemptId: first.attemptId,
+    resultId: settled.resultId,
+    owner: "agent",
+    classification: { failureKind: "fatal" },
+    summary: "verification-abort",
+    evidence: { source: "test" },
+    rationale: "abort",
+  });
+  assert.equal(abort.action, "abort");
+  assert.deepEqual(readTerminalTaskRecoveryAbort("M001", "S01", "T01"), {
+    recoveryActionId: abort.recoveryActionId,
+  });
+
+  // The lifecycle reaches a terminal head without advancing the Attempt's
+  // Kernel lineage (reconcile/legacy completion), then the operator reopens.
+  const fence = readDomainOperationFence();
+  executeDomainOperation({
+    operationType: "test.task.complete",
+    idempotencyKey: "reopen/complete",
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: "test",
+    sourceTransport: "test",
+    payload: {},
+  }, (context) => {
+    adoptOrTransitionLifecycle(context, { itemKind: "task", ...task, lifecycleStatus: "completed" });
+    database().prepare(`UPDATE tasks SET status = 'complete' WHERE id = 'T01'`).run();
+    return {
+      events: [{ eventType: "test.task.complete", entityType: "task", entityId: "M001/S01/T01", payload: {}, destinations: ["test"] }],
+      projections: [{ projectionKey: "test/m001/s01/t01/complete", projectionKind: "test", rendererVersion: "1" }],
+    };
+  });
+  database().prepare(`UPDATE unit_dispatches SET status = 'failed' WHERE id = ?`).run(firstDispatchId);
+  reopenTask({
+    invocation: { idempotencyKey: "reopen/reopen", sourceTransport: "internal", actorType: "user", actorId: "user-1" },
+    task,
+    reason: "redo after fixing the verification guard",
+  });
+
+  assert.equal(readTaskRecoveryResumeEligibility(abort.recoveryActionId).eligible, false);
+  assert.equal(
+    readTerminalTaskRecoveryAbort("M001", "S01", "T01"),
+    null,
+    "no dispatch guard may advertise a resume the reopened lifecycle cannot satisfy",
+  );
+
+  let ran = false;
+  const result = await runWithTaskExecutionAttempt(input({
+    dispatchId: insertClaimedDispatch(2),
+  }), async () => {
+    ran = true;
+    return { action: "next", data: {} };
+  }, canonicalDeps());
+
+  assert.equal(ran, true, "the reopened Task must dispatch a fresh executor run");
+  assert.notEqual(
+    (result as { reason?: string }).reason?.includes(abort.recoveryActionId),
+    true,
+    "the stale abort must not be advertised after reopen",
+  );
+  const latest = readLatestTaskAttempt(task);
+  assert.equal(latest?.attemptNumber, 2);
+  assert.equal(latest?.retryOfAttemptId, first.attemptId);
+  assert.equal(
+    (database().prepare(`SELECT lifecycle_status FROM workflow_item_lifecycles WHERE task_id = 'T01'`).get() as { lifecycle_status: string }).lifecycle_status,
+    "in_progress",
+  );
+});
 
 test("agent remediation of a failed Technical Verdict runs in a lineage-linked Attempt", async () => {
   const { publishVerifiedTaskExecution, runWithTaskExecutionAttempt } = await subject();
@@ -1988,6 +2082,7 @@ test("settled Task publication delegates replay validation to the stable publica
       workerId: "worker-1",
       milestoneLeaseToken: 7,
     }),
+    readTaskLifecycleStatus: () => "in_progress",
     async publishVerifiedTaskCompletion() {
       publicationCalls++;
       throw rejected;
@@ -1995,6 +2090,30 @@ test("settled Task publication delegates replay validation to the stable publica
   }), rejected);
 
   assert.equal(publicationCalls, 1);
+});
+
+test("a voided settled Attempt on a reopened Task is not replayed as a publication (#1948)", async () => {
+  const { publishVerifiedTaskExecution } = await subject();
+  let publicationCalls = 0;
+
+  await assert.rejects(publishVerifiedTaskExecution({ ...input(), basePath: "/project" }, {
+    readLatestTaskAttempt: () => ({
+      attemptId: "attempt-7",
+      attemptNumber: 7,
+      state: "settled",
+      outcome: "succeeded",
+      nextStage: "settled",
+      coordinationDispatchId: 41,
+      workerId: "worker-1",
+      milestoneLeaseToken: 7,
+    }),
+    readTaskLifecycleStatus: () => "ready",
+    async publishVerifiedTaskCompletion() {
+      publicationCalls++;
+    },
+  }), /requires a succeeded Attempt at the verify stage/);
+
+  assert.equal(publicationCalls, 0);
 });
 
 test("failed Task execution cannot publish after host verification", async () => {

--- a/src/resources/extensions/gsd/tests/task-recovery-convergence.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-convergence.test.ts
@@ -23,13 +23,15 @@ import {
 import {
   cancelTask,
   readPendingTaskRecoveryContext,
+  readTaskRecoveryResumeEligibility,
   readTaskRecoveryRoute,
   recordFailureAndSelectRecovery,
   reopenTask,
   resolveTaskBlocker,
   resumeTaskRecovery,
 } from "../task-recovery-domain-operation.ts";
-import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.ts";
+import { claimTaskAttempt, readLatestTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.ts";
+import { readTerminalTaskRecoveryAbort } from "../artifact-verification.ts";
 import { recordTaskTechnicalVerdict } from "../task-verification-domain-operation.ts";
 import type { ExecutionInvocation } from "../execution-invocation.ts";
 import {
@@ -486,6 +488,63 @@ test("agent recovery exhausts durably, resumes once, then passes host verificati
   `).all().map((entry) => Number((entry as Record<string, unknown>).resulting_revision));
   assert.deepEqual(revisions, [...revisions].sort((left, right) => left - right));
   assert.equal(new Set(revisions).size, revisions.length, "every committed operation owns one revision");
+});
+
+test("reopen closes a stale route head so the prior abort is history, not a lever (#1948)", async () => {
+  const taskId = "T01";
+  seedProject([taskId]);
+  const failed = seedFailedAttempt(taskId);
+  const abort = recordFailureAndSelectRecovery({
+    invocation: invocation("reopen-void/route"),
+    attemptId: failed.attemptId,
+    resultId: failed.resultId,
+    owner: "agent",
+    classification: { failureKind: "fatal" },
+    summary: "verification-abort",
+    evidence: { source: "test" },
+    rationale: "abort",
+  });
+  assert.equal(abort.action, "abort");
+  assert.equal(readLatestTaskAttempt({ milestoneId: "M001", sliceId: "S01", taskId })?.nextStage, "route");
+
+  // Terminal lifecycle head reached without advancing the Attempt Kernel lineage.
+  const fence = readDomainOperationFence();
+  executeDomainOperation({
+    operationType: "test.task.complete",
+    idempotencyKey: "reopen-void/complete",
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: "test",
+    sourceTransport: "test",
+    payload: { taskId },
+  }, (context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId,
+      lifecycleStatus: "completed",
+    });
+    db().prepare(`UPDATE tasks SET status = 'complete' WHERE id = :task_id`).run({ ":task_id": taskId });
+    return {
+      events: [{ eventType: "test.task.complete", entityType: "task", entityId: `M001/S01/${taskId}`, payload: {}, destinations: ["test"] }],
+      projections: [{ projectionKey: `test/${taskId}/complete-void`.toLowerCase(), projectionKind: "test", rendererVersion: "1" }],
+    };
+  });
+
+  const reopened = reopenTask({
+    invocation: invocation("reopen-void/reopen", "user"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId },
+    reason: "redo after repair",
+  });
+  assert.equal(reopened.canonicalStatus, "ready");
+
+  const latest = readLatestTaskAttempt({ milestoneId: "M001", sliceId: "S01", taskId });
+  assert.equal(latest?.attemptId, failed.attemptId, "reopen must not erase Attempt history");
+  assert.equal(latest?.nextStage, "settled", "reopen closes the stale route head");
+  assert.equal(readTaskRecoveryResumeEligibility(abort.recoveryActionId).eligible, false);
+  assert.equal(readTerminalTaskRecoveryAbort("M001", "S01", taskId), null);
+  assert.equal(count("workflow_execution_attempts"), 1);
 });
 
 test("reopen and cancel survive projection obstruction while stale artifacts and UAT scopes remain non-authoritative", async () => {


### PR DESCRIPTION
Stacked on #1946 — merge after it; diff vs #1946: https://github.com/open-gsd/gsd-pi/compare/issue/1944-bug-resume-consumed-abort-route-stays-te-1787477716...fix/issue-1948-reopen-voids-stale-abort

## TL;DR

**What:** `gsd_task_reopen` now closes the prior Attempt's stale `route` Kernel head, and the task-execution cutover only treats an agent abort as the operative blocker when that route head is live.
**Why:** After a reopen, every guard advertised `gsd_task_recovery_resume <id>` for an abort whose lifecycle is now `ready`, so the resume rejected with `lifecycle-in-progress` and the task was permanently stuck (#1948).
**How:** Restore one invariant — a reopened lifecycle has no operative route head — and make the cutover and the retry claim agree on the same condition (`nextStage === "route"`).

Fixes #1948

## What

- `task-lifecycle-domain-operation.ts` — `reopenTask` calls a new `voidStaleRouteHead`: if the lifecycle's Kernel head is `route`, it appends `route -> closeout -> settled` checkpoints for that Attempt inside the same reopen Domain Operation. Attempt history is preserved; only the head moves.
- `auto/task-execution-cutover.ts` — the predecessor `task-recovery-abort` break is gated on `predecessor.nextStage === "route"`, the same condition `claimRunningAttempt` uses before demanding route-head authority. `publishVerifiedTaskExecution`'s replay branch additionally refuses a `ready` lifecycle, so a voided succeeded Attempt (verification-abort flavor) on a reopened Task cannot be replayed as a publication. A committed publication whose PLAN projection failed (lifecycle `completed`) stays replayable, as before.
- `task-execution-domain-operation.ts` — small `readTaskLifecycleStatus` reader used by that replay guard (injectable through `VerifiedTaskPublicationDeps`).
- Tests: domain-level (reopen closes the route head, abort becomes ineligible, dispatch guard returns null), cutover-level (reopen over a stale abort → guard null → a fresh retry Attempt is claimed and the executor runs, lifecycle `in_progress`), and the replay guard (voided settled Attempt on a `ready` lifecycle is not published). Each fails without its fix.

## Why

On 1.16.1 a task can reach lifecycle `completed` while its latest Attempt is still parked at `route` with a never-resumed agent abort (reconcile/legacy completion paths do not advance the Kernel head). `gsd_task_reopen` then sets `ready` but leaves the abort route and the route head intact. Three predicates disagree: `readTerminalTaskRecoveryAbort` / the cutover name the abort as the exit, `readTaskRecoveryResumeEligibility` rejects `lifecycle-in-progress`, and `claimRunningAttempt` refuses a retry claim over the route head without authority. Every advertised lever is dead and the liveness backstop re-wedges forever.

#1946 already stops `readTerminalTaskRecoveryAbort` from naming ineligible routes, but the cutover still broke with the same dead id and the claim would still throw, so the deadlock only moved from `dispatch-rule-stop` to `unit-break`. This PR fixes the remaining half at its source.

## How

Reopen is where the operator explicitly discards the prior lineage, so that is where the route head is closed; `route -> closeout -> settled` is the only policy-legal path (`db/kernel-stage-policy.ts`) and matches the shape a normal "reopen after published completion" already has. With the head at `settled`, `claimRunningAttempt` needs no route authority, the resume guard reports the abort as history, and the cutover (now keyed on the same `nextStage === "route"` condition) claims a fresh Attempt with `retry_of_attempt_id` pointing at the voided one.

Alternatives considered: accepting `ready` in the resume guard (would let a resume re-authorize a lineage the operator asked to discard), or refusing reopen while a route head is open (defeats the operator's intent in #1948).

### Relationship to #1955

#1955 (auto-opened for the same issue) takes the guard side: it adds a `task.reopened`-event authority (`isTaskRecoveryReopenAuthorized`) so the retry claim and the guards treat the old abort as re-authorized, and it touches 13 files including the orchestrator, liveness backstop and `auto.ts`. This PR is smaller (3 source files), does not re-authorize a lineage the operator discarded — the old abort stays ineligible history and the next Attempt is a plain fresh retry — and keys the cutover on the exact condition `claimRunningAttempt` already uses, so the guards and the claim cannot drift apart again. If #1955 lands first, its reopen-authority path becomes unreachable for reopened tasks (the head is no longer `route`), so the two are compatible but one should be dropped.

## Change type

- [x] `fix` — Bug fix

## Verification

- `pnpm run typecheck:extensions` — clean
- `pnpm run test:compile` + standalone: `auto-task-execution-cutover`, `task-recovery-convergence`, `task-lifecycle-domain-operation`, `auto-orchestrator`, `task-recovery-domain-operation`, `auto-loop`, `auto-liveness-backstop-1655`, `provider-errors` — 389 pass, 0 fail
- The three new tests fail without the source changes (all three with none applied; cutover + replay tests with only the reopen change applied).
- `pnpm run test:unit:compiled` (full suite, this worktree): 14367 passed, 37 failed, 28 skipped. All 37 failures are environmental in this nested worktree (`build:pi` cannot complete here, so `@gsd/agent-modes/dist`, the headless CLI, and the native fault-injection build are missing: `headless-*`, `read-cli-*`, `migrate-safety-audit` native tree tests, graph build, workflow-authority baseline CLI, prompt golden fixture size gate). None touch the changed files. The one real hit from the first run (`task-completion-compatibility-adapter`: committed publication replay after PLAN projection failure) drove the `ready`-only replay guard above; that file now passes standalone (429 pass across the 9 files listed plus it).

This PR is AI-assisted.

