### PR TITLE
fix(pi-coding-agent): make execCommand's SIGKILL escalation actually fire

### DIFF
--- a/packages/pi-coding-agent/src/core/exec.ts
+++ b/packages/pi-coding-agent/src/core/exec.ts
@@ -48,17 +48,23 @@ export async function execCommand(
 		let stderr = "";
 		let killed = false;
 		let timeoutId: NodeJS.Timeout | undefined;
+		let escalationId: NodeJS.Timeout | undefined;
 
 		const killProcess = () => {
 			if (!killed) {
 				killed = true;
 				proc.kill("SIGTERM");
-				// Force kill after 5 seconds if SIGTERM doesn't work
-				setTimeout(() => {
-					if (!proc.killed) {
+				// Force kill after 5 seconds if SIGTERM doesn't work.
+				// `subprocess.killed` only means kill() was called, not that the
+				// process exited — check actual liveness, or a SIGTERM-immune
+				// child would never be escalated and the caller would hang
+				// forever despite passing `timeout`.
+				escalationId = setTimeout(() => {
+					if (proc.exitCode === null && proc.signalCode === null) {
 						proc.kill("SIGKILL");
 					}
 				}, 5000);
+				escalationId.unref?.();
 			}
 		};
 
@@ -91,13 +97,15 @@ export async function execCommand(
 		waitForChildProcess(proc)
 			.then((code) => {
 				if (timeoutId) clearTimeout(timeoutId);
+				if (escalationId) clearTimeout(escalationId);
 				if (options?.signal) {
 					options.signal.removeEventListener("abort", killProcess);
 				}
-				resolve({ stdout, stderr, code: code ?? 0, killed });
+				resolve({ stdout, stderr, code: code ?? (killed ? 1 : 0), killed });
 			})
 			.catch((_err) => {
 				if (timeoutId) clearTimeout(timeoutId);
+				if (escalationId) clearTimeout(escalationId);
 				if (options?.signal) {
 					options.signal.removeEventListener("abort", killProcess);
 				}

--- a/packages/pi-coding-agent/test/exec-timeout-escalation.test.ts
+++ b/packages/pi-coding-agent/test/exec-timeout-escalation.test.ts
@@ -1,0 +1,43 @@
+/**
+ * execCommand timeout escalation. Regression test for the dead SIGKILL
+ * escalation: `subprocess.killed` is true the moment kill() is called, so the
+ * old escalation check never fired and a SIGTERM-immune child hung the
+ * promise forever despite the caller passing `timeout`.
+ */
+import { describe, expect, it } from "vitest";
+import { execCommand } from "../src/core/exec.js";
+
+describe("execCommand timeout", () => {
+	it("resolves normally for a fast command", async () => {
+		const res = await execCommand(process.execPath, ["-e", "process.exit(0)"], process.cwd());
+		expect(res.code).toBe(0);
+		expect(res.killed).toBe(false);
+	});
+
+	it("propagates the exit code", async () => {
+		const res = await execCommand(process.execPath, ["-e", "process.exit(7)"], process.cwd());
+		expect(res.code).toBe(7);
+	});
+
+	// A child that installs a no-op SIGTERM handler must still be SIGKILLed by
+	// the escalation timer, so the promise settles shortly after the 5s grace.
+	it("escalates to SIGKILL when the child ignores SIGTERM", async () => {
+		const timeoutMs = 300;
+		const started = Date.now();
+		const res = await Promise.race([
+			execCommand(
+				process.execPath,
+				["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 100);"],
+				process.cwd(),
+				{ timeout: timeoutMs },
+			),
+			new Promise<never>((_, reject) =>
+				setTimeout(() => reject(new Error("execCommand never settled — SIGKILL escalation did not fire")), 15_000),
+			),
+		]);
+		const elapsed = Date.now() - started;
+		expect(res.killed).toBe(true);
+		expect(elapsed).toBeGreaterThanOrEqual(timeoutMs);
+		expect(elapsed).toBeLessThan(10_000);
+	});
+});


### PR DESCRIPTION
`core/exec.ts` sent SIGTERM on timeout, then 5s later checked `if (!proc.killed)` before escalating to SIGKILL. But Node's `subprocess.killed` means "kill() was called", not "the process exited" — it is true immediately after the SIGTERM, so the escalation branch was dead code. A child that ignores SIGTERM was never force-killed and `waitForChildProcess` never settled, hanging the documented `pi.exec(..., { timeout })` contract (used by the extension loader).

- escalation now checks real liveness (`exitCode === null && signalCode === null`)
- the escalation timer is unref'd and cleared on completion
- a signal-killed child now resolves with exit code 1 instead of 0 (was: reported success)

New test spawns a SIGTERM-immune child and asserts the promise settles via SIGKILL; verified it fails against the unfixed code with the exact hang this fixes.