### PR TITLE
test(live-workflow): run full auto to milestone completion; fix two-step recover seeding

### DIFF
--- a/tests/live-workflow/README.md
+++ b/tests/live-workflow/README.md
@@ -10,22 +10,34 @@ This is the live counterpart to the other two test layers:
 | --- | --- | --- | --- | --- |
 | Fake-LLM e2e | `tests/e2e` | scripted JSONL transcript | none | yes (required gate) |
 | Provider smoke | `tests/live` | real API, transport only | yes | no (manual) |
-| **Workflow** | `tests/live-workflow` | **real agent, single unit** | yes | optional release CI + manual |
+| **Workflow** | `tests/live-workflow` | **real agent, one unit or full `auto`** | yes | optional release CI + manual |
 
 These exist to answer one question the other layers can't: *does a real agent,
-given a real plan, actually execute a dispatched unit to a correct, durable
-outcome through gsd's real gates?* They are slow and cost real tokens, so they
-never run in the default suite. Production release CI runs them as a non-blocking
-optional smoke against the configured live workflow model.
+given a real plan, actually execute through gsd's real gates to a correct,
+durable outcome?* They are slow and cost real tokens, so they never run in the
+default suite. Production release CI runs them as a non-blocking optional smoke
+against the configured live workflow model.
 
-> **Why `next`, not `auto`?** The harness dispatches a single unit with
-> `gsd headless next` rather than running the full `auto` loop. A real agent
-> sails through task → slice → UAT, but `auto`'s final *milestone closeout* is
-> built around human-gated checkpoints (e.g. a depth-verification confirmation)
-> that the fake-LLM e2e tests script around with `--answers`; a real agent's
-> closeout turn hangs in non-supervised headless mode. `next` runs the same
-> real dispatch + verification gates and exits cleanly, which is the part worth
-> smoke-testing live.
+Two scenarios:
+
+| Script | Seed | Command | Proves | Default budget |
+| --- | --- | --- | --- | --- |
+| `test-tiny-milestone.ts` | 1 slice / 1 task | `gsd headless next` | one real agent turn passes the dispatch + verification gates and exits 0 | 300 s |
+| `test-multi-slice-auto.ts` | S01 → S02 → S03, 5 tasks | `gsd headless auto` | the whole loop — every execute-task, every complete-slice (in dependency order), milestone closeout — finishes headlessly: exit 0, all five per-task verifications pass, M001 + all slices + all tasks are `complete` in `.gsd/gsd.db`, ≥5 new commits, no liveness/wedge/pause/error lines on stderr | 1800 s |
+
+The `auto` scenario is the one that matches what a user runs. A real agent's
+closeout does complete headlessly on `main` (verified 2026-08-23 with
+`kimi-for-coding`: the 1-task seed closed M001 in 273 s with 0 wedge lines).
+`next` stays as the fast, cheap smoke of a single dispatch.
+
+Status of the multi-slice scenario on `main` (2026-08-23, `kimi-for-coding`):
+S01 → S02 → S03 all completed in order, but milestone validation returned
+`needs-remediation` (the agent's own S03 UAT invented a `formatAnswer(7)` check
+that the fixture never specified), `gsd_reassess_roadmap` added S04, and
+plan-slice S04 failed pre-execution checks twice with identical inputs
+(planning artifacts listed as task inputs) — liveness backstop wedge, exit 10.
+The scenario fails until that closeout path is fixed; on failure it saves
+`gsd.db` next to the transcript for post-mortem.
 
 ## Running
 
@@ -44,6 +56,16 @@ Without `GSD_LIVE_TESTS=1` the runner is a no-op. With it set but no provider
 credential in the environment, each test **skips** (POSIX exit 77) rather than
 failing.
 
+If your credentials live in `~/.gsd/agent/auth.json` (no `*_API_KEY` in the
+shell), opt in to forwarding your real HOME so the child authenticates exactly
+like you do:
+
+```bash
+GSD_LIVE_TESTS=1 GSD_LIVE_WORKFLOW_USE_HOME=1 \
+GSD_SMOKE_BINARY="$(pwd)/dist/loader.js" \
+node --experimental-strip-types tests/live-workflow/test-multi-slice-auto.ts
+```
+
 ### Env knobs
 
 | Var | Default | Purpose |
@@ -52,32 +74,44 @@ failing.
 | `GSD_SMOKE_BINARY` | `gsd` on PATH | Built binary to drive (recommended). |
 | `*_API_KEY` / `*_OAUTH_TOKEN` | — | Provider credential, forwarded to the child. At least one required. Provider-agnostic. |
 | `GSD_LIVE_WORKFLOW_MODEL` | auto-resolved (`openai/gpt-5.4-mini` in optional release CI) | Force a model id. Unset = gsd picks the default for whichever provider's credential is present. |
-| `GSD_LIVE_WORKFLOW_TIMEOUT_MS` | `300000` | Per-run dispatch timeout (wall-clock budget). Raise for slower models. |
+| `GSD_LIVE_WORKFLOW_USE_HOME` | — | `1` forwards your real `HOME` so the child reads `~/.gsd/agent/auth.json` and prefs. Counts as a credential source. Off by default: the child normally gets an isolated, fresh home. |
+| `GSD_LIVE_WORKFLOW_TIMEOUT_MS` | `300000` (`next`) / `1800000` (`auto`) | Per-run dispatch timeout (wall-clock budget). Overrides the scenario default. Raise for slower models. |
+| `GSD_LIVE_WORKFLOW_RUNNER_TIMEOUT_MS` | — | Optional extra per-test deadline for `run.ts`. Unset = none; each scenario already kills its own gsd child at its budget. |
 | `GSD_LIVE_WORKFLOW_OUTPUT` | `text` | Output format. `text` = readable transcript; `stream-json` = machine-parseable JSONL. |
 
 ## How it works
 
 Each `test-*.ts` script:
 
