### PR TITLE
feat(gsd): cheaper/better same-tier Copilot model suggestions and notifications

### DIFF
--- a/docs/dev/ADR-012-provider-id-vs-api-shape.md
+++ b/docs/dev/ADR-012-provider-id-vs-api-shape.md
@@ -52,6 +52,7 @@ A small set of call sites legitimately keys on `provider`. These are **not** gat
 - **Display labels / onboarding copy** (`onboarding.ts`). Surface-only, no behavior impact.
 - **Live provider-account catalog state** (`copilot-model-catalog.ts`, `copilot-overlay-writer.ts`, `commands/handlers/copilot-models.ts`). GitHub Copilot's live `/models` sync, its remote-only-model quarantine/registration logic, and the `/gsd copilot-models` command all exist specifically to talk to the `github-copilot` transport's authenticated account state — the check is inherently transport-specific, not API-shape-specific.
 - **Session-start catalog refresh coordinator** (`copilot-catalog-session-refresh.ts`). GSD-W018's opt-in automatic refresh reuses the same GitHub Copilot auth-token resolution as the manual `/gsd copilot-models` command, for the same transport-specific reason.
+- **Session-start cheaper-alternative notification gate** (`bootstrap/register-hooks.ts`). GSD-W017's post-refresh notification only ever evaluates the active model when it is on the `github-copilot` transport, since the cheaper-alternative comparison itself is scoped to that account's live catalog and economics.
 
 These sites are enumerated in the allowlist at `src/tests/provider-equality-allowlist.test.ts`.
 

--- a/docs/dev/ADR-012-provider-id-vs-api-shape.md
+++ b/docs/dev/ADR-012-provider-id-vs-api-shape.md
@@ -51,6 +51,7 @@ A small set of call sites legitimately keys on `provider`. These are **not** gat
 - **Default-provider migrations** (`provider-migrations.ts`). Moving persisted settings from the `anthropic` transport to the `claude-code` transport is intentionally provider-id specific.
 - **Display labels / onboarding copy** (`onboarding.ts`). Surface-only, no behavior impact.
 - **Live provider-account catalog state** (`copilot-model-catalog.ts`, `copilot-overlay-writer.ts`, `commands/handlers/copilot-models.ts`). GitHub Copilot's live `/models` sync, its remote-only-model quarantine/registration logic, and the `/gsd copilot-models` command all exist specifically to talk to the `github-copilot` transport's authenticated account state — the check is inherently transport-specific, not API-shape-specific.
+- **Session-start catalog refresh coordinator** (`copilot-catalog-session-refresh.ts`). GSD-W018's opt-in automatic refresh reuses the same GitHub Copilot auth-token resolution as the manual `/gsd copilot-models` command, for the same transport-specific reason.
 
 These sites are enumerated in the allowlist at `src/tests/provider-equality-allowlist.test.ts`.
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -599,14 +599,66 @@ function triggerCopilotCatalogSessionRefresh(ctx: ExtensionContext, basePath: st
         basePath,
         preferences: prefs?.preferences,
       });
-      if (!notifyOnChanges || !result.ok || result.changedModelIds.length === 0) return;
-      ctx.ui.notify(
-        `GitHub Copilot model catalog: ${result.changedModelIds.length} model(s) changed since the last check. Run /gsd copilot-models changes for details.`,
-        "info",
-      );
+      if (!result.ok) return;
+
+      if (notifyOnChanges && result.changedModelIds.length > 0) {
+        ctx.ui.notify(
+          `GitHub Copilot model catalog: ${result.changedModelIds.length} model(s) changed since the last check. Run /gsd copilot-models changes for details.`,
+          "info",
+        );
+      }
+
+      // GSD-W017: after a completed refresh, check whether the currently
+      // active model (if it's a GitHub Copilot model) now has a qualifying
+      // cheaper/better same-tier alternative — independent of whether the
+      // catalog itself changed, since this may be the first refresh to ever
+      // surface it. Never fires for models on other providers, never
+      // switches the model.
+      if (ctx.model?.provider === "github-copilot" && ctx.model.id) {
+        const { maybeNotifyCheaperAlternative } = await import("../copilot-catalog-notifications.js");
+        maybeNotifyCheaperAlternative({
+          ctx,
+          accountScope: basePath,
+          selectedModelProvider: ctx.model.provider,
+          selectedModelId: ctx.model.id,
+          snapshot: result.snapshot,
+        });
+      }
     } catch {
       // Non-fatal: session startup must never fail because of this, and the
       // coordinator itself never surfaces auth/network failures as errors.
+    }
+  })();
+}
+
+/**
+ * GSD-W017: notify (never auto-switch) when the user explicitly selects or
+ * cycles to a GitHub Copilot model that has a qualifying cheaper/better
+ * same-tier alternative. Deliberately excludes `source: "restore"` (session
+ * resume/model-registry re-application, not a fresh user choice) and never
+ * fires for non-Copilot providers or automatic/dynamic routing, which never
+ * emits this event in the first place.
+ */
+function notifyOnManualCopilotModelSelection(
+  event: { model: { provider?: string; id: string }; source: "set" | "cycle" | "restore" },
+  ctx: ExtensionContext,
+): void {
+  if (event.source === "restore") return;
+  if (!event.model.id) return;
+  void (async () => {
+    try {
+      const basePath = contextBasePath(ctx);
+      const { getLastKnownCopilotCatalogSnapshot } = await import("../copilot-catalog-session-refresh.js");
+      const { maybeNotifyCheaperAlternative } = await import("../copilot-catalog-notifications.js");
+      maybeNotifyCheaperAlternative({
+        ctx,
+        accountScope: basePath,
+        selectedModelProvider: event.model.provider,
+        selectedModelId: event.model.id,
+        snapshot: getLastKnownCopilotCatalogSnapshot(basePath),
+      });
+    } catch {
+      // Non-fatal: never let an advisory notification break model selection.
     }
   })();
 }
@@ -2091,8 +2143,9 @@ export function registerHooks(
     }
   });
 
