### PR TITLE
fix(issue): [bug] model router ignores dotted Copilot model IDs and pins all phases to the ceiling model

### DIFF
--- a/docs/user-docs/dynamic-model-routing.md
+++ b/docs/user-docs/dynamic-model-routing.md
@@ -69,10 +69,27 @@ Keep `cross_provider: false` when routing inside a flat-rate subscription unless
 Override which model is used for each tier. When omitted, the router uses a built-in capability mapping that knows common model families:
 
 - **Light:** `claude-haiku-4-5`, `gpt-4o-mini`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.1-codex-mini`, `gpt-5.3-codex-spark`, `gpt-5.4-mini`, `gemini-2.0-flash`
-- **Standard:** `claude-sonnet-4-6`, `gpt-4o`, `gpt-4.1`, `gpt-5.1-codex-max`, `gemini-2.5-pro`, `deepseek-chat`
-- **Heavy:** `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8`, `gpt-5`, `gpt-5-pro`, `gpt-5.1`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `o1`, `o3`, `o4-mini`
+- **Standard:** `claude-sonnet-4`, `claude-sonnet-4-5`, `claude-sonnet-4-6`, `gpt-4o`, `gpt-4.1`, `gpt-5.1-codex-max`, `gemini-2.5-pro`, `deepseek-chat`
+- **Heavy:** `claude-opus-4-5`, `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8`, `gpt-5`, `gpt-5-pro`, `gpt-5.1`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `o1`, `o3`, `o4-mini`
 
 Token profiles use the same tier mapping. `budget`, `balanced`, and `quality` declare per-phase tier intentions, then GSD resolves those tiers against the models currently available from your configured providers. This means a profile can resolve to OpenAI, Gemini, Anthropic, or another provider-specific model instead of hardcoding Claude-family defaults.
+
+### Model ID normalization
+
+Tier, cost, capability-profile, availability, and override lookups use a provider-independent model identity. The router trims whitespace, ignores case, removes a provider prefix up to the final `/`, and treats `.`, `_`, and `-` separator runs as equivalent. For example, all of these resolve to the same internal identity:
+
+```text
+github-copilot/claude-sonnet-4.6
+github-copilot/claude_sonnet_4_6
+CLAUDE-SONNET-4-6
+```
+
+This canonicalization is only for matching. It does not rewrite the selected registry entry: complexity-routing decisions retain the available model ID, including its provider prefix, and tier resolution preserves the bare ID's separator spelling if it removes a prefix. A dotted Copilot ID is therefore dispatched with its dotted spelling rather than the router's internal hyphenated key. Explicit provider-qualified `tier_models` values are also preserved, which disambiguates providers that expose the same bare model ID.
+
+Unknown models use two safe fallback paths, each warning once per canonical model identity for the life of the process:
+
+- An unknown model explicitly configured as a phase's primary model is honored exactly and is not downgraded, because the router cannot safely infer its ceiling.
+- An unknown model encountered while building routing candidates is treated as Standard tier, receives neutral capability scores of 50, and receives an expensive comparison cost so it is not assumed to be a cheap option.
 
 ### `escalate_on_failure`
 
@@ -127,9 +144,9 @@ Each model has a built-in **capability profile** — a 7-dimension score (0–10
 | `longContext` | Handling large codebases and long documents |
 | `instruction` | Following structured instructions precisely |
 
-**Built-in profiles** ship for the Claude 4.6/4.7 family, the OpenAI GPT-4.x and GPT-5.x lines (including GPT-5.5), the o-series reasoning models (`o1`, `o3`, `o4-mini`, `o4-mini-deep-research`), Gemini 2.0/2.5, and `deepseek-chat`. The full table lives in `src/resources/extensions/gsd/model-router.ts` (`MODEL_CAPABILITY_PROFILES`).
+**Built-in profiles** ship for Claude 4 and 4.5 models (`claude-sonnet-4`, `claude-sonnet-4-5`, `claude-opus-4-5`, and `claude-haiku-4-5`) as well as later Claude families, the OpenAI GPT-4.x and GPT-5.x lines (including GPT-5.5), the o-series reasoning models (`o1`, `o3`, `o4-mini`, `o4-mini-deep-research`), Gemini 2.0/2.5, and `deepseek-chat`. The full table lives in `src/resources/extensions/gsd/model-router.ts` (`MODEL_CAPABILITY_PROFILES`).
 
-Models without a built-in profile receive **uniform scores of 50** across all dimensions. This is a cold-start policy — unknown models compete but don't have an advantage. From the user's perspective, routing behaves the same as before capability scoring was introduced for those models.
+Models without a built-in profile receive **uniform scores of 50** across all dimensions. This is the neutral-capability part of the unknown-model fallback described above; the router also assigns an expensive comparison cost and emits a deduplicated warning.
 
 **Profiles are heuristic rankings, not benchmarks.** They represent approximate relative strengths, not verified benchmark results. Use user overrides (below) to correct them for models you know well.
 

--- a/docs/zh-CN/user-docs/dynamic-model-routing.md
+++ b/docs/zh-CN/user-docs/dynamic-model-routing.md
@@ -53,8 +53,25 @@ dynamic_routing:
 覆盖每个 tier 默认使用的 model。如果省略，router 会使用内置 capability mapping，它已经知道一些常见 model 家族的大致定位：
 
 - **Light：** `claude-haiku-4-5`、`gpt-4o-mini`、`gemini-2.0-flash`
-- **Standard：** `claude-sonnet-4-6`、`gpt-4o`、`gemini-2.5-pro`
-- **Heavy：** `claude-opus-4-6`、`gpt-4.5-preview`、`gemini-2.5-pro`
+- **Standard：** `claude-sonnet-4`、`claude-sonnet-4-5`、`claude-sonnet-4-6`、`gpt-4o`、`gemini-2.5-pro`
+- **Heavy：** `claude-opus-4-5`、`claude-opus-4-6`、`claude-opus-4-7`、`claude-opus-4-8`、`gpt-5`、`o3`
+
+### Model ID 规范化
+
+router 在查询 tier、成本、capability profile、可用性和用户覆盖项时，会使用与 provider 无关的 model identity。它会去除首尾空白、忽略大小写、移除最后一个 `/` 之前的 provider 前缀，并把连续的 `.`、`_` 和 `-` 视为等价分隔符。例如，以下 ID 都会映射到同一个内部 identity：
+
+```text
+github-copilot/claude-sonnet-4.6
+github-copilot/claude_sonnet_4_6
+CLAUDE-SONNET-4-6
+```
+
+规范化仅用于匹配，不会改写选中的 registry entry：复杂度路由决策会保留可用 model ID（包括 provider 前缀）；tier resolution 即使移除前缀，也会保留 bare ID 原有的分隔符拼写。因此，带点号的 Copilot ID 在派发时仍使用带点号的拼写，而不是 router 内部的连字符 key。显式指定的、带 provider 前缀的 `tier_models` 值也会保留，以便区分提供相同 bare model ID 的多个 providers。
+
+未知 models 有两条安全 fallback 路径；每个规范化后的 model identity 在同一进程生命周期内只会触发一次对应 warning：
+
+- 如果未知 model 被显式配置为某个 phase 的 primary model，router 会原样采用它且不进行降级，因为 router 无法可靠推断其能力上限。
+- 如果未知 model 出现在路由候选集合中，router 会把它视为 Standard tier，给所有 capability 维度赋中性分数 50，并使用较高的比较成本，避免把它误判为低价选项。
 
 ### `escalate_on_failure`
 
@@ -99,9 +116,9 @@ dynamic_routing:
 | `longContext` | 处理大代码库和长文档的能力 |
 | `instruction` | 精确遵循结构化指令的能力 |
 
-目前 9 个 models 带有内置 profile：`claude-opus-4-6`、`claude-sonnet-4-6`、`claude-haiku-4-5`、`gpt-4o`、`gpt-4o-mini`、`gemini-2.5-pro`、`gemini-2.0-flash`、`deepseek-chat`、`o3`。
+内置 profiles 覆盖 Claude 4 和 4.5 models（`claude-sonnet-4`、`claude-sonnet-4-5`、`claude-opus-4-5` 和 `claude-haiku-4-5`），也覆盖后续 Claude families、OpenAI GPT-4.x 和 GPT-5.x 系列、o-series reasoning models（`o1`、`o3`、`o4-mini`、`o4-mini-deep-research`）、Gemini 2.0/2.5 以及 `deepseek-chat`。完整表格位于 `src/resources/extensions/gsd/model-router.ts` 的 `MODEL_CAPABILITY_PROFILES`。
 
-没有内置 profile 的 models 会收到**全维度均为 50** 的默认分数。这是一个冷启动策略：未知模型可以参与竞争，但不会凭空占优。从用户角度看，这类模型的路由行为和 capability scoring 引入前保持一致。
+没有内置 profile 的 models 会收到**全维度均为 50** 的默认分数。这是上文未知 model fallback 的中性 capability 部分；router 还会给它们分配较高的比较成本，并输出去重后的 warning。
 
 **这些 profiles 是启发式排序，不是 benchmark。** 它们表达的是大致的相对优势，而不是经过严格验证的 benchmark 结果。如果你很了解某个 model，可通过用户覆盖项（见下文）修正这些分值。
 

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -88,6 +88,8 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "gemini-flash-2.0": "light",
 
   // Standard-tier models
+  "claude-sonnet-4": "standard",
+  "claude-sonnet-4-5": "standard",
   "claude-sonnet-4-6": "standard",
   "claude-sonnet-5": "standard",           // GA on GitHub Copilot, Anthropic, Vertex, Bedrock
   "claude-sonnet-4-5-20250514": "standard",
@@ -99,6 +101,7 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "deepseek-chat": "standard",
 
   // Heavy-tier models (most capable)
+  "claude-opus-4-5": "heavy",
   "claude-opus-4-6": "heavy",
   "claude-opus-4-7": "heavy",
   "claude-opus-4-8": "heavy",
@@ -131,9 +134,12 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
 const MODEL_COST_PER_1K_INPUT: Record<string, number> = {
   "claude-haiku-4-5": 0.0008,
   "claude-3-5-haiku-latest": 0.0008,
+  "claude-sonnet-4": 0.003,
+  "claude-sonnet-4-5": 0.003,
   "claude-sonnet-4-6": 0.003,
   "claude-sonnet-5": 0.003,                // $3.00/M input; matches Sonnet 4.x pricing
   "claude-sonnet-4-5-20250514": 0.003,
+  "claude-opus-4-5": 0.005,
   "claude-opus-4-6": 0.005,
   "claude-opus-4-7": 0.005,
   "claude-opus-4-8": 0.005,
@@ -176,11 +182,14 @@ const MODEL_COST_PER_1K_INPUT: Record<string, number> = {
 
 export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   // ── Anthropic ──────────────────────────────────────────────────────────────
+  "claude-opus-4-5":              { coding: 95, debugging: 90, research: 85, reasoning: 95, speed: 30, longContext: 80, instruction: 90 },
   "claude-opus-4-6":              { coding: 95, debugging: 90, research: 85, reasoning: 95, speed: 30, longContext: 80, instruction: 90 },
   "claude-opus-4-7":              { coding: 95, debugging: 90, research: 85, reasoning: 95, speed: 30, longContext: 80, instruction: 90 },
   "claude-opus-4-8":              { coding: 97, debugging: 92, research: 87, reasoning: 97, speed: 30, longContext: 85, instruction: 92 },
   "claude-opus-5":                { coding: 97, debugging: 92, research: 87, reasoning: 97, speed: 30, longContext: 85, instruction: 92 },
   "claude-fable-5":               { coding: 97, debugging: 92, research: 87, reasoning: 97, speed: 30, longContext: 85, instruction: 92 },
+  "claude-sonnet-4":              { coding: 85, debugging: 80, research: 75, reasoning: 80, speed: 60, longContext: 75, instruction: 85 },
+  "claude-sonnet-4-5":            { coding: 85, debugging: 80, research: 75, reasoning: 80, speed: 60, longContext: 75, instruction: 85 },
   "claude-sonnet-4-6":            { coding: 85, debugging: 80, research: 75, reasoning: 80, speed: 60, longContext: 75, instruction: 85 },
   "claude-sonnet-5":              { coding: 90, debugging: 85, research: 80, reasoning: 87, speed: 55, longContext: 80, instruction: 88 },
   "claude-sonnet-4-5-20250514":   { coding: 85, debugging: 80, research: 75, reasoning: 80, speed: 60, longContext: 75, instruction: 85 },
@@ -316,9 +325,12 @@ export function scoreEligibleModels(
   capabilityOverrides?: Record<string, Partial<ModelCapabilities>>,
 ): Array<{ modelId: string; score: number }> {
   const scored = eligibleModelIds.map(modelId => {
-    const bareId = bareModelId(modelId);
-    const builtin = MODEL_CAPABILITY_PROFILES[bareId];
-    const override = capabilityOverrides?.[modelId] ?? capabilityOverrides?.[bareId];
+    const bareId = modelId.split("/").pop() ?? modelId;
+    const canonicalId = canonicalModelId(modelId);
+    const builtin = MODEL_CAPABILITY_PROFILES[canonicalId];
+    const override = capabilityOverrides?.[modelId]
+      ?? capabilityOverrides?.[bareId]
+      ?? capabilityOverrides?.[canonicalId];
     const profile: ModelCapabilities = builtin
       ? override ? { ...builtin, ...override } : builtin
       : { coding: 50, debugging: 50, research: 50, reasoning: 50, speed: 50, longContext: 50, instruction: 50 };
@@ -327,8 +339,8 @@ export function scoreEligibleModels(
   scored.sort((a, b) => {
     const scoreDiff = b.score - a.score;
     if (Math.abs(scoreDiff) > 2) return scoreDiff;
-    const costA = MODEL_COST_PER_1K_INPUT[a.modelId] ?? Infinity;
-    const costB = MODEL_COST_PER_1K_INPUT[b.modelId] ?? Infinity;
+    const costA = getModelCost(a.modelId);
+    const costB = getModelCost(b.modelId);
     if (costA !== costB) return costA - costB;
     return a.modelId.localeCompare(b.modelId);
   });
@@ -354,8 +366,8 @@ export function getEligibleModels(
     // Exact match
     if (availableModelIds.includes(explicitModel)) return [explicitModel];
     // Provider-prefix-stripped match
-    const bareExplicit = bareModelId(explicitModel);
-    const match = availableModelIds.find(id => bareModelId(id) === bareExplicit);
+    const bareExplicit = canonicalModelId(explicitModel);
+    const match = availableModelIds.find(id => canonicalModelId(id) === bareExplicit);
     if (match) return [match];
   }
 
@@ -646,7 +658,7 @@ function findModelForTier(
   // Same-provider only: keep models whose bare ID matches a canonical
   // Anthropic ID at this tier (i.e., a claude-* model in the tier map).
   const sameProvider = eligible.filter(id => {
-    const bare = bareModelId(id);
+    const bare = canonicalModelId(id);
     return MODEL_CAPABILITY_TIER[bare] === tier && bare.startsWith("claude-");
   });
 
@@ -741,17 +753,17 @@ function findAvailableModelId(
   if (!preferredModelId) return undefined;
   if (availableModelIds.includes(preferredModelId)) return preferredModelId;
 
-  const preferredBare = bareModelId(preferredModelId);
+  const preferredBare = canonicalModelId(preferredModelId);
   if (!preferredBare) return undefined;
   const preferredProvider = modelProvider(preferredModelId)?.toLowerCase();
   if (preferredProvider) {
     const providerMatch = availableModelIds.find(id =>
-      modelProvider(id)?.toLowerCase() === preferredProvider && bareModelId(id) === preferredBare
+      modelProvider(id)?.toLowerCase() === preferredProvider && canonicalModelId(id) === preferredBare
     );
     if (providerMatch) return providerMatch;
   }
 
-  return availableModelIds.find(id => bareModelId(id) === preferredBare);
+  return availableModelIds.find(id => canonicalModelId(id) === preferredBare);
 }
 
 function modelSatisfiesTier(modelId: string, tier: ComplexityTier): boolean {
@@ -770,21 +782,21 @@ function findPreferredModelForTier(
 
 /**
  * Check whether a model ID is present in the available models list.
- * Handles bare IDs ("claude-opus-4-6") and provider-prefixed IDs ("anthropic/claude-opus-4-6").
+ * Handles provider prefixes and dotted/hyphenated aliases.
  */
 function isModelAvailable(modelId: string, availableModelIds: string[]): boolean {
   if (availableModelIds.includes(modelId)) return true;
-  // Strip provider prefix for comparison. Treat trailing-slash IDs ("provider/")
-  // as no-bare-ID rather than empty-string match (which would erroneously match
-  // any other "provider/" ID).
-  const bare = bareModelId(modelId);
+  // Canonicalize provider prefixes and aliases for comparison. Treat
+  // trailing-slash IDs ("provider/") as no-bare-ID rather than empty-string
+  // match (which would erroneously match any other "provider/" ID).
+  const bare = canonicalModelId(modelId);
   if (!bare) return false;
-  return availableModelIds.some(id => bareModelId(id) === bare);
+  return availableModelIds.some(id => canonicalModelId(id) === bare);
 }
 
 function getModelTier(modelId: string): ComplexityTier {
-  // Strip provider prefix if present
-  const bareId = bareModelId(modelId);
+  // Normalize provider prefixes and dotted aliases before lookup.
+  const bareId = canonicalModelId(modelId);
 
   // Check exact match first
   if (MODEL_CAPABILITY_TIER[bareId]) return MODEL_CAPABILITY_TIER[bareId];
@@ -800,7 +812,7 @@ function getModelTier(modelId: string): ComplexityTier {
 
 /** Check if a model ID has a known capability tier mapping. (#2192) */
 function isKnownModel(modelId: string): boolean {
-  const bareId = bareModelId(modelId);
+  const bareId = canonicalModelId(modelId);
   if (MODEL_CAPABILITY_TIER[bareId]) return true;
   for (const knownId of Object.keys(MODEL_CAPABILITY_TIER)) {
     if (bareId.includes(knownId) || knownId.includes(bareId)) return true;
@@ -809,7 +821,7 @@ function isKnownModel(modelId: string): boolean {
 }
 
 function getModelCost(modelId: string): number {
-  const bareId = bareModelId(modelId);
+  const bareId = canonicalModelId(modelId);
 
   if (MODEL_COST_PER_1K_INPUT[bareId] !== undefined) {
     return MODEL_COST_PER_1K_INPUT[bareId];
@@ -834,15 +846,23 @@ function normalizeResolvedTierModelId(
     return modelId;
   }
 
-  const bareId = bareModelId(modelId);
-  return MODEL_CAPABILITY_TIER[bareId] ? bareId : modelId;
+  const canonicalId = canonicalModelId(modelId);
+  if (!MODEL_CAPABILITY_TIER[canonicalId]) return modelId;
+  return modelId.split("/").pop() ?? modelId;
 }
 
-function bareModelId(modelId: string): string {
-  if (!modelId.includes("/")) return modelId;
-  // .pop() never returns undefined on a non-empty string but ?? guards future
-  // refactors and avoids the misleading non-null assertion.
-  return modelId.split("/").pop() ?? modelId;
+function canonicalModelId(modelId: string): string {
+  const bareId = modelId.includes("/")
+    // .pop() never returns undefined on a non-empty string but ?? guards future
+    // refactors and avoids the misleading non-null assertion.
+    ? modelId.split("/").pop() ?? modelId
+    : modelId;
+
+  // GitHub Copilot dispatches Claude versions with dots while the shared
+  // router registries use hyphens (for example, 4.6 vs 4-6).
+  return bareId.startsWith("claude-")
+    ? bareId.replace(/(\d)\.(?=\d)/g, "$1-")
+    : bareId;
 }
 
 // ─── Provider-specific Tool Limits ─────────────────────────────────────────

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -66,6 +66,50 @@ export interface ModelCapabilities {
   instruction: number;
 }
 
+/**
+ * Semantic aliases whose spelling differs by more than separator or casing.
+ * Both keys and values are canonical so formatting variants never need entries.
+ */
+const MODEL_ID_ALIASES: Readonly<Record<string, string>> = {
+  "gemini-flash-2-0": "gemini-2-0-flash",
+};
+
+const warnedUnknownConfiguredModelIds = new Set<string>();
+const warnedUnknownRoutingModelIds = new Set<string>();
+
+/**
+ * Return the provider-independent key used by all routing registries.
+ * Dispatch continues to use the original registry ID; this value is only for
+ * matching model identities across provider prefixes and formatting variants.
+ */
+export function canonicalizeModelId(modelId: string): string {
+  const trimmedId = modelId.trim();
+  const slash = trimmedId.lastIndexOf("/");
+  const bareId = slash >= 0 ? trimmedId.slice(slash + 1) : trimmedId;
+  const canonicalId = bareId.trim().toLowerCase().replace(/[._-]+/g, "-");
+  return MODEL_ID_ALIASES[canonicalId] ?? canonicalId;
+}
+
+function warnUnknownConfiguredModel(modelId: string): void {
+  const warningKey = canonicalizeModelId(modelId) || modelId;
+  if (warnedUnknownConfiguredModelIds.has(warningKey)) return;
+  warnedUnknownConfiguredModelIds.add(warningKey);
+  console.warn(
+    `[gsd] Dynamic routing does not recognize configured model "${modelId}"; ` +
+      "honoring the configured model without downgrade.",
+  );
+}
+
+function warnUnknownRoutingModel(modelId: string): void {
+  const warningKey = canonicalizeModelId(modelId) || modelId;
+  if (warnedUnknownRoutingModelIds.has(warningKey)) return;
+  warnedUnknownRoutingModelIds.add(warningKey);
+  console.warn(
+    `[gsd] Dynamic routing does not recognize model "${modelId}"; using safe defaults ` +
+      "(standard tier, neutral capabilities, and expensive cost).",
+  );
+}
+
 // ─── Known Model Tiers ───────────────────────────────────────────────────────
 // Maps known model IDs to their capability tier. Used when tier_models is not
 // explicitly configured to pick the best available model for each tier.
@@ -76,16 +120,15 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "claude-3-5-haiku-latest": "light",
   "claude-3-haiku-20240307": "light",
   "gpt-4o-mini": "light",
-  "gpt-4.1-mini": "light",
-  "gpt-4.1-nano": "light",
+  "gpt-4-1-mini": "light",
+  "gpt-4-1-nano": "light",
   "gpt-5-mini": "light",
   "gpt-5-nano": "light",
-  "gpt-5.4-mini": "light",
-  "gpt-5.1-codex-mini": "light",
-  "gpt-5.3-codex-spark": "light",
-  "mai-code-1.1-flash": "light",
-  "gemini-2.0-flash": "light",
-  "gemini-flash-2.0": "light",
+  "gpt-5-4-mini": "light",
+  "gpt-5-1-codex-mini": "light",
+  "gpt-5-3-codex-spark": "light",
+  "mai-code-1-1-flash": "light",
+  "gemini-2-0-flash": "light",
 
   // Standard-tier models
   "claude-sonnet-4": "standard",
@@ -95,9 +138,9 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "claude-sonnet-4-5-20250514": "standard",
   "claude-3-5-sonnet-latest": "standard",
   "gpt-4o": "standard",
-  "gpt-4.1": "standard",
-  "gpt-5.1-codex-max": "standard",
-  "gemini-2.5-pro": "standard",
+  "gpt-4-1": "standard",
+  "gpt-5-1-codex-max": "standard",
+  "gemini-2-5-pro": "standard",
   "deepseek-chat": "standard",
 
   // Heavy-tier models (most capable)
@@ -111,20 +154,20 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "gpt-4-turbo": "heavy",
   "gpt-5": "heavy",
   "gpt-5-pro": "heavy",
-  "gpt-5.1": "heavy",
-  "gpt-5.2": "heavy",
-  "gpt-5.2-codex": "heavy",
-  "gpt-5.3-codex": "heavy",
-  "gpt-5.4": "heavy",
-  "gpt-5.5": "heavy",
-  "gpt-5.6-sol": "heavy",
-  "gpt-5.6-terra": "heavy",
-  "gpt-5.6-luna": "heavy",
+  "gpt-5-1": "heavy",
+  "gpt-5-2": "heavy",
+  "gpt-5-2-codex": "heavy",
+  "gpt-5-3-codex": "heavy",
+  "gpt-5-4": "heavy",
+  "gpt-5-5": "heavy",
+  "gpt-5-6-sol": "heavy",
+  "gpt-5-6-terra": "heavy",
+  "gpt-5-6-luna": "heavy",
   "o1": "heavy",
   "o3": "heavy",
   "o4-mini": "heavy",
   "o4-mini-deep-research": "heavy",
-  "grok-4.5": "heavy",
+  "grok-4-5": "heavy",
 };
 
 // ─── Cost Table (per 1K input tokens, approximate USD) ───────────────────────
@@ -147,33 +190,33 @@ const MODEL_COST_PER_1K_INPUT: Record<string, number> = {
   "claude-fable-5": 0.010,
   "gpt-4o-mini": 0.00015,
   "gpt-4o": 0.0025,
-  "gpt-4.1": 0.002,
-  "gpt-4.1-mini": 0.0004,
-  "gpt-4.1-nano": 0.0001,
+  "gpt-4-1": 0.002,
+  "gpt-4-1-mini": 0.0004,
+  "gpt-4-1-nano": 0.0001,
   "gpt-5": 0.01,
   "gpt-5-mini": 0.0003,
   "gpt-5-nano": 0.0001,
-  "gpt-5.4-mini": 0.00075,
+  "gpt-5-4-mini": 0.00075,
   "gpt-5-pro": 0.015,
-  "gpt-5.1": 0.005,
-  "gpt-5.1-codex-max": 0.003,
-  "gpt-5.1-codex-mini": 0.0003,
-  "gpt-5.2": 0.005,
-  "gpt-5.2-codex": 0.005,
-  "gpt-5.3-codex": 0.005,
-  "gpt-5.3-codex-spark": 0.0003,
-  "mai-code-1.1-flash": 0.0002,
-  "gpt-5.4": 0.005,
-  "gpt-5.5": 0.005,
-  "gpt-5.6-sol": 0.005,
-  "gpt-5.6-terra": 0.0025,
-  "gpt-5.6-luna": 0.001,
+  "gpt-5-1": 0.005,
+  "gpt-5-1-codex-max": 0.003,
+  "gpt-5-1-codex-mini": 0.0003,
+  "gpt-5-2": 0.005,
+  "gpt-5-2-codex": 0.005,
+  "gpt-5-3-codex": 0.005,
+  "gpt-5-3-codex-spark": 0.0003,
+  "mai-code-1-1-flash": 0.0002,
+  "gpt-5-4": 0.005,
+  "gpt-5-5": 0.005,
+  "gpt-5-6-sol": 0.005,
+  "gpt-5-6-terra": 0.0025,
+  "gpt-5-6-luna": 0.001,
   "o4-mini": 0.005,
   "o4-mini-deep-research": 0.005,
-  "gemini-2.0-flash": 0.0001,
-  "gemini-2.5-pro": 0.00125,
+  "gemini-2-0-flash": 0.0001,
+  "gemini-2-5-pro": 0.00125,
   "deepseek-chat": 0.00014,
-  "grok-4.5": 0.002,
+  "grok-4-5": 0.002,
 };
 
 // ─── Capability Profiles Data Table ──────────────────────────────────────────
@@ -203,31 +246,31 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   "gpt-4o":                       { coding: 80, debugging: 75, research: 70, reasoning: 75, speed: 65, longContext: 70, instruction: 80 },
   "gpt-4o-mini":                  { coding: 55, debugging: 45, research: 40, reasoning: 45, speed: 90, longContext: 45, instruction: 70 },
   "gpt-4-turbo":                  { coding: 78, debugging: 72, research: 68, reasoning: 72, speed: 50, longContext: 65, instruction: 78 },
-  "gpt-4.1":                      { coding: 82, debugging: 78, research: 72, reasoning: 78, speed: 62, longContext: 72, instruction: 82 },
-  "gpt-4.1-mini":                 { coding: 58, debugging: 48, research: 42, reasoning: 48, speed: 88, longContext: 48, instruction: 72 },
-  "gpt-4.1-nano":                 { coding: 40, debugging: 30, research: 25, reasoning: 30, speed: 95, longContext: 30, instruction: 60 },
+  "gpt-4-1":                      { coding: 82, debugging: 78, research: 72, reasoning: 78, speed: 62, longContext: 72, instruction: 82 },
+  "gpt-4-1-mini":                 { coding: 58, debugging: 48, research: 42, reasoning: 48, speed: 88, longContext: 48, instruction: 72 },
+  "gpt-4-1-nano":                 { coding: 40, debugging: 30, research: 25, reasoning: 30, speed: 95, longContext: 30, instruction: 60 },
   "gpt-5":                        { coding: 92, debugging: 88, research: 85, reasoning: 92, speed: 40, longContext: 85, instruction: 90 },
   "gpt-5-mini":                   { coding: 62, debugging: 52, research: 48, reasoning: 52, speed: 88, longContext: 52, instruction: 74 },
   "gpt-5-nano":                   { coding: 42, debugging: 32, research: 28, reasoning: 32, speed: 95, longContext: 32, instruction: 62 },
-  "gpt-5.4-mini":                 { coding: 70, debugging: 60, research: 55, reasoning: 60, speed: 84, longContext: 60, instruction: 78 },
+  "gpt-5-4-mini":                 { coding: 70, debugging: 60, research: 55, reasoning: 60, speed: 84, longContext: 60, instruction: 78 },
   "gpt-5-pro":                    { coding: 94, debugging: 90, research: 88, reasoning: 94, speed: 35, longContext: 88, instruction: 92 },
-  "gpt-5.1":                      { coding: 93, debugging: 89, research: 86, reasoning: 93, speed: 42, longContext: 86, instruction: 91 },
-  "gpt-5.1-codex-max":            { coding: 90, debugging: 85, research: 70, reasoning: 85, speed: 55, longContext: 75, instruction: 85 },
-  "gpt-5.1-codex-mini":           { coding: 65, debugging: 55, research: 40, reasoning: 50, speed: 88, longContext: 48, instruction: 72 },
-  "gpt-5.2":                      { coding: 93, debugging: 90, research: 87, reasoning: 93, speed: 42, longContext: 87, instruction: 91 },
-  "gpt-5.2-codex":                { coding: 93, debugging: 90, research: 72, reasoning: 88, speed: 50, longContext: 78, instruction: 88 },
-  "gpt-5.3-codex":                { coding: 94, debugging: 91, research: 74, reasoning: 89, speed: 50, longContext: 80, instruction: 89 },
-  "gpt-5.3-codex-spark":          { coding: 68, debugging: 58, research: 42, reasoning: 52, speed: 90, longContext: 50, instruction: 74 },
-  "mai-code-1.1-flash":           { coding: 78, debugging: 68, research: 45, reasoning: 62, speed: 96, longContext: 70, instruction: 78 },
-  "gpt-5.4":                      { coding: 95, debugging: 92, research: 88, reasoning: 94, speed: 42, longContext: 88, instruction: 92 },
+  "gpt-5-1":                      { coding: 93, debugging: 89, research: 86, reasoning: 93, speed: 42, longContext: 86, instruction: 91 },
+  "gpt-5-1-codex-max":            { coding: 90, debugging: 85, research: 70, reasoning: 85, speed: 55, longContext: 75, instruction: 85 },
+  "gpt-5-1-codex-mini":           { coding: 65, debugging: 55, research: 40, reasoning: 50, speed: 88, longContext: 48, instruction: 72 },
+  "gpt-5-2":                      { coding: 93, debugging: 90, research: 87, reasoning: 93, speed: 42, longContext: 87, instruction: 91 },
+  "gpt-5-2-codex":                { coding: 93, debugging: 90, research: 72, reasoning: 88, speed: 50, longContext: 78, instruction: 88 },
+  "gpt-5-3-codex":                { coding: 94, debugging: 91, research: 74, reasoning: 89, speed: 50, longContext: 80, instruction: 89 },
+  "gpt-5-3-codex-spark":          { coding: 68, debugging: 58, research: 42, reasoning: 52, speed: 90, longContext: 50, instruction: 74 },
+  "mai-code-1-1-flash":           { coding: 78, debugging: 68, research: 45, reasoning: 62, speed: 96, longContext: 70, instruction: 78 },
+  "gpt-5-4":                      { coding: 95, debugging: 92, research: 88, reasoning: 94, speed: 42, longContext: 88, instruction: 92 },
   // GPT-5.5 scores are relative to the existing gpt-5.4 profile and backed by
   // OpenAI's 2026-04-23 published eval deltas across coding, tool use, and long context.
   // Source: https://openai.com/index/introducing-gpt-5-5/
-  "gpt-5.5":                      { coding: 96, debugging: 93, research: 89, reasoning: 95, speed: 42, longContext: 90, instruction: 93 },
+  "gpt-5-5":                      { coding: 96, debugging: 93, research: 89, reasoning: 95, speed: 42, longContext: 90, instruction: 93 },
   // GPT-5.6 profiles are provisional until official eval results are available.
-  "gpt-5.6-sol":                  { coding: 97, debugging: 94, research: 90, reasoning: 96, speed: 42, longContext: 91, instruction: 94 },
-  "gpt-5.6-terra":                { coding: 96, debugging: 93, research: 89, reasoning: 95, speed: 48, longContext: 91, instruction: 93 },
-  "gpt-5.6-luna":                 { coding: 92, debugging: 88, research: 84, reasoning: 91, speed: 72, longContext: 91, instruction: 90 },
+  "gpt-5-6-sol":                  { coding: 97, debugging: 94, research: 90, reasoning: 96, speed: 42, longContext: 91, instruction: 94 },
+  "gpt-5-6-terra":                { coding: 96, debugging: 93, research: 89, reasoning: 95, speed: 48, longContext: 91, instruction: 93 },
+  "gpt-5-6-luna":                 { coding: 92, debugging: 88, research: 84, reasoning: 91, speed: 72, longContext: 91, instruction: 90 },
 
   // ── OpenAI o-series (reasoning-first) ──────────────────────────────────────
   "o1":                           { coding: 78, debugging: 82, research: 78, reasoning: 90, speed: 20, longContext: 65, instruction: 82 },
@@ -236,9 +279,8 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   "o4-mini-deep-research":        { coding: 75, debugging: 80, research: 85, reasoning: 88, speed: 30, longContext: 80, instruction: 80 },
 
   // ── Google ─────────────────────────────────────────────────────────────────
-  "gemini-2.5-pro":               { coding: 75, debugging: 70, research: 85, reasoning: 75, speed: 55, longContext: 90, instruction: 75 },
-  "gemini-2.0-flash":             { coding: 50, debugging: 40, research: 50, reasoning: 40, speed: 95, longContext: 60, instruction: 65 },
-  "gemini-flash-2.0":             { coding: 50, debugging: 40, research: 50, reasoning: 40, speed: 95, longContext: 60, instruction: 65 },
+  "gemini-2-5-pro":               { coding: 75, debugging: 70, research: 85, reasoning: 75, speed: 55, longContext: 90, instruction: 75 },
+  "gemini-2-0-flash":             { coding: 50, debugging: 40, research: 50, reasoning: 40, speed: 95, longContext: 60, instruction: 65 },
 
   // ── DeepSeek ───────────────────────────────────────────────────────────────
   "deepseek-chat":                { coding: 75, debugging: 65, research: 55, reasoning: 70, speed: 70, longContext: 55, instruction: 65 },
@@ -246,7 +288,7 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   // ── xAI ────────────────────────────────────────────────────────────────────
   // Grok 4.5 (2026-07): Opus-class frontier model tuned for coding and agentic
   // work; notably faster and more token-efficient than peer heavy models.
-  "grok-4.5":                     { coding: 95, debugging: 90, research: 82, reasoning: 93, speed: 55, longContext: 80, instruction: 90 },
+  "grok-4-5":                     { coding: 95, debugging: 90, research: 82, reasoning: 93, speed: 55, longContext: 80, instruction: 90 },
 };
 
 // ─── Base Task Requirements Data Table ───────────────────────────────────────
@@ -288,6 +330,21 @@ export function scoreModel(
   return weightSum > 0 ? weightedSum / weightSum : 50;
 }
 
+function findCapabilityOverride(
+  modelId: string,
+  capabilityOverrides?: Record<string, Partial<ModelCapabilities>>,
+): Partial<ModelCapabilities> | undefined {
+  if (!capabilityOverrides) return undefined;
+
+  const bareId = modelId.split("/").pop() ?? modelId;
+  const directOverride = capabilityOverrides[modelId] ?? capabilityOverrides[bareId];
+  if (directOverride) return directOverride;
+
+  const canonicalId = canonicalizeModelId(modelId);
+  return capabilityOverrides[canonicalId]
+    ?? Object.entries(capabilityOverrides).find(([id]) => canonicalizeModelId(id) === canonicalId)?.[1];
+}
+
 /**
  * Compute dynamic task requirements from unit type and optional task metadata.
  * Returns a requirement vector refined by task-specific signals.
@@ -325,12 +382,10 @@ export function scoreEligibleModels(
   capabilityOverrides?: Record<string, Partial<ModelCapabilities>>,
 ): Array<{ modelId: string; score: number }> {
   const scored = eligibleModelIds.map(modelId => {
-    const bareId = modelId.split("/").pop() ?? modelId;
-    const canonicalId = canonicalModelId(modelId);
+    const canonicalId = canonicalizeModelId(modelId);
     const builtin = MODEL_CAPABILITY_PROFILES[canonicalId];
-    const override = capabilityOverrides?.[modelId]
-      ?? capabilityOverrides?.[bareId]
-      ?? capabilityOverrides?.[canonicalId];
+    if (!builtin) warnUnknownRoutingModel(modelId);
+    const override = findCapabilityOverride(modelId, capabilityOverrides);
     const profile: ModelCapabilities = builtin
       ? override ? { ...builtin, ...override } : builtin
       : { coding: 50, debugging: 50, research: 50, reasoning: 50, speed: 50, longContext: 50, instruction: 50 };
@@ -366,8 +421,8 @@ export function getEligibleModels(
     // Exact match
     if (availableModelIds.includes(explicitModel)) return [explicitModel];
     // Provider-prefix-stripped match
-    const bareExplicit = canonicalModelId(explicitModel);
-    const match = availableModelIds.find(id => canonicalModelId(id) === bareExplicit);
+    const canonicalExplicitModelId = canonicalizeModelId(explicitModel);
+    const match = availableModelIds.find(id => canonicalizeModelId(id) === canonicalExplicitModelId);
     if (match) return [match];
   }
 
@@ -409,7 +464,8 @@ export function loadCapabilityOverrides(
   if (!prefs.modelOverrides) return result;
   for (const [modelId, overrideEntry] of Object.entries(prefs.modelOverrides)) {
     if (overrideEntry.capabilities) {
-      result[modelId] = overrideEntry.capabilities;
+      const canonicalId = canonicalizeModelId(modelId);
+      if (canonicalId) result[canonicalId] = overrideEntry.capabilities;
     }
   }
   return result;
@@ -457,7 +513,6 @@ export function resolveModelForComplexity(
   }
 
   const configuredPrimary = phaseConfig.primary;
-  const configuredTier = getModelTier(configuredPrimary);
   const requestedTier = classification.tier;
 
   // If the configured model is unknown (not in MODEL_CAPABILITY_TIER),
@@ -466,6 +521,7 @@ export function resolveModelForComplexity(
   // standard/light unit get downgraded to tier_models, silently ignoring
   // the user's configuration. (#2192)
   if (!isKnownModel(configuredPrimary)) {
+    warnUnknownConfiguredModel(configuredPrimary);
     return {
       modelId: configuredPrimary,
       fallbacks: phaseConfig.fallbacks,
@@ -475,6 +531,8 @@ export function resolveModelForComplexity(
       selectionMethod: "tier-only",
     };
   }
+
+  const configuredTier = getModelTier(configuredPrimary);
 
   // Downgrade-only: if requested tier >= configured tier, no change
   if (tierOrdinal(requestedTier) >= tierOrdinal(configuredTier)) {
@@ -658,7 +716,7 @@ function findModelForTier(
   // Same-provider only: keep models whose bare ID matches a canonical
   // Anthropic ID at this tier (i.e., a claude-* model in the tier map).
   const sameProvider = eligible.filter(id => {
-    const bare = canonicalModelId(id);
+    const bare = canonicalizeModelId(id);
     return MODEL_CAPABILITY_TIER[bare] === tier && bare.startsWith("claude-");
   });
 
@@ -742,8 +800,9 @@ export function resolveModelForTier(
 // ─── Internal ────────────────────────────────────────────────────────────────
 
 function modelProvider(modelId: string): string | undefined {
-  const slash = modelId.indexOf("/");
-  return slash > 0 ? modelId.slice(0, slash) : undefined;
+  const trimmedId = modelId.trim();
+  const slash = trimmedId.indexOf("/");
+  return slash > 0 ? trimmedId.slice(0, slash).trim() : undefined;
 }
 
 function findAvailableModelId(
@@ -753,17 +812,17 @@ function findAvailableModelId(
   if (!preferredModelId) return undefined;
   if (availableModelIds.includes(preferredModelId)) return preferredModelId;
 
-  const preferredBare = canonicalModelId(preferredModelId);
+  const preferredBare = canonicalizeModelId(preferredModelId);
   if (!preferredBare) return undefined;
   const preferredProvider = modelProvider(preferredModelId)?.toLowerCase();
   if (preferredProvider) {
     const providerMatch = availableModelIds.find(id =>
-      modelProvider(id)?.toLowerCase() === preferredProvider && canonicalModelId(id) === preferredBare
+      modelProvider(id)?.toLowerCase() === preferredProvider && canonicalizeModelId(id) === preferredBare
     );
     if (providerMatch) return providerMatch;
   }
 
-  return availableModelIds.find(id => canonicalModelId(id) === preferredBare);
+  return availableModelIds.find(id => canonicalizeModelId(id) === preferredBare);
 }
 
 function modelSatisfiesTier(modelId: string, tier: ComplexityTier): boolean {
@@ -782,57 +841,41 @@ function findPreferredModelForTier(
 
 /**
  * Check whether a model ID is present in the available models list.
- * Handles provider prefixes and dotted/hyphenated aliases.
+ * Handles provider prefixes plus casing and separator variants.
  */
 function isModelAvailable(modelId: string, availableModelIds: string[]): boolean {
   if (availableModelIds.includes(modelId)) return true;
-  // Canonicalize provider prefixes and aliases for comparison. Treat
+  // Canonicalize provider prefixes and formatting variants for comparison. Treat
   // trailing-slash IDs ("provider/") as no-bare-ID rather than empty-string
   // match (which would erroneously match any other "provider/" ID).
-  const bare = canonicalModelId(modelId);
+  const bare = canonicalizeModelId(modelId);
   if (!bare) return false;
-  return availableModelIds.some(id => canonicalModelId(id) === bare);
+  return availableModelIds.some(id => canonicalizeModelId(id) === bare);
 }
 
 function getModelTier(modelId: string): ComplexityTier {
-  // Normalize provider prefixes and dotted aliases before lookup.
-  const bareId = canonicalModelId(modelId);
-
-  // Check exact match first
+  // Normalize provider prefixes, casing, and separators before lookup.
+  const bareId = canonicalizeModelId(modelId);
   if (MODEL_CAPABILITY_TIER[bareId]) return MODEL_CAPABILITY_TIER[bareId];
 
-  // Check if any known model ID is a prefix/suffix match
-  for (const [knownId, tier] of Object.entries(MODEL_CAPABILITY_TIER)) {
-    if (bareId.includes(knownId) || knownId.includes(bareId)) return tier;
-  }
-
   // Unknown models are assumed standard (per D-15: avoids silently ignoring user config)
+  warnUnknownRoutingModel(modelId);
   return "standard";
 }
 
 /** Check if a model ID has a known capability tier mapping. (#2192) */
 function isKnownModel(modelId: string): boolean {
-  const bareId = canonicalModelId(modelId);
-  if (MODEL_CAPABILITY_TIER[bareId]) return true;
-  for (const knownId of Object.keys(MODEL_CAPABILITY_TIER)) {
-    if (bareId.includes(knownId) || knownId.includes(bareId)) return true;
-  }
-  return false;
+  const bareId = canonicalizeModelId(modelId);
+  return Boolean(bareId && MODEL_CAPABILITY_TIER[bareId]);
 }
 
 function getModelCost(modelId: string): number {
-  const bareId = canonicalModelId(modelId);
+  const bareId = canonicalizeModelId(modelId);
 
-  if (MODEL_COST_PER_1K_INPUT[bareId] !== undefined) {
-    return MODEL_COST_PER_1K_INPUT[bareId];
-  }
-
-  // Check partial matches
-  for (const [knownId, cost] of Object.entries(MODEL_COST_PER_1K_INPUT)) {
-    if (bareId.includes(knownId) || knownId.includes(bareId)) return cost;
-  }
+  if (MODEL_COST_PER_1K_INPUT[bareId] !== undefined) return MODEL_COST_PER_1K_INPUT[bareId];
 
   // Unknown cost — assume expensive to avoid routing to unknown cheap models
+  warnUnknownRoutingModel(modelId);
   return 999;
 }
 
@@ -846,23 +889,9 @@ function normalizeResolvedTierModelId(
     return modelId;
   }
 
-  const canonicalId = canonicalModelId(modelId);
+  const canonicalId = canonicalizeModelId(modelId);
   if (!MODEL_CAPABILITY_TIER[canonicalId]) return modelId;
   return modelId.split("/").pop() ?? modelId;
-}
-
-function canonicalModelId(modelId: string): string {
-  const bareId = modelId.includes("/")
-    // .pop() never returns undefined on a non-empty string but ?? guards future
-    // refactors and avoids the misleading non-null assertion.
-    ? modelId.split("/").pop() ?? modelId
-    : modelId;
-
-  // GitHub Copilot dispatches Claude versions with dots while the shared
-  // router registries use hyphens (for example, 4.6 vs 4-6).
-  return bareId.startsWith("claude-")
-    ? bareId.replace(/(\d)\.(?=\d)/g, "$1-")
-    : bareId;
 }
 
 // ─── Provider-specific Tool Limits ─────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -16,6 +16,7 @@ import {
   computeTaskRequirements,
   scoreEligibleModels,
   getEligibleModels,
+  canonicalizeModelId,
   MODEL_CAPABILITY_PROFILES,
   MODEL_CAPABILITY_TIER,
 } from "../model-router.js";
@@ -129,40 +130,73 @@ test("downgrades from opus to sonnet for standard tier", () => {
   assert.equal(result.wasDowngraded, true);
 });
 
-test("downgrades dotted GitHub Copilot Claude IDs by their canonical tier", () => {
+test("separator variants preserve GitHub Copilot downgrade and ceiling semantics", async (t) => {
   const config = { ...defaultRoutingConfig(), enabled: true };
-  const copilotModels = [
-    "github-copilot/claude-opus-4.6",
-    "github-copilot/claude-sonnet-4.6",
-    "github-copilot/claude-haiku-4.5",
+  const variants = [
+    ["dotted", "claude-opus-4.6", "claude-sonnet-4.6", "claude-haiku-4.5"],
+    ["underscored", "claude_opus_4_6", "claude_sonnet_4_6", "claude_haiku_4_5"],
+    ["hyphenated", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
   ];
 
-  const standard = resolveModelForComplexity(
-    makeClassification("standard"),
-    { primary: "github-copilot/claude-opus-4.6", fallbacks: [] },
-    config,
-    copilotModels,
-  );
-  assert.equal(standard.modelId, "github-copilot/claude-sonnet-4.6");
-  assert.equal(standard.wasDowngraded, true);
+  for (const [label, opus, sonnet, haiku] of variants) {
+    await t.test(label, () => {
+      const qualify = (id: string) => `github-copilot/${id}`;
+      const copilotModels = [qualify(opus), qualify(sonnet), qualify(haiku)];
 
-  const light = resolveModelForComplexity(
-    makeClassification("light"),
-    { primary: "github-copilot/claude-opus-4.6", fallbacks: [] },
-    config,
-    copilotModels,
-  );
-  assert.equal(light.modelId, "github-copilot/claude-haiku-4.5");
-  assert.equal(light.wasDowngraded, true);
+      const standard = resolveModelForComplexity(
+        makeClassification("standard"),
+        { primary: qualify(opus), fallbacks: [] },
+        config,
+        copilotModels,
+      );
+      assert.equal(standard.modelId, qualify(sonnet));
+      assert.equal(standard.wasDowngraded, true);
 
-  const heavy = resolveModelForComplexity(
-    makeClassification("heavy"),
-    { primary: "github-copilot/claude-opus-4.6", fallbacks: [] },
-    config,
-    copilotModels,
-  );
-  assert.equal(heavy.modelId, "github-copilot/claude-opus-4.6");
-  assert.equal(heavy.wasDowngraded, false);
+      const light = resolveModelForComplexity(
+        makeClassification("light"),
+        { primary: qualify(opus), fallbacks: [] },
+        config,
+        copilotModels,
+      );
+      assert.equal(light.modelId, qualify(haiku));
+      assert.equal(light.wasDowngraded, true);
+
+      const heavy = resolveModelForComplexity(
+        makeClassification("heavy"),
+        { primary: qualify(opus), fallbacks: [] },
+        config,
+        copilotModels,
+      );
+      assert.equal(heavy.modelId, qualify(opus));
+      assert.equal(heavy.wasDowngraded, false);
+    });
+  }
+});
+
+test("canonicalizeModelId normalizes provider prefixes, whitespace, casing, and separators", () => {
+  const variants = [
+    "github-copilot/claude-sonnet-4.6",
+    "github-copilot/claude_sonnet_4_6",
+    "  GITHUB-COPILOT/CLAUDE-SONNET-4-6  ",
+    "openai/gpt_4.1-mini",
+    "google/gemini-flash-2.0",
+  ];
+  assert.deepEqual(variants.map(canonicalizeModelId), [
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-6",
+    "gpt-4-1-mini",
+    "gemini-2-0-flash",
+  ]);
+});
+
+test("routing registries store canonical keys only", () => {
+  for (const modelId of [
+    ...Object.keys(MODEL_CAPABILITY_TIER),
+    ...Object.keys(MODEL_CAPABILITY_PROFILES),
+  ]) {
+    assert.equal(modelId, canonicalizeModelId(modelId));
+  }
 });
 
 // ─── Explicit tier_models ────────────────────────────────────────────────────
@@ -267,8 +301,10 @@ test("falls back to configured model when no light-tier model available", () => 
 
 // ─── #2192: Unknown models honor explicit config ─────────────────────────────
 
-test("#2192: unknown model is not downgraded — respects user config", () => {
+test("#2192: unknown model warns and is not downgraded", (t) => {
   const config = { ...defaultRoutingConfig(), enabled: true };
+  const warnings: string[] = [];
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
   const result = resolveModelForComplexity(
     makeClassification("light"),
     { primary: "some-future-unknown-model-v9", fallbacks: [] },
@@ -278,6 +314,8 @@ test("#2192: unknown model is not downgraded — respects user config", () => {
   assert.equal(result.modelId, "some-future-unknown-model-v9", "unknown model should be used as-is");
   assert.equal(result.wasDowngraded, false, "should not be downgraded");
   assert.ok(result.reason.includes("not in the known tier map"), "reason should explain why");
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? "", /does not recognize.*honoring the configured model/i);
 });
 
 test("#2192: unknown model with provider prefix is not downgraded", () => {
@@ -1419,15 +1457,19 @@ describe("getModelTier unknown default", () => {
     assert.equal(result.modelId, "claude-sonnet-4-6");
   });
 
-  test("unknown model in getEligibleModels defaults to standard tier", () => {
+  test("unknown model in getEligibleModels warns and defaults to standard tier", (t) => {
     // Per D-15: getModelTier returns "standard" for unknown models
     const config: DynamicRoutingConfig = defaultRoutingConfig();
+    const warnings: string[] = [];
+    t.mock.method(console, "warn", (message: string) => warnings.push(message));
     const standardModels = getEligibleModels("standard", ["totally-unknown-model-abc"], config);
     const lightModels = getEligibleModels("light", ["totally-unknown-model-abc"], config);
     const heavyModels = getEligibleModels("heavy", ["totally-unknown-model-abc"], config);
     assert.ok(standardModels.includes("totally-unknown-model-abc"), "Unknown model should be in standard tier");
     assert.equal(lightModels.length, 0, "Unknown model should NOT be in light tier");
     assert.equal(heavyModels.length, 0, "Unknown model should NOT be in heavy tier");
+    assert.equal(warnings.length, 1, "unknown routing warnings should be deduplicated by canonical ID");
+    assert.match(warnings[0] ?? "", /safe defaults.*standard tier.*neutral capabilities.*expensive cost/i);
   });
 });
 

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -129,6 +129,42 @@ test("downgrades from opus to sonnet for standard tier", () => {
   assert.equal(result.wasDowngraded, true);
 });
 
+test("downgrades dotted GitHub Copilot Claude IDs by their canonical tier", () => {
+  const config = { ...defaultRoutingConfig(), enabled: true };
+  const copilotModels = [
+    "github-copilot/claude-opus-4.6",
+    "github-copilot/claude-sonnet-4.6",
+    "github-copilot/claude-haiku-4.5",
+  ];
+
+  const standard = resolveModelForComplexity(
+    makeClassification("standard"),
+    { primary: "github-copilot/claude-opus-4.6", fallbacks: [] },
+    config,
+    copilotModels,
+  );
+  assert.equal(standard.modelId, "github-copilot/claude-sonnet-4.6");
+  assert.equal(standard.wasDowngraded, true);
+
+  const light = resolveModelForComplexity(
+    makeClassification("light"),
+    { primary: "github-copilot/claude-opus-4.6", fallbacks: [] },
+    config,
+    copilotModels,
+  );
+  assert.equal(light.modelId, "github-copilot/claude-haiku-4.5");
+  assert.equal(light.wasDowngraded, true);
+
+  const heavy = resolveModelForComplexity(
+    makeClassification("heavy"),
+    { primary: "github-copilot/claude-opus-4.6", fallbacks: [] },
+    config,
+    copilotModels,
+  );
+  assert.equal(heavy.modelId, "github-copilot/claude-opus-4.6");
+  assert.equal(heavy.wasDowngraded, false);
+});
+
 // ─── Explicit tier_models ────────────────────────────────────────────────────
 
 test("uses explicit tier_models when configured", () => {
@@ -479,6 +515,11 @@ test("resolveModelForTier: handles provider-prefixed available models", () => {
   assert.equal(result, "claude-opus-4-6");
 });
 
+test("resolveModelForTier: preserves dotted Copilot dispatch spelling", () => {
+  const result = resolveModelForTier("heavy", ["github-copilot/claude-opus-4.6"]);
+  assert.equal(result, "claude-opus-4.6");
+});
+
 test("resolveModelForTier: picks Gemini models when only Google available", () => {
   const result = resolveModelForTier("light", ["gemini-2.5-pro", "gemini-2.0-flash"]);
   assert.equal(result, "gemini-2.0-flash");
@@ -807,6 +848,54 @@ test("scoreEligibleModels uses bare capability profiles for provider-qualified I
     (scored[0]?.score ?? 0) > (scored[1]?.score ?? 0),
     "provider-qualified IDs should still use the built-in bare model capability profile",
   );
+});
+
+test("scoreEligibleModels uses canonical profiles for dotted GitHub Copilot Claude IDs", () => {
+  const scored = scoreEligibleModels(
+    ["github-copilot/claude-sonnet-4.6", "unknown/model"],
+    { coding: 1 },
+  );
+
+  assert.equal(scored[0]?.modelId, "github-copilot/claude-sonnet-4.6");
+  assert.equal(scored[0]?.score, MODEL_CAPABILITY_PROFILES["claude-sonnet-4-6"].coding);
+});
+
+test("scoreEligibleModels honors dotted bare-ID capability overrides", () => {
+  const scored = scoreEligibleModels(
+    ["github-copilot/claude-sonnet-4.6", "gpt-4o"],
+    { coding: 1 },
+    { "claude-sonnet-4.6": { coding: 30 } },
+  );
+
+  assert.equal(scored[0]?.modelId, "gpt-4o");
+});
+
+test("scoreEligibleModels uses canonical costs for provider-qualified dotted IDs", () => {
+  const scored = scoreEligibleModels(
+    ["github-copilot/claude-opus-4.6", "gpt-5"],
+    {},
+  );
+
+  assert.equal(scored[0]?.modelId, "github-copilot/claude-opus-4.6");
+});
+
+test("all cataloged GitHub Copilot Claude aliases have tiers and capability profiles", () => {
+  const aliases: Array<[string, "light" | "standard" | "heavy"]> = [
+    ["claude-haiku-4.5", "light"],
+    ["claude-opus-4.5", "heavy"],
+    ["claude-opus-4.6", "heavy"],
+    ["claude-opus-4.7", "heavy"],
+    ["claude-opus-4.8", "heavy"],
+    ["claude-sonnet-4", "standard"],
+    ["claude-sonnet-4.5", "standard"],
+    ["claude-sonnet-4.6", "standard"],
+  ];
+
+  for (const [alias, tier] of aliases) {
+    const qualified = `github-copilot/${alias}`;
+    assert.deepEqual(getEligibleModels(tier, [qualified], defaultRoutingConfig()), [qualified]);
+    assert.notEqual(scoreEligibleModels([qualified], { coding: 1 })[0]?.score, 50);
+  }
 });
 
 test("scoreModel computes weighted average of capability × requirement", () => {


### PR DESCRIPTION
## Summary
- Normalized dotted Copilot Claude model aliases across routing tables and verified correct tier downgrades and ceiling preservation.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2034
- [#2034 [bug] model router ignores dotted Copilot model IDs and pins all phases to the ceiling model](https://github.com/open-gsd/gsd-pi/issues/2034)

## User
- @pimmink

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2034-bug-model-router-ignores-dotted-copilot--1787911165`