### PR TITLE
fix(legacy-import): carry Verification/Inputs/Expected Output from a task's ### section into its import claim

### DIFF
--- a/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
+++ b/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
@@ -713,6 +713,54 @@ function interpretFlat(
   for (const file of files) interpretFlatArtifact(file, claimsByDirectory, candidates, diagnoses);
 }
 
+const TASK_SECTION_FIELDS = {
+  "inputs": "inputs",
+  "expected output": "expected_output",
+  "verification": "verify",
+  "verify": "verify",
+} as const;
+
+type TaskSectionField = (typeof TASK_SECTION_FIELDS)[keyof typeof TASK_SECTION_FIELDS];
+
+/**
+ * Detail (verify/inputs/expected_output) from the task's own `### Txx:`
+ * section in the same plan file. Checkbox task lines only carry status and
+ * title; the per-task section is where plans state Inputs, Expected Output,
+ * and Verification bullets. Missing section or bullets → the field is
+ * omitted, leaving the canonical column at its empty default.
+ */
+function taskSectionDetail(
+  file: SourceFile,
+  taskId: string,
+): { verify?: string; inputs?: string[]; expected_output?: string[] } {
+  const headingPattern = new RegExp(`^###\\s+${taskId}\\b`, "u");
+  const start = file.lines.findIndex((line) => headingPattern.test(line.text));
+  if (start < 0) return {};
+  const buckets: Record<TaskSectionField, string[]> = { verify: [], inputs: [], expected_output: [] };
+  let current: TaskSectionField | undefined;
+  for (const line of file.lines.slice(start + 1)) {
+    if (/^#{1,3}\s/u.test(line.text)) break;
+    const text = line.text.trim();
+    if (text === "") continue;
+    const label = /^(inputs|expected output|verification|verify):$/iu.exec(text);
+    if (label !== null) {
+      current = TASK_SECTION_FIELDS[label[1].toLowerCase() as keyof typeof TASK_SECTION_FIELDS];
+      continue;
+    }
+    const bullet = /^[-*]\s+(.+)$/u.exec(text);
+    if (bullet === null || current === undefined) {
+      current = undefined;
+      continue;
+    }
+    buckets[current].push(bullet[1].replaceAll("`", "").trim());
+  }
+  return {
+    ...(buckets.verify.length > 0 ? { verify: buckets.verify.join("\n") } : {}),
+    ...(buckets.inputs.length > 0 ? { inputs: buckets.inputs } : {}),
+    ...(buckets.expected_output.length > 0 ? { expected_output: buckets.expected_output } : {}),
+  };
+}
+
 function nestedTaskCandidates(
   file: SourceFile,
   milestoneId: string,
@@ -766,6 +814,7 @@ function nestedTaskCandidates(
         slice_id: sliceId,
         status: entry.match[1].toLowerCase() === "x" ? "complete" : "pending",
         title: entry.match[3].trim(),
+        ...taskSectionDetail(file, entry.match[2]),
       }, "nested-checkbox-task", entry.span);
     }
     return;

