### PR TITLE
fix(auto): abort the live host turn on permanent provider-error pause; completion gate names its recovery lever and admits blocker reports

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -921,11 +921,16 @@ export async function handleAgentEnd(
     }
 
     // --- Permanent / unknown: pause indefinitely ---
+    // Abort the live host turn: the supervisor is about to settle the running
+    // Attempt as failed, and a host session that transparently retried the
+    // failed request would otherwise keep executing against torn-down attempt
+    // state (split-brain, #1973). The transient branch above deliberately does
+    // NOT abort — it auto-resumes the same unit in the same session.
     await pauseAutoForProviderError(ctx.ui, errorDetail, () => pauseAuto(ctx, pi, {
       message: `Provider error: ${errorDetail}`,
       category: "provider",
       isTransient: false,
-    }), {
+    }, { abortActiveTurn: true }), {
       isRateLimit: false,
       isTransient: false,
       retryAfterMs: 0,

--- a/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
+++ b/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
@@ -23,9 +23,11 @@ import {
   type TaskQualityGateContent,
 } from "./quality-gate-closure.js";
 import {
+  readLatestTaskAttempt,
   settleTaskAttempt,
   type StagedTaskCompletionMutation,
 } from "./task-execution-domain-operation.js";
+import { readTaskRecoveryRoute } from "./task-recovery-domain-operation.js";
 import { readTaskTechnicalVerdict } from "./task-verification-domain-operation.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import {
@@ -136,9 +138,48 @@ function replayAttemptId(
   return row ? String(row["attempt_id"]) : undefined;
 }
 
+export interface TaskCompletionAuthorityOptions {
+  /**
+   * gsd_task_complete(blockerDiscovered: true): a blocker report is an
+   * escalation channel, not a completion — it must always be recordable, even
+   * when the supervisor already settled the Attempt out from under a surviving
+   * session (#1973). When set, the running-attempt gate routes to the legacy
+   * write path (a durable DB write that needs no Attempt) instead of throwing.
+   */
+  blockerReport?: boolean;
+}
+
+/**
+ * Describe the latest Attempt's settled state and any recorded recovery
+ * action so a session rejected by the running-attempt gate learns the
+ * sanctioned exit instead of a bare rejection (#1973). Best-effort: an empty
+ * string when nothing useful can be read.
+ */
+function latestAttemptRecoveryContext(task: TaskCompletionIdentity): string {
+  try {
+    const attempt = readLatestTaskAttempt(task);
+    if (!attempt) return "";
+    const settled = attempt.state === "settled"
+      ? ` settled with outcome=${attempt.outcome ?? "unknown"}${
+        attempt.resultFailureClass ? ` failureClass=${attempt.resultFailureClass}` : ""}`
+      : " still marked running";
+    const route = readTaskRecoveryRoute(attempt.attemptId);
+    const lever = route
+      ? route.resumeAuthorized
+        ? ` Recovery action ${route.recoveryActionId} (${route.action}) authorizes resume — ` +
+          `call gsd_task_recovery_resume with recoveryActionId "${route.recoveryActionId}".`
+        : ` Recovery action ${route.recoveryActionId} (${route.action}) is recorded for this Attempt.`
+      : "";
+    return ` Latest Attempt ${attempt.attemptId} is${settled}.${lever}`;
+  } catch {
+    return "";
+  }
+}
+
 export function resolveTaskCompletionAuthority(
   task: TaskCompletionIdentity,
   idempotencyKey?: string,
+  options?: TaskCompletionAuthorityOptions,
 ): TaskCompletionAuthority {
   if (idempotencyKey && replayAttemptId(idempotencyKey, task)) return "canonical";
   if (idempotencyKey) {
@@ -190,16 +231,19 @@ export function resolveTaskCompletionAuthority(
     return "legacy";
   }
   if (Number(lifecycle["has_held_running_attempt"]) === 1) return "canonical";
+  if (options?.blockerReport) return "legacy";
   if (Number(lifecycle["has_running_attempt"]) === 1) {
     throw new Error(
       "Canonical Task completion found an orphaned running Attempt whose milestone lease is no " +
       "longer held. Dry-run gsd_task_settle and apply it only if the lease is reported " +
-      "reclaimable; otherwise re-enter `/gsd auto` to recover under the current lease.",
+      "reclaimable; otherwise re-enter `/gsd auto` to recover under the current lease." +
+      latestAttemptRecoveryContext(task),
     );
   }
   throw new Error(
     "Canonical Task completion has no running Attempt to close. Re-enter `/gsd auto` to resume " +
-    "the Task from its durable checkpoint.",
+    "the Task from its durable checkpoint." +
+    latestAttemptRecoveryContext(task),
   );
 }
 

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -1355,3 +1355,60 @@ test("model-error branch in agent-end-recovery attempts fallback before any term
     "model-error fallback must not persistently block the model (#1533)",
   );
 });
