### PR TITLE
fix(extensions): parse pinned specifiers on update-all, harden temp cleanups, unique registry staging

### DIFF
--- a/src/extension-registry.ts
+++ b/src/extension-registry.ts
@@ -94,7 +94,10 @@ function saveRegistry(registry: ExtensionRegistry): void {
   const filePath = getRegistryPath();
   try {
     mkdirSync(dirname(filePath), { recursive: true });
-    const tmp = filePath + ".tmp";
+    // Unique staging name: a fixed ".tmp" name makes concurrent writers
+    // (a syncing session vs. a slash-command install) rename each other's
+    // half-written staging file out from under them.
+    const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
     writeFileSync(tmp, JSON.stringify(registry, null, 2), "utf-8");
     renameSync(tmp, filePath);
   } catch {

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -624,12 +624,15 @@ async function updateAllExtensions(
     }
 
     const current = entry.version ?? "0.0.0";
-    const packageName = entry.installedFrom;
-    if (!packageName) {
+    const installedFrom = entry.installedFrom;
+    if (!installedFrom) {
       ctx.ui.notify(`  ${entry.id}: no recorded install source — skip`, "info");
       skipped++;
       continue;
     }
+    // installedFrom may carry a version pin (pkg@1.2.3); the registry API
+    // needs the bare package name (same parse as updateSingleExtension).
+    const { name: packageName } = parseNpmSpecifier(installedFrom.replace(/^npm:/, ""));
 
     const latest = await getLatestNpmVersion(packageName);
     if (!latest) {
@@ -718,7 +721,9 @@ function installFromNpm(specifier: string, installedExtDir: string, ctx: Extensi
     if (extractDir && existsSync(extractDir)) {
       try { rmSync(extractDir, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
-    rmSync(packDir, { recursive: true, force: true });
+    // best-effort: Windows AV/indexers can hold the fresh .tgz briefly and
+    // EPERM here must not escape the finally over a successful install
+    try { rmSync(packDir, { recursive: true, force: true }); } catch { /* best-effort */ }
   }
 }
 

--- a/src/resources/extensions/gsd/tests/commands-extensions-update-all-pinned.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-extensions-update-all-pinned.test.ts
@@ -1,0 +1,75 @@
+// gsd-pi — Regression test: update-all must query the registry by bare package
+// name even when installedFrom carries a version pin (pkg@1.2.3), which
+// previously produced registry.npmjs.org/pkg@1.2.3/latest → 404 → skip.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { handleExtensions } from "../commands-extensions.ts";
+
+test("update-all resolves pinned installedFrom to the bare package name", async (t) => {
+	const root = mkdtempSync(join(tmpdir(), "gsd-ext-update-pinned-"));
+	const previousHome = process.env.GSD_HOME;
+	t.after(() => {
+		if (previousHome === undefined) delete process.env.GSD_HOME;
+		else process.env.GSD_HOME = previousHome;
+		delete (globalThis as { __gsdLastFetchUrl?: string }).__gsdLastFetchUrl;
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	// GSD_HOME is the .gsd config dir itself, so the registry lives at
+	// $GSD_HOME/extensions/registry.json.
+	const gsdHomeDir = join(root, "home", ".gsd");
+	mkdirSync(join(gsdHomeDir, "extensions"), { recursive: true });
+	writeFileSync(
+		join(gsdHomeDir, "extensions", "registry.json"),
+		JSON.stringify({
+			version: 1,
+			entries: {
+				"demo-ext": {
+					id: "demo-ext",
+					enabled: true,
+					source: "user",
+					installType: "npm",
+					installedFrom: "@scope/demo-ext@0.8.0",
+					version: "0.8.0",
+				},
+			},
+		}),
+	);
+	process.env.GSD_HOME = gsdHomeDir;
+
+	const fetchedUrls: string[] = [];
+	const previousFetch = globalThis.fetch;
+	globalThis.fetch = (async (input: string | URL | Request) => {
+		const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+		fetchedUrls.push(url);
+		return new Response(JSON.stringify({ version: "0.9.0" }), { status: 200 });
+	}) as typeof fetch;
+	t.after(() => {
+		globalThis.fetch = previousFetch;
+	});
+
+	const notices: string[] = [];
+	const ctx = {
+		ui: {
+			notify: (message: string) => notices.push(message),
+		},
+	} as unknown as ExtensionCommandContext;
+
+	await handleExtensions("update", ctx);
+
+	assert.equal(fetchedUrls.length, 1, "exactly one registry lookup expected");
+	assert.equal(
+		fetchedUrls[0],
+		"https://registry.npmjs.org/@scope/demo-ext/latest",
+		"must query the bare package name, not the pinned specifier",
+	);
+	assert.ok(
+		fetchedUrls[0]!.includes("@0.8.0") === false,
+		"the version pin must never reach the registry URL",
+	);
+});

--- a/src/rtk.ts
+++ b/src/rtk.ts
@@ -371,7 +371,9 @@ export async function ensureRtkAvailable(options: EnsureRtkOptions = {}): Promis
       reason: error instanceof Error ? error.message : String(error),
     };
   } finally {
-    rmSync(tempRoot, { recursive: true, force: true });
+    // best-effort: on Windows the extracted files can be held briefly by
+    // AV/indexers; EPERM here must not escape over the real result
+    try { rmSync(tempRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
   }
 }
 


### PR DESCRIPTION
Three robustness fixes in the extensions install/update surface (audit follow-ups, related to the #2005-#2008 cluster):

1. **Pinned installs can never update.** `updateAllExtensions` passed `entry.installedFrom` raw into `registry.npmjs.org/<name>/latest`; a pinned install (`pkg@1.2.3`) produced `registry.npmjs.org/pkg@1.2.3/latest` → 404 → permanently "could not fetch latest version — skip". Now parses the specifier exactly like `updateSingleExtension`, which already did this correctly.

2. **Cleanup EPERM escapes the finally.** `installFromNpm` removed `packDir` unguarded in its `finally`; on Windows an AV/indexer holding the fresh .tgz throws EPERM out of the cleanup path and converts a successful install into an unhandled failure. Now best-effort, matching the adjacent `extractDir` cleanup. Same fix in `rtk.ts`'s bootstrap cleanup.

3. **Registry staging race.** `saveRegistry` staged through a fixed `registry.json.tmp`; two concurrent writers could rename each other's half-written staging file out from under them (losing saves ENOENT-silently). Staging names are now pid/timestamp-unique.

Existing extension-registry/discovery suites pass.