### PR TITLE
fix(issue): [Bug]: initResources() never inspects the destination, so a torn ~/.gsd/agent/ copy is never repaired — and hasMissingBundledResourceFiles() has no caller

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -746,7 +746,8 @@ export function initResources(agentDir: string, skillsDir: string = join(agentDi
   if (manifest && isCurrentPackageManifest(manifest) && manifest.gsdVersion === currentVersion) {
     // Version matches — check content fingerprint for same-version staleness.
     const currentHash = getCurrentResourceFingerprint()
-    if (manifest.contentHash && manifest.contentHash === currentHash) {
+    if (manifest.contentHash && manifest.contentHash === currentHash
+      && !hasMissingBundledResourceFiles(extensionsDir, bundledExtensionsDir)) {
       return
     }
   }

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -586,8 +586,9 @@ test("initResources repairs missing bundled extension files with a current manif
   initResources(fakeAgentDir, skillsDir);
 
   const extensionsDir = join(fakeAgentDir, "extensions", "gsd");
-  const missingFile = join(extensionsDir, "debug-logger.ts");
-  const corruptedFile = join(extensionsDir, "auto.ts");
+  const extensionSuffix = existsSync(join(extensionsDir, "auto.ts")) ? ".ts" : ".js";
+  const missingFile = join(extensionsDir, `debug-logger${extensionSuffix}`);
+  const corruptedFile = join(extensionsDir, `auto${extensionSuffix}`);
   const originalCorruptedContent = readFileSync(corruptedFile, "utf-8");
 
   rmSync(missingFile);

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -543,7 +543,7 @@ test("initResources syncs top-level shared resources used by extension imports",
   );
 });
 
-test("initResources steady-state hash match returns before recursive drift checks", async (t) => {
+test("initResources steady-state extension match skips refresh for non-extension drift", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-fast-path-"));
   const fakeAgentDir = join(tmp, ".gsd", "agent");
   const skillsDir = join(tmp, "skills");
@@ -564,12 +564,42 @@ test("initResources steady-state hash match returns before recursive drift check
 
   assert.doesNotThrow(
     () => initResources(fakeAgentDir, skillsDir),
-    "matching manifest hash should return before walking installed resource trees",
+    "matching manifest and extensions should skip the refresh path",
   );
   assert.equal(
     readFileSync(sharedDir, "utf-8"),
     "not a directory",
     "matching manifest hash should skip the refresh path",
+  );
+});
+
+test("initResources repairs missing bundled extension files with a current manifest", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-extension-drift-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const skillsDir = join(tmp, "skills");
+
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir, skillsDir);
+
+  const extensionsDir = join(fakeAgentDir, "extensions", "gsd");
+  const missingFile = join(extensionsDir, "debug-logger.ts");
+  const corruptedFile = join(extensionsDir, "auto.ts");
+  const originalCorruptedContent = readFileSync(corruptedFile, "utf-8");
+
+  rmSync(missingFile);
+  writeFileSync(corruptedFile, "CORRUPTED\n");
+
+  initResources(fakeAgentDir, skillsDir);
+
+  assert.equal(existsSync(missingFile), true, "missing bundled extension files should be restored");
+  assert.equal(
+    readFileSync(corruptedFile, "utf-8"),
+    originalCorruptedContent,
+    "a repair sync should overwrite other drifted extension files",
   );
 });
 


### PR DESCRIPTION
## Summary
- Repaired torn managed extension copies by checking destination completeness before skipping sync, with regression verification.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2028
- [#2028 [Bug]: initResources() never inspects the destination, so a torn ~/.gsd/agent/ copy is never repaired — and hasMissingBundledResourceFiles() has no caller](https://github.com/open-gsd/gsd-pi/issues/2028)

## User
- @bbasketballer75

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2028-bug-initresources-never-inspects-the-des-1787883811`