### PR TITLE
fix(issue): Windows: projection-lock transient wedges auto-mode after 2 strikes — loop re-detects transience from taxonomy-labeled reason string, regex no longer matches (defeats #1690/#1856 backoff budget)

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -35,6 +35,7 @@ import {
 } from "./unit-phase.js";
 import { debugLog } from "../debug-logger.js";
 import { markBlockedStopReason } from "../stop-notice.js";
+import { isTransientProjectionLockError } from "../projection-root-errors.js";
 import {
   formatWedgeTripNotice,
   recordNonAdvancingOutcome,
@@ -1475,8 +1476,10 @@ export async function autoLoop(
             s.pendingOrchestrationDispatch = null;
             const pausedMsg = orchestrationResult.reason ?? "orchestration transient pause";
             const backoffMs = orchestrationResult.backoffMs;
-            const projectionLockTransient =
-              orchestrationResult.failureKind === "projection-lock-transient";
+            const projectionLockTransient = (
+              orchestrationResult.failureKind === "projection-lock-transient" ||
+              isTransientProjectionLockError(pausedMsg)
+            ) && Array.isArray(backoffMs) && backoffMs.length > 0;
             const projectionLockBackoffMs = projectionLockTransient ? backoffMs ?? [] : [];
             let pauseAttempt: number;
             if (projectionLockTransient) {

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -64,6 +64,7 @@ import { parseUnitId } from "../unit-id.js";
 import { logWarning } from "../workflow-logger.js";
 import { normalizeRealPath } from "../paths.js";
 import { preserveProjectionChanges } from "../projection-worker.js";
+import { throwIfTransientProjectionLockError } from "../projection-root-errors.js";
 import { buildDispatchKey } from "./dispatch-key.js";
 import {
   COMPLETED_NO_ADVANCE_GUARD_ID,
@@ -133,6 +134,7 @@ function now(): number {
  * @internal
  */
 let _projectionRebuildFn: ((projectRoot: string) => Promise<void>) | null = null;
+let _preserveProjectionChangesFn: typeof preserveProjectionChanges | null = null;
 
 function noRemainingUnitsOutcome(stateSnapshot: GSDState): AutoTerminalOutcome {
   if (stateSnapshot.phase === "complete") {
@@ -663,8 +665,11 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   > {
     const activeBasePath = this.getLiveDispatchBasePath();
     try {
-      await preserveProjectionChanges(activeBasePath);
+      await (_preserveProjectionChangesFn ?? preserveProjectionChanges)(activeBasePath);
     } catch (error) {
+      // Keep transient Windows projection-lock failures on the typed recovery
+      // path so autoLoop receives their classification and bounded backoff.
+      throwIfTransientProjectionLockError(error);
       const reason = `Projection observation failed: ${getErrorMessage(error)}`;
       logWarning("reconcile", reason);
       return {
@@ -1908,4 +1913,12 @@ export function _setProjectionRebuildFnForTests(
 ): () => void {
   _projectionRebuildFn = fn;
   return () => { _projectionRebuildFn = null; };
+}
+
+/** @internal Test-only override for projection observation failures. */
+export function _setPreserveProjectionChangesFnForTests(
+  fn: typeof preserveProjectionChanges | null,
+): () => void {
+  _preserveProjectionChangesFn = fn;
+  return () => { _preserveProjectionChangesFn = null; };
 }

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -5368,7 +5368,7 @@ test("ADR-047 #1655: identical transient pauses trip at the loop outcome boundar
   }
 });
 
-test("#1852: projection-lock transient pauses exhaust their backoff and never wedge", async () => {
+test("#1852/#2001: projection-lock transient pauses exhaust their backoff and never wedge", async () => {
   _resetPendingResolve();
 
   const ctx = makeMockCtx();
@@ -5383,10 +5383,15 @@ test("#1852: projection-lock transient pauses exhaust their backoff and never we
     start: async () => ({ kind: "stopped" as const, reason: "unused" }),
     advance: async () => {
       advanceCalls++;
+      const legacyFallback = advanceCalls > 4;
       return {
         kind: "paused" as const,
-        reason: "Projection root busy: native projection root identity locking failed",
-        failureKind: "projection-lock-transient" as const,
+        reason: legacyFallback
+          ? "projection root operation failed: file in use (os error 32)"
+          : "Projection root busy: native projection root identity locking failed",
+        failureKind: legacyFallback
+          ? "runtime-unknown" as const
+          : "projection-lock-transient" as const,
         backoffMs: [1, 1, 1],
       };
     },
@@ -5423,8 +5428,8 @@ test("#1852: projection-lock transient pauses exhaust their backoff and never we
     assert.equal(deps.callLog.includes("stopAuto"), true, "the class budget still stops a never-healing transient");
     assert.match(stopReason, /^Blocked: /);
 
-    // A later manual restart can exhaust the same naturally-identical lock
-    // failure again without that recurrence becoming an ADR-047 wedge.
+    // A later manual restart from a legacy adapter without the typed
+    // classification still uses the message fallback without creating a wedge.
     s.active = true;
     stopReason = "";
     await autoLoop(ctx, pi, s, deps);

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  _setPreserveProjectionChangesFnForTests,
   classifyAutoAdvanceFailure,
   createAutoOrchestrator,
   decideOrchestratorDispatch,
@@ -1218,6 +1219,29 @@ test("projection lock classification survives the paused result boundary", () =>
   assert.equal(result.failureKind, "projection-lock-transient");
   assert.ok(result.backoffMs && result.backoffMs.length > 0);
   assert.equal(result.reason, "Projection root busy: native projection root identity locking failed");
+});
+
+test("advance() propagates projection observation lock failures as typed pauses (#2001)", async (t) => {
+  const f = makeFixture();
+  t.after(() => f.cleanup());
+  const nativeError = new Error("native projection root identity locking failed", {
+    cause: new Error("projection root operation failed: The process cannot access the file (os error 32)"),
+  });
+  const restoreProjectionObservation = _setPreserveProjectionChangesFnForTests(async () => {
+    throw nativeError;
+  });
+  t.after(restoreProjectionObservation);
+
+  const result = await f.orchestrator.advance();
+
+  assert.equal(result.kind, "paused");
+  if (result.kind !== "paused") throw new Error("expected paused projection-lock recovery");
+  assert.equal(result.failureKind, "projection-lock-transient");
+  assert.ok(result.backoffMs && result.backoffMs.length > 0);
+  assert.equal(result.reason, "Projection root busy: native projection root identity locking failed");
+  assert.equal(f.orchestrator.getStatus().phase, "paused");
+  assert.ok(f.journalNames().includes("advance-paused"));
+  assert.ok(!f.journalNames().includes("advance-blocked"));
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Auto-mode now applies the full projection-lock backoff without triggering ADR-047, with regression coverage for typed and legacy errors.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2001
- [#2001 Windows: projection-lock transient wedges auto-mode after 2 strikes — loop re-detects transience from taxonomy-labeled reason string, regex no longer matches (defeats #1690/#1856 backoff budget)](https://github.com/open-gsd/gsd-pi/issues/2001)

## User
- @Plamen6

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2001-windows-projection-lock-transient-wedges-1787670421`