### PR TITLE
fix(issue): [Bug]: 503 no_available_providers never reaches model fallback — core-retry hand-off keys on a display-only string

### DIFF
--- a/docs/extension-sdk/api-reference.md
+++ b/docs/extension-sdk/api-reference.md
@@ -345,7 +345,7 @@ Agent lifecycle events carry optional correlation metadata when the current prov
 |-------|------|-------------|-------------|
 | `before_agent_start` | `BeforeAgentStartEvent` | `BeforeAgentStartEventResult` | After user submits prompt, before agent loop. Can inject system prompt or message. |
 | `agent_start` | `AgentStartEvent` | — | Agent loop started. May include `sessionId` and `turnId`. |
-| `agent_end` | `AgentEndEvent` | — | Agent loop ended. Includes `messages`; may include `sessionId`, `turnId`, and `abortOrigin`. |
+| `agent_end` | `AgentEndEvent` | — | Agent loop ended. Includes `messages`; may include `willRetry`, `sessionId`, `turnId`, and `abortOrigin`. |
 | `stop` | `StopEvent` | — | Agent is truly idle with no follow-up or steering pending. May include `sessionId`, `turnId`, and `abortOrigin`. |
 | `turn_start` | `TurnStartEvent` | — | Start of each turn. Includes `turnIndex` and `timestamp`; may include `sessionId` and `turnId`. |
 | `turn_end` | `TurnEndEvent` | — | End of each turn. Includes `turnIndex`, `message`, and `toolResults`; may include `sessionId` and `turnId`. |

--- a/packages/gsd-agent-core/src/session/agent-session-events.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-events.ts
@@ -54,11 +54,13 @@ export class AgentSessionEventsModule {
 			}
 		}
 
+		const agentEndWillRetry = event.type === "agent_end" ? this.willRetryAfterAgentEnd(event) : undefined;
+
 		// Emit to extensions first
-		await this.emitExtensionEvent(event);
+		await this.emitExtensionEvent(event, agentEndWillRetry);
 
 		// Notify all listeners
