### PR TITLE
fix(issue): plan-milestone prompt mentions forbidden gsd_resume, then recovery marks failed planning as completed S00-blocker

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -2289,7 +2289,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       // - User-input waits in deep setup: pause instead of retrying or writing
       //   placeholders while the agent is waiting for approval.
       // - Deterministic policy rejection (#4973): structural write-gate failure
-      //   that will recur on every retry, so write a blocker placeholder.
+      //   that will recur on every retry, so surface a blocker without retrying.
       // - DB infra failure (#2517): completion tool returned db_unavailable, so
       //   the artifact was never written. Retrying can never succeed.
       // - Tool invocation error (#2883/#3595): malformed JSON args or queued
@@ -2356,17 +2356,24 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         return "dispatched";
       } else if (!triggerArtifactVerified && s.lastToolInvocationError && isDeterministicPolicyError(s.lastToolInvocationError)) {
         const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
+        const planningBlocked = s.currentUnit.type === "plan-milestone";
         debugLog("postUnit", { phase: "deterministic-policy-error-placeholder", unitType: s.currentUnit.type, unitId: s.currentUnit.id, error: s.lastToolInvocationError });
-        const reason = `Deterministic policy rejection for ${s.currentUnit.type} "${s.currentUnit.id}": ${s.lastToolInvocationError}. Retrying cannot resolve this gate — writing blocker placeholder to advance pipeline.`;
+        const reason = `Deterministic policy rejection for ${s.currentUnit.type} "${s.currentUnit.id}": ${s.lastToolInvocationError}. Retrying cannot resolve this gate — ${planningBlocked ? "recording a fail-closed planning blocker" : "writing blocker placeholder to advance pipeline"}.`;
         s.lastToolInvocationError = null;
         s.pendingVerificationRetry = null;
         s.verificationRetryCount.delete(retryKey);
         s.verificationRetryFailureHashes.delete(retryKey);
         writeBlockerPlaceholder(s.currentUnit.type, s.currentUnit.id, s.basePath, reason);
         ctx.ui.notify(
-          `${s.currentUnit.type} ${s.currentUnit.id} — deterministic policy rejection, wrote blocker placeholder (no retries)`,
-          "warning",
+          planningBlocked
+            ? `${s.currentUnit.type} ${s.currentUnit.id} — deterministic policy rejection, recorded planning blocker and paused (no work marked complete)`
+            : `${s.currentUnit.type} ${s.currentUnit.id} — deterministic policy rejection, wrote blocker placeholder (no retries)`,
+          planningBlocked ? "error" : "warning",
         );
+        if (planningBlocked) {
+          await pauseAuto(ctx, pi);
+          return "dispatched";
+        }
         // Fall through to "continue" — do NOT enter the retry or db-unavailable paths.
       } else if (!triggerArtifactVerified && diagnoseWorktreeIntegrityFailure(verificationBasePath)) {
         const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -11,7 +11,6 @@
 
 import { parseUnitId } from "./unit-id.js";
 import { MILESTONE_ID_RE } from "./milestone-ids.js";
-import { appendEvent } from "./workflow-events.js";
 import { clearParseCache } from "./files.js";
 import {
   isDbAvailable,
@@ -20,7 +19,7 @@ import {
   getSlice,
   getSliceTasks,
   getPendingGatesForTurn,
-  insertSlice,
+  insertGateRun,
   getMilestone,
   immediateTransaction,
   updateMilestoneStatus,
@@ -29,7 +28,7 @@ import {
   recordMilestoneCommitAttribution,
 } from "./gsd-db.js";
 import { refreshWorkflowDatabaseFromDisk } from "./db-workspace.js";
-import { isValidationTerminal } from "./state.js";
+import { invalidateStateCache, isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
 import { readIntegrationBranch } from "./git-service.js";
@@ -450,23 +449,7 @@ export function writeReactiveExecuteBlocker(
 }
 
 /**
- * Whether a milestone already has canonical Domain-Operation lifecycle
- * history. Adopted milestones must not have a fabricated blocker slice
- * inserted to paper over a stuck plan-milestone unit (fail-closed).
- */
-function hasAdoptedMilestoneHistory(milestoneId: string): boolean {
-  return Boolean(getDb().prepare(`
-    SELECT 1 AS adopted
-    FROM workflow_item_lifecycles
-    WHERE item_kind = 'milestone'
-      AND milestone_id = :milestone_id
-      AND slice_id IS NULL
-      AND task_id IS NULL
-  `).get({ ":milestone_id": milestoneId }));
-}
-
-/**
- * Write a placeholder artifact so the pipeline can advance past a stuck unit.
+ * Write a placeholder artifact so recovery can surface a stuck unit.
  * Returns the relative path written, or null if the path couldn't be resolved.
  */
 export function writeBlockerPlaceholder(
@@ -487,7 +470,9 @@ export function writeBlockerPlaceholder(
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   const recoveryLine = unitType === "research-project"
     ? "This placeholder was written by auto-mode so the project research gate can stop fail-closed."
-    : "This placeholder was written by auto-mode so the pipeline can advance.";
+    : unitType === "plan-milestone"
+      ? "This diagnostic records a fail-closed planning gate; it is not a roadmap or completed milestone work."
+      : "This placeholder was written by auto-mode so the pipeline can advance.";
   const content = [
     `# BLOCKER — auto-mode recovery failed`,
     ``,
@@ -508,23 +493,34 @@ export function writeBlockerPlaceholder(
   clearPathCache();
   clearParseCache();
 
-  // Legacy non-Task placeholder handling remains until its owning lifecycle
-  // cutover. Task placeholders are diagnostic-only.
+  // A failed milestone plan must stop durably without fabricating a completed
+  // slice. The recovery gate remains authoritative while the milestone has no
+  // real slices; a later successful plan supersedes it by creating those rows.
   if (isDbAvailable()) {
     const { milestone: mid } = parseUnitId(unitId);
-    const ts = new Date().toISOString();
-    // Insert a placeholder complete slice so deriveState sees activeMilestoneSlices.length > 0
-    // and exits the pre-planning phase. Without this, activeMilestoneSlices stays empty
-    // after the blocker ROADMAP.md is written, causing deriveState to return phase:'pre-planning'
-    // indefinitely and re-dispatching plan-milestone in an infinite loop (#4378).
     if (unitType === "plan-milestone" && mid) {
-      if (hasAdoptedMilestoneHistory(mid)) {
-        logWarning("recovery", `Skipping fabricated S00-blocker slice for ${mid}: adopted canonical milestone history exists (fail-closed; see S05 for the real cascade).`);
-      } else {
-        try {
-          insertSlice({ id: "S00-blocker", milestoneId: mid, title: "Blocker placeholder — planning failed", status: "complete", sequence: 0 });
-        } catch (e) { logWarning("recovery", `insertSlice placeholder failed for plan-milestone recovery: ${e instanceof Error ? e.message : String(e)}`); }
-        try { appendEvent(base, { cmd: "plan-milestone", params: { milestoneId: mid }, ts, actor: "system", trigger_reason: "blocker-placeholder-recovery" }); } catch (e) { logWarning("recovery", `appendEvent failed for plan-milestone recovery: ${e instanceof Error ? e.message : String(e)}`); }
+      const recordedAt = new Date().toISOString();
+      try {
+        insertGateRun({
+          traceId: `auto-recovery:${mid}`,
+          turnId: `plan-milestone:${mid}:${recordedAt}`,
+          gateId: "plan-milestone-recovery",
+          gateType: "policy",
+          unitType,
+          unitId,
+          milestoneId: mid,
+          outcome: "manual-attention",
+          failureClass: "manual-attention",
+          rationale: reason,
+          findings: `Diagnostic artifact: ${blockerArtifactPath}`,
+          attempt: 1,
+          maxAttempts: 1,
+          retryable: false,
+          evaluatedAt: recordedAt,
+        });
+        invalidateStateCache();
+      } catch (e) {
+        logWarning("recovery", `planning blocker persistence failed for plan-milestone recovery: ${e instanceof Error ? e.message : String(e)}`);
       }
     }
   }

--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -307,26 +307,35 @@ export async function recoverTimedOutUnit(
     return "paused";
   }
 
-  // Retries exhausted — write a blocker placeholder and advance the pipeline
-  // instead of silently stalling.
+  // Retries exhausted — surface a blocker instead of silently stalling.
+  // Milestone planning pauses fail-closed; legacy units retain their existing
+  // placeholder-and-advance behavior.
   const placeholder = writeBlockerPlaceholder(
     unitType, unitId, basePath,
     `${reason} recovery exhausted ${maxRecoveryAttempts} attempts without producing the artifact.`,
   );
 
   if (placeholder) {
+    const planningBlocked = unitType === "plan-milestone";
     writeUnitRuntimeRecord(basePath, unitType, unitId, currentUnitStartedAt, {
-      phase: "skipped",
+      phase: planningBlocked ? "paused" : "skipped",
       recoveryAttempts: recoveryAttempts + 1,
       lastRecoveryReason: reason,
     });
-    ctx.ui.notify(
-      `${unitType} ${unitId} skipped after ${maxRecoveryAttempts} recovery attempts. Blocker placeholder written to ${placeholder}. Advancing pipeline. (attempt ${attemptNumber})`,
-      "warning",
-    );
+    if (planningBlocked) {
+      ctx.ui.notify(
+        `${unitType} ${unitId} blocked after ${maxRecoveryAttempts} recovery attempts. Diagnostic written to ${placeholder}; no milestone work was marked complete. Pausing for repair. (attempt ${attemptNumber})`,
+        "error",
+      );
+    } else {
+      ctx.ui.notify(
+        `${unitType} ${unitId} skipped after ${maxRecoveryAttempts} recovery attempts. Blocker placeholder written to ${placeholder}. Advancing pipeline. (attempt ${attemptNumber})`,
+        "warning",
+      );
+    }
     unitRecoveryCount.delete(recoveryKey);
     bumpAndResolveSynthetic(`timeout-recovery:${reason}:${unitType}/${unitId}`);
-    return "recovered";
+    return planningBlocked ? "paused" : "recovered";
   }
 
   // Fallback: couldn't resolve artifact path — pause as before.

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -638,6 +638,31 @@ export function getMilestone(id: string): MilestoneRow | null {
   return rowToMilestone(row);
 }
 
+export interface PlanMilestoneRecoveryBlock {
+  reason: string;
+}
+
+/** Latest unresolved fail-closed recovery gate for a milestone with no executable plan. */
+export function getPlanMilestoneRecoveryBlock(milestoneId: string): PlanMilestoneRecoveryBlock | null {
+  const db = getDbOrNull();
+  if (!db) return null;
+  const row = db.prepare(`
+    SELECT outcome, rationale, findings
+    FROM gate_runs
+    WHERE gate_id = 'plan-milestone-recovery'
+      AND unit_type = 'plan-milestone'
+      AND milestone_id = :milestone_id
+    ORDER BY id DESC
+    LIMIT 1
+  `).get({ ":milestone_id": milestoneId });
+  if (!row || row["outcome"] !== "manual-attention") return null;
+  const rationale = typeof row["rationale"] === "string" ? row["rationale"].trim() : "";
+  const findings = typeof row["findings"] === "string" ? row["findings"].trim() : "";
+  return {
+    reason: rationale || findings || `Milestone ${milestoneId} planning failed.`,
+  };
+}
+
 export function getActiveMilestoneFromDb(): MilestoneRow | null {
   if (!getDbOrNull()!) return null;
   const row = getDbOrNull()!.prepare(

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -18,6 +18,7 @@ import {
   getAllMilestones,
   getArtifact,
   getMilestoneScopedArtifacts,
+  getPlanMilestoneRecoveryBlock,
   getPendingGateCountForTurn,
   getReplanHistory,
   getRequirementCounts,
@@ -481,6 +482,15 @@ export async function deriveStateFromDb(
   }
 
   if (activeMilestoneSlices.length === 0) {
+    const planningBlocker = getPlanMilestoneRecoveryBlock(activeMilestone.id);
+    if (planningBlocker) {
+      return buildDerivedState(
+        { activeMilestone, registry, requirements, milestoneProgress },
+        'blocked',
+        `Milestone ${activeMilestone.id} planning is blocked. Resolve the planning failure before resuming auto-mode.`,
+        { blockers: [planningBlocker.reason] },
+      );
+    }
     const phase = activeMilestoneHasDraft ? 'needs-discussion' as const : 'pre-planning' as const;
     const nextAction = activeMilestoneHasDraft
       ? `Discuss draft context for milestone ${activeMilestone.id}.`

--- a/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
@@ -2,7 +2,8 @@
 //
 // When gsd_summary_save returns context_write_blocked (a deterministic write-gate
 // rejection), the retry controller must NOT re-dispatch with escalating model tiers.
-// Instead it must write a blocker placeholder and advance the pipeline immediately.
+// Instead it must surface a blocker without retrying. Milestone planning pauses
+// fail-closed; legacy units may retain placeholder-and-advance recovery.
 //
 // Test 5 — deterministic error short-circuits retry:
 //   - isDeterministicPolicyError correctly classifies context_write_blocked errors
@@ -31,6 +32,13 @@ import {
 import { AutoSession } from "../auto/session.ts";
 import { _setAutoActiveForTest } from "../auto.ts";
 import { escalateTier } from "../model-router.ts";
+import {
+  closeDatabase,
+  getMilestoneSlices,
+  getPlanMilestoneRecoveryBlock,
+  insertMilestone,
+  openDatabase,
+} from "../gsd-db.ts";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -255,6 +263,43 @@ describe("Test 5 — postUnitPreVerification short-circuits on deterministic err
       existsSync(placeholderPath),
       `blocker placeholder must be written at ${placeholderPath}`,
     );
+  });
+
+  test("plan-milestone deterministic rejection records a blocker and pauses without fake work", async (t) => {
+    const { postUnitPreVerification } = await import("../auto-post-unit.ts");
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    t.after(() => closeDatabase());
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.currentUnit = { type: "plan-milestone", id: "M001", startedAt: Date.now() };
+    s.lastToolInvocationError = "This is a mechanical gate: gsd_resume is not allowed";
+
+    const notifications: string[] = [];
+    let pauseCalled = false;
+    const pctx = {
+      s,
+      ctx: { ui: { notify: (message: string) => notifications.push(message) } },
+      pi: {},
+      buildSnapshotOpts: () => ({}) as any,
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto: async () => { pauseCalled = true; },
+      updateProgressWidget: () => {},
+    } as any;
+
+    const result = await postUnitPreVerification(pctx, {
+      skipSettleDelay: true,
+      skipWorktreeSync: true,
+    });
+
+    assert.strictEqual(result, "dispatched", "failed milestone planning must pause auto-mode");
+    assert.strictEqual(pauseCalled, true);
+    assert.deepEqual(getMilestoneSlices("M001"), [], "recovery must not create S00-blocker");
+    assert.match(getPlanMilestoneRecoveryBlock("M001")?.reason ?? "", /gsd_resume is not allowed/);
+    assert.ok(notifications.some((message) => message.includes("no work marked complete")));
   });
 });
 

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -10,7 +10,7 @@ import { createRequire } from "node:module";
 
 import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, diagnoseWorktreeIntegrityFailure, buildLoopRemediationSteps, writeBlockerPlaceholder, refreshRecoveryDbForArtifact, writeReactiveExecuteBlocker } from "../auto-recovery.ts";
 import { resolveMilestoneFile } from "../paths.ts";
-import { _getAdapter, openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, insertAssessment, getMilestone, getMilestoneCommitAttributionShas, getTask, getSlice, saveGateResult, updateMilestoneStatus } from "../gsd-db.ts";
+import { _getAdapter, openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, insertAssessment, getMilestone, getMilestoneCommitAttributionShas, getPlanMilestoneRecoveryBlock, getTask, getSlice, saveGateResult, updateMilestoneStatus } from "../gsd-db.ts";
 import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.ts";
 import { recordFailureAndSelectRecovery } from "../task-recovery-domain-operation.ts";
 import { internalExecutionInvocation } from "../execution-invocation.ts";
@@ -2664,6 +2664,11 @@ test("writeBlockerPlaceholder fails closed instead of inserting an S00-blocker s
       getSlice("M001", "S00-blocker"),
       null,
       "adopted milestone must not get a fabricated S00-blocker slice",
+    );
+    assert.match(
+      getPlanMilestoneRecoveryBlock("M001")?.reason ?? "",
+      /verification retries exhausted/,
+      "adopted milestone planning failures still need a durable blocker",
     );
     const events = readEvents(join(base, ".gsd", "event-log.jsonl"));
     assert.equal(

--- a/src/resources/extensions/gsd/tests/blocker-placeholder-logs.test.ts
+++ b/src/resources/extensions/gsd/tests/blocker-placeholder-logs.test.ts
@@ -1,9 +1,8 @@
 // gsd-pi — Blocker-placeholder recovery log coverage.
 //
-// writeBlockerPlaceholder (auto-recovery.ts:782) writes a placeholder artifact
-// so the pipeline can surface a stuck unit. Diagnostic placeholders never
-// fabricate Task or Slice lifecycle authority. The remaining plan-milestone
-// compatibility writes are best-effort and log recovery warnings on failure.
+// writeBlockerPlaceholder writes a placeholder artifact so the pipeline can
+// surface a stuck unit. Diagnostic placeholders never fabricate Task or Slice
+// lifecycle authority. Plan-milestone records a durable recovery gate instead.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -87,22 +86,20 @@ test("writeBlockerPlaceholder never reads or changes Slice authority", () => {
   }
 });
 
-test("writeBlockerPlaceholder logs a recovery warning when the plan-milestone insertSlice throws (auto-recovery.ts:853)", () => {
+test("writeBlockerPlaceholder logs a recovery warning when the plan-milestone blocker gate cannot persist", () => {
   const base = makeBase();
   try {
     openDatabase(join(base, ".gsd", "gsd.db"));
-    // Drop slices so the S00-blocker insertSlice throws inside the
-    // plan-milestone placeholder branch.
-    _getAdapter()!.exec("DROP TABLE slices");
+    _getAdapter()!.exec("DROP TABLE gate_runs");
 
     const { logs } = captureLogs(() =>
       writeBlockerPlaceholder("plan-milestone", "M001", base, "exhausted retries"),
     );
 
     const warn = recoveryWarnings(logs).find((w) =>
-      /insertSlice placeholder failed for plan-milestone recovery/u.test(w.message),
+      /planning blocker persistence failed for plan-milestone recovery/u.test(w.message),
     );
-    assert.ok(warn, "a recovery warning must be logged when the blocker slice insert throws");
+    assert.ok(warn, "a recovery warning must be logged when the durable blocker write throws");
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });
@@ -148,21 +145,24 @@ test("writeBlockerPlaceholder never appends Slice lifecycle events", () => {
   }
 });
 
-test("writeBlockerPlaceholder logs a recovery warning when the plan-milestone appendEvent throws (auto-recovery.ts:908)", () => {
+test("writeBlockerPlaceholder never appends plan-milestone lifecycle events", () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-blocker-logs-pm-"));
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
   try {
     openDatabase(join(base, ".gsd", "gsd.db"));
-    // Slices table intact so the S00-blocker insertSlice (:907) succeeds;
-    // block the workflow-event append so the plan-milestone appendEvent (:908) throws.
+    insertMilestone({ id: "M001", title: "M", status: "active" });
+    // If recovery still appends a lifecycle event, this path forces it to fail
+    // and emit a warning. Durable planning blockers belong in gate_runs.
     mkdirSync(join(base, ".gsd", "event-log.jsonl"), { recursive: true });
 
     const { logs } = captureLogs(() =>
       writeBlockerPlaceholder("plan-milestone", "M001", base, "exhausted retries"),
     );
 
-    const warn = recoveryWarnings(logs).find((w) => /appendEvent failed for plan-milestone recovery/u.test(w.message));
-    assert.ok(warn, "a recovery warning must be logged when the plan-milestone appendEvent throws");
+    assert.equal(
+      recoveryWarnings(logs).some((warning) => /appendEvent failed for plan-milestone recovery/u.test(warning.message)),
+      false,
+    );
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
@@ -8,7 +8,15 @@ import {
   verifyExpectedArtifact,
   buildLoopRemediationSteps,
 } from "../../auto-recovery.ts";
-import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../../gsd-db.ts";
+import {
+  closeDatabase,
+  getMilestoneSlices,
+  getPlanMilestoneRecoveryBlock,
+  insertMilestone,
+  insertSlice,
+  openDatabase,
+} from "../../gsd-db.ts";
+import { deriveState, invalidateStateCache } from "../../state.ts";
 import { drainLogs, setStderrLoggingEnabled, _resetLogs } from "../../workflow-logger.ts";
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
@@ -465,32 +473,37 @@ test('writeBlockerPlaceholder: complete-slice diagnostics never fabricate Slice 
   }
 });
 
-test('writeBlockerPlaceholder: inserts placeholder slice for plan-milestone so deriveState exits pre-planning (#4378)', async () => {
+test('writeBlockerPlaceholder: plan-milestone failure records a durable blocker without completed slices', async (t) => {
   const base = createFixtureBase();
-  try {
-    const { openDatabase, closeDatabase, insertMilestone, getMilestoneSlices, isDbAvailable } =
-      await import("../../gsd-db.ts");
+  t.after(() => cleanup(base));
+  const dbPath = join(base, ".gsd", "gsd.db");
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
 
-    const dbPath = join(base, ".gsd", "gsd.db");
-    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  openDatabase(dbPath);
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
 
-    openDatabase(dbPath);
-    try {
-      insertMilestone({ id: "M001", title: "Test", status: "active" });
+  writeBlockerPlaceholder("plan-milestone", "M001", base, "idle recovery exhausted");
 
-      // Before fix: writeBlockerPlaceholder wrote the placeholder ROADMAP.md but
-      // never updated the DB, so activeMilestoneSlices.length === 0 on next deriveState
-      // call → state.phase stays 'pre-planning' → plan-milestone dispatches again → infinite loop
-      writeBlockerPlaceholder("plan-milestone", "M001", base, "idle recovery exhausted");
+  const slices = getMilestoneSlices("M001");
+  assert.deepEqual(slices, [], "planning recovery must not fabricate completed milestone work");
+  assert.match(
+    getPlanMilestoneRecoveryBlock("M001")?.reason ?? "",
+    /idle recovery exhausted/,
+    "planning failure should be durably queryable",
+  );
 
-      const slices = getMilestoneSlices("M001");
-      assert.ok(slices.length > 0,
-        "writeBlockerPlaceholder must insert a placeholder slice for plan-milestone so " +
-        "deriveState sees activeMilestoneSlices.length > 0 and exits pre-planning phase (#4378)");
-    } finally {
-      if (isDbAvailable()) closeDatabase();
-    }
-  } finally {
-    cleanup(base);
-  }
+  invalidateStateCache();
+  const state = await deriveState(base);
+  assert.equal(state.phase, "blocked", "planning failure must stop dispatch before validation");
+  assert.equal(state.activeMilestone?.id, "M001");
+  assert.match(state.blockers.join("\n"), /idle recovery exhausted/);
+
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Real work", status: "pending" });
+  invalidateStateCache();
+  const recoveredState = await deriveState(base);
+  assert.notEqual(
+    recoveredState.phase,
+    "blocked",
+    "a successfully persisted real slice should supersede the recovery gate",
+  );
 });

--- a/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
+++ b/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 
 import { buildCompleteMilestonePrompt, buildPlanMilestonePrompt } from "../auto-prompts.ts";
 import { createWorkspace, scopeMilestone } from "../workspace.ts";
+import { getUnitToolSurfaceContract } from "../unit-tool-contracts.ts";
 import {
   closeDatabase,
   insertMilestone,
@@ -86,6 +87,28 @@ test("plan-milestone prompt includes tiny untyped project classification and one
   } finally {
     cleanupRepo(base);
   }
+});
+
+test("plan-milestone prompt references only lifecycle tools allowed by its unit contract", async (t) => {
+  const base = makeRepo({ "hello.py": "print('hello')\n" });
+  t.after(() => cleanupRepo(base));
+  const prompt = await buildPlanMilestonePrompt(
+    "M001",
+    "Add hello command",
+    base,
+    scopeMilestone(createWorkspace(base), "M001"),
+    "minimal",
+  );
+  const allowed = new Set<string>(getUnitToolSurfaceContract("plan-milestone")?.allowedGsdTools ?? []);
+  const referenced = new Set(
+    Array.from(prompt.matchAll(/\b(gsd_[a-z0-9_]+)\b/gu), (match) => match[1]!),
+  );
+
+  assert.ok(referenced.size > 0, "rendered prompt should name its persistence tools");
+  for (const toolName of referenced) {
+    assert.ok(allowed.has(toolName), `rendered plan-milestone prompt must allow ${toolName}`);
+  }
+  assert.doesNotMatch(prompt, /\bgsd_(?:resume|exec|exec_search)\b/);
 });
 
 test("plan-milestone prompt includes small untyped project 1-2 slice guidance", async () => {

--- a/src/resources/extensions/gsd/tests/stalled-tool-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/stalled-tool-recovery.test.ts
@@ -20,7 +20,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { verifyExpectedArtifact } from "../auto-recovery.ts";
 import { recoverTimedOutUnit, type RecoveryContext } from "../auto-timeout-recovery.ts";
-import { closeDatabase, insertAssessment, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.ts";
+import { closeDatabase, getMilestoneSlices, getPlanMilestoneRecoveryBlock, insertAssessment, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.ts";
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -217,6 +217,39 @@ function makeRecordingCtx() {
     rmSync(base, { recursive: true, force: true });
   }
 }
+
+// ═══ plan-milestone timeout recovery fails closed without fake work ═══
+
+test("plan-milestone timeout recovery persists a blocker and pauses", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-timeout-plan-milestone-blocked-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  const ctx = makeRecordingCtx();
+  const pi = makeRecordingPi();
+  const recoveryContext: RecoveryContext = {
+    basePath: base,
+    verbose: false,
+    currentUnitStartedAt: Date.now(),
+    unitRecoveryCount: new Map(),
+  };
+
+  assert.equal(await recoverTimedOutUnit(ctx, pi, "plan-milestone", "M001", "idle", recoveryContext), "recovered");
+  assert.equal(await recoverTimedOutUnit(ctx, pi, "plan-milestone", "M001", "idle", recoveryContext), "recovered");
+  assert.equal(await recoverTimedOutUnit(ctx, pi, "plan-milestone", "M001", "idle", recoveryContext), "paused");
+
+  assert.deepEqual(getMilestoneSlices("M001"), [], "timeout recovery must not fabricate a completed slice");
+  assert.match(getPlanMilestoneRecoveryBlock("M001")?.reason ?? "", /recovery exhausted/);
+  assert.ok(
+    ctx.notifications.some((entry: { message: string }) => entry.message.includes("no milestone work was marked complete")),
+    "timeout recovery should explain why planning paused",
+  );
+});
 
 // ═══ plan-slice verification accepts completed task summaries ═══════════════
 

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -187,6 +187,14 @@ const laneLabelByMode: Record<string, string> = {
 };
 
 const contextModeGuidanceOverrideExpectedTools: Record<string, readonly string[]> = {
+  "plan-milestone": [
+    "gsd_milestone_status",
+    "gsd_plan_milestone",
+    "gsd_plan_slice",
+    "gsd_plan_task",
+    "gsd_decision_save",
+    "gsd_requirement_update",
+  ],
   "discuss-milestone": [
     "ask_user_questions",
     "gsd_summary_save",
@@ -343,6 +351,17 @@ test("Context Mode composer: research-project guidance steers to reconnaissance 
 
 test("Context Mode composer: narrow planning guidance steers only to contracted tools", () => {
   const cases = [
+    {
+      unitType: "plan-milestone",
+      expectedTools: [
+        "gsd_milestone_status",
+        "gsd_plan_milestone",
+        "gsd_plan_slice",
+        "gsd_plan_task",
+        "gsd_decision_save",
+        "gsd_requirement_update",
+      ],
+    },
     {
       unitType: "replan-slice",
       expectedTools: ["gsd_replan_slice", "gsd_decision_save"],

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -141,6 +141,8 @@ const CONTEXT_MODE_GUIDANCE_BY_LANE: Record<Exclude<ContextModePolicy, "none">, 
 // with narrower tool contracts than their shared Context Mode lane, so their
 // guidance must name only tools the unit can actually call.
 export const CONTEXT_MODE_GUIDANCE_BY_UNIT: Readonly<Record<string, string>> = {
+  "plan-milestone":
+    "Use preloaded context and `gsd_milestone_status` for milestone state. Persist planning with `gsd_plan_milestone`, `gsd_plan_slice`, or `gsd_plan_task`; use `gsd_decision_save` and `gsd_requirement_update` when needed. These are the only GSD lifecycle tools available in this unit.",
   "discuss-milestone":
     "Use `ask_user_questions` to continue the milestone interview, then persist outcomes with `gsd_summary_save`, `gsd_decision_save`, `gsd_requirement_save`, `gsd_requirement_update`, `gsd_plan_milestone`, or `gsd_milestone_generate_id` as appropriate.",
   "discuss-slice":


### PR DESCRIPTION
## Summary
- Restricted plan-milestone tool guidance and made planning failures stop durably without synthetic completion.

## Bugs Addressed
- [x] **Plan-milestone prompt recommends a forbidden lifecycle tool**
- [x] **Planning failure recovery creates a falsely completed blocker slice**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2021
- [#2021 plan-milestone prompt mentions forbidden gsd_resume, then recovery marks failed planning as completed S00-blocker](https://github.com/open-gsd/gsd-pi/issues/2021)

## User
- @ventus78

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2021-plan-milestone-prompt-mentions-forbidden-1787814928`