+
+test("#1973: permanent/unknown provider-error pause aborts the still-live host turn", async () => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-unknown-pause-abort-"));
+  let abortCalls = 0;
+
+  try {
+    resetTransientRetryState();
+    autoSession.reset();
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    process.chdir(base);
+
+    autoSession.active = true;
+    autoSession.basePath = base;
+    autoSession.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+
+    const ctx = {
+      model: { provider: "openai-codex", id: "gpt-5.5" },
+      modelRegistry: { getAvailable: () => [] },
+      isIdle: () => false,
+      abort: () => {
+        abortCalls += 1;
+      },
+      ui: {
+        notify: () => {},
+        setStatus: () => {},
+        setWidget: () => {},
+        setWorkingMessage: () => {},
+      },
+    } as any;
+    const pi = {
+      setModel: async () => false,
+      sendMessage: () => {},
+    } as any;
+
+    await handleAgentEnd(pi, {
+      messages: [{
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "provider exploded in a completely novel way",
+      }],
+    } as any, ctx);
+
+    assert.equal(
+      abortCalls,
+      1,
+      "permanent/unknown pause must abort the live host turn so a surviving session cannot keep executing against a torn-down Attempt",
+    );
+    assert.equal(autoSession.active, false, "auto-mode must be paused");
+    assert.equal(autoSession.paused, true, "pause must be recorded");
+  } finally {
+    _resetPendingResolve();
+    autoSession.reset();
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/task-completion-compatibility-adapter.test.ts
+++ b/src/resources/extensions/gsd/tests/task-completion-compatibility-adapter.test.ts
@@ -36,6 +36,8 @@ import {
   readLatestTaskAttempt,
   settleTaskAttempt,
 } from "../task-execution-domain-operation.js";
+import { recordFailureAndSelectRecovery } from "../task-recovery-domain-operation.js";
+import { resolveTaskCompletionAuthority } from "../task-completion-compatibility-adapter.js";
 import { recordTaskTechnicalVerdict } from "../task-verification-domain-operation.js";
 import { captureVerificationSourceSnapshot } from "../verification-source-integrity.js";
 import {
@@ -1463,4 +1465,48 @@ test("auto publication replays a committed Task completion after PLAN projection
     operations: count("workflow_operations"),
     checkpoints: count("workflow_kernel_checkpoints"),
   }, beforeReplay);
+});
+
+test("#1973: attempt-gate rejection names the settled outcome and recovery lever; blocker reports bypass the gate", () => {
+  const { attemptId } = createFixture();
+  const settlement = settleTaskAttempt({
+    invocation: invocation("task-completion/settle-provider-failure"),
+    attemptId,
+    outcome: "failed",
+    failureClass: "provider",
+    summary: "Provider error: : Request timed out.",
+    output: {},
+  });
+  const routed = recordFailureAndSelectRecovery({
+    invocation: invocation("task-completion/route-provider-failure"),
+    attemptId,
+    resultId: settlement.resultId,
+    owner: "agent",
+    classification: { failureKind: "fatal" },
+    summary: "supervisor tore down the attempt on a provider timeout",
+    evidence: { source: "agent-end-recovery" },
+    rationale: "provider error classified as terminal",
+  });
+
+  assert.throws(
+    () => resolveTaskCompletionAuthority(TASK),
+    (err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      assert.match(message, /no running Attempt/);
+      assert.ok(message.includes(attemptId), "gate error must name the settled Attempt");
+      assert.match(message, /outcome=failed/);
+      assert.match(message, /failureClass=provider/);
+      assert.ok(
+        message.includes(routed.recoveryActionId),
+        "gate error must surface the recorded recovery action id",
+      );
+      return true;
+    },
+  );
+
+  assert.equal(
+    resolveTaskCompletionAuthority(TASK, undefined, { blockerReport: true }),
+    "legacy",
+    "blockerDiscovered reports must route to the legacy durable write instead of dead-ending on the gate",
+  );
 });

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -423,7 +423,7 @@ export async function handleCompleteTask(
       milestoneId: params.milestoneId,
       sliceId: params.sliceId,
       taskId: params.taskId,
-    }) === "canonical") {
+    }, undefined, { blockerReport: params.blockerDiscovered === true }) === "canonical") {
       return { error: "canonical Task completion requires the durable Attempt completion pipeline" };
     }
   } catch (error) {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -925,7 +925,9 @@ export async function executeTaskComplete(
       sliceId: params.sliceId,
       taskId: params.taskId,
     };
-    const authority = resolveTaskCompletionAuthority(task, invocation?.idempotencyKey);
+    const authority = resolveTaskCompletionAuthority(task, invocation?.idempotencyKey, {
+      blockerReport: params.blockerDiscovered === true,
+    });
     if (authority === "canonical") {
       if (!invocation) {
         throw new Error("Canonical Task completion requires private invocation identity");


### PR DESCRIPTION
## TL;DR
**What**: Abort the live host turn when a permanent/unknown provider error pauses auto-mode, and make the canonical completion gate survivable: rejections now name the settled Attempt state and recovery lever, and `blockerDiscovered: true` bypasses the running-attempt gate.
**Why**: A mid-unit provider timeout tore down the running Attempt while the host session kept executing; the surviving session's `gsd_task_complete` calls (including the blocker fallback) were permanently rejected with no named exit. Closes #1973.
**How**: `pauseAuto(..., { abortActiveTurn: true })` on the permanent/unknown branch; enrich `resolveTaskCompletionAuthority` throws via the existing `readLatestTaskAttempt`/`readTaskRecoveryRoute` readers; route blocker reports to the legacy durable write.

## What
- `bootstrap/agent-end-recovery.ts` — the permanent/unknown provider-error pause now passes `abortActiveTurn: true`, so a still-alive host session cannot keep executing after the supervisor settles the Attempt as failed (Hardening A).
- `task-completion-compatibility-adapter.ts` — when the running-attempt gate throws (orphaned or no-running-Attempt), the error now appends the latest Attempt's settled `outcome`/`failureClass` and any recorded recovery action id, naming `gsd_task_recovery_resume` with the exact `recoveryActionId` when resume is authorized (Hardening B, enrichment).
- `task-completion-compatibility-adapter.ts` + `tools/complete-task.ts` + `tools/workflow-tool-executors.ts` — `blockerDiscovered: true` completions are exempt from the running-attempt gate: they route to the legacy `handleCompleteTask` write, a durable DB transaction (`insertTask` with `blocker_discovered`/`blocker_source`) that requires no running Attempt. Recording a blocker is an escalation channel, not a completion, so it must always be recordable (Hardening B, exemption). A held running Attempt still takes the canonical staged path.
- Tests: one `handleAgentEnd` test asserting `ctx.abort()` fires on the permanent/unknown pause (verified failing without the fix), one adapter test asserting the enriched gate error (attempt id, `outcome=failed`, `failureClass=provider`, recovery action id) and that `blockerReport` returns `legacy`.

## Why
Closes #1973.

Forensics in the issue show a `Request timed out.` mid-unit failure classified `isTransient: false`, pausing auto-mode and settling the Attempt as failed while the host session transparently retried and finished the work — then all three `gsd_task_complete` calls (including `blockerDiscovered: true`) were rejected with `Canonical Task completion requires a running or replay-matched Attempt`, leaving verified work stranded on disk.

**Defect 1 (classifier) is already fixed on main by #1946**: `request timed out` is in `NETWORK_RE`, and `classifyError("Provider error: : Request timed out.")` returns `{ kind: "network" }` (transient) — covered by the #1944 regression test in `terminated-transient.test.ts` (21/21 pass). No regex extension was made for `Session creation timed out`-style variants: that string is GSD-generated with `isTransient: true` at its only source (`auto/run-unit.ts:160`) and consumed by dedicated handling in `auto/unit-phase.ts`, so it never reaches `classifyError`; the issue's broader `timed[ _-]?out` regex would speculatively reclassify unrelated timeout phrasings.

**Transient branch deliberately unchanged**: `pauseTransientWithBackoff` auto-resumes the same unit in the same session (`resumeAutoAfterProviderDelay`), so aborting the live turn there would kill the session the auto-resume depends on — the split-brain only exists on the terminal path, where the supervisor settles the Attempt and never returns to this session.

## How
- Permanent/unknown branch passes a fourth `pauseAuto` argument (`{ abortActiveTurn: true }`); `pauseAuto` already implements the abort (`options.abortActiveTurn && ctx && !ctx.isIdle() && ctx.abort()`).
- `resolveTaskCompletionAuthority` gains an optional `options.blockerReport`; both existing call sites pass `params.blockerDiscovered === true`. The enrichment is best-effort (try/catch) and reuses the existing readers — no new queries beyond `readLatestTaskAttempt` + `readTaskRecoveryRoute`.
- Existing gate-message assertions in `task-settle.test.ts` still pass (the enrichment appends; base text is preserved).

Verification (all standalone, compiled via `pnpm run test:compile`):
- `terminated-transient.test.js` 21/21, `provider-errors.test.js` 92/92 (new #1973 test included; fails without the fix), `task-completion-compatibility-adapter.test.js` 41/41 (new #1973 test included), `task-settle.test.js` 10/10, `complete-task*.test.js` all pass, `task-completion-executor-identity.test.js` 10/10, `agent-end-retry.test.js` pass.
- `pnpm run typecheck:extensions` clean. Root `tsc --noEmit --incremental false` shows only the known environmental nested-worktree `cli.ts`/ModelRegistry duplicate-declaration error (resolution leak between worktree and main checkout `node_modules`; untouched by this change).
