### PR TITLE
feat(gsd): session-start GitHub Copilot catalog refresh and runtime model activation

### DIFF
--- a/docs/dev/ADR-012-provider-id-vs-api-shape.md
+++ b/docs/dev/ADR-012-provider-id-vs-api-shape.md
@@ -51,6 +51,7 @@ A small set of call sites legitimately keys on `provider`. These are **not** gat
 - **Default-provider migrations** (`provider-migrations.ts`). Moving persisted settings from the `anthropic` transport to the `claude-code` transport is intentionally provider-id specific.
 - **Display labels / onboarding copy** (`onboarding.ts`). Surface-only, no behavior impact.
 - **Live provider-account catalog state** (`copilot-model-catalog.ts`, `copilot-overlay-writer.ts`, `commands/handlers/copilot-models.ts`). GitHub Copilot's live `/models` sync, its remote-only-model quarantine/registration logic, and the `/gsd copilot-models` command all exist specifically to talk to the `github-copilot` transport's authenticated account state — the check is inherently transport-specific, not API-shape-specific.
+- **Session-start catalog refresh coordinator** (`copilot-catalog-session-refresh.ts`). GSD-W018's opt-in automatic refresh reuses the same GitHub Copilot auth-token resolution as the manual `/gsd copilot-models` command, for the same transport-specific reason.
 
 These sites are enumerated in the allowlist at `src/tests/provider-equality-allowlist.test.ts`.
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -570,6 +570,47 @@ async function syncServiceTierStatus(ctx: ExtensionContext): Promise<void> {
   ctx.ui.setStatus("gsd-fast", formatServiceTierFooterStatus(getEffectiveServiceTier(), ctx.model?.id));
 }
 
