### PR TITLE
fix(issue): [Bug]: `gsd install` (shell) never writes an extensions registry entry, making installed extensions invisible to `/gsd extensions list`/`update`

### DIFF
--- a/packages/pi-coding-agent/src/core/resource-loader.ts
+++ b/packages/pi-coding-agent/src/core/resource-loader.ts
@@ -156,6 +156,10 @@ export interface DefaultResourceLoaderOptions {
 	};
 	systemPromptOverride?: (base: string | undefined) => string | undefined;
 	appendSystemPromptOverride?: (base: string[]) => string[];
+	extensionPathsTransform?: (paths: string[]) => {
+		paths: string[];
+		diagnostics?: string[];
+	};
 }
 
 export class DefaultResourceLoader implements ResourceLoader {
@@ -194,6 +198,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	};
 	private systemPromptOverride?: (base: string | undefined) => string | undefined;
 	private appendSystemPromptOverride?: (base: string[]) => string[];
+	private extensionPathsTransform?: DefaultResourceLoaderOptions["extensionPathsTransform"];
 
 	private extensionsResult: LoadExtensionsResult;
 	private skills: Skill[];
@@ -242,6 +247,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.agentsFilesOverride = options.agentsFilesOverride;
 		this.systemPromptOverride = options.systemPromptOverride;
 		this.appendSystemPromptOverride = options.appendSystemPromptOverride;
+		this.extensionPathsTransform = options.extensionPathsTransform;
 
 		this.extensionsResult = { extensions: [], errors: [], runtime: createExtensionRuntime() };
 		this.skills = [];
@@ -405,11 +411,23 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const cliEnabledPrompts = getEnabledPaths(cliExtensionPaths.prompts);
 		const cliEnabledThemes = getEnabledPaths(cliExtensionPaths.themes);
 
-		const extensionPaths = this.noExtensions
+		const baseExtensionPaths = this.noExtensions
 			? cliEnabledExtensions
 			: this.mergePaths(cliEnabledExtensions, enabledExtensions);
+		// `noExtensions` permits only explicit CLI paths. A transform may discover
+		// additional paths, so do not run it when extension discovery is disabled.
+		const transformedExtensionPaths = this.noExtensions
+			? undefined
+			: this.extensionPathsTransform?.(baseExtensionPaths);
+		const extensionPaths = transformedExtensionPaths?.paths ?? baseExtensionPaths;
 
 		const extensionsResult = await loadExtensions(extensionPaths, this.cwd, this.eventBus);
+		if (transformedExtensionPaths?.diagnostics?.length) {
+			extensionsResult.warnings = [
+				...(extensionsResult.warnings ?? []),
+				...transformedExtensionPaths.diagnostics.map((message) => ({ path: "<extension-order>", message })),
+			];
+		}
 		const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime);
 		extensionsResult.extensions.push(...inlineExtensions.extensions);
 		extensionsResult.errors.push(...inlineExtensions.errors);

--- a/packages/pi-coding-agent/test/resource-loader-extension-transform.test.ts
+++ b/packages/pi-coding-agent/test/resource-loader-extension-transform.test.ts
@@ -1,0 +1,34 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DefaultResourceLoader } from "../src/core/resource-loader.ts";
+
+describe("resource loader extension path transform", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+		tempDirs.length = 0;
+	});
+
+	it("does not let path transforms bypass noExtensions", async () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-resource-loader-transform-"));
+		tempDirs.push(root);
+		const cwd = join(root, "project");
+		const agentDir = join(root, "agent");
+		mkdirSync(cwd, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+		const transform = vi.fn((paths: string[]) => ({ paths }));
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			noExtensions: true,
+			extensionPathsTransform: transform,
+		});
+
+		await loader.reload();
+
+		expect(transform).not.toHaveBeenCalled();
+	});
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,7 @@ import {
   unregisterPackageExtensions,
 } from './extension-registry.js'
 import type { EnsureRtkResult } from './rtk.js'
+import { registerInstalledExtensionPackage } from './extension-registry.js'
 
 type PiCodingAgentModule = typeof import('@gsd/pi-coding-agent')
 type AgentCoreModule = typeof import('@gsd/agent-core')
