### PR TITLE
fix(mcp-server): mirror canonical read payloads into structuredContent

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -3681,4 +3681,64 @@ describe("validateProjectDir", () => {
       /must be an absolute path/,
     );
   });
+
+  it("mirrors gsd_decision_list rows into structuredContent (details is stripped over the wire)", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_decision_list");
+      assert.ok(tool, "gsd_decision_list must be registered");
+
+      openDatabase(join(base, ".gsd", "gsd.db"));
+      createMemory({
+        category: "architecture",
+        content: "decision memory fixture",
+        scope: "global",
+        confidence: 0.85,
+        structuredFields: {
+          sourceDecisionId: "D001",
+          when_context: "test",
+          scope: "global",
+          decision: "Mirror read payloads over MCP",
+          choice: "structuredContent",
+          rationale: "the details field is dropped by the MCP transport",
+          made_by: "agent",
+          revisable: "yes",
+          superseded_by: null,
+        },
+      });
+
+      const result = await tool.handler({ projectDir: base }) as {
+        content?: Array<{ text?: string }>;
+        structuredContent?: { count?: number; decisions?: Array<{ id?: string }> };
+      };
+      assert.match(result.content?.[0]?.text ?? "", /Found 1 decision/);
+      assert.ok(result.structuredContent, "payload must ride on structuredContent");
+      assert.equal(result.structuredContent.count, 1);
+      assert.equal(result.structuredContent.decisions?.[0]?.id, "D001");
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("mirrors canonical read errors into structuredContent", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_decision_list");
+      assert.ok(tool, "gsd_decision_list must be registered");
+
+      const result = await tool.handler({ projectDir: base }) as {
+        content?: Array<{ text?: string }>;
+        structuredContent?: { error?: string };
+      };
+      assert.match(result.content?.[0]?.text ?? "", /Error/);
+      assert.ok(result.structuredContent, "error details must ride on structuredContent");
+      assert.equal(result.structuredContent.error, "db_unavailable");
+    } finally {
+      cleanup(base);
+    }
+  });
 });

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1299,10 +1299,10 @@ async function runSerializedWorkflowDbOperation<T>(
   });
 }
 
