### PR TITLE
fix(issue): Authorized recovery prompt becomes stale after auto claims successor Attempt

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -179,7 +179,7 @@ function renderBlockingReworkFindingsBlock(mid: string, sid: string, tid: string
 export function renderTaskRecoveryDispatchContext(
   recovery: PendingTaskRecoveryContext,
 ): string {
-  const isResume = recovery.action === "resume";
+  const isAuthorizedContinuation = recovery.resumeAuthorized === true;
   let executionContract: string;
   switch (recovery.action) {
     case "retry":
@@ -196,8 +196,8 @@ export function renderTaskRecoveryDispatchContext(
         ? "The replacement Task plan is durable. Execute that replacement plan; do not repeat the invalid plan."
         : "The current Task plan is superseded. This planning unit must call `gsd_replan_task`, then stop before implementation.";
       break;
-    case "resume":
-      executionContract = "Apply and verify the explicitly authorized repair evidence before continuing the Task.";
+    case "continue":
+      executionContract = "Resume authorization is already durable and this dispatch owns its successor Attempt. Do not call `gsd_task_recovery_resume`; continue from the checkpoint.";
       break;
   }
   return [
@@ -210,7 +210,7 @@ export function renderTaskRecoveryDispatchContext(
     `**Failure:** ${recovery.summary}`,
     `**Rationale:** ${recovery.rationale}`,
     `**Work checkpoint:** ${recovery.checkpoint.checkpointId}`,
-    isResume
+    isAuthorizedContinuation
       ? `**Repair summary:** ${recovery.checkpoint.confirmedContext}`
       : `**Confirmed context:** ${recovery.checkpoint.confirmedContext}`,
     `**Unresolved:** ${recovery.checkpoint.unresolvedSummary}`,
@@ -221,7 +221,7 @@ export function renderTaskRecoveryDispatchContext(
     "```json",
     JSON.stringify(recovery.evidence, null, 2),
     "```",
-    ...(isResume
+    ...(isAuthorizedContinuation
       ? [
           "",
           "### Authorized Resume Evidence",

--- a/src/resources/extensions/gsd/task-recovery-domain-operation.ts
+++ b/src/resources/extensions/gsd/task-recovery-domain-operation.ts
@@ -117,8 +117,12 @@ export interface TaskRecoveryResumeReceipt {
   workCheckpointId: string;
 }
 
-export interface PendingTaskRecoveryContext {
-  action: Extract<RecoveryDecision["action"], "retry" | "repair" | "remediate" | "replan"> | "resume";
+type PendingTaskRecoveryAction = Extract<
+  RecoveryDecision["action"],
+  "retry" | "repair" | "remediate" | "replan"
+>;
+
+interface PendingTaskRecoveryContextBase {
   recoveryActionId: string;
   attemptId: string;
   resultId: string;
@@ -135,6 +139,14 @@ export interface PendingTaskRecoveryContext {
     suggestedNextAction: string;
   };
 }
+
+export type PendingTaskRecoveryContext = PendingTaskRecoveryContextBase & (
+  | {
+      action: PendingTaskRecoveryAction;
+      resumeAuthorized?: false;
+    }
+  | { action: "continue"; resumeAuthorized: true }
+);
 
 export interface BlockerResolutionReceipt {
   status: ReceiptStatus;
@@ -428,9 +440,9 @@ export function readPendingTaskRecoveryContext(
     checkpoint = resumed;
   }
   return {
-    action: storedAction === "abort"
-      ? "resume"
-      : storedAction as PendingTaskRecoveryContext["action"],
+    ...(storedAction === "abort"
+      ? { action: "continue" as const, resumeAuthorized: true as const }
+      : { action: storedAction as PendingTaskRecoveryAction }),
     recoveryActionId: String(stored["recovery_action_id"]),
     attemptId,
     resultId: String(stored["result_id"]),

--- a/src/resources/extensions/gsd/tests/task-recovery-convergence.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-convergence.test.ts
@@ -45,6 +45,7 @@ import { executeTaskReopen } from "../tools/workflow-tool-executors.ts";
 import { registerWorkflowTools } from "../../../../../packages/mcp-server/src/workflow-tools.ts";
 import { handleReopenTask } from "../tools/reopen-task.ts";
 import { writeReactiveExecuteBlocker } from "../auto-recovery.ts";
+import { buildCustomEngineIterationData } from "../auto/workflow-custom-engine-iteration.ts";
 import { shouldBlockAutoUnitToolCall } from "../auto-unit-tool-scope.ts";
 import { buildRunUatCanonicalToolNames } from "../tool-presentation-plan.ts";
 
@@ -424,6 +425,27 @@ test("agent recovery exhausts durably, resumes once, then passes host verificati
   assert.equal(resumed.status, "committed");
   assert.equal(readTaskRecoveryRoute(third.attemptId)?.resumeAuthorized, true);
 
+  const recoveryPrompt = (await buildCustomEngineIterationData({
+    step: {
+      unitType: "execute-task",
+      unitId: `M001/S01/${taskId}`,
+      prompt: "Continue the custom-engine Task.",
+    },
+    basePath,
+    canonicalProjectRoot: basePath,
+    currentMilestoneId: "M001",
+    deriveState: async () => ({
+      activeMilestone: { id: "M001", title: "Recovery" },
+      activeSlice: { id: "S01", title: "Convergence" },
+      activeTask: { id: taskId, title: "Task T01" },
+      phase: "executing",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      registry: [],
+    }),
+    logPostDerive: () => {},
+  })).prompt;
   const dispatchId4 = insertClaimedDispatch(taskId, 4);
   const claim4 = claimTaskAttempt({
     invocation: invocation("convergence/claim/4"),
@@ -433,6 +455,9 @@ test("agent recovery exhausts durably, resumes once, then passes host verificati
     coordinationDispatchId: dispatchId4,
     retryOfAttemptId: third.attemptId,
   });
+  assert.match(recoveryPrompt, /Required action:\*\* continue/);
+  assert.match(recoveryPrompt, /do not call `gsd_task_recovery_resume`/i);
+  assert.doesNotMatch(recoveryPrompt, /Required action:\*\* resume/);
   const settled4 = await stageTaskCompletion(
     completionInput(basePath, taskId, "convergence/settle/4"),
   );

--- a/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts
@@ -1192,7 +1192,8 @@ test("durable budget use survives retries and exhausts to agent abort", async ()
     sliceId: "S01",
     taskId: "T01",
   }), {
-    action: "resume",
+    action: "continue",
+    resumeAuthorized: true,
     recoveryActionId: third.recoveryActionId,
     attemptId: thirdFailure.attemptId,
     resultId: thirdFailure.resultId,
@@ -1246,12 +1247,14 @@ test("durable budget use survives retries and exhausts to agent abort", async ()
     logPostDerive: () => {},
   })).prompt;
   for (const prompt of [builtInPrompt, customPrompt]) {
-    assert.match(prompt, /Required action:\*\* resume/);
+    assert.match(prompt, /Required action:\*\* continue/);
     assert.match(prompt, new RegExp(summaries[2]));
     assert.match(prompt, /The missing tool surface was restored in the executor runtime/);
     assert.match(prompt, /open-gsd\/gsd-pi#1457/);
     assert.match(prompt, /focused recovery tests passed/);
-    assert.match(prompt, /apply and verify the explicitly authorized repair evidence/i);
+    assert.match(prompt, /resume authorization is already durable/i);
+    assert.match(prompt, /do not call `gsd_task_recovery_resume`/i);
+    assert.match(prompt, /continue from the checkpoint/i);
   }
   assert.match(customPrompt, /Non-authoritative Custom Engine Context/);
   assert.deepEqual(row(`
@@ -1391,7 +1394,7 @@ test("deterministic repair abort resumes after restart and is consumed by one su
     milestoneId: "M001",
     sliceId: "S01",
     taskId: "T01",
-  })?.action, "resume");
+  })?.action, "continue");
 
   const thirdDispatchId = insertClaimedDispatch(3);
   const third = claimTaskAttempt({


### PR DESCRIPTION
## Summary
- Fixed stale authorized recovery prompts and verified the continuation flow with focused tests and typechecking.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1988
- [#1988 Authorized recovery prompt becomes stale after auto claims successor Attempt](https://github.com/open-gsd/gsd-pi/issues/1988)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1988-authorized-recovery-prompt-becomes-stale-1787575270`