+/**
+ * GSD-W018: optionally refresh the GitHub Copilot live model catalog at
+ * session start, gated by `copilot_catalog.refresh_on_session_start`
+ * (default "off"). Fire-and-forget by design — never awaited on the startup
+ * path — so a slow/unavailable network never delays the welcome banner.
+ * Covers both a terminal/CLI session start and the first `@gsd` invocation
+ * from an editor chat context, since both converge on this same
+ * `session_start` event (the VS Code chat participant starts/connects to the
+ * same underlying agent session rather than running a separate lifecycle).
+ */
+function triggerCopilotCatalogSessionRefresh(ctx: ExtensionContext, basePath: string): void {
+  void (async () => {
+    try {
+      const { loadEffectiveGSDPreferences } = await import("../preferences.js");
+      const prefs = loadEffectiveGSDPreferences(basePath);
+      const {
+        startCopilotCatalogSessionRefresh,
+        resolveCopilotCatalogRefreshMode,
+        resolveCopilotCatalogNotifyOnChanges,
+      } = await import("../copilot-catalog-session-refresh.js");
+
+      if (resolveCopilotCatalogRefreshMode(prefs?.preferences) === "off") return;
+      const notifyOnChanges = resolveCopilotCatalogNotifyOnChanges(prefs?.preferences);
+
+      const result = await startCopilotCatalogSessionRefresh({
+        ctx,
+        basePath,
+        preferences: prefs?.preferences,
+      });
+      if (!notifyOnChanges || !result.ok || result.changedModelIds.length === 0) return;
+      ctx.ui.notify(
+        `GitHub Copilot model catalog: ${result.changedModelIds.length} model(s) changed since the last check. Run /gsd copilot-models changes for details.`,
+        "info",
+      );
+    } catch {
+      // Non-fatal: session startup must never fail because of this, and the
+      // coordinator itself never surfaces auth/network failures as errors.
+    }
+  })();
+}
+
 async function applyDisabledModelProviderPolicy(ctx: ExtensionContext): Promise<void> {
   try {
     const { resolveDisabledModelProvidersFromPreferences } = await import("../preferences.js");
@@ -1076,6 +1117,7 @@ export function registerHooks(
     clearDeferredDestructiveConfirmationPause();
     await resetAskUserQuestionsTurnCache();
     await syncServiceTierStatus(ctx);
+    triggerCopilotCatalogSessionRefresh(ctx, basePath);
     await applyDisabledModelProviderPolicy(ctx);
     await applyCompactionThresholdOverride(ctx);
     await prepareWorkflowMcpForHookContext(ctx, basePath);

--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -171,6 +171,11 @@ export function classifyRemoteCopilotModel(
 			stale: false,
 			billingUnit: "tokens",
 		},
+		// BUNDLED_COST_TABLE entries are keyed by bare model ID and are not
+		// provider-qualified — without this, a same-named model priced by a
+		// different provider (e.g. OpenAI's "gpt-5.4") could silently be
+		// reported as this Copilot model's known price. See model-cost-table.ts.
+		disableImplicitFallback: true,
 	});
 	const fallbackPrices = economics.tokenPrices?.default;
 	const hasKnownPricing =

--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -41,6 +41,7 @@ import {
 } from "./copilot-model-catalog.js";
 import { resolveModelEconomics } from "./model-cost-table.js";
 import {
+	canonicalizeModelId,
 	getModelProfileConfidence,
 	MODEL_CAPABILITY_TIER,
 	type CapabilityProfileConfidence,
@@ -158,7 +159,7 @@ export function classifyRemoteCopilotModel(
 		};
 	}
 
-	const tier = MODEL_CAPABILITY_TIER[record.id];
+	const tier = MODEL_CAPABILITY_TIER[canonicalizeModelId(record.id)];
 	const profileConfidence = getModelProfileConfidence(record.id);
 	const hasKnownLimits =
 		typeof record.execution.contextWindow === "number" && typeof record.execution.maxTokens === "number";

--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -1,0 +1,424 @@
+// Project/App: gsd-pi
+// File Purpose: GSD-W018 — session-start GitHub Copilot catalog refresh
+// coordinator and 3-tier runtime model classification.
+//
+// Extends the explicit, user-invoked `/gsd copilot-models sync` (GSD-W014)
+// with an OPT-IN automatic refresh at GSD session start, gated by
+// `copilot_catalog.refresh_on_session_start` (default "off"). Reuses the
+// same read-only fetch/sanitize/last-known-good pipeline from
+// `copilot-model-catalog.ts` — this module never duplicates network/auth
+// logic, it only coordinates *when* to call it and classifies the result for
+// safe runtime selection.
+//
+// Invariants:
+//   - Never blocks ordinary session startup: callers must fire-and-forget
+//     via `startCopilotCatalogSessionRefresh`, never await it synchronously
+//     on the startup path.
+//   - At most one in-flight refresh per basePath — concurrent triggers (e.g.
+//     a terminal session racing a VS Code daemon connect) share one promise.
+//   - Never triggers or waits on an OAuth/login flow: auth resolution reuses
+//     `ctx.modelRegistry.getApiKey()`, which only ever returns a token that
+//     is already available, and any thrown/missing token is treated as
+//     "auth unavailable, skip silently" — never surfaced as an error.
+//   - Bounded wall-clock timeout; a slow/hanging fetch never wedges startup
+//     or a caller awaiting the in-flight refresh (e.g. the model picker).
+//   - Classification never fabricates capability or pricing data: unknown
+//     stays unknown (manual-only), and structurally incomplete records are
+//     quarantined rather than silently defaulted.
+//   - State here is session-scoped only (module-level, per basePath) —
+//     nothing is persisted to disk, mirroring the existing
+//     `commands/handlers/copilot-models.ts` session-scoped snapshot.
+
+import type { ExtensionContext } from "@gsd/pi-coding-agent";
+import { getGitHubCopilotBaseUrl } from "@gsd/pi-ai/oauth";
+
+import {
+	applyLastKnownGood,
+	diffCatalogSnapshots,
+	fetchGitHubCopilotModels,
+	type CopilotModelRecord,
+	type CopilotModelSnapshot,
+} from "./copilot-model-catalog.js";
+import { resolveModelEconomics } from "./model-cost-table.js";
+import {
+	getModelProfileConfidence,
+	MODEL_CAPABILITY_TIER,
+	type CapabilityProfileConfidence,
+} from "./model-router.js";
+import type {
+	CopilotCatalogPreferences,
+	CopilotCatalogRefreshMode,
+} from "./preferences-types.js";
+
+// ─── Config resolution (pure — no I/O, no defaults hidden elsewhere) ───────
+
+export const DEFAULT_COPILOT_CATALOG_STALE_AFTER_MS = 6 * 60 * 60 * 1000; // 6h
+export const DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS = 10_000;
+const MIN_STALE_AFTER_MS = 60_000; // 1 minute
+const MAX_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+type PreferencesLike = { copilot_catalog?: CopilotCatalogPreferences } | null | undefined;
+
+/** Resolve the effective refresh mode. Default is "off" — matches KNOWN_PREFERENCE_KEYS/validation defaults. */
+export function resolveCopilotCatalogRefreshMode(
+	prefs: PreferencesLike,
+): CopilotCatalogRefreshMode {
+	return prefs?.copilot_catalog?.refresh_on_session_start ?? "off";
+}
+
+/** Resolve whether a non-blocking notification should surface catalog changes. Default: true. */
+export function resolveCopilotCatalogNotifyOnChanges(prefs: PreferencesLike): boolean {
+	return prefs?.copilot_catalog?.notify_on_changes ?? true;
+}
+
+/** Resolve the "if_stale" staleness threshold in ms, clamped to a sane range. Default: 6h. */
+export function resolveCopilotCatalogStaleAfterMs(prefs: PreferencesLike): number {
+	const raw = prefs?.copilot_catalog?.stale_after_ms;
+	if (typeof raw !== "number" || !Number.isFinite(raw)) {
+		return DEFAULT_COPILOT_CATALOG_STALE_AFTER_MS;
+	}
+	return Math.min(Math.max(raw, MIN_STALE_AFTER_MS), MAX_STALE_AFTER_MS);
+}
+
+/**
+ * Pure decision of whether a refresh should run for the given mode/staleness
+ * state. No I/O — safe to unit test directly.
+ */
+export function shouldTriggerCopilotCatalogRefresh(
+	mode: CopilotCatalogRefreshMode,
+	lastRefreshedAtMs: number | null,
+	nowMs: number,
+	staleAfterMs: number,
+): boolean {
+	if (mode === "off") return false;
+	if (mode === "always") return true;
+	if (lastRefreshedAtMs === null) return true;
+	return nowMs - lastRefreshedAtMs >= staleAfterMs;
+}
+
+// ─── Runtime model classification (Class A / B / C) ────────────────────────
+
+/**
+ * - "trusted" (Class A): capability tier, profile confidence, and pricing are
+ *   all known — exposed for manual selection AND eligible for automatic
+ *   routing (subject to the existing routing confidence/economics gates in
+ *   model-router.ts).
+ * - "manual-only" (Class B): the live record is transport-valid
+ *   (`tool_call: true`) but capability tier, profile confidence, or pricing
+ *   is unknown — selectable manually, never auto-routed, never used for
+ *   cheaper-model suggestions.
+ * - "quarantined" (Class C): structurally incomplete (not tool-call capable)
+ *   — not exposed as selectable, not routed, not suggested.
+ */
+export type ModelRuntimeClass = "trusted" | "manual-only" | "quarantined";
+
+export interface ModelClassification {
+	modelClass: ModelRuntimeClass;
+	reasons: string[];
+	tier?: string;
+	profileConfidence?: CapabilityProfileConfidence;
+	hasKnownPricing: boolean;
+}
+
+/**
+ * Classify a single live-catalog GitHub Copilot model for safe runtime
+ * exposure (GSD-W018 Decision 6). Never invents capability or pricing data —
+ * absence of evidence always resolves to "manual-only" or "quarantined",
+ * never a synthesized "trusted" classification.
+ */
+export function classifyRemoteCopilotModel(
+	record: CopilotModelRecord,
+): ModelClassification {
+	if (!record.execution.toolCalls) {
+		return {
+			modelClass: "quarantined",
+			reasons: ["missing required tool-call capability"],
+			hasKnownPricing: false,
+		};
+	}
+	if (record.availability.policyState === "disabled" || record.availability.policyState === "restricted") {
+		return {
+			modelClass: "quarantined",
+			reasons: [`policy state: ${record.availability.policyState}`],
+			hasKnownPricing: false,
+		};
+	}
+	if (record.availability.preview) {
+		return {
+			modelClass: "quarantined",
+			reasons: ["preview model — not yet stable for automatic exposure"],
+			hasKnownPricing: false,
+		};
+	}
+	if (record.conflicts.length > 0) {
+		return {
+			modelClass: "quarantined",
+			reasons: [`unresolved normalization conflict(s): ${record.conflicts.join(", ")}`],
+			hasKnownPricing: false,
+		};
+	}
+
+	const tier = MODEL_CAPABILITY_TIER[record.id];
+	const profileConfidence = getModelProfileConfidence(record.id);
+	const hasKnownLimits =
+		typeof record.execution.contextWindow === "number" && typeof record.execution.maxTokens === "number";
+	const hasBillingOnRecord = record.billing.inputPer1k !== undefined && record.billing.outputPer1k !== undefined;
+	const economics = resolveModelEconomics({
+		provider: "github-copilot",
+		modelId: record.id,
+		fallbackEconomics: {
+			source: "bundled-fallback",
+			stale: false,
+			billingUnit: "tokens",
+		},
+	});
+	const fallbackPrices = economics.tokenPrices?.default;
+	const hasKnownPricing =
+		hasBillingOnRecord ||
+		economics.source !== "bundled-fallback" ||
+		Boolean(fallbackPrices && (fallbackPrices.inputPer1k > 0 || fallbackPrices.outputPer1k > 0));
+
+	if (tier && profileConfidence !== "unknown" && hasKnownPricing && hasKnownLimits) {
+		return {
+			modelClass: "trusted",
+			reasons: [
+				`capability tier known (${tier})`,
+				`profile confidence: ${profileConfidence}`,
+				"pricing known",
+				"context/token limits known",
+			],
+			tier,
+			profileConfidence,
+			hasKnownPricing,
+		};
+	}
+
+	const reasons: string[] = [];
+	if (!tier) reasons.push("no known capability tier");
+	if (profileConfidence === "unknown") reasons.push("no capability profile (unknown confidence)");
+	if (!hasKnownPricing) reasons.push("no known pricing");
+	if (!hasKnownLimits) reasons.push("no known context/token limits");
+
+	return {
+		modelClass: "manual-only",
+		reasons,
+		tier,
+		profileConfidence,
+		hasKnownPricing,
+	};
+}
+
+// ─── Session-start refresh coordinator ─────────────────────────────────────
+
+export interface CopilotCatalogSessionRefreshResult {
+	/** False when the refresh was skipped entirely (mode=off, not stale, no provider, no token). */
+	ran: boolean;
+	ok: boolean;
+	reason?: string;
+	snapshot: CopilotModelSnapshot | null;
+	classifications: Record<string, ModelClassification>;
+	changedModelIds: string[];
+}
+
+const NOOP_RESULT: Readonly<CopilotCatalogSessionRefreshResult> = Object.freeze({
+	ran: false,
+	ok: false,
+	snapshot: null,
+	classifications: {},
+	changedModelIds: [],
+});
+
+// Session-scoped only (module-level, per basePath) — never persisted to disk.
+const inFlightRefreshes = new Map<string, Promise<CopilotCatalogSessionRefreshResult>>();
+const lastRefreshedAtByBasePath = new Map<string, number>();
+const lastSnapshotByBasePath = new Map<string, CopilotModelSnapshot>();
+
+/** Test-only hook to reset module-level session state between test cases. */
+export function _resetCopilotCatalogSessionRefreshStateForTests(): void {
+	inFlightRefreshes.clear();
+	lastRefreshedAtByBasePath.clear();
+	lastSnapshotByBasePath.clear();
+}
+
+function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	onTimeout: T,
+): Promise<T> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			resolve(onTimeout);
+		}, timeoutMs);
+		promise.then(
+			(value) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolve(value);
+			},
+			() => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolve(onTimeout);
+			},
+		);
+	});
+}
+
+export interface RefreshCopilotCatalogSessionOptions {
+	ctx: ExtensionContext;
+	basePath: string;
+	preferences: PreferencesLike;
+	/** Injectable clock for tests. Defaults to Date.now. */
+	now?: () => number;
+	/** Injectable fetch for tests. */
+	fetchImpl?: typeof fetch;
+	/** Injectable timeout for tests. Defaults to DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS. */
+	timeoutMs?: number;
+}
+
+async function runCopilotCatalogRefresh(
+	options: RefreshCopilotCatalogSessionOptions,
+): Promise<CopilotCatalogSessionRefreshResult> {
+	const { ctx, basePath } = options;
+	const nowFn = options.now ?? Date.now;
+
+	const available = ctx.modelRegistry.getAvailable();
+	const copilotModel = available.find((model) => model.provider === "github-copilot");
+	if (!copilotModel) {
+		return { ...NOOP_RESULT, ran: true, reason: "provider-not-configured" };
+	}
+
+	let token: string | undefined;
+	try {
+		token = await ctx.modelRegistry.getApiKey(copilotModel);
+	} catch {
+		// Never surface auth resolution failures as errors, and never trigger
+		// a login/OAuth flow — silently skip this session's refresh.
+		return { ...NOOP_RESULT, ran: true, reason: "auth-unavailable" };
+	}
+	if (!token) {
+		return { ...NOOP_RESULT, ran: true, reason: "auth-unavailable" };
+	}
+
+	const baseUrl = getGitHubCopilotBaseUrl(token);
+	const previousSnapshot = lastSnapshotByBasePath.get(basePath) ?? null;
+
+	let fetchResult: Awaited<ReturnType<typeof fetchGitHubCopilotModels>>;
+	try {
+		fetchResult = await fetchGitHubCopilotModels({
+			provider: "github-copilot",
+			authToken: token,
+			baseUrl,
+			fetchImpl: options.fetchImpl,
+		});
+	} catch (err) {
+		return {
+			...NOOP_RESULT,
+			ran: true,
+			ok: false,
+			reason: err instanceof Error ? err.message : "fetch-failed",
+			snapshot: previousSnapshot,
+		};
+	}
+
+	const ok = !fetchResult.skipped && fetchResult.models.length > 0 && Boolean(fetchResult.snapshot);
+	const nextSnapshot = previousSnapshot
+		? applyLastKnownGood(previousSnapshot, { ok, snapshot: ok ? fetchResult.snapshot! : null })
+		: ok
+			? fetchResult.snapshot!
+			: null;
+
+	if (!nextSnapshot) {
+		return {
+			...NOOP_RESULT,
+			ran: true,
+			ok: false,
+			reason: fetchResult.reason ?? "empty-response",
+		};
+	}
+
+	lastSnapshotByBasePath.set(basePath, nextSnapshot);
+	lastRefreshedAtByBasePath.set(basePath, nowFn());
+
+	const classifications: Record<string, ModelClassification> = {};
+	for (const model of nextSnapshot.models) {
+		classifications[model.id] = classifyRemoteCopilotModel(model);
+	}
+
+	const changedModelIds = previousSnapshot
+		? (() => {
+				const diff = diffCatalogSnapshots(previousSnapshot, nextSnapshot);
+				return [...diff.added, ...diff.changed].map((model) => model.id);
+			})()
+		: nextSnapshot.models.map((model) => model.id);
+
+	return {
+		ran: true,
+		ok: true,
+		snapshot: nextSnapshot,
+		classifications,
+		changedModelIds,
+	};
+}
+
+/**
+ * Start (or join an already in-flight) session-start Copilot catalog
+ * refresh. Callers on the startup path MUST NOT `await` this synchronously —
+ * fire it and let it resolve in the background (`void
+ * startCopilotCatalogSessionRefresh(...)`), per the non-blocking-startup
+ * invariant. `awaitCopilotCatalogSessionRefresh` is the bounded-wait join
+ * point for callers (e.g. the model picker) that need the result.
+ *
+ * Returns `NOOP_RESULT` synchronously-resolved when the mode is "off" or
+ * "if_stale" and the snapshot is not yet stale — no promise is stored in
+ * that case, so `awaitCopilotCatalogSessionRefresh` has nothing to join.
+ */
+export function startCopilotCatalogSessionRefresh(
+	options: RefreshCopilotCatalogSessionOptions,
+): Promise<CopilotCatalogSessionRefreshResult> {
+	const { basePath, preferences } = options;
+	const nowFn = options.now ?? Date.now;
+	const mode = resolveCopilotCatalogRefreshMode(preferences);
+	const staleAfterMs = resolveCopilotCatalogStaleAfterMs(preferences);
+	const lastRefreshedAt = lastRefreshedAtByBasePath.get(basePath) ?? null;
+
+	if (!shouldTriggerCopilotCatalogRefresh(mode, lastRefreshedAt, nowFn(), staleAfterMs)) {
+		return Promise.resolve(NOOP_RESULT);
+	}
+
+	const existing = inFlightRefreshes.get(basePath);
+	if (existing) return existing;
+
+	const timeoutMs = options.timeoutMs ?? DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS;
+	const timedOutResult: CopilotCatalogSessionRefreshResult = {
+		...NOOP_RESULT,
+		ran: true,
+		reason: "timeout",
+	};
+	const runPromise = withTimeout(runCopilotCatalogRefresh(options), timeoutMs, timedOutResult).finally(() => {
+		inFlightRefreshes.delete(basePath);
+	});
+
+	inFlightRefreshes.set(basePath, runPromise);
+	return runPromise;
+}
+
+/**
+ * Await an in-flight refresh for `basePath`, bounded by `timeoutMs`. Used by
+ * the model picker so a just-started refresh can populate newly available
+ * models before the picker renders, without ever blocking indefinitely.
+ * Resolves immediately with `NOOP_RESULT` when nothing is in flight.
+ */
+export function awaitCopilotCatalogSessionRefresh(
+	basePath: string,
+	timeoutMs = DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS,
+): Promise<CopilotCatalogSessionRefreshResult> {
+	const pending = inFlightRefreshes.get(basePath);
+	if (!pending) return Promise.resolve(NOOP_RESULT);
+	return withTimeout(pending, timeoutMs, { ...NOOP_RESULT, ran: true, reason: "timeout" });
+}

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -86,6 +86,30 @@ export interface ContextModeConfig {
 export function isContextModeEnabled(prefs: { context_mode?: ContextModeConfig } | null | undefined): boolean {
   return prefs?.context_mode?.enabled !== false;
 }
+
+/**
+ * Automatic GitHub Copilot live-catalog refresh at GSD session start
+ * (GSD-W018). Extends the explicit, user-invoked `/gsd copilot-models sync`
+ * (GSD-W014) command — this setting only controls whether a refresh ALSO
+ * runs automatically when a GSD session starts (terminal session or the
+ * first `@gsd` invocation in an editor chat context).
+ */
+export type CopilotCatalogRefreshMode = "off" | "if_stale" | "always";
+
+export interface CopilotCatalogPreferences {
+  /**
+   * - "off" (default): never refresh automatically; explicit
+   *   `/gsd copilot-models sync` remains the only trigger.
+   * - "if_stale": refresh at most once per session, only when the
+   *   account-scoped snapshot is older than `stale_after_ms`.
+   * - "always": refresh once for every newly started GSD session.
+   */
+  refresh_on_session_start?: CopilotCatalogRefreshMode;
+  /** Surface a non-blocking notification when the refresh finds catalog changes. Default: true. */
+  notify_on_changes?: boolean;
+  /** Staleness threshold in ms for "if_stale" mode. Default: 21_600_000 (6h). Range: 60_000–604_800_000 (1min–7d). */
+  stale_after_ms?: number;
+}
 import type { GitHubSyncConfig } from "../github-sync/types.js";
 
 // ─── Workflow Modes ──────────────────────────────────────────────────────────
@@ -185,6 +209,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "language",
   "context_window_override",
   "context_mode",
+  "copilot_catalog",
   "planning_depth",
   "claude_code_mcp",
   "workspace",
@@ -537,6 +562,8 @@ export interface GSDPreferences {
    * disabled with `context_mode.enabled: false`.
    */
   context_mode?: ContextModeConfig;
+  /** Automatic GitHub Copilot live-catalog refresh at session start (GSD-W018). Default: off. */
+  copilot_catalog?: CopilotCatalogPreferences;
   token_profile?: TokenProfile;
   phases?: PhaseSkipPreferences;
   /**

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -1135,6 +1135,43 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  // ─── Copilot Catalog Session Refresh (GSD-W018) ─────────────────────────
+  if (preferences.copilot_catalog !== undefined) {
+    if (typeof preferences.copilot_catalog === "object" && preferences.copilot_catalog !== null) {
+      const catalog = preferences.copilot_catalog as unknown as Record<string, unknown>;
+      const validCatalog: Record<string, unknown> = {};
+      const validRefreshModes = new Set(["off", "if_stale", "always"]);
+
+      if (catalog.refresh_on_session_start !== undefined) {
+        if (typeof catalog.refresh_on_session_start === "string" && validRefreshModes.has(catalog.refresh_on_session_start)) {
+          validCatalog.refresh_on_session_start = catalog.refresh_on_session_start;
+        } else {
+          errors.push('copilot_catalog.refresh_on_session_start must be one of: off, if_stale, always');
+        }
+      }
+      if (catalog.notify_on_changes !== undefined) {
+        if (typeof catalog.notify_on_changes === "boolean") validCatalog.notify_on_changes = catalog.notify_on_changes;
+        else errors.push("copilot_catalog.notify_on_changes must be a boolean");
+      }
+      if (catalog.stale_after_ms !== undefined) {
+        const ms = catalog.stale_after_ms;
+        if (typeof ms === "number" && ms >= 60_000 && ms <= 604_800_000) validCatalog.stale_after_ms = Math.floor(ms);
+        else errors.push("copilot_catalog.stale_after_ms must be a number between 60000 and 604800000");
+      }
+      for (const key of Object.keys(catalog)) {
+        if (key !== "refresh_on_session_start" && key !== "notify_on_changes" && key !== "stale_after_ms") {
+          warnings.push(`unknown copilot_catalog key "${key}" — ignored`);
+        }
+      }
+
+      if (Object.keys(validCatalog).length > 0) {
+        validated.copilot_catalog = validCatalog as any;
+      }
+    } else {
+      errors.push("copilot_catalog must be an object");
+    }
+  }
+
   // ─── Parallel Config ────────────────────────────────────────────────────
   if (preferences.parallel && typeof preferences.parallel === "object") {
     const p = preferences.parallel as unknown as Record<string, unknown>;

--- a/src/resources/extensions/gsd/tests/copilot-catalog-preferences-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-preferences-validation.test.ts
@@ -1,0 +1,67 @@
+// Validation tests for GSD-W018's `copilot_catalog` preference block
+// (refresh_on_session_start / notify_on_changes / stale_after_ms).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validatePreferences } from "../preferences.js";
+
+test("copilot_catalog: valid config passes through with no errors", () => {
+  const { errors, preferences } = validatePreferences({
+    copilot_catalog: {
+      refresh_on_session_start: "if_stale",
+      notify_on_changes: false,
+      stale_after_ms: 3_600_000,
+    },
+  } as any);
+
+  assert.deepEqual(errors, []);
+  assert.deepEqual(preferences.copilot_catalog, {
+    refresh_on_session_start: "if_stale",
+    notify_on_changes: false,
+    stale_after_ms: 3_600_000,
+  });
+});
+
+test("copilot_catalog: omitted config produces no errors and no default injection", () => {
+  const { errors, preferences } = validatePreferences({} as any);
+  assert.deepEqual(errors, []);
+  assert.equal(preferences.copilot_catalog, undefined);
+});
+
+test("copilot_catalog: rejects an invalid refresh_on_session_start value", () => {
+  const { errors } = validatePreferences({
+    copilot_catalog: { refresh_on_session_start: "sometimes" },
+  } as any);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0]!, /refresh_on_session_start must be one of: off, if_stale, always/);
+});
+
+test("copilot_catalog: rejects a non-boolean notify_on_changes", () => {
+  const { errors } = validatePreferences({
+    copilot_catalog: { notify_on_changes: "yes" },
+  } as any);
+  assert.match(errors[0]!, /notify_on_changes must be a boolean/);
+});
+
+test("copilot_catalog: rejects an out-of-range stale_after_ms", () => {
+  const tooLow = validatePreferences({ copilot_catalog: { stale_after_ms: 1000 } } as any);
+  assert.match(tooLow.errors[0]!, /stale_after_ms must be a number between 60000 and 604800000/);
+
+  const tooHigh = validatePreferences({ copilot_catalog: { stale_after_ms: 1e12 } } as any);
+  assert.match(tooHigh.errors[0]!, /stale_after_ms must be a number between 60000 and 604800000/);
+});
+
+test("copilot_catalog: warns on unknown sub-keys without rejecting known ones", () => {
+  const { errors, warnings, preferences } = validatePreferences({
+    copilot_catalog: { refresh_on_session_start: "always", made_up_key: true },
+  } as any);
+  assert.deepEqual(errors, []);
+  assert.ok(warnings.some((w) => w.includes('unknown copilot_catalog key "made_up_key"')));
+  assert.equal(preferences.copilot_catalog?.refresh_on_session_start, "always");
+});
+
+test("copilot_catalog: rejects a non-object value", () => {
+  const { errors } = validatePreferences({ copilot_catalog: "always" } as any);
+  assert.match(errors[0]!, /copilot_catalog must be an object/);
+});

--- a/src/resources/extensions/gsd/tests/copilot-catalog-session-refresh.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-session-refresh.test.ts
@@ -1,0 +1,409 @@
+// Regression/behavior tests for GSD-W018: the session-start GitHub Copilot
+// catalog refresh coordinator and 3-tier runtime model classification.
+// Exercises the coordinator's dedup/timeout/auth-safety contract and the
+// classifier's refusal to fabricate capability or pricing data — as opposed
+// to the production command wiring covered by copilot-models-handler.test.ts.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	_resetCopilotCatalogSessionRefreshStateForTests,
+	awaitCopilotCatalogSessionRefresh,
+	classifyRemoteCopilotModel,
+	resolveCopilotCatalogNotifyOnChanges,
+	resolveCopilotCatalogRefreshMode,
+	resolveCopilotCatalogStaleAfterMs,
+	shouldTriggerCopilotCatalogRefresh,
+	startCopilotCatalogSessionRefresh,
+	type CopilotCatalogSessionRefreshResult,
+} from "../copilot-catalog-session-refresh.js";
+import type { CopilotModelRecord } from "../copilot-model-catalog.js";
+
+interface FakeModel {
+	id: string;
+	provider: string;
+}
+
+function createFakeCtx(options: {
+	models?: FakeModel[];
+	apiKey?: string | undefined;
+	apiKeyThrows?: boolean;
+}): { ctx: any; notifications: Array<{ message: string; level: string }> } {
+	const notifications: Array<{ message: string; level: string }> = [];
+	const models = options.models ?? [];
+	const ctx = {
+		modelRegistry: {
+			getAvailable: () => models,
+			getApiKey: async (_model: FakeModel) => {
+				if (options.apiKeyThrows) throw new Error("token refresh failed");
+				return options.apiKey;
+			},
+		},
+		ui: {
+			notify: (message: string, level: string = "info") => {
+				notifications.push({ message, level });
+			},
+		},
+	};
+	return { ctx, notifications };
+}
+
+function jsonResponse(data: Array<Record<string, unknown>>) {
+	return async () => ({ ok: true, json: async () => ({ data }) }) as unknown as Response;
+}
+
+function neverResolves() {
+	return (async () => new Promise<Response>(() => {})) as unknown as typeof fetch;
+}
+
+function buildRecord(overrides: Partial<CopilotModelRecord> = {}): CopilotModelRecord {
+	return {
+		provider: "github-copilot",
+		id: "claude-sonnet-5",
+		registryId: "github-copilot/claude-sonnet-5",
+		name: "Claude Sonnet 5",
+		availability: { enabled: true, pickerEnabled: true, preview: false, policyState: "enabled" },
+		execution: {
+			toolCalls: true,
+			supportedEndpoints: [],
+			reasoningLevels: [],
+			contextWindow: 200_000,
+			maxTokens: 8_192,
+		},
+		billing: { billingUnit: "tokens", inputPer1k: 0.003, outputPer1k: 0.015 },
+		provenance: {
+			displayName: { source: "provider-live", freshness: "fresh" },
+			availability: { source: "provider-live", freshness: "fresh" },
+			endpoints: { source: "provider-live", freshness: "fresh" },
+			reasoning: { source: "provider-live", freshness: "fresh" },
+			limits: { source: "provider-live", freshness: "fresh" },
+			billingUnit: { source: "provider-live", freshness: "fresh" },
+			tokenPrices: { source: "provider-live", freshness: "fresh" },
+			requestMultiplier: { source: "unknown", freshness: "unknown" },
+			promotion: { source: "unknown", freshness: "unknown" },
+		},
+		conflicts: [],
+		hash: "test-hash",
+		...overrides,
+	} as CopilotModelRecord;
+}
+
+// ─── Config resolution ──────────────────────────────────────────────────────
+
+test("resolveCopilotCatalogRefreshMode defaults to off", () => {
+	assert.equal(resolveCopilotCatalogRefreshMode(undefined), "off");
+	assert.equal(resolveCopilotCatalogRefreshMode({}), "off");
+	assert.equal(resolveCopilotCatalogRefreshMode({ copilot_catalog: {} }), "off");
+});
+
+test("resolveCopilotCatalogRefreshMode respects configured mode", () => {
+	assert.equal(
+		resolveCopilotCatalogRefreshMode({ copilot_catalog: { refresh_on_session_start: "always" } }),
+		"always",
+	);
+	assert.equal(
+		resolveCopilotCatalogRefreshMode({ copilot_catalog: { refresh_on_session_start: "if_stale" } }),
+		"if_stale",
+	);
+});
+
+test("resolveCopilotCatalogNotifyOnChanges defaults to true", () => {
+	assert.equal(resolveCopilotCatalogNotifyOnChanges(undefined), true);
+	assert.equal(resolveCopilotCatalogNotifyOnChanges({ copilot_catalog: { notify_on_changes: false } }), false);
+});
+
+test("resolveCopilotCatalogStaleAfterMs defaults and clamps out-of-range values", () => {
+	assert.equal(resolveCopilotCatalogStaleAfterMs(undefined), 6 * 60 * 60 * 1000);
+	assert.equal(
+		resolveCopilotCatalogStaleAfterMs({ copilot_catalog: { stale_after_ms: 30_000 } }),
+		60_000,
+		"clamped up to the 1-minute floor",
+	);
+	assert.equal(
+		resolveCopilotCatalogStaleAfterMs({ copilot_catalog: { stale_after_ms: 999_999_999_999 } }),
+		604_800_000,
+		"clamped down to the 7-day ceiling",
+	);
+});
+
+// ─── shouldTriggerCopilotCatalogRefresh (pure) ──────────────────────────────
+
+test("shouldTriggerCopilotCatalogRefresh: off never triggers", () => {
+	assert.equal(shouldTriggerCopilotCatalogRefresh("off", null, Date.now(), 1000), false);
+	assert.equal(shouldTriggerCopilotCatalogRefresh("off", 0, Date.now(), 1000), false);
+});
+
+test("shouldTriggerCopilotCatalogRefresh: always triggers every time", () => {
+	assert.equal(shouldTriggerCopilotCatalogRefresh("always", Date.now(), Date.now(), 1000), true);
+});
+
+test("shouldTriggerCopilotCatalogRefresh: if_stale triggers on first run and after the threshold", () => {
+	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", null, 1000, 500), true, "no prior refresh yet");
+	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 1400, 500), false, "still fresh");
+	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 1500, 500), true, "exactly at threshold");
+	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 2000, 500), true, "past threshold");
+});
+
+// ─── classifyRemoteCopilotModel (pure) ──────────────────────────────────────
+
+test("classifyRemoteCopilotModel: trusted when tier, profile, pricing, and limits are all known", () => {
+	const result = classifyRemoteCopilotModel(buildRecord());
+	assert.equal(result.modelClass, "trusted");
+	assert.equal(result.tier, "standard");
+	assert.equal(result.hasKnownPricing, true);
+});
+
+test("classifyRemoteCopilotModel: manual-only when capability tier is unknown", () => {
+	const result = classifyRemoteCopilotModel(buildRecord({ id: "some-brand-new-unlisted-model" }));
+	assert.equal(result.modelClass, "manual-only");
+	assert.ok(result.reasons.some((reason) => reason.includes("capability tier")));
+});
+
+test("classifyRemoteCopilotModel: manual-only when pricing is unknown and tier/profile are unknown too", () => {
+	const result = classifyRemoteCopilotModel(
+		buildRecord({ id: "some-brand-new-unlisted-model-2", billing: { billingUnit: "unknown" } }),
+	);
+	assert.equal(result.modelClass, "manual-only");
+	assert.equal(result.hasKnownPricing, false);
+});
+
+test("classifyRemoteCopilotModel: quarantined when not tool-call capable", () => {
+	const result = classifyRemoteCopilotModel(
+		buildRecord({ execution: { ...buildRecord().execution, toolCalls: false } }),
+	);
+	assert.equal(result.modelClass, "quarantined");
+	assert.match(result.reasons[0]!, /tool-call/);
+});
+
+test("classifyRemoteCopilotModel: quarantined when policy-restricted or disabled", () => {
+	const restricted = classifyRemoteCopilotModel(
+		buildRecord({ availability: { ...buildRecord().availability, policyState: "restricted" } }),
+	);
+	assert.equal(restricted.modelClass, "quarantined");
+
+	const disabled = classifyRemoteCopilotModel(
+		buildRecord({ availability: { ...buildRecord().availability, policyState: "disabled" } }),
+	);
+	assert.equal(disabled.modelClass, "quarantined");
+});
+
+test("classifyRemoteCopilotModel: quarantined when preview", () => {
+	const result = classifyRemoteCopilotModel(
+		buildRecord({ availability: { ...buildRecord().availability, preview: true } }),
+	);
+	assert.equal(result.modelClass, "quarantined");
+	assert.match(result.reasons[0]!, /preview/);
+});
+
+test("classifyRemoteCopilotModel: quarantined when normalization reported conflicts", () => {
+	const result = classifyRemoteCopilotModel(buildRecord({ conflicts: ["endpoint mismatch"] }));
+	assert.equal(result.modelClass, "quarantined");
+	assert.match(result.reasons[0]!, /conflict/);
+});
+
+// ─── startCopilotCatalogSessionRefresh (coordinator) ────────────────────────
+
+test("startCopilotCatalogSessionRefresh: mode off makes zero network requests", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	let fetchCalled = false;
+	const { ctx } = createFakeCtx({ models: [{ id: "claude-sonnet-5", provider: "github-copilot" }], apiKey: "tok" });
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "off" } },
+		fetchImpl: (async () => {
+			fetchCalled = true;
+			throw new Error("must not be called");
+		}) as unknown as typeof fetch,
+	});
+
+	assert.equal(fetchCalled, false);
+	assert.equal(result.ran, false);
+});
+
+test("startCopilotCatalogSessionRefresh: no configured Copilot provider skips without error", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({ models: [] });
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+	});
+
+	assert.equal(result.ran, true);
+	assert.equal(result.ok, false);
+	assert.equal(result.reason, "provider-not-configured");
+});
+
+test("startCopilotCatalogSessionRefresh: missing token skips silently, never throws, never fetches", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	let fetchCalled = false;
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: undefined,
+	});
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+		fetchImpl: (async () => {
+			fetchCalled = true;
+			throw new Error("must not be called");
+		}) as unknown as typeof fetch,
+	});
+
+	assert.equal(fetchCalled, false);
+	assert.equal(result.ok, false);
+	assert.equal(result.reason, "auth-unavailable");
+});
+
+test("startCopilotCatalogSessionRefresh: a throwing getApiKey never triggers a login flow and never throws", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKeyThrows: true,
+	});
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+	});
+
+	assert.equal(result.reason, "auth-unavailable");
+});
+
+test("startCopilotCatalogSessionRefresh: successful refresh classifies models and reports changes", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+		fetchImpl: jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]),
+	});
+
+	assert.equal(result.ok, true);
+	assert.ok(result.snapshot);
+	assert.equal(result.changedModelIds.length, 1, "first-ever snapshot reports every model as changed");
+	assert.ok(result.classifications["claude-sonnet-5"]);
+});
+
+test("startCopilotCatalogSessionRefresh: no-diff second refresh reports zero changes", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+	const fetchImpl = jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]);
+	const preferences = { copilot_catalog: { refresh_on_session_start: "always" as const } };
+
+	await startCopilotCatalogSessionRefresh({ ctx, basePath: "/project-2", preferences, fetchImpl });
+	const second = await startCopilotCatalogSessionRefresh({ ctx, basePath: "/project-2", preferences, fetchImpl });
+
+	assert.equal(second.ok, true);
+	assert.equal(second.changedModelIds.length, 0);
+});
+
+test("startCopilotCatalogSessionRefresh: a failed refresh preserves the last-known-good snapshot", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+	const preferences = { copilot_catalog: { refresh_on_session_start: "always" as const } };
+
+	const first = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project-3",
+		preferences,
+		fetchImpl: jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]),
+	});
+	assert.equal(first.ok, true);
+
+	const second = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project-3",
+		preferences,
+		fetchImpl: (async () => {
+			throw new Error("network down");
+		}) as unknown as typeof fetch,
+	});
+
+	assert.equal(second.ok, false);
+	assert.deepEqual(second.snapshot, first.snapshot, "last-known-good snapshot is preserved on failure");
+});
+
+test("startCopilotCatalogSessionRefresh: concurrent calls for the same basePath share one in-flight refresh", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	let fetchCallCount = 0;
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+	const preferences = { copilot_catalog: { refresh_on_session_start: "always" as const } };
+	const fetchImpl = (async () => {
+		fetchCallCount += 1;
+		return { ok: true, json: async () => ({ data: [{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }] }) } as unknown as Response;
+	}) as unknown as typeof fetch;
+
+	const [a, b] = await Promise.all([
+		startCopilotCatalogSessionRefresh({ ctx, basePath: "/project-4", preferences, fetchImpl }),
+		startCopilotCatalogSessionRefresh({ ctx, basePath: "/project-4", preferences, fetchImpl }),
+	]);
+
+	assert.equal(fetchCallCount, 1, "only one network request for two simultaneous triggers");
+	assert.equal(a, b, "both callers receive the exact same result object");
+});
+
+test("startCopilotCatalogSessionRefresh: a hanging fetch resolves via the bounded timeout instead of hanging", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project-5",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+		fetchImpl: neverResolves(),
+		timeoutMs: 25,
+	});
+
+	assert.equal(result.reason, "timeout");
+});
+
+test("awaitCopilotCatalogSessionRefresh: resolves immediately when nothing is in flight", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const result = await awaitCopilotCatalogSessionRefresh("/no-such-project", 50);
+	assert.equal(result.ran, false);
+});
+
+test("awaitCopilotCatalogSessionRefresh: joins an in-flight refresh started elsewhere", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+
+	const started: Promise<CopilotCatalogSessionRefreshResult> = startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project-6",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+		fetchImpl: jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]),
+	});
+
+	const joined = await awaitCopilotCatalogSessionRefresh("/project-6", 1000);
+	const original = await started;
+	assert.equal(joined.ok, original.ok);
+	assert.deepEqual(joined.snapshot, original.snapshot);
+});

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -107,6 +107,7 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   language: "en",
   context_window_override: 128000,
   context_mode: { enabled: true },
+  copilot_catalog: { refresh_on_session_start: "if_stale", notify_on_changes: true, stale_after_ms: 3_600_000 },
   planning_depth: "deep",
   claude_code_mcp: { per_model: { "claude-haiku": { allowed_servers: ["gsd-workflow"] } } },
   workspace: {

--- a/src/tests/provider-equality-allowlist.test.ts
+++ b/src/tests/provider-equality-allowlist.test.ts
@@ -103,6 +103,8 @@ const ALLOWED_FILES: Record<string, string> = {
     "github-copilot-only fetch gate — the whole module exists to talk to the Copilot /models endpoint",
   "src/resources/extensions/gsd/copilot-overlay-writer.ts":
     "remote-only GitHub Copilot candidate subtraction is a transport-specific quarantine check and must not fabricate metadata",
+  "src/resources/extensions/gsd/copilot-catalog-session-refresh.ts":
+    "session-start refresh coordinator needs the github-copilot provider specifically to resolve its own auth token, not API shape",
 };
 
 function shouldScan(path: string): boolean {


### PR DESCRIPTION
## Stacked submission — depends on #1978

**This PR depends on #1978 (live GitHub Copilot model-catalog sync). Do not merge until #1978 lands.**

Because a PR's base branch must exist on `open-gsd/gsd-pi` itself, this PR is opened with `base: main` (the same as #1978) rather than against #1978's fork-only branch. As a direct consequence, the diff below currently shows #1978's 18 commits plus this branch's own 2 commits — this is expected for a stacked PR and will shrink to just this branch's own commits once #1978 merges and this branch is rebased onto the new `main`.

## TL;DR

**What:** Adds an opt-in (default off) automatic refresh of the GitHub Copilot live model catalog at GSD session start, plus a 3-tier runtime model classification (trusted / manual-only / quarantined).

**Why:** #1978 made the live catalog inspectable via an explicit command; this closes the gap where a newly available model goes unnoticed for an entire session because nobody thought to run it.

**How:** A session-scoped coordinator (`copilot-catalog-session-refresh.ts`) reuses #1978's existing fetch/last-known-good pipeline, deduplicates concurrent triggers, never blocks startup, never triggers a login flow, and classifies each live-catalog model from its own `availability` / `execution` / `billing` / `conflicts` fields without ever fabricating capability or pricing data.

## What
- New `src/resources/extensions/gsd/copilot-catalog-session-refresh.ts`: config resolvers (`resolveCopilotCatalogRefreshMode`, `resolveCopilotCatalogNotifyOnChanges`, `resolveCopilotCatalogStaleAfterMs`), the pure `shouldTriggerCopilotCatalogRefresh` decision, the `startCopilotCatalogSessionRefresh` / `awaitCopilotCatalogSessionRefresh` coordinator pair (dedup + bounded timeout), `classifyRemoteCopilotModel` (3-tier classification), and `getLastKnownCopilotCatalogSnapshot`.
- Modified `preferences-types.ts` / `preferences-validation.ts`: new `copilot_catalog` preference block with full validation (enum, boolean, clamped numeric range, unknown-key warnings).
- Modified `bootstrap/register-hooks.ts`: wires the coordinator into `session_start` only (not `session_switch`), fire-and-forget.
- Modified `docs/dev/ADR-012-provider-id-vs-api-shape.md` and `src/tests/provider-equality-allowlist.test.ts`: documents the new transport-specific `github-copilot` check this coordinator needs for its own auth-token resolution.

## Why
Closes the "session never notices a newly available model" gap without introducing any new required network calls — the feature is disabled by default and every network path it does have reuses #1978's already-reviewed fetch/last-known-good pipeline rather than duplicating it.

## How
Extension-first, reusing #1978's interfaces as fixed dependencies (`fetchGitHubCopilotModels`, `applyLastKnownGood`, `diffCatalogSnapshots`) and GSD's existing capability/economics tables (`getModelProfileConfidence`, `MODEL_CAPABILITY_TIER`, `resolveModelEconomics`). No new Pi-repo dependency, no core/auto-mode changes.

## Architecture boundaries
- GitHub Copilot only; disabled by default (`refresh_on_session_start: off`).
- Fire-and-forget: the coordinator is never awaited on the session-start path, so a slow or unavailable network never delays ordinary startup.
- Never triggers or waits on an OAuth/login flow: auth resolution only ever returns a token that is already available.
- Classification never invents data: unknown capability/pricing/limits always resolve to "manual-only" (still selectable, never auto-routed), and structurally incomplete records are always quarantined, never silently defaulted to trusted.

## Change-type checklist
- [x] `feat` — New feature or capability
- [x] `fix` — Bug fixes found during development
- [x] `test` — 32 new tests
- [x] `docs` — ADR-012 allowlist update
- [ ] `refactor`
- [ ] `chore`

## Rollback notes
Fully additive and default-off: the new preference block defaults every subkey to its safe/disabled value, so an installation that never sets `copilot_catalog.refresh_on_session_start` sees zero behavior change. The `session_start` hook addition is a single guarded function call; removing it (or reverting the commit) fully restores prior behavior.

## AI-assistance disclosure
This PR was prepared with AI assistance (GitHub Copilot coding agent). All code was tested to the same standard as human-written code and is understood by the human maintainer of this fork.
