### PR TITLE
fix(test): raise baseline invariant timeout to cover slower machines

### DIFF
--- a/scripts/workflow-authority-baseline.mjs
+++ b/scripts/workflow-authority-baseline.mjs
@@ -62,13 +62,14 @@ function commandForInvariant(invariant) {
   };
 }
 
-// Per-invariant hang watchdog. The default is the historical 60s; slower
-// machines can raise it via the env var (fault-boundary-matrix alone has been
-// measured at 67-85s). Four invariants run sequentially, so 4 x this value must
-// stay under BASELINE_SPAWN_TIMEOUT_MS in src/tests/workflow-authority-baseline.test.ts,
+// Per-invariant hang watchdog. The default covers fault-boundary-matrix on
+// slower machines, where it has been measured at 67-85s against the
+// historical 60s cap (that cap turned a slow machine into a false timeout).
+// Four invariants run sequentially, so 4 x this value must stay under
+// BASELINE_SPAWN_TIMEOUT_MS in src/tests/workflow-authority-baseline.test.ts,
 // which wraps the whole CLI run.
 export const INVARIANT_TIMEOUT_ENV = "GSD_BASELINE_INVARIANT_TIMEOUT_MS";
-const DEFAULT_INVARIANT_TIMEOUT_MS = 60_000;
+const DEFAULT_INVARIANT_TIMEOUT_MS = 90_000;
 
 export function invariantTimeoutMs(env = process.env) {
   return Number(env[INVARIANT_TIMEOUT_ENV]) || DEFAULT_INVARIANT_TIMEOUT_MS;

--- a/src/tests/workflow-authority-baseline.test.ts
+++ b/src/tests/workflow-authority-baseline.test.ts
@@ -8,7 +8,7 @@ import test from "node:test";
 
 const baselinePath = join(process.cwd(), "scripts/workflow-authority-baseline.mjs");
 const baseline = await import(pathToFileURL(baselinePath).href);
-const BASELINE_SPAWN_TIMEOUT_MS = 255_000;
+const BASELINE_SPAWN_TIMEOUT_MS = 375_000; // 4 x 90s invariant budget + headroom
 const BASELINE_TEST_TIMEOUT_MS = 270_000;
 
 test("workflow authority baseline reports four fixed invariants in stable order", () => {


### PR DESCRIPTION
The per-invariant hang watchdog defaults to the historical 60s, but `fault-boundary-matrix` alone measures 67–85s on slower machines — so a perfectly healthy run fails its own watchdog (and the failure message tells you to raise `GSD_BASELINE_INVARIANT_TIMEOUT_MS` by hand, which nobody should have to discover per machine).

Raises the default to 90s and the wrapping `BASELINE_SPAWN_TIMEOUT_MS` to 375s (4 × 90s + headroom), preserving the documented invariant that 4 × per-invariant budget stays under the wrapper. Env override still wins.