### PR TITLE
fix(auto): pause canonical needs-attention validation for human review instead of retrying into a wedge

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -640,7 +640,11 @@ async function runValidateMilestonePostCheck(
   }
   if (verdict === "needs-attention") {
     const canonicalValidation = isMilestoneLifecycleAdopted(mid);
-    if (canonicalValidation) {
+    // A needs-attention verdict is a legitimate, stable outcome — not a
+    // technical failure. Canonical validation gets one bounded re-validation
+    // (the evidence may be stale); when the verdict recurs, pause for human
+    // review instead of retrying until the liveness backstop wedges.
+    if (canonicalValidation && (s.verificationRetryCount.get(retryKey) ?? 0) < 1) {
       await persistMilestoneValidationGate(
         "retry",
         "verification",
@@ -652,6 +656,7 @@ async function runValidateMilestonePostCheck(
         `Milestone ${mid} canonical validation needs fresh objective evidence. Repair or rerun verification, then call gsd_validate_milestone again.`,
       );
     }
+    clearValidationRetry();
     ctx.ui.notify(
       `Milestone ${mid} validation returned verdict=needs-attention. Pausing for human review.`,
       "error",
@@ -661,7 +666,9 @@ async function runValidateMilestonePostCheck(
         `validate-milestone: pausing — verdict=needs-attention for ${mid}.`,
         `Review details with /gsd status.`,
         `After fixing the issue, run /gsd validate-milestone.`,
-        `To accept the finding, run /gsd verdict pass --rationale "why this is okay".`,
+        canonicalValidation
+          ? `Canonical validation cannot be overridden with /gsd verdict; re-validate with current evidence.`
+          : `To accept the finding, run /gsd verdict pass --rationale "why this is okay".`,
         `To defer it, run /gsd park ${mid}.`,
         "",
       ].join("\n"),

--- a/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
@@ -267,6 +267,40 @@ describe("validate-milestone stuck-loop guard (#4094)", () => {
     assert.match(s.pendingVerificationRetry?.failureContext ?? "", /objective evidence/i);
   });
 
+  test("pauses with a manual-attention gate when adopted needs-attention recurs after the bounded retry", async () => {
+    insertMilestone({ id: "M001" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice 1", status: "complete" });
+    writeCanonicalValidation("inconclusive");
+    writeValidationFile("needs-attention");
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, "validate-milestone", "M001");
+    const stderrWrites: string[] = [];
+    const stderrWrite = mock.method(process.stderr, "write", (chunk: unknown) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    try {
+      const first = await runPostUnitVerification({ s, ctx, pi } as VerificationContext, pauseAutoMock);
+      assert.equal(first, "retry");
+
+      const second = await runPostUnitVerification({ s, ctx, pi } as VerificationContext, pauseAutoMock);
+      assert.equal(second, "pause");
+    } finally {
+      stderrWrite.mock.restore();
+    }
+
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+    assert.equal(s.pendingVerificationRetry, null);
+    assert.match(ctx.ui.notify.mock.calls.at(-1)?.arguments[0] ?? "", /needs-attention/);
+    const guidance = stderrWrites.join("");
+    assert.match(guidance, /\/gsd validate-milestone/);
+    assert.match(guidance, /\/gsd park M001/);
+    assert.doesNotMatch(guidance, /\/gsd verdict pass/);
+  });
+
   test("pauses adopted validation only for a pending subjective UAT decision", async () => {
     insertMilestone({ id: "M001" });
     insertSlice({ id: "S01", milestoneId: "M001", title: "Slice 1", status: "complete" });


### PR DESCRIPTION
## TL;DR

**What:** A canonical (lifecycle-adopted) milestone whose validation returns `needs-attention` now gets one bounded re-validation, then pauses auto-mode for human review with a `manual-attention` gate.
**Why:** It was retried as a technical failure on every identical verdict until the liveness backstop wedged (`finalize-retry`, exit 10) with a misleading `/gsd rebuild markdown` exit.
**How:** Reuse the existing `verificationRetryCount` attempt in the `needs-attention` branch of `auto-verification.ts`; on recurrence fall through to the existing pause path shared with unadopted milestones.

## What

- `src/resources/extensions/gsd/auto-verification.ts`: canonical `needs-attention` retries only while no prior verification retry is recorded for the unit; otherwise clears the retry state and takes the notify + `manual-attention` gate + `pauseAuto` path. The stderr guidance for canonical milestones names `/gsd validate-milestone` and `/gsd park <M>`; `/gsd verdict pass` is printed only for unadopted milestones because `commands-verdict.ts` rejects canonical overrides by design.
- `src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts`: new test — canonical milestone + `needs-attention` twice → first call `retry`, second call `pause`, `pendingVerificationRetry` cleared, guidance lists validate-milestone/park and not `verdict pass`.

## Why

Closes #1965

The duplicate-failure-context guard in `applyVerificationRetryPolicy` does not catch this loop because the post-unit git commit clears the unit's failure hash on every successful commit, so each re-validation looked like a fresh failure and the liveness backstop was the only stop.

## How

Pause already maps to `finalize-break:verification-pause` (a terminal stop, not a retry closeout), so it cannot feed the `finalize-retry` wedge. No new counters or limits: the single retry is the attempt the helper already tracks.

Verified:
- `pnpm run test:compile`, then standalone: `validate-milestone-stuck-guard` 15/15, `auto-verification` 8/8, `auto-liveness-backstop-1655` 18/18, `validate-milestone-write-order` 17/17, `validate-milestone-timeout-recovery` 2/2, `validate-milestone-prompt-verification-classes` 3/3.
- `pnpm run typecheck:extensions` clean.