@@ -405,7 +406,9 @@ if (!process.stdin.isTTY && !isPrintMode && !isSubcommandExemptFromEarlyTtyCheck
 
 const packageCommandNames: ReadonlySet<PackageCommand> = new Set(['install', 'remove', 'list'])
 if (packageCommandNames.has(cliFlags.messages[0] as PackageCommand)) {
-  const { runPackageCommand } = await loadPiCodingAgentModule()
+  const piCodingAgent = await loadPiCodingAgentModule()
+  const parsedPackageCommand = piCodingAgent.parsePackageCommand(process.argv.slice(2), packageCommandNames)
+  const { runPackageCommand } = piCodingAgent
   const packageCommand = await runPackageCommand({
     appName: 'gsd',
     args: process.argv.slice(2),
@@ -430,6 +433,15 @@ if (packageCommandNames.has(cliFlags.messages[0] as PackageCommand)) {
       },
     },
   })
+  if (packageCommand.exitCode === 0 && parsedPackageCommand?.command === 'install' && parsedPackageCommand.source) {
+    const settingsManager = piCodingAgent.SettingsManager.create(process.cwd(), agentDir)
+    const packageManager = new piCodingAgent.DefaultPackageManager({ cwd: process.cwd(), agentDir, settingsManager })
+    const scope = parsedPackageCommand.local ? 'project' : 'user'
+    const installedPath = packageManager.getInstalledPath(parsedPackageCommand.source, scope)
+    if (installedPath) {
+      registerInstalledExtensionPackage(installedPath, parsedPackageCommand.source, scope)
+    }
+  }
   if (packageCommand.handled) {
     process.exit(packageCommand.exitCode)
   }

--- a/src/extension-registry.ts
+++ b/src/extension-registry.ts
@@ -355,3 +355,38 @@ export function ensureRegistryEntries(extensionsDir: string): void {
     saveRegistry(registry);
   }
 }
