### PR TITLE
fix(issue): [Bug]: verification auto-fix retry counter resets every attempt (always 1/2) and after the third identical gate failure auto-mode deadlocks silently — no retry, no pause, no wedge, until the headless timeout

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1560,7 +1560,6 @@ async function runCloseoutGitAction(
 
       s.lastGitActionStatus = "ok";
       s.verificationRetryCount.delete(gitCommitRemediationRetryKey(unit.type, unit.id));
-      s.verificationRetryFailureHashes.delete(verificationRetryKey(unit.type, unit.id));
 
       if (turnAction === "commit" && gitResult.commitMessage) {
         ctx.ui.notify(formatPostUnitStatusCard("✓ Commit", gitResult.commitMessage.split("\n")[0]), "info");
@@ -2298,8 +2297,6 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         }
         s.lastToolInvocationError = null;
         s.toolUnavailableRetries = 0;
-        s.verificationRetryCount.delete(retryKey);
-        s.verificationRetryFailureHashes.delete(retryKey);
         s.exhaustedVerificationUnits.delete(retryKey);
         saveCustomVerifyRetryCounts(s, {
           logFailure: err => debugLog("postUnit", {
@@ -2616,8 +2613,13 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           s.pendingVerificationRetry = null;
         }
         s.toolUnavailableRetries = 0;
-        s.verificationRetryCount.delete(retryKey);
-        s.verificationRetryFailureHashes.delete(retryKey);
+        // A DB-backed Task at this point has only staged a succeeded Attempt;
+        // the host verification gate still owns the terminal pass/fail. Keep
+        // its attempt-independent retry state until that gate actually passes.
+        if (s.currentUnit.type !== "execute-task" || !isDbAvailable()) {
+          s.verificationRetryCount.delete(retryKey);
+          s.verificationRetryFailureHashes.delete(retryKey);
+        }
         s.exhaustedVerificationUnits.delete(retryKey);
         saveCustomVerifyRetryCounts(s, { logFailure: err => debugLog("postUnit", { phase: "save-verify-retries-failed", error: err instanceof Error ? err.message : String(err) }) });
 

--- a/src/resources/extensions/gsd/auto/finalize.ts
+++ b/src/resources/extensions/gsd/auto/finalize.ts
@@ -275,6 +275,14 @@ export async function runFinalize(
       const abortReason = abortId
         ? `verification-abort (recoveryActionId: ${abortId}; resume with /gsd recover ${abortId})`
         : "verification-abort";
+      const abortMessage = abortId
+        ? `Verification recovery budget exhausted. Auto-mode is paused (recoveryActionId: ${abortId}). Resume with /gsd recover ${abortId}.`
+        : "Verification recovery budget exhausted. Auto-mode is paused; run /gsd recover to inspect recovery options.";
+      ctx.ui.notify(abortMessage, "error");
+      await deps.pauseAuto(ctx, pi, {
+        message: abortMessage,
+        category: "unknown",
+      });
       debugLog("autoLoop", { phase: "exit", reason: abortReason });
       clearFinalizingUnit();
       return { action: "break", reason: abortReason };

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -219,6 +219,56 @@ test("runFinalize keeps a durable Task verification retry agent-owned across rep
   assert.equal(s.pendingVerificationRetry?.attempt, 2);
 });
 
+test("runFinalize pauses and notifies when durable Task verification aborts", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-finalize-task-abort-"));
+  t.after(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const s = new AutoSession();
+  s.basePath = base;
+  s.currentUnit = {
+    type: "execute-task",
+    id: "M001/S01/T01",
+    startedAt: 1,
+  };
+  const notifications: Array<{ message: string; severity?: string }> = [];
+  let pauseCalls = 0;
+
+  const result = await runFinalizeWithDeps(
+    s,
+    {
+      pauseAuto: async () => {
+        pauseCalls++;
+      },
+      runPostUnitVerification: async () => {
+        s.lastTaskRecoveryAbortId = "recovery-action-1971";
+        return "abort";
+      },
+    },
+    {
+      ui: {
+        notify(message: string, severity?: string) {
+          notifications.push({ message, severity });
+        },
+      },
+    },
+  );
+
+  assert.deepEqual(result, {
+    action: "break",
+    reason: "verification-abort (recoveryActionId: recovery-action-1971; resume with /gsd recover recovery-action-1971)",
+  });
+  assert.equal(pauseCalls, 1);
+  assert.ok(
+    notifications.some(({ message, severity }) =>
+      severity === "error" &&
+      message.includes("recoveryActionId: recovery-action-1971") &&
+      message.includes("/gsd recover recovery-action-1971")
+    ),
+  );
+});
+
 test("runFinalize still pauses a non-Task verification retry with a repeated failure signature", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-finalize-slice-retry-"));
   t.after(() => {

--- a/src/resources/extensions/gsd/tests/auto-post-unit-verification-retry-state.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-verification-retry-state.test.ts
@@ -1,0 +1,123 @@
+// Project/App: gsd-pi
+// File Purpose: Verification retry state lifecycle regression tests for DB-backed Tasks.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { postUnitPreVerification } from "../auto-post-unit.ts";
+import { AutoSession } from "../auto/session.ts";
+import { verificationRetryKey } from "../auto/verification-retry-policy.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../gsd-db.ts";
+import { registerAutoWorker } from "../db/auto-workers.ts";
+import { claimMilestoneLease } from "../db/milestone-leases.ts";
+import { recordDispatchClaim } from "../db/unit-dispatches.ts";
+import { internalExecutionInvocation } from "../execution-invocation.ts";
+import { normalizeRealPath } from "../paths.ts";
+import {
+  claimTaskAttempt,
+  settleTaskAttempt,
+} from "../task-execution-domain-operation.ts";
+
+function createTaskFixture(t: { after(fn: () => void): void }): {
+  base: string;
+  session: AutoSession;
+  retryKey: string;
+} {
+  const base = mkdtempSync(join(tmpdir(), "gsd-post-unit-retry-state-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* database may already be closed */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "PREFERENCES.md"), "---\nversion: 1\n---\n");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# Milestone\n");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"), "# Slice\n");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-PLAN.md"), "# Task\n");
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active" });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task", status: "pending" });
+
+  const session = new AutoSession();
+  session.active = true;
+  session.basePath = base;
+  session.originalBasePath = base;
+  session.canonicalProjectRoot = base;
+  session.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+  const retryKey = verificationRetryKey("execute-task", "M001/S01/T01");
+  session.verificationRetryCount.set(retryKey, 1);
+  session.verificationRetryFailureHashes.set(retryKey, "same-host-gate-failure");
+  return { base, session, retryKey };
+}
+
+async function runPreVerification(session: AutoSession): Promise<string> {
+  return postUnitPreVerification(
+    {
+      s: session,
+      ctx: { ui: { notify() {} } } as any,
+      pi: {} as any,
+      buildSnapshotOpts: () => ({}) as any,
+      lockBase: () => session.basePath,
+      stopAuto: async () => {},
+      pauseAuto: async () => {},
+      updateProgressWidget: () => {},
+    },
+    { skipSettleDelay: true, skipWorktreeSync: true },
+  );
+}
+
+test("DB-backed Task artifact readiness preserves host verification retry state", async (t) => {
+  const { base, session, retryKey } = createTaskFixture(t);
+  const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
+  const lease = claimMilestoneLease(workerId, "M001");
+  assert.equal(lease.ok, true);
+  if (!lease.ok) return;
+  const dispatch = recordDispatchClaim({
+    traceId: "post-unit-retry-state",
+    workerId,
+    milestoneLeaseToken: lease.token,
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T01",
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+  });
+  assert.equal(dispatch.ok, true);
+  if (!dispatch.ok) return;
+  const attempt = claimTaskAttempt({
+    invocation: internalExecutionInvocation("test:post-unit-retry-state:claim"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId,
+    milestoneLeaseToken: lease.token,
+    coordinationDispatchId: dispatch.dispatchId,
+  });
+  settleTaskAttempt({
+    invocation: internalExecutionInvocation("test:post-unit-retry-state:settle"),
+    attemptId: attempt.attemptId,
+    outcome: "succeeded",
+    failureClass: "none",
+    summary: "candidate awaits host verification",
+    output: {},
+  });
+
+  assert.equal(await runPreVerification(session), "continue");
+  assert.equal(session.verificationRetryCount.get(retryKey), 1);
+  assert.equal(session.verificationRetryFailureHashes.get(retryKey), "same-host-gate-failure");
+});
+
+test("DB-backed Task artifact deferral preserves host verification retry state", async (t) => {
+  const { session, retryKey } = createTaskFixture(t);
+
+  assert.equal(await runPreVerification(session), "continue");
+  assert.equal(session.verificationRetryCount.get(retryKey), 1);
+  assert.equal(session.verificationRetryFailureHashes.get(retryKey), "same-host-gate-failure");
+});

--- a/src/resources/extensions/gsd/tests/auto-post-unit-verification-retry-state.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-verification-retry-state.test.ts
@@ -51,7 +51,8 @@ function createTaskFixture(t: { after(fn: () => void): void }): {
   session.active = true;
   session.basePath = base;
   session.originalBasePath = base;
-  session.canonicalProjectRoot = base;
+  // canonicalProjectRoot is a derived getter — with basePath/originalBasePath
+  // set above it already resolves to normalizeRealPath(base).
   session.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
   const retryKey = verificationRetryKey("execute-task", "M001/S01/T01");
   session.verificationRetryCount.set(retryKey, 1);

--- a/src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts
+++ b/src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../task-execution-domain-operation.ts";
 import { readTaskRecoveryRoute } from "../task-recovery-domain-operation.ts";
 import { recaptureVerifiedSourceAfterDeferredCloseout } from "../auto/verified-source-recapture.ts";
+import { verificationRetryKey } from "../auto/verification-retry-policy.ts";
 import { captureVerificationSourceSnapshot } from "../verification-source-integrity.ts";
 import {
   readTaskTechnicalVerdict,
@@ -149,6 +150,8 @@ test("blocking evidence-xref routes recovery and clears evidence before pausing"
     s.active = true;
     s.basePath = base;
     s.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+    const retryKey = verificationRetryKey("execute-task", "M001/S01/T01");
+    s.verificationRetryFailureHashes.set(retryKey, "prior-host-gate-failure");
 
     let pauseCalled = false;
     const notifications: string[] = [];
@@ -178,6 +181,11 @@ test("blocking evidence-xref routes recovery and clears evidence before pausing"
     // enters the verified-task publication boundary.
     assert.equal(result, "evidence-xref-blocked");
     assert.equal(pauseCalled, true);
+    assert.equal(
+      s.verificationRetryFailureHashes.get(retryKey),
+      "prior-host-gate-failure",
+      "pre-gate git closeout must not reset host verification retry state",
+    );
     assert.ok(
       notifications.some((message) => message.includes("claimed passing verification")),
       `expected evidence-xref notification, got: ${notifications.join("\n")}`,

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -1124,6 +1124,34 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.ok(messages.some((m: string) => m.includes("Verification failed") && m.includes("auto-fix attempt 1/2")));
   });
 
+  test("host verification reports the second attempt from preserved Task retry state", async () => {
+    createFailingVerifyTask();
+    writePreferences({
+      enhanced_verification: true,
+      enhanced_verification_post: false,
+      verification_auto_fix: true,
+      verification_max_retries: 2,
+    });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+    s.verificationRetryCount.set("execute-task:M001/S01/T01", 1);
+
+    const result = await runPostUnitVerification(makeVerificationContext(s, ctx, pi), pauseAutoMock);
+
+    assert.equal(result, "retry");
+    assert.equal(s.pendingVerificationRetry?.attempt, 2);
+    assert.equal(s.verificationRetryCount.get("execute-task:M001/S01/T01"), 2);
+    const messages = ctx.ui.notify.mock.calls.map((call: { arguments: unknown[] }) => String(call.arguments[0]));
+    assert.ok(
+      messages.some((message: string) =>
+        message.includes("Verification failed") && message.includes("auto-fix attempt 2/2")
+      ),
+    );
+  });
+
   test("post-execution checker infrastructure failure records inconclusive and retries", async () => {
     createPostExecFailureTask();
     writePreferences({


### PR DESCRIPTION
## Summary
- Preserved verification retries across attempts and made exhausted recovery pause visibly with focused regression coverage.

## Bugs Addressed
- [x] **Verification auto-fix counter resets before each host gate**
- [x] **Durable verification abort silently leaves auto mode idle**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1971
- [#1971 [Bug]: verification auto-fix retry counter resets every attempt (always 1/2) and after the third identical gate failure auto-mode deadlocks silently — no retry, no pause, no wedge, until the headless timeout](https://github.com/open-gsd/gsd-pi/issues/1971)

## User
- @jeremymcs

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1971-bug-verification-auto-fix-retry-counter--1787515988`