### PR TITLE
fix(issue): [Bug]: gsd_task_settle --reconcileLifecycle cannot reconcile orphaned in_progress lifecycle row whose latest Attempt outcome is succeeded (variant of #1983)

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2482,7 +2482,7 @@ const taskSettleParams = {
   reason: nonEmptyString("reason").describe("Operator rationale recorded on the settled Attempt Result"),
   apply: z.boolean().optional().describe("Actually settle; omit or false for a dry run that changes nothing"),
   reconcileLifecycle: z.boolean().optional().describe(
-    "After settling (or if already interrupted), adopt ready/completed to match tasks.status without deleting SUMMARYs",
+    "After settling or an interrupted Attempt, adopt ready/completed; after a succeeded Attempt, adopt completed. Preserve SUMMARYs",
   ),
 };
 const taskSettleSchema = z.object(taskSettleParams);

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -2625,7 +2625,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 			"Run without apply first and read the planned rows before mutating.",
 			"Settles under the Attempt's held lease, or safely reclaims an expired/released lease when its worker is no longer live; never steals a live peer's lease.",
 			"A second apply is a no-op — the tool is idempotent.",
-			"reconcileLifecycle adopts ready/completed to match tasks.status after the interrupted Attempt without deleting SUMMARYs.",
+			"reconcileLifecycle adopts ready/completed after an interrupted Attempt, or completed after a succeeded Attempt, without deleting SUMMARYs.",
 		],
 		parameters: Type.Object(
 			{
@@ -2644,7 +2644,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 				reconcileLifecycle: Type.Optional(
 					Type.Boolean({
 						description:
-							"After settling (or if already interrupted), adopt ready/completed to match tasks.status without deleting SUMMARYs.",
+							"After settling or an interrupted Attempt, adopt ready/completed; after a succeeded Attempt, adopt completed. Preserve SUMMARYs.",
 					}),
 				),
 			},

--- a/src/resources/extensions/gsd/task-settle.ts
+++ b/src/resources/extensions/gsd/task-settle.ts
@@ -1,7 +1,7 @@
 // Project/App: gsd-pi
 // File Purpose: Operator Task settle — human-gated, dry-run-first reconciliation
 // of a running Task Attempt whose executor is gone, plus optional lifecycle
-// adopt after an interrupted Attempt (#1749).
+// adopt after an interrupted Attempt or succeeded completion (#1749, #2018).
 
 import { executeDomainOperation } from "./db/domain-operation.js";
 import { getDb } from "./db/engine.js";
@@ -263,7 +263,7 @@ function targetCanonicalStatus(legacyStatus: string): "ready" | "completed" {
   if (normalized === "completed") return "completed";
   throw new Error(
     `gsd_task_settle: reconcileLifecycle only repairs a pending/complete mismatch ` +
-    `after an interrupted Attempt; tasks.status is ${legacyStatus}`,
+    `after an interrupted Attempt or succeeded completion; tasks.status is ${legacyStatus}`,
   );
 }
 
@@ -279,7 +279,8 @@ function lifecycleTransitionSteps(
     return ["completed"];
   }
   throw new Error(
-    `gsd_task_settle: cannot reconcile lifecycle ${from} → ${to} after an interrupted Attempt`,
+    `gsd_task_settle: cannot reconcile lifecycle ${from} → ${to} after an interrupted ` +
+    `Attempt or succeeded completion`,
   );
 }
 