-async function runSerializedCanonicalReadOperation<T>(
+async function runSerializedCanonicalReadOperation(
   projectDir: string,
-  fn: (adapter: { close(): void }) => Promise<T>,
-): Promise<T> {
+  fn: (adapter: { close(): void }) => Promise<unknown>,
+): Promise<unknown> {
   return runSerializedWorkflowOperation(async () => {
     const { resolveProjectRootDbPath, openWorkflowDatabaseIsolated } = await importWorkflowRuntimeModule<any>(
       "../../../src/resources/extensions/gsd/db-workspace.js",
@@ -1316,7 +1316,9 @@ async function runSerializedCanonicalReadOperation<T>(
       throw new Error("Database adapter not available (db_unavailable)");
     }
     try {
-      return await fn(adapter);
+      // Canonical read tools return their payload in `details`, which the MCP
+      // wire drops — mirror it into structuredContent like every other tool.
+      return adaptExecutorResult(await fn(adapter));
     } finally {
       adapter.close();
     }
@@ -1327,7 +1329,7 @@ function mapCanonicalReadError(
   operation: "list_decisions" | "get_decision" | "list_requirements" | "get_requirement",
   message: string,
   id?: string,
-): { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> } {
+): unknown {
   const dbUnavailable = message.includes("db_unavailable") || message.includes("not available");
   const details: Record<string, unknown> = {
     operation,
@@ -1346,13 +1348,13 @@ function mapCanonicalReadError(
         ? "listing requirements"
         : "fetching requirement";
 
-  return {
+  return adaptExecutorResult({
     content: [{
       type: "text" as const,
       text: dbUnavailable ? "Error: GSD database is not available." : `Error ${actionLabel}: ${message}`,
     }],
     details,
-  };
+  });
 }
 
 async function enforceWorkflowWriteGate(

--- a/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
@@ -88,7 +88,9 @@ function mcpTool(tools: McpTool[], name: string): McpTool {
 }
 
 function readError(result: Record<string, unknown>): string | undefined {
-  const details = result.details as Record<string, unknown> | undefined;
+  // MCP transports drop the non-standard details field; errors ride on
+  // structuredContent (see adaptExecutorResult). Native passes details through.
+  const details = (result.structuredContent ?? result.details) as Record<string, unknown> | undefined;
   return typeof details?.error === "string" ? (details.error as string) : undefined;
 }
 
@@ -130,8 +132,10 @@ test("canonical read tools: missing DB returns db_unavailable and does not creat
     assert.equal(existsSync(dbPath), false, "native read should not create gsd.db as side effect");
 
     const mcpList = await mcpTool(mcp, "gsd_requirement_list").handler({ projectDir: base });
-    const mcpDetails = (mcpList as { details?: Record<string, unknown> }).details;
-    assert.equal(mcpDetails?.error, "db_unavailable");
+    // MCP transports drop the non-standard details field; the error detail now
+    // rides on structuredContent (see adaptExecutorResult).
+    const mcpRecord = mcpList as { details?: Record<string, unknown>; structuredContent?: Record<string, unknown> };
+    assert.equal(mcpRecord.structuredContent?.error, "db_unavailable");
     assert.equal(existsSync(dbPath), false, "MCP read should not create gsd.db as side effect");
   } finally {
     cleanup([base]);
@@ -170,7 +174,7 @@ test("canonical read tools: reading project B does not switch global DB handle f
       projectDir: baseB,
       limit: 10,
     });
-    const mcpCount = ((mcpList as { details?: { count?: number } }).details?.count ?? -1);
+    const mcpCount = ((mcpList as { structuredContent?: { count?: number } }).structuredContent?.count ?? -1);
     assert.equal(mcpCount, 1, "MCP isolated read should query project B rows");
     assert.equal(getDbPath(), before, "MCP isolated read must keep global DB path unchanged");
   } finally {
@@ -201,7 +205,7 @@ test("canonical read tools: query_error returns structured error and does not br
     assert.equal(nativeDetails?.error, "query_error");
 
     const mcpResult = await mcpTool(mcp, "gsd_requirement_list").handler({ projectDir: base });
-    const mcpDetails = (mcpResult as { details?: Record<string, unknown> }).details;
+    const mcpDetails = (mcpResult as { structuredContent?: Record<string, unknown> }).structuredContent;
     assert.equal(mcpDetails?.error, "query_error");
 
     const isolated = (await import("../db-workspace.ts")).openWorkflowDatabaseIsolated(dbPath);
@@ -234,7 +238,7 @@ test("canonical read tools: native and MCP read the same canonical requirement r
       projectDir: base,
       id: "R777",
     });
-    const mcpRequirement = (mcpGet as { details?: { requirement?: Record<string, unknown> } }).details?.requirement;
+    const mcpRequirement = (mcpGet as { structuredContent?: { requirement?: Record<string, unknown> } }).structuredContent?.requirement;
 
     assert.equal(nativeRequirement?.id, "R777");
     assert.equal(mcpRequirement?.id, "R777");
@@ -266,7 +270,7 @@ test("canonical read parity: empty valid DB returns consistent empty list semant
     });
 
     const nativeDetails = nativeList.details as { count?: number; error?: string } | undefined;
-    const mcpDetails = mcpList.details as { count?: number; error?: string } | undefined;
+    const mcpDetails = mcpList.structuredContent as { count?: number; error?: string } | undefined;
 
     assert.equal(nativeDetails?.error, undefined);
     assert.equal(mcpDetails?.error, undefined);


### PR DESCRIPTION
The four canonical read tools (`gsd_decision_list`, `gsd_decision_get`, `gsd_requirement_list`, `gsd_requirement_get`) returned their payloads in a `details` field, which the MCP protocol drops over the wire — the file's own `adaptExecutorResult` doc (added for the save_gate_result renderer) explains the mechanism, and every other tool already routes through it. These four bypassed the adapter, so over a real MCP transport the agent got `Found N decision(s).` with zero rows.

Fix centralizes the adapter inside `runSerializedCanonicalReadOperation` and `mapCanonicalReadError` so all read tools (and future ones) inherit it.

The parity tests call handlers in-process, where `details` survives — which is why this never failed there. New regression tests assert the list payload and the error path both surface via `structuredContent`.