### PR TITLE
fix(pi-ai): map unknown and paused Anthropic stop reasons to the error terminal instead of throwing

### DIFF
--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -690,7 +690,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					}
 				} else if (event.type === "message_delta") {
 					if (event.delta.stop_reason) {
-						output.stopReason = mapStopReason(event.delta.stop_reason);
+						const mapped = mapStopReason(event.delta.stop_reason);
+						output.stopReason = mapped.stopReason;
+						if (mapped.errorMessage) {
+							output.errorMessage = mapped.errorMessage;
+						}
 					}
 					// Only update usage fields if present (not null).
 					// Preserves input_tokens from message_start when proxies omit it in message_delta.
@@ -718,7 +722,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			}
 
 			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
+				// Preserve the specific reason mapped by mapStopReason; the catch
+				// below copies this message into output.errorMessage.
+				throw new Error(output.errorMessage ?? "An unknown error occurred");
 			}
 
 			stream.push({ type: "done", reason: output.stopReason, message: output });
@@ -1278,24 +1284,34 @@ function convertTools(
 	});
 }
 
-function mapStopReason(reason: Anthropic.Messages.StopReason | string): StopReason {
+function mapStopReason(reason: Anthropic.Messages.StopReason | string): {
+	stopReason: StopReason;
+	errorMessage?: string;
+} {
 	switch (reason) {
 		case "end_turn":
-			return "stop";
+			return { stopReason: "stop" };
 		case "max_tokens":
-			return "length";
+			return { stopReason: "length" };
 		case "tool_use":
-			return "toolUse";
+			return { stopReason: "toolUse" };
 		case "refusal":
-			return "error";
-		case "pause_turn": // Stop is good enough -> resubmit
-			return "stop";
+			return { stopReason: "error", errorMessage: "Provider stop_reason: refusal" };
+		case "pause_turn":
+			// Anthropic paused this long-running turn server-side; nothing here
+			// resubmits, so mapping it to "stop" would silently truncate the run.
+			return {
+				stopReason: "error",
+				errorMessage: "Provider stop_reason: pause_turn (turn paused by provider; resubmit to continue)",
+			};
 		case "stop_sequence":
-			return "stop"; // We don't supply stop sequences, so this should never happen
+			return { stopReason: "stop" }; // We don't supply stop sequences, so this should never happen
 		case "sensitive": // Content flagged by safety filters (not yet in SDK types)
-			return "error";
+			return { stopReason: "error", errorMessage: "Provider stop_reason: sensitive" };
 		default:
-			// Handle unknown stop reasons gracefully (API may add new values)
-			throw new Error(`Unhandled stop reason: ${reason}`);
+			// Handle unknown stop reasons gracefully (API may add new values):
+			// map to the error terminal instead of throwing mid-stream, which
+			// aborted the turn and dropped any partial output on replay.
+			return { stopReason: "error", errorMessage: `Provider stop_reason: ${reason}` };
 	}
 }

--- a/packages/pi-ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/pi-ai/test/anthropic-sse-parsing.test.ts
@@ -517,4 +517,56 @@ describe("Anthropic raw SSE parsing", () => {
 			],
 		});
 	});
+
+	// A new/proxied stop reason used to throw mid-stream, aborting the turn and
+	// dropping partial output. It must map to the error terminal instead.
+	it.each(["some_new_stop_reason", "pause_turn"])("maps unknown stop reason %s to error with errorMessage instead of throwing", async (stopReason) => {
+		const model = getModel("anthropic", "claude-opus-4-8");
+		const context: Context = {
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			tools: [],
+		};
+
+		const response = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_stop",
+						usage: { input_tokens: 1, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+					},
+				}),
+			},
+			{
+				event: "content_block_start",
+				data: JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "partial" } }),
+			},
+			{
+				event: "content_block_stop",
+				data: JSON.stringify({ type: "content_block_stop", index: 0 }),
+			},
+			{
+				event: "message_delta",
+				data: JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: stopReason },
+					usage: { input_tokens: 1, output_tokens: 2, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+				}),
+			},
+			{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+		]);
+
+		const stream = streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(response),
+		});
+
+		const final = await stream.result();
+		expect(final.stopReason).toBe("error");
+		expect(final.errorMessage).toContain(stopReason);
+	});
 });


### PR DESCRIPTION
Three problems in the Anthropic stop-reason path, all hitting every anthropic-compat provider (kimi-coding, z.ai, cloudflare gateway, copilot):

1. `mapStopReason`'s default branch threw on unrecognized reasons, directly contradicting its comment about graceful handling. A new API value or a proxy-introduced reason aborted the turn mid-stream, and the partial output was then skipped on replay (transform paths drop `stopReason: "error"` messages).

2. `pause_turn` mapped to plain `"stop"` with a "resubmit" comment, but nothing anywhere resubmits — Anthropic's paused long-running turns ended looking complete while truncated. Now surfaces as an error naming the lever.

3. The post-stream guard threw a generic `"An unknown error occurred"` for any error-mapped stop reason, overwriting the specific message. It now throws with the mapped `errorMessage` so it survives the catch that copies it onto the output message.

Unknown reasons now land on the same `stopReason: "error" + errorMessage` terminal that openai-completions uses, instead of throwing. Covered by SSE-level tests for both a synthetic future stop reason and `pause_turn`.