### PR TITLE
fix(legacy-import): map every checkbox task line in a nested slice plan

### DIFF
--- a/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
+++ b/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
@@ -81,6 +81,22 @@ function firstMatch(
   return undefined;
 }
 
+function allMatches(
+  file: SourceFile,
+  patterns: readonly RegExp[],
+): { line: SourceLine; match: RegExpExecArray; span: TextSpan }[] {
+  const found: { line: SourceLine; match: RegExpExecArray; span: TextSpan }[] = [];
+  for (const line of file.lines) {
+    for (const pattern of patterns) {
+      const match = pattern.exec(line.text);
+      if (match === null) continue;
+      found.push({ line, match, span: matchSpan(line, match) });
+      break;
+    }
+  }
+  return found;
+}
+
 function frontmatterField(file: SourceFile, name: string): FrontmatterField | undefined {
   if (file.lines[0]?.text !== "---") return undefined;
   const closingIndex = file.lines.findIndex((line, index) => index > 0 && line.text === "---");
@@ -704,8 +720,11 @@ function nestedTaskCandidates(
   candidates: PendingCandidate[],
   diagnoses: PendingDiagnosis[],
 ): void {
-  const checkbox = firstMatch(file, /^-\s+\[([ xX])\]\s+\*\*(T\d+):\s+(.+?)\*\*(?:\s+`est:[^`]+`)?$/u)
-    ?? firstMatch(file, /^-\s+\[([ xX])\]\s+(T\d+)\s+(.+)$/u);
+  const checkboxes = allMatches(file, [
+    /^-\s+\[([ xX])\]\s+\*\*(T\d+):\s+(.+?)\*\*(?:\s+`est:[^`]+`)?$/u,
+    /^-\s+\[([ xX])\]\s+(T\d+)\s+(.+)$/u,
+  ]);
+  const checkbox = checkboxes[0];
   const heading = firstMatch(file, /^##\s+(T\d+)\s+(.+)$/u);
   const xml = firstMatch(file, /<task\s+id="(T\d+)"\s+status="([^"]+)">([^<]+)<\/task>/u);
   const h1 = firstMatch(file, /^#\s+(T\d+):\s+(.+)$/u);
@@ -721,19 +740,43 @@ function nestedTaskCandidates(
     );
     return;
   }
+  if (checkbox !== undefined) {
+    // Every checkbox task line in the plan is its own task claim, in file order.
+    const matched = new Set(checkboxes.map((entry) => entry.line));
+    for (const line of file.lines) {
+      if (matched.has(line) || !/^-\s+\[[ xX]\]\s+\**T\d+/u.test(line.text)) continue;
+      addLegacyImportDiagnosis(
+        diagnoses,
+        file,
+        "unmapped-checkbox-task",
+        "warning",
+        "Checkbox task line matches no supported task grammar and produced no task claim.",
+        "unsupported",
+        line.start,
+        line.end,
+      );
+    }
+    for (const entry of checkboxes) {
+      addCandidate(candidates, file, {
+        kind: "task",
+        key: `${milestoneId}/${sliceId}/${entry.match[2]}`,
+      }, {
+        id: entry.match[2],
+        milestone_id: milestoneId,
+        slice_id: sliceId,
+        status: entry.match[1].toLowerCase() === "x" ? "complete" : "pending",
+        title: entry.match[3].trim(),
+      }, "nested-checkbox-task", entry.span);
+    }
+    return;
+  }
   const path = file.entry.logical_path;
   let taskId: string;
   let title: string;
   let status: "complete" | "pending";
   let reason: string;
   let span: TextSpan;
-  if (checkbox !== undefined) {
-    taskId = checkbox.match[2];
-    title = checkbox.match[3].trim();
-    status = checkbox.match[1].toLowerCase() === "x" ? "complete" : "pending";
-    reason = "nested-checkbox-task";
-    span = checkbox.span;
-  } else if (heading !== undefined) {
+  if (heading !== undefined) {
     taskId = heading.match[1];
     title = heading.match[2].trim();
     status = firstMatch(file, /^Status:\s*complete\s*$/iu) === undefined ? "pending" : "complete";

--- a/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
+++ b/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
@@ -1168,6 +1168,46 @@ describe("legacy .gsd captured-byte interpretation", () => {
     assert.deepEqual(semantics(lowercaseResult), semantics(canonicalResult));
   });
 
+  test("maps every checkbox task line in a nested slice plan and flags unsupported ones", (t) => {
+    const interpretation = interpretLegacyGsdCapture(captureFiles(t, {
+      "milestones/M001/M001-ROADMAP.md": [
+        "# M001: Foundation",
+        "",
+        "- [ ] S01 Core setup",
+        "",
+      ].join("\n"),
+      "milestones/M001/slices/S01/S01-PLAN.md": [
+        "# S01: Core setup",
+        "",
+        "## Tasks",
+        "",
+        "- [ ] **T01: Make answer() return 42** `est:2m`",
+        "- [x] **T02: Add double(n)** `est:2m`",
+        "- [ ] **T03** Missing colon grammar",
+        "",
+        "### T01: Make answer() return 42",
+        "### T02: Add double(n)",
+        "",
+      ].join("\n"),
+    }));
+
+    assert.deepEqual(
+      interpretation.candidates
+        .filter((candidate) => candidate.target.kind === "task")
+        .map((candidate) => [candidate.target.key, candidate.reason_code, candidate.normalized]),
+      [
+        ["M001/S01/T01", "nested-checkbox-task", { id: "T01", milestone_id: "M001", slice_id: "S01", status: "pending", title: "Make answer() return 42" }],
+        ["M001/S01/T02", "nested-checkbox-task", { id: "T02", milestone_id: "M001", slice_id: "S01", status: "complete", title: "Add double(n)" }],
+      ],
+    );
+    assert.deepEqual(
+      interpretation.diagnoses
+        .filter((diagnosis) => diagnosis.code === "unmapped-checkbox-task")
+        .map((diagnosis) => [diagnosis.severity, diagnosis.raw_value]),
+      [["warning", "- [ ] **T03** Missing colon grammar"]],
+    );
+  });
+
   test("fails closed on malformed structured data", (t) => {
     const malformed = interpretLegacyGsdCapture(captureFiles(t, {
       "state-manifest.json": "{\"milestones\":[",


### PR DESCRIPTION
## TL;DR

- **What:** Legacy import now emits one task claim per `- [ ] **Txx: title**` line in a nested `S0x-PLAN.md`, and reports checkbox task lines it cannot parse as an `unmapped-checkbox-task` warning.
- **Why:** Only the first checkbox task per slice was imported; every later task was silently dropped with no diagnosis.
- **How:** Replace the single `firstMatch` lookup with an all-lines scan in `nestedTaskCandidates`; add a regression test.

## What

- `src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts`
  - New `allMatches` helper that returns every line matching one of the checkbox grammars, in file order.
  - `nestedTaskCandidates` emits a `nested-checkbox-task` claim per matched line (`[x]` stays `complete`, `[ ]` stays `pending`).
  - Checkbox task lines that match no supported grammar (for example `- [ ] **T03** title`) now produce a `warning` diagnosis with disposition `unsupported` instead of vanishing.
- `src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts`
  - New case: a two-task slice plan plus one unsupported line asserts two task claims with the correct ids/titles/status and one `unmapped-checkbox-task` diagnosis.

## Why

Closes #1963

`gsd headless recover` on the `seedMultiSliceMilestone` layout reported `Changes: 7 create` and imported only `T01` for each of S01/S02/S03; every `T02` was missing from the mappings and from the `tasks` table after approval, with no warning. The grammar resolution used `firstMatch`, so the checkbox list collapsed to its first item.

## How

- Single-grammar ambiguity detection is unchanged: the checkbox family still counts as one grammar, so mixed-grammar files are still rejected as `ambiguous-task-membership`.
- Existing single-task corpus oracles are unaffected (one line still yields one claim with the same span).
- Verified with:
  - `pnpm run test:compile`
  - `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/legacy-import-{preview-gsd,corpus,preview-public-corpus,preview,application-plan-corpus}.test.js` — 105 pass, 0 fail
  - `pnpm run typecheck:extensions` — clean
