### PR TITLE
fix(pi-agent-core): end the loop stream with an error message when runAgentLoop throws

### DIFF
--- a/packages/pi-agent-core/src/agent-loop-streaming.test.ts
+++ b/packages/pi-agent-core/src/agent-loop-streaming.test.ts
@@ -8,7 +8,7 @@ import {
 	type Model,
 	type UserMessage,
 } from "@gsd/pi-ai";
-import { agentLoop } from "./agent-loop.js";
+import { agentLoop, agentLoopContinue } from "./agent-loop.js";
 import type { AgentContext, AgentLoopConfig, AgentMessage } from "./types.js";
 
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
@@ -129,4 +129,57 @@ test("agent loop accumulates streamed content and emits fresh message objects", 
 	}
 	assert.deepEqual(contentSnapshots[11]?.[2], toolCall);
 	assert.equal(new Set(updateMessages).size, updateMessages.length);
+});
+
+test("agentLoop ends the stream with an error message when the loop throws", async () => {
+	const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		// Throwing here simulates setup failures (context conversion, missing
+		// API key, hook errors) that escape the per-turn error handling.
+		convertToLlm: () => {
+			throw new Error("context conversion exploded");
+		},
+	};
+	const events: Array<{ type: string }> = [];
+	const stream = agentLoop([createUserMessage("hi")], context, config);
+
+	const collected: Array<{ type: string }> = [];
+	for await (const event of stream) {
+		collected.push(event);
+		events.push(event);
+	}
+
+	const finalMessages = await stream.result();
+	const last = finalMessages.at(-1) as AssistantMessage;
+	assert.equal(last.stopReason, "error");
+	assert.match(last.errorMessage ?? "", /context conversion exploded/);
+	// The stream must have terminated: the consumer above returned instead of hanging.
+	assert.ok(collected.some((e) => e.type === "message_end"));
+});
+
+test("agentLoopContinue ends the stream with an error message when the loop throws", async () => {
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [createUserMessage("hi")],
+		tools: [],
+	};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		getSteeringMessages: () => {
+			throw new Error("steering hook exploded");
+		},
+	};
+	const stream = agentLoopContinue(context, config);
+
+	const collected: Array<{ type: string }> = [];
+	for await (const event of stream) {
+		collected.push(event);
+	}
+
+	const finalMessages = await stream.result();
+	const last = finalMessages.at(-1) as AssistantMessage;
+	assert.equal(last.stopReason, "error");
+	assert.match(last.errorMessage ?? "", /steering hook exploded/);
 });

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -50,6 +50,41 @@ const ZERO_USAGE = {
 } as const;
 
 /**
+ * Close a loop stream after `runAgentLoop*` threw outside the per-turn error
+ * handling (e.g. context conversion, API key resolution, or a hook threw).
+ * Without this the rejection is unhandled (fatal under Node's default) and
+ * the stream never ends, hanging every consumer.
+ *
+ * Emits a final assistant message with stopReason "error" — the documented
+ * error contract — then ends the stream with that message as the result.
+ */
+function endLoopStreamWithError(
+	stream: ReturnType<typeof createAgentStream>,
+	config: AgentLoopConfig,
+	err: unknown,
+): void {
+	const message: AssistantMessage = {
+		role: "assistant",
+		content: [
+			{
+				type: "text",
+				text: `Agent loop failed: ${err instanceof Error ? err.message : String(err)}`,
+			},
+		],
+		api: config.model.api,
+		provider: config.model.provider,
+		model: config.model.id,
+		usage: ZERO_USAGE,
+		stopReason: "error",
+		errorMessage: err instanceof Error ? err.message : String(err),
+		timestamp: Date.now(),
+	};
+	stream.push({ type: "message_start", message });
+	stream.push({ type: "message_end", message });
+	stream.end([message]);
+}
+
+/**
  * Start an agent loop with a new prompt message.
  * The prompt is added to the context and events are emitted for it.
  */
@@ -71,9 +106,13 @@ export function agentLoop(
 		},
 		signal,
 		streamFn,
-	).then((messages) => {
-		stream.end(messages);
-	});
+	)
+		.then((messages) => {
+			stream.end(messages);
+		})
+		.catch((err) => {
+			endLoopStreamWithError(stream, config, err);
+		});
 
 	return stream;
 }
@@ -110,9 +149,13 @@ export function agentLoopContinue(
 		},
 		signal,
 		streamFn,
-	).then((messages) => {
-		stream.end(messages);
-	});
+	)
+		.then((messages) => {
+			stream.end(messages);
+		})
+		.catch((err) => {
+			endLoopStreamWithError(stream, config, err);
+		});
 
 	return stream;
 }


### PR DESCRIPTION
`agentLoop()` / `agentLoopContinue()` attached only `.then()` to the underlying promise. A throw from `convertToLlm`, `getApiKey`, a steering hook, or `streamFn` (e.g. a provider throwing synchronously on a missing API key) produced an unhandled rejection (process-fatal under Node ≥15 defaults) and `stream.end()` never ran — every consumer iterating the returned `EventStream` hung forever.

Both entry points now catch and terminate the stream with a final assistant message carrying `stopReason: "error"` + `errorMessage` — the documented error contract in types.ts — so consumers observe a normal terminal instead of hanging.

Tests cover both entry points with throwing converters/hooks. Note: the pi-agent-core suite has 26 pre-existing failures on current main (identical with and without this diff; appears environment/native-addon related) — flagged separately.