### PR TITLE
fix(mcp-server): validate projectDir and verify the recorded PID before gsd_cancel signals it

### DIFF
--- a/packages/mcp-server/src/pid-registry.test.ts
+++ b/packages/mcp-server/src/pid-registry.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import {
   readMcpRegistry,
   registerMcpInstance,
+  signalAutoLockPid,
   sweepProjectOrphanMcpServers,
   unregisterMcpInstance,
   type McpInstanceEntry,
@@ -795,5 +796,96 @@ describe('unregisterMcpInstance', () => {
 
   test('no-ops on missing registry', () => {
     assert.doesNotThrow(() => unregisterMcpInstance(tmp, registryPath));
+  });
+});
+
+describe('signalAutoLockPid', () => {
+  const lock = (pid: number, startedAt: string) => ({ pid, startedAt });
+
+  const probes = (overrides: {
+    alive?: boolean;
+    startMs?: number | null;
+    cwd?: string | null;
+  } = {}) => {
+    const signals: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+    return {
+      signals,
+      opts: {
+        kill: (pid: number, signal?: NodeJS.Signals | 0) => {
+          if (overrides.alive === false && signal === 0) {
+            const err = new Error('ESRCH') as NodeJS.ErrnoException;
+            err.code = 'ESRCH';
+            throw err;
+          }
+          signals.push({ pid, signal });
+        },
+        getProcessStartTime: () => overrides.startMs ?? null,
+        getProcessCwd: () => overrides.cwd ?? null,
+      } as const,
+    };
+  };
+
+  test('rejects locks without a usable pid or startedAt', () => {
+    for (const bad of [null, undefined, 'x', {}, { pid: 1 }, { pid: -3, startedAt: new Date().toISOString() }, { pid: 1.5, startedAt: new Date().toISOString() }, { pid: 1, startedAt: 'not-a-date' }]) {
+      assert.equal(signalAutoLockPid(bad, '/tmp/project', probes().opts), 'invalid-lock');
+    }
+  });
+
+  test('reports already-dead when the recorded pid is gone', () => {
+    const { opts } = probes({ alive: false });
+    assert.equal(signalAutoLockPid(lock(1, new Date().toISOString()), '/tmp/project', opts), 'already-dead');
+  });
+
+  test('refuses to signal a recycled pid whose start time is after the lock', () => {
+    const recorded = Date.now() - 1_000;
+    const { opts, signals } = probes({ startMs: recorded + 120_000 });
+    const res = signalAutoLockPid(lock(7, new Date(recorded).toISOString()), '/tmp/project', opts);
+    assert.equal(res, 'stale-lock');
+    // only the liveness probe (signal 0) may have been sent, never SIGTERM
+    assert.ok(signals.every((s) => s.signal === 0));
+  });
+
+  test('accepts a pid whose start time is within the skew window', () => {
+    const recorded = Date.now() - 1_000;
+    const { opts, signals } = probes({ startMs: recorded + 30_000 });
+    assert.equal(signalAutoLockPid(lock(7, new Date(recorded).toISOString()), '/tmp/project', opts), 'signaled');
+    assert.ok(signals.some((s) => s.signal === 'SIGTERM'));
+  });
+
+  test('refuses a live process rooted outside the project directory', () => {
+    const recorded = Date.now() - 1_000;
+    const { opts, signals } = probes({ startMs: recorded, cwd: '/tmp/other-project' });
+    const res = signalAutoLockPid(lock(7, new Date(recorded).toISOString()), '/tmp/project', opts);
+    assert.equal(res, 'foreign-cwd');
+    assert.ok(signals.every((s) => s.signal === 0));
+  });
+
+  test('accepts a live process rooted inside the project directory', () => {
+    const recorded = Date.now() - 1_000;
+    const { opts, signals } = probes({ startMs: recorded, cwd: '/tmp/project' });
+    assert.equal(signalAutoLockPid(lock(7, new Date(recorded).toISOString()), '/tmp/project', opts), 'signaled');
+    assert.ok(signals.some((s) => s.signal === 'SIGTERM'));
+  });
+
+  test('tolerates unknown cwd when the start time matches', () => {
+    const recorded = Date.now() - 1_000;
+    const { opts, signals } = probes({ startMs: recorded, cwd: null });
+    assert.equal(signalAutoLockPid(lock(7, new Date(recorded).toISOString()), '/tmp/project', opts), 'signaled');
+    assert.ok(signals.some((s) => s.signal === 'SIGTERM'));
+  });
+
+  test('surfaces SIGTERM failures as errors', () => {
+    const recorded = Date.now() - 1_000;
+    const signals: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+    const opts = {
+      kill: (pid: number, signal?: NodeJS.Signals | 0) => {
+        if (signal === 'SIGTERM') throw new Error('EPERM');
+        signals.push({ pid, signal });
+      },
+      getProcessStartTime: () => recorded,
+      getProcessCwd: () => null,
+    };
+    const res = signalAutoLockPid(lock(7, new Date(recorded).toISOString()), '/tmp/project', opts);
+    assert.deepEqual(res, { error: 'EPERM' });
   });
 });

--- a/packages/mcp-server/src/pid-registry.ts
+++ b/packages/mcp-server/src/pid-registry.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync, mkdirSync, renameSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, renameSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
@@ -491,6 +491,80 @@ function killPid(
     if (isAlreadyDead) return 'already-dead';
     return { error: error instanceof Error ? error.message : String(error) };
   }
+}
+
+export type SignalAutoLockPidOptions = {
+  kill?: (pid: number, signal?: NodeJS.Signals | 0) => void;
+  getProcessCwd?: (pid: number) => string | null;
+  getProcessStartTime?: (pid: number) => number | null;
+};
+
+export type SignalAutoLockPidResult =
+  | 'signaled'
+  | 'already-dead'
+  | 'stale-lock'
+  | 'foreign-cwd'
+  | 'invalid-lock'
+  | { error: string };
+
+/**
+ * Verify and signal the PID recorded in a project's `.gsd/auto.lock`.
+ *
+ * The lock only records `pid` + `startedAt`; between write and read that PID
+ * can be recycled by an unrelated process. Mirrors the killPid() policy above:
+ * refuse to signal unless the live process's start time is no later than the
+ * recorded one (within STALE_PID_START_SKEW_MS) and its cwd is rooted in the
+ * project directory. An unknown cwd is tolerated (start time is the primary
+ * identity); an unparseable `startedAt` invalidates the lock — a foreign or
+ * corrupt lock must not authorize a signal.
+ */
+export function signalAutoLockPid(
+  lock: unknown,
+  projectDir: string,
+  options: SignalAutoLockPidOptions = {},
+): SignalAutoLockPidResult {
+  if (!lock || typeof lock !== 'object') return 'invalid-lock';
+  const { pid, startedAt } = lock as { pid?: unknown; startedAt?: unknown };
+  if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) return 'invalid-lock';
+  const recordedMs = typeof startedAt === 'string' ? Date.parse(startedAt) : NaN;
+  if (!Number.isFinite(recordedMs)) return 'invalid-lock';
+
+  const sendSignal = options.kill ?? ((target: number, signal?: NodeJS.Signals | 0) => process.kill(target, signal));
+  const getProcessCwd = options.getProcessCwd ?? defaultGetProcessCwd;
+  const getProcessStartTime = options.getProcessStartTime ?? defaultGetProcessStartTime;
+
+  try {
+    sendSignal(pid, 0);
+  } catch (error) {
+    const isAlreadyDead =
+      error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ESRCH';
+    if (isAlreadyDead) return 'already-dead';
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+
+  const actualStartMs = getProcessStartTime(pid);
+  if (actualStartMs !== null && actualStartMs > recordedMs + STALE_PID_START_SKEW_MS) {
+    return 'stale-lock';
+  }
+
+  const cwd = getProcessCwd(pid);
+  if (cwd !== null) {
+    const cwdKey = resolveComparableProjectPath(normalizeProcessCwd(cwd));
+    const projectKeys = [resolveComparableProjectPath(projectDir)];
+    try {
+      projectKeys.push(resolveComparableProjectPath(realpathSync(projectDir)));
+    } catch {
+      // projectDir vanished between the lock read and now — the raw key above still applies
+    }
+    if (!projectKeys.includes(cwdKey)) return 'foreign-cwd';
+  }
+
+  try {
+    sendSignal(pid, 'SIGTERM');
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+  return 'signaled';
 }
 
 /**

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1219,17 +1219,20 @@ export async function createMcpServer(
         if (!sessionId && !projectDir) {
           return errorContent('Either sessionId or projectDir must be provided');
         }
+        // Same validation gsd_cancel_by_project applies — projectDir reaches
+        // cancelSessionByDir, which reads .gsd/auto.lock under it.
+        const validatedDir = projectDir ? validateProjectDir(projectDir) : undefined;
         if (sessionId) {
           try {
             await sessionManager.cancelSession(sessionId);
           } catch (err) {
-            if (!projectDir || !(err instanceof Error) || !err.message.includes('Session not found')) {
+            if (!validatedDir || !(err instanceof Error) || !err.message.includes('Session not found')) {
               throw err;
             }
-            await sessionManager.cancelSessionByDir(projectDir);
+            await sessionManager.cancelSessionByDir(validatedDir);
           }
-        } else if (projectDir) {
-          await sessionManager.cancelSessionByDir(projectDir);
+        } else if (validatedDir) {
+          await sessionManager.cancelSessionByDir(validatedDir);
         }
         return jsonContent({ cancelled: true });
       } catch (err) {

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -18,6 +18,7 @@ import type {
   SessionStatus,
 } from './types.js';
 import { MAX_EVENTS, INIT_TIMEOUT_MS } from './types.js';
+import { signalAutoLockPid } from './pid-registry.js';
 
 // ---------------------------------------------------------------------------
 // Inlined detection logic (from headless-events.ts — no internal package imports)
@@ -305,12 +306,8 @@ export class SessionManager {
     const lockPath = join(projectDir, '.gsd', 'auto.lock');
     if (!existsSync(lockPath)) return false;
     try {
-      const lockData = JSON.parse(readFileSync(lockPath, 'utf-8')) as { pid?: number };
-      const pid = lockData.pid;
-      if (typeof pid !== 'number') return false;
-      try { process.kill(pid, 0); } catch { return false; }
-      process.kill(pid, 'SIGTERM');
-      return true;
+      const lockData = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      return signalAutoLockPid(lockData, projectDir) === 'signaled';
     } catch {
       return false;
     }


### PR DESCRIPTION
Closes the arbitrary-process-kill path in `gsd_cancel`:

1. **Missing path validation.** `gsd_cancel` passed `projectDir` straight into `cancelSessionByDir` while its sibling `gsd_cancel_by_project` validated the same input. Any LLM-supplied path could select the lock file the fallback reads. Both call sites now go through `validateProjectDir`.

2. **No PID-reuse guard.** The detached-auto fallback read `<projectDir>/.gsd/auto.lock` and SIGTERMed the recorded pid after only `kill(pid, 0)` — a stale lock plus a recycled PID signaled an unrelated process. The new `signalAutoLockPid()` in pid-registry.ts mirrors the existing `killPid()` policy: the live process must not have started materially after the lock was written (60s skew), and its cwd must be rooted in the project directory when discoverable. An unparseable `startedAt` invalidates the lock rather than authorizing the signal (the session-lock writer always emits an ISO timestamp).

Tests: `signalAutoLockPid` policy tests with injected probes (stale start, foreign cwd, dead pid, invalid lock, SIGTERM failure). Existing mcp-server + pid-registry suites pass.