### PR TITLE
fix(issue): [Bug] plan-slice timeout writes invalid canonical PLAN then enters finalize-retry wedge

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -51,7 +51,7 @@ import {
 import { execFileSync } from "node:child_process";
 
 import { LAYOUT_SEGMENTS } from "./layout-policy.js";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import {
   resolveExpectedArtifactPath,
   diagnoseExpectedArtifact,
@@ -449,7 +449,26 @@ export function writeReactiveExecuteBlocker(
 }
 
 /**
+ * Whether a milestone already has canonical Domain-Operation lifecycle
+ * history. Adopted milestones must not have a fabricated blocker slice
+ * inserted to paper over a stuck plan-milestone unit (fail-closed).
+ */
+function hasAdoptedMilestoneHistory(milestoneId: string): boolean {
+  return Boolean(getDb().prepare(`
+    SELECT 1 AS adopted
+    FROM workflow_item_lifecycles
+    WHERE item_kind = 'milestone'
+      AND milestone_id = :milestone_id
+      AND slice_id IS NULL
+      AND task_id IS NULL
+  `).get({ ":milestone_id": milestoneId }));
+}
+
+/**
  * Write a placeholder artifact so recovery can surface a stuck unit.
+ * Task and slice-plan completion projections use diagnostic sidecars
+ * instead of canonical artifact paths.
+
  * Returns the relative path written, or null if the path couldn't be resolved.
  */
 export function writeBlockerPlaceholder(
@@ -463,15 +482,24 @@ export function writeBlockerPlaceholder(
   if (!canonicalArtifactPath) return null;
   const blockerArtifactPath = unitType === "execute-task"
     ? canonicalArtifactPath.replace(/-SUMMARY\.md$/u, "-RECOVERY-BLOCKER.md")
-    : canonicalArtifactPath;
-  // A Task blocker must never occupy its canonical completion projection.
-  if (unitType === "execute-task" && blockerArtifactPath === canonicalArtifactPath) return null;
+    : unitType === "plan-slice"
+      ? canonicalArtifactPath.replace(/-PLAN\.md$/u, "-RECOVERY-BLOCKER.md")
+      : canonicalArtifactPath;
+  // DB-backed Task and slice-plan blockers must never occupy their canonical
+  // completion projections.
+  if (
+    (unitType === "execute-task" || unitType === "plan-slice") &&
+    blockerArtifactPath === canonicalArtifactPath
+  ) return null;
   const dir = dirname(blockerArtifactPath);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   const recoveryLine = unitType === "research-project"
     ? "This placeholder was written by auto-mode so the project research gate can stop fail-closed."
     : unitType === "plan-milestone"
       ? "This diagnostic records a fail-closed planning gate; it is not a roadmap or completed milestone work."
+      : unitType === "plan-slice"
+        ? "This diagnostic does not complete slice planning; auto-mode must remain paused until a valid plan is persisted."
+
       : "This placeholder was written by auto-mode so the pipeline can advance.";
   const content = [
     `# BLOCKER — auto-mode recovery failed`,
@@ -525,7 +553,9 @@ export function writeBlockerPlaceholder(
     }
   }
 
-  return diagnoseExpectedArtifact(unitType, unitId, base);
+  return unitType === "plan-slice"
+    ? relative(base, blockerArtifactPath)
+    : diagnoseExpectedArtifact(unitType, unitId, base);
 }
 
 // ─── Merge State Reconciliation ───────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -290,18 +290,20 @@ export async function recoverTimedOutUnit(
     return "recovered";
   }
 
-  // #4175: For complete-milestone, never write a blocker placeholder — a stub
-  // SUMMARY has no recovery value (milestone is terminal), it does not update
-  // DB status, and downstream merge paths can treat the stub as a legitimate
-  // completion signal. Pause instead so the worktree branch is preserved.
-  if (unitType === "complete-milestone") {
+  // #4175/#1995: Never replace canonical lifecycle projections with blocker
+  // placeholders. They cannot update the required DB state, so finalization
+  // rejects them and retries unchanged input indefinitely. Pause fail-closed.
+  if (unitType === "complete-milestone" || unitType === "plan-slice") {
     writeUnitRuntimeRecord(basePath, unitType, unitId, currentUnitStartedAt, {
       phase: "paused",
       recoveryAttempts: recoveryAttempts + 1,
       lastRecoveryReason: reason,
     });
+    const message = unitType === "complete-milestone"
+      ? `Milestone ${unitId} ${reason}-recovery exhausted ${maxRecoveryAttempts} attempt(s) — worktree branch preserved. Re-run /gsd auto once blockers are resolved.`
+      : `Slice plan ${unitId} ${reason}-recovery exhausted ${maxRecoveryAttempts} attempt(s) — canonical PLAN preserved. Re-run /gsd auto once blockers are resolved.`;
     ctx.ui.notify(
-      `Milestone ${unitId} ${reason}-recovery exhausted ${maxRecoveryAttempts} attempt(s) — worktree branch preserved. Re-run /gsd auto once blockers are resolved.`,
+      message,
       "error",
     );
     return "paused";

--- a/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
@@ -12,11 +12,15 @@ import {
   closeDatabase,
   getMilestoneSlices,
   getPlanMilestoneRecoveryBlock,
+  getSlice,
+  getSliceTasks,
   insertMilestone,
   insertSlice,
   openDatabase,
 } from "../../gsd-db.ts";
 import { deriveState, invalidateStateCache } from "../../state.ts";
+import { recoverTimedOutUnit } from "../../auto-timeout-recovery.ts";
+import { readUnitRuntimeRecord, writeUnitRuntimeRecord } from "../../unit-runtime.ts";
 import { drainLogs, setStderrLoggingEnabled, _resetLogs } from "../../workflow-logger.ts";
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
@@ -153,6 +157,67 @@ test('writeBlockerPlaceholder: writes file for research-milestone', () => {
   } finally {
     cleanup(base);
   }
+});
+
+test('writeBlockerPlaceholder: plan-slice diagnostics preserve the canonical PLAN', (t) => {
+  const base = createFixtureBase();
+  t.after(() => cleanup(base));
+  const planPath = resolveExpectedArtifactPath("plan-slice", "M001/S01", base)!;
+  const blockerPath = planPath.replace(/-PLAN\.md$/u, "-RECOVERY-BLOCKER.md");
+  const partialPlan = "# S01: Partial plan\n\nPlanning was interrupted before tasks were persisted.\n";
+  writeFileSync(planPath, partialPlan, "utf-8");
+
+  const result = writeBlockerPlaceholder(
+    "plan-slice",
+    "M001/S01",
+    base,
+    "idle recovery exhausted 2 attempts",
+  );
+
+  assert.equal(result, join(".gsd", "milestones", "M001", "slices", "S01", "S01-RECOVERY-BLOCKER.md"));
+  assert.equal(readFileSync(planPath, "utf-8"), partialPlan, "the canonical PLAN must remain untouched");
+  assert.equal(existsSync(blockerPath), true, "the recovery diagnostic should use a sidecar");
+  assert.match(readFileSync(blockerPath, "utf-8"), /idle recovery exhausted 2 attempts/u);
+});
+
+test('exhausted plan-slice timeout recovery pauses without fabricating completion', async (t) => {
+  const base = createFixtureBase();
+  t.after(() => cleanup(base));
+  const planPath = resolveExpectedArtifactPath("plan-slice", "M001/S01", base)!;
+  const blockerPath = planPath.replace(/-PLAN\.md$/u, "-RECOVERY-BLOCKER.md");
+  const partialPlan = "# S01: Partial plan\n\nPlanning was interrupted before tasks were persisted.\n";
+  const startedAt = Date.now();
+  const notifications: string[] = [];
+  const messages: unknown[] = [];
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "Test Slice", status: "pending" });
+  writeFileSync(planPath, partialPlan, "utf-8");
+  writeUnitRuntimeRecord(base, "plan-slice", "M001/S01", startedAt, { recoveryAttempts: 2 });
+
+  const result = await recoverTimedOutUnit(
+    { ui: { notify: (message: string) => notifications.push(message) } } as any,
+    { sendMessage: (message: unknown) => messages.push(message) } as any,
+    "plan-slice",
+    "M001/S01",
+    "idle",
+    {
+      basePath: base,
+      verbose: false,
+      currentUnitStartedAt: startedAt,
+      unitRecoveryCount: new Map(),
+    },
+  );
+
+  assert.equal(result, "paused", "exhausted planning recovery must stop fail-closed");
+  assert.equal(readUnitRuntimeRecord(base, "plan-slice", "M001/S01")?.phase, "paused");
+  assert.equal(readFileSync(planPath, "utf-8"), partialPlan, "the partial canonical PLAN must be preserved");
+  assert.equal(existsSync(blockerPath), false, "timeout pause does not need to fabricate an artifact");
+  assert.equal(getSlice("M001", "S01")?.status, "pending", "recovery must leave the slice pending");
+  assert.equal(getSliceTasks("M001", "S01").length, 0, "recovery must not fabricate task rows");
+  assert.equal(messages.length, 0, "exhaustion must not schedule another model turn");
+  assert.equal(notifications.filter((message) => message.includes("recovery exhausted")).length, 1);
+  assert.equal(notifications.some((message) => message.includes("Advancing pipeline")), false);
 });
 
 test('writeBlockerPlaceholder: unknown type → null', () => {


### PR DESCRIPTION
## Summary
- Plan-slice timeout recovery now pauses safely while preserving canonical plans and DB state, with regression coverage and syntax verification.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #1995
- [#1995 [Bug] plan-slice timeout writes invalid canonical PLAN then enters finalize-retry wedge](https://github.com/open-gsd/gsd-pi/issues/1995)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/1995-bug-plan-slice-timeout-writes-invalid-ca-1787622072`