### PR TITLE
fix(daemon): don't dereference cleared pendingBlocker in relay success log

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-package-dist.cjs && tsc",
-    "test": "pnpm run build && node --test dist/daemon.test.js dist/message-batcher.test.js"
+    "test": "pnpm run build && node --test dist/daemon.test.js dist/message-batcher.test.js dist/event-bridge.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",

--- a/packages/daemon/src/event-bridge.test.ts
+++ b/packages/daemon/src/event-bridge.test.ts
@@ -462,6 +462,10 @@ describe('EventBridge', () => {
       const session = createMockSession({ pendingBlocker: blocker, status: 'blocked' });
       const { bridge, sessionManager, client } = buildBridge();
       sessionManager.getSession = mock.fn(() => session);
+      // Real resolveBlocker clears pendingBlocker before the bridge logs success
+      sessionManager.resolveBlocker = mock.fn(async () => {
+        session.pendingBlocker = null;
+      });
       bridge.start();
 
       sessionManager.emit('session:started', {
@@ -481,6 +485,10 @@ describe('EventBridge', () => {
 
       assert.equal(mockFn(sessionManager.resolveBlocker).mock.callCount(), 1);
       assert.equal(mockFn(sessionManager.resolveBlocker).mock.calls[0]!.arguments[1], 'my-api-key-value');
+      // Success path must not surface a failure reply (regression: success log
+      // dereferenced the already-cleared pendingBlocker and threw)
+      assert.equal(mockFn(msg.reply).mock.callCount(), 0);
+      assert.equal(mockFn(msg.react).mock.callCount(), 1);
     });
 
     it('ignores bot messages', async () => {

--- a/packages/daemon/src/event-bridge.ts
+++ b/packages/daemon/src/event-bridge.ts
@@ -464,12 +464,13 @@ export class EventBridge {
 
     // If session has a pending blocker with input/editor method, resolve it
     if (session.pendingBlocker && (session.pendingBlocker.method === 'input' || session.pendingBlocker.method === 'editor')) {
+      const blockerMethod = session.pendingBlocker.method;
       try {
         await this.sessionManager.resolveBlocker(sessionId, message.content);
         await message.react('✅').catch(() => {});
         this.logger.info('bridge: blocker resolved via relay', {
           sessionId,
-          method: session.pendingBlocker.method,
+          method: blockerMethod,
         });
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Every successful blocker resolution via a typed Discord message replied with a failure. `resolveBlocker()` sets `session.pendingBlocker = null` (session-manager), then the success-path log read `session.pendingBlocker.method` — a TypeError that landed in the catch block and sent `Failed to resolve blocker: Cannot read properties of null` to the user after the ✅ react had already fired.

Captures the method before resolving.

Also adds `dist/event-bridge.test.js` to the package test script: it was built but never executed by `pnpm test`, which is how this stayed invisible. Note the daemon package has several other test files (`session-manager`, `orchestrator`, `discord-bot`, …) that are built but not run by the package script — left out of scope here, flagged for follow-up.

Regression test asserts the success path posts no error reply and reacts once; verified it fails against the unfixed code.