### PR TITLE
fix(daemon): port mcp-server's PATH lookup and empty-sessionId guards

### DIFF
--- a/packages/daemon/src/session-manager.test.ts
+++ b/packages/daemon/src/session-manager.test.ts
@@ -13,10 +13,10 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { Logger } from './logger.js';
 import { SessionManager } from './session-manager.js';
 import { MAX_EVENTS } from './types.js';
 import type { ManagedSession, PendingBlocker } from './types.js';
-import { Logger } from './logger.js';
 
 // ---------------------------------------------------------------------------
 // Mock RpcClient (duck-typed to match RpcClient interface)
@@ -1095,5 +1095,46 @@ describe('SessionManager', () => {
     await manager.cleanup();
 
     assert.equal(manager.getAllSessions().length, 0);
+  });
+});
+
+describe('SessionManager parity guards', () => {
+  it('getSession rejects an empty sessionId instead of matching the first in-flight session', () => {
+    const manager = new SessionManager(new Logger({ filePath: join(tmpdir(), `sm-parity-${Date.now()}.log`), level: 'error' }));
+    // In-progress sessions carry an empty sessionId until init resolves; an
+    // empty lookup must not silently target them.
+    assert.equal(manager.getSession(''), undefined);
+    assert.equal(manager.getSession(undefined as unknown as string), undefined);
+  });
+
+  it('resolveCLIPath honors GSD_CLI_PATH', () => {
+    const fakeCli = join(tmpdir(), `gsd-cli-${Date.now()}`);
+    writeFileSync(fakeCli, '#!/bin/sh\n');
+    try {
+      const prev = process.env['GSD_CLI_PATH'];
+      process.env['GSD_CLI_PATH'] = fakeCli;
+      try {
+        assert.equal(resolve(SessionManager.resolveCLIPath()), resolve(fakeCli));
+      } finally {
+        if (prev === undefined) delete process.env['GSD_CLI_PATH'];
+        else process.env['GSD_CLI_PATH'] = prev;
+      }
+    } finally {
+      rmSync(fakeCli, { force: true });
+    }
+  });
+
+  it('resolveCLIPath finds an executable on PATH without relying on `which`', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gsd-path-'));
+    const fakeCli = join(dir, process.platform === 'win32' ? 'gsd.cmd' : 'gsd');
+    writeFileSync(fakeCli, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n');
+    const prevPath = process.env['PATH'];
+    process.env['PATH'] = dir;
+    try {
+      assert.equal(resolve(SessionManager.resolveCLIPath()), resolve(fakeCli));
+    } finally {
+      process.env['PATH'] = prevPath ?? '';
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/daemon/src/session-manager.ts
+++ b/packages/daemon/src/session-manager.ts
@@ -13,8 +13,8 @@
  * - projectName field on ManagedSession
  */
 
-import { execSync } from 'node:child_process';
-import { basename, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { basename, delimiter, join, resolve } from 'node:path';
 import { EventEmitter } from 'node:events';
 import { RpcClient } from '@opengsd/rpc-client';
 import type { RpcCostUpdateEvent, RpcExtensionUIRequest, RpcInitResult, SdkAgentEvent } from '@opengsd/contracts';
@@ -46,6 +46,30 @@ const TERMINAL_PREFIXES = [
   'no active milestone',
   'auto-mode idle',
 ];
+
+function getPathEnvValue(env: NodeJS.ProcessEnv = process.env): string {
+  return env['PATH'] ?? env['Path'] ?? env['path'] ?? '';
+}
+
+// PATHEXT-aware PATH lookup; `which` does not exist on Windows. Mirrored from
+// packages/mcp-server/src/session-manager.ts — keep both copies in sync.
+function findExecutableOnPath(command: string): string | null {
+  const pathValue = getPathEnvValue();
+  if (!pathValue) return null;
+  const extensions = process.platform === 'win32'
+    ? ['', ...(process.env['PATHEXT'] ?? '.COM;.EXE;.BAT;.CMD')
+      .split(';')
+      .filter(Boolean)]
+    : [''];
+  for (const dir of pathValue.split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of extensions) {
+      const candidate = join(dir, `${command}${ext}`);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
 
 function isTerminalNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false;
@@ -223,8 +247,14 @@ export class SessionManager extends EventEmitter {
   /**
    * Look up a session by sessionId.
    * Linear scan is fine — we expect <10 concurrent sessions.
+   *
+   * Empty sessionId is rejected explicitly: in-progress sessions carry an
+   * empty sessionId until init() resolves, so an empty-string lookup would
+   * otherwise match the first in-flight session and silently target the
+   * wrong one (e.g. cancel a different caller's session).
    */
   getSession(sessionId: string): ManagedSession | undefined {
+    if (!sessionId) return undefined;
     for (const session of this.sessions.values()) {
       if (session.sessionId === sessionId) return session;
     }
@@ -424,12 +454,8 @@ export class SessionManager extends EventEmitter {
     const envPath = process.env['GSD_CLI_PATH'];
     if (envPath) return resolve(envPath);
 
-    try {
-      const gsdBin = execSync('which gsd', { encoding: 'utf-8' }).trim();
-      if (gsdBin) return resolve(gsdBin);
-    } catch {
-      // which failed
-    }
+    const gsdBin = findExecutableOnPath('gsd');
+    if (gsdBin) return resolve(gsdBin);
 
     throw new Error(
       'Cannot find GSD CLI. Set GSD_CLI_PATH environment variable or ensure `gsd` is in PATH.'


### PR DESCRIPTION
The daemon and mcp-server each carry a near-identical SessionManager, and the daemon's copy had drifted from fixes already present upstream of it in mcp-server:

1. **Windows-dead CLI resolution.** `resolveCLIPath` ran `execSync('which gsd')` — `which` doesn't exist on Windows, so the daemon threw even when `gsd`/`gsd.cmd` was on PATH. Ports the mcp-server's PATHEXT-aware `findExecutableOnPath` scan.

2. **Wrong-session kill on empty identifier.** `getSession('')` matched the first in-flight session (sessions carry an empty `sessionId` until init resolves), and `orchestrator-tools` feeds LLM-controlled identifiers straight in — so an empty string could cancel a different caller's session. Ports the mcp-server's explicit empty-id rejection.

Tests cover the empty-id guard, `GSD_CLI_PATH` priority, and a PATH-only lookup without `which`.