### PR TITLE
fix(pre-exec): auto-repair planning-artifact refs in task inputs/files; lead retry context with real findings

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -336,25 +336,38 @@ function formatPreExecutionFinding(check: PreExecutionCheckJSON): string {
   return `[${category}] ${target}: ${message}`;
 }
 
-function formatPreExecutionRetryContext(input: {
+/** Guidance that only applies when checkVerificationCommands rejected a Verify command. */
+const UNSAFE_VERIFY_COMMAND_GUIDANCE = [
+  "Rewrite the slice plan so every task has safe, mechanically runnable Verify commands.",
+  "Verify commands must not use shell pipes, redirects, semicolons, backticks, command substitution, output trimming, or grep regex alternation with \"|\".",
+  "Use package scripts, node:test files, or separate simple commands joined only with \"&&\" when multiple checks are needed.",
+];
+
+function isUnsafeVerifyCommandCheck(check: PreExecutionCheckJSON): boolean {
+  return check.category === "tool" && check.message.startsWith("Unsafe or non-runnable Verify command");
+}
+
+/**
+ * Failure context for the re-dispatched planning unit. The findings lead so
+ * the ledger summary (and the liveness-backstop wedge hint derived from it)
+ * names the real blocker; the Verify-command guidance is appended only when
+ * a Verify command was actually rejected.
+ */
+export function formatPreExecutionRetryContext(input: {
   unitType: string;
   unitId: string;
   verdictExcerpt: string;
-  findings: string[];
+  checks: PreExecutionCheckJSON[];
   evidencePath: string;
 }): string {
-  const findings = input.findings.length > 0
-    ? input.findings.map((finding) => `- ${finding}`).join("\n")
+  const findings = input.checks.length > 0
+    ? input.checks.map((check) => `- ${formatPreExecutionFinding(check)}`).join("\n")
     : "- No specific findings captured";
   return [
-    `Pre-execution checks failed after ${input.unitType} ${input.unitId}.`,
-    "Rewrite the slice plan so every task has safe, mechanically runnable Verify commands.",
-    "Verify commands must not use shell pipes, redirects, semicolons, backticks, command substitution, output trimming, or grep regex alternation with \"|\".",
-    "Use package scripts, node:test files, or separate simple commands joined only with \"&&\" when multiple checks are needed.",
-    "",
-    `Verdict: ${input.verdictExcerpt}`,
+    `Pre-execution checks failed after ${input.unitType} ${input.unitId}: ${input.verdictExcerpt}`,
     "Findings:",
     findings,
+    ...(input.checks.some(isUnsafeVerifyCommandCheck) ? ["", ...UNSAFE_VERIFY_COMMAND_GUIDANCE] : []),
     "",
     `Evidence: ${input.evidencePath}`,
   ].join("\n");
@@ -2967,7 +2980,7 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
               unitType: currentUnit.type,
               unitId: currentUnit.id,
               verdictExcerpt,
-              findings,
+              checks,
               evidencePath,
             }),
             attempt,

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -676,14 +676,46 @@ function isPlanningArtifactReference(
   );
 }
 
