### PR TITLE
fix(issue): Loop guard blocks legitimate large-project planning after six requirement saves

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -20,10 +20,10 @@
  * varied surfaces (bash → `node -e` → CLI), each with a different
  * signature, so the identical-args streak never trips, while allowing
  * tool-heavy turns that are making progress. Progress means a successful file
- * mutation (edit/write) or a successful shell/exec call (bg_shell,
- * gsd_uat_exec, …) — so a local model running a legitimate iterative
- * debugging loop (restart server, npm install, curl an endpoint) is not
- * blocked as a false loop (#1206). Whichever guard trips first blocks.
+ * mutation (edit/write), durable workflow mutation, or shell/exec call
+ * (bg_shell, gsd_uat_exec, …) — so legitimate persistence and iterative
+ * debugging loops are not blocked as false loops (#1206, #1985). Whichever
+ * guard trips first blocks.
  *
  * Thresholds, exempt tools, and enable flags are user-tunable (#1198) via the
  * `tool_call_loop_guard` key in `.gsd/PREFERENCES.md` and `GSD_TOOL_LOOP_*`
@@ -34,7 +34,8 @@
 import { createHash } from "node:crypto";
 import { INHERENTLY_REPEATABLE_TOOL_SET } from "./core-session-tools.js";
 import { hasBrowserContractPrefix } from "../../shared/browser-contract.js";
-import { canonicalToolName } from "../engine-hook-contract.js";
+import { canonicalToolName, canonicalWorkflowToolName } from "../engine-hook-contract.js";
+import { WORKFLOW_TOOL_CONTRACTS } from "../workflow-tool-surface.js";
 
 /** Built-in defaults. Preserved when preferences/env do not override them. */
 const DEFAULT_MAX_CONSECUTIVE_IDENTICAL_CALLS = 4;
@@ -47,6 +48,13 @@ const STRICT_LOOP_TOOLS = new Set(["ask_user_questions"]);
 const MAX_CONSECUTIVE_STRICT = 1;
 
 const STATE_MUTATING_TOOL_SET = new Set(["edit", "write", "multi_edit", "notebook_edit"]);
+
+/** Canonical DB-backed workflow tools whose successful results are durable progress. */
+const DURABLE_WORKFLOW_MUTATING_TOOL_SET = new Set(
+  WORKFLOW_TOOL_CONTRACTS
+    .filter((tool) => tool.writePolicy === "write")
+    .map((tool) => tool.canonicalName),
+);
 
 /**
  * Successful shell/exec calls are state progression too (#1206), not just file
@@ -256,7 +264,7 @@ function hashToolCall(toolName: string, args: Record<string, unknown>): string {
  *  1. Identical-signature streak (config.maxConsecutiveIdentical, strict for
  *     ask_user_questions).
  *  2. Per-tool-name cap (config.perToolDefaultCap / config.perToolRepeatableCap),
- *     independent of args, reset after file-mutation progress — catches
+ *     independent of args, reset after successful state progress — catches
  *     improvisation loops (#783).
  *
  * Both guards, their thresholds, and the per-tool exempt set are user-tunable
@@ -346,10 +354,10 @@ export function checkToolCallLoop(
 
 /**
  * Record successful state progress so Guard 2 can decay on the next count.
- * File mutations (edit/write/…) and successful shell/exec calls (bash,
- * bg_shell, gsd_uat_exec, …) both count as progress (#1092, #1206). The caller
- * only invokes this for non-error results, so failing improvisation loops
- * (#783) never decay and still trip the per-tool cap.
+ * File mutations (edit/write/…), durable workflow mutations, and successful
+ * shell/exec calls (bash, bg_shell, gsd_uat_exec, …) count as progress (#1092,
+ * #1206, #1985). Failed results never decay, including workflow tools that
+ * report failure through `details.error` instead of the event error flag.
  */
 export function recordToolCallLoopMutation(toolName: string, details?: unknown): void {
   if (!enabled) return;
@@ -357,8 +365,19 @@ export function recordToolCallLoopMutation(toolName: string, details?: unknown):
     mutationEpoch++;
     return;
   }
-  if (!STATE_PROGRESSING_EXEC_TOOL_SET.has(toolName)) return;
-  if (toolName === "bg_shell" && details !== undefined && !isSuccessfulBgShellLoopProgress(details)) return;
+  if (STATE_PROGRESSING_EXEC_TOOL_SET.has(toolName)) {
+    if (toolName === "bg_shell" && details !== undefined && !isSuccessfulBgShellLoopProgress(details)) return;
+    mutationEpoch++;
+    return;
+  }
+  if (!DURABLE_WORKFLOW_MUTATING_TOOL_SET.has(canonicalWorkflowToolName(toolName))) return;
+  if (
+    details !== null
+    && typeof details === "object"
+    && Object.hasOwn(details, "error")
+    && (details as Record<string, unknown>).error !== null
+    && (details as Record<string, unknown>).error !== undefined
+  ) return;
   mutationEpoch++;
 }
 

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -253,6 +253,60 @@ console.log('\n── Loop guard: mutation progress decays per-tool counts (#109
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Durable workflow mutations count as progress (#1985)
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n── Loop guard: durable workflow mutations count as progress (#1985) ──');
+
+{
+  resetToolCallLoopGuard();
+
+  for (let i = 1; i <= 20; i++) {
+    const result = checkToolCallLoop('gsd_requirement_save', {
+      description: `Requirement ${i}`,
+    });
+    assert.ok(result.block === false, `successful requirement save ${i} should be allowed`);
+    assert.deepStrictEqual(
+      getToolCallCountForTool('gsd_requirement_save'),
+      1,
+      `requirement-save count should decay before call ${i}`,
+    );
+    recordToolCallLoopMutation('gsd_requirement_save', { id: `R${String(i).padStart(3, '0')}` });
+  }
+}
+
+{
+  resetToolCallLoopGuard();
+
+  for (let i = 1; i <= 6; i++) {
+    const result = checkToolCallLoop('gsd_requirement_save', {
+      description: `Failed requirement ${i}`,
+    });
+    assert.ok(result.block === false, `failed requirement save ${i} should be allowed up to the cap`);
+    recordToolCallLoopMutation('gsd_requirement_save', { error: 'db_unavailable' });
+  }
+  const blocked = checkToolCallLoop('gsd_requirement_save', {
+    description: 'Failed requirement 7',
+  });
+  assert.ok(blocked.block === true, '7th failed requirement save should be blocked by the per-tool cap');
+  assert.ok(blocked.reason?.includes('repeated tool'), 'failed saves should be caught by Guard 2');
+}
+
+{
+  resetToolCallLoopGuard();
+  const input = { description: 'Same requirement' };
+
+  for (let i = 1; i <= 4; i++) {
+    const result = checkToolCallLoop('gsd_requirement_save', input);
+    assert.ok(result.block === false, `identical requirement save ${i} should be allowed`);
+    recordToolCallLoopMutation('gsd_requirement_save', { id: `R${String(i).padStart(3, '0')}` });
+  }
+  const blocked = checkToolCallLoop('gsd_requirement_save', input);
+  assert.ok(blocked.block === true, '5th identical requirement save should still be blocked by Guard 1');
+  assert.ok(blocked.reason?.includes('identical args'), 'identical saves should be caught by Guard 1');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Successful shell/exec progress decays per-tool counts (#1206)
 // ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
- Durable workflow mutations now advance loop progress while failed and identical calls remain guarded.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1985
- [#1985 Loop guard blocks legitimate large-project planning after six requirement saves](https://github.com/open-gsd/gsd-pi/issues/1985)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1985-loop-guard-blocks-legitimate-large-proje-1787559310`