### PR TITLE
fix(auto): keep the verification auto-fix retry bound attempt-independent and pause loudly on durable abort

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -451,6 +451,16 @@ function gitCommitRemediationRetryKey(unitType: string, unitId: string): string 
   return `git-commit:${verificationRetryKey(unitType, unitId)}`;
 }
 
+/**
+ * DB-backed execute-task verification recovery is owned by the durable
+ * authority (Attempt/Result/Verdict/Recovery rows) and the host verification
+ * gate — not the legacy artifact retry ladder. Its shared retry key must not
+ * be cleared by post-unit artifact verification (#1971).
+ */
+function isDurableVerificationTask(unitType: string): boolean {
+  return unitType === "execute-task" && isDbAvailable();
+}
+
 function stripKnownIdPrefix(value: string | undefined | null, id: string): string | undefined {
   const raw = String(value ?? "").trim();
   if (!raw) return undefined;
@@ -2291,15 +2301,19 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       // root artifact write. If a premature write hits the write gate in the
       // same turn, the user wait is the meaningful state; pause instead of
       // writing a placeholder over PROJECT/REQUIREMENTS.
-      if (!triggerArtifactVerified && s.currentUnit.type === "execute-task" && isDbAvailable()) {
+      if (!triggerArtifactVerified && isDurableVerificationTask(s.currentUnit.type)) {
         const retryKey = verificationRetryKey(s.currentUnit.type, s.currentUnit.id);
         if (s.pendingVerificationRetry?.unitId === s.currentUnit.id) {
           s.pendingVerificationRetry = null;
         }
         s.lastToolInvocationError = null;
         s.toolUnavailableRetries = 0;
-        s.verificationRetryCount.delete(retryKey);
-        s.verificationRetryFailureHashes.delete(retryKey);
+        // Deliberately keep verificationRetryCount / verificationRetryFailureHashes:
+        // the host verification gate's auto-fix counter shares this key and must
+        // stay attempt-independent (per unit + failure). Deleting it here reset
+        // the bound to "attempt 1/2" on every new Attempt, so exhaustion was
+        // never visibly reached (#1971). The gate clears both itself on
+        // pass/pause/abort.
         s.exhaustedVerificationUnits.delete(retryKey);
         saveCustomVerifyRetryCounts(s, {
           logFailure: err => debugLog("postUnit", {
@@ -2616,8 +2630,17 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           s.pendingVerificationRetry = null;
         }
         s.toolUnavailableRetries = 0;
-        s.verificationRetryCount.delete(retryKey);
-        s.verificationRetryFailureHashes.delete(retryKey);
+        // For a DB-backed execute-task, artifact readiness only proves the
+        // Attempt staged a Result at the verify stage — the host verification
+        // gate has not run yet. Its auto-fix retry counter shares this key and
+        // must stay attempt-independent (per unit + failure): every
+        // gsd_task_complete creates a NEW Attempt, so clearing here reset the
+        // bound to "attempt 1/2" on each retry and exhaustion was never
+        // visibly reached (#1971). The gate clears both on pass/pause/abort.
+        if (!isDurableVerificationTask(s.currentUnit.type)) {
+          s.verificationRetryCount.delete(retryKey);
+          s.verificationRetryFailureHashes.delete(retryKey);
+        }
         s.exhaustedVerificationUnits.delete(retryKey);
         saveCustomVerifyRetryCounts(s, { logFailure: err => debugLog("postUnit", { phase: "save-verify-retries-failed", error: err instanceof Error ? err.message : String(err) }) });
 

--- a/src/resources/extensions/gsd/auto/finalize.ts
+++ b/src/resources/extensions/gsd/auto/finalize.ts
@@ -275,6 +275,17 @@ export async function runFinalize(
       const abortReason = abortId
         ? `verification-abort (recoveryActionId: ${abortId}; resume with /gsd recover ${abortId})`
         : "verification-abort";
+      // Never exit silently: breaking without a terminal notification left a
+      // headless session idling with nothing scheduled until an external
+      // timeout — the loop exits on the first abort, so the ADR-047 trip-at-2
+      // backstop can never fire in-session (#1971). Pause with the sanctioned
+      // exit so the operator sees the recovery instruction and /gsd auto can
+      // resume after `/gsd recover`. pauseAuto notifies the errorContext
+      // message itself, so no separate notify here.
+      const abortMessage = abortId
+        ? `Verification auto-fix retries are exhausted — durable recovery aborted this task. Resume with /gsd recover ${abortId} after fixing the failure.`
+        : "Verification was aborted by durable task recovery.";
+      await deps.pauseAuto(ctx, pi, { message: abortMessage, category: "unknown" });
       debugLog("autoLoop", { phase: "exit", reason: abortReason });
       clearFinalizingUnit();
       return { action: "break", reason: abortReason };

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -4342,7 +4342,7 @@ test("autoLoop handles verification retry by continuing loop", async (t) => {
   }
 });
 
-test("autoLoop stops machine-terminal verification abort without pausing or publishing", async () => {
+test("autoLoop pauses a machine-terminal verification abort with a terminal notification (#1971)", async () => {
   _resetPendingResolve();
   mock.timers.enable({ apis: ["Date", "setTimeout"], now: 10_000 });
   try {
@@ -4351,13 +4351,23 @@ test("autoLoop stops machine-terminal verification abort without pausing or publ
     ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
     const pi = makeMockPi();
     const s = makeLoopSession();
-    let pauseCalls = 0;
+    const pauseMessages: string[] = [];
     let postVerificationCalls = 0;
     let publicationCalls = 0;
 
     const deps = makeMockDeps({
-      runPostUnitVerification: async () => "abort" as const,
-      pauseAuto: async () => { pauseCalls++; },
+      runPostUnitVerification: async () => {
+        s.lastTaskRecoveryAbortId = "recovery-action-1";
+        return "abort" as const;
+      },
+      pauseAuto: async (
+        _ctx?: unknown,
+        _pi?: unknown,
+        errorContext?: { message?: string },
+      ) => {
+        // Production pauseAuto notifies the errorContext message itself.
+        pauseMessages.push(errorContext?.message ?? "");
+      },
       postUnitPostVerification: async () => {
         postVerificationCalls++;
         s.active = false;
@@ -4373,10 +4383,16 @@ test("autoLoop stops machine-terminal verification abort without pausing or publ
     mock.timers.tick(30_000);
     await loopPromise;
 
-    assert.equal(pauseCalls, 0);
+    // The loop must never silent-idle after a terminal abort (#1971): auto-mode
+    // pauses with a message carrying the recoveryActionId so the operator sees
+    // the /gsd recover instruction and /gsd auto can resume afterwards.
+    assert.equal(pauseMessages.length, 1, "verification abort must pause auto-mode");
+    assert.ok(
+      pauseMessages[0]?.includes("/gsd recover recovery-action-1"),
+      `expected the pause message to name the recovery action, got: ${JSON.stringify(pauseMessages)}`,
+    );
     assert.equal(postVerificationCalls, 0);
     assert.equal(publicationCalls, 0);
-    assert.equal(s.active, true, "verification abort ends the loop without inventing a human pause state");
   } finally {
     mock.timers.reset();
   }

--- a/src/resources/extensions/gsd/tests/auto-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-verification.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../auto-verification.ts";
 import { DEFAULT_COMMAND_TIMEOUT_MS } from "../constants.ts";
 import { describeHostVerificationRationale } from "../verification-verdict.ts";
+import { cleanup, makeTempRepo } from "./test-utils.ts";
 
 function createVerificationContext(currentUnit: { type: string; id: string } | null) {
 	return {
@@ -216,4 +217,91 @@ test("verification_timeout_ms unset stays 120s; set value is enforced (#1759)", 
 	assert.equal(_resolveVerificationTimeoutMsForTest(undefined), DEFAULT_COMMAND_TIMEOUT_MS);
 	assert.equal(_resolveVerificationTimeoutMsForTest({}), DEFAULT_COMMAND_TIMEOUT_MS);
 	assert.equal(_resolveVerificationTimeoutMsForTest({ verification_timeout_ms: 2500 }), 2500);
+});
+
+test("identical gate failures count 1/2, then 2/2, then exhaust into a durable abort (#1971)", async (t) => {
+	const basePath = makeTempRepo("gsd-auto-fix-retry-bound-");
+	t.after(() => cleanup(basePath));
+	const notifications: string[] = [];
+	let routeCalls = 0;
+	let attemptNumber = 0;
+	let paused = false;
+	const session = {
+		basePath,
+		canonicalProjectRoot: basePath,
+		currentUnit: { type: "execute-task", id: "M001/S01/T01" },
+		lastTaskRecoveryAbortId: null as string | null,
+		pendingVerificationRetry: null as { unitId: string } | null,
+		verificationRetryCount: new Map<string, number>(),
+		verificationRetryFailureHashes: new Map<string, string>(),
+	};
+	const taskAuthority = {
+		readLatestTaskAttempt: () => ({
+			// Every gsd_task_complete creates a NEW Attempt; the retry bound must
+			// be per unit + failure, not per attemptId.
+			attemptId: `attempt-${attemptNumber}`,
+			resultId: `result-${attemptNumber}`,
+			state: "settled",
+			outcome: "succeeded",
+			nextStage: "verify",
+		}),
+		readTaskTechnicalVerdict: () => null,
+		recordTaskTechnicalVerdict: () => ({
+			verdictId: `verdict-${attemptNumber}`,
+			evidenceId: `evidence-${attemptNumber}`,
+		}),
+		invalidateTaskTechnicalPass: () => { throw new Error("must not invalidate"); },
+		routeTaskFailure: () => {
+			routeCalls++;
+			// Mirrors the durable remediation budget (recovery-policy.ts:
+			// verification-failed → remediate, maxUses 2, per task + fingerprint).
+			if (routeCalls <= 2) {
+				return { action: "remediate", status: "applied", recoveryActionId: `ra-${routeCalls}` };
+			}
+			return { action: "abort", status: "applied", resumeAuthorized: false, recoveryActionId: "ra-3" };
+		},
+	};
+	const runGate = async () => runPostUnitVerification({
+		s: session,
+		ctx: { ui: { notify: (message: string) => notifications.push(message) } },
+		pi: {},
+		taskAuthority,
+		runVerificationGate: () => ({
+			passed: false,
+			checks: [{
+				command: "npm test",
+				exitCode: 1,
+				stdout: "",
+				stderr: "Cannot find module './later-task-module'",
+				durationMs: 10,
+			}],
+			discoverySource: "task-plan",
+			timestamp: Date.now(),
+		}),
+	} as never, async () => {
+		paused = true;
+	});
+
+	attemptNumber = 1;
+	assert.equal(await runGate(), "retry");
+	assert.ok(
+		notifications.some((message) => message.includes("auto-fix attempt 1/")),
+		`first failure must announce attempt 1, got: ${JSON.stringify(notifications)}`,
+	);
+	// The auto-loop consumes the pending retry when it re-dispatches the unit.
+	session.pendingVerificationRetry = null;
+
+	attemptNumber = 2;
+	assert.equal(await runGate(), "retry");
+	assert.ok(
+		notifications.some((message) => message.includes("auto-fix attempt 2/")),
+		`second identical failure must announce attempt 2, not reset to 1 (got: ${JSON.stringify(notifications)})`,
+	);
+	session.pendingVerificationRetry = null;
+
+	attemptNumber = 3;
+	assert.equal(await runGate(), "abort", "the exhausted durable budget must surface as abort");
+	assert.equal(session.lastTaskRecoveryAbortId, "ra-3");
+	assert.equal(session.verificationRetryCount.size, 0, "abort clears the per-unit retry counter");
+	assert.equal(paused, false, "the gate defers the pause to the finalize abort path");
 });

--- a/src/resources/extensions/gsd/tests/post-unit-task-recovery-authority.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-task-recovery-authority.test.ts
@@ -5,13 +5,23 @@ import test from "node:test";
 
 import { postUnitPreVerification, type PostUnitContext } from "../auto-post-unit.ts";
 import { AutoSession } from "../auto/session.ts";
+import { executeDomainOperation } from "../db/domain-operation.ts";
 import {
+  adoptOrTransitionLifecycle,
+  readDomainOperationFence,
+} from "../db/writers/lifecycle-commands.ts";
+import {
+  _getAdapter,
   closeDatabase,
   insertMilestone,
   insertSlice,
   insertTask,
   openDatabase,
 } from "../gsd-db.ts";
+import {
+  claimTaskAttempt,
+  settleTaskAttempt,
+} from "../task-execution-domain-operation.ts";
 import { cleanup, makeTempRepo } from "./test-utils.ts";
 
 function createTaskContext(basePath: string, pauseCalls: string[]): PostUnitContext {
@@ -79,7 +89,14 @@ test("DB-backed execute-task missing an Attempt Result bypasses generic artifact
 
   assert.equal(result, "continue");
   assert.equal(pctx.s.pendingVerificationRetry, null);
-  assert.equal(pctx.s.verificationRetryCount.size, 0);
+  // The host verification gate's auto-fix counter shares this key and must
+  // stay attempt-independent — deleting it here reset the retry bound to
+  // "attempt 1/2" on every new Attempt (#1971).
+  assert.equal(
+    pctx.s.verificationRetryCount.get("execute-task:M001/S01/T01"),
+    3,
+    "host auto-fix retry counter must survive the durable-authority deferral",
+  );
   assert.deepEqual(pauseCalls, []);
 });
 
@@ -117,5 +134,115 @@ test("DB-backed execute-task deterministic errors cannot write an artifact place
   );
   assert.equal(pctx.s.pendingVerificationRetry, null);
   assert.equal(pctx.s.lastToolInvocationError, null);
+  assert.deepEqual(pauseCalls, []);
+});
+
+// ── #1971: a staged Attempt awaiting host verification must not reset the
+// host auto-fix retry counter. Artifact readiness ("verify") only proves the
+// Attempt staged a Result — the host verification gate has not run yet, so the
+// "verification succeeded" clear must skip the shared retry key or every new
+// gsd_task_complete resets the bound to "attempt 1/2" and exhaustion is never
+// visibly reached.
+function stageAwaitingVerificationAttempt(): void {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  adapter.exec(`
+    INSERT INTO workers (
+      worker_id, host, pid, started_at, version, last_heartbeat_at, status,
+      project_root_realpath
+    ) VALUES (
+      'worker-1', 'test-host', 1, '2026-07-12T00:00:00.000Z', 'test',
+      '2026-07-12T00:00:00.000Z', 'active', '/tmp/project'
+    );
+    INSERT INTO milestone_leases (
+      milestone_id, worker_id, fencing_token, acquired_at, expires_at, status
+    ) VALUES (
+      'M001', 'worker-1', 7, '2026-07-12T00:00:00.000Z',
+      '2099-07-12T00:00:00.000Z', 'held'
+    );
+    INSERT INTO unit_dispatches (
+      trace_id, turn_id, worker_id, milestone_lease_token,
+      milestone_id, slice_id, task_id, unit_type, unit_id,
+      status, attempt_n, started_at
+    ) VALUES (
+      'trace-1971', 'turn-1971', 'worker-1', 7, 'M001', 'S01', 'T01',
+      'execute-task', 'M001/S01/T01', 'claimed', 1, '2026-07-12T00:00:00.000Z'
+    );
+  `);
+  const fence = readDomainOperationFence();
+  executeDomainOperation({
+    operationType: "test.task.ready",
+    idempotencyKey: "fixture-1971/task-ready",
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: "test",
+    sourceTransport: "test",
+    payload: { taskId: "T01" },
+  }, (context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      lifecycleStatus: "ready",
+    });
+    return {
+      events: [{
+        eventType: "test.task.ready",
+        entityType: "task",
+        entityId: "M001/S01/T01",
+        payload: { taskId: "T01" },
+        destinations: ["test"],
+      }],
+      projections: [{
+        projectionKey: "test-1971/m001/s01/t01",
+        projectionKind: "test",
+        rendererVersion: "1",
+      }],
+    };
+  });
+  const dispatchRow = adapter
+    .prepare("SELECT MAX(id) AS id FROM unit_dispatches")
+    .get() as { id: number };
+  const claimed = claimTaskAttempt({
+    invocation: { idempotencyKey: "fixture-1971/claim", sourceTransport: "internal", actorType: "agent" },
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+    coordinationDispatchId: Number(dispatchRow.id),
+  });
+  settleTaskAttempt({
+    invocation: { idempotencyKey: "fixture-1971/settle", sourceTransport: "internal", actorType: "agent" },
+    attemptId: claimed.attemptId,
+    outcome: "succeeded",
+    failureClass: "none",
+    summary: "task work staged",
+    output: {},
+  });
+}
+
+test("staged awaiting-verification Attempt preserves the host auto-fix retry counter (#1971)", async (t) => {
+  const basePath = scaffoldDbBackedTask();
+  t.after(() => {
+    closeDatabase();
+    cleanup(basePath);
+  });
+  stageAwaitingVerificationAttempt();
+  const pauseCalls: string[] = [];
+  const pctx = createTaskContext(basePath, pauseCalls);
+  // As if the host gate already failed this unit once ("auto-fix attempt 1/2").
+  pctx.s.verificationRetryCount.set("execute-task:M001/S01/T01", 1);
+
+  const result = await postUnitPreVerification(pctx, {
+    skipSettleDelay: true,
+    skipWorktreeSync: true,
+  });
+
+  assert.equal(result, "continue");
+  assert.equal(
+    pctx.s.verificationRetryCount.get("execute-task:M001/S01/T01"),
+    1,
+    "a new staged Attempt must not reset the host auto-fix retry counter",
+  );
   assert.deepEqual(pauseCalls, []);
 });


### PR DESCRIPTION
## TL;DR What/Why/How

The verification auto-fix retry counter was wiped by post-unit artifact verification on every new Attempt, so the bound always read "attempt 1/2", and when the durable recovery budget aborted the task on the third identical failure the auto loop broke out silently — no pause, no notification, no wedge — leaving headless sessions idle until an external timeout. Keep the counter attempt-independent for DB-backed execute-task units and make the finalize verification-abort path notify and pause.

## What

- `auto-post-unit.ts`: `postUnitPreVerification` no longer deletes `verificationRetryCount`/`verificationRetryFailureHashes` for a DB-backed `execute-task` — neither in the deferred-to-durable-authority branch nor in the artifact-verified clear. For those units, artifact readiness (`readExecuteTaskArtifactReadiness` → "verify") only proves the Attempt staged a Result; the host verification gate has not run yet, and the gate owns clearing those keys on pass/pause/abort. All other unit types keep the existing clears.
- `auto/finalize.ts`: the `verificationResult === "abort"` break now calls `deps.pauseAuto` with an errorContext message carrying the `recoveryActionId` and the `/gsd recover` resume instruction before breaking (production `pauseAuto` notifies that message), so the loop can never silent-idle after a durable abort. The #1942/#1593 break-reason contract is unchanged.
- Tests: gate-level exhaustion bed (1/2 → 2/2 → abort), post-unit regression for the counter reset with a real staged awaiting-verification Attempt, and the auto-loop abort test updated from "silent break" to "pause with terminal notification".

## Why

Closes #1971.

Live run 2026-08-23 (main `c84f72b79`, kimi-for-coding, `gsd headless auto`, `M001/S01/T01`): three `gsd_task_complete` Attempts, three identical `npm test` gate failures. Notifications: FAILED, "auto-fix attempt 1/2", FAILED, "auto-fix attempt 1/2" again (counter reset — 2/2 never reached), FAILED — then nothing for ~28 minutes until the harness's 1800s timeout. Two composing defects:

1. Every `gsd_task_complete` creates a new Attempt; artifact verification reports the staged Attempt as "verified" and the post-unit clear wiped the shared retry key each iteration, so the session bound was derived per-attempt instead of per unit+failure. Users burn tokens in what looks like a bounded auto-fix loop that never advances its counter. The bound stays the existing `verification_max_retries` surface / durable remediation budget (`recovery-policy.ts`, maxUses 2 per task + failure fingerprint) — no new max is introduced.
2. The durable budget correctly aborts on the third identical failure, but `runFinalize` broke the loop with only a `debugLog`. The ADR-047 liveness backstop (#1805) trips at occurrence 2 and the loop exits on the first abort occurrence, so it can never fire in-session; nothing notified, paused, or stopped the session.

## How

- The counter lifecycle for DB-backed execute-task units is owned entirely by the host verification gate (`auto-verification.ts` already clears both keys on pass, unrunnable pause, execution-fault pause, and durable abort), so the fix removes the competing post-unit clears instead of adding new state.
- The finalize abort path now pauses via the existing `pauseAuto(ctx, pi, { message, category })` convention (same as the gate's own pause paths), so the operator gets exactly one notification naming the sanctioned exit (`/gsd recover <recoveryActionId>`); the break reason string from #1942 is unchanged.
- Verified: `pnpm run test:compile`; standalone compiled runs of `auto-verification` (9 pass, incl. new 1/2 → 2/2 → abort bed), `post-unit-task-recovery-authority` (3 pass; the new staged-Attempt regression fails without the fix — verified by reverting the compiled guard), `auto-loop` (134 pass, abort test now asserts pause + recovery message), `verification-gate` + `enhanced-verification-integration` + `auto-task-execution-cutover` (196 pass), `deep-project-auto-loop` (43 pass), `auto-phases-lifecycle` + `journal-integration` (32 pass), `auto-loop-break-reason-ledger` + `finalize-timeout-guard` + `post-unit-git-failure` + `post-unit-retry-on-orchestrator-bridge` (15 pass), `verification-retry-policy` (5 pass), post-unit artifact/sidecar/custom-engine files (38 pass). `pnpm run typecheck:extensions` clean; root `tsc --noEmit --incremental false` shows only the pre-existing environmental nested-worktree `cli.ts` phantom error.