+/** Task IO fields that are auto-repaired rather than blocked. */
+export type RepairablePlanningIOField = "inputs" | "files";
+
 /**
- * Block GSD planning artifacts in task IO fields (inputs, files, expectedOutput).
+ * Drop GSD planning-artifact references from a task's `inputs` and `files`
+ * and return the removed entries. The arrays are replaced, never mutated, so
+ * tool params can be passed in without leaking into the raw request.
  *
- * For inputs/files the violation smuggles a projection into the executor's
- * preloaded source context; for expectedOutput it promises a write the runtime
- * write-gate would reject mid-execution. Both get a precise message so the
- * planning retry steers toward *removing* the reference, not creating the file.
- * checkFilePathConsistency and checkTaskOrdering skip entries this check owns.
+ * Shared by the plan-persist tools (gsd_plan_slice / gsd_plan_task) and
+ * checkPlanningArtifactReferences so the stored rows and the dispatch-gate
+ * check agree: a preloaded projection listed as input is merely redundant and
+ * must not cost a re-plan round.
+ */
+export function stripPlanningArtifactReferences(
+  task: { inputs: string[]; files: string[] },
+  basePath: string,
+  context?: PreExecutionCheckContext,
+): Array<{ label: RepairablePlanningIOField; path: string }> {
+  const removed: Array<{ label: RepairablePlanningIOField; path: string }> = [];
+  for (const label of ["inputs", "files"] as const) {
+    const kept = task[label].filter((entry) => {
+      const artifact = isPlanningArtifactReference(entry, basePath, context);
+      if (artifact) removed.push({ label, path: entry });
+      return !artifact;
+    });
+    if (kept.length !== task[label].length) task[label] = kept;
+  }
+  return removed;
+}
+
+/**
+ * Repair or block GSD planning artifacts in task IO fields.
+ *
+ * For inputs/files the reference only duplicates context the executor already
+ * has preloaded, so it is stripped from the task and reported as a
+ * non-blocking finding. For expectedOutput it promises a write the runtime
+ * write-gate would reject mid-execution, so it stays blocking with a message
+ * that steers the planning retry toward *removing* the reference, not creating
+ * the file. checkFilePathConsistency and checkTaskOrdering skip entries this
+ * check owns.
  */
 export function checkPlanningArtifactReferences(
   tasks: TaskRow[],
@@ -693,26 +725,24 @@ export function checkPlanningArtifactReferences(
   const results: PreExecutionCheckJSON[] = [];
 
   for (const task of tasks) {
-    const fields = [
-      { label: "inputs", entries: task.inputs },
-      { label: "files", entries: task.files },
-      { label: "expectedOutput", entries: task.expected_output },
-    ];
-    for (const { label, entries } of fields) {
-      for (const file of entries) {
-        if (!isPlanningArtifactReference(file, basePath, context)) continue;
-        const message =
-          label === "expectedOutput"
-            ? `Task ${task.id} lists '${file}' in expectedOutput — GSD planning artifacts are written by workflow tools (e.g. gsd_summary_save), never by tasks; remove it`
-            : `Task ${task.id} lists '${file}' in ${label} — GSD planning artifacts are projections preloaded as context, never task ${label}; remove it`;
-        results.push({
-          category: "file",
-          target: file,
-          passed: false,
-          message,
-          blocking: true,
-        });
-      }
+    for (const { label, path } of stripPlanningArtifactReferences(task, basePath, context)) {
+      results.push({
+        category: "file",
+        target: path,
+        passed: false,
+        message: `Task ${task.id}: removed '${path}' from ${label}: GSD planning artifacts are preloaded context`,
+        blocking: false,
+      });
+    }
+    for (const file of task.expected_output) {
+      if (!isPlanningArtifactReference(file, basePath, context)) continue;
+      results.push({
+        category: "file",
+        target: file,
+        passed: false,
+        message: `Task ${task.id} lists '${file}' in expectedOutput — GSD planning artifacts are written by workflow tools (e.g. gsd_summary_save), never by tasks; remove it`,
+        blocking: true,
+      });
     }
   }
 

--- a/src/resources/extensions/gsd/prompts/validate-milestone.md
+++ b/src/resources/extensions/gsd/prompts/validate-milestone.md
@@ -82,6 +82,7 @@ If verdict is `needs-remediation`:
 - First call `gsd_validate_milestone` to persist this failed validation verdict.
 - Then use `gsd_reassess_roadmap` to add remediation slices instead of editing `{{roadmapPath}}` manually.
 - Those slices will be planned and executed before validation re-runs.
+- Remediation slices fix code, tests, or docs. Never make a `.gsd/` planning artifact (SUMMARY, ASSESSMENT, PLAN, …) a remediation deliverable: those are preloaded as context and rewritten by workflow tools on the next validation pass, so a task that lists one as an input, file, or expected output cannot pass pre-execution checks.
 
 **You MUST call `gsd_validate_milestone` before finishing. Do not manually write `{{validationPath}}`.**
 

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -873,6 +873,34 @@ test('handlePlanSlice rejects absolute task IO paths outside the active worktree
   }
 });
 
+test('handlePlanSlice strips GSD planning artifacts from task inputs/files instead of refusing the plan', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    const params = validParams();
+    const result = await handlePlanSlice({
+      ...params,
+      tasks: [
+        {
+          ...params.tasks[0],
+          inputs: ['.gsd/phases/01-test/01-01-ASSESSMENT.md', ...params.tasks[0].inputs],
+          files: [...params.tasks[0].files, '.gsd/phases/01-test/01-01-SUMMARY.md'],
+        },
+        params.tasks[1],
+      ],
+    }, base);
+
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+    const tasks = getSliceTasks('M001', 'S02');
+    assert.deepEqual(tasks[0]?.inputs, params.tasks[0].inputs);
+    assert.deepEqual(tasks[0]?.files, params.tasks[0].files);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanSlice rejects missing task input paths before persisting tasks', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tests/plan-task.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-task.test.ts
@@ -99,6 +99,28 @@ test('handlePlanTask writes planning state and renders the flat-phase slice plan
   }
 });
 