-1. **Seeds a tiny milestone** in a throwaway git project — one slice, one task
-   whose verification is a runnable command (`node --test ...`). The bundled
-   test *fails* until the agent does the work. A `package.json` `test` script is
+1. **Seeds a milestone** in a throwaway git project — one slice/one task for
+   `next`, three dependent slices/five tasks for `auto` — where every task's
+   verification is a runnable command (`node --test ...`). The bundled tests
+   *fail* until the agent does the work. A `package.json` `test` script is
    included so gsd's verification gate has a host-owned check to discover and
-   run; after seeding it runs `gsd headless recover` and commits the result so
-   the pre-dispatch `git diff --check` guard sees a clean tree.
+   run. After seeding it runs the **two-step** `gsd headless recover`: the
+   first call prints an import preview and a `--preview=sha256:<hash>` hint
+   (exit non-zero), the second call with that hash applies it. The result is
+   committed so the pre-dispatch `git diff --check` guard sees a clean tree.
 2. **Forwards credentials from the environment.** Any `*_API_KEY` /
    `*_OAUTH_TOKEN` in your shell is passed to the child; nothing reads or
    touches your real `~/.gsd`. The child keeps the e2e harness's isolated,
    fresh agent home, so the test behaves identically locally and in CI.
    Provider-agnostic by construction — no vendor is named anywhere.
-3. **Dispatches one unit**: `gsd headless --output-format text --verbose
-   --timeout <T> --max-restarts 0 [--model <M>] next`. `next` runs a single
-   real agent turn (execute-task) through the verification gate, then exits —
-   no milestone-closeout tail (see "Why `next`, not `auto`?" above).
+   (`GSD_LIVE_WORKFLOW_USE_HOME=1` is the opt-in exception, see above.)
+3. **Dispatches**: `gsd headless --output-format text --verbose
+   --timeout <T> --max-restarts 0 [--model <M>] <next|auto>`. `next` runs a
+   single real agent turn (execute-task) through the verification gate, then
+   exits; `auto` keeps dispatching until the milestone is closed.
 4. **Asserts on durable outcomes only** — never on agent prose, which drifts:
    - exit code `0` (success; `10`=blocked, `1`=error/timeout, `11`=cancelled),
    - the task's own verification command now **passes**,
