### PR TITLE
perf(verify-merge): heavy-gate classifier and compile-once optimization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,13 @@ CI is tiered to match local scripts. See [Test confidence stack](docs/dev/test-c
 ```bash
 pnpm run verify:fast    # ~1–3 min: same scans as CI fast-gates (secrets, docs injection, skill refs)
 pnpm run verify:pr      # ~5–15 min: fast inner loop — build:core → typecheck:extensions → test:unit
-pnpm run verify:merge   # ~20–40 min: CI PR blocking parity (native test addon, build, all test jobs, validate-pack)
+pnpm run verify:merge:needed -- --base upstream/main  # decide whether this diff really needs the full merge gate
+pnpm run verify:merge   # ~20–60+ min on large diffs: CI PR blocking parity (native test addon, build, all test jobs, validate-pack)
 pnpm run verify:full    # Alias for verify:merge
 pnpm run audit:test-confidence   # Inventory report: runners, tiers, thin areas
 ```
 
-Run `verify:fast` on every push. While iterating, `verify:pr` is enough for a quick check. **Before requesting review** on a PR that touches `src/`, `packages/`, or tests, run **`verify:merge`** — a passing `verify:pr` alone does not match what CI requires to merge.
+Run `verify:fast` on every push. While iterating, `verify:pr` is enough for a quick check. Before requesting review, run `pnpm run verify:merge:needed -- --base upstream/main` first. If it reports that the diff is `heavy-code-changed=true`, run `verify:merge`; otherwise `verify:fast` plus targeted checks is enough unless you want extra confidence. A passing `verify:pr` alone does not match what CI requires when the heavy Linux gate will run.
 
 `verify:merge` builds the native engine with `pnpm run build:native:test` (needs Rust/`rustc`) and copies `native/addon/*.node` into `dist-test/native/addon/` with `GSD_NATIVE_PREFER_LOCAL=1`, matching CI. Without that, compiled unit tests fail on a fresh checkout because the published `@opengsd/engine-*` binary can lag N-API exports such as `ProjectionRootIdentityLock`.
 
@@ -114,7 +115,7 @@ git fetch origin
 git rebase origin/main
 ```
 
-CI must pass before your PR will be reviewed. Run `pnpm run verify:fast` on every push and `pnpm run verify:merge` before requesting review on code changes.
+CI must pass before your PR will be reviewed. Run `pnpm run verify:fast` on every push, use `pnpm run verify:merge:needed -- --base upstream/main` to decide whether the full local merge gate is warranted, and reserve `pnpm run verify:merge` for diffs that would trigger CI's heavy Linux build/test gate or when you explicitly want the extra confidence.
 
 ## Working with GSD (team workflow)
 
@@ -163,7 +164,7 @@ If this is a non-trivial change, explain the design and any alternatives you con
 ### Requirements
 
 - **CI must pass.** If your PR breaks tests, fix them before requesting review.
-- **Run `pnpm run verify:merge` locally before requesting review.** Use `verify:pr` only as a fast inner loop. See [Local development](#local-development) and [Test confidence stack](docs/dev/test-confidence-stack.md).
+- **Run `pnpm run verify:merge` locally before requesting review only when `pnpm run verify:merge:needed -- --base upstream/main` says the diff triggers the heavy CI gate.** Use `verify:pr` only as a fast inner loop. See [Local development](#local-development) and [Test confidence stack](docs/dev/test-confidence-stack.md).
 - **One concern per PR.** A bug fix is a bug fix. A feature is a feature. Don't bundle unrelated changes.
 - **No drive-by formatting.** Don't reformat code you didn't change. Don't reorder imports in files you're not modifying.
 - **Link issues when relevant.** Not mandatory for every PR, but if an issue exists, reference it.

--- a/docs/dev/ci-cd-pipeline.md
+++ b/docs/dev/ci-cd-pipeline.md
@@ -110,7 +110,7 @@ See [Test confidence stack](./test-confidence-stack.md) for the code-area → ru
 | Platform | Docker e2e step in `build`, `windows-portability` | Path-gated; Docker runs only when `docker-changed=true`, Windows runs only when portability paths change | Yes when triggered |
 | Platform (warn) | Windows e2e smoke step inside `windows-portability` | `windows-e2e-changed=true` | **No** (`continue-on-error: true`) |
 
-**Local before review:** `npm run verify:merge` — sequential parity with PR blocking jobs above (except path-gated platform jobs).
+**Local before review:** run `npm run verify:merge:needed -- --base upstream/main` first. If it reports `heavy-code-changed=true`, then run `npm run verify:merge` for sequential parity with the PR-blocking Linux jobs above (except path-gated platform jobs). If not, `verify:fast` plus targeted checks is usually sufficient.
 
 **Branch protection:** Required checks should include `fast-gates` and `build` for full Linux merge confidence. Keep `windows-portability` required only if GitHub branch protection is configured to handle skipped path-gated checks correctly.
 

--- a/docs/dev/test-confidence-stack.md
+++ b/docs/dev/test-confidence-stack.md
@@ -8,7 +8,8 @@ This document maps **what protects what** across local scripts and CI. Use it wh
 |------|-------------|---------------|---------------|
 | Every push | `npm run verify:fast` | `fast-gates` | Yes |
 | Fast iteration while editing | `npm run verify:pr` | Partial `build` job (`build:core` + unit tests) | No — not sufficient alone |
-| **Before requesting PR review** | **`npm run verify:merge`** | `build` | Yes (when `heavy-code-changed`) |
+| Decide whether the heavy merge gate is needed | `npm run verify:merge:needed -- --base upstream/main` | `fast-gates` path classification | No — advisory |
+| **Before requesting PR review on heavy-code changes** | **`npm run verify:merge`** | `build` | Yes (when `heavy-code-changed`) |
 | Full evaluation baseline | `npm run test:evaluation` | Partial (blocking tiers + auxiliary) | No |
 | Repo-wide coverage report | `npm run test:coverage:full` | `Coverage report` workflow | Separate workflow |
 | Coverage thresholds | `npm run test:coverage` | `Coverage report` workflow | Separate workflow |
@@ -64,7 +65,7 @@ When `heavy-code-changed=true`, CI runs the Linux build and test stack in one jo
 Native package tests are skipped in the main Linux package-test step unless native/portability paths changed; otherwise a full Rust native rebuild can dominate unrelated CI runs.
 Compiled package tests use Node's `--test-force-exit` so leaked handles in one package do not idle until the CI watchdog fires after all assertions pass.
 
-Local parity: **`npm run verify:merge`** (runs the same npm scripts sequentially, including `verify:extension-coverage`). It also builds `pnpm run build:native:test` and stages `dist-test/native/addon/` with `GSD_NATIVE_PREFER_LOCAL=1`, matching the CI `build` job. Requires a local Rust toolchain.
+Local parity: **`npm run verify:merge`** (runs the same npm scripts sequentially, including `verify:extension-coverage`). It also builds `pnpm run build:native:test` and stages `dist-test/native/addon/` with `GSD_NATIVE_PREFER_LOCAL=1`, matching the CI `build` job; requires a local Rust toolchain. Use `npm run verify:merge:needed -- --base upstream/main` first so you only pay for it when the diff would actually trigger CI's heavy Linux gate.
 
 `verify:fast` also runs:
 
@@ -88,7 +89,7 @@ Local parity: **`npm run verify:merge`** (runs the same npm scripts sequentially
 
 `verify:pr` is a **fast inner loop** (~5–15 min): `build:core` → `typecheck:extensions` → `test:unit`.
 
-It is intentionally lighter than CI. Do not treat a passing `verify:pr` as merge-ready. Use `verify:merge` before requesting review.
+It is intentionally lighter than CI. Do not treat a passing `verify:pr` as merge-ready when `verify:merge:needed` says the diff triggers the heavy Linux gate. Start with `verify:merge:needed`, then pay for `verify:merge` only when the path classification says it matters or when you want extra confidence.
 
 `verify:full` is an alias for `verify:merge` (kept for backward compatibility).
 

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "verify:fast": "pnpm install --frozen-lockfile --ignore-scripts && bash scripts/ci-fast-gates.sh",
     "verify:pr": "pnpm run build:core && pnpm run typecheck:extensions && pnpm run test:unit && pnpm run gate:lifecycle-shadow-no-cutover",
     "verify:merge": "bash scripts/verify-merge.sh",
+    "verify:merge:needed": "bash scripts/verify-merge-needed.sh",
     "verify:full": "pnpm run verify:merge",
     "pipeline:version-stamp": "node scripts/version-stamp.mjs",
     "release:changelog": "node scripts/generate-changelog.mjs",

--- a/scripts/__tests__/verify-merge.test.mjs
+++ b/scripts/__tests__/verify-merge.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import test from "node:test";
+
+const verifyMergeScript = readFileSync("scripts/verify-merge.sh", "utf8");
+const verifyMergeNeededScript = readFileSync("scripts/verify-merge-needed.sh", "utf8");
+
+test("verify:merge compiles test artifacts once and reuses compiled suites", () => {
+  assert.equal((verifyMergeScript.match(/pnpm run test:compile/g) ?? []).length, 1);
+  assert.match(verifyMergeScript, /pnpm run test:unit:compiled/);
+  assert.match(verifyMergeScript, /pnpm run test:packages:compiled/);
+  assert.doesNotMatch(verifyMergeScript, /pnpm run test:unit\b(?!:compiled)/);
+  assert.doesNotMatch(verifyMergeScript, /pnpm run test:packages\b(?!:compiled)/);
+});
+
+test("verify:merge uses the stale-aware web host build path", () => {
+  assert.match(verifyMergeScript, /node scripts\/build-web-if-stale\.cjs/);
+  assert.doesNotMatch(verifyMergeScript, /pnpm run build:web-host/);
+});
+
+test("verify:merge mirrors CI portability gating for native package tests", () => {
+  assert.match(verifyMergeScript, /bash scripts\/ci-classify-changes\.sh/);
+  assert.ok(
+    verifyMergeScript.includes("PORTABILITY_CHANGED=\"$(sed -n 's/^portability-changed=//p'"),
+  );
+  assert.match(verifyMergeScript, /GSD_SKIP_NATIVE_PACKAGE_TESTS=0 pnpm run test:packages:compiled/);
+  assert.match(verifyMergeScript, /GSD_SKIP_NATIVE_PACKAGE_TESTS=1 pnpm run test:packages:compiled/);
+});
+
+test("verify:merge preserves pre-existing required checks", () => {
+  assert.match(verifyMergeScript, /pnpm --filter @gsd\/pi-ai test/);
+  assert.match(verifyMergeScript, /pnpm run test:integration/);
+  assert.match(verifyMergeScript, /pnpm run test:e2e/);
+  assert.match(verifyMergeScript, /pnpm run validate-pack/);
+  assert.match(verifyMergeScript, /pnpm run verify:workspace-coverage/);
+  assert.match(verifyMergeScript, /pnpm run verify:extension-coverage/);
+});
+
+test("verify:merge:needed tolerates the literal `--` that `pnpm run ... -- --base` forwards", () => {
+  // Reproduces the exact invocation documented in CONTRIBUTING.md / package.json:
+  // `pnpm run verify:merge:needed -- --base <ref> --head <ref>` forwards a literal
+  // leading `--` token to the underlying script (npm/pnpm do not strip it).
+  const result = spawnSync(
+    "bash",
+    ["scripts/verify-merge-needed.sh", "--", "--base", "HEAD", "--head", "HEAD"],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Base ref: HEAD/);
+  assert.match(result.stdout, /Head ref: HEAD/);
+});
+
+test("verify:merge:needed script is exposed in package.json and reuses CI classification", () => {
+  const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+  assert.equal(pkg.scripts["verify:merge:needed"], "bash scripts/verify-merge-needed.sh");
+  assert.match(verifyMergeNeededScript, /bash scripts\/ci-classify-changes\.sh/);
+  assert.match(verifyMergeNeededScript, /VERIFY_MERGE_VERBOSE/);
+  assert.match(verifyMergeNeededScript, /verify:merge is not required/);
+  assert.match(verifyMergeNeededScript, /verify:merge is required/);
+});
+
+test("verify:merge:needed rejects --base/--head with no value instead of an unbound-variable crash", () => {
+  for (const flag of ["--base", "--head"]) {
+    const result = spawnSync("bash", ["scripts/verify-merge-needed.sh", flag], { encoding: "utf8" });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, new RegExp(`${flag} requires a value`));
+  }
+});
+
+test("verify:merge:needed rejects unknown flags with a usage message", () => {
+  const result = spawnSync("bash", ["scripts/verify-merge-needed.sh", "--nope"], { encoding: "utf8" });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /usage: bash scripts\/verify-merge-needed\.sh/);
+});
+
+test("verify:merge:needed warns when the working tree has uncommitted/untracked changes", () => {
+  const scratchFile = "scripts/__tests__/.verify-merge-needed-scratch-file";
+  writeFileSync(scratchFile, "scratch\n");
+  try {
+    const result = spawnSync(
+      "bash",
+      ["scripts/verify-merge-needed.sh", "--base", "HEAD", "--head", "HEAD"],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /uncommitted or untracked changes present/);
+  } finally {
+    unlinkSync(scratchFile);
+  }
+});
+
+test("verify:merge:needed does not warn about the working tree when --head is an explicit non-HEAD ref", () => {
+  const scratchFile = "scripts/__tests__/.verify-merge-needed-scratch-file-2";
+  writeFileSync(scratchFile, "scratch\n");
+  try {
+    const result = spawnSync(
+      "bash",
+      ["scripts/verify-merge-needed.sh", "--base", "HEAD~1", "--head", "HEAD~1"],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stderr, /uncommitted or untracked changes present/);
+  } finally {
+    unlinkSync(scratchFile);
+  }
+});
+
+test("verify:merge:needed fails safe (does not crash) when classification itself fails", (t) => {
+  // Reproduces the exact CI failure this was written to fix: on a shallow/single-commit
+  // checkout, `git diff --name-only <base> <head>` AND ci-classify-changes.sh's own
+  // `HEAD~1` fallback both fail with exit 128 ("unknown revision"). A normal, full-history
+  // local checkout can't reproduce that fallback failure organically (HEAD~1 always
+  // resolves here), so this test forces the same failure mode directly by temporarily
+  // swapping in a classify script that always fails, and restores the original after.
+  const classifyPath = "scripts/ci-classify-changes.sh";
+  const original = readFileSync(classifyPath, "utf8");
+  writeFileSync(classifyPath, "#!/usr/bin/env bash\nexit 1\n");
+  t.after(() => writeFileSync(classifyPath, original));
+
+  const result = spawnSync(
+    "bash",
+    ["scripts/verify-merge-needed.sh", "--base", "HEAD~1", "--head", "HEAD"],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /classification failed/);
+  assert.match(result.stdout, /Recommendation: verify:merge is required/);
+});
+
+test("verify:merge and verify:merge:needed both wrap the classify call so a non-zero exit can't crash the script", () => {
+  for (const script of [verifyMergeScript, verifyMergeNeededScript]) {
+    assert.match(script, /bash scripts\/ci-classify-changes\.sh.*\|\| CLASSIFY_EXIT=\$\?/s);
+    assert.match(script, /CLASSIFY_EXIT.*-ne 0.*-s.*CLASSIFY_OUTPUT/s);
+  }
+});

--- a/scripts/verify-merge-needed.sh
+++ b/scripts/verify-merge-needed.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Advisory decision helper for whether verify:merge is worth running locally.
+# Known caveat (pre-existing in scripts/ci-classify-changes.sh, not fixed here):
+# if BASE_REF/HEAD_REF don't resolve, the classifier silently falls back to
+# `HEAD~1`, which can under-report a multi-commit diff. When in doubt, or on a
+# shallow/unusual checkout, just run verify:merge directly.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+DEFAULT_BASE_REF="upstream/main"
+if ! git rev-parse --verify "$DEFAULT_BASE_REF" >/dev/null 2>&1; then
+  DEFAULT_BASE_REF="origin/main"
+fi
+
+BASE_REF="$DEFAULT_BASE_REF"
+HEAD_REF="HEAD"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --)
+      # pnpm/npm forward a literal `--` from `pnpm run ... -- --base ...`; skip it.
+      shift
+      ;;
+    --base)
+      [ $# -ge 2 ] || { echo "error: --base requires a value" >&2; exit 2; }
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --head)
+      [ $# -ge 2 ] || { echo "error: --head requires a value" >&2; exit 2; }
+      HEAD_REF="$2"
+      shift 2
+      ;;
+    *)
+      echo "usage: bash scripts/verify-merge-needed.sh [--base <ref>] [--head <ref>]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+CLASSIFY_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/verify-merge-needed.XXXXXX")"
+cleanup() {
+  rm -f "$CLASSIFY_OUTPUT"
+}
+trap cleanup EXIT
+
+echo "── verify:merge scope check ──"
+echo "Base ref: $BASE_REF"
+echo "Head ref: $HEAD_REF"
+
+# Advisory only: classification is diff-based (committed BASE..HEAD), so it can't see
+# staged/unstaged/untracked changes. Warn rather than fail closed so this stays usable
+# mid-edit; commit (or stash) before trusting the recommendation for real.
+if [ "$HEAD_REF" = "HEAD" ] && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+  echo "Warning: uncommitted or untracked changes present -- this recommendation only reflects committed history ($BASE_REF..HEAD)." >&2
+fi
+
+CLASSIFY_EXIT=0
+if [ "${VERIFY_MERGE_VERBOSE:-0}" = "1" ]; then
+  GITHUB_OUTPUT="$CLASSIFY_OUTPUT" \
+    EVENT_NAME=pull_request \
+    PR_BASE_SHA="$BASE_REF" \
+    HEAD_SHA="$HEAD_REF" \
+    bash scripts/ci-classify-changes.sh || CLASSIFY_EXIT=$?
+else
+  GITHUB_OUTPUT="$CLASSIFY_OUTPUT" \
+    EVENT_NAME=pull_request \
+    PR_BASE_SHA="$BASE_REF" \
+    HEAD_SHA="$HEAD_REF" \
+    bash scripts/ci-classify-changes.sh >/dev/null 2>&1 || CLASSIFY_EXIT=$?
+fi
+
+# Fail SAFE, not closed: see the matching comment in verify-merge.sh.
+if [ "$CLASSIFY_EXIT" -ne 0 ] || [ ! -s "$CLASSIFY_OUTPUT" ]; then
+  echo "Warning: change classification failed (base ref '$BASE_REF' may not resolve in this checkout, e.g. a shallow clone) -- defaulting to recommending verify:merge." >&2
+  HEAVY_CODE_CHANGED="true"
+  PORTABILITY_CHANGED="true"
+  DOCKER_CHANGED="true"
+else
+  HEAVY_CODE_CHANGED="$(sed -n 's/^heavy-code-changed=//p' "$CLASSIFY_OUTPUT" | tail -n 1)"
+  PORTABILITY_CHANGED="$(sed -n 's/^portability-changed=//p' "$CLASSIFY_OUTPUT" | tail -n 1)"
+  DOCKER_CHANGED="$(sed -n 's/^docker-changed=//p' "$CLASSIFY_OUTPUT" | tail -n 1)"
+  [ -n "$HEAVY_CODE_CHANGED" ] || HEAVY_CODE_CHANGED="true"
+  [ -n "$PORTABILITY_CHANGED" ] || PORTABILITY_CHANGED="true"
+  [ -n "$DOCKER_CHANGED" ] || DOCKER_CHANGED="true"
+fi
+
+if [ "$HEAVY_CODE_CHANGED" = "true" ]; then
+  echo "Recommendation: verify:merge is required before review for this diff."
+else
+  echo "Recommendation: verify:merge is not required for CI parity for this diff."
+  echo "Recommended minimum: pnpm run verify:fast plus targeted checks for touched files."
+fi
+
+if [ "$PORTABILITY_CHANGED" = "true" ]; then
+  echo "Additional note: portability-sensitive paths changed; expect Windows/native coverage to matter."
+fi
+
+if [ "$DOCKER_CHANGED" = "true" ]; then
+  echo "Additional note: docker-sensitive paths changed; also run pnpm run test:e2e:docker before review."
+fi
+
+if [ "${VERIFY_MERGE_VERBOSE:-0}" = "1" ]; then
+  echo "Verbose mode preserved the raw change classification output above."
+fi

--- a/scripts/verify-merge.sh
+++ b/scripts/verify-merge.sh
@@ -6,7 +6,63 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+CLASSIFY_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/verify-merge-classify.XXXXXX")"
+cleanup() {
+	rm -f "$CLASSIFY_OUTPUT"
+}
+trap cleanup EXIT
+
+DEFAULT_BASE_REF="upstream/main"
+if ! git rev-parse --verify "$DEFAULT_BASE_REF" >/dev/null 2>&1; then
+	DEFAULT_BASE_REF="origin/main"
+fi
+VERIFY_MERGE_BASE_REF="${VERIFY_MERGE_BASE_REF:-$DEFAULT_BASE_REF}"
+VERIFY_MERGE_HEAD_REF="${VERIFY_MERGE_HEAD_REF:-HEAD}"
+
 echo "── verify:merge (CI PR blocking parity) ──"
+
+echo "── classify changes vs ${VERIFY_MERGE_BASE_REF} ──"
+CLASSIFY_EXIT=0
+if [ "${VERIFY_MERGE_VERBOSE:-0}" = "1" ]; then
+	GITHUB_OUTPUT="$CLASSIFY_OUTPUT" \
+		EVENT_NAME=pull_request \
+		PR_BASE_SHA="$VERIFY_MERGE_BASE_REF" \
+		HEAD_SHA="$VERIFY_MERGE_HEAD_REF" \
+		bash scripts/ci-classify-changes.sh || CLASSIFY_EXIT=$?
+else
+	GITHUB_OUTPUT="$CLASSIFY_OUTPUT" \
+		EVENT_NAME=pull_request \
+		PR_BASE_SHA="$VERIFY_MERGE_BASE_REF" \
+		HEAD_SHA="$VERIFY_MERGE_HEAD_REF" \
+		bash scripts/ci-classify-changes.sh >/dev/null 2>&1 || CLASSIFY_EXIT=$?
+fi
+
+# Fail SAFE, not closed: an unresolvable base ref (e.g. a shallow/single-commit
+# checkout without origin/main fetched) must never silently skip real coverage.
+# If classification didn't produce a trustworthy answer, default every gate to
+# the heavy/full path instead of aborting or guessing "nothing changed".
+if [ "$CLASSIFY_EXIT" -ne 0 ] || [ ! -s "$CLASSIFY_OUTPUT" ]; then
+	echo "verify:merge note: change classification failed (base ref '${VERIFY_MERGE_BASE_REF}' may not resolve in this checkout, e.g. a shallow clone) -- defaulting to the safe/heavy path for every gate below."
+	PORTABILITY_CHANGED="true"
+	DOCKER_CHANGED="true"
+	HEAVY_CODE_CHANGED="true"
+else
+	PORTABILITY_CHANGED="$(sed -n 's/^portability-changed=//p' "$CLASSIFY_OUTPUT" | tail -n 1)"
+	DOCKER_CHANGED="$(sed -n 's/^docker-changed=//p' "$CLASSIFY_OUTPUT" | tail -n 1)"
+	HEAVY_CODE_CHANGED="$(sed -n 's/^heavy-code-changed=//p' "$CLASSIFY_OUTPUT" | tail -n 1)"
+	[ -n "$PORTABILITY_CHANGED" ] || PORTABILITY_CHANGED="true"
+	[ -n "$DOCKER_CHANGED" ] || DOCKER_CHANGED="true"
+	[ -n "$HEAVY_CODE_CHANGED" ] || HEAVY_CODE_CHANGED="true"
+fi
+
+if [ "$HEAVY_CODE_CHANGED" != "true" ]; then
+	echo "verify:merge note: CI would skip heavy build/test jobs for this diff; prefer verify:fast unless you need extra confidence."
+else
+	echo "verify:merge note: CI would run the heavy Linux build/test gate for this diff."
+fi
+if [ "$DOCKER_CHANGED" = "true" ]; then
+	echo "verify:merge note: docker paths changed; local CI parity still also needs pnpm run test:e2e:docker."
+fi
 
 echo "── native addon from source (test-fault-injection) ──"
 if ! command -v rustc >/dev/null 2>&1; then
@@ -17,12 +73,14 @@ if ! command -v rustc >/dev/null 2>&1; then
 fi
 pnpm run build:native:test
 
+echo "── install dependencies ──"
+pnpm install --frozen-lockfile
+
 echo "── build:core ──"
 pnpm run build:core
 
-echo "── web host (required by validate-pack) ──"
-pnpm install --frozen-lockfile
-pnpm run build:web-host
+echo "── web host (stale-aware; required by validate-pack) ──"
+node scripts/build-web-if-stale.cjs
 
 echo "── typecheck:extensions ──"
 pnpm run typecheck:extensions
@@ -36,15 +94,21 @@ pnpm run verify:workspace-coverage
 echo "── verify:extension-coverage ──"
 pnpm run verify:extension-coverage
 
-echo "── test:unit ──"
+echo "── compile test artifacts ──"
 pnpm run test:compile
+
+echo "── test:unit ──"
 mkdir -p dist-test/native/addon
 cp native/addon/*.node dist-test/native/addon/
 export GSD_NATIVE_PREFER_LOCAL=1
 pnpm run test:unit:compiled
 
 echo "── test:packages ──"
-pnpm run test:packages
+if [ "$PORTABILITY_CHANGED" = "true" ]; then
+	GSD_SKIP_NATIVE_PACKAGE_TESTS=0 pnpm run test:packages:compiled
+else
+	GSD_SKIP_NATIVE_PACKAGE_TESTS=1 pnpm run test:packages:compiled
+fi
 
 echo "── test:pi-ai (vitest) ──"
 pnpm --filter @gsd/pi-ai test


### PR DESCRIPTION
## TL;DR

**What:** Adds `pnpm run verify:merge:needed` — a fast, advisory pre-check that classifies a diff against CI's own path-based heavy-gate logic (`scripts/ci-classify-changes.sh`) and reports whether the expensive `verify:merge` local gate is actually worth running. Also optimizes `verify:merge` itself: installs dependencies once (was duplicated), builds the web host only when stale (was unconditional), compiles test artifacts once and reuses the compiled output for both `test:unit` and `test:packages` (was recompiled per step), and skips the full native package-test suite unless portability-sensitive paths changed — mirroring the same gating CI's own `build` job already applies.

**Why:** `verify:merge` is CI-parity-heavy by design (~20-60+ min on large diffs), but most day-to-day diffs (docs, a single extension file, a test) never touch anything CI's own heavy Linux gate cares about. Today there's no cheap way to know that before paying for the full run.

**How:** `scripts/verify-merge-needed.sh` is a new, self-contained decision script: it reuses the exact same `ci-classify-changes.sh` CI already runs for path-based gating, so its answer is never a second, drifting heuristic. It's advisory only — diff-based, so it warns (not fails) when the working tree has uncommitted/untracked changes it can't see, and fails *safe* (defaults every gate to the heavy/full path) rather than crashing if a base ref can't be resolved (e.g. a shallow checkout), never silently skipping real coverage.

## What

- New `scripts/verify-merge-needed.sh` (`pnpm run verify:merge:needed -- --base <ref> --head <ref>`): runs the classifier, prints a plain recommendation, warns on a dirty working tree, guards `--base`/`--head` against a missing value, and fails safe if classification itself fails.
- `scripts/verify-merge.sh`: runs the same classifier for context (printed, not enforced — this script is what CI parity actually requires), installs once, builds the web host via the existing stale-aware helper instead of unconditionally, compiles test artifacts once, and gates `test:packages` behind the same `portability-changed` signal CI uses. Every pre-existing required step is preserved unchanged (native-addon build, `validate-pack`, workspace/extension coverage, the `pi-ai` vitest suite, integration, e2e).
- `scripts/__tests__/verify-merge.test.mjs`: 12 tests covering the optimization invariants (no step silently dropped, compile-once, install-once), the `--` forwarding behavior `pnpm run ... -- --base` relies on, the new value guards, the dirty-tree warning, and the fail-safe classify wrapper (reproduces the exact CI failure this was written to fix, via a temporarily-swapped broken classify script, then restores it).
- Documents the new script in `CONTRIBUTING.md` and the two `docs/dev/` guides.

## Review process

This branch sat untracked locally for a few days before being rebased onto current `upstream/main`, which required resolving a real merge conflict with an unrelated, newer upstream fix (native test-fault-injection addon build on a fresh checkout, gated behind a `rustc` check) — both pieces of logic are preserved.

Cross-AI reviewed before submission: `codex review --commit` (codex-cli) and an independent Claude Opus 4.6 pass, run separately. Real, non-overlapping findings from both were fixed:
- Missing value guard for `--base`/`--head` (would crash with an unbound-variable error instead of a clean usage message).
- The advisory classifier couldn't see uncommitted/untracked changes — now warns instead of silently trusting stale committed history.
- **The classify step could crash `verify:merge`/`verify:merge:needed` outright** on a checkout where the base ref can't be resolved (e.g. shallow clone) — `ci-classify-changes.sh`'s own `HEAD~1` fallback also fails with no parent commit. This was caught for real during exact-SHA remote verification (see below) and fixed by making both scripts fail *safe* (default to the heavy/full path) instead of propagating the crash.

Two additional review findings were verified accurate but deliberately left out of scope (pre-existing behavior in files this PR doesn't otherwise touch, not this PR's concern): `scripts/build-web-if-stale.cjs`'s mtime-based staleness check doesn't cover `packages/*`, the lockfile, or `scripts/stage-web-standalone.cjs`; `scripts/ci-classify-changes.sh` itself falls back to `HEAD~1` rather than failing loudly when a base ref is unresolvable (the specific behavior that surfaced the classify-crash bug above, worked around at the call sites rather than changed at the source, to keep this PR to one concern).

## Validation

- Local: `bash -n` syntax-checked both scripts; `node --test scripts/__tests__/verify-merge.test.mjs` — 12/12 pass.
- Remote, exact-SHA (`pimmink/gsd-pi-ci`, `remote-full-gate.yml`): both `verify-pr (literal)` and `verify-merge (literal)` — the actual unmodified scripts, run for real against this exact commit — came back fully green (19m41s and 33m36s respectively). An earlier dispatch against the pre-fix commit reproduced the shallow-checkout classify crash live, confirming the bug was real before the fix, not just theoretical.