+test('handlePlanTask strips GSD planning artifacts from inputs/files instead of persisting them', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParent();
+    const params = validParams();
+    const result = await handlePlanTask({
+      ...params,
+      inputs: ['.gsd/phases/01-test/01-01-ASSESSMENT.md', ...params.inputs],
+      files: [...params.files, '.gsd/phases/01-test/01-01-SUMMARY.md'],
+    }, base);
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+    const task = getTask('M001', 'S02', 'T02');
+    assert.deepEqual(task?.inputs, params.inputs);
+    assert.deepEqual(task?.files, params.files);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanTask seeds execute-task gate rows for incremental planning', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
@@ -22,6 +22,7 @@ import { AutoSession } from "../auto/session.ts";
 import { resolveDispatch } from "../auto-dispatch.ts";
 import type { DispatchContext } from "../auto-dispatch.ts";
 import { buildPlanSlicePrompt } from "../auto-prompts.ts";
+import { formatPreExecutionRetryContext } from "../auto-post-unit.ts";
 import {
   openDatabase,
   closeDatabase,
@@ -70,6 +71,41 @@ function cleanup(base: string, originalCwd: string): void {
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
+
+test("pre-exec retry context leads with the real findings and only adds Verify guidance for unsafe Verify commands", () => {
+  const artifactCheck = {
+    category: "file" as const,
+    target: ".gsd/phases/01-answer-fixture/01-03-ASSESSMENT.md",
+    passed: false,
+    message: "Task T03 lists '.gsd/phases/01-answer-fixture/01-03-ASSESSMENT.md' in expectedOutput — GSD planning artifacts are written by workflow tools (e.g. gsd_summary_save), never by tasks; remove it",
+    blocking: true,
+  };
+  const base = {
+    unitType: "plan-slice",
+    unitId: "M001/S04",
+    verdictExcerpt: "status=fail; 1 blocking issue detected",
+    evidencePath: ".gsd/phases/01-answer-fixture/S04-PRE-EXEC-VERIFY.json",
+  };
+
+  const artifactContext = formatPreExecutionRetryContext({ ...base, checks: [artifactCheck] });
+  // The liveness backstop excerpts the first 300 chars of this text as the
+  // wedge's sanctioned exit, so the real blocker must come first.
+  assert.ok(artifactContext.slice(0, 300).includes("01-03-ASSESSMENT.md' in expectedOutput"));
+  assert.ok(!artifactContext.includes("Verify commands must not use shell pipes"));
+
+  const verifyContext = formatPreExecutionRetryContext({
+    ...base,
+    checks: [{
+      category: "tool",
+      target: "T01 Verify",
+      passed: false,
+      message: "Unsafe or non-runnable Verify command: cat a | grep b (pipes are not allowed)",
+      blocking: true,
+    }],
+  });
+  assert.ok(verifyContext.includes("Unsafe or non-runnable Verify command"));
+  assert.ok(verifyContext.includes("Verify commands must not use shell pipes"));
+});
 
 test("#4551: AutoSession.lastPreExecFailure defaults to null", () => {
   const s = new AutoSession();

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -1022,10 +1022,10 @@ describe("runPreExecutionChecks", () => {
 
   // Supersedes #5492: .gsd metadata inputs used to be accepted in worktree mode
   // by resolving from the canonical project root. Task inputs are source files
-  // only (CONTEXT.md "Task Input") — planning artifacts are now blocked with a
-  // removal message regardless of where they resolve. The canonical-root
-  // resolution itself remains for merged-but-unsynced source files.
-  test("blocks .gsd metadata inputs even when resolvable from canonical project root in worktree mode", async () => {
+  // only (CONTEXT.md "Task Input") — planning artifacts are now stripped with
+  // a non-blocking finding regardless of where they resolve. The
+  // canonical-root resolution itself remains for merged-but-unsynced source files.
+  test("strips .gsd metadata inputs even when resolvable from canonical project root in worktree mode", async () => {
     const projectRoot = join(tmpdir(), `pre-exec-project-root-${Date.now()}`);
     const worktreeRoot = join(tmpdir(), `pre-exec-worktree-root-${Date.now()}`);
     mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
@@ -1045,9 +1045,11 @@ describe("runPreExecutionChecks", () => {
       const result = await runPreExecutionChecks(tasks, worktreeRoot, {
         canonicalProjectRoot: projectRoot,
       });
-      assert.equal(result.status, "fail");
+      assert.equal(result.status, "warn");
       assert.equal(result.checks.length, 1);
-      assert.ok(result.checks[0].message.includes("preloaded as context"));
+      assert.equal(result.checks[0].blocking, false);
+      assert.ok(result.checks[0].message.includes("preloaded context"));
+      assert.deepEqual(tasks[0].inputs, []);
     } finally {
       rmSync(projectRoot, { recursive: true, force: true });
       rmSync(worktreeRoot, { recursive: true, force: true });
@@ -2358,30 +2360,49 @@ describe("checkPlanningArtifactReferences", () => {
     }
   }
 
-  test("blocks .gsd/ paths in inputs even when the file exists", () => {
+  test("strips .gsd/ paths from inputs and files as a non-blocking repair, keeping source entries", () => {
     withTempDir((tempDir) => {
-      const artifactDir = join(tempDir, ".gsd", "milestones", "M001");
+      const artifactDir = join(tempDir, ".gsd", "phases", "01-answer-fixture");
       mkdirSync(artifactDir, { recursive: true });
-      writeFileSync(join(artifactDir, "M001-CONTEXT.md"), "# context");
+      writeFileSync(join(artifactDir, "01-03-ASSESSMENT.md"), "# assessment");
+      mkdirSync(join(tempDir, "src"), { recursive: true });
+      writeFileSync(join(tempDir, "src", "answer.ts"), "export {};");
 
       const tasks = [
-        createTask({ id: "T01", inputs: [".gsd/milestones/M001/M001-CONTEXT.md"] }),
+        createTask({
+          id: "T03",
+          inputs: [".gsd/phases/01-answer-fixture/01-03-ASSESSMENT.md", "src/answer.ts"],
+          files: ["src/answer.ts", ".gsd/phases/01-answer-fixture/01-03-SUMMARY.md"],
+        }),
       ];
 
       const results = checkPlanningArtifactReferences(tasks, tempDir);
-      assert.equal(results.length, 1);
-      assert.equal(results[0].blocking, true);
-      assert.ok(results[0].message.includes("preloaded as context"));
+      assert.equal(results.length, 2);
+      assert.ok(results.every((r) => !r.passed && r.blocking === false));
+      assert.equal(
+        results[0].message,
+        "Task T03: removed '.gsd/phases/01-answer-fixture/01-03-ASSESSMENT.md' from inputs: GSD planning artifacts are preloaded context",
+      );
+      assert.equal(
+        results[1].message,
+        "Task T03: removed '.gsd/phases/01-answer-fixture/01-03-SUMMARY.md' from files: GSD planning artifacts are preloaded context",
+      );
+      assert.deepEqual(tasks[0].inputs, ["src/answer.ts"]);
+      assert.deepEqual(tasks[0].files, ["src/answer.ts"]);
+
+      // Re-running on the repaired rows finds nothing left to flag.
+      assert.deepEqual(checkPlanningArtifactReferences(tasks, tempDir), []);
     });
   });
 
-  test("blocks bare artifact names that do not resolve to a real file, with the truthful message", () => {
+  test("strips bare artifact names that do not resolve to a real file, with the truthful message", () => {
     withTempDir((tempDir) => {
       const tasks = [createTask({ id: "T01", inputs: ["M001-CONTEXT.md"] })];
 
       const results = checkPlanningArtifactReferences(tasks, tempDir);
       assert.equal(results.length, 1);
-      assert.ok(results[0].message.includes("preloaded as context"));
+      assert.equal(results[0].blocking, false);
+      assert.ok(results[0].message.includes("preloaded context"));
       assert.ok(!results[0].message.includes("doesn't exist"));
 
       // The consistency check must not double-report the same entry with the
@@ -2411,7 +2432,7 @@ describe("checkPlanningArtifactReferences", () => {
     });
   });
 
-  test("blocks .planning/ and .audits/ paths in files", () => {
+  test("strips .planning/ and .audits/ paths from files", () => {
     withTempDir((tempDir) => {
       const tasks = [
         createTask({ id: "T01", files: [".planning/codebase/STACK.md", ".audits/security.md"] }),
@@ -2419,7 +2440,8 @@ describe("checkPlanningArtifactReferences", () => {
 
       const results = checkPlanningArtifactReferences(tasks, tempDir);
       assert.equal(results.length, 2);
-      assert.ok(results.every((r) => r.blocking && r.message.includes("never task files")));
+      assert.ok(results.every((r) => r.blocking === false && r.message.includes("from files")));
+      assert.deepEqual(tasks[0].files, []);
     });
   });
 
@@ -2442,7 +2464,9 @@ describe("checkPlanningArtifactReferences", () => {
       assert.equal(results.length, 2);
       const outputFinding = results.find((r) => r.message.includes("expectedOutput"));
       assert.ok(outputFinding);
+      assert.equal(outputFinding.blocking, true);
       assert.ok(outputFinding.message.includes("written by workflow tools"));
+      assert.deepEqual(tasks[0].expected_output, [".gsd/milestones/M001/M001-SUMMARY.md"]);
 
       assert.deepEqual(checkTaskOrdering(tasks, tempDir), []);
     });
@@ -2461,15 +2485,15 @@ describe("checkPlanningArtifactReferences", () => {
     });
   });
 
-  test("runPreExecutionChecks surfaces artifact findings as blocking failures", async () => {
+  test("runPreExecutionChecks surfaces input artifact repairs as warnings, not failures", async () => {
     const tempDir = join(tmpdir(), `pre-exec-artifact-run-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });
     try {
       const tasks = [createTask({ id: "T01", inputs: ["M001-CONTEXT.md"] })];
       const result: PreExecutionResult = await runPreExecutionChecks(tasks, tempDir);
-      assert.equal(result.status, "fail");
+      assert.equal(result.status, "warn");
       assert.ok(
-        result.checks.some((c) => !c.passed && c.blocking && c.message.includes("preloaded as context")),
+        result.checks.some((c) => !c.passed && c.blocking === false && c.message.includes("preloaded context")),
       );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
@@ -2489,15 +2513,15 @@ describe("checkPlanningArtifactReferences", () => {
     });
   });
 
-  test("blocks .GSD/ paths with mixed casing (case-insensitive metadata dir match)", () => {
+  test("strips .GSD/ paths with mixed casing (case-insensitive metadata dir match)", () => {
     withTempDir((tempDir) => {
       const tasks = [
         createTask({ id: "T01", inputs: [".GSD/milestones/M001/M001-CONTEXT.md"] }),
       ];
       const results = checkPlanningArtifactReferences(tasks, tempDir);
       assert.equal(results.length, 1);
-      assert.equal(results[0].blocking, true);
-      assert.ok(results[0].message.includes("preloaded as context"));
+      assert.equal(results[0].blocking, false);
+      assert.deepEqual(tasks[0].inputs, []);
     });
   });
 });

--- a/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
@@ -324,8 +324,12 @@ describe("Pre-execution checks → retry/pause wiring", () => {
     assert.equal(s.pendingVerificationRetry?.unitId, "M001/S01");
     assert.equal(s.pendingVerificationRetry?.attempt, 1);
     assert.ok(
-      s.pendingVerificationRetry?.failureContext.includes("Verify commands must not use shell pipes"),
-      "retry context should tell the planner how to produce safe Verify commands",
+      s.pendingVerificationRetry?.failureContext.includes("nonexistent-file-that-does-not-exist.ts"),
+      "retry context should lead with the actual blocking finding",
+    );
+    assert.ok(
+      !s.pendingVerificationRetry?.failureContext.includes("Verify commands must not use shell pipes"),
+      "Verify-command guidance must not be attached to a failure that is not about Verify commands",
     );
     assert.ok(
       s.pendingVerificationRetry?.failureContext.includes("S01-PRE-EXEC-VERIFY.json"),

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -25,7 +25,7 @@ import { writeManifestAndFlush } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
 import { validatePathOnlyPlanningFields, validatePlanningPathScope } from "../planning-path-scope.js";
-import { runTaskPathChecks } from "../pre-execution-checks.js";
+import { runTaskPathChecks, stripPlanningArtifactReferences } from "../pre-execution-checks.js";
 import type { TaskRow } from "../db-task-slice-rows.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { normalizeRealPath, resolveSliceFile, resolveTaskFile } from "../paths.js";
@@ -285,13 +285,19 @@ function toTaskRows(params: PlanSliceParams, defaultTargets: string[]): TaskRow[
   }));
 }
 
+/**
+ * Run the shared path checks on the task payload before it is persisted.
+ * Planning-artifact references in `inputs` / `files` are stripped from
+ * `params.tasks` in place (they are redundant — the executor preloads those
+ * projections) so the stored rows never carry them; only blocking findings
+ * are returned.
+ */
 function validateTaskPathsBeforePersist(
   params: PlanSliceParams,
   basePath: string,
   defaultTargets: string[],
   allowedRoots: string[],
 ): string | null {
-  const taskRows = toTaskRows(params, defaultTargets);
   const baseRoot = resolve(basePath);
   const additionalRoots = allowedRoots
     .map((root) => resolve(root))
@@ -305,6 +311,10 @@ function validateTaskPathsBeforePersist(
         ...(canonicalProjectRoot !== undefined ? { canonicalProjectRoot } : {}),
       }
     : undefined;
+  for (const task of params.tasks ?? []) {
+    stripPlanningArtifactReferences(task, basePath, context);
+  }
+  const taskRows = toTaskRows(params, defaultTargets);
   const checks = runTaskPathChecks(taskRows, basePath, context);
   const blocking = checks.filter((check) => !check.passed && check.blocking);
 

--- a/src/resources/extensions/gsd/tools/plan-task.ts
+++ b/src/resources/extensions/gsd/tools/plan-task.ts
@@ -24,6 +24,7 @@ import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { validatePathOnlyPlanningFields, validatePlanningPathScope } from "../planning-path-scope.js";
+import { stripPlanningArtifactReferences } from "../pre-execution-checks.js";
 import {
   createRepositoryRegistryFromPreferences,
   defaultRepositoryTargets,
@@ -184,6 +185,10 @@ export async function handlePlanTask(
   } catch (err) {
     return { error: `validation failed: ${(err as Error).message}` };
   }
+  // Planning artifacts in inputs/files are redundant (the executor preloads
+  // them); drop them here so the stored row never carries them and the
+  // dispatch-gate check has nothing to re-flag.
+  stripPlanningArtifactReferences(params, basePath);
 
   const toolRequirementError = validateTaskToolRequirements(params.taskId, params.requiredWorkflowTools ?? []);
   if (toolRequirementError) {


### PR DESCRIPTION
## TL;DR

**What:** `.gsd` planning-artifact references in task `inputs`/`files` are now stripped at plan-persist time and reported as a non-blocking pre-exec finding instead of blocking the slice; the pre-exec retry context (and therefore the liveness-backstop wedge hint) leads with the real findings instead of the Verify-command boilerplate.
**Why:** A remediation plan-slice that listed the ASSESSMENT/SUMMARY it was asked to reconcile could never pass the dispatch gate, re-planned into the identical plan, and wedged with a misleading "rewrite Verify commands" exit (#1961).
**How:** Shared `stripPlanningArtifactReferences` helper used by `checkPlanningArtifactReferences`, `gsd_plan_slice` and `gsd_plan_task`; `formatPreExecutionRetryContext` takes the checks and only appends Verify guidance when `checkVerificationCommands` rejected a command; one prevention line in the validate-milestone prompt.

## What

- `pre-execution-checks.ts`: new `stripPlanningArtifactReferences(task, basePath, context)` replaces `inputs`/`files` arrays minus artifact refs and returns what it removed. `checkPlanningArtifactReferences` uses it and emits `blocking: false` findings (`Task T03: removed '<path>' from inputs: GSD planning artifacts are preloaded context`). `expectedOutput` stays blocking with the unchanged workflow-tools message.
- `tools/plan-slice.ts`, `tools/plan-task.ts`: strip before persisting so DB rows (and the rendered PLAN.md) never carry the references. Both persist paths are covered because the live run planned tasks through `gsd_plan_task`, which never ran the path checks.
- `auto-post-unit.ts`: `formatPreExecutionRetryContext` now leads with `Pre-execution checks failed after <unit>: <verdict>` + findings; the three Verify-command lines are appended only when a `[tool] … Unsafe or non-runnable Verify command` check is present. The ledger summary (`finalize-retry: <first line…>`) feeds the wedge's sanctioned exit, so the first 300 chars now name the actual blocker.
- `prompts/validate-milestone.md`: remediation slices must not make `.gsd` planning artifacts deliverables (plan-slice.md already carried the matching rule for task IO).
- Tests: updated the inputs/files blocking assertions in `pre-execution-checks.test.ts` and `pre-execution-pause-wiring.test.ts`; added strip + non-blocking coverage, persist-gate coverage in `plan-slice.test.ts` / `plan-task.test.ts`, and a `formatPreExecutionRetryContext` test for both branches in `pre-exec-gate-loop.test.ts`.

Failure-context plumbing was checked and **does** reach the re-dispatched prompt on two paths, so no change there: `beginPreExecRepair` sets `s.lastPreExecFailure` (consumed by the `planning → plan-slice` dispatch rule into `buildPlanSlicePrompt`'s "Fix these specific issues" block) and `s.pendingVerificationRetry.failureContext` (prepended by `runUnitPhase`). With `expectedOutput` still blocking, a plan that makes an artifact a deliverable still gets one bounded retry; the prompt line and the now-accurate findings are what steer it.

## Why

Closes #1961

## How

- `pnpm run test:compile`, then standalone: `pre-execution-checks`, `pre-exec-gate-loop`, `pre-execution-pause-wiring`, `plan-slice`, `plan-task`, `pre-execution-fail-closed`, `pre-exec-backtick-strip` — 208/208 pass; `auto-liveness-backstop-1655` (covers `loop-sanctioned-exits`), `auto-post-unit-*` — 43/43 pass.
- `pnpm run typecheck:extensions` clean. Root `tsc --noEmit --incremental false`: only the known nested-worktree `src/cli.ts` ModelRegistry identity error (environmental, unrelated).
- Acceptance bed not run locally: `build:core` fails in the nested worktree at the known `pi-coding-agent` private-property resolution leak, so there is no `dist/loader.js`; relying on the unit tests and CI.