-  pi.on("model_select", async (_event, ctx) => {
+  pi.on("model_select", async (event, ctx) => {
     await syncServiceTierStatus(ctx);
+    notifyOnManualCopilotModelSelection(event, ctx);
   });
 
   pi.on("before_provider_request", async (event) => {

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -570,6 +570,47 @@ async function syncServiceTierStatus(ctx: ExtensionContext): Promise<void> {
   ctx.ui.setStatus("gsd-fast", formatServiceTierFooterStatus(getEffectiveServiceTier(), ctx.model?.id));
 }
 
+/**
+ * GSD-W018: optionally refresh the GitHub Copilot live model catalog at
+ * session start, gated by `copilot_catalog.refresh_on_session_start`
+ * (default "off"). Fire-and-forget by design — never awaited on the startup
+ * path — so a slow/unavailable network never delays the welcome banner.
+ * Covers both a terminal/CLI session start and the first `@gsd` invocation
+ * from an editor chat context, since both converge on this same
+ * `session_start` event (the VS Code chat participant starts/connects to the
+ * same underlying agent session rather than running a separate lifecycle).
+ */
+function triggerCopilotCatalogSessionRefresh(ctx: ExtensionContext, basePath: string): void {
+  void (async () => {
+    try {
+      const { loadEffectiveGSDPreferences } = await import("../preferences.js");
+      const prefs = loadEffectiveGSDPreferences(basePath);
+      const {
+        startCopilotCatalogSessionRefresh,
+        resolveCopilotCatalogRefreshMode,
+        resolveCopilotCatalogNotifyOnChanges,
+      } = await import("../copilot-catalog-session-refresh.js");
+
+      if (resolveCopilotCatalogRefreshMode(prefs?.preferences) === "off") return;
+      const notifyOnChanges = resolveCopilotCatalogNotifyOnChanges(prefs?.preferences);
+
+      const result = await startCopilotCatalogSessionRefresh({
+        ctx,
+        basePath,
+        preferences: prefs?.preferences,
+      });
+      if (!notifyOnChanges || !result.ok || result.changedModelIds.length === 0) return;
+      ctx.ui.notify(
+        `GitHub Copilot model catalog: ${result.changedModelIds.length} model(s) changed since the last check. Run /gsd copilot-models changes for details.`,
+        "info",
+      );
+    } catch {
+      // Non-fatal: session startup must never fail because of this, and the
+      // coordinator itself never surfaces auth/network failures as errors.
+    }
+  })();
+}
+
 async function applyDisabledModelProviderPolicy(ctx: ExtensionContext): Promise<void> {
   try {
     const { resolveDisabledModelProvidersFromPreferences } = await import("../preferences.js");
@@ -1076,6 +1117,7 @@ export function registerHooks(
     clearDeferredDestructiveConfirmationPause();
     await resetAskUserQuestionsTurnCache();
     await syncServiceTierStatus(ctx);
+    triggerCopilotCatalogSessionRefresh(ctx, basePath);
     await applyDisabledModelProviderPolicy(ctx);
     await applyCompactionThresholdOverride(ctx);
     await prepareWorkflowMcpForHookContext(ctx, basePath);

--- a/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
+++ b/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
@@ -516,7 +516,7 @@ export function findCheaperSameTierOption(
   ctx: ExtensionContext,
   snapshot: CopilotModelSnapshot | null,
 ): CheaperSameTierSuggestion | null {
-  const targetTier = MODEL_CAPABILITY_TIER[bareId];
+  const targetTier = MODEL_CAPABILITY_TIER[canonicalizeModelId(bareId)];
   if (!targetTier) return null;
 
   const targetLiveRecord = findLiveRecord(snapshot, bareId);
@@ -541,7 +541,7 @@ export function findCheaperSameTierOption(
   for (const candidateModel of sessionModels) {
     const candidateBareId = normalizeBareModelId(candidateModel.id);
     if (!candidateBareId || candidateBareId === bareId) continue;
-    if (MODEL_CAPABILITY_TIER[candidateBareId] !== targetTier) continue;
+    if (MODEL_CAPABILITY_TIER[canonicalizeModelId(candidateBareId)] !== targetTier) continue;
 
     const candidateConfidence = getModelProfileConfidence(candidateBareId);
     if (candidateConfidence === "unknown") continue;

--- a/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
+++ b/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
@@ -402,7 +402,7 @@ function stripJsonComments(input: string): string {
  * itself) so pricing/why never fail because of this best-effort lookup.
  */
 function readGithubCopilotModelsJsonCost(
-  ctx: ExtensionCommandContext,
+  ctx: ExtensionContext,
   modelId: string,
 ): { input: number; output: number; cacheRead: number; cacheWrite: number } | undefined {
   try {
@@ -430,7 +430,7 @@ function readGithubCopilotModelsJsonCost(
   }
 }
 
-function buildUserOverrideEconomics(ctx: ExtensionCommandContext, modelId: string): Partial<RuntimeModelEconomics> | undefined {
+function buildUserOverrideEconomics(ctx: ExtensionContext, modelId: string): Partial<RuntimeModelEconomics> | undefined {
   const cost = readGithubCopilotModelsJsonCost(ctx, modelId);
   if (!cost || !hasMeaningfulCost(cost)) return undefined;
   return {
@@ -441,7 +441,7 @@ function buildUserOverrideEconomics(ctx: ExtensionCommandContext, modelId: strin
 }
 
 function resolveEconomicsForModel(
-  ctx: ExtensionCommandContext,
+  ctx: ExtensionContext,
   bareId: string,
   liveRecord: CopilotModelRecord | undefined,
   localModel: Model<Api> | undefined,

--- a/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
+++ b/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
@@ -7,7 +7,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 import type { Api, Model } from "@gsd/pi-ai";
 import { getGitHubCopilotBaseUrl } from "@gsd/pi-ai/oauth";
-import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import type { ExtensionCommandContext, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import {
   CopilotCatalogFetchError,
@@ -25,8 +25,13 @@ import {
   registerCopilotModelsInOverlay,
   resolveGsdModelsCatalogPath,
 } from "../../copilot-overlay-writer.js";
-import { resolveModelEconomics, type RuntimeModelEconomics } from "../../model-cost-table.js";
-import { canonicalizeModelId, getModelProfileConfidence, MODEL_CAPABILITY_TIER } from "../../model-router.js";
+import { lookupModelCost, resolveModelEconomics, type RuntimeModelEconomics } from "../../model-cost-table.js";
+import {
+  canonicalizeModelId,
+  getModelProfileConfidence,
+  MODEL_CAPABILITY_TIER,
+  PROFILE_CONFIDENCE_ORDINAL,
+} from "../../model-router.js";
 
 interface CopilotCatalogDiffState {
   firstAccepted: boolean;
@@ -215,7 +220,7 @@ async function resolveCurrentAccountView(ctx: ExtensionCommandContext): Promise<
   };
 }
 
-function localCopilotModels(ctx: ExtensionCommandContext): Model<Api>[] {
+function localCopilotModels(ctx: ExtensionContext): Model<Api>[] {
   return ctx.modelRegistry.getAll().filter((model) => model.provider === "github-copilot");
 }
 
@@ -468,6 +473,147 @@ function economicsFreshnessSummary(economics: RuntimeModelEconomics): string {
   return economics.provenance.defaultTokenPrices?.freshness ?? "unknown";
 }
 
+export interface CheaperSameTierSuggestion {
+  modelId: string;
+  tier: string;
+  confidence: ReturnType<typeof getModelProfileConfidence>;
+  economics: RuntimeModelEconomics & {
+    tokenPrices: { default: { inputPer1k: number; outputPer1k: number } };
+  };
+  inputSavings: number;
+  outputSavings: number;
+}
+
+function hasKnownDefaultPricing(
+  economics: RuntimeModelEconomics,
+): economics is RuntimeModelEconomics & {
+  tokenPrices: { default: { inputPer1k: number; outputPer1k: number } };
+} {
+  return !!(
+    economics.tokenPrices?.default
+    && Number.isFinite(economics.tokenPrices.default.inputPer1k)
+    && Number.isFinite(economics.tokenPrices.default.outputPer1k)
+  );
+}
+
+function isBlockedForAutomaticRouting(record: CopilotModelRecord | undefined): boolean {
+  return (
+    record?.availability.policyState === "disabled"
+    || record?.availability.policyState === "restricted"
+    || record?.availability.preview === true
+  );
+}
+
+function formatCheaperSameTierOption(
+  suggestion: CheaperSameTierSuggestion,
+): string {
+  const prices = suggestion.economics.tokenPrices.default;
+  return `- cheaper same-tier option: github-copilot/${suggestion.modelId} (${suggestion.tier}, ${suggestion.confidence}, $${prices.inputPer1k.toFixed(4)} / $${prices.outputPer1k.toFixed(4)} per 1K) — saves $${suggestion.inputSavings.toFixed(4)} input / $${suggestion.outputSavings.toFixed(4)} output per 1K`;
+}
+
+export function findCheaperSameTierOption(
+  bareId: string,
+  ctx: ExtensionContext,
+  snapshot: CopilotModelSnapshot | null,
+): CheaperSameTierSuggestion | null {
+  const targetTier = MODEL_CAPABILITY_TIER[bareId];
+  if (!targetTier) return null;
+
+  const targetLiveRecord = findLiveRecord(snapshot, bareId);
+  if (isBlockedForAutomaticRouting(targetLiveRecord)) return null;
+
+  const sessionModels = ctx.modelRegistry
+    .getAvailable()
+    .filter((model) => model.provider === "github-copilot");
+  if (!sessionModels.some((model) => normalizeBareModelId(model.id) === bareId)) {
+    return null;
+  }
+
+  const targetEconomics = resolveEconomicsForModel(
+    ctx,
+    bareId,
+    targetLiveRecord,
+    findLocalModel(ctx, bareId),
+  );
+  if (!hasKnownDefaultPricing(targetEconomics)) return null;
+
+  let bestSuggestion: CheaperSameTierSuggestion | null = null;
+  for (const candidateModel of sessionModels) {
+    const candidateBareId = normalizeBareModelId(candidateModel.id);
+    if (!candidateBareId || candidateBareId === bareId) continue;
+    if (MODEL_CAPABILITY_TIER[candidateBareId] !== targetTier) continue;
+
+    const candidateConfidence = getModelProfileConfidence(candidateBareId);
+    if (candidateConfidence === "unknown") continue;
+
+    const candidateLiveRecord = findLiveRecord(snapshot, candidateBareId);
+    if (isBlockedForAutomaticRouting(candidateLiveRecord)) continue;
+
+    const candidateEconomics = resolveEconomicsForModel(
+      ctx,
+      candidateBareId,
+      candidateLiveRecord,
+      findLocalModel(ctx, candidateBareId) ?? candidateModel,
+    );
+    if (!hasKnownDefaultPricing(candidateEconomics)) continue;
+
+    const inputSavings =
+      targetEconomics.tokenPrices.default.inputPer1k
+      - candidateEconomics.tokenPrices.default.inputPer1k;
+    const outputSavings =
+      targetEconomics.tokenPrices.default.outputPer1k
+      - candidateEconomics.tokenPrices.default.outputPer1k;
+
+    const candidateIsStrictlyCheaper =
+      inputSavings >= 0
+      && outputSavings >= 0
+      && (inputSavings > 0 || outputSavings > 0);
+    if (!candidateIsStrictlyCheaper) continue;
+
+    const nextSuggestion: CheaperSameTierSuggestion = {
+      modelId: candidateBareId,
+      tier: targetTier,
+      confidence: candidateConfidence,
+      economics: candidateEconomics,
+      inputSavings,
+      outputSavings,
+    };
+
+    if (!bestSuggestion) {
+      bestSuggestion = nextSuggestion;
+      continue;
+    }
+
+    const currentPrices = bestSuggestion.economics.tokenPrices.default;
+    const nextPrices = candidateEconomics.tokenPrices.default;
+    const isBetterChoice =
+      nextPrices.inputPer1k < currentPrices.inputPer1k
+      || (
+        nextPrices.inputPer1k === currentPrices.inputPer1k
+        && nextPrices.outputPer1k < currentPrices.outputPer1k
+      )
+      || (
+        nextPrices.inputPer1k === currentPrices.inputPer1k
+        && nextPrices.outputPer1k === currentPrices.outputPer1k
+        && PROFILE_CONFIDENCE_ORDINAL[candidateConfidence]
+          > PROFILE_CONFIDENCE_ORDINAL[bestSuggestion.confidence]
+      )
+      || (
+        nextPrices.inputPer1k === currentPrices.inputPer1k
+        && nextPrices.outputPer1k === currentPrices.outputPer1k
+        && PROFILE_CONFIDENCE_ORDINAL[candidateConfidence]
+          === PROFILE_CONFIDENCE_ORDINAL[bestSuggestion.confidence]
+        && candidateBareId.localeCompare(bestSuggestion.modelId) < 0
+      );
+
+    if (isBetterChoice) {
+      bestSuggestion = nextSuggestion;
+    }
+  }
+
+  return bestSuggestion;
+}
+
 function formatPromotion(
   promotion?: {
     discountPercent?: number;
@@ -566,7 +712,7 @@ function findLiveRecord(snapshot: CopilotModelSnapshot | null, bareId: string): 
   return snapshot?.models.find((model) => normalizeBareModelId(model.id) === bareId);
 }
 
-function findLocalModel(ctx: ExtensionCommandContext, bareId: string): Model<Api> | undefined {
+function findLocalModel(ctx: ExtensionContext, bareId: string): Model<Api> | undefined {
   return localCopilotModels(ctx).find((model) => normalizeBareModelId(model.id) === bareId);
 }
 
@@ -587,6 +733,7 @@ function buildWhyExplanation(
   const tier = MODEL_CAPABILITY_TIER[canonicalizeModelId(bareId)] ?? "unknown";
   const confidence = getModelProfileConfidence(bareId);
   const economics = resolveEconomicsForModel(ctx, bareId, liveRecord, localModel);
+  const cheaperSameTierOption = findCheaperSameTierOption(bareId, ctx, snapshot);
 
   let routingEligible = false;
   let routingReason = "no live/task routing context available";
@@ -648,13 +795,22 @@ function buildWhyExplanation(
     `- freshness: ${economicsFreshnessSummary(economics)}`,
     `- request billing: ${economics.requestMultiplier !== undefined ? `${economics.requestMultiplier}x (${economics.provenance.requestMultiplier?.source ?? economics.source}/${economics.provenance.requestMultiplier?.freshness ?? "unknown"})` : "unknown"}`,
     `- promotion: ${formatPromotion(liveRecord?.billing.promotion ?? economics.promotion)}`,
+    ...(cheaperSameTierOption
+      ? [formatCheaperSameTierOption(cheaperSameTierOption)]
+      : []),
     `- automatic routing eligible: ${routingEligible ? "yes" : "no"}`,
     `- reason: ${routingReason}`,    ...(routingCaveats.length > 0 ? [`- routing caveats: ${routingCaveats.join("; ")}`] : []),    `- task routing context: unavailable (no active classification context)` ,
     `- guidance: ${guidance}`,
   ].join("\n");
 }
 
-function formatPricingRecord(ctx: ExtensionCommandContext, record: CopilotModelRecord | undefined, localModel: Model<Api> | undefined, bareId: string): string[] {
+function formatPricingRecord(
+  ctx: ExtensionCommandContext,
+  record: CopilotModelRecord | undefined,
+  localModel: Model<Api> | undefined,
+  bareId: string,
+  snapshot: CopilotModelSnapshot | null,
+): string[] {
   const economics = resolveEconomicsForModel(ctx, bareId, record, localModel);
   const lines = [
     `GitHub Copilot pricing: github-copilot/${bareId}`,
@@ -662,6 +818,10 @@ function formatPricingRecord(ctx: ExtensionCommandContext, record: CopilotModelR
     `- source: ${economicsSourceSummary(economics)}`,
     `- freshness: ${economicsFreshnessSummary(economics)}`,
   ];
+  const cheaperSameTierOption = findCheaperSameTierOption(bareId, ctx, snapshot);
+  if (cheaperSameTierOption) {
+    lines.push(formatCheaperSameTierOption(cheaperSameTierOption));
+  }
 
   if (economics.tokenPrices?.default) {
     lines.push(
@@ -933,7 +1093,13 @@ export async function handleCopilotModels(
     if (parsed.target) {
       const bareId = parsed.target;
       ctx.ui.notify(
-        formatPricingRecord(ctx, findLiveRecord(currentSnapshot, bareId), findLocalModel(ctx, bareId), bareId).join("\n"),
+        formatPricingRecord(
+          ctx,
+          findLiveRecord(currentSnapshot, bareId),
+          findLocalModel(ctx, bareId),
+          bareId,
+          currentSnapshot,
+        ).join("\n"),
         "info",
       );
       return;
@@ -947,7 +1113,13 @@ export async function handleCopilotModels(
     }
     const blocks = records.map((record) => {
       const bareId = normalizeBareModelId(record.id);
-      return formatPricingRecord(ctx, findLiveRecord(snapshot, bareId), findLocalModel(ctx, bareId), bareId).join("\n");
+      return formatPricingRecord(
+        ctx,
+        findLiveRecord(snapshot, bareId),
+        findLocalModel(ctx, bareId),
+        bareId,
+        snapshot,
+      ).join("\n");
     });
     ctx.ui.notify(blocks.join("\n\n"), "info");
     return;

--- a/src/resources/extensions/gsd/copilot-catalog-notifications.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-notifications.ts
@@ -1,0 +1,130 @@
+// Project/App: gsd-pi
+// File Purpose: GSD-W017 — non-blocking notifications for cheaper/better
+// same-tier GitHub Copilot alternatives, triggered by manual model
+// selection or a completed GSD-W018 session-start catalog refresh.
+//
+// Never fires for automatic/dynamic routing selections: those never emit the
+// `model_select` event this module is wired to (auto-mode applies models
+// directly through the model registry, not through the interactive
+// set/cycle/restore selection path). Never switches the model automatically
+// — purely advisory, deduplicated by a fingerprint of (account scope,
+// selected model, suggested model, catalog revision) so a stable pairing is
+// only ever announced once until something material changes.
+
+import { createHash } from "node:crypto";
+
+import type { ExtensionContext } from "@gsd/pi-coding-agent";
+
+import { findCheaperSameTierOption, type CheaperSameTierSuggestion } from "./commands/handlers/copilot-models.js";
+import type { CopilotModelSnapshot } from "./copilot-model-catalog.js";
+import { MODEL_CAPABILITY_PROFILES, type ModelCapabilities } from "./model-router.js";
+
+// Session-scoped only — never persisted to disk, mirrors the existing
+// per-account notification dedup pattern in commands/handlers/copilot-models.ts.
+const notifiedFingerprints = new Set<string>();
+
+/** Test-only hook to reset module-level session state between test cases. */
+export function _resetCopilotCatalogNotificationStateForTests(): void {
+	notifiedFingerprints.clear();
+}
+
+function bareModelId(modelId: string): string {
+	return modelId.includes("/") ? (modelId.split("/").pop() ?? modelId) : modelId;
+}
+
+/** Average of the 7 capability dimensions. */
+function averageCapabilityScore(profile: ModelCapabilities): number {
+	const values = Object.values(profile);
+	return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+/**
+ * Pure comparison of two capability profiles. A small margin (avoids noise
+ * from rounding-equivalent profiles) is required before calling the
+ * candidate "higher" — anything else (including missing data) resolves to
+ * "equal-or-lower", the safer default for messaging purposes.
+ */
+export function compareCapabilityScores(
+	selected: ModelCapabilities | undefined,
+	candidate: ModelCapabilities | undefined,
+): "higher" | "equal-or-lower" {
+	if (!selected || !candidate) return "equal-or-lower";
+	return averageCapabilityScore(candidate) > averageCapabilityScore(selected) + 1 ? "higher" : "equal-or-lower";
+}
+
+function isHigherCapability(selectedBareId: string, candidateBareId: string): boolean {
+	return (
+		compareCapabilityScores(MODEL_CAPABILITY_PROFILES[selectedBareId], MODEL_CAPABILITY_PROFILES[candidateBareId])
+		=== "higher"
+	);
+}
+
+function buildFingerprint(
+	accountScope: string,
+	selectedBareId: string,
+	suggestion: CheaperSameTierSuggestion,
+	snapshot: CopilotModelSnapshot | null,
+): string {
+	const revision = snapshot?.hash ?? "no-snapshot";
+	return createHash("sha256")
+		.update(`${accountScope}\n${selectedBareId}\ngithub-copilot/${suggestion.modelId}\n${revision}`)
+		.digest("hex");
+}
+
+function formatNotificationMessage(
+	selectedBareId: string,
+	suggestion: CheaperSameTierSuggestion,
+	higherCapability: boolean,
+): string {
+	const label = higherCapability ? "better, cheaper alternative" : "cheaper equivalent";
+	return [
+		`GitHub Copilot: a ${label} to github-copilot/${selectedBareId} is available — github-copilot/${suggestion.modelId}`,
+		`(saves $${suggestion.inputSavings.toFixed(4)} input / $${suggestion.outputSavings.toFixed(4)} output per 1K).`,
+		`The current model was not changed. Run /gsd copilot-models why github-copilot/${suggestion.modelId} for details.`,
+	].join(" ");
+}
+
+export interface NotifyCheaperAlternativeOptions {
+	ctx: ExtensionContext;
+	/**
+	 * Opaque scope key segmenting the dedup fingerprint. Uses the session's
+	 * basePath (the same scoping unit GSD-W018's coordinator and
+	 * register-hooks.ts already key state by) rather than re-deriving a
+	 * per-account token hash purely for deduplication — within one GSD
+	 * project session there is realistically one active Copilot account, and
+	 * the worst case of a coarser scope is one redundant notification, never
+	 * a wrong or fabricated one.
+	 */
+	accountScope: string;
+	/** Provider of the currently selected/active model. Non-"github-copilot" providers are always a no-op. */
+	selectedModelProvider: string | undefined;
+	/** The currently selected/active GitHub Copilot model id (bare or provider-qualified). */
+	selectedModelId: string;
+	snapshot: CopilotModelSnapshot | null;
+}
+
+/**
+ * Check whether the given (already-selected/active) GitHub Copilot model has
+ * a qualifying cheaper or better-and-cheaper same-tier alternative, and fire
+ * a deduplicated, non-blocking notification if so. Never mutates the active
+ * model, routing state, or any persisted file. Returns true when a
+ * notification was actually sent (false when no qualifying alternative
+ * exists, or the exact pairing was already announced for this catalog
+ * revision).
+ */
+export function maybeNotifyCheaperAlternative(options: NotifyCheaperAlternativeOptions): boolean {
+	const { ctx, accountScope, selectedModelProvider, selectedModelId, snapshot } = options;
+	if (selectedModelProvider !== "github-copilot") return false;
+	const bareId = bareModelId(selectedModelId);
+
+	const suggestion = findCheaperSameTierOption(bareId, ctx, snapshot);
+	if (!suggestion) return false;
+
+	const fingerprint = buildFingerprint(accountScope, bareId, suggestion, snapshot);
+	if (notifiedFingerprints.has(fingerprint)) return false;
+	notifiedFingerprints.add(fingerprint);
+
+	const higherCapability = isHigherCapability(bareId, suggestion.modelId);
+	ctx.ui.notify(formatNotificationMessage(bareId, suggestion, higherCapability), "info");
+	return true;
+}

--- a/src/resources/extensions/gsd/copilot-catalog-notifications.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-notifications.ts
@@ -17,7 +17,7 @@ import type { ExtensionContext } from "@gsd/pi-coding-agent";
 
 import { findCheaperSameTierOption, type CheaperSameTierSuggestion } from "./commands/handlers/copilot-models.js";
 import type { CopilotModelSnapshot } from "./copilot-model-catalog.js";
-import { MODEL_CAPABILITY_PROFILES, type ModelCapabilities } from "./model-router.js";
+import { canonicalizeModelId, MODEL_CAPABILITY_PROFILES, type ModelCapabilities } from "./model-router.js";
 
 // Session-scoped only — never persisted to disk, mirrors the existing
 // per-account notification dedup pattern in commands/handlers/copilot-models.ts.
@@ -54,7 +54,10 @@ export function compareCapabilityScores(
 
 function isHigherCapability(selectedBareId: string, candidateBareId: string): boolean {
 	return (
-		compareCapabilityScores(MODEL_CAPABILITY_PROFILES[selectedBareId], MODEL_CAPABILITY_PROFILES[candidateBareId])
+		compareCapabilityScores(
+			MODEL_CAPABILITY_PROFILES[canonicalizeModelId(selectedBareId)],
+			MODEL_CAPABILITY_PROFILES[canonicalizeModelId(candidateBareId)],
+		)
 		=== "higher"
 	);
 }

--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -428,3 +428,15 @@ export function awaitCopilotCatalogSessionRefresh(
 	if (!pending) return Promise.resolve(NOOP_RESULT);
 	return withTimeout(pending, timeoutMs, { ...NOOP_RESULT, ran: true, reason: "timeout" });
 }
+
+/**
+ * Read the last-known-good snapshot captured by a prior session-start
+ * refresh for `basePath`, without triggering a new fetch. Returns `null`
+ * when no refresh has ever succeeded for this basePath (e.g. mode is "off",
+ * or every attempt so far failed with no snapshot to fall back on). Used by
+ * the GSD-W017 notification feature so it can react to a completed refresh
+ * without re-deriving auth or re-fetching itself.
+ */
+export function getLastKnownCopilotCatalogSnapshot(basePath: string): CopilotModelSnapshot | null {
+	return lastSnapshotByBasePath.get(basePath) ?? null;
+}

--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -171,6 +171,11 @@ export function classifyRemoteCopilotModel(
 			stale: false,
 			billingUnit: "tokens",
 		},
+		// BUNDLED_COST_TABLE entries are keyed by bare model ID and are not
+		// provider-qualified — without this, a same-named model priced by a
+		// different provider (e.g. OpenAI's "gpt-5.4") could silently be
+		// reported as this Copilot model's known price. See model-cost-table.ts.
+		disableImplicitFallback: true,
 	});
 	const fallbackPrices = economics.tokenPrices?.default;
 	const hasKnownPricing =

--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -41,6 +41,7 @@ import {
 } from "./copilot-model-catalog.js";
 import { resolveModelEconomics } from "./model-cost-table.js";
 import {
+	canonicalizeModelId,
 	getModelProfileConfidence,
 	MODEL_CAPABILITY_TIER,
 	type CapabilityProfileConfidence,
@@ -158,7 +159,7 @@ export function classifyRemoteCopilotModel(
 		};
 	}
 
-	const tier = MODEL_CAPABILITY_TIER[record.id];
+	const tier = MODEL_CAPABILITY_TIER[canonicalizeModelId(record.id)];
 	const profileConfidence = getModelProfileConfidence(record.id);
 	const hasKnownLimits =
 		typeof record.execution.contextWindow === "number" && typeof record.execution.maxTokens === "number";

--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -1,0 +1,424 @@
+// Project/App: gsd-pi
+// File Purpose: GSD-W018 — session-start GitHub Copilot catalog refresh
+// coordinator and 3-tier runtime model classification.
+//
+// Extends the explicit, user-invoked `/gsd copilot-models sync` (GSD-W014)
+// with an OPT-IN automatic refresh at GSD session start, gated by
+// `copilot_catalog.refresh_on_session_start` (default "off"). Reuses the
+// same read-only fetch/sanitize/last-known-good pipeline from
+// `copilot-model-catalog.ts` — this module never duplicates network/auth
+// logic, it only coordinates *when* to call it and classifies the result for
+// safe runtime selection.
+//
+// Invariants:
+//   - Never blocks ordinary session startup: callers must fire-and-forget
+//     via `startCopilotCatalogSessionRefresh`, never await it synchronously
+//     on the startup path.
+//   - At most one in-flight refresh per basePath — concurrent triggers (e.g.
+//     a terminal session racing a VS Code daemon connect) share one promise.
+//   - Never triggers or waits on an OAuth/login flow: auth resolution reuses
+//     `ctx.modelRegistry.getApiKey()`, which only ever returns a token that
+//     is already available, and any thrown/missing token is treated as
+//     "auth unavailable, skip silently" — never surfaced as an error.
+//   - Bounded wall-clock timeout; a slow/hanging fetch never wedges startup
+//     or a caller awaiting the in-flight refresh (e.g. the model picker).
+//   - Classification never fabricates capability or pricing data: unknown
+//     stays unknown (manual-only), and structurally incomplete records are
+//     quarantined rather than silently defaulted.
+//   - State here is session-scoped only (module-level, per basePath) —
+//     nothing is persisted to disk, mirroring the existing
+//     `commands/handlers/copilot-models.ts` session-scoped snapshot.
+
+import type { ExtensionContext } from "@gsd/pi-coding-agent";
+import { getGitHubCopilotBaseUrl } from "@gsd/pi-ai/oauth";
+
+import {
+	applyLastKnownGood,
+	diffCatalogSnapshots,
+	fetchGitHubCopilotModels,
+	type CopilotModelRecord,
+	type CopilotModelSnapshot,
+} from "./copilot-model-catalog.js";
+import { resolveModelEconomics } from "./model-cost-table.js";
+import {
+	getModelProfileConfidence,
+	MODEL_CAPABILITY_TIER,
+	type CapabilityProfileConfidence,
+} from "./model-router.js";
+import type {
+	CopilotCatalogPreferences,
+	CopilotCatalogRefreshMode,
+} from "./preferences-types.js";
+
+// ─── Config resolution (pure — no I/O, no defaults hidden elsewhere) ───────
+
+export const DEFAULT_COPILOT_CATALOG_STALE_AFTER_MS = 6 * 60 * 60 * 1000; // 6h
+export const DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS = 10_000;
+const MIN_STALE_AFTER_MS = 60_000; // 1 minute
+const MAX_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+type PreferencesLike = { copilot_catalog?: CopilotCatalogPreferences } | null | undefined;
+
+/** Resolve the effective refresh mode. Default is "off" — matches KNOWN_PREFERENCE_KEYS/validation defaults. */
+export function resolveCopilotCatalogRefreshMode(
+	prefs: PreferencesLike,
+): CopilotCatalogRefreshMode {
+	return prefs?.copilot_catalog?.refresh_on_session_start ?? "off";
+}
+
+/** Resolve whether a non-blocking notification should surface catalog changes. Default: true. */
+export function resolveCopilotCatalogNotifyOnChanges(prefs: PreferencesLike): boolean {
+	return prefs?.copilot_catalog?.notify_on_changes ?? true;
+}
+
+/** Resolve the "if_stale" staleness threshold in ms, clamped to a sane range. Default: 6h. */
+export function resolveCopilotCatalogStaleAfterMs(prefs: PreferencesLike): number {
+	const raw = prefs?.copilot_catalog?.stale_after_ms;
+	if (typeof raw !== "number" || !Number.isFinite(raw)) {
+		return DEFAULT_COPILOT_CATALOG_STALE_AFTER_MS;
+	}
+	return Math.min(Math.max(raw, MIN_STALE_AFTER_MS), MAX_STALE_AFTER_MS);
+}
+
+/**
+ * Pure decision of whether a refresh should run for the given mode/staleness
+ * state. No I/O — safe to unit test directly.
+ */
+export function shouldTriggerCopilotCatalogRefresh(
+	mode: CopilotCatalogRefreshMode,
+	lastRefreshedAtMs: number | null,
+	nowMs: number,
+	staleAfterMs: number,
+): boolean {
+	if (mode === "off") return false;
+	if (mode === "always") return true;
+	if (lastRefreshedAtMs === null) return true;
+	return nowMs - lastRefreshedAtMs >= staleAfterMs;
+}
+
+// ─── Runtime model classification (Class A / B / C) ────────────────────────
+
+/**
+ * - "trusted" (Class A): capability tier, profile confidence, and pricing are
+ *   all known — exposed for manual selection AND eligible for automatic
+ *   routing (subject to the existing routing confidence/economics gates in
+ *   model-router.ts).
+ * - "manual-only" (Class B): the live record is transport-valid
+ *   (`tool_call: true`) but capability tier, profile confidence, or pricing
+ *   is unknown — selectable manually, never auto-routed, never used for
+ *   cheaper-model suggestions.
+ * - "quarantined" (Class C): structurally incomplete (not tool-call capable)
+ *   — not exposed as selectable, not routed, not suggested.
+ */
+export type ModelRuntimeClass = "trusted" | "manual-only" | "quarantined";
+
+export interface ModelClassification {
+	modelClass: ModelRuntimeClass;
+	reasons: string[];
+	tier?: string;
+	profileConfidence?: CapabilityProfileConfidence;
+	hasKnownPricing: boolean;
+}
+
+/**
+ * Classify a single live-catalog GitHub Copilot model for safe runtime
+ * exposure (GSD-W018 Decision 6). Never invents capability or pricing data —
+ * absence of evidence always resolves to "manual-only" or "quarantined",
+ * never a synthesized "trusted" classification.
+ */
+export function classifyRemoteCopilotModel(
+	record: CopilotModelRecord,
+): ModelClassification {
+	if (!record.execution.toolCalls) {
+		return {
+			modelClass: "quarantined",
+			reasons: ["missing required tool-call capability"],
+			hasKnownPricing: false,
+		};
+	}
+	if (record.availability.policyState === "disabled" || record.availability.policyState === "restricted") {
+		return {
+			modelClass: "quarantined",
+			reasons: [`policy state: ${record.availability.policyState}`],
+			hasKnownPricing: false,
+		};
+	}
+	if (record.availability.preview) {
+		return {
+			modelClass: "quarantined",
+			reasons: ["preview model — not yet stable for automatic exposure"],
+			hasKnownPricing: false,
+		};
+	}
+	if (record.conflicts.length > 0) {
+		return {
+			modelClass: "quarantined",
+			reasons: [`unresolved normalization conflict(s): ${record.conflicts.join(", ")}`],
+			hasKnownPricing: false,
+		};
+	}
+
+	const tier = MODEL_CAPABILITY_TIER[record.id];
+	const profileConfidence = getModelProfileConfidence(record.id);
+	const hasKnownLimits =
+		typeof record.execution.contextWindow === "number" && typeof record.execution.maxTokens === "number";
+	const hasBillingOnRecord = record.billing.inputPer1k !== undefined && record.billing.outputPer1k !== undefined;
+	const economics = resolveModelEconomics({
+		provider: "github-copilot",
+		modelId: record.id,
+		fallbackEconomics: {
+			source: "bundled-fallback",
+			stale: false,
+			billingUnit: "tokens",
+		},
+	});
+	const fallbackPrices = economics.tokenPrices?.default;
+	const hasKnownPricing =
+		hasBillingOnRecord ||
+		economics.source !== "bundled-fallback" ||
+		Boolean(fallbackPrices && (fallbackPrices.inputPer1k > 0 || fallbackPrices.outputPer1k > 0));
+
+	if (tier && profileConfidence !== "unknown" && hasKnownPricing && hasKnownLimits) {
+		return {
+			modelClass: "trusted",
+			reasons: [
+				`capability tier known (${tier})`,
+				`profile confidence: ${profileConfidence}`,
+				"pricing known",
+				"context/token limits known",
+			],
+			tier,
+			profileConfidence,
+			hasKnownPricing,
+		};
+	}
+
+	const reasons: string[] = [];
+	if (!tier) reasons.push("no known capability tier");
+	if (profileConfidence === "unknown") reasons.push("no capability profile (unknown confidence)");
+	if (!hasKnownPricing) reasons.push("no known pricing");
+	if (!hasKnownLimits) reasons.push("no known context/token limits");
+
+	return {
+		modelClass: "manual-only",
+		reasons,
+		tier,
+		profileConfidence,
+		hasKnownPricing,
+	};
+}
+
+// ─── Session-start refresh coordinator ─────────────────────────────────────
+
+export interface CopilotCatalogSessionRefreshResult {
+	/** False when the refresh was skipped entirely (mode=off, not stale, no provider, no token). */
+	ran: boolean;
+	ok: boolean;
+	reason?: string;
+	snapshot: CopilotModelSnapshot | null;
+	classifications: Record<string, ModelClassification>;
+	changedModelIds: string[];
+}
+
+const NOOP_RESULT: Readonly<CopilotCatalogSessionRefreshResult> = Object.freeze({
+	ran: false,
+	ok: false,
+	snapshot: null,
+	classifications: {},
+	changedModelIds: [],
+});
+
+// Session-scoped only (module-level, per basePath) — never persisted to disk.
+const inFlightRefreshes = new Map<string, Promise<CopilotCatalogSessionRefreshResult>>();
+const lastRefreshedAtByBasePath = new Map<string, number>();
+const lastSnapshotByBasePath = new Map<string, CopilotModelSnapshot>();
+
+/** Test-only hook to reset module-level session state between test cases. */
+export function _resetCopilotCatalogSessionRefreshStateForTests(): void {
+	inFlightRefreshes.clear();
+	lastRefreshedAtByBasePath.clear();
+	lastSnapshotByBasePath.clear();
+}
+
+function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	onTimeout: T,
+): Promise<T> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			resolve(onTimeout);
+		}, timeoutMs);
+		promise.then(
+			(value) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolve(value);
+			},
+			() => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolve(onTimeout);
+			},
+		);
+	});
+}
+
+export interface RefreshCopilotCatalogSessionOptions {
+	ctx: ExtensionContext;
+	basePath: string;
+	preferences: PreferencesLike;
+	/** Injectable clock for tests. Defaults to Date.now. */
+	now?: () => number;
+	/** Injectable fetch for tests. */
+	fetchImpl?: typeof fetch;
+	/** Injectable timeout for tests. Defaults to DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS. */
+	timeoutMs?: number;
+}
+
+async function runCopilotCatalogRefresh(
+	options: RefreshCopilotCatalogSessionOptions,
+): Promise<CopilotCatalogSessionRefreshResult> {
+	const { ctx, basePath } = options;
+	const nowFn = options.now ?? Date.now;
+
+	const available = ctx.modelRegistry.getAvailable();
+	const copilotModel = available.find((model) => model.provider === "github-copilot");
+	if (!copilotModel) {
+		return { ...NOOP_RESULT, ran: true, reason: "provider-not-configured" };
+	}
+
+	let token: string | undefined;
+	try {
+		token = await ctx.modelRegistry.getApiKey(copilotModel);
+	} catch {
+		// Never surface auth resolution failures as errors, and never trigger
+		// a login/OAuth flow — silently skip this session's refresh.
+		return { ...NOOP_RESULT, ran: true, reason: "auth-unavailable" };
+	}
+	if (!token) {
+		return { ...NOOP_RESULT, ran: true, reason: "auth-unavailable" };
+	}
+
+	const baseUrl = getGitHubCopilotBaseUrl(token);
+	const previousSnapshot = lastSnapshotByBasePath.get(basePath) ?? null;
+
+	let fetchResult: Awaited<ReturnType<typeof fetchGitHubCopilotModels>>;
+	try {
+		fetchResult = await fetchGitHubCopilotModels({
+			provider: "github-copilot",
+			authToken: token,
+			baseUrl,
+			fetchImpl: options.fetchImpl,
+		});
+	} catch (err) {
+		return {
+			...NOOP_RESULT,
+			ran: true,
+			ok: false,
+			reason: err instanceof Error ? err.message : "fetch-failed",
+			snapshot: previousSnapshot,
+		};
+	}
+
+	const ok = !fetchResult.skipped && fetchResult.models.length > 0 && Boolean(fetchResult.snapshot);
+	const nextSnapshot = previousSnapshot
+		? applyLastKnownGood(previousSnapshot, { ok, snapshot: ok ? fetchResult.snapshot! : null })
+		: ok
+			? fetchResult.snapshot!
+			: null;
+
+	if (!nextSnapshot) {
+		return {
+			...NOOP_RESULT,
+			ran: true,
+			ok: false,
+			reason: fetchResult.reason ?? "empty-response",
+		};
+	}
+
+	lastSnapshotByBasePath.set(basePath, nextSnapshot);
+	lastRefreshedAtByBasePath.set(basePath, nowFn());
+
+	const classifications: Record<string, ModelClassification> = {};
+	for (const model of nextSnapshot.models) {
+		classifications[model.id] = classifyRemoteCopilotModel(model);
+	}
+
+	const changedModelIds = previousSnapshot
+		? (() => {
+				const diff = diffCatalogSnapshots(previousSnapshot, nextSnapshot);
+				return [...diff.added, ...diff.changed].map((model) => model.id);
+			})()
+		: nextSnapshot.models.map((model) => model.id);
+
+	return {
+		ran: true,
+		ok: true,
+		snapshot: nextSnapshot,
+		classifications,
+		changedModelIds,
+	};
+}
+
+/**
+ * Start (or join an already in-flight) session-start Copilot catalog
+ * refresh. Callers on the startup path MUST NOT `await` this synchronously —
+ * fire it and let it resolve in the background (`void
+ * startCopilotCatalogSessionRefresh(...)`), per the non-blocking-startup
+ * invariant. `awaitCopilotCatalogSessionRefresh` is the bounded-wait join
+ * point for callers (e.g. the model picker) that need the result.
+ *
+ * Returns `NOOP_RESULT` synchronously-resolved when the mode is "off" or
+ * "if_stale" and the snapshot is not yet stale — no promise is stored in
+ * that case, so `awaitCopilotCatalogSessionRefresh` has nothing to join.
+ */
+export function startCopilotCatalogSessionRefresh(
+	options: RefreshCopilotCatalogSessionOptions,
+): Promise<CopilotCatalogSessionRefreshResult> {
+	const { basePath, preferences } = options;
+	const nowFn = options.now ?? Date.now;
+	const mode = resolveCopilotCatalogRefreshMode(preferences);
+	const staleAfterMs = resolveCopilotCatalogStaleAfterMs(preferences);
+	const lastRefreshedAt = lastRefreshedAtByBasePath.get(basePath) ?? null;
+
+	if (!shouldTriggerCopilotCatalogRefresh(mode, lastRefreshedAt, nowFn(), staleAfterMs)) {
+		return Promise.resolve(NOOP_RESULT);
+	}
+
+	const existing = inFlightRefreshes.get(basePath);
+	if (existing) return existing;
+
+	const timeoutMs = options.timeoutMs ?? DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS;
+	const timedOutResult: CopilotCatalogSessionRefreshResult = {
+		...NOOP_RESULT,
+		ran: true,
+		reason: "timeout",
+	};
+	const runPromise = withTimeout(runCopilotCatalogRefresh(options), timeoutMs, timedOutResult).finally(() => {
+		inFlightRefreshes.delete(basePath);
+	});
+
+	inFlightRefreshes.set(basePath, runPromise);
+	return runPromise;
+}
+
+/**
+ * Await an in-flight refresh for `basePath`, bounded by `timeoutMs`. Used by
+ * the model picker so a just-started refresh can populate newly available
+ * models before the picker renders, without ever blocking indefinitely.
+ * Resolves immediately with `NOOP_RESULT` when nothing is in flight.
+ */
+export function awaitCopilotCatalogSessionRefresh(
+	basePath: string,
+	timeoutMs = DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS,
+): Promise<CopilotCatalogSessionRefreshResult> {
+	const pending = inFlightRefreshes.get(basePath);
+	if (!pending) return Promise.resolve(NOOP_RESULT);
+	return withTimeout(pending, timeoutMs, { ...NOOP_RESULT, ran: true, reason: "timeout" });
+}

--- a/src/resources/extensions/gsd/model-cost-table.ts
+++ b/src/resources/extensions/gsd/model-cost-table.ts
@@ -405,6 +405,7 @@ export const BUNDLED_COST_TABLE: ModelCostEntry[] = [
   { id: "claude-opus-5", inputPer1k: 0.005, outputPer1k: 0.025, updatedAt: "2026-08-12" },
   { id: "claude-fable-5", inputPer1k: 0.010, outputPer1k: 0.050, updatedAt: "2026-06-09" },
   { id: "claude-sonnet-4-6", inputPer1k: 0.003, outputPer1k: 0.015, updatedAt: "2025-03-15" },
+  { id: "claude-sonnet-5", inputPer1k: 0.003, outputPer1k: 0.015, updatedAt: "2026-08-12" },
   { id: "claude-haiku-4-5", inputPer1k: 0.0008, outputPer1k: 0.004, updatedAt: "2025-03-15" },
   { id: "claude-sonnet-4-5-20250514", inputPer1k: 0.003, outputPer1k: 0.015, updatedAt: "2025-03-15" },
   { id: "claude-3-5-sonnet-latest", inputPer1k: 0.003, outputPer1k: 0.015, updatedAt: "2025-03-15" },

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -86,6 +86,30 @@ export interface ContextModeConfig {
 export function isContextModeEnabled(prefs: { context_mode?: ContextModeConfig } | null | undefined): boolean {
   return prefs?.context_mode?.enabled !== false;
 }
+
+/**
+ * Automatic GitHub Copilot live-catalog refresh at GSD session start
+ * (GSD-W018). Extends the explicit, user-invoked `/gsd copilot-models sync`
+ * (GSD-W014) command — this setting only controls whether a refresh ALSO
+ * runs automatically when a GSD session starts (terminal session or the
+ * first `@gsd` invocation in an editor chat context).
+ */
+export type CopilotCatalogRefreshMode = "off" | "if_stale" | "always";
+
+export interface CopilotCatalogPreferences {
+  /**
+   * - "off" (default): never refresh automatically; explicit
+   *   `/gsd copilot-models sync` remains the only trigger.
+   * - "if_stale": refresh at most once per session, only when the
+   *   account-scoped snapshot is older than `stale_after_ms`.
+   * - "always": refresh once for every newly started GSD session.
+   */
+  refresh_on_session_start?: CopilotCatalogRefreshMode;
+  /** Surface a non-blocking notification when the refresh finds catalog changes. Default: true. */
+  notify_on_changes?: boolean;
+  /** Staleness threshold in ms for "if_stale" mode. Default: 21_600_000 (6h). Range: 60_000–604_800_000 (1min–7d). */
+  stale_after_ms?: number;
+}
 import type { GitHubSyncConfig } from "../github-sync/types.js";
 
 // ─── Workflow Modes ──────────────────────────────────────────────────────────
@@ -185,6 +209,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "language",
   "context_window_override",
   "context_mode",
+  "copilot_catalog",
   "planning_depth",
   "claude_code_mcp",
   "workspace",
@@ -537,6 +562,8 @@ export interface GSDPreferences {
    * disabled with `context_mode.enabled: false`.
    */
   context_mode?: ContextModeConfig;
+  /** Automatic GitHub Copilot live-catalog refresh at session start (GSD-W018). Default: off. */
+  copilot_catalog?: CopilotCatalogPreferences;
   token_profile?: TokenProfile;
   phases?: PhaseSkipPreferences;
   /**

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -1135,6 +1135,43 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  // ─── Copilot Catalog Session Refresh (GSD-W018) ─────────────────────────
+  if (preferences.copilot_catalog !== undefined) {
+    if (typeof preferences.copilot_catalog === "object" && preferences.copilot_catalog !== null) {
+      const catalog = preferences.copilot_catalog as unknown as Record<string, unknown>;
+      const validCatalog: Record<string, unknown> = {};
+      const validRefreshModes = new Set(["off", "if_stale", "always"]);
+
+      if (catalog.refresh_on_session_start !== undefined) {
+        if (typeof catalog.refresh_on_session_start === "string" && validRefreshModes.has(catalog.refresh_on_session_start)) {
+          validCatalog.refresh_on_session_start = catalog.refresh_on_session_start;
+        } else {
+          errors.push('copilot_catalog.refresh_on_session_start must be one of: off, if_stale, always');
+        }
+      }
+      if (catalog.notify_on_changes !== undefined) {
+        if (typeof catalog.notify_on_changes === "boolean") validCatalog.notify_on_changes = catalog.notify_on_changes;
+        else errors.push("copilot_catalog.notify_on_changes must be a boolean");
+      }
+      if (catalog.stale_after_ms !== undefined) {
+        const ms = catalog.stale_after_ms;
+        if (typeof ms === "number" && ms >= 60_000 && ms <= 604_800_000) validCatalog.stale_after_ms = Math.floor(ms);
+        else errors.push("copilot_catalog.stale_after_ms must be a number between 60000 and 604800000");
+      }
+      for (const key of Object.keys(catalog)) {
+        if (key !== "refresh_on_session_start" && key !== "notify_on_changes" && key !== "stale_after_ms") {
+          warnings.push(`unknown copilot_catalog key "${key}" — ignored`);
+        }
+      }
+
+      if (Object.keys(validCatalog).length > 0) {
+        validated.copilot_catalog = validCatalog as any;
+      }
+    } else {
+      errors.push("copilot_catalog must be an object");
+    }
+  }
+
   // ─── Parallel Config ────────────────────────────────────────────────────
   if (preferences.parallel && typeof preferences.parallel === "object") {
     const p = preferences.parallel as unknown as Record<string, unknown>;

--- a/src/resources/extensions/gsd/tests/copilot-catalog-notifications.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-notifications.test.ts
@@ -1,0 +1,194 @@
+// Regression/behavior tests for GSD-W017's non-blocking cheaper/better
+// same-tier notification feature (copilot-catalog-notifications.ts).
+// Exercises the messaging distinction, fingerprint-based dedup, and
+// provider/scope gating on top of the already-tested suggestion-finding
+// logic in copilot-models-handler.test.ts.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  _resetCopilotCatalogNotificationStateForTests,
+  compareCapabilityScores,
+  maybeNotifyCheaperAlternative,
+} from "../copilot-catalog-notifications.js";
+import { _resetCopilotModelsSessionStateForTests } from "../commands/handlers/copilot-models.js";
+
+interface FakeModel {
+  id: string;
+  provider: string;
+}
+
+function createFakeCtx(models: FakeModel[]): { ctx: any; notifications: Array<{ message: string; level: string }> } {
+  const notifications: Array<{ message: string; level: string }> = [];
+  const ctx = {
+    modelRegistry: {
+      getAvailable: () => models,
+      getApiKey: async () => undefined,
+    },
+    ui: {
+      notify: (message: string, level: string = "info") => {
+        notifications.push({ message, level });
+      },
+    },
+  };
+  return { ctx, notifications };
+}
+
+const SAME_TIER_SESSION: FakeModel[] = [
+  { id: "claude-sonnet-5", provider: "github-copilot" },
+  { id: "gpt-4.1", provider: "github-copilot" },
+  { id: "mai-code-1.1-flash", provider: "github-copilot" },
+];
+
+// ─── compareCapabilityScores (pure) ─────────────────────────────────────────
+
+test("compareCapabilityScores: higher when candidate average exceeds selected by more than the margin", () => {
+  const selected = { coding: 50, debugging: 50, research: 50, reasoning: 50, speed: 50, longContext: 50, instruction: 50 };
+  const candidate = { coding: 60, debugging: 60, research: 60, reasoning: 60, speed: 60, longContext: 60, instruction: 60 };
+  assert.equal(compareCapabilityScores(selected, candidate), "higher");
+});
+
+test("compareCapabilityScores: equal-or-lower when within the noise margin or candidate is lower", () => {
+  const selected = { coding: 50, debugging: 50, research: 50, reasoning: 50, speed: 50, longContext: 50, instruction: 50 };
+  const closeCandidate = { ...selected, coding: 50.5 };
+  assert.equal(compareCapabilityScores(selected, closeCandidate), "equal-or-lower");
+
+  const lowerCandidate = { ...selected, coding: 10 };
+  assert.equal(compareCapabilityScores(selected, lowerCandidate), "equal-or-lower");
+});
+
+test("compareCapabilityScores: equal-or-lower when either profile is missing (never guesses)", () => {
+  const selected = { coding: 50, debugging: 50, research: 50, reasoning: 50, speed: 50, longContext: 50, instruction: 50 };
+  assert.equal(compareCapabilityScores(undefined, selected), "equal-or-lower");
+  assert.equal(compareCapabilityScores(selected, undefined), "equal-or-lower");
+});
+
+// ─── maybeNotifyCheaperAlternative ──────────────────────────────────────────
+
+test("maybeNotifyCheaperAlternative: no qualifying alternative sends no notification", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx([{ id: "claude-sonnet-5", provider: "github-copilot" }]);
+
+  const sent = maybeNotifyCheaperAlternative({
+    ctx,
+    accountScope: "/project",
+    selectedModelProvider: "github-copilot",
+    selectedModelId: "claude-sonnet-5",
+    snapshot: null,
+  });
+
+  assert.equal(sent, false);
+  assert.equal(notifications.length, 0);
+});
+
+test("maybeNotifyCheaperAlternative: non-Copilot provider is always a no-op", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+
+  const sent = maybeNotifyCheaperAlternative({
+    ctx,
+    accountScope: "/project",
+    selectedModelProvider: "openai",
+    selectedModelId: "claude-sonnet-5",
+    snapshot: null,
+  });
+
+  assert.equal(sent, false);
+  assert.equal(notifications.length, 0);
+});
+
+test("maybeNotifyCheaperAlternative: same-tier cheaper option notifies as a cheaper equivalent", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+
+  const sent = maybeNotifyCheaperAlternative({
+    ctx,
+    accountScope: "/project",
+    selectedModelProvider: "github-copilot",
+    selectedModelId: "claude-sonnet-5",
+    snapshot: null,
+  });
+
+  assert.equal(sent, true);
+  assert.equal(notifications.length, 1);
+  assert.match(notifications[0]!.message, /cheaper equivalent to github-copilot\/claude-sonnet-5/);
+  assert.match(notifications[0]!.message, /github-copilot\/gpt-4\.1/);
+  assert.match(notifications[0]!.message, /current model was not changed/i);
+  assert.doesNotMatch(notifications[0]!.message, /better, cheaper alternative/);
+});
+
+test("maybeNotifyCheaperAlternative: never leaks tokens or raw provider payloads in the message", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+
+  maybeNotifyCheaperAlternative({
+    ctx,
+    accountScope: "secret-account-scope-value",
+    selectedModelProvider: "github-copilot",
+    selectedModelId: "claude-sonnet-5",
+    snapshot: null,
+  });
+
+  assert.doesNotMatch(notifications[0]!.message, /secret-account-scope-value/);
+  assert.doesNotMatch(notifications[0]!.message, /Bearer|token|gho_|ghu_/i);
+});
+
+test("maybeNotifyCheaperAlternative: deduplicates the identical pairing within the same scope and revision", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+  const call = () =>
+    maybeNotifyCheaperAlternative({
+      ctx,
+      accountScope: "/project",
+      selectedModelProvider: "github-copilot",
+      selectedModelId: "claude-sonnet-5",
+      snapshot: null,
+    });
+
+  assert.equal(call(), true, "first call notifies");
+  assert.equal(call(), false, "second identical call is deduped");
+  assert.equal(notifications.length, 1);
+});
+
+test("maybeNotifyCheaperAlternative: a different scope re-notifies despite the identical pairing", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+  const notifyFor = (scope: string) =>
+    maybeNotifyCheaperAlternative({
+      ctx,
+      accountScope: scope,
+      selectedModelProvider: "github-copilot",
+      selectedModelId: "claude-sonnet-5",
+      snapshot: null,
+    });
+
+  assert.equal(notifyFor("/project-a"), true);
+  assert.equal(notifyFor("/project-b"), true, "a different scope is not deduped against a different scope");
+  assert.equal(notifications.length, 2);
+});
+
+test("maybeNotifyCheaperAlternative: a changed catalog revision allows a fresh notification", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+  const notifyWithSnapshot = (hash: string | undefined) =>
+    maybeNotifyCheaperAlternative({
+      ctx,
+      accountScope: "/project",
+      selectedModelProvider: "github-copilot",
+      selectedModelId: "claude-sonnet-5",
+      snapshot: hash ? ({ hash, generatedAt: "", modelCount: 0, models: [] } as any) : null,
+    });
+
+  assert.equal(notifyWithSnapshot(undefined), true);
+  assert.equal(notifyWithSnapshot(undefined), false, "same revision (no snapshot) is deduped");
+  assert.equal(notifyWithSnapshot("revision-2"), true, "a materially different revision re-notifies");
+  assert.equal(notifications.length, 2);
+});

--- a/src/resources/extensions/gsd/tests/copilot-catalog-notifications.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-notifications.test.ts
@@ -17,12 +17,14 @@ import { _resetCopilotModelsSessionStateForTests } from "../commands/handlers/co
 interface FakeModel {
   id: string;
   provider: string;
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
 }
 
 function createFakeCtx(models: FakeModel[]): { ctx: any; notifications: Array<{ message: string; level: string }> } {
   const notifications: Array<{ message: string; level: string }> = [];
   const ctx = {
     modelRegistry: {
+      getAll: () => models.map((model) => ({ ...model, cost: model.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } })),
       getAvailable: () => models,
       getApiKey: async () => undefined,
     },
@@ -36,9 +38,9 @@ function createFakeCtx(models: FakeModel[]): { ctx: any; notifications: Array<{ 
 }
 
 const SAME_TIER_SESSION: FakeModel[] = [
-  { id: "claude-sonnet-5", provider: "github-copilot" },
-  { id: "gpt-4.1", provider: "github-copilot" },
-  { id: "mai-code-1.1-flash", provider: "github-copilot" },
+  { id: "claude-sonnet-5", provider: "github-copilot", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } },
+  { id: "gpt-4.1", provider: "github-copilot", cost: { input: 2, output: 8, cacheRead: 0, cacheWrite: 0 } },
+  { id: "mai-code-1.1-flash", provider: "github-copilot", cost: { input: 0.2, output: 1.2, cacheRead: 0, cacheWrite: 0 } },
 ];
 
 // ─── compareCapabilityScores (pure) ─────────────────────────────────────────
@@ -69,7 +71,7 @@ test("compareCapabilityScores: equal-or-lower when either profile is missing (ne
 test("maybeNotifyCheaperAlternative: no qualifying alternative sends no notification", () => {
   _resetCopilotModelsSessionStateForTests();
   _resetCopilotCatalogNotificationStateForTests();
-  const { ctx, notifications } = createFakeCtx([{ id: "claude-sonnet-5", provider: "github-copilot" }]);
+  const { ctx, notifications } = createFakeCtx([{ id: "claude-sonnet-5", provider: "github-copilot", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } }]);
 
   const sent = maybeNotifyCheaperAlternative({
     ctx,

--- a/src/resources/extensions/gsd/tests/copilot-catalog-preferences-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-preferences-validation.test.ts
@@ -1,0 +1,67 @@
+// Validation tests for GSD-W018's `copilot_catalog` preference block
+// (refresh_on_session_start / notify_on_changes / stale_after_ms).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validatePreferences } from "../preferences.js";
+
+test("copilot_catalog: valid config passes through with no errors", () => {
+  const { errors, preferences } = validatePreferences({
+    copilot_catalog: {
+      refresh_on_session_start: "if_stale",
+      notify_on_changes: false,
+      stale_after_ms: 3_600_000,
+    },
+  } as any);
+
+  assert.deepEqual(errors, []);
+  assert.deepEqual(preferences.copilot_catalog, {
+    refresh_on_session_start: "if_stale",
+    notify_on_changes: false,
+    stale_after_ms: 3_600_000,
+  });
+});
+
+test("copilot_catalog: omitted config produces no errors and no default injection", () => {
+  const { errors, preferences } = validatePreferences({} as any);
+  assert.deepEqual(errors, []);
+  assert.equal(preferences.copilot_catalog, undefined);
+});
+
+test("copilot_catalog: rejects an invalid refresh_on_session_start value", () => {
+  const { errors } = validatePreferences({
+    copilot_catalog: { refresh_on_session_start: "sometimes" },
+  } as any);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0]!, /refresh_on_session_start must be one of: off, if_stale, always/);
+});
+
+test("copilot_catalog: rejects a non-boolean notify_on_changes", () => {
+  const { errors } = validatePreferences({
+    copilot_catalog: { notify_on_changes: "yes" },
+  } as any);
+  assert.match(errors[0]!, /notify_on_changes must be a boolean/);
+});
+
+test("copilot_catalog: rejects an out-of-range stale_after_ms", () => {
+  const tooLow = validatePreferences({ copilot_catalog: { stale_after_ms: 1000 } } as any);
+  assert.match(tooLow.errors[0]!, /stale_after_ms must be a number between 60000 and 604800000/);
+
+  const tooHigh = validatePreferences({ copilot_catalog: { stale_after_ms: 1e12 } } as any);
+  assert.match(tooHigh.errors[0]!, /stale_after_ms must be a number between 60000 and 604800000/);
+});
+
+test("copilot_catalog: warns on unknown sub-keys without rejecting known ones", () => {
+  const { errors, warnings, preferences } = validatePreferences({
+    copilot_catalog: { refresh_on_session_start: "always", made_up_key: true },
+  } as any);
+  assert.deepEqual(errors, []);
+  assert.ok(warnings.some((w) => w.includes('unknown copilot_catalog key "made_up_key"')));
+  assert.equal(preferences.copilot_catalog?.refresh_on_session_start, "always");
+});
+
+test("copilot_catalog: rejects a non-object value", () => {
+  const { errors } = validatePreferences({ copilot_catalog: "always" } as any);
+  assert.match(errors[0]!, /copilot_catalog must be an object/);
+});

--- a/src/resources/extensions/gsd/tests/copilot-catalog-session-refresh.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-session-refresh.test.ts
@@ -1,0 +1,409 @@
+// Regression/behavior tests for GSD-W018: the session-start GitHub Copilot
+// catalog refresh coordinator and 3-tier runtime model classification.
+// Exercises the coordinator's dedup/timeout/auth-safety contract and the
+// classifier's refusal to fabricate capability or pricing data — as opposed
+// to the production command wiring covered by copilot-models-handler.test.ts.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	_resetCopilotCatalogSessionRefreshStateForTests,
+	awaitCopilotCatalogSessionRefresh,
+	classifyRemoteCopilotModel,
+	resolveCopilotCatalogNotifyOnChanges,
+	resolveCopilotCatalogRefreshMode,
+	resolveCopilotCatalogStaleAfterMs,
+	shouldTriggerCopilotCatalogRefresh,
+	startCopilotCatalogSessionRefresh,
+	type CopilotCatalogSessionRefreshResult,
+} from "../copilot-catalog-session-refresh.js";
+import type { CopilotModelRecord } from "../copilot-model-catalog.js";
+
+interface FakeModel {
+	id: string;
+	provider: string;
+}
+
+function createFakeCtx(options: {
+	models?: FakeModel[];
+	apiKey?: string | undefined;
+	apiKeyThrows?: boolean;
+}): { ctx: any; notifications: Array<{ message: string; level: string }> } {
+	const notifications: Array<{ message: string; level: string }> = [];
+	const models = options.models ?? [];
+	const ctx = {
+		modelRegistry: {
+			getAvailable: () => models,
+			getApiKey: async (_model: FakeModel) => {
+				if (options.apiKeyThrows) throw new Error("token refresh failed");
+				return options.apiKey;
+			},
+		},
+		ui: {
+			notify: (message: string, level: string = "info") => {
+				notifications.push({ message, level });
+			},
+		},
+	};
+	return { ctx, notifications };
+}
+
+function jsonResponse(data: Array<Record<string, unknown>>) {
+	return async () => ({ ok: true, json: async () => ({ data }) }) as unknown as Response;
+}
+
+function neverResolves() {
+	return (async () => new Promise<Response>(() => {})) as unknown as typeof fetch;
+}
+
+function buildRecord(overrides: Partial<CopilotModelRecord> = {}): CopilotModelRecord {
+	return {
+		provider: "github-copilot",
+		id: "claude-sonnet-5",
+		registryId: "github-copilot/claude-sonnet-5",
+		name: "Claude Sonnet 5",
+		availability: { enabled: true, pickerEnabled: true, preview: false, policyState: "enabled" },
+		execution: {
+			toolCalls: true,
+			supportedEndpoints: [],
+			reasoningLevels: [],
+			contextWindow: 200_000,
+			maxTokens: 8_192,
+		},
+		billing: { billingUnit: "tokens", inputPer1k: 0.003, outputPer1k: 0.015 },
+		provenance: {
+			displayName: { source: "provider-live", freshness: "fresh" },
+			availability: { source: "provider-live", freshness: "fresh" },
+			endpoints: { source: "provider-live", freshness: "fresh" },
+			reasoning: { source: "provider-live", freshness: "fresh" },
+			limits: { source: "provider-live", freshness: "fresh" },
+			billingUnit: { source: "provider-live", freshness: "fresh" },
+			tokenPrices: { source: "provider-live", freshness: "fresh" },
+			requestMultiplier: { source: "unknown", freshness: "unknown" },
+			promotion: { source: "unknown", freshness: "unknown" },
+		},
+		conflicts: [],
+		hash: "test-hash",
+		...overrides,
+	} as CopilotModelRecord;
+}
+
+// ─── Config resolution ──────────────────────────────────────────────────────
+
+test("resolveCopilotCatalogRefreshMode defaults to off", () => {
+	assert.equal(resolveCopilotCatalogRefreshMode(undefined), "off");
+	assert.equal(resolveCopilotCatalogRefreshMode({}), "off");
+	assert.equal(resolveCopilotCatalogRefreshMode({ copilot_catalog: {} }), "off");
+});
+
+test("resolveCopilotCatalogRefreshMode respects configured mode", () => {
+	assert.equal(
+		resolveCopilotCatalogRefreshMode({ copilot_catalog: { refresh_on_session_start: "always" } }),
+		"always",
+	);
+	assert.equal(
+		resolveCopilotCatalogRefreshMode({ copilot_catalog: { refresh_on_session_start: "if_stale" } }),
+		"if_stale",
+	);
+});
+
+test("resolveCopilotCatalogNotifyOnChanges defaults to true", () => {
+	assert.equal(resolveCopilotCatalogNotifyOnChanges(undefined), true);
+	assert.equal(resolveCopilotCatalogNotifyOnChanges({ copilot_catalog: { notify_on_changes: false } }), false);
+});
+
+test("resolveCopilotCatalogStaleAfterMs defaults and clamps out-of-range values", () => {
+	assert.equal(resolveCopilotCatalogStaleAfterMs(undefined), 6 * 60 * 60 * 1000);
+	assert.equal(
+		resolveCopilotCatalogStaleAfterMs({ copilot_catalog: { stale_after_ms: 30_000 } }),
+		60_000,
+		"clamped up to the 1-minute floor",
+	);
+	assert.equal(
+		resolveCopilotCatalogStaleAfterMs({ copilot_catalog: { stale_after_ms: 999_999_999_999 } }),
+		604_800_000,
+		"clamped down to the 7-day ceiling",
+	);
+});
+
+// ─── shouldTriggerCopilotCatalogRefresh (pure) ──────────────────────────────
+
+test("shouldTriggerCopilotCatalogRefresh: off never triggers", () => {
+	assert.equal(shouldTriggerCopilotCatalogRefresh("off", null, Date.now(), 1000), false);
+	assert.equal(shouldTriggerCopilotCatalogRefresh("off", 0, Date.now(), 1000), false);
+});
+
+test("shouldTriggerCopilotCatalogRefresh: always triggers every time", () => {
+	assert.equal(shouldTriggerCopilotCatalogRefresh("always", Date.now(), Date.now(), 1000), true);
+});
+
+test("shouldTriggerCopilotCatalogRefresh: if_stale triggers on first run and after the threshold", () => {
+	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", null, 1000, 500), true, "no prior refresh yet");
+	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 1400, 500), false, "still fresh");
+	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 1500, 500), true, "exactly at threshold");
+	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 2000, 500), true, "past threshold");
+});
+
+// ─── classifyRemoteCopilotModel (pure) ──────────────────────────────────────
+
+test("classifyRemoteCopilotModel: trusted when tier, profile, pricing, and limits are all known", () => {
+	const result = classifyRemoteCopilotModel(buildRecord());
+	assert.equal(result.modelClass, "trusted");
+	assert.equal(result.tier, "standard");
+	assert.equal(result.hasKnownPricing, true);
+});
+
+test("classifyRemoteCopilotModel: manual-only when capability tier is unknown", () => {
+	const result = classifyRemoteCopilotModel(buildRecord({ id: "some-brand-new-unlisted-model" }));
+	assert.equal(result.modelClass, "manual-only");
+	assert.ok(result.reasons.some((reason) => reason.includes("capability tier")));
+});
+
+test("classifyRemoteCopilotModel: manual-only when pricing is unknown and tier/profile are unknown too", () => {
+	const result = classifyRemoteCopilotModel(
+		buildRecord({ id: "some-brand-new-unlisted-model-2", billing: { billingUnit: "unknown" } }),
+	);
+	assert.equal(result.modelClass, "manual-only");
+	assert.equal(result.hasKnownPricing, false);
+});
+
+test("classifyRemoteCopilotModel: quarantined when not tool-call capable", () => {
+	const result = classifyRemoteCopilotModel(
+		buildRecord({ execution: { ...buildRecord().execution, toolCalls: false } }),
+	);
+	assert.equal(result.modelClass, "quarantined");
+	assert.match(result.reasons[0]!, /tool-call/);
+});
+
+test("classifyRemoteCopilotModel: quarantined when policy-restricted or disabled", () => {
+	const restricted = classifyRemoteCopilotModel(
+		buildRecord({ availability: { ...buildRecord().availability, policyState: "restricted" } }),
+	);
+	assert.equal(restricted.modelClass, "quarantined");
+
+	const disabled = classifyRemoteCopilotModel(
+		buildRecord({ availability: { ...buildRecord().availability, policyState: "disabled" } }),
+	);
+	assert.equal(disabled.modelClass, "quarantined");
+});
+
+test("classifyRemoteCopilotModel: quarantined when preview", () => {
+	const result = classifyRemoteCopilotModel(
+		buildRecord({ availability: { ...buildRecord().availability, preview: true } }),
+	);
+	assert.equal(result.modelClass, "quarantined");
+	assert.match(result.reasons[0]!, /preview/);
+});
+
+test("classifyRemoteCopilotModel: quarantined when normalization reported conflicts", () => {
+	const result = classifyRemoteCopilotModel(buildRecord({ conflicts: ["endpoint mismatch"] }));
+	assert.equal(result.modelClass, "quarantined");
+	assert.match(result.reasons[0]!, /conflict/);
+});
+
+// ─── startCopilotCatalogSessionRefresh (coordinator) ────────────────────────
+
+test("startCopilotCatalogSessionRefresh: mode off makes zero network requests", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	let fetchCalled = false;
+	const { ctx } = createFakeCtx({ models: [{ id: "claude-sonnet-5", provider: "github-copilot" }], apiKey: "tok" });
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "off" } },
+		fetchImpl: (async () => {
+			fetchCalled = true;
+			throw new Error("must not be called");
+		}) as unknown as typeof fetch,
+	});
+
+	assert.equal(fetchCalled, false);
+	assert.equal(result.ran, false);
+});
+
+test("startCopilotCatalogSessionRefresh: no configured Copilot provider skips without error", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({ models: [] });
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+	});
+
+	assert.equal(result.ran, true);
+	assert.equal(result.ok, false);
+	assert.equal(result.reason, "provider-not-configured");
+});
+
+test("startCopilotCatalogSessionRefresh: missing token skips silently, never throws, never fetches", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	let fetchCalled = false;
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: undefined,
+	});
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+		fetchImpl: (async () => {
+			fetchCalled = true;
+			throw new Error("must not be called");
+		}) as unknown as typeof fetch,
+	});
+
+	assert.equal(fetchCalled, false);
+	assert.equal(result.ok, false);
+	assert.equal(result.reason, "auth-unavailable");
+});
+
+test("startCopilotCatalogSessionRefresh: a throwing getApiKey never triggers a login flow and never throws", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKeyThrows: true,
+	});
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+	});
+
+	assert.equal(result.reason, "auth-unavailable");
+});
+
+test("startCopilotCatalogSessionRefresh: successful refresh classifies models and reports changes", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+		fetchImpl: jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]),
+	});
+
+	assert.equal(result.ok, true);
+	assert.ok(result.snapshot);
+	assert.equal(result.changedModelIds.length, 1, "first-ever snapshot reports every model as changed");
+	assert.ok(result.classifications["claude-sonnet-5"]);
+});
+
+test("startCopilotCatalogSessionRefresh: no-diff second refresh reports zero changes", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+	const fetchImpl = jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]);
+	const preferences = { copilot_catalog: { refresh_on_session_start: "always" as const } };
+
+	await startCopilotCatalogSessionRefresh({ ctx, basePath: "/project-2", preferences, fetchImpl });
+	const second = await startCopilotCatalogSessionRefresh({ ctx, basePath: "/project-2", preferences, fetchImpl });
+
+	assert.equal(second.ok, true);
+	assert.equal(second.changedModelIds.length, 0);
+});
+
+test("startCopilotCatalogSessionRefresh: a failed refresh preserves the last-known-good snapshot", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+	const preferences = { copilot_catalog: { refresh_on_session_start: "always" as const } };
+
+	const first = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project-3",
+		preferences,
+		fetchImpl: jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]),
+	});
+	assert.equal(first.ok, true);
+
+	const second = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project-3",
+		preferences,
+		fetchImpl: (async () => {
+			throw new Error("network down");
+		}) as unknown as typeof fetch,
+	});
+
+	assert.equal(second.ok, false);
+	assert.deepEqual(second.snapshot, first.snapshot, "last-known-good snapshot is preserved on failure");
+});
+
+test("startCopilotCatalogSessionRefresh: concurrent calls for the same basePath share one in-flight refresh", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	let fetchCallCount = 0;
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+	const preferences = { copilot_catalog: { refresh_on_session_start: "always" as const } };
+	const fetchImpl = (async () => {
+		fetchCallCount += 1;
+		return { ok: true, json: async () => ({ data: [{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }] }) } as unknown as Response;
+	}) as unknown as typeof fetch;
+
+	const [a, b] = await Promise.all([
+		startCopilotCatalogSessionRefresh({ ctx, basePath: "/project-4", preferences, fetchImpl }),
+		startCopilotCatalogSessionRefresh({ ctx, basePath: "/project-4", preferences, fetchImpl }),
+	]);
+
+	assert.equal(fetchCallCount, 1, "only one network request for two simultaneous triggers");
+	assert.equal(a, b, "both callers receive the exact same result object");
+});
+
+test("startCopilotCatalogSessionRefresh: a hanging fetch resolves via the bounded timeout instead of hanging", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+
+	const result = await startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project-5",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+		fetchImpl: neverResolves(),
+		timeoutMs: 25,
+	});
+
+	assert.equal(result.reason, "timeout");
+});
+
+test("awaitCopilotCatalogSessionRefresh: resolves immediately when nothing is in flight", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const result = await awaitCopilotCatalogSessionRefresh("/no-such-project", 50);
+	assert.equal(result.ran, false);
+});
+
+test("awaitCopilotCatalogSessionRefresh: joins an in-flight refresh started elsewhere", async () => {
+	_resetCopilotCatalogSessionRefreshStateForTests();
+	const { ctx } = createFakeCtx({
+		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
+		apiKey: "token-abc",
+	});
+
+	const started: Promise<CopilotCatalogSessionRefreshResult> = startCopilotCatalogSessionRefresh({
+		ctx,
+		basePath: "/project-6",
+		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
+		fetchImpl: jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]),
+	});
+
+	const joined = await awaitCopilotCatalogSessionRefresh("/project-6", 1000);
+	const original = await started;
+	assert.equal(joined.ok, original.ok);
+	assert.deepEqual(joined.snapshot, original.snapshot);
+});

--- a/src/resources/extensions/gsd/tests/copilot-models-handler.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-models-handler.test.ts
@@ -1051,6 +1051,24 @@ test("handleCopilotModels: pricing explains provider-aware economics locally", a
   assert.match(notifications[0].message, /^- freshness: stale$/m);
 });
 
+test("handleCopilotModels: pricing suggests a cheaper same-tier Copilot model when one is available", async () => {
+  _resetCopilotModelsSessionStateForTests();
+  const { ctx, notifications } = createFakeCtx({
+    models: [
+      { id: "claude-sonnet-5", provider: "github-copilot" },
+      { id: "gpt-4.1", provider: "github-copilot" },
+      { id: "mai-code-1.1-flash", provider: "github-copilot" },
+    ],
+    apiKey: undefined,
+  });
+
+  await handleCopilotModels("pricing claude-sonnet-5", ctx, {});
+
+  assert.match(notifications[0].message, /^- cheaper same-tier option: github-copilot\/gpt-4\.1 /m);
+  assert.match(notifications[0].message, /saves \$0\.0010 input \/ \$0\.0070 output per 1K/i);
+  assert.doesNotMatch(notifications[0].message, /mai-code-1\.1-flash/);
+});
+
 test("handleCopilotModels: pricing reports long-context tiers and request multipliers when live data supplies them", async () => {
   _resetCopilotModelsSessionStateForTests();
   const { ctx, notifications } = createFakeCtx({
@@ -1226,6 +1244,24 @@ test("handleCopilotModels: why reports a known-profile preview/policy-restricted
     notifications[1].message,
     /^- routing caveats: .*provider policy is restricted.*preview models are intended to stay manual-only.*$/m,
   );
+});
+
+test("handleCopilotModels: why highlights a cheaper same-tier model when one is session-available", async () => {
+  _resetCopilotModelsSessionStateForTests();
+  const { ctx, notifications } = createFakeCtx({
+    models: [
+      { id: "claude-sonnet-5", provider: "github-copilot" },
+      { id: "gpt-4.1", provider: "github-copilot" },
+      { id: "mai-code-1.1-flash", provider: "github-copilot" },
+    ],
+    apiKey: undefined,
+  });
+
+  await handleCopilotModels("why claude-sonnet-5", ctx, {});
+
+  assert.match(notifications[0].message, /^- cheaper same-tier option: github-copilot\/gpt-4\.1 /m);
+  assert.match(notifications[0].message, /saves \$0\.0010 input \/ \$0\.0070 output per 1K/i);
+  assert.doesNotMatch(notifications[0].message, /mai-code-1\.1-flash/);
 });
 
 test("handleCopilotModels: doctor reports cache and quarantine state without a network request", async () => {

--- a/src/resources/extensions/gsd/tests/copilot-models-handler.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-models-handler.test.ts
@@ -1055,9 +1055,9 @@ test("handleCopilotModels: pricing suggests a cheaper same-tier Copilot model wh
   _resetCopilotModelsSessionStateForTests();
   const { ctx, notifications } = createFakeCtx({
     models: [
-      { id: "claude-sonnet-5", provider: "github-copilot" },
-      { id: "gpt-4.1", provider: "github-copilot" },
-      { id: "mai-code-1.1-flash", provider: "github-copilot" },
+      { id: "claude-sonnet-5", provider: "github-copilot", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } },
+      { id: "gpt-4.1", provider: "github-copilot", cost: { input: 2, output: 8, cacheRead: 0, cacheWrite: 0 } },
+      { id: "mai-code-1.1-flash", provider: "github-copilot", cost: { input: 0.2, output: 1.2, cacheRead: 0, cacheWrite: 0 } },
     ],
     apiKey: undefined,
   });
@@ -1250,9 +1250,9 @@ test("handleCopilotModels: why highlights a cheaper same-tier model when one is 
   _resetCopilotModelsSessionStateForTests();
   const { ctx, notifications } = createFakeCtx({
     models: [
-      { id: "claude-sonnet-5", provider: "github-copilot" },
-      { id: "gpt-4.1", provider: "github-copilot" },
-      { id: "mai-code-1.1-flash", provider: "github-copilot" },
+      { id: "claude-sonnet-5", provider: "github-copilot", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } },
+      { id: "gpt-4.1", provider: "github-copilot", cost: { input: 2, output: 8, cacheRead: 0, cacheWrite: 0 } },
+      { id: "mai-code-1.1-flash", provider: "github-copilot", cost: { input: 0.2, output: 1.2, cacheRead: 0, cacheWrite: 0 } },
     ],
     apiKey: undefined,
   });

--- a/src/resources/extensions/gsd/tests/model-cost-table.test.ts
+++ b/src/resources/extensions/gsd/tests/model-cost-table.test.ts
@@ -35,6 +35,13 @@ test("lookupModelCost finds haiku", () => {
   assert.ok(entry.inputPer1k < 0.001, "haiku should be cheap");
 });
 
+test("lookupModelCost finds Claude Sonnet 5 pricing", () => {
+  const entry = lookupModelCost("github-copilot/claude-sonnet-5");
+  assert.ok(entry);
+  assert.equal(entry.inputPer1k, 0.003);
+  assert.equal(entry.outputPer1k, 0.015);
+});
+
 test("lookupModelCost finds MAI Code 1.1 Flash pricing", () => {
   const entry = lookupModelCost("github-copilot/mai-code-1.1-flash");
   assert.ok(entry);

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -107,6 +107,7 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   language: "en",
   context_window_override: 128000,
   context_mode: { enabled: true },
+  copilot_catalog: { refresh_on_session_start: "if_stale", notify_on_changes: true, stale_after_ms: 3_600_000 },
   planning_depth: "deep",
   claude_code_mcp: { per_model: { "claude-haiku": { allowed_servers: ["gsd-workflow"] } } },
   workspace: {

--- a/src/tests/provider-equality-allowlist.test.ts
+++ b/src/tests/provider-equality-allowlist.test.ts
@@ -103,6 +103,8 @@ const ALLOWED_FILES: Record<string, string> = {
     "github-copilot-only fetch gate — the whole module exists to talk to the Copilot /models endpoint",
   "src/resources/extensions/gsd/copilot-overlay-writer.ts":
     "remote-only GitHub Copilot candidate subtraction is a transport-specific quarantine check and must not fabricate metadata",
+  "src/resources/extensions/gsd/copilot-catalog-session-refresh.ts":
+    "session-start refresh coordinator needs the github-copilot provider specifically to resolve its own auth token, not API shape",
 };
 
 function shouldScan(path: string): boolean {

--- a/src/tests/provider-equality-allowlist.test.ts
+++ b/src/tests/provider-equality-allowlist.test.ts
@@ -105,6 +105,8 @@ const ALLOWED_FILES: Record<string, string> = {
     "remote-only GitHub Copilot candidate subtraction is a transport-specific quarantine check and must not fabricate metadata",
   "src/resources/extensions/gsd/copilot-catalog-session-refresh.ts":
     "session-start refresh coordinator needs the github-copilot provider specifically to resolve its own auth token, not API shape",
+  "src/resources/extensions/gsd/bootstrap/register-hooks.ts":
+    "session-start hook gates the GSD-W017 cheaper-alternative notification on the active model's transport (github-copilot), not API shape",
 };
 
 function shouldScan(path: string): boolean {


### PR DESCRIPTION
## Stacked submission — depends on #1978 and #1979

**This PR depends on #1978 (live catalog sync) and #1979 (session-start refresh). Do not merge until both land.**

Because a PR's base branch must exist on `open-gsd/gsd-pi` itself, this PR is opened with `base: main` rather than against #1979's fork-only branch. As a direct consequence, the diff below currently shows #1978's 18 commits + #1979's 2 commits + this branch's own 1 commit — expected for a stacked PR, and it will shrink to just this branch's own commit once both merge and this branch is rebased onto the new `main`. This is the last of the three; once it merges, all three features are fully upstream.

## TL;DR

**What:** Explicit cheaper-same-tier suggestion text in `/gsd copilot-models pricing`/`why`, plus a real non-blocking, deduplicated notification when the active GitHub Copilot model has a qualifying cheaper (or better-and-cheaper) same-tier alternative.

**Why:** Closes the "user never finds out they're on a needlessly expensive model" gap without any automatic switching or background routing changes.

**How:** A new `copilot-catalog-notifications.ts` reuses the existing `findCheaperSameTierOption` suggestion logic (already used by the `pricing`/`why` text), adds a pure capability-score comparison for "equivalent" vs. "better" messaging, and is wired to two lifecycle triggers: manual model selection (`model_select`, `source: set|cycle` only) and #1979's session-start refresh completion.

## What
- New `src/resources/extensions/gsd/copilot-catalog-notifications.ts`: `maybeNotifyCheaperAlternative` (fingerprint-deduped, provider-gated) and the pure `compareCapabilityScores` helper.
- Modified `commands/handlers/copilot-models.ts`: widens `findCheaperSameTierOption`, `findLocalModel`, and `localCopilotModels` from `ExtensionCommandContext` to `ExtensionContext` (structurally sufficient — both only ever touch `ctx.modelRegistry`), a non-breaking change for all existing callers.
- Modified `copilot-catalog-session-refresh.ts` (#1979): adds `getLastKnownCopilotCatalogSnapshot`.
- Modified `bootstrap/register-hooks.ts`: wires the `model_select` hook (excludes `source: "restore"`) and adds a post-refresh check inside the existing #1979 session-start trigger.
- Modified `docs/dev/ADR-012-provider-id-vs-api-shape.md` / `src/tests/provider-equality-allowlist.test.ts`: allowlists the new transport-specific `github-copilot` gate in `register-hooks.ts`.
- Retained from the original suggestion-text implementation: the bundled `claude-sonnet-5` pricing fallback (independently confirmed authoritative against `packages/pi-ai/src/models.generated.ts`) and its existing focused tests.

## Why
The suggestion-finding logic already existed and was already tested; this PR turns it into an actual proactive signal instead of requiring the user to run an explicit command to notice it.

## How
Extension-first. No new network calls of its own — the notification feature only ever reads the snapshot #1979's coordinator (or the explicit `/gsd copilot-models` command) already fetched; it never fetches independently.

## Architecture boundaries
- GitHub Copilot only. Advisory only: never mutates the active model, routing policy, or any persisted file.
- Never fires for automatic/dynamic routing selections, which do not emit the `model_select` event this feature listens to.
- Never fabricates capability or pricing data: an unknown profile always resolves to the safer "equal-or-lower capability" (cheaper equivalent) messaging, never a guessed "better" claim.
- Deduplicated by a fingerprint of (scope, selected model, suggested model, catalog revision) — a stable pairing is announced once; a material economics/catalog change allows a fresh notification.

## Change-type checklist
- [x] `feat` — New notification feature
- [x] `test` — 10 new tests (81 total for this feature area)
- [x] `docs` — ADR-012 allowlist update
- [ ] `fix`
- [ ] `refactor`
- [ ] `chore`

## Rollback notes
Fully additive: the new module and its two call sites can be removed with no schema/format changes elsewhere. The suggestion-text portion of `pricing`/`why` predates this PR and is unaffected by a rollback of just the notification wiring.

## AI-assistance disclosure
This PR was prepared with AI assistance (GitHub Copilot coding agent). All code was tested to the same standard as human-written code and is understood by the human maintainer of this fork.
