### PR TITLE
fix(legacy-import): take only the code span of a Verification bullet as the verify command

### DIFF
--- a/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
+++ b/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
@@ -729,6 +729,17 @@ type TaskSectionField = (typeof TASK_SECTION_FIELDS)[keyof typeof TASK_SECTION_F
  * and Verification bullets. Missing section or bullets → the field is
  * omitted, leaving the canonical column at its empty default.
  */
+/**
+ * A Verification bullet is prose around a command: `- Verify: \`node --test\` exits 0.`
+ * Only the code span is runnable; the label and trailing prose are not (#1981).
+ * Without a code span the whole bullet (minus a leading label) is the command.
+ */
+function verifyCommandFromBullet(text: string): string {
+  const span = /`([^`]+)`/u.exec(text);
+  if (span !== null) return span[1]!.trim();
+  return text.replace(/^(?:verification|verify):\s*/iu, "").trim();
+}
+
 function taskSectionDetail(
   file: SourceFile,
   taskId: string,
@@ -752,7 +763,9 @@ function taskSectionDetail(
       current = undefined;
       continue;
     }
-    buckets[current].push(bullet[1].replaceAll("`", "").trim());
+    buckets[current].push(
+      current === "verify" ? verifyCommandFromBullet(bullet[1]) : bullet[1].replaceAll("`", "").trim(),
+    );
   }
   return {
     ...(buckets.verify.length > 0 ? { verify: buckets.verify.join("\n") } : {}),

--- a/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
+++ b/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
@@ -1200,7 +1200,7 @@ describe("legacy .gsd captured-byte interpretation", () => {
         "### T02: Add double(n)",
         "",
         "Verify:",
-        "- `node --test test/double.test.js`",
+        "- Verify: `node --test test/double.test.js` exits 0.",
         "",
       ].join("\n"),
     }));


### PR DESCRIPTION
## TL;DR
**What:** The nested `.gsd` importer now stores only the backticked code span of a Verification bullet as the task's verify command (or the text minus a leading `Verify:` label when there is no code span).
**Why:** After #1970 a bullet like `- Verify: \`node --test test/answer.test.js\` exits 0.` became the literal verify command, the gate hit command-not-found and paused — this blocked the 1.16.2 release at NPM Publish's post-publish acceptance-bed verification (run 32671099488).
**How:** `verifyCommandFromBullet()` in `legacy-import-preview-gsd-hierarchy.ts`; the multi-task import test now uses the prose-bullet shape.

## What
- `src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts`: verify bucket goes through `verifyCommandFromBullet`; inputs/expected_output unchanged.
- `tests/legacy-import-preview-gsd.test.ts`: T02 bullet is now `- Verify: \`…\` exits 0.` and still yields `node --test test/double.test.js`.

## Why
Closes #1981

## How
Verified: legacy-import-preview-gsd + legacy-import-application 75/75; typecheck:extensions clean; acceptance bed against a fresh `build:core` → COMPLETED (was WEDGED on main @ fdc4c943a with the reported guard).