### PR TITLE
docs(configuration): document subagent exemption from stalled-tool budget

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -608,6 +608,10 @@ auto_supervisor:
   stalled_tool_timeout_minutes: 5  # recover a tool that hangs mid-call (default: 5)
 ```
 
+Long-running coordination tools (`subagent`, and its `Task` alias) are exempt from
+`stalled_tool_timeout_minutes`: a subagent running parallel reviewers can legitimately
+outlast this budget. A genuinely hung subagent is still bounded by `hard_timeout_minutes`.
+
 ### `min_request_interval_ms`
 
 Minimum milliseconds between auto-mode LLM request dispatches. Use this to proactively slow auto-mode on rate-limited providers and reduce 429 errors. Set to `0` to disable.

--- a/docs/zh-CN/user-docs/configuration.md
+++ b/docs/zh-CN/user-docs/configuration.md
@@ -331,6 +331,9 @@ auto_supervisor:
   stalled_tool_timeout_minutes: 5  # 恢复在调用中卡死的 tool（默认：5）
 ```
 
+长时协调工具（`subagent` 及其 `Task` 别名）不受 `stalled_tool_timeout_minutes` 约束——并行
+reviewer 的 subagent 合法运行可能远超该预算。真正卡死的 subagent 仍由 `hard_timeout_minutes` 兜底。
+
 ### `budget_ceiling`
 
 自动模式期间允许消耗的最大美元金额。不需要 `$`，直接填数字：


### PR DESCRIPTION
## TL;DR

**What:** Document that `subagent` (and its `Task` alias) are exempt from `stalled_tool_timeout_minutes`.
**Why:** The existing description ("recover a tool that hangs mid-call") no longer covers coordination tools after #2053.
**How:** One paragraph added under the `stalled_tool_timeout_minutes` yaml block in both the English and zh-CN configuration docs.

## What

- `docs/user-docs/configuration.md`: +4 lines after the `auto_supervisor` yaml block
- `docs/zh-CN/user-docs/configuration.md`: +3 lines at the same location

No code changes. Documentation only.

## Why

`docs/user-docs/configuration.md:608` (and its zh-CN counterpart at
`docs/zh-CN/user-docs/configuration.md:331`) describe
`stalled_tool_timeout_minutes` as recovering "a tool that hangs mid-call".
The behavior reported in #2052 was fixed in code by #2053 (merged as
`590a37a3`): long-running coordination tools — `subagent` and its `Task`
alias — are now exempt from the stalled-tool watchdog and are instead
bounded by `hard_timeout_minutes`. The docs still describe semantics the
code no longer has; this PR closes that documentation gap.

## How

Adds one paragraph under each language's `stalled_tool_timeout_minutes`
yaml block stating the exemption and the hard-timeout backstop, mirroring
the implementation in `auto-tool-tracking.ts`
(`LONG_RUNNING_COORDINATION_TOOLS`).

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — steps described above
- [x] No tests needed — documentation-only change; the two modified files are prose under `docs/`, with no executable behavior to test. Behavior was verified by reading the merged #2053 source rather than by running code.

## AI disclosure

- [x] This PR includes AI-assisted code

Documentation text was drafted with an AI coding assistant; the underlying
behavior was verified against the merged #2053 source
(`auto-tool-tracking.ts` / `auto-timers.ts`) before submission.