### PR TITLE
fix(state-reconciliation): stop mapping remediation slice ids onto other slices' plan files

### DIFF
--- a/src/resources/extensions/gsd/layout-policy.ts
+++ b/src/resources/extensions/gsd/layout-policy.ts
@@ -61,13 +61,39 @@ export function milestoneIdUniqueSuffix(milestoneId: string): string | undefined
   return milestoneId.match(TEAM_MILESTONE_ID_RE)?.[2]?.toLowerCase();
 }
 
+const CANONICAL_SLICE_ID_RE = /^S0*(\d+)(?:-.*)?$/i;
+
 /**
  * Extract the numeric portion of a slice id (S01 → 1, S01-replan → 1).
  * Used by the renderer to derive the plan number from the DB's slice_id.
  */
 export function sliceIdToPlanNum(sliceId: string): number {
-  const m = sliceId.match(/^S0*(\d+)(?:-.*)?$/i);
+  const m = sliceId.match(CANONICAL_SLICE_ID_RE);
   return m ? Number.parseInt(m[1]!, 10) : 1;
+}
+
+/**
+ * File-name segment identifying a slice inside flat-phase plan file names
+ * (#1975). Canonical S-ids (S01, S01-replan) keep the zero-padded plan
+ * number, so existing NN-MM-SUFFIX.md layouts are untouched. Any other id
+ * (e.g. a remediation slice R01 added by gsd_reassess_roadmap) uses the id
+ * itself: digits guessed from a non-canonical id would map the slice onto
+ * another slice's files (R01 → S01's 01-01-SUMMARY.md), on both read and
+ * write.
+ */
+export function slicePlanSegment(sliceId: string): string {
+  const m = sliceId.match(CANONICAL_SLICE_ID_RE);
+  if (m) return pad(Number.parseInt(m[1]!, 10));
+  if (/^\d+$/.test(sliceId)) return pad(Number.parseInt(sliceId, 10));
+  return sliceId;
+}
+
+/**
+ * Plan file name derived from a slice id: `NN-<segment>-SUFFIX.md`
+ * (e.g. "01-01-PLAN.md" for S01, "01-R01-PLAN.md" for R01).
+ */
+export function slicePlanFileName(phaseNum: number, sliceId: string, suffix: string): string {
+  return `${pad(phaseNum)}-${slicePlanSegment(sliceId)}-${suffix}.md`;
 }
 
 /**

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -20,10 +20,10 @@ import { gsdHome } from "./gsd-home.js";
 import { findWorktreeSegment, isGsdWorktreePath, resolveExternalStateProjectGsdFromWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
 import {
   LAYOUT_SEGMENTS,
-  planFileName,
   milestoneIdToPhaseNum,
   milestoneIdUniqueSuffix,
-  sliceIdToPlanNum,
+  slicePlanFileName,
+  slicePlanSegment,
   canonicalPhaseDirName,
 } from "./layout-policy.js";
 
@@ -217,10 +217,9 @@ export function buildMilestoneFileName(milestoneId: string, suffix: string): str
 export function buildSliceFileName(sliceId: string, suffix: string): string {
   // Flat-phase: plan files need both phase and plan numbers (NN-MM-SUFFIX.md),
   // but this helper only has the sliceId. Callers needing the full name should
-  // use planFileName() from layout-policy. This returns MM-SUFFIX.md for any
-  // incremental callers that haven't migrated yet.
-  const planNum = sliceIdToPlanNum(sliceId);
-  return `${String(planNum).padStart(2, "0")}-${suffix}.md`;
+  // use slicePlanFileName() from layout-policy. This returns MM-SUFFIX.md for
+  // any incremental callers that haven't migrated yet.
+  return `${slicePlanSegment(sliceId)}-${suffix}.md`;
 }
 
 /**
@@ -937,18 +936,21 @@ export function resolveSliceFile(
 ): string | null {
   const phaseDir = resolveMilestonePath(basePath, milestoneId);
   if (!phaseDir) return null;
-  // Flat-phase: plan files are NN-MM-SUFFIX.md inside the phase dir
+  // Flat-phase: plan files are NN-MM-SUFFIX.md inside the phase dir.
+  // The segment comes from the canonical layout mapping, never from digits
+  // guessed out of a non-canonical slice id (#1975): R01 must not resolve
+  // to S01's 01-01-* files.
   const phaseNum = milestoneIdToPhaseNum(milestoneId);
-  const planNum = sliceIdToPlanNum(sliceId);
-  const flatName = planFileName(phaseNum, planNum, suffix);
+  const planSegment = slicePlanSegment(sliceId);
+  const flatName = slicePlanFileName(phaseNum, sliceId, suffix);
   const flatPath = join(phaseDir, flatName);
   if (isExistingFile(flatPath)) return flatPath;
   // Also check plan-number-only format MM-SUFFIX.md (written by buildSliceFileName)
-  const planOnlyName = `${String(planNum).padStart(2, "0")}-${suffix}.md`;
+  const planOnlyName = `${planSegment}-${suffix}.md`;
   const planOnlyPath = join(phaseDir, planOnlyName);
   if (isExistingFile(planOnlyPath)) return planOnlyPath;
   // Try prefix match for the phase+plan number (handles suffix variations)
-  const planPrefix = `${String(phaseNum).padStart(2, "0")}-${String(planNum).padStart(2, "0")}-`;
+  const planPrefix = `${String(phaseNum).padStart(2, "0")}-${planSegment}-`;
   try {
     for (const entry of readdirSync(phaseDir, { withFileTypes: true })) {
       if (entry.isFile() && entry.name.startsWith(planPrefix) && entry.name.endsWith(`-${suffix}.md`)) {
@@ -1128,7 +1130,7 @@ export function targetSliceFile(
     : milestoneDir;
   const fileName = isLegacy
     ? `${sliceId}-${suffix}.md`
-    : planFileName(milestoneIdToPhaseNum(milestoneId), sliceIdToPlanNum(sliceId), suffix);
+    : slicePlanFileName(milestoneIdToPhaseNum(milestoneId), sliceId, suffix);
   return join(dir, fileName);
 }
 

--- a/src/resources/extensions/gsd/tests/remediation-slice-artifact-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/remediation-slice-artifact-drift.test.ts
@@ -1,0 +1,100 @@
+// Project/App: gsd-pi
+// File Purpose: #1975 — a remediation slice (R01) must never resolve to
+// another slice's flat-phase plan files. sliceIdToPlanNum's fallback mapped
+// every non-canonical slice id to plan 1, so the artifact/DB drift scan saw
+// S01's 01-01-SUMMARY.md as R01's and paused auto right after
+// gsd_reassess_roadmap with a false "SUMMARY on disk while DB status is
+// pending". Genuine drift (R01's OWN summary on disk while pending) must
+// still be reported.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../gsd-db.ts";
+import { detectArtifactDbDrift } from "../state-reconciliation/drift/artifact-db.ts";
+import { resolveSliceFile, targetSliceFile, _clearGsdRootCache } from "../paths.ts";
+import { slicePlanSegment } from "../layout-policy.ts";
+import type { DriftContext } from "../state-reconciliation/types.ts";
+import type { GSDState } from "../types.ts";
+
+function stubState(): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "M" },
+    activeSlice: null,
+    activeTask: null,
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+    requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+    progress: { milestones: { done: 0, total: 1 } },
+  };
+}
+
+function setupFixture(base: string): string {
+  const phaseDir = join(base, ".gsd", "phases", "01-answer-fixture");
+  mkdirSync(phaseDir, { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "M", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Done slice", status: "complete", risk: "low", depends: [], sequence: 1 });
+  insertSlice({ id: "R01", milestoneId: "M001", title: "Remediation", status: "pending", risk: "low", depends: [], sequence: 2 });
+  // S01 completed normally; its SUMMARY projection is on disk.
+  writeFileSync(join(phaseDir, "01-01-SUMMARY.md"), "# S01 Summary\n");
+  return phaseDir;
+}
+
+test("#1975: fresh pending R01 does not inherit S01's 01-01-SUMMARY.md as drift", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-remediation-drift-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    _clearGsdRootCache();
+    rmSync(base, { recursive: true, force: true });
+  });
+  _clearGsdRootCache();
+  setupFixture(base);
+
+  // R01 must not resolve to S01's file at the path layer.
+  assert.equal(resolveSliceFile(base, "M001", "R01", "SUMMARY"), null);
+  // And R01's canonical write target is its own distinct file.
+  assert.match(targetSliceFile(base, "M001", "R01", "SUMMARY", "M"), /01-R01-SUMMARY\.md$/);
+
+  const state = stubState();
+  const ctx: DriftContext = { basePath: base, state };
+  const drifts = detectArtifactDbDrift(state, ctx);
+  const r01Drift = drifts.filter((d) => "sliceId" in d && d.sliceId === "R01");
+  assert.deepEqual(r01Drift, [], "fresh remediation slice must not match another slice's SUMMARY");
+});
+
+test("#1975: R01's own SUMMARY on disk while R01 is pending is still drift", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-remediation-drift-pos-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    _clearGsdRootCache();
+    rmSync(base, { recursive: true, force: true });
+  });
+  _clearGsdRootCache();
+  const phaseDir = setupFixture(base);
+  // R01's own SUMMARY was written while the DB still says pending.
+  writeFileSync(join(phaseDir, "01-R01-SUMMARY.md"), "# R01 Summary\n");
+
+  const state = stubState();
+  const ctx: DriftContext = { basePath: base, state };
+  const drifts = detectArtifactDbDrift(state, ctx);
+  const r01Drift = drifts.find(
+    (d) => d.kind === "artifact-db-status-divergence" && d.sliceId === "R01",
+  );
+  assert.ok(r01Drift, "R01's own SUMMARY while pending must still be reported as drift");
+});
+
+test("#1975: slicePlanSegment keeps S-ids numeric and other ids verbatim", () => {
+  assert.equal(slicePlanSegment("S01"), "01");
+  assert.equal(slicePlanSegment("S01-replan"), "01");
+  assert.equal(slicePlanSegment("s03-x"), "03");
+  assert.equal(slicePlanSegment("R01"), "R01");
+  assert.equal(slicePlanSegment("R02"), "R02");
+  assert.equal(slicePlanSegment("01"), "01");
+});


### PR DESCRIPTION
## TL;DR

**What:** Slice file names are now derived from the canonical layout mapping, so a remediation slice (`R01`) can never resolve to — or overwrite — another slice's `NN-MM-*` files.
**Why:** `sliceIdToPlanNum` falls back to plan `1` for any non-`S` slice id, so the artifact/DB drift scan saw S01's `01-01-SUMMARY.md` as R01's and paused auto with a false "SUMMARY on disk while DB status is pending" right after `gsd_reassess_roadmap`.
**How:** New `slicePlanSegment`/`slicePlanFileName` in `layout-policy.ts`; the three slice-file call sites in `paths.ts` use them instead of digits parsed from the slice id.

## What

- `src/resources/extensions/gsd/layout-policy.ts`: add `slicePlanSegment(sliceId)` — canonical `S` ids (including descriptive suffixes, #1785) keep the zero-padded plan number; bare numeric ids stay numeric; any other id (e.g. `R01`) uses the id itself as the file segment. Add `slicePlanFileName(phaseNum, sliceId, suffix)` composing `NN-<segment>-SUFFIX.md`. `sliceIdToPlanNum` is unchanged.
- `src/resources/extensions/gsd/paths.ts`: `buildSliceFileName`, `resolveSliceFile`, and `targetSliceFile` route through the new segment mapping instead of `sliceIdToPlanNum` digits. Existing `NN-MM` layouts for canonical slices are byte-identical.
- `src/resources/extensions/gsd/tests/remediation-slice-artifact-drift.test.ts`: regression tests — S01 complete with `01-01-SUMMARY.md` on disk plus fresh pending R01 reports no drift for R01 and `resolveSliceFile(R01, SUMMARY)` is null; R01's own `01-R01-SUMMARY.md` while R01 is pending still reports drift; segment mapping unit cases.

## Why

Closes #1975

Live run (main 0216d7463, headless auto): S01–S03 fully complete, `gsd_validate_milestone` → needs-remediation, `gsd_reassess_roadmap` added `R01`/`R02`. Immediately after the reassess tool returned — before any R01 unit dispatched or any R01 artifact existed — auto paused with "Artifact/DB status drift in M001/R01: slice R01 has SUMMARY on disk while DB status is pending" and exited 10. The disk only held S01–S03's SUMMARYs.

Root cause: `sliceIdToPlanNum` matches only `^S0*(\d+)` and returns `1` otherwise, so every non-canonical slice id (`R01`, `R02`, …) mapped onto plan `01` — S01's files — on both the read path (`resolveSliceFile`, used by the drift scan in `state-reconciliation/drift/artifact-db.ts`) and the write path (`targetSliceFile`, used by the renderer, which would have clobbered S01's SUMMARY once R01 completed).

## How

The fix sits at the single shared seam all slice-file naming funnels through. A slice whose artifacts were never projected can no longer match another slice's files, because non-canonical ids get their own distinct segment (`01-R01-SUMMARY.md`). Canonical `S` ids — including descriptive suffixes like `S01-replan` — produce exactly the same names as before, so no existing project layout changes.

Verified:

- `pnpm run test:compile`, then standalone: new regression file (3/3), plus layout-policy, slice-id-suffix-plan-files, artifact-db-drift-memo, state-reconciliation-drift, flat-phase renderer/round-trip/validation/migration, markdown-renderer, paths-cache, paths-migration-staging, slice-disk-reconcile, roadmap-missing-drift-1634, gsd-rebuild, system-flat-phase-layout, planning-layout-detect, derive-state-db-disk-reconcile, reconciliation-edge-cases: 212 pass / 0 fail (14 skipped).
- md-importer, migration-auto-check, reassess-* (domain-operation, detection, handler), auto-remediate-slice-status, auto-artifact-paths: 90 pass / 0 fail.
- `pnpm run typecheck:extensions` clean; root `tsc --noEmit --incremental false` clean apart from the known environmental nested-worktree phantom in `src/cli.ts` (untouched by this change).