@@ -289,13 +290,15 @@ function planLifecycleReconcile(
   hasRunningAttempt: boolean,
 ): TaskLifecycleReconcileRow[] {
   const latest = readLatestTaskAttempt(task);
-  if (!hasRunningAttempt && latest?.outcome !== "interrupted") {
+  const state = readTaskLifecycleState(task);
+  const succeededCompletion = latest?.outcome === "succeeded" &&
+    normalizeLegacyLifecycleStatus(state.legacyStatus) === "completed";
+  if (!hasRunningAttempt && latest?.outcome !== "interrupted" && !succeededCompletion) {
     throw new Error(
-      "gsd_task_settle: reconcileLifecycle requires an interrupted Attempt " +
-      "(settle the running Attempt first)",
+      "gsd_task_settle: reconcileLifecycle requires an interrupted Attempt or a succeeded " +
+      "Attempt with tasks.status complete (settle the running Attempt first)",
     );
   }
-  const state = readTaskLifecycleState(task);
   const target = targetCanonicalStatus(state.legacyStatus);
   const fromStatus = state.lifecycleStatus;
   if (fromStatus === null) {
@@ -421,8 +424,8 @@ export function planTaskSettle(
  * owner or replacement lease remains fail-closed.
  *
  * Optional `reconcileLifecycle` then adopts ready/completed to match
- * tasks.status after that interrupted Attempt, without reopening or deleting
- * SUMMARY projections (#1749).
+ * tasks.status after an interrupted Attempt or succeeded completion, without
+ * reopening or deleting SUMMARY projections (#1749).
  */
 export function applyTaskSettle(input: {
   invocation: ExecutionInvocation;

--- a/src/resources/extensions/gsd/tests/task-settle.test.ts
+++ b/src/resources/extensions/gsd/tests/task-settle.test.ts
@@ -14,7 +14,11 @@ import {
   adoptOrTransitionLifecycle,
   readDomainOperationFence,
 } from "../db/writers/lifecycle-commands.ts";
-import { claimTaskAttempt, readTaskAttempt } from "../task-execution-domain-operation.ts";
+import {
+  claimTaskAttempt,
+  readTaskAttempt,
+  settleTaskAttempt,
+} from "../task-execution-domain-operation.ts";
 import { applyTaskSettle, planTaskSettle } from "../task-settle.ts";
 import { resolveTaskCompletionAuthority } from "../task-completion-compatibility-adapter.ts";
 import type { ExecutionInvocation } from "../execution-invocation.ts";
@@ -447,6 +451,46 @@ test("reconcileLifecycle adopts completed for complete after interrupt without d
     applied.proof?.note ?? "",
     /no current passing Technical Verdict/,
   );
+});
+
+test("reconcileLifecycle adopts completed after an out-of-band succeeded Attempt (#2018)", () => {
+  const { attemptId, dir } = seedRunningAttempt();
+  settleTaskAttempt({
+    invocation: invocation("fixture/succeed"),
+    attemptId,
+    outcome: "succeeded",
+    failureClass: "none",
+    summary: "executor completed out of band",
+    output: { completed: true },
+  });
+  assert.equal(readTaskAttempt(attemptId)?.outcome, "succeeded");
+  assert.equal(taskLifecycleStatus(), "in_progress");
+
+  assert.throws(
+    () => planTaskSettle(TASK, "operator repair", { reconcileLifecycle: true }),
+    /succeeded Attempt with tasks.status complete/,
+    "a succeeded Attempt must not reconcile a legacy pending task back to ready",
+  );
+
+  const summaryPath = restoreSummary(dir, "# Out-of-band completion SUMMARY", "complete");
+  const planned = planTaskSettle(TASK, "operator repair", { reconcileLifecycle: true });
+  assert.equal(planned.rows.length, 0);
+  assert.deepEqual(
+    planned.lifecycleRows.map((row) => `${row.currentStatus}->${row.targetStatus}`),
+    ["in_progress->completed"],
+  );
+
+  const applied = applyTaskSettle({
+    invocation: invocation("settle/reconcile/succeeded"),
+    task: TASK,
+    reason: "operator repair",
+    reconcileLifecycle: true,
+  });
+  assert.equal(applied.settled, false);
+  assert.equal(applied.reconciled, true);
+  assert.equal(taskLifecycleStatus(), "completed");
+  assert.equal(existsSync(summaryPath), true);
+  assert.equal(readFileSync(summaryPath, "utf8"), "# Out-of-band completion SUMMARY");
 });
 
 test("reconcileLifecycle reports when completed repair still lacks passing proof (#1749)", () => {


### PR DESCRIPTION
## Summary
- Reconciled succeeded orphaned task lifecycles safely, with regression coverage and static checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2018
- [#2018 [Bug]: gsd_task_settle --reconcileLifecycle cannot reconcile orphaned in_progress lifecycle row whose latest Attempt outcome is succeeded (variant of #1983)](https://github.com/open-gsd/gsd-pi/issues/2018)

## User
- @k-juarez

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2018-bug-gsd-task-settle-reconcilelifecycle-c-1787810238`