### PR TITLE
fix(issue): [Bug]: plan-slice content validator counts 0 tasks when task ids are slice-qualified (S07-T01) — unrecoverable finalize-retry wedge, sanctioned exit cannot fix it

### DIFF
--- a/src/resources/extensions/gsd/safety/content-validator.ts
+++ b/src/resources/extensions/gsd/safety/content-validator.ts
@@ -46,8 +46,8 @@ export function validateContent(
 
 type ContentValidatorFn = (content: string) => ContentViolation[];
 
-// Matches both legacy "**T01: title**" and flat-phase "**T01**: title" checkbox formats.
-const TASK_MARKER_RE = /^\s*(?:-\s+\[[ xX]\]\s+\*\*T\d+(?:\*\*)?:|#{2,4}\s+T\d+\b)/gm;
+// Matches local or slice-qualified task IDs in legacy and flat-phase formats.
+const TASK_MARKER_RE = /^\s*(?:-\s+\[[ xX]\]\s+\*\*(?:S\d+[.-])?T\d+(?:\*\*)?:|#{2,4}\s+(?:S\d+[.-])?T\d+\b)/gm;
 const SLICE_MARKER_RE = /^\s*(?:-\s+\[[ xX]\]\s+\*\*S\d+:|#{2,4}\s+S\d+\b)/gm;
 
 const VALIDATORS: Record<string, ContentValidatorFn> = {

--- a/src/resources/extensions/gsd/tests/content-validator.test.ts
+++ b/src/resources/extensions/gsd/tests/content-validator.test.ts
@@ -72,3 +72,25 @@ test("validateContent marks empty slice plans as blocking", () => {
     rmSync(base, { recursive: true, force: true });
   }
 });
+
+test("validateContent accepts slice-qualified task IDs", (t) => {
+  for (const taskId of ["S07-T01", "S07.T01"]) {
+    const { base, path } = makeTempFile([
+      "# S07: Qualified tasks",
+      "",
+      "## Tasks",
+      "",
+      `- [ ] **${taskId}**: Implement the fix`,
+      "",
+      "## Files",
+      "",
+      "- `src/example.ts`",
+      "",
+      "Verify: pnpm test",
+      "",
+    ].join("\n"));
+    t.after(() => rmSync(base, { recursive: true, force: true }));
+
+    assert.deepEqual(validateContent("plan-slice", path), [], taskId);
+  }
+});


### PR DESCRIPTION
## Summary
- Fixed slice-qualified task ID validation with focused regression tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2026
- [#2026 [Bug]: plan-slice content validator counts 0 tasks when task ids are slice-qualified (S07-T01) — unrecoverable finalize-retry wedge, sanctioned exit cannot fix it](https://github.com/open-gsd/gsd-pi/issues/2026)

## User
- @bbasketballer75

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2026-bug-plan-slice-content-validator-counts--1787880448`