### PR TITLE
release: v1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 
 ## [Unreleased]
 
+## [1.16.2] - 2026-08-25
+
+### Fixed
+- **tui**: hide completed project sentinel
+- **headless**: classify live workflow outcomes structurally
+- **gsd**: recover failed UAT closeout
+- **legacy-import**: take only the code span of a Verification bullet as the verify command (#1982)
+- **auto**: abort the live host turn on permanent provider-error pause; completion gate names its recovery lever and admits blocker reports (#1977)
+- **state-reconciliation**: stop mapping remediation slice ids onto other slices' plan files (#1976)
+- **auto**: keep the verification auto-fix retry bound attempt-independent and pause loudly on durable abort (#1972)
+- **legacy-import**: carry Verification/Inputs/Expected Output from a task's ### section into its import claim (#1970)
+- **headless**: keep timeout status when SIGTERMed child exits cleanly (#1969)
+- **auto**: pause canonical needs-attention validation for human review instead of retrying into a wedge (#1966)
+- **legacy-import**: map every checkbox task line in a nested slice plan (#1964)
+- **pre-exec**: auto-repair planning-artifact refs in task inputs/files; lead retry context with real findings (#1962)
+- **issue**: [Bug]: auto-mode escape-path violation — resumed-once task-recovery abort re-settled with dead worker names an already-consumed recoveryActionId as its only exit; transient Codex usage_limit_reached escalated to terminal abort (1.16.1) (#1917)
+- **dashboard**: reload milestone data when the DB project revision changes (#1958)
+- **gsd**: void stale abort route on task reopen so recovery levers stay live (#1948) (#1957)
+- **issue**: [Bug]: resume-consumed abort route stays terminal after its retry succeeds — staged completion never reaches host verification, dead already-resumed lever is the only exit (1.16.1) (#1946)
+- **issue**: [Bug]: orchestrator orphaned-active-unit guard deadlocks settled attempts with a never-resumed abort — agent-tool-only exit is unreachable and even gsd_task_recovery_resume cannot clear the guard (1.16.1) (#1942)
+- **remote-questions**: add GSD_DISABLE_REMOTE_QUESTIONS guard and isolate ask-user tests (#1954)
+- **baseline**: make per-invariant timeout overridable via GSD_BASELINE_INVARIANT_TIMEOUT_MS (#1953)
+- **issue**: Windows: verification gate mangles nested-quote verify commands (cmd /c without windowsVerbatimArguments) -> deterministic host/agent divergence -> unbreakable finalize-break wedge (#1940)
+- **issue**: [Bug]: provider usage_limit_reached during execute-task closeout strands a running Attempt with a dead lease; no in-context recovery can complete or settle it (#1918)
+- **issue**: Legacy import drops completion state: CLOSED milestones import as active, done tasks import as pending (preview knows 173/174 done) (#1914)
+- **verification-gate**: parse <item> wrappers in task Verify and stop silent fallback to package.json (#1951)
+- **issue**: [Bug]: validate-milestone recovery tells validator to write VALIDATION.md instead of calling gsd_validate_milestone (#1921)
+- **auto**: verify reassess-roadmap against the milestone-scoped ROADMAP-ASSESSMENT.md (#1950)
+- **dispatch-guard**: do not block dispatch on an earlier placeholder milestone with no slice rows (#1949)
+- **issue**: Windows: verification gate scores a missing OS command (grep 'is not recognized') as a real failure, not command-not-found -> unbreakable auto-fix loop -> liveness wedge (#1945)
+- **issue**: [Bug]: post-execution import check cannot resolve `.d.ts` targets — `resolveImportPath` omits the extension, blocking task completion on committed generated declaration files (1.16.1) (#1938)
+- **issue**: [Bug]: checkTmuxKeyboardSetup emits false positive warning when tmux show times out or returns undefined
+- **issue**: Bug: gsd_task_complete knownIssues validation rejects LLM {"item": "..."} wrapper — wedges task as orphaned-active-unit (1.16.x)
+- **issue**: [Bug]: `gsd_plan_slice` fails rendering projections on Windows with persistent `os error 32` after restart
+- **issue**: Add a bounded selective route to discard orphaned milestone reservations (headless + slash)
+- **bug-2**: Quick tasks have no non-interactive entry point headless quick tasks now return structured lifecycle details and meaningful failure codes.
+- **bug-1**: CLI silently ignores `quick` and its task arguments direct `gsd quick` invocations now dispatch through headless mode without losing task arguments.
+- **issue**: gsd quick lacks the right-sizing flags gsd-core has (--research/--validate/--discuss/--full)
+- **bug-2**: Default 30-second exec timeout kills valid verification builds verification and build workloads now inherit the configured verification timeout without changing unrelated exec defaults.
+- **bug-1**: Windows cmd.exe cannot execute forward-slash package-manager path Windows verification now invokes relative package-manager paths using native backslashes and an explicit `.\` prefix.
+- **issue**: Depth verification ignores answers[id].answers result shape
+- **issue**: [Bug]: gsd_exec default timeout is 30s (sourced from exec_timeout_ms, not verification_timeout_ms) — silently kills legitimate verify/build chains and mislabels them as timeouts, driving re-dispatch loops
+- **bug-2**: Paused auto results discard typed projection-lock failures paused results preserve typed projection-lock failures through liveness adjudication.
+- **bug-1**: Initial projection bootstrap locks the worktree CWD on Windows bootstrap now identity-locks `.gsd` instead of the worktree CWD.
+- **ci**: land production npm releases through RELEASE_PAT (#1904)
+
 ## [1.16.1] - 2026-08-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ See [CHANGELOG.md](./CHANGELOG.md) for release-by-release fixes and [Legacy Rele
 ## Latest Release Highlights
 
 <!-- release-highlights:start -->
-Latest release: **v1.16.1**
+Latest release: **v1.16.2**
 
-- **issue:** Fix(gsd): prevent slice plans from assigning phase-owned lifecycle mutations to execute-task (#1899).
-- **issue:** Branch isolation makes recorded integration branch disappear in unborn repositories (#1900).
-- **Fixed:** Restore broken star history chart (#1902).
-- **issue:** Re-entrant session lock acquisition releases ownership and wedges auto-mode (#1901).
-- **issue:** Migration staging resolves to live repo .gsd (#1866) (#1879).
-- **issue:** Post-unit gates audit stale HEAD and ignore evidence-backed GSD-only task verification (#1898).
-- **issue:** No sanctioned task lifecycle reconcile after repair (#1749) (#1893).
-- **issue:** Phase-dir slug drift and lock rmSync no-op (#1526) (#1892).
+- **tui:** Hide completed project sentinel.
+- **headless:** Classify live workflow outcomes structurally.
+- **gsd:** Recover failed UAT closeout.
+- **legacy-import:** Take only the code span of a Verification bullet as the verify command (#1982).
+- **auto:** Abort the live host turn on permanent provider-error pause; completion gate names its recovery lever and admits blocker reports (#1977).
+- **state-reconciliation:** Stop mapping remediation slice ids onto other slices' plan files (#1976).
+- **auto:** Keep the verification auto-fix retry bound attempt-independent and pause loudly on durable abort (#1972).
+- **legacy-import:** Carry Verification/Inputs/Expected Output from a task's ### section into its import claim (#1970).
 
 <!-- release-highlights:end -->
 

--- a/extensions/google-search/package.json
+++ b/extensions/google-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-extensions/google-search",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Web search via Google with AI-synthesized answers and source citations",
   "type": "module",
   "keywords": [

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -215,7 +215,7 @@ class GsdMcpClient:
                 "params": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.16.1"},
+                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.16.2"},
                 },
             }
         )

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-gsd-hermes"
-version = "1.16.1"
+version = "1.16.2"
 description = "Hermes Agent plugin — GSD structured delivery engine integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-ast"
-version = "1.16.1"
+version = "1.16.2"
 dependencies = [
  "ast-grep-core",
  "globset",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-engine"
-version = "1.16.1"
+version = "1.16.2"
 dependencies = [
  "arboard",
  "dashmap",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-grep"
-version = "1.16.1"
+version = "1.16.2"
 dependencies = [
  "grep-matcher",
  "grep-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "1.16.1"
+version = "1.16.2"
 edition = "2021"
 license = "MIT"
 authors = ["GSD Contributors"]

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-arm64",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-x64",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-arm64-gnu",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-x64-gnu",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-win32-x64-msvc",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
   "repository": {
@@ -208,11 +208,11 @@
   },
   "optionalDependencies": {
     "@mariozechner/clipboard": "0.3.6",
-    "@opengsd/engine-darwin-arm64": "1.16.1",
-    "@opengsd/engine-darwin-x64": "1.16.1",
-    "@opengsd/engine-linux-arm64-gnu": "1.16.1",
-    "@opengsd/engine-linux-x64-gnu": "1.16.1",
-    "@opengsd/engine-win32-x64-msvc": "1.16.1",
+    "@opengsd/engine-darwin-arm64": "1.16.2",
+    "@opengsd/engine-darwin-x64": "1.16.2",
+    "@opengsd/engine-linux-arm64-gnu": "1.16.2",
+    "@opengsd/engine-linux-x64-gnu": "1.16.2",
+    "@opengsd/engine-win32-x64-msvc": "1.16.2",
     "fsevents": "~2.3.3",
     "koffi": "^2.9.0",
     "node-pty": "^1.1.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/contracts",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Shared public contracts for GSD workspace boundaries",
   "license": "MIT",
   "gsd": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/daemon",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "GSD daemon — background process for project monitoring and Discord integration",
   "license": "MIT",
   "repository": {

--- a/packages/gsd-agent-core/package.json
+++ b/packages/gsd-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-core",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "GSD session orchestration layer on top of @gsd/pi-coding-agent",
   "type": "module",
   "gsd": {

--- a/packages/gsd-agent-modes/package.json
+++ b/packages/gsd-agent-modes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-modes",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "GSD run modes and CLI layer",
   "type": "module",
   "gsd": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/mcp-server",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "MCP server exposing GSD orchestration tools for compatible clients",
   "license": "MIT",
   "gsd": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/native",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Native Rust bindings for GSD — high-performance native modules via N-API",
   "type": "commonjs",
   "gsd": {

--- a/packages/pi-agent-core/package.json
+++ b/packages/pi-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-agent-core",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "General-purpose agent with transport abstraction, state management, and attachment support",
   "type": "module",
   "gsd": {

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-ai",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Unified LLM API with automatic model discovery and provider configuration",
   "type": "module",
   "gsd": {

--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-coding-agent",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Coding agent CLI (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-tui",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Terminal UI library (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/rpc-client/package.json
+++ b/packages/rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/rpc-client",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Standalone RPC client SDK for GSD — zero internal dependencies",
   "license": "MIT",
   "gsd": {

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glittercowboy/gsd",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "piConfig": {
     "name": "gsd",
     "configDir": ".gsd"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,20 +169,20 @@ importers:
         specifier: 0.3.6
         version: 0.3.6
       '@opengsd/engine-darwin-arm64':
-        specifier: 1.16.1
-        version: 1.16.1
+        specifier: 1.16.2
+        version: 1.16.2
       '@opengsd/engine-darwin-x64':
-        specifier: 1.16.1
-        version: 1.16.1
+        specifier: 1.16.2
+        version: 1.16.2
       '@opengsd/engine-linux-arm64-gnu':
-        specifier: 1.16.1
-        version: 1.16.1
+        specifier: 1.16.2
+        version: 1.16.2
       '@opengsd/engine-linux-x64-gnu':
-        specifier: 1.16.1
-        version: 1.16.1
+        specifier: 1.16.2
+        version: 1.16.2
       '@opengsd/engine-win32-x64-msvc':
-        specifier: 1.16.1
-        version: 1.16.1
+        specifier: 1.16.2
+        version: 1.16.2
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -2001,28 +2001,28 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@opengsd/engine-darwin-arm64@1.16.1':
-    resolution: {integrity: sha512-s/nRzOE1LhD1kbn8V85G5Zg4Ad7j9RdXSZSxmO8O/Dd984PEmPqO99B0oMXIpEqaLUQ244hIV+N5iL5s/pbK2Q==}
+  '@opengsd/engine-darwin-arm64@1.16.2':
+    resolution: {integrity: sha512-EQ90IR+6XTSJXXf9Ni1qTzcWXRbBbOabP43ooT2nLcGTCvA4HYoGYWSI07Xppo/lAiylPizetU1PN+IGieZkzA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@opengsd/engine-darwin-x64@1.16.1':
-    resolution: {integrity: sha512-T/qxOF+gsHJXhGPhmoaSdk+0erDbkzI19ekYwvYo9B8Hqtmh7eDh1lT1K0cNeOXHqldWBjnB3L5Q6QmDZq16iw==}
+  '@opengsd/engine-darwin-x64@1.16.2':
+    resolution: {integrity: sha512-Gz6NVngtNslezpyCIEGOfseCviZc0z2CeA3JiFMxfn5qXiJ/xKwPwH4wQpglP/JGB8Hx6eaBzMf0wC5F/AzuvQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@opengsd/engine-linux-arm64-gnu@1.16.1':
-    resolution: {integrity: sha512-BCtdkWqlfNuSCQqOUlB2jlezYps8Gu7v8+nMsYpb+W7H6b6EVJtjty7unww6/QAayLPVMcyaLVFduJoNcPydUA==}
+  '@opengsd/engine-linux-arm64-gnu@1.16.2':
+    resolution: {integrity: sha512-O9ATcKSmeHtJS2Ln6yYiA3hhz3+EPEA2bbBdw5bBeMWtUdRLYbrtgIrkTZ1On99265AmsUxbfGB1WR513ntJhw==}
     cpu: [arm64]
     os: [linux]
 
-  '@opengsd/engine-linux-x64-gnu@1.16.1':
-    resolution: {integrity: sha512-SmuTwXJrJd/oyY1PBUDo+p5fBMRVbQKazuIrqksPqCTH3FUDw5TpVRqVv7OIBY6ZhI+iItTseRgCd/ZnIxpGRA==}
+  '@opengsd/engine-linux-x64-gnu@1.16.2':
+    resolution: {integrity: sha512-Fl65dtTn/qBhDAqTR/RjiySkl+PodphizX8TphKqF18ESm1JoqU4X51N5QJ/vqZfxHXN5Y8t7E0C8671lKquUw==}
     cpu: [x64]
     os: [linux]
 
-  '@opengsd/engine-win32-x64-msvc@1.16.1':
-    resolution: {integrity: sha512-nJBn2dAS42+lbbksz2nV+/CjmdaNG9P38GdXJBZhcqgDQUQADWOezWEskiVow97olXIzbdOR/3heqIPd/u1agA==}
+  '@opengsd/engine-win32-x64-msvc@1.16.2':
+    resolution: {integrity: sha512-2CyRxZznHKDZn+JCuw/i97+PqnxvCXNARV0b6bzb5td6DomblyTSNJr5GNIkRt1uevDdmRqnimN3eEeGwmNINA==}
     cpu: [x64]
     os: [win32]
 
@@ -7715,19 +7715,19 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@opengsd/engine-darwin-arm64@1.16.1':
+  '@opengsd/engine-darwin-arm64@1.16.2':
     optional: true
 
-  '@opengsd/engine-darwin-x64@1.16.1':
+  '@opengsd/engine-darwin-x64@1.16.2':
     optional: true
 
-  '@opengsd/engine-linux-arm64-gnu@1.16.1':
+  '@opengsd/engine-linux-arm64-gnu@1.16.2':
     optional: true
 
-  '@opengsd/engine-linux-x64-gnu@1.16.1':
+  '@opengsd/engine-linux-x64-gnu@1.16.2':
     optional: true
 
-  '@opengsd/engine-win32-x64-msvc@1.16.1':
+  '@opengsd/engine-win32-x64-msvc@1.16.2':
     optional: true
 
   '@opengsd/gsd-browser@0.2.2': {}


### PR DESCRIPTION
Version bump for v1.16.2. Direct push to main was rejected by branch rules, so the release commit lands through the merge queue. npm, the `v1.16.2` tag and the GitHub release are already published.