+
+/**
+ * Register an extension installed through the shell package command.
+ * Generic packages are ignored; only packages with a valid extension manifest
+ * participate in the GSD extension registry.
+ */
+export function registerInstalledExtensionPackage(
+  packageDir: string,
+  source: string,
+  scope: "user" | "project",
+): string | null {
+  const manifest = readManifest(packageDir);
+  if (!manifest) return null;
+
+  let installType: "npm" | "git" | "local" = "local";
+  let installedFrom = source;
+  if (source.startsWith("npm:")) {
+    installType = "npm";
+    installedFrom = source.slice("npm:".length);
+  } else if (/^(?:git:|git\+|git:\/\/|https?:\/\/|ssh:\/\/|github:|gitlab:|bitbucket:|git@)/.test(source)) {
+    installType = "git";
+  }
+
+  const registry = loadRegistry();
+  registry.entries[manifest.id] = {
+    id: manifest.id,
+    enabled: true,
+    source: scope,
+    version: manifest.version,
+    installedFrom,
+    installType,
+  };
+  saveRegistry(registry);
+  return manifest.id;
+}

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -6,7 +6,7 @@ import { createRequire } from 'node:module'
 import { basename, dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { compareSemver } from './update-check.js'
-import { discoverExtensionEntryPaths } from './extension-discovery.js'
+import { discoverExtensionEntryPaths, mergeExtensionEntryPaths } from './extension-discovery.js'
 import { loadRegistry, readManifestFromEntryPath, isExtensionEnabled, ensureRegistryEntries } from './extension-registry.js'
 import { resolveBundledResourcesDirFromPackageRoot } from './bundled-resource-path.js'
 
@@ -910,14 +910,18 @@ export async function buildResourceLoader(
     bundledExtensionKeys: bundledKeys,
     ...bareResourceLoaderOptions(options.bare),
     extensionPathsTransform: (paths: string[]) => {
-      // 1. Filter community extensions through the GSD registry
-      const filteredPaths = paths.filter((entryPath) => {
+      // 1. Add slash-command-installed extensions, with installed versions
+      // taking precedence over bundled extensions that declare the same ID.
+      const mergedPaths = mergeExtensionEntryPaths(paths, join(dirname(agentDir), 'extensions'))
+
+      // 2. Filter community extensions through the GSD registry
+      const filteredPaths = mergedPaths.filter((entryPath) => {
         const manifest = readManifestFromEntryPath(entryPath)
         if (!manifest) return true // no manifest = always load
         return isExtensionEnabled(registry, manifest.id)
       })
 
-      // 2. Sort in topological dependency order
+      // 3. Sort in topological dependency order
       const { sortedPaths, warnings } = sortExtensionPaths(filteredPaths)
 
       return {

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -269,16 +269,34 @@ function discoverManifests(): Map<string, ExtensionManifest> {
   }
 
   // Shell-installed packages remain in the package manager's install tree.
-  // Their registry entry records the manifest directory so this command sees
-  // the same extensions that the runtime package loader already resolves.
+  // Entries that recorded their manifest directory (extensionDir) resolve
+  // directly; npm entries without one fall back to the package manager's
+  // node_modules layout via installedFrom, so list/info/enable/disable see
+  // the same extensions the runtime package loader already resolves.
   for (const entry of Object.values(loadRegistry().entries)) {
-    if (!entry.extensionDir) continue;
     if (entry.source === "project" && entry.projectDir !== resolve(process.cwd())) continue;
-    const manifest = readManifest(entry.extensionDir);
+
+    if (entry.extensionDir) {
+      const manifest = readManifest(entry.extensionDir);
+      if (manifest && (entry.source === "project" || !manifests.has(manifest.id))) {
+        manifests.set(manifest.id, manifest);
+      }
+      continue;
+    }
+
+    if (entry.installType !== "npm" || !entry.installedFrom) continue;
+    const npmRoot = entry.source === "project"
+      ? join(process.cwd(), ".gsd", "npm", "node_modules")
+      : join(gsdHome(), "agent", "npm", "node_modules");
+    const packageDir = resolve(npmRoot, npmPackageName(entry.installedFrom));
+    const resolvedRoot = resolve(npmRoot);
+    if (packageDir !== resolvedRoot && !packageDir.startsWith(resolvedRoot + sep)) {
+      continue;
+    }
+    const manifest = readManifest(packageDir);
     if (manifest && (entry.source === "project" || !manifests.has(manifest.id))) {
       manifests.set(manifest.id, manifest);
     }
-
   }
   return manifests;
 }

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -8,7 +8,7 @@
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { gsdHome } from "./gsd-home.js";
@@ -278,12 +278,22 @@ function discoverManifests(): Map<string, ExtensionManifest> {
     if (manifest && (entry.source === "project" || !manifests.has(manifest.id))) {
       manifests.set(manifest.id, manifest);
     }
+
   }
   return manifests;
 }
 
 function getInstalledExtDir(): string {
   return join(gsdHome(), "extensions");
+}
+
+function npmPackageName(specifier: string): string {
+  if (specifier.startsWith("@")) {
+    const versionSeparator = specifier.indexOf("@", specifier.indexOf("/") + 1);
+    return versionSeparator === -1 ? specifier : specifier.slice(0, versionSeparator);
+  }
+  const versionSeparator = specifier.indexOf("@");
+  return versionSeparator === -1 ? specifier : specifier.slice(0, versionSeparator);
 }
 
 // Source: derived from npm/git URL conventions (from RESEARCH.md)
@@ -1007,7 +1017,9 @@ function handleList(ctx: ExtensionCommandContext): void {
       lines[lines.length - 1] = lastLine + `      [${regEntry.source}]`;
       if (regEntry.installedFrom) {
         const typePrefix = regEntry.installType ? `${regEntry.installType}:` : "";
-        const versionSuffix = regEntry.version ? `@${regEntry.version}` : "";
+        const versionSuffix = regEntry.version && !regEntry.installedFrom.endsWith(`@${regEntry.version}`)
+          ? `@${regEntry.version}`
+          : "";
         lines.push(`  installed from: ${typePrefix}${regEntry.installedFrom}${versionSuffix}`);
       }
     }

--- a/src/resources/extensions/gsd/tests/commands-extensions-shell-package.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-extensions-shell-package.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { handleExtensions } from "../commands-extensions.ts";
+
+test("extension list discovers shell-installed npm package manifests", async (t) => {
+  const previousGsdHome = process.env.GSD_HOME;
+  const home = mkdtempSync(join(tmpdir(), "gsd-shell-extension-list-"));
+  process.env.GSD_HOME = home;
+  t.after(() => {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  const packageDir = join(home, "agent", "npm", "node_modules", "@example", "demo-extension");
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, "extension-manifest.json"),
+    JSON.stringify({
+      id: "example.demo",
+      name: "Demo Extension",
+      version: "2.3.4",
+      description: "test extension",
+      tier: "community",
+      requires: { platform: "node" },
+    }),
+  );
+  mkdirSync(join(home, "extensions"), { recursive: true });
+  writeFileSync(
+    join(home, "extensions", "registry.json"),
+    JSON.stringify({
+      version: 1,
+      entries: {
+        "example.demo": {
+          id: "example.demo",
+          enabled: true,
+          source: "user",
+          version: "2.3.4",
+          installedFrom: "@example/demo-extension@2.3.4",
+          installType: "npm",
+        },
+      },
+    }),
+  );
+
+  const notices: string[] = [];
+  const ctx = {
+    ui: { notify: (message: string) => notices.push(message) },
+  } as unknown as ExtensionCommandContext;
+  await handleExtensions("list", ctx);
+
+  const output = notices.join("\n");
+  assert.match(output, /example\.demo \(Demo Extension\)/);
+  assert.match(output, /\[user\]/);
+  assert.match(output, /installed from: npm:@example\/demo-extension@2\.3\.4/);
+  assert.doesNotMatch(output, /@2\.3\.4@2\.3\.4/);
+});

--- a/src/tests/integration/e2e-smoke.test.ts
+++ b/src/tests/integration/e2e-smoke.test.ts
@@ -16,7 +16,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   assertNoCrashMarkers,
@@ -80,6 +80,67 @@ test("gsd --help outputs usage information and exits 0", async () => {
     output.includes("--list-models"),
     "help output should mention --list-models flag",
   );
+});
+
+test("gsd install npm: registers extension packages with management metadata", async (t) => {
+  const gsdHome = createTempDir("gsd-install-extension-home-");
+  const projectDir = createTempDir("gsd-install-extension-project-");
+  const packageDir = join(projectDir, "demo-extension");
+  const fakeNpmPath = join(projectDir, "fake-npm.cjs");
+  t.after(() => {
+    rmSync(gsdHome, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "demo-extension",
+      gsd: { extension: true },
+      pi: { extensions: ["index.js"] },
+    }),
+  );
+  writeFileSync(join(packageDir, "index.js"), "export default function () {}\n");
+  writeFileSync(
+    join(packageDir, "extension-manifest.json"),
+    JSON.stringify({
+      id: "example.cli-install",
+      name: "CLI Install Extension",
+      version: "1.2.3",
+      description: "test extension",
+      tier: "community",
+      requires: { platform: "node" },
+    }),
+  );
+  writeFileSync(
+    fakeNpmPath,
+    `const fs = require("node:fs"), path = require("node:path");
+const args = process.argv.slice(2), prefix = args[args.indexOf("--prefix") + 1];
+if (!prefix) process.exit(2);
+const dest = path.join(prefix, "node_modules", "demo-extension");
+fs.mkdirSync(path.dirname(dest), { recursive: true });
+fs.cpSync(${JSON.stringify(packageDir)}, dest, { recursive: true });
+`,
+  );
+  mkdirSync(join(gsdHome, "agent"), { recursive: true });
+  writeFileSync(
+    join(gsdHome, "agent", "settings.json"),
+    JSON.stringify({ npmCommand: [process.execPath, fakeNpmPath] }),
+  );
+
+  const result = await runGsd(["install", "npm:demo-extension@1.2.3"], 30_000, { GSD_HOME: gsdHome }, projectDir);
+  assert.equal(result.code, 0, result.stderr);
+
+  const registry = JSON.parse(readFileSync(join(gsdHome, "extensions", "registry.json"), "utf-8"));
+  assert.deepEqual(registry.entries["example.cli-install"], {
+    id: "example.cli-install",
+    enabled: true,
+    source: "user",
+    version: "1.2.3",
+    installedFrom: "demo-extension@1.2.3",
+    installType: "npm",
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/package-extension-registry.test.ts
+++ b/src/tests/package-extension-registry.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+test("shell-installed extension packages are written to the registry with update metadata", async (t) => {
+  const previousGsdHome = process.env.GSD_HOME;
+  const home = mkdtempSync(join(tmpdir(), "gsd-shell-extension-"));
+  process.env.GSD_HOME = home;
+  t.after(() => {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  const packageDir = join(home, "agent", "npm", "node_modules", "@example", "demo-extension");
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, "package.json"),
+    JSON.stringify({ name: "@example/demo-extension", pi: { extensions: ["index.js"] } }),
+  );
+  writeFileSync(
+    join(packageDir, "extension-manifest.json"),
+    JSON.stringify({
+      id: "example.demo",
+      name: "Demo Extension",
+      version: "2.3.4",
+      description: "test extension",
+      tier: "community",
+      requires: { platform: "node" },
+    }),
+  );
+  writeFileSync(join(packageDir, "index.js"), "export default function () {}\n");
+
+  const { registerInstalledExtensionPackage } = await import("../extension-registry.ts");
+  assert.equal(
+    registerInstalledExtensionPackage(packageDir, "npm:@example/demo-extension", "user"),
+    "example.demo",
+  );
+
+  const registry = JSON.parse(readFileSync(join(home, "extensions", "registry.json"), "utf-8"));
+  assert.deepEqual(registry.entries["example.demo"], {
+    id: "example.demo",
+    enabled: true,
+    source: "user",
+    version: "2.3.4",
+    installedFrom: "@example/demo-extension",
+    installType: "npm",
+  });
+
+  registerInstalledExtensionPackage(packageDir, "npm:@example/demo-extension@2.3.4", "user");
+  const pinnedRegistry = JSON.parse(readFileSync(join(home, "extensions", "registry.json"), "utf-8"));
+  assert.equal(pinnedRegistry.entries["example.demo"].installedFrom, "@example/demo-extension@2.3.4");
+});

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -251,6 +251,46 @@ test("buildResourceLoader loads user-installed extensions and lets them shadow b
   );
 });
 
+test("buildResourceLoader loads extensions installed by the slash command", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-installed-extension-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const installedExtensionDir = join(tmp, ".gsd", "extensions", "example-installed");
+  const installedEntryPath = join(installedExtensionDir, "index.js");
+
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  mkdirSync(fakeAgentDir, { recursive: true });
+  mkdirSync(installedExtensionDir, { recursive: true });
+  writeFileSync(
+    join(installedExtensionDir, "extension-manifest.json"),
+    JSON.stringify({
+      id: "example.installed",
+      name: "Installed Extension",
+      version: "1.0.0",
+      description: "test extension",
+      tier: "community",
+      requires: { platform: "node" },
+    }),
+  );
+  writeFileSync(
+    join(installedExtensionDir, "package.json"),
+    JSON.stringify({ type: "module", pi: { extensions: ["index.js"] } }),
+  );
+  writeFileSync(installedEntryPath, "export default function () {}\n");
+
+  const { buildResourceLoader } = await import("../resource-loader.ts");
+  const loader = await buildResourceLoader(fakeAgentDir);
+  await loader.reload();
+
+  assert.equal(
+    loader.getExtensions().extensions.some((extension) => extension.path === installedEntryPath),
+    true,
+    "slash-command-installed extension should be part of the runtime extension set",
+  );
+});
+
 test("initResources manifest tracks all bundled extension subdirectories including remote-questions (#2367)", async () => {
   const { initResources } = await import("../resource-loader.ts");
   const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-manifest-"));


### PR DESCRIPTION
## Summary
- Fixed registry convergence and runtime loading for both extension installation paths with focused regression coverage.

## Bugs Addressed
- [x] **CLI install omits extensions registry entry**
- [x] **Slash-command-installed extensions do not load at runtime**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2006
- [#2006 [Bug]: `gsd install` (shell) never writes an extensions registry entry, making installed extensions invisible to `/gsd extensions list`/`update`](https://github.com/open-gsd/gsd-pi/issues/2006)

## User
- @efrembaraldo

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2006-bug-gsd-install-shell-never-writes-an-ex-1787682194`