-   - the agent added at least one git commit.
+   - the agent added at least one git commit,
+   - (`auto` only) every per-task verification passes, `milestones`/`slices`/
+     `tasks` rows for M001 and all seeded slices/tasks read `complete` in
+     `.gsd/gsd.db`, slices' `completed_at` respects the `depends` order,
+     commits grew by at least the task count, and the child's **stderr** has
+     no line matching `/liveness|wedge|Cannot dispatch|paused|error/i`
+     (stdout, where the agent's tool output lands, is not scanned).
 
 Artifacts (transcript + raw streams) are written under `test-results/e2e/` for
 post-mortem.

--- a/tests/live-workflow/harness.ts
+++ b/tests/live-workflow/harness.ts
@@ -8,6 +8,11 @@
  * runs the same way locally and in CI. This is provider-agnostic: it never
  * names a vendor; whatever key you export is what the agent authenticates with.
  *
+ * Opt-in exception: GSD_LIVE_WORKFLOW_USE_HOME=1 forwards the real HOME so the
+ * child reads the operator's ~/.gsd/agent/auth.json (and prefs) exactly like
+ * a user would. Use it on a machine whose credentials live in auth.json
+ * rather than in env vars.
+ *
  * Model selection is left to gsd's resolver: with no `--model`, a fresh home
  * auto-picks the default model for whichever provider has a valid credential
  * present (see packages/pi-coding-agent/src/core/model-resolver.ts). Set
@@ -20,6 +25,7 @@ import { join } from "node:path";
 import { gsdAsync, gsdSync, stripAnsi, type SpawnSyncResult, type TmpProject } from "../e2e/_shared/index.ts";
 
 const CRED_RE = /_API_KEY$|_OAUTH_TOKEN$/;
+const USE_HOME_ENV = "GSD_LIVE_WORKFLOW_USE_HOME";
 const CLAUDE_CODE_PROVIDER = "claude-code";
 const CLAUDE_CODE_CLI_ALIAS = "claude-code-cli";
 
@@ -71,7 +77,13 @@ export function credentialNames(): string[] {
   if (isClaudeCodeWorkflowModel() && isClaudeCodeCliAuthenticated()) {
     names.push("CLAUDE_CODE_CLI");
   }
+  if (usesOperatorHome()) names.push(USE_HOME_ENV);
   return names;
+}
+
+/** True when the operator opted in to forwarding the real HOME (auth.json). */
+export function usesOperatorHome(): boolean {
+  return process.env[USE_HOME_ENV] === "1";
 }
 
 /**
@@ -87,14 +99,15 @@ export function hasUsableCredentials(): boolean {
  * current environment. buildE2eEnv() in gsdSync already forwards non-GSD_ vars,
  * but we re-pass them explicitly so credential delivery is self-documenting and
  * resilient to future harness changes. No GSD_HOME bridge — the child uses its
- * isolated, fresh agent home.
+ * isolated, fresh agent home — unless GSD_LIVE_WORKFLOW_USE_HOME=1 (or a
+ * Claude Code CLI model) asks for the operator's real HOME.
  */
 export function liveEnv(extra: Record<string, string> = {}): Record<string, string> {
-  const claudeCodeEnv: Record<string, string> = {};
-  if (isClaudeCodeWorkflowModel() && process.env.HOME) {
-    claudeCodeEnv.HOME = process.env.HOME;
+  const homeEnv: Record<string, string> = {};
+  if ((isClaudeCodeWorkflowModel() || usesOperatorHome()) && process.env.HOME) {
+    homeEnv.HOME = process.env.HOME;
   }
-  return { ...detectCredentialEnv(), ...claudeCodeEnv, ...extra };
+  return { ...detectCredentialEnv(), ...homeEnv, ...extra };
 }
 
 function git(dir: string, args: string[]): void {
@@ -102,52 +115,205 @@ function git(dir: string, args: string[]): void {
 }
 
 /**
- * Seed a deliberately tiny, unambiguous milestone: one slice, one task whose
- * verification is a runnable command. The fixture's test FAILS until the
- * agent does the work, so "did the live agent actually do something" is a
- * durable, prose-free assertion: re-run the verification command afterward.
- *
- * Returns the verification command (argv) the caller asserts on.
+ * `gsd headless recover` is two-step: the first call prints an import preview
+ * (`re-run with --preview=sha256:<hash>`) and exits non-zero; the second call
+ * with that hash applies it. Same dance as tests/acceptance-bed.
  */
-export function seedTinyMilestone(project: TmpProject): { verifyArgv: string[] } {
-  // Fixture under test: answer() returns the wrong value until the agent fixes it.
-  // The `test` script matters: gsd's verification gate independently discovers a
-  // host-owned check to run at task completion (package.json scripts are one of
-  // its discovery sources). Without a discoverable check the gate fails with
-  // "no runnable host-owned verification checks" and auto pauses.
+function recoverWithApproval(dir: string): void {
+  const preview = gsdSync(["headless", "recover"], { cwd: dir, timeoutMs: 60_000, env: liveEnv() });
+  const previewHash = /re-run with --preview=(sha256:[0-9a-f]{64})/u.exec(preview.stderrClean)?.[1];
+  if (!previewHash) {
+    throw new Error(
+      `headless recover printed no preview hash (code=${preview.code}):\n${preview.stderrClean.slice(0, 1200)}`,
+    );
+  }
+  const approved = gsdSync(["headless", "recover", `--preview=${previewHash}`], {
+    cwd: dir,
+    timeoutMs: 60_000,
+    env: liveEnv(),
+  });
+  if (approved.code !== 0) {
+    throw new Error(`headless recover approval failed (code=${approved.code}):\n${approved.stderrClean.slice(0, 1200)}`);
+  }
+}
+
+/** One task of a seeded fixture: a source file the agent must write/fix and a node:test file that fails until it does. */
+export interface FixtureTask {
+  id: string;
+  title: string;
+  /** Source file the task produces. */
+  file: string;
+  /** Initial (wrong) content; omit to leave the file absent until the agent creates it. */
+  stub?: string;
+  /** Exact expected behaviour, quoted in the plan as the task's Expected Output. */
+  expected: string;
+  testFile: string;
+  testSource: string;
+  /** Verification command argv (after `node`). */
+  verifyArgv: string[];
+}
+
+export interface FixtureSlice {
+  id: string;
+  title: string;
+  depends: string[];
+  demo: string;
+  tasks: FixtureTask[];
+}
+
+function nodeTest(source: string, name: string, body: string): string {
+  return [
+    'const test = require("node:test");',
+    'const assert = require("node:assert/strict");',
+    `const ${source}`,
+    "",
+    `test(${JSON.stringify(name)}, () => {`,
+    `  ${body}`,
+    "});",
+    "",
+  ].join("\n");
+}
+
+const ANSWER_TASK: FixtureTask = {
+  id: "T01",
+  title: "Make answer() return 42",
+  file: "src/answer.js",
+  stub: "function answer() {\n  return 0;\n}\n\nmodule.exports = { answer };\n",
+  expected: "`answer()` returns `42`",
+  testFile: "test/answer.test.js",
+  testSource: nodeTest('{ answer } = require("../src/answer.js");', "answer returns 42", "assert.equal(answer(), 42);"),
+  verifyArgv: ["--test", "test/answer.test.js"],
+};
+
+/** One slice, one task — the cheapest real dispatch. */
+const TINY_SLICES: FixtureSlice[] = [
+  { id: "S01", title: "Fix answer", depends: [], demo: "answer() returns 42 and the test passes.", tasks: [ANSWER_TASK] },
+];
+
+/** Three dependent slices, five tasks — enough to exercise slice progression and closeout. */
+const MULTI_SLICES: FixtureSlice[] = [
+  {
+    id: "S01",
+    title: "Answer and double",
+    depends: [],
+    demo: "answer() returns 42 and double(n) returns 2n; both tests pass.",
+    tasks: [
+      ANSWER_TASK,
+      {
+        id: "T02",
+        title: "Add double(n)",
+        file: "src/double.js",
+        expected: "`double(n)` returns `n * 2`, exported as `module.exports = { double }`",
+        testFile: "test/double.test.js",
+        testSource: nodeTest('{ double } = require("../src/double.js");', "double doubles", "assert.equal(double(21), 42);"),
+        verifyArgv: ["--test", "test/double.test.js"],
+      },
+    ],
+  },
+  {
+    id: "S02",
+    title: "Sum and format",
+    depends: ["S01"],
+    demo: "sum(a, b) adds and formatAnswer() renders \"answer: 42\" using answer() and sum().",
+    tasks: [
+      {
+        id: "T01",
+        title: "Add sum(a, b)",
+        file: "src/sum.js",
+        expected: "`sum(a, b)` returns `a + b`, exported as `module.exports = { sum }`",
+        testFile: "test/sum.test.js",
+        testSource: nodeTest('{ sum } = require("../src/sum.js");', "sum adds", "assert.equal(sum(40, 2), 42);"),
+        verifyArgv: ["--test", "test/sum.test.js"],
+      },
+      {
+        id: "T02",
+        title: "Add formatAnswer()",
+        file: "src/format.js",
+        expected:
+          '`formatAnswer()` returns the string `"answer: 42"` built from `answer()` (src/answer.js) and `sum()` (src/sum.js), exported as `module.exports = { formatAnswer }`',
+        testFile: "test/format.test.js",
+        testSource: nodeTest(
+          '{ formatAnswer } = require("../src/format.js");',
+          "formatAnswer renders the answer",
+          'assert.equal(formatAnswer(), "answer: 42");',
+        ),
+        verifyArgv: ["--test", "test/format.test.js"],
+      },
+    ],
+  },
+  {
+    id: "S03",
+    title: "Public index",
+    depends: ["S02"],
+    demo: "src/index.js re-exports answer, double, sum and formatAnswer; the whole suite passes.",
+    tasks: [
+      {
+        id: "T01",
+        title: "Add src/index.js exporting all four functions",
+        file: "src/index.js",
+        expected: "`src/index.js` exports `{ answer, double, sum, formatAnswer }` from the four modules",
+        testFile: "test/index.test.js",
+        testSource: nodeTest(
+          'api = require("../src/index.js");',
+          "index exports all four functions",
+          'assert.deepEqual(Object.keys(api).sort(), ["answer", "double", "formatAnswer", "sum"]);\n  assert.equal(api.formatAnswer(), "answer: 42");',
+        ),
+        verifyArgv: ["--test"],
+      },
+    ],
+  },
+];
+
+function planMarkdown(slice: FixtureSlice): string {
+  const lines = [`# ${slice.id}: ${slice.title}`, "", `**Goal:** ${slice.demo}`, "", "## Tasks", ""];
+  for (const task of slice.tasks) lines.push(`- [ ] **${task.id}: ${task.title}** \`est:2m\``);
+  for (const task of slice.tasks) {
+    lines.push(
+      "",
+      `### ${task.id}: ${task.title}`,
+      "",
+      "Inputs:",
+      `- \`${task.file}\``,
+      `- \`${task.testFile}\``,
+      "",
+      "Expected Output:",
+      `- \`${task.file}\` — ${task.expected}`,
+      "",
+      "Verification:",
+      `- \`node ${task.verifyArgv.join(" ")}\``,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Write the fixture + GSD milestone markdown, commit, run the two-step recover
+ * and commit again so the tree is clean for auto's pre-dispatch guard.
+ *
+ * The package.json `test` script matters: gsd's verification gate independently
+ * discovers a host-owned check to run at task completion (package.json scripts
+ * are one of its discovery sources). Without a discoverable check the gate
+ * fails with "no runnable host-owned verification checks" and auto pauses.
+ *
+ * Every fixture test FAILS until the agent does the work, so "did the live
+ * agent actually do something" is a durable, prose-free assertion: re-run the
+ * verification commands afterward.
+ */
+function seedMilestone(project: TmpProject, slices: FixtureSlice[], testScript: string): void {
   project.writeFile(
     "package.json",
-    JSON.stringify(
-      {
-        name: "gsd-live-fixture",
-        version: "0.0.0",
-        private: true,
-        scripts: { test: "node --test test/answer.test.js" },
-      },
-      null,
-      2,
-    ) + "\n",
+    JSON.stringify({ name: "gsd-live-fixture", version: "0.0.0", private: true, scripts: { test: testScript } }, null, 2) +
+      "\n",
   );
   project.writeFile(".gitignore", "node_modules\n");
-  project.writeFile("src/answer.js", "function answer() {\n  return 0;\n}\n\nmodule.exports = { answer };\n");
-  project.writeFile(
-    "test/answer.test.js",
-    [
-      'const test = require("node:test");',
-      'const assert = require("node:assert/strict");',
-      'const { answer } = require("../src/answer.js");',
-      "",
-      'test("answer returns 42", () => {',
-      "  assert.equal(answer(), 42);",
-      "});",
-      "",
-    ].join("\n"),
-  );
+  for (const task of slices.flatMap((s) => s.tasks)) {
+    if (task.stub !== undefined) project.writeFile(task.file, task.stub);
+    project.writeFile(task.testFile, task.testSource);
+  }
 
   // GSD milestone structure (mirrors the layout the fake-LLM headless tests seed).
   const milestoneDir = join(".gsd", "milestones", "M001");
-  const sliceDir = join(milestoneDir, "slices", "S01");
-
   project.writeFile(
     join(milestoneDir, "M001-CONTEXT.md"),
     ["# M001: Answer Fixture", "", "## Purpose", "Live end-to-end smoke of the auto-orchestration loop.", ""].join("\n"),
@@ -159,50 +325,23 @@ export function seedTinyMilestone(project: TmpProject): { verifyArgv: string[] }
       "",
       "## Slices",
       "",
-      "- [ ] **S01: Fix answer** `risk:low` `depends:[]`",
-      "  > Demo: answer() returns 42 and the test passes.",
-      "",
+      ...slices.flatMap((s) => [
+        `- [ ] **${s.id}: ${s.title}** \`risk:low\` \`depends:[${s.depends.join(",")}]\``,
+        `  > Demo: ${s.demo}`,
+        "",
+      ]),
     ].join("\n"),
   );
-  project.writeFile(
-    join(sliceDir, "S01-PLAN.md"),
-    [
-      "# S01: Fix answer",
-      "",
-      "**Goal:** Make `answer()` return 42 so the existing test passes.",
-      "",
-      "## Tasks",
-      "",
-      "- [ ] **T01: Make answer() return 42** `est:2m`",
-      "",
-      "### T01: Make answer() return 42",
-      "",
-      "Inputs:",
-      "- `src/answer.js`",
-      "- `test/answer.test.js`",
-      "",
-      "Expected Output:",
-      "- `src/answer.js` — `answer()` returns `42`",
-      "",
-      "Verification:",
-      "- `node --test test/answer.test.js`",
-      "",
-    ].join("\n"),
-  );
+  for (const slice of slices) {
+    project.writeFile(join(milestoneDir, "slices", slice.id, `${slice.id}-PLAN.md`), planMarkdown(slice));
+  }
 
   // Commit the fixture so recover starts from a clean tree.
   git(project.dir, ["add", "-A"]);
   git(project.dir, ["commit", "-m", "test: seed live-workflow answer fixture"]);
 
   // Rebuild the DB hierarchy from the on-disk markdown so auto can dispatch.
-  const recover = gsdSync(["headless", "recover"], {
-    cwd: project.dir,
-    timeoutMs: 60_000,
-    env: liveEnv(),
-  });
-  if (recover.code !== 0) {
-    throw new Error(`headless recover failed (code=${recover.code}):\n${recover.stderrClean.slice(0, 1200)}`);
-  }
+  recoverWithApproval(project.dir);
 
   // recover rewrites the markdown projection (canonical formatting) and drops
   // the DB / backups, leaving the tree dirty — and gsd's pre-dispatch guard
@@ -211,8 +350,27 @@ export function seedTinyMilestone(project: TmpProject): { verifyArgv: string[] }
   // recovered state so the tree is clean, exactly as real usage would.
   git(project.dir, ["add", "-A"]);
   git(project.dir, ["commit", "--allow-empty", "-m", "chore: absorb gsd recover state"]);
+}
 
-  return { verifyArgv: ["--test", "test/answer.test.js"] };
+/**
+ * Seed a deliberately tiny, unambiguous milestone: one slice, one task whose
+ * verification is a runnable command. Returns the verification argv the
+ * caller asserts on.
+ */
+export function seedTinyMilestone(project: TmpProject): { verifyArgv: string[] } {
+  seedMilestone(project, TINY_SLICES, "node --test test/answer.test.js");
+  return { verifyArgv: ANSWER_TASK.verifyArgv };
+}
+
+/**
+ * Seed a three-slice milestone (S01 → S02 → S03, five tasks) so a full `auto`
+ * run must progress through dependent slices before closeout. Returns the
+ * seeded slices (for per-task verification and ordering assertions) and the
+ * whole-suite verification argv.
+ */
+export function seedMultiSliceMilestone(project: TmpProject): { verifyArgv: string[]; slices: FixtureSlice[] } {
+  seedMilestone(project, MULTI_SLICES, "node --test");
+  return { verifyArgv: ["--test"], slices: MULTI_SLICES };
 }
 
 /** Run the seeded task's verification command in the project dir. */

--- a/tests/live-workflow/harness.unit.test.ts
+++ b/tests/live-workflow/harness.unit.test.ts
@@ -1,7 +1,40 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isClaudeCodeWorkflowModel, liveEnv, normalizeLiveWorkflowModel } from "./harness.ts";
+import {
+  credentialNames,
+  hasUsableCredentials,
+  isClaudeCodeWorkflowModel,
+  liveEnv,
+  normalizeLiveWorkflowModel,
+} from "./harness.ts";
+
+function withEnv(t: { after: (fn: () => void) => void }, overrides: Record<string, string | undefined>): void {
+  const previous = Object.fromEntries(Object.keys(overrides).map((k) => [k, process.env[k]]));
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  t.after(() => {
+    for (const [k, v] of Object.entries(previous)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+}
+
+test("GSD_LIVE_WORKFLOW_USE_HOME=1 forwards HOME and counts as a credential source", (t) => {
+  withEnv(t, { GSD_LIVE_WORKFLOW_MODEL: undefined, GSD_LIVE_WORKFLOW_USE_HOME: "1", HOME: "/tmp/operator-home" });
+  assert.equal(liveEnv().HOME, "/tmp/operator-home");
+  assert.ok(credentialNames().includes("GSD_LIVE_WORKFLOW_USE_HOME"));
+  assert.equal(hasUsableCredentials(), true);
+});
+
+test("without GSD_LIVE_WORKFLOW_USE_HOME the child keeps an isolated HOME", (t) => {
+  withEnv(t, { GSD_LIVE_WORKFLOW_MODEL: undefined, GSD_LIVE_WORKFLOW_USE_HOME: undefined, HOME: "/tmp/operator-home" });
+  assert.equal(liveEnv().HOME, undefined);
+  assert.ok(!credentialNames().includes("GSD_LIVE_WORKFLOW_USE_HOME"));
+});
 
 test("normalizeLiveWorkflowModel maps claude-code-cli aliases to the registered provider", () => {
   assert.equal(normalizeLiveWorkflowModel("claude-code-cli"), "claude-code");
@@ -19,16 +52,7 @@ test("isClaudeCodeWorkflowModel recognizes Claude Code CLI workflow models", () 
 });
 
 test("liveEnv preserves HOME when live workflow targets Claude Code CLI", (t) => {
-  const previousModel = process.env.GSD_LIVE_WORKFLOW_MODEL;
-  const previousHome = process.env.HOME;
-  process.env.GSD_LIVE_WORKFLOW_MODEL = "claude-code/claude-haiku-4-5";
-  process.env.HOME = "/tmp/real-claude-home";
-  t.after(() => {
-    if (previousModel === undefined) delete process.env.GSD_LIVE_WORKFLOW_MODEL;
-    else process.env.GSD_LIVE_WORKFLOW_MODEL = previousModel;
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
-  });
+  withEnv(t, { GSD_LIVE_WORKFLOW_MODEL: "claude-code/claude-haiku-4-5", HOME: "/tmp/real-claude-home" });
 
   assert.equal(liveEnv().HOME, "/tmp/real-claude-home");
   assert.equal(liveEnv({ HOME: "/tmp/custom-home" }).HOME, "/tmp/custom-home");

--- a/tests/live-workflow/run.ts
+++ b/tests/live-workflow/run.ts
@@ -1,11 +1,13 @@
 /**
  * Live-workflow runner.
  *
- * Drives the REAL `gsd` binary to dispatch a REAL agent unit (`gsd headless
- * next`) against a REAL model — no fake-LLM transcript. Each `test-*.ts`
- * script seeds a tiny milestone in a throwaway project, dispatches one unit,
- * and asserts on durable outcomes (the verification command passes, git has
- * the agent's work) rather than on agent prose, which drifts every run.
+ * Drives the REAL `gsd` binary against a REAL model — no fake-LLM transcript.
+ * Each `test-*.ts` script seeds a tiny milestone in a throwaway project, then
+ * dispatches either one unit (`gsd headless next`, test-tiny-milestone.ts) or
+ * the full loop (`gsd headless auto`, test-multi-slice-auto.ts), and
+ * asserts on durable outcomes (the verification command passes, git has the
+ * agent's work, the milestone is closed in gsd.db) rather than on agent
+ * prose, which drifts every run.
  *
  * This is the live counterpart to tests/e2e (fake LLM) and tests/live
  * (provider transport smoke). It is slow and costs real tokens, so it is
@@ -22,7 +24,13 @@
  *                                    falls back to `gsd` on PATH if unset)
  *   GSD_LIVE_WORKFLOW_MODEL=<id>     optional model override; default uses the
  *                                    configured default model (model-agnostic)
- *   GSD_LIVE_WORKFLOW_TIMEOUT_MS     optional dispatch timeout (default 300000)
+ *   GSD_LIVE_WORKFLOW_TIMEOUT_MS     optional dispatch timeout (default 300000
+ *                                    for `next`, 1800000 for `auto`)
+ *   GSD_LIVE_WORKFLOW_RUNNER_TIMEOUT_MS optional extra per-test deadline for
+ *                                    this runner (unset = none; scenarios
+ *                                    enforce their own budget)
+ *   GSD_LIVE_WORKFLOW_USE_HOME=1     forward the real HOME so the child uses
+ *                                    ~/.gsd/agent/auth.json (counts as a credential)
  */
 import { readdirSync, existsSync } from "fs";
 import { execFileSync } from "child_process";
@@ -50,7 +58,13 @@ if (!smokeBinary) {
   console.log("GSD_SMOKE_BINARY not set — falling back to `gsd` on PATH.");
 }
 
-const perTestTimeoutMs = Number(process.env.GSD_LIVE_WORKFLOW_RUNNER_TIMEOUT_MS ?? 900_000);
+// Each scenario enforces its own wall-clock budget (GSD_LIVE_WORKFLOW_TIMEOUT_MS
+// or the scenario default) and kills the gsd child itself, so the runner adds
+// no second deadline unless asked to. A runner deadline shorter than a
+// scenario budget would mask a real wedge as a runner kill.
+const perTestTimeoutMs = process.env.GSD_LIVE_WORKFLOW_RUNNER_TIMEOUT_MS
+  ? Number(process.env.GSD_LIVE_WORKFLOW_RUNNER_TIMEOUT_MS)
+  : undefined;
 
 const testFiles = readdirSync(__dirname)
   .filter((f) => f.startsWith("test-") && f.endsWith(".ts"))

--- a/tests/live-workflow/scenario.ts
+++ b/tests/live-workflow/scenario.ts
@@ -1,12 +1,15 @@
 /**
  * Live-workflow scenario runner.
  *
- * Each scenario seeds an isolated project, dispatches one real workflow Unit,
- * and asserts durable outcomes. Scenario files stay small: they describe the
+ * Each scenario seeds an isolated project, dispatches a real workflow run
+ * (`next` for one unit, `auto` for the whole milestone), and asserts durable
+ * outcomes. Scenario files stay small: they describe the
  * seed and proof, while this module owns the shared live-run interface.
  */
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { artifactsFor, createTmpProject, type TmpProject } from "../e2e/_shared/index.ts";
 import {
@@ -23,7 +26,8 @@ export interface LiveWorkflowScenario {
   skipReason?: string | null;
   seed(project: TmpProject): LiveWorkflowSeed;
   dispatch?: {
-    command?: "next";
+    command?: "next" | "auto";
+    /** Scenario default; GSD_LIVE_WORKFLOW_TIMEOUT_MS always wins when set. */
     timeoutMs?: number;
     maxRestarts?: number;
   };
@@ -46,6 +50,8 @@ export interface LiveWorkflowRunResult {
   stdout: string;
   stderr: string;
   events: readonly Record<string, unknown>[];
+  commitsBefore: number;
+  commitsAfter: number;
 }
 
 type LiveWorkflowOutputFormat = "text" | "stream-json";
@@ -60,7 +66,7 @@ function resolveOutputFormat(): LiveWorkflowOutputFormat {
 }
 
 function resolveTimeoutMs(scenario: LiveWorkflowScenario): number {
-  return scenario.dispatch?.timeoutMs ?? Number(process.env.GSD_LIVE_WORKFLOW_TIMEOUT_MS ?? 300_000);
+  return Number(process.env.GSD_LIVE_WORKFLOW_TIMEOUT_MS ?? scenario.dispatch?.timeoutMs ?? 300_000);
 }
 
 function parseJsonEvents(stdout: string): Record<string, unknown>[] {
@@ -109,7 +115,7 @@ export async function runLiveWorkflowScenario(scenario: LiveWorkflowScenario): P
   if (process.env.GSD_LIVE_TESTS !== "1") skip("set GSD_LIVE_TESTS=1 to enable");
   if (scenario.skipReason) skip(scenario.skipReason);
   if (!hasUsableCredentials()) {
-    skip("no provider credentials in env (export a *_API_KEY or *_OAUTH_TOKEN)");
+    skip("no provider credentials in env (export a *_API_KEY or *_OAUTH_TOKEN, or set GSD_LIVE_WORKFLOW_USE_HOME=1)");
   }
   console.log(`Credentials: ${credentialNames().join(", ")}`);
 
@@ -207,8 +213,17 @@ export async function runLiveWorkflowScenario(scenario: LiveWorkflowScenario): P
       stdout: result.stdout,
       stderr: result.stderr,
       events,
+      commitsBefore,
+      commitsAfter,
     };
   } catch (err) {
+    // Keep the DB next to the transcript so a blocked/wedged run can be
+    // post-mortemed (milestone/slice/task rows, wedge records) after cleanup.
+    const dbPath = join(project.dir, ".gsd", "gsd.db");
+    if (existsSync(dbPath)) {
+      artifacts.write("gsd.db", readFileSync(dbPath));
+      console.log(`gsd.db: ${artifacts.dir}/gsd.db`);
+    }
     project.cleanup();
     throw err;
   }

--- a/tests/live-workflow/test-multi-slice-auto.ts
+++ b/tests/live-workflow/test-multi-slice-auto.ts
@@ -1,0 +1,103 @@
+/**
+ * Live workflow: three dependent slices, five tasks, real agent, FULL
+ * `gsd headless auto` to milestone completion.
+ *
+ * Seeds S01 → S02 → S03 (see seedMultiSliceMilestone) and runs the whole auto
+ * loop headlessly with a real model: every execute-task, every
+ * complete-slice, and the milestone closeout. It proves the loop reaches the
+ * fixed point a user expects — not just that one agent turn did work.
+ *
+ * Proof is durable only — never agent prose: exit code, each task's own
+ * verification command, git history, milestone/slice/task rows in gsd.db
+ * (including slice completion order), and the absence of liveness/wedge/
+ * pause/error lines on the child's stderr.
+ *
+ * Exit: 0 pass · 77 skip (no creds) · non-zero fail.
+ */
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { stripAnsi } from "../e2e/_shared/index.ts";
+import { type FixtureSlice, runVerification, seedMultiSliceMilestone } from "./harness.ts";
+import { runLiveWorkflowScenario } from "./scenario.ts";
+
+// Authority: a manual single-task auto run on 2026-08-23 took ~275s
+// (kimi-for-coding); five tasks plus closeout need room. Override with
+// GSD_LIVE_WORKFLOW_TIMEOUT_MS.
+const AUTO_TIMEOUT_MS = 1_800_000;
+// Only the child's stderr is scanned: that is where gsd's operator
+// notifications (liveness, wedge, pause, provider errors) land. Fixture test
+// output from the agent's tool calls goes to stdout and is not scanned.
+const STDERR_FAILURE_RE = /liveness|wedge|Cannot dispatch|paused|error/i;
+
+let slices: FixtureSlice[] = [];
+
+const result = await runLiveWorkflowScenario({
+  slug: "live-multi-slice-auto",
+  seed: (project) => {
+    const seed = seedMultiSliceMilestone(project);
+    slices = seed.slices;
+    return seed;
+  },
+  dispatch: { command: "auto", timeoutMs: AUTO_TIMEOUT_MS },
+  expect: { commits: "increased" },
+});
+
+try {
+  const badLines = stripAnsi(result.stderr).split("\n").filter((line) => STDERR_FAILURE_RE.test(line));
+  assert.equal(badLines.length, 0, `auto reported liveness/wedge/pause/error lines on stderr:\n${badLines.join("\n")}`);
+
+  const taskCount = slices.reduce((n, s) => n + s.tasks.length, 0);
+  assert.ok(
+    result.commitsAfter - result.commitsBefore >= taskCount,
+    `expected at least ${taskCount} new commits (one per task), got ${result.commitsAfter - result.commitsBefore}`,
+  );
+
+  for (const slice of slices) {
+    for (const task of slice.tasks) {
+      const verify = runVerification(result.project, task.verifyArgv);
+      assert.ok(verify.ok, `${slice.id}/${task.id} verification fails:\n${verify.output}`);
+    }
+  }
+
+  const db = new DatabaseSync(join(result.project.dir, ".gsd", "gsd.db"), { readOnly: true });
+  try {
+    const milestone = db.prepare("SELECT status FROM milestones WHERE id = 'M001'").get() as { status?: string } | undefined;
+    assert.equal(milestone?.status, "complete", "M001 not complete");
+
+    const sliceRows = db
+      .prepare("SELECT id, status, completed_at FROM slices WHERE milestone_id = 'M001' ORDER BY id")
+      .all() as { id: string; status: string; completed_at: string | null }[];
+    assert.deepEqual(
+      sliceRows.map((r) => [r.id, r.status]),
+      slices.map((s) => [s.id, "complete"]),
+      "every seeded slice should be complete",
+    );
+    for (let i = 1; i < sliceRows.length; i++) {
+      const prev = sliceRows[i - 1];
+      const cur = sliceRows[i];
+      assert.ok(prev.completed_at && cur.completed_at, `${prev.id}/${cur.id} missing completed_at`);
+      assert.ok(
+        prev.completed_at <= cur.completed_at,
+        `${cur.id} (depends on ${prev.id}) completed at ${cur.completed_at}, before ${prev.id} at ${prev.completed_at}`,
+      );
+    }
+
+    const taskRows = db
+      .prepare("SELECT slice_id, id, status FROM tasks WHERE milestone_id = 'M001' ORDER BY slice_id, id")
+      .all() as { slice_id: string; id: string; status: string }[];
+    assert.deepEqual(
+      taskRows.map((r) => [r.slice_id, r.id, r.status]),
+      slices.flatMap((s) => s.tasks.map((t) => [s.id, t.id, "complete"])),
+      "every seeded task should be complete",
+    );
+  } finally {
+    db.close();
+  }
+  console.log(
+    `PASS: live agent ran auto to milestone completion (M001, ${slices.length} slices, ${taskCount} tasks complete in dependency order).`,
+  );
+} finally {
+  result.project.cleanup();
+}

--- a/tests/live-workflow/test-tiny-milestone.ts
+++ b/tests/live-workflow/test-tiny-milestone.ts
@@ -4,12 +4,9 @@
  * Seeds a one-slice/one-task milestone whose task is "make answer() return
  * 42" (the bundled test fails until then), then dispatches ONE unit with
  * `gsd headless next` — a real agent turn that edits the code and passes the
- * host-owned verification gate, after which step-mode exits 0. We use `next`
- * rather than `auto` deliberately: `auto` would loop into milestone closeout,
- * which is built around human-gated checkpoints that don't resolve in
- * non-supervised headless mode (the agent's closeout turn hangs with no
- * output). `next` exercises the real agent through the real dispatch +
- * verification gates without that interactive tail.
+ * host-owned verification gate, after which step-mode exits 0. This is the
+ * fast, cheap smoke of one dispatch; test-multi-slice-auto.ts runs the full
+ * `auto` loop over three dependent slices to milestone completion.
  *
  * Proof is durable only — never agent prose: exit code + the task's own
  * verification command + git history.


### PR DESCRIPTION
## TL;DR

**What:** Fix live-workflow seeding against the two-step `headless recover`, and add a live scenario that drives a real model through full `gsd headless auto` over three dependent slices to milestone completion.
**Why:** Every `tests/live-workflow` test has been failing at seed time on `main`, and the suite only ever proved one `next` unit — never that `auto` closes a milestone headlessly, which is what users run.
**How:** Seeding does the preview/approve recover dance (same as the acceptance bed); `scenario.ts` accepts `command: "auto"`; a new `test-multi-slice-auto.ts` asserts only durable outcomes (exit 0, per-task verifications, `gsd.db` rows, slice order, commit count, clean stderr).

## What

`tests/live-workflow/` only:

- `harness.ts` — `recoverWithApproval()` (preview hash → `--preview=<hash>`); seed is now data-driven (`FixtureSlice`/`FixtureTask`) with `seedTinyMilestone` (1 slice / 1 task, unchanged content) and new `seedMultiSliceMilestone` (S01 → S02 → S03, 5 tasks, each with its own failing `node:test`); opt-in `GSD_LIVE_WORKFLOW_USE_HOME=1` forwards the real HOME so the child uses `~/.gsd/agent/auth.json` and counts as a credential source.
- `scenario.ts` — `dispatch.command: "next" | "auto"`; `GSD_LIVE_WORKFLOW_TIMEOUT_MS` overrides a scenario default; result exposes `commitsBefore/After`; on failure `gsd.db` is saved next to the transcript.
- `test-multi-slice-auto.ts` — new; default budget 1 800 000 ms.
- `run.ts` — no longer imposes its own 900 s per-test deadline (scenarios enforce their own budget; `GSD_LIVE_WORKFLOW_RUNNER_TIMEOUT_MS` stays as an opt-in).
- `harness.unit.test.ts` — covers the HOME knob.
- `README.md` — replaces the stale "Why `next`, not `auto`?" paragraph; documents the two-step recover, the new scenario, and the knobs.

## Why

1. `seedTinyMilestone` ran `gsd headless recover` once and expected exit 0. On `main` recover prints an import preview and exits 1; approval is a second call with `--preview=sha256:…`. So the live-workflow suite could not even seed.
2. The README claimed a real agent's `auto` closeout hangs headlessly. A real run today (1-slice seed, `kimi-for-coding`) closed M001/S01/T01 in 273 s with exit 0 and zero wedge lines, so that claim is stale and `auto` is testable.
3. A multi-slice `auto` run is the shape users hit. Running it for real surfaced a closeout wedge (see below), which is exactly what this scenario is for.

## How

Verification run locally:

- `node --experimental-strip-types --test tests/live-workflow/harness.unit.test.ts` → 5 pass, 0 fail.
- Ad hoc `tsc --noEmit` over the live-workflow files is clean (the only error is pre-existing in `tests/e2e/_shared/spawn.ts`, untouched; these files are in no tsconfig).
- Real run, 1-slice seed via `auto` with `GSD_LIVE_WORKFLOW_USE_HOME=1` (`kimi-for-coding`): **PASS** — exit 0, verification passes, M001/S01/T01 `complete`, no liveness/wedge lines.
- Real run, multi-slice seed via `auto`: **exit 10 (blocked)** after S01, S02, S03 all completed in dependency order. Milestone validation returned `needs-remediation` because the agent's own S03 UAT invented a `formatAnswer(7)` check the fixture never specified; `gsd_reassess_roadmap` added S04; plan-slice S04 then failed pre-execution checks twice with identical inputs (the plan listed `.gsd/phases/.../01-03-ASSESSMENT.md` and `01-03-SUMMARY.md` as task inputs/files) and the liveness backstop tripped (wedge `W-a4a25a24`). The wedge hint ("rewrite Verify commands") does not match the actual failure (planning artifacts as task inputs). 14 units, 3.22M tokens. The scenario fails on `main` until that closeout path is fixed; the README records this.

The live suite is opt-in (`GSD_LIVE_TESTS=1`) and not a CI gate, so the known failure does not affect CI.

- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
