### PR TITLE
chore(deps): bump undici from 7.28.0 to 7.29.0

### DIFF
--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -48,7 +48,7 @@
     "sql.js": "^1.14.1",
     "strip-ansi": "^7.1.0",
     "typebox": "1.1.38",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "yaml": "2.9.0",
     "@gsd/agent-core": "workspace:*",
     "@gsd/native": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,8 +438,8 @@ importers:
         specifier: 1.1.38
         version: 1.1.38
       undici:
-        specifier: 7.28.0
-        version: 7.28.0
+        specifier: 7.29.0
+        version: 7.29.0
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -5967,6 +5967,10 @@ packages:
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -12355,6 +12359,8 @@ snapshots:
   undici@6.27.0: {}
 
   undici@7.28.0: {}
+
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
Same bump as #1603, re-cut from current main — the original dependabot branch had accumulated stale merge commits and a lockfile conflict with #1631. Single dependency change in `packages/pi-coding-agent` + regenerated lockfile.

Supersedes #1603.