-		this.emit(event.type === "agent_end" ? { ...event, willRetry: this.willRetryAfterAgentEnd(event) } : event);
+		this.emit(event.type === "agent_end" ? { ...event, willRetry: agentEndWillRetry ?? false } : event);
 
 		// Handle session persistence
 		if (event.type === "message_end") {
@@ -155,12 +157,16 @@ export class AgentSessionEventsModule {
 		Object.assign(targetRecord, replacement);
 	}
 
-	async emitExtensionEvent(event: AgentEvent): Promise<void> {
+	async emitExtensionEvent(event: AgentEvent, agentEndWillRetry?: boolean): Promise<void> {
 		if (event.type === "agent_start") {
 			this.host._turnIndex = 0;
 			await this.host._extensionRunner.emit({ type: "agent_start" });
 		} else if (event.type === "agent_end") {
-			await this.host._extensionRunner.emit({ type: "agent_end", messages: event.messages });
+			await this.host._extensionRunner.emit({
+				type: "agent_end",
+				messages: event.messages,
+				willRetry: agentEndWillRetry ?? false,
+			});
 		} else if (event.type === "turn_start") {
 			const extensionEvent: TurnStartEvent = {
 				type: "turn_start",

--- a/packages/pi-coding-agent/docs/extensions.md
+++ b/packages/pi-coding-agent/docs/extensions.md
@@ -509,6 +509,7 @@ pi.on("agent_start", async (_event, ctx) => {});
 
 pi.on("agent_end", async (event, ctx) => {
   // event.messages - messages from this prompt
+  // event.willRetry - whether core will retry after handlers finish (when available)
 });
 ```
 

--- a/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
@@ -709,6 +709,8 @@ export interface AgentStartEvent {
 export interface AgentEndEvent {
 	type: "agent_end";
 	messages: AgentMessage[];
+	/** Whether core will retry the failed turn after extension handlers finish. */
+	willRetry?: boolean;
 }
 
 /** Fired at the start of each turn */

--- a/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -122,7 +122,17 @@ describe("AgentSession retry and event characterization", () => {
 	});
 
 	it("exhausts max retries and emits a failure event", async () => {
-		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } } });
+		const extensionWillRetry: Array<boolean | undefined> = [];
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_end", (event) => {
+						extensionWillRetry.push(event.willRetry);
+					});
+				},
+			],
+		});
 		harnesses.push(harness);
 		const retryEvents: string[] = [];
 		harness.session.subscribe((event) => {
@@ -140,6 +150,7 @@ describe("AgentSession retry and event characterization", () => {
 
 		expect(retryEvents).toEqual(["start:1", "start:2", "end:false"]);
 		expect(harness.eventsOfType("agent_end").map((event) => event.willRetry)).toEqual([true, true, false]);
+		expect(extensionWillRetry).toEqual([true, true, false]);
 		expect(harness.faux.state.callCount).toBe(3);
 		expect(harness.session.isRetrying).toBe(false);
 	});

--- a/src/resources/extensions/gsd/auto/types.ts
+++ b/src/resources/extensions/gsd/auto/types.ts
@@ -41,10 +41,13 @@ export const BUDGET_THRESHOLDS: Array<{
 
 /**
  * Minimal shape of the event parameter from pi.on("agent_end", ...).
- * The full event has more fields, but the loop only needs messages.
+ * The full event has more fields, but the loop only needs messages plus the
+ * core-retry hand-off signal when the host provides it.
  */
 export interface AgentEndEvent {
   messages: unknown[];
+  /** Present on session events; optional for legacy hosts and synthetic events. */
+  willRetry?: boolean;
   sessionId?: string;
   turnId?: string;
   abortOrigin?: "session-transition" | "user" | "timeout" | "unknown";

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -785,10 +785,14 @@ export async function handleAgentEnd(
     }
 
     // ── 1b. Defer to Core RetryHandler for most transient errors ────────
-    // Core retries transient failures in-session after this handler.
-    // Keep that behavior for non-rate-limit classes to avoid pause/retry races,
-    // but let rate-limit continue into model fallback logic below (#4373).
-    if (shouldDeferTransientErrorToCoreRetry(cls, rawErrorMsg, rawErrorMsg || displayMsg)) {
+    // Core retries transient failures in-session after this handler. Its
+    // explicit willRetry=false signal hands exhausted retries off to model
+    // fallback; legacy events still use the rendered-prefix compatibility check.
+    // Keep rate limits on model fallback logic below (#4373).
+    if (
+      event.willRetry !== false
+      && shouldDeferTransientErrorToCoreRetry(cls, rawErrorMsg, rawErrorMsg || displayMsg)
+    ) {
       return;
     }
 

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -718,7 +718,7 @@ test("usage-limit agent_end resolves a credential-cooldown cancellation without 
   }
 });
 
-test("retry-exhausted abort/unknown provider stop reasons trigger model fallback (#1364)", async () => {
+test("retry-exhausted transient provider errors trigger model fallback (#1364, #2031)", async () => {
   const originalCwd = process.cwd();
   const originalSetTimeout = globalThis.setTimeout;
 
@@ -730,7 +730,23 @@ test("retry-exhausted abort/unknown provider stop reasons trigger model fallback
   }) as typeof setTimeout;
 
   try {
-    for (const reason of ["abort", "unknown"]) {
+    for (const { reason, errorMessage, willRetry } of [
+      {
+        reason: "abort",
+        errorMessage: "Retry failed after 3 attempts: Unhandled stop reason: abort",
+        willRetry: undefined,
+      },
+      {
+        reason: "unknown",
+        errorMessage: "Retry failed after 3 attempts: Unhandled stop reason: unknown",
+        willRetry: undefined,
+      },
+      {
+        reason: "no_available_providers",
+        errorMessage: '503 {"error":{"type":"no_available_providers","message":"No available providers"}}',
+        willRetry: false,
+      },
+    ]) {
       const base = mkdtempSync(join(tmpdir(), `gsd-stop-reason-${reason}-`));
       const notifications: Array<{ message: string; level?: string }> = [];
       const setModelCalls: string[] = [];
@@ -789,10 +805,11 @@ test("retry-exhausted abort/unknown provider stop reasons trigger model fallback
         } as any;
 
         await handleAgentEnd(pi, {
+          willRetry,
           messages: [{
             role: "assistant",
             stopReason: "error",
-            errorMessage: `Retry failed after 3 attempts: Unhandled stop reason: ${reason}`,
+            errorMessage,
           }],
         } as any, ctx);
 


### PR DESCRIPTION
## Summary
- Exposed core retry exhaustion to model fallback with regression coverage and clean static verification.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2031
- [#2031 [Bug]: 503 no_available_providers never reaches model fallback — core-retry hand-off keys on a display-only string](https://github.com/open-gsd/gsd-pi/issues/2031)

## User
- @Jack11111eee

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2031-bug-503-no-available-providers-never-rea-1787897480`