### PR TITLE
fix(headless): keep timeout status when SIGTERMed child exits cleanly

### DIFF
--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -246,6 +246,17 @@ export function classifyHeadlessFinalStatus(args: {
 }
 
 /**
+ * Map a child-process exit observed before any terminal notification to the
+ * run's exit code. A clean child exit (code 0) counts as success only when
+ * the parent-initiated overall timeout has NOT fired: after the deadline the
+ * parent SIGTERMs the child, and a clean shutdown must keep the timeout's
+ * error exit code instead of masking the incomplete run as success (#1967).
+ */
+export function classifyChildExitWithoutTerminal(code: number | null, timedOut: boolean): number {
+  return code === 0 && !timedOut ? EXIT_SUCCESS : EXIT_ERROR
+}
+
+/**
  * Decide whether a failed run is restart-eligible.
  */
 export function shouldRestartHeadlessRun(summary: HeadlessRunSummary): boolean {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -35,6 +35,7 @@ import {
   shouldArmHeadlessIdleTimeout,
   shouldRestartHeadlessRun,
   classifyHeadlessFinalStatus,
+  classifyChildExitWithoutTerminal,
   EXIT_SUCCESS,
   EXIT_ERROR,
   EXIT_BLOCKED,
@@ -661,8 +662,13 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   const responseTimeout = options.responseTimeout ?? 30_000
 
   // Overall timeout (disabled when options.timeout === 0, e.g. auto-mode)
+  let timedOut = false
   const timeoutTimer = options.timeout > 0
     ? setTimeout(() => {
+        // A terminal notification that already completed the run wins the race
+        // against the deadline — keep its success/blocked outcome.
+        if (completed) return
+        timedOut = true
         process.stderr.write(`[headless] Timeout after ${options.timeout / 1000}s\n`)
         exitCode = EXIT_ERROR
         resolveCompletion()
@@ -1054,14 +1060,16 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   if (internalProcess) {
     internalProcess.on('exit', (code: number | null) => {
       if (!completed) {
-        if (code === 0) {
+        if (code === 0 && timedOut) {
+          // The overall --timeout fired and cleanup SIGTERMed the child; its
+          // clean shutdown must not mask the incomplete run as success (#1967).
+          process.stderr.write('[headless] Child exited cleanly (code 0) after timeout — run did not complete\n')
+        } else if (code === 0) {
           process.stderr.write('[headless] Child exited cleanly (code 0) without terminal notification\n')
-          exitCode = EXIT_SUCCESS
         } else {
-          const msg = `[headless] Child process exited unexpectedly with code ${code ?? 'null'}\n`
-          process.stderr.write(msg)
-          exitCode = EXIT_ERROR
+          process.stderr.write(`[headless] Child process exited unexpectedly with code ${code ?? 'null'}\n`)
         }
+        exitCode = classifyChildExitWithoutTerminal(code, timedOut)
         resolveCompletion()
       }
     })

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -162,6 +162,7 @@ import {
   shouldArmHeadlessIdleTimeout,
   hasDeterministicNoWorkTail,
   classifyHeadlessFinalStatus,
+  classifyChildExitWithoutTerminal,
   shouldRestartHeadlessRun,
 } from '../headless-events.js'
 
@@ -400,6 +401,38 @@ test('classifyHeadlessFinalStatus: deterministic tail maps to no-work-determinis
     ],
   })
   assert.equal(status, 'no-work-deterministic')
+})
+
+// ─── classifyChildExitWithoutTerminal (#1967) ────────────────────────────
+
+test('classifyChildExitWithoutTerminal: clean child exit with no timeout is success', () => {
+  assert.equal(classifyChildExitWithoutTerminal(0, false), EXIT_SUCCESS)
+})
+
+test('classifyChildExitWithoutTerminal: clean child exit after timeout keeps error exit code', () => {
+  // The parent-initiated --timeout fired, cleanup SIGTERMed the child, and the
+  // child shut down cleanly (code 0). That must NOT count as success (#1967).
+  assert.equal(classifyChildExitWithoutTerminal(0, true), EXIT_ERROR)
+})
+
+test('classifyChildExitWithoutTerminal: non-zero child exit is error regardless of timeout', () => {
+  assert.equal(classifyChildExitWithoutTerminal(1, false), EXIT_ERROR)
+  assert.equal(classifyChildExitWithoutTerminal(1, true), EXIT_ERROR)
+})
+
+test('classifyChildExitWithoutTerminal: null child exit code is error', () => {
+  assert.equal(classifyChildExitWithoutTerminal(null, false), EXIT_ERROR)
+})
+
+test('timed-out clean child exit classifies as timeout status (#1967)', () => {
+  const exitCode = classifyChildExitWithoutTerminal(0, true)
+  const status = classifyHeadlessFinalStatus({
+    blocked: false,
+    exitCode,
+    totalEvents: 42,
+    recentEvents: [],
+  })
+  assert.equal(status, 'timeout')
 })
 
 test('shouldRestartHeadlessRun: deterministic no-work tail is not restartable', () => {


### PR DESCRIPTION
## TL;DR
**What:** Stop `gsd headless --timeout` expiry from reporting `status: "success"` / exit 0 when the SIGTERMed child exits cleanly.
**Why:** A timed-out incomplete auto run was indistinguishable from a successful one for CI, scripts, and the live-workflow harness.
**How:** Track that the deadline fired and keep the timeout's error exit code when the child's post-SIGTERM clean exit is observed without a terminal notification.

## What
- `src/headless.ts`: the overall-timeout callback now records `timedOut` (and no-ops if a terminal notification already completed the run); the child-exit handler maps the exit through the new helper instead of unconditionally overwriting `exitCode = EXIT_SUCCESS` on a clean exit. A timed-out clean exit logs `Child exited cleanly (code 0) after timeout — run did not complete`.
- `src/headless-events.ts`: new `classifyChildExitWithoutTerminal(code, timedOut)` — a clean child exit counts as success only when the parent-initiated timeout has not fired.
- `src/tests/headless-events.test.ts`: unit tests for the new mapping, including the end-to-end classification that a timed-out clean exit yields status `timeout` / exit 1.

## Why
`--timeout` expiry set `EXIT_ERROR` and resolved completion, but cleanup's `client.stop()` SIGTERMs the child; the child shut down cleanly (code 0) and the `internalProcess.on('exit')` handler — `completed` still false — overwrote the exit code with `EXIT_SUCCESS`. The run then classified as `complete` and emitted `{"type":"headless_result","status":"success","exitCode":0,...}` despite the milestone being incomplete (observed live 2026-08-23 on main `c84f72b79`: `Timeout after 1800s` → `Child exited cleanly (code 0) without terminal notification` → `Status: complete`).

Closes #1967

## How
- Behavior now matches the documented exit-code table (`docs/user-docs/commands.md`: `1` = error or timeout) — no doc change needed.
- Child-initiated clean completion that races the deadline WITH a terminal notification stays success: the terminal-notification path sets `completed`/`EXIT_SUCCESS` as before, and the timeout callback now returns early when `completed` is already set.
- Restart semantics are unchanged: a timed-out run classifies as `timeout` exactly as a nonzero post-SIGTERM child exit already did.

## Verification
- `pnpm run test:compile` then `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/tests/headless-events.test.js` — 53 pass, 0 fail.
- Root `npx tsc -p tsconfig.json --noEmit --incremental false`: no errors in any touched file (only the known environmental nested-worktree `extensions/ollama` resolution-leak errors, unrelated and untouched).
