### PR TITLE
fix(cmux): use current split and surface CLI commands

### DIFF
--- a/src/resources/extensions/cmux/index.ts
+++ b/src/resources/extensions/cmux/index.ts
@@ -295,9 +295,10 @@ export class CmuxClient {
   }
 
   async listSurfaceIds(): Promise<string[]> {
-    const stdout = await this.runAsync(this.appendWorkspace(["list-surfaces", "--json", "--id-format", "both"]));
-    const parsed = stdout ? parseJson(stdout) : null;
-    return extractSurfaceIds(parsed);
+    // Current cmux no longer exposes `list-surfaces`. `tree` is workspace-scoped
+    // and includes every live surface ref, which is enough for this compatibility helper.
+    const stdout = await this.runAsync(this.appendWorkspace(["tree"]));
+    return extractSurfaceIds(stdout);
   }
 
   async createSplit(direction: "right" | "down" | "left" | "up"): Promise<string | null> {
@@ -309,15 +310,12 @@ export class CmuxClient {
     direction: "right" | "down" | "left" | "up",
   ): Promise<string | null> {
     if (!this.config.splits) return null;
-    const before = new Set(await this.listSurfaceIds());
     const args = ["new-split", direction];
     const scopedArgs = this.appendSurface(this.appendWorkspace(args), sourceSurfaceId);
-    await this.runAsync(scopedArgs);
-    const after = await this.listSurfaceIds();
-    for (const id of after) {
-      if (!before.has(id)) return id;
-    }
-    return null;
+    const stdout = await this.runAsync(scopedArgs);
+    // Current cmux prints e.g. `OK surface:17 workspace:2`. Use the returned
+    // surface directly instead of racing a before/after surface enumeration.
+    return extractSurfaceIds(stdout)[0] ?? null;
   }
 
   /**
@@ -371,13 +369,13 @@ export class CmuxClient {
 
   async sendSurface(surfaceId: string, text: string): Promise<boolean> {
     const payload = text.endsWith("\n") ? text : `${text}\n`;
-    const stdout = await this.runAsync(["send-surface", "--surface", surfaceId, payload]);
+    const stdout = await this.runAsync(["send", "--surface", surfaceId, payload]);
     return stdout !== null;
   }
 
-  // Send Ctrl-C (ETX) to a surface to interrupt the running command.
+  // Use cmux's key encoder instead of hand-encoding ETX for Ctrl-C.
   async sendInterrupt(surfaceId: string): Promise<boolean> {
-    const stdout = await this.runAsync(["send-surface", "--surface", surfaceId, "\x03"]);
+    const stdout = await this.runAsync(["send-key", "--surface", surfaceId, "ctrl+c"]);
     return stdout !== null;
   }
 }
@@ -432,29 +430,9 @@ function parseJson(text: string): unknown {
   }
 }
 
-function extractSurfaceIds(value: unknown): string[] {
-  const found = new Set<string>();
-
-  const visit = (node: unknown): void => {
-    if (Array.isArray(node)) {
-      for (const item of node) visit(item);
-      return;
-    }
-    if (!node || typeof node !== "object") return;
-
-    for (const [key, child] of Object.entries(node as Record<string, unknown>)) {
-      if (
-        typeof child === "string"
-        && (key === "surface_id" || key === "surface" || (key === "id" && child.includes("surface")))
-      ) {
-        found.add(child);
-      }
-      visit(child);
-    }
-  };
-
-  visit(value);
-  return Array.from(found);
+function extractSurfaceIds(text: string | null): string[] {
+  if (!text) return [];
+  return Array.from(new Set(text.match(/\bsurface:\d+\b/g) ?? []));
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/cmux.test.ts
+++ b/src/resources/extensions/gsd/tests/cmux.test.ts
@@ -277,8 +277,8 @@ describe("createGridLayout", () => {
   });
 });
 
-describe("CmuxClient stdio isolation", () => {
-  test("runSync and runAsync execute the cmux CLI without inheriting test stdin", async () => {
+describe("CmuxClient CLI integration", () => {
+  test("uses current cmux split, send, and interrupt commands without inheriting test stdin", async () => {
     const binDir = fs.mkdtempSync(path.join(tmpdir(), "cmux-bin-"));
     const logPath = path.join(binDir, "calls.jsonl");
     const cmuxPath = path.join(binDir, "cmux");
@@ -288,8 +288,10 @@ describe("CmuxClient stdio isolation", () => {
       [
         "#!/usr/bin/env node",
         "const fs = require('node:fs');",
-        `fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(process.argv.slice(2)) + '\\n');`,
-        "if (process.argv.includes('--json')) process.stdout.write(JSON.stringify({surfaces:[{id:'surface-1'}]}));",
+        "const args = process.argv.slice(2);",
+        `fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(args) + '\\n');`,
+        "if (args[0] === 'tree') process.stdout.write('workspace:1\\n  pane:1\\n    surface:3\\n    surface:4\\n');",
+        "else if (args[0] === 'new-split') process.stdout.write('OK surface:17 workspace:1\\n');",
         "else process.stdout.write('ok');",
       ].join("\n"),
       "utf-8",
@@ -311,7 +313,12 @@ describe("CmuxClient stdio isolation", () => {
       });
 
       client.setStatus("M001", "executing");
-      await client.listSurfaceIds();
+      assert.deepEqual(await client.listSurfaceIds(), ["surface:3", "surface:4"]);
+      const surface = await client.createSplitFrom("surface:3", "right");
+      assert.equal(surface, "surface:17");
+      if (!surface) throw new Error("new-split did not return a surface ref");
+      assert.equal(await client.sendSurface(surface, "echo hello"), true);
+      assert.equal(await client.sendInterrupt(surface), true);
 
       const calls = fs.readFileSync(logPath, "utf-8").trim().split("\n").map((line) => JSON.parse(line));
       const commandPrefixes = calls.map((call) => call.slice(0, 2));
@@ -319,10 +326,20 @@ describe("CmuxClient stdio isolation", () => {
         commandPrefixes.some((prefix) => JSON.stringify(prefix) === JSON.stringify(["set-status", "gsd"])),
         "set-status command should be invoked",
       );
-      assert.ok(
-        commandPrefixes.some((prefix) => JSON.stringify(prefix) === JSON.stringify(["list-surfaces", "--json"])),
-        "list-surfaces command should be invoked",
+      assert.deepEqual(
+        calls.find((call) => call[0] === "new-split"),
+        ["new-split", "right", "--workspace", "workspace-1", "--surface", "surface:3"],
       );
+      assert.deepEqual(
+        calls.find((call) => call[0] === "send"),
+        ["send", "--surface", "surface:17", "echo hello\n"],
+      );
+      assert.deepEqual(
+        calls.find((call) => call[0] === "send-key"),
+        ["send-key", "--surface", "surface:17", "ctrl+c"],
+      );
+      assert.equal(calls.some((call) => call[0] === "list-surfaces"), false);
+      assert.equal(calls.some((call) => call[0] === "send-surface"), false);
     } finally {
       process.env.PATH = originalPath;
       fs.rmSync(binDir, { recursive: true, force: true });


### PR DESCRIPTION
## Linked issue

Closes #2050

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Updates the cmux integration to use the current cmux CLI for split creation, surface command delivery, and interrupts.  
**Why:** GSD currently creates cmux split panes but fails to attach subagents to them because it still calls obsolete `list-surfaces` and `send-surface` commands.  
**How:** Use the surface ID returned directly by `cmux new-split`, replace `send-surface` with `send`, use `send-key ... ctrl+c` for interrupts, and update the cmux integration tests accordingly.

## What

This change updates the cmux adapter in `src/resources/extensions/cmux/index.ts` and its focused tests in `src/resources/extensions/gsd/tests/cmux.test.ts`.

The cmux integration now:

- uses `cmux tree` for the compatibility `listSurfaceIds()` helper instead of the removed `list-surfaces` command;
- obtains the newly created surface directly from the output of `cmux new-split`;
- uses `cmux send --surface ...` instead of the removed `send-surface` command;
- uses `cmux send-key --surface ... ctrl+c` for interrupting a subagent;
- no longer performs a before/after surface-list diff when creating a split;
- includes updated tests that exercise the current `tree`, `new-split`, `send`, and `send-key` command flow and assert that the obsolete commands are not used.

The change is limited to the cmux integration and its tests.

## Why

With `cmux.splits` enabled, GSD can successfully create the expected split panes, but the panes remain plain shell sessions instead of displaying the corresponding GSD/Pi subagents.

The subagents themselves continue to run through the fallback child-process path, which results in behavior like:

```text
subagent dispatch        ✅
subagent remains alive   ✅
cmux split created       ✅
subagent shown in split  ❌
split contains only zsh  ❌
```

The current adapter still calls CLI commands that are no longer available in current cmux versions:

```text
list-surfaces
send-surface
```

As a result, `new-split` can succeed and visually create a pane, while GSD fails to resolve/use the new surface and falls back to invisible child-process execution.

This is closely related to the previously reported `gsd-build/gsd-2#2971`, where the same stale cmux CLI usage caused empty split panes while agents continued through the fallback execution path.

## How

`cmux new-split` already returns the newly created surface reference, for example:

```text
OK surface:17 workspace:2
```

Instead of enumerating all surfaces before and after the split and calculating the difference, `createSplitFrom()` now extracts `surface:17` directly from that response.

This removes both:

1. the dependency on the obsolete `list-surfaces` command for split creation; and
2. the race inherent in discovering the newly created surface via before/after enumeration.

For surface interaction, the adapter now uses the current cmux commands:

```text
cmux send --surface surface:17 ...
cmux send-key --surface surface:17 ctrl+c
```

`listSurfaceIds()` is retained as a compatibility/helper API, but now extracts `surface:N` references from the workspace-scoped `cmux tree` output.

The focused cmux test uses a fake `cmux` executable to verify that:

- `tree` surface references are parsed correctly;
- `new-split` returns and resolves the new surface;
- commands are sent using `send`;
- interrupts are sent using `send-key ... ctrl+c`;
- `list-surfaces` is never invoked;
- `send-surface` is never invoked.

A separate micro-harness was also used while preparing the change to verify the expected `new-split → surface extraction → send → send-key` flow.

Full repository CI has not been run locally; the PR CI should provide the full project validation.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Focused test coverage was updated to validate the current cmux CLI interaction using a fake `cmux` executable.

Expected CI validation should include the existing cmux test suite and extension type checking.

For manual verification in cmux:

1. Enable `cmux.splits`.
2. Start a GSD workflow that dispatches a subagent.
3. Confirm the new split is created.
4. Confirm the subagent process/output appears in the new split instead of leaving a plain zsh prompt.
5. Cancel/interrupt a running subagent and confirm the process is interrupted correctly.

## AI disclosure

- [x] This PR includes AI-assisted code

The change was prepared with ChatGPT (GPT-5.6 Sol). The implementation was reviewed against the current `open-gsd/gsd-pi` cmux/subagent code paths and current cmux CLI behavior. Focused test coverage was updated for split creation, surface resolution, command delivery, interrupt delivery, and removal of obsolete cmux CLI calls.