--- a/src/resources/extensions/gsd/tests/legacy-import-application.test.ts
+++ b/src/resources/extensions/gsd/tests/legacy-import-application.test.ts
@@ -103,6 +103,7 @@ function getApplyLegacyImport(): ApplyLegacyImport {
 function prepareCase(
   caseName: "gsd-nested" | "custom-workflow",
   seed?: () => void,
+  mutateSource?: (sourceDirectory: string) => void,
 ): PreparedApplicationCase {
   applicationSequence += 1;
   const workspace = mkdtempSync(join(tmpdir(), `gsd-legacy-application-${caseName}-`));
@@ -116,6 +117,7 @@ function prepareCase(
     verbatimSymlinks: true,
   });
   mkdirSync(destination);
+  mutateSource?.(source);
   assert.equal(openDatabase(databasePath), true);
   seed?.();
   const roots = createLegacyImportCorpusSourceRoots(source);
@@ -681,6 +683,39 @@ test("public Application commits one real mutating Preview with exact durable ou
   assert.deepEqual(row("SELECT revision, authority_epoch FROM project_authority WHERE singleton = 1"), {
     revision: prepared.base.authority.revision + 1,
     authority_epoch: prepared.base.authority.authority_epoch,
+  });
+});
+
+test("Application persists per-task Verification, Inputs, and Expected Output from a nested slice plan", () => {
+  const applyLegacyImport = getApplyLegacyImport();
+  const prepared = prepareCase("gsd-nested", undefined, (source) => {
+    appendFileSync(
+      join(source, ".gsd", "milestones", "M001-foundation", "slices", "S01-core", "S01-PLAN.md"),
+      [
+        "",
+        "### T01: Create the project skeleton",
+        "",
+        "Inputs:",
+        "- `src/skeleton.js`",
+        "- `test/skeleton.test.js`",
+        "",
+        "Expected Output:",
+        "- `src/skeleton.js` — module skeleton exists",
+        "",
+        "Verification:",
+        "- `node --test test/skeleton.test.js`",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  applyLegacyImport(prepared.input);
+
+  assert.deepEqual(row(`SELECT verify, inputs, expected_output FROM tasks
+    WHERE milestone_id = 'M001' AND slice_id = 'S01' AND id = 'T01'`), {
+    verify: "node --test test/skeleton.test.js",
+    inputs: "[\"src/skeleton.js\",\"test/skeleton.test.js\"]",
+    expected_output: "[\"src/skeleton.js — module skeleton exists\"]",
   });
 });
 

--- a/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
+++ b/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
@@ -1186,7 +1186,21 @@ describe("legacy .gsd captured-byte interpretation", () => {
         "- [ ] **T03** Missing colon grammar",
         "",
         "### T01: Make answer() return 42",
+        "",
+        "Inputs:",
+        "- `src/answer.js`",
+        "- `test/answer.test.js`",
+        "",
+        "Expected Output:",
+        "- `src/answer.js` — `answer()` returns `42`",
+        "",
+        "Verification:",
+        "- `node --test test/answer.test.js`",
+        "",
         "### T02: Add double(n)",
+        "",
+        "Verify:",
+        "- `node --test test/double.test.js`",
         "",
       ].join("\n"),
     }));
@@ -1196,8 +1210,24 @@ describe("legacy .gsd captured-byte interpretation", () => {
         .filter((candidate) => candidate.target.kind === "task")
         .map((candidate) => [candidate.target.key, candidate.reason_code, candidate.normalized]),
       [
-        ["M001/S01/T01", "nested-checkbox-task", { id: "T01", milestone_id: "M001", slice_id: "S01", status: "pending", title: "Make answer() return 42" }],
-        ["M001/S01/T02", "nested-checkbox-task", { id: "T02", milestone_id: "M001", slice_id: "S01", status: "complete", title: "Add double(n)" }],
+        ["M001/S01/T01", "nested-checkbox-task", {
+          id: "T01",
+          milestone_id: "M001",
+          slice_id: "S01",
+          status: "pending",
+          title: "Make answer() return 42",
+          verify: "node --test test/answer.test.js",
+          inputs: ["src/answer.js", "test/answer.test.js"],
+          expected_output: ["src/answer.js — answer() returns 42"],
+        }],
+        ["M001/S01/T02", "nested-checkbox-task", {
+          id: "T02",
+          milestone_id: "M001",
+          slice_id: "S01",
+          status: "complete",
+          title: "Add double(n)",
+          verify: "node --test test/double.test.js",
+        }],
       ],
     );
     assert.deepEqual(


### PR DESCRIPTION
## TL;DR

**What:** Legacy import of a nested slice plan now parses each task's `### Txx:` section (`Verification:`/`Verify:`, `Inputs:`, `Expected Output:` bullets) into the task claim, so imported task rows carry `verify`, `inputs`, and `expected_output` instead of empty defaults.
**Why:** Imported tasks with `verify=''` force the verification gate onto the project-wide `package.json` test script, which runs the full suite and fails on later tasks' not-yet-written modules — the first task can never pass its gate. Closes #1968.
**How:** `taskSectionDetail()` in the hierarchy preview finds the task's `### Txx:` section in the same PLAN file and maps its labeled bullets onto the canonical task fields the adapter already supports.

## What

- `src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts`: when the nested checkbox grammar emits a task claim, also read that task's `### Txx:` section — `Verification:`/`Verify:` bullets → `verify` (newline-joined, backticks stripped), `Inputs:` bullets → `inputs`, `Expected Output:` bullets → `expected_output`. Missing section or bullets → fields omitted, leaving the empty defaults exactly as before.
- Extended the multi-task checkbox preview test (#1964) so both tasks' claims are asserted to carry their section detail, covering both `Verification:` and `Verify:` spellings.
- Added an application-level test: preview → apply → read the `tasks` row, proving `verify`, `inputs`, and `expected_output` land in the DB.

## Why

Closes #1968.

`tests/live-workflow/harness.ts` `seedMultiSliceMilestone` writes per-task sections in `S01-PLAN.md`, but after two-step `gsd headless recover` every task row had `verify=''` and `inputs='[]'`. In a live run (2026-08-23, main c84f72b79) the verification gate found no task-plan verify, fell back to `npm test` (`node --test`, full suite), and T01 could never pass — driving re-dispatch loops.

The canonical `tasks` columns and the legacy-import task adapter (`verify`, `inputs`, `expected_output`, incl. JSON-column normalization) already supported these fields; only the preview parser dropped them.

## How

- `taskSectionDetail(file, taskId)` scans the same PLAN file for `^### Txx` and collects labeled bullet lists until the next heading. Bullets are backtick-stripped; `verify` is newline-joined.
- The detail object is spread into the existing `nested-checkbox-task` candidate value, so claim identity/shape is unchanged when no section exists.

## Verification

- `pnpm run test:compile`, then all `legacy-import-*` + `parsers-legacy-importers` compiled test files standalone: 544 pass, 0 fail.
- `npx tsc -p tsconfig.json --noEmit --incremental false`: only the known environmental nested-worktree phantom (`src/cli.ts(709)` resolving `ModelRegistry` from the main checkout's dist); `pnpm run typecheck:extensions`: clean.
- Deterministic repro: built the worktree, seeded `seedMultiSliceMilestone` through two-step `gsd headless recover` with `GSD_SMOKE_BINARY=<worktree>/dist/loader.js` — `sqlite3 .gsd/gsd.db "select id,verify from tasks;"` now shows every task's `node --test <file>` command (previously empty).
