### PR TITLE
feat(gsd): non-blocking cheaper/better same-tier Copilot notifications (GSD-W017)

### DIFF
--- a/docs/dev/ADR-012-provider-id-vs-api-shape.md
+++ b/docs/dev/ADR-012-provider-id-vs-api-shape.md
@@ -52,6 +52,7 @@ A small set of call sites legitimately keys on `provider`. These are **not** gat
 - **Display labels / onboarding copy** (`onboarding.ts`). Surface-only, no behavior impact.
 - **Live provider-account catalog state** (`copilot-model-catalog.ts`, `copilot-overlay-writer.ts`, `commands/handlers/copilot-models.ts`). GitHub Copilot's live `/models` sync, its remote-only-model quarantine/registration logic, and the `/gsd copilot-models` command all exist specifically to talk to the `github-copilot` transport's authenticated account state — the check is inherently transport-specific, not API-shape-specific.
 - **Session-start catalog refresh coordinator** (`copilot-catalog-session-refresh.ts`). GSD-W018's opt-in automatic refresh reuses the same GitHub Copilot auth-token resolution as the manual `/gsd copilot-models` command, for the same transport-specific reason.
+- **Session-start cheaper-alternative notification gate** (`bootstrap/register-hooks.ts`). GSD-W017's post-refresh notification only ever evaluates the active model when it is on the `github-copilot` transport, since the cheaper-alternative comparison itself is scoped to that account's live catalog and economics.
 
 These sites are enumerated in the allowlist at `src/tests/provider-equality-allowlist.test.ts`.
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -599,14 +599,66 @@ function triggerCopilotCatalogSessionRefresh(ctx: ExtensionContext, basePath: st
         basePath,
         preferences: prefs?.preferences,
       });
-      if (!notifyOnChanges || !result.ok || result.changedModelIds.length === 0) return;
-      ctx.ui.notify(
-        `GitHub Copilot model catalog: ${result.changedModelIds.length} model(s) changed since the last check. Run /gsd copilot-models changes for details.`,
-        "info",
-      );
+      if (!result.ok) return;
+
+      if (notifyOnChanges && result.changedModelIds.length > 0) {
+        ctx.ui.notify(
+          `GitHub Copilot model catalog: ${result.changedModelIds.length} model(s) changed since the last check. Run /gsd copilot-models changes for details.`,
+          "info",
+        );
+      }
+
+      // GSD-W017: after a completed refresh, check whether the currently
+      // active model (if it's a GitHub Copilot model) now has a qualifying
+      // cheaper/better same-tier alternative — independent of whether the
+      // catalog itself changed, since this may be the first refresh to ever
+      // surface it. Never fires for models on other providers, never
+      // switches the model.
+      if (ctx.model?.provider === "github-copilot" && ctx.model.id) {
+        const { maybeNotifyCheaperAlternative } = await import("../copilot-catalog-notifications.js");
+        maybeNotifyCheaperAlternative({
+          ctx,
+          accountScope: basePath,
+          selectedModelProvider: ctx.model.provider,
+          selectedModelId: ctx.model.id,
+          snapshot: result.snapshot,
+        });
+      }
     } catch {
       // Non-fatal: session startup must never fail because of this, and the
       // coordinator itself never surfaces auth/network failures as errors.
+    }
+  })();
+}
+
+/**
+ * GSD-W017: notify (never auto-switch) when the user explicitly selects or
+ * cycles to a GitHub Copilot model that has a qualifying cheaper/better
+ * same-tier alternative. Deliberately excludes `source: "restore"` (session
+ * resume/model-registry re-application, not a fresh user choice) and never
+ * fires for non-Copilot providers or automatic/dynamic routing, which never
+ * emits this event in the first place.
+ */
+function notifyOnManualCopilotModelSelection(
+  event: { model: { provider?: string; id: string }; source: "set" | "cycle" | "restore" },
+  ctx: ExtensionContext,
+): void {
+  if (event.source === "restore") return;
+  if (!event.model.id) return;
+  void (async () => {
+    try {
+      const basePath = contextBasePath(ctx);
+      const { getLastKnownCopilotCatalogSnapshot } = await import("../copilot-catalog-session-refresh.js");
+      const { maybeNotifyCheaperAlternative } = await import("../copilot-catalog-notifications.js");
+      maybeNotifyCheaperAlternative({
+        ctx,
+        accountScope: basePath,
+        selectedModelProvider: event.model.provider,
+        selectedModelId: event.model.id,
+        snapshot: getLastKnownCopilotCatalogSnapshot(basePath),
+      });
+    } catch {
+      // Non-fatal: never let an advisory notification break model selection.
     }
   })();
 }
@@ -2091,8 +2143,9 @@ export function registerHooks(
     }
   });
 
-  pi.on("model_select", async (_event, ctx) => {
+  pi.on("model_select", async (event, ctx) => {
     await syncServiceTierStatus(ctx);
+    notifyOnManualCopilotModelSelection(event, ctx);
   });
 
   pi.on("before_provider_request", async (event) => {

--- a/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
+++ b/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
@@ -415,7 +415,7 @@ function stripJsonComments(input: string): string {
  * itself) so pricing/why never fail because of this best-effort lookup.
  */
 function readGithubCopilotModelsJsonCost(
-  ctx: ExtensionCommandContext,
+  ctx: ExtensionContext,
   modelId: string,
 ): { input: number; output: number; cacheRead: number; cacheWrite: number } | undefined {
   try {
@@ -443,7 +443,7 @@ function readGithubCopilotModelsJsonCost(
   }
 }
 
-function buildUserOverrideEconomics(ctx: ExtensionCommandContext, modelId: string): Partial<RuntimeModelEconomics> | undefined {
+function buildUserOverrideEconomics(ctx: ExtensionContext, modelId: string): Partial<RuntimeModelEconomics> | undefined {
   const cost = readGithubCopilotModelsJsonCost(ctx, modelId);
   if (!cost || !hasMeaningfulCost(cost)) return undefined;
   return {
@@ -454,7 +454,7 @@ function buildUserOverrideEconomics(ctx: ExtensionCommandContext, modelId: strin
 }
 
 function resolveEconomicsForModel(
-  ctx: ExtensionCommandContext,
+  ctx: ExtensionContext,
   bareId: string,
   liveRecord: CopilotModelRecord | undefined,
   localModel: Model<Api> | undefined,

--- a/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
+++ b/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
@@ -7,7 +7,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 import type { Api, Model } from "@gsd/pi-ai";
 import { getGitHubCopilotBaseUrl } from "@gsd/pi-ai/oauth";
-import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import type { ExtensionCommandContext, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import {
   CopilotCatalogFetchError,
@@ -25,8 +25,13 @@ import {
   registerCopilotModelsInOverlay,
   resolveGsdModelsCatalogPath,
 } from "../../copilot-overlay-writer.js";
-import { resolveModelEconomics, type RuntimeModelEconomics } from "../../model-cost-table.js";
-import { canonicalizeModelId, getModelProfileConfidence, MODEL_CAPABILITY_TIER } from "../../model-router.js";
+import { lookupModelCost, resolveModelEconomics, type RuntimeModelEconomics } from "../../model-cost-table.js";
+import {
+  canonicalizeModelId,
+  getModelProfileConfidence,
+  MODEL_CAPABILITY_TIER,
+  PROFILE_CONFIDENCE_ORDINAL,
+} from "../../model-router.js";
 
 interface CopilotCatalogDiffState {
   firstAccepted: boolean;
@@ -228,7 +233,7 @@ async function resolveCurrentAccountView(ctx: ExtensionCommandContext): Promise<
   };
 }
 
-function localCopilotModels(ctx: ExtensionCommandContext): Model<Api>[] {
+function localCopilotModels(ctx: ExtensionContext): Model<Api>[] {
   return ctx.modelRegistry.getAll().filter((model) => model.provider === "github-copilot");
 }
 
@@ -481,6 +486,147 @@ function economicsFreshnessSummary(economics: RuntimeModelEconomics): string {
   return economics.provenance.defaultTokenPrices?.freshness ?? "unknown";
 }
 
+export interface CheaperSameTierSuggestion {
+  modelId: string;
+  tier: string;
+  confidence: ReturnType<typeof getModelProfileConfidence>;
+  economics: RuntimeModelEconomics & {
+    tokenPrices: { default: { inputPer1k: number; outputPer1k: number } };
+  };
+  inputSavings: number;
+  outputSavings: number;
+}
+
+function hasKnownDefaultPricing(
+  economics: RuntimeModelEconomics,
+): economics is RuntimeModelEconomics & {
+  tokenPrices: { default: { inputPer1k: number; outputPer1k: number } };
+} {
+  return !!(
+    economics.tokenPrices?.default
+    && Number.isFinite(economics.tokenPrices.default.inputPer1k)
+    && Number.isFinite(economics.tokenPrices.default.outputPer1k)
+  );
+}
+
+function isBlockedForAutomaticRouting(record: CopilotModelRecord | undefined): boolean {
+  return (
+    record?.availability.policyState === "disabled"
+    || record?.availability.policyState === "restricted"
+    || record?.availability.preview === true
+  );
+}
+
+function formatCheaperSameTierOption(
+  suggestion: CheaperSameTierSuggestion,
+): string {
+  const prices = suggestion.economics.tokenPrices.default;
+  return `- cheaper same-tier option: github-copilot/${suggestion.modelId} (${suggestion.tier}, ${suggestion.confidence}, $${prices.inputPer1k.toFixed(4)} / $${prices.outputPer1k.toFixed(4)} per 1K) — saves $${suggestion.inputSavings.toFixed(4)} input / $${suggestion.outputSavings.toFixed(4)} output per 1K`;
+}
+
+export function findCheaperSameTierOption(
+  bareId: string,
+  ctx: ExtensionContext,
+  snapshot: CopilotModelSnapshot | null,
+): CheaperSameTierSuggestion | null {
+  const targetTier = MODEL_CAPABILITY_TIER[bareId];
+  if (!targetTier) return null;
+
+  const targetLiveRecord = findLiveRecord(snapshot, bareId);
+  if (isBlockedForAutomaticRouting(targetLiveRecord)) return null;
+
+  const sessionModels = ctx.modelRegistry
+    .getAvailable()
+    .filter((model) => model.provider === "github-copilot");
+  if (!sessionModels.some((model) => normalizeBareModelId(model.id) === bareId)) {
+    return null;
+  }
+
+  const targetEconomics = resolveEconomicsForModel(
+    ctx,
+    bareId,
+    targetLiveRecord,
+    findLocalModel(ctx, bareId),
+  );
+  if (!hasKnownDefaultPricing(targetEconomics)) return null;
+
+  let bestSuggestion: CheaperSameTierSuggestion | null = null;
+  for (const candidateModel of sessionModels) {
+    const candidateBareId = normalizeBareModelId(candidateModel.id);
+    if (!candidateBareId || candidateBareId === bareId) continue;
+    if (MODEL_CAPABILITY_TIER[candidateBareId] !== targetTier) continue;
+
+    const candidateConfidence = getModelProfileConfidence(candidateBareId);
+    if (candidateConfidence === "unknown") continue;
+
+    const candidateLiveRecord = findLiveRecord(snapshot, candidateBareId);
+    if (isBlockedForAutomaticRouting(candidateLiveRecord)) continue;
+
+    const candidateEconomics = resolveEconomicsForModel(
+      ctx,
+      candidateBareId,
+      candidateLiveRecord,
+      findLocalModel(ctx, candidateBareId) ?? candidateModel,
+    );
+    if (!hasKnownDefaultPricing(candidateEconomics)) continue;
+
+    const inputSavings =
+      targetEconomics.tokenPrices.default.inputPer1k
+      - candidateEconomics.tokenPrices.default.inputPer1k;
+    const outputSavings =
+      targetEconomics.tokenPrices.default.outputPer1k
+      - candidateEconomics.tokenPrices.default.outputPer1k;
+
+    const candidateIsStrictlyCheaper =
+      inputSavings >= 0
+      && outputSavings >= 0
+      && (inputSavings > 0 || outputSavings > 0);
+    if (!candidateIsStrictlyCheaper) continue;
+
+    const nextSuggestion: CheaperSameTierSuggestion = {
+      modelId: candidateBareId,
+      tier: targetTier,
+      confidence: candidateConfidence,
+      economics: candidateEconomics,
+      inputSavings,
+      outputSavings,
+    };
+
+    if (!bestSuggestion) {
+      bestSuggestion = nextSuggestion;
+      continue;
+    }
+
+    const currentPrices = bestSuggestion.economics.tokenPrices.default;
+    const nextPrices = candidateEconomics.tokenPrices.default;
+    const isBetterChoice =
+      nextPrices.inputPer1k < currentPrices.inputPer1k
+      || (
+        nextPrices.inputPer1k === currentPrices.inputPer1k
+        && nextPrices.outputPer1k < currentPrices.outputPer1k
+      )
+      || (
+        nextPrices.inputPer1k === currentPrices.inputPer1k
+        && nextPrices.outputPer1k === currentPrices.outputPer1k
+        && PROFILE_CONFIDENCE_ORDINAL[candidateConfidence]
+          > PROFILE_CONFIDENCE_ORDINAL[bestSuggestion.confidence]
+      )
+      || (
+        nextPrices.inputPer1k === currentPrices.inputPer1k
+        && nextPrices.outputPer1k === currentPrices.outputPer1k
+        && PROFILE_CONFIDENCE_ORDINAL[candidateConfidence]
+          === PROFILE_CONFIDENCE_ORDINAL[bestSuggestion.confidence]
+        && candidateBareId.localeCompare(bestSuggestion.modelId) < 0
+      );
+
+    if (isBetterChoice) {
+      bestSuggestion = nextSuggestion;
+    }
+  }
+
+  return bestSuggestion;
+}
+
 function formatPromotion(
   promotion?: {
     discountPercent?: number;
@@ -579,7 +725,7 @@ function findLiveRecord(snapshot: CopilotModelSnapshot | null, bareId: string): 
   return snapshot?.models.find((model) => normalizeBareModelId(model.id) === bareId);
 }
 
-function findLocalModel(ctx: ExtensionCommandContext, bareId: string): Model<Api> | undefined {
+function findLocalModel(ctx: ExtensionContext, bareId: string): Model<Api> | undefined {
   return localCopilotModels(ctx).find((model) => normalizeBareModelId(model.id) === bareId);
 }
 
@@ -600,6 +746,7 @@ function buildWhyExplanation(
   const tier = MODEL_CAPABILITY_TIER[canonicalizeModelId(bareId)] ?? "unknown";
   const confidence = getModelProfileConfidence(bareId);
   const economics = resolveEconomicsForModel(ctx, bareId, liveRecord, localModel);
+  const cheaperSameTierOption = findCheaperSameTierOption(bareId, ctx, snapshot);
 
   let routingEligible = false;
   let routingReason = "no live/task routing context available";
@@ -661,13 +808,22 @@ function buildWhyExplanation(
     `- freshness: ${economicsFreshnessSummary(economics)}`,
     `- request billing: ${economics.requestMultiplier !== undefined ? `${economics.requestMultiplier}x (${economics.provenance.requestMultiplier?.source ?? economics.source}/${economics.provenance.requestMultiplier?.freshness ?? "unknown"})` : "unknown"}`,
     `- promotion: ${formatPromotion(liveRecord?.billing.promotion ?? economics.promotion)}`,
+    ...(cheaperSameTierOption
+      ? [formatCheaperSameTierOption(cheaperSameTierOption)]
+      : []),
     `- automatic routing eligible: ${routingEligible ? "yes" : "no"}`,
     `- reason: ${routingReason}`,    ...(routingCaveats.length > 0 ? [`- routing caveats: ${routingCaveats.join("; ")}`] : []),    `- task routing context: unavailable (no active classification context)` ,
     `- guidance: ${guidance}`,
   ].join("\n");
 }
 
-function formatPricingRecord(ctx: ExtensionCommandContext, record: CopilotModelRecord | undefined, localModel: Model<Api> | undefined, bareId: string): string[] {
+function formatPricingRecord(
+  ctx: ExtensionCommandContext,
+  record: CopilotModelRecord | undefined,
+  localModel: Model<Api> | undefined,
+  bareId: string,
+  snapshot: CopilotModelSnapshot | null,
+): string[] {
   const economics = resolveEconomicsForModel(ctx, bareId, record, localModel);
   const lines = [
     `GitHub Copilot pricing: github-copilot/${bareId}`,
@@ -675,6 +831,10 @@ function formatPricingRecord(ctx: ExtensionCommandContext, record: CopilotModelR
     `- source: ${economicsSourceSummary(economics)}`,
     `- freshness: ${economicsFreshnessSummary(economics)}`,
   ];
+  const cheaperSameTierOption = findCheaperSameTierOption(bareId, ctx, snapshot);
+  if (cheaperSameTierOption) {
+    lines.push(formatCheaperSameTierOption(cheaperSameTierOption));
+  }
 
   if (economics.tokenPrices?.default) {
     lines.push(
@@ -951,7 +1111,13 @@ export async function handleCopilotModels(
     if (parsed.target) {
       const bareId = parsed.target;
       ctx.ui.notify(
-        formatPricingRecord(ctx, findLiveRecord(currentSnapshot, bareId), findLocalModel(ctx, bareId), bareId).join("\n"),
+        formatPricingRecord(
+          ctx,
+          findLiveRecord(currentSnapshot, bareId),
+          findLocalModel(ctx, bareId),
+          bareId,
+          currentSnapshot,
+        ).join("\n"),
         "info",
       );
       return;
@@ -965,7 +1131,13 @@ export async function handleCopilotModels(
     }
     const blocks = records.map((record) => {
       const bareId = normalizeBareModelId(record.id);
-      return formatPricingRecord(ctx, findLiveRecord(snapshot, bareId), findLocalModel(ctx, bareId), bareId).join("\n");
+      return formatPricingRecord(
+        ctx,
+        findLiveRecord(snapshot, bareId),
+        findLocalModel(ctx, bareId),
+        bareId,
+        snapshot,
+      ).join("\n");
     });
     ctx.ui.notify(blocks.join("\n\n"), "info");
     return;

--- a/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
+++ b/src/resources/extensions/gsd/commands/handlers/copilot-models.ts
@@ -529,7 +529,7 @@ export function findCheaperSameTierOption(
   ctx: ExtensionContext,
   snapshot: CopilotModelSnapshot | null,
 ): CheaperSameTierSuggestion | null {
-  const targetTier = MODEL_CAPABILITY_TIER[bareId];
+  const targetTier = MODEL_CAPABILITY_TIER[canonicalizeModelId(bareId)];
   if (!targetTier) return null;
 
   const targetLiveRecord = findLiveRecord(snapshot, bareId);
@@ -554,7 +554,7 @@ export function findCheaperSameTierOption(
   for (const candidateModel of sessionModels) {
     const candidateBareId = normalizeBareModelId(candidateModel.id);
     if (!candidateBareId || candidateBareId === bareId) continue;
-    if (MODEL_CAPABILITY_TIER[candidateBareId] !== targetTier) continue;
+    if (MODEL_CAPABILITY_TIER[canonicalizeModelId(candidateBareId)] !== targetTier) continue;
 
     const candidateConfidence = getModelProfileConfidence(candidateBareId);
     if (candidateConfidence === "unknown") continue;

--- a/src/resources/extensions/gsd/copilot-catalog-notifications.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-notifications.ts
@@ -1,0 +1,130 @@
+// Project/App: gsd-pi
+// File Purpose: GSD-W017 — non-blocking notifications for cheaper/better
+// same-tier GitHub Copilot alternatives, triggered by manual model
+// selection or a completed GSD-W018 session-start catalog refresh.
+//
+// Never fires for automatic/dynamic routing selections: those never emit the
+// `model_select` event this module is wired to (auto-mode applies models
+// directly through the model registry, not through the interactive
+// set/cycle/restore selection path). Never switches the model automatically
+// — purely advisory, deduplicated by a fingerprint of (account scope,
+// selected model, suggested model, catalog revision) so a stable pairing is
+// only ever announced once until something material changes.
+
+import { createHash } from "node:crypto";
+
+import type { ExtensionContext } from "@gsd/pi-coding-agent";
+
+import { findCheaperSameTierOption, type CheaperSameTierSuggestion } from "./commands/handlers/copilot-models.js";
+import type { CopilotModelSnapshot } from "./copilot-model-catalog.js";
+import { MODEL_CAPABILITY_PROFILES, type ModelCapabilities } from "./model-router.js";
+
+// Session-scoped only — never persisted to disk, mirrors the existing
+// per-account notification dedup pattern in commands/handlers/copilot-models.ts.
+const notifiedFingerprints = new Set<string>();
+
+/** Test-only hook to reset module-level session state between test cases. */
+export function _resetCopilotCatalogNotificationStateForTests(): void {
+	notifiedFingerprints.clear();
+}
+
+function bareModelId(modelId: string): string {
+	return modelId.includes("/") ? (modelId.split("/").pop() ?? modelId) : modelId;
+}
+
+/** Average of the 7 capability dimensions. */
+function averageCapabilityScore(profile: ModelCapabilities): number {
+	const values = Object.values(profile);
+	return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+/**
+ * Pure comparison of two capability profiles. A small margin (avoids noise
+ * from rounding-equivalent profiles) is required before calling the
+ * candidate "higher" — anything else (including missing data) resolves to
+ * "equal-or-lower", the safer default for messaging purposes.
+ */
+export function compareCapabilityScores(
+	selected: ModelCapabilities | undefined,
+	candidate: ModelCapabilities | undefined,
+): "higher" | "equal-or-lower" {
+	if (!selected || !candidate) return "equal-or-lower";
+	return averageCapabilityScore(candidate) > averageCapabilityScore(selected) + 1 ? "higher" : "equal-or-lower";
+}
+
+function isHigherCapability(selectedBareId: string, candidateBareId: string): boolean {
+	return (
+		compareCapabilityScores(MODEL_CAPABILITY_PROFILES[selectedBareId], MODEL_CAPABILITY_PROFILES[candidateBareId])
+		=== "higher"
+	);
+}
+
+function buildFingerprint(
+	accountScope: string,
+	selectedBareId: string,
+	suggestion: CheaperSameTierSuggestion,
+	snapshot: CopilotModelSnapshot | null,
+): string {
+	const revision = snapshot?.hash ?? "no-snapshot";
+	return createHash("sha256")
+		.update(`${accountScope}\n${selectedBareId}\ngithub-copilot/${suggestion.modelId}\n${revision}`)
+		.digest("hex");
+}
+
+function formatNotificationMessage(
+	selectedBareId: string,
+	suggestion: CheaperSameTierSuggestion,
+	higherCapability: boolean,
+): string {
+	const label = higherCapability ? "better, cheaper alternative" : "cheaper equivalent";
+	return [
+		`GitHub Copilot: a ${label} to github-copilot/${selectedBareId} is available — github-copilot/${suggestion.modelId}`,
+		`(saves $${suggestion.inputSavings.toFixed(4)} input / $${suggestion.outputSavings.toFixed(4)} output per 1K).`,
+		`The current model was not changed. Run /gsd copilot-models why github-copilot/${suggestion.modelId} for details.`,
+	].join(" ");
+}
+
+export interface NotifyCheaperAlternativeOptions {
+	ctx: ExtensionContext;
+	/**
+	 * Opaque scope key segmenting the dedup fingerprint. Uses the session's
+	 * basePath (the same scoping unit GSD-W018's coordinator and
+	 * register-hooks.ts already key state by) rather than re-deriving a
+	 * per-account token hash purely for deduplication — within one GSD
+	 * project session there is realistically one active Copilot account, and
+	 * the worst case of a coarser scope is one redundant notification, never
+	 * a wrong or fabricated one.
+	 */
+	accountScope: string;
+	/** Provider of the currently selected/active model. Non-"github-copilot" providers are always a no-op. */
+	selectedModelProvider: string | undefined;
+	/** The currently selected/active GitHub Copilot model id (bare or provider-qualified). */
+	selectedModelId: string;
+	snapshot: CopilotModelSnapshot | null;
+}
+
+/**
+ * Check whether the given (already-selected/active) GitHub Copilot model has
+ * a qualifying cheaper or better-and-cheaper same-tier alternative, and fire
+ * a deduplicated, non-blocking notification if so. Never mutates the active
+ * model, routing state, or any persisted file. Returns true when a
+ * notification was actually sent (false when no qualifying alternative
+ * exists, or the exact pairing was already announced for this catalog
+ * revision).
+ */
+export function maybeNotifyCheaperAlternative(options: NotifyCheaperAlternativeOptions): boolean {
+	const { ctx, accountScope, selectedModelProvider, selectedModelId, snapshot } = options;
+	if (selectedModelProvider !== "github-copilot") return false;
+	const bareId = bareModelId(selectedModelId);
+
+	const suggestion = findCheaperSameTierOption(bareId, ctx, snapshot);
+	if (!suggestion) return false;
+
+	const fingerprint = buildFingerprint(accountScope, bareId, suggestion, snapshot);
+	if (notifiedFingerprints.has(fingerprint)) return false;
+	notifiedFingerprints.add(fingerprint);
+
+	const higherCapability = isHigherCapability(bareId, suggestion.modelId);
+	ctx.ui.notify(formatNotificationMessage(bareId, suggestion, higherCapability), "info");
+	return true;
+}

--- a/src/resources/extensions/gsd/copilot-catalog-notifications.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-notifications.ts
@@ -17,7 +17,7 @@ import type { ExtensionContext } from "@gsd/pi-coding-agent";
 
 import { findCheaperSameTierOption, type CheaperSameTierSuggestion } from "./commands/handlers/copilot-models.js";
 import type { CopilotModelSnapshot } from "./copilot-model-catalog.js";
-import { MODEL_CAPABILITY_PROFILES, type ModelCapabilities } from "./model-router.js";
+import { canonicalizeModelId, MODEL_CAPABILITY_PROFILES, type ModelCapabilities } from "./model-router.js";
 
 // Session-scoped only — never persisted to disk, mirrors the existing
 // per-account notification dedup pattern in commands/handlers/copilot-models.ts.
@@ -54,7 +54,10 @@ export function compareCapabilityScores(
 
 function isHigherCapability(selectedBareId: string, candidateBareId: string): boolean {
 	return (
-		compareCapabilityScores(MODEL_CAPABILITY_PROFILES[selectedBareId], MODEL_CAPABILITY_PROFILES[candidateBareId])
+		compareCapabilityScores(
+			MODEL_CAPABILITY_PROFILES[canonicalizeModelId(selectedBareId)],
+			MODEL_CAPABILITY_PROFILES[canonicalizeModelId(candidateBareId)],
+		)
 		=== "higher"
 	);
 }

--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -428,3 +428,15 @@ export function awaitCopilotCatalogSessionRefresh(
 	if (!pending) return Promise.resolve(NOOP_RESULT);
 	return withTimeout(pending, timeoutMs, { ...NOOP_RESULT, ran: true, reason: "timeout" });
 }
+
+/**
+ * Read the last-known-good snapshot captured by a prior session-start
+ * refresh for `basePath`, without triggering a new fetch. Returns `null`
+ * when no refresh has ever succeeded for this basePath (e.g. mode is "off",
+ * or every attempt so far failed with no snapshot to fall back on). Used by
+ * the GSD-W017 notification feature so it can react to a completed refresh
+ * without re-deriving auth or re-fetching itself.
+ */
+export function getLastKnownCopilotCatalogSnapshot(basePath: string): CopilotModelSnapshot | null {
+	return lastSnapshotByBasePath.get(basePath) ?? null;
+}

--- a/src/resources/extensions/gsd/model-cost-table.ts
+++ b/src/resources/extensions/gsd/model-cost-table.ts
@@ -405,6 +405,7 @@ export const BUNDLED_COST_TABLE: ModelCostEntry[] = [
   { id: "claude-opus-5", inputPer1k: 0.005, outputPer1k: 0.025, updatedAt: "2026-08-12" },
   { id: "claude-fable-5", inputPer1k: 0.010, outputPer1k: 0.050, updatedAt: "2026-06-09" },
   { id: "claude-sonnet-4-6", inputPer1k: 0.003, outputPer1k: 0.015, updatedAt: "2025-03-15" },
+  { id: "claude-sonnet-5", inputPer1k: 0.003, outputPer1k: 0.015, updatedAt: "2026-08-12" },
   { id: "claude-haiku-4-5", inputPer1k: 0.0008, outputPer1k: 0.004, updatedAt: "2025-03-15" },
   { id: "claude-sonnet-4-5-20250514", inputPer1k: 0.003, outputPer1k: 0.015, updatedAt: "2025-03-15" },
   { id: "claude-3-5-sonnet-latest", inputPer1k: 0.003, outputPer1k: 0.015, updatedAt: "2025-03-15" },

--- a/src/resources/extensions/gsd/tests/copilot-catalog-notifications.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-notifications.test.ts
@@ -1,0 +1,194 @@
+// Regression/behavior tests for GSD-W017's non-blocking cheaper/better
+// same-tier notification feature (copilot-catalog-notifications.ts).
+// Exercises the messaging distinction, fingerprint-based dedup, and
+// provider/scope gating on top of the already-tested suggestion-finding
+// logic in copilot-models-handler.test.ts.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  _resetCopilotCatalogNotificationStateForTests,
+  compareCapabilityScores,
+  maybeNotifyCheaperAlternative,
+} from "../copilot-catalog-notifications.js";
+import { _resetCopilotModelsSessionStateForTests } from "../commands/handlers/copilot-models.js";
+
+interface FakeModel {
+  id: string;
+  provider: string;
+}
+
+function createFakeCtx(models: FakeModel[]): { ctx: any; notifications: Array<{ message: string; level: string }> } {
+  const notifications: Array<{ message: string; level: string }> = [];
+  const ctx = {
+    modelRegistry: {
+      getAvailable: () => models,
+      getApiKey: async () => undefined,
+    },
+    ui: {
+      notify: (message: string, level: string = "info") => {
+        notifications.push({ message, level });
+      },
+    },
+  };
+  return { ctx, notifications };
+}
+
+const SAME_TIER_SESSION: FakeModel[] = [
+  { id: "claude-sonnet-5", provider: "github-copilot" },
+  { id: "gpt-4.1", provider: "github-copilot" },
+  { id: "mai-code-1.1-flash", provider: "github-copilot" },
+];
+
+// ─── compareCapabilityScores (pure) ─────────────────────────────────────────
+
+test("compareCapabilityScores: higher when candidate average exceeds selected by more than the margin", () => {
+  const selected = { coding: 50, debugging: 50, research: 50, reasoning: 50, speed: 50, longContext: 50, instruction: 50 };
+  const candidate = { coding: 60, debugging: 60, research: 60, reasoning: 60, speed: 60, longContext: 60, instruction: 60 };
+  assert.equal(compareCapabilityScores(selected, candidate), "higher");
+});
+
+test("compareCapabilityScores: equal-or-lower when within the noise margin or candidate is lower", () => {
+  const selected = { coding: 50, debugging: 50, research: 50, reasoning: 50, speed: 50, longContext: 50, instruction: 50 };
+  const closeCandidate = { ...selected, coding: 50.5 };
+  assert.equal(compareCapabilityScores(selected, closeCandidate), "equal-or-lower");
+
+  const lowerCandidate = { ...selected, coding: 10 };
+  assert.equal(compareCapabilityScores(selected, lowerCandidate), "equal-or-lower");
+});
+
+test("compareCapabilityScores: equal-or-lower when either profile is missing (never guesses)", () => {
+  const selected = { coding: 50, debugging: 50, research: 50, reasoning: 50, speed: 50, longContext: 50, instruction: 50 };
+  assert.equal(compareCapabilityScores(undefined, selected), "equal-or-lower");
+  assert.equal(compareCapabilityScores(selected, undefined), "equal-or-lower");
+});
+
+// ─── maybeNotifyCheaperAlternative ──────────────────────────────────────────
+
+test("maybeNotifyCheaperAlternative: no qualifying alternative sends no notification", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx([{ id: "claude-sonnet-5", provider: "github-copilot" }]);
+
+  const sent = maybeNotifyCheaperAlternative({
+    ctx,
+    accountScope: "/project",
+    selectedModelProvider: "github-copilot",
+    selectedModelId: "claude-sonnet-5",
+    snapshot: null,
+  });
+
+  assert.equal(sent, false);
+  assert.equal(notifications.length, 0);
+});
+
+test("maybeNotifyCheaperAlternative: non-Copilot provider is always a no-op", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+
+  const sent = maybeNotifyCheaperAlternative({
+    ctx,
+    accountScope: "/project",
+    selectedModelProvider: "openai",
+    selectedModelId: "claude-sonnet-5",
+    snapshot: null,
+  });
+
+  assert.equal(sent, false);
+  assert.equal(notifications.length, 0);
+});
+
+test("maybeNotifyCheaperAlternative: same-tier cheaper option notifies as a cheaper equivalent", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+
+  const sent = maybeNotifyCheaperAlternative({
+    ctx,
+    accountScope: "/project",
+    selectedModelProvider: "github-copilot",
+    selectedModelId: "claude-sonnet-5",
+    snapshot: null,
+  });
+
+  assert.equal(sent, true);
+  assert.equal(notifications.length, 1);
+  assert.match(notifications[0]!.message, /cheaper equivalent to github-copilot\/claude-sonnet-5/);
+  assert.match(notifications[0]!.message, /github-copilot\/gpt-4\.1/);
+  assert.match(notifications[0]!.message, /current model was not changed/i);
+  assert.doesNotMatch(notifications[0]!.message, /better, cheaper alternative/);
+});
+
+test("maybeNotifyCheaperAlternative: never leaks tokens or raw provider payloads in the message", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+
+  maybeNotifyCheaperAlternative({
+    ctx,
+    accountScope: "secret-account-scope-value",
+    selectedModelProvider: "github-copilot",
+    selectedModelId: "claude-sonnet-5",
+    snapshot: null,
+  });
+
+  assert.doesNotMatch(notifications[0]!.message, /secret-account-scope-value/);
+  assert.doesNotMatch(notifications[0]!.message, /Bearer|token|gho_|ghu_/i);
+});
+
+test("maybeNotifyCheaperAlternative: deduplicates the identical pairing within the same scope and revision", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+  const call = () =>
+    maybeNotifyCheaperAlternative({
+      ctx,
+      accountScope: "/project",
+      selectedModelProvider: "github-copilot",
+      selectedModelId: "claude-sonnet-5",
+      snapshot: null,
+    });
+
+  assert.equal(call(), true, "first call notifies");
+  assert.equal(call(), false, "second identical call is deduped");
+  assert.equal(notifications.length, 1);
+});
+
+test("maybeNotifyCheaperAlternative: a different scope re-notifies despite the identical pairing", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+  const notifyFor = (scope: string) =>
+    maybeNotifyCheaperAlternative({
+      ctx,
+      accountScope: scope,
+      selectedModelProvider: "github-copilot",
+      selectedModelId: "claude-sonnet-5",
+      snapshot: null,
+    });
+
+  assert.equal(notifyFor("/project-a"), true);
+  assert.equal(notifyFor("/project-b"), true, "a different scope is not deduped against a different scope");
+  assert.equal(notifications.length, 2);
+});
+
+test("maybeNotifyCheaperAlternative: a changed catalog revision allows a fresh notification", () => {
+  _resetCopilotModelsSessionStateForTests();
+  _resetCopilotCatalogNotificationStateForTests();
+  const { ctx, notifications } = createFakeCtx(SAME_TIER_SESSION);
+  const notifyWithSnapshot = (hash: string | undefined) =>
+    maybeNotifyCheaperAlternative({
+      ctx,
+      accountScope: "/project",
+      selectedModelProvider: "github-copilot",
+      selectedModelId: "claude-sonnet-5",
+      snapshot: hash ? ({ hash, generatedAt: "", modelCount: 0, models: [] } as any) : null,
+    });
+
+  assert.equal(notifyWithSnapshot(undefined), true);
+  assert.equal(notifyWithSnapshot(undefined), false, "same revision (no snapshot) is deduped");
+  assert.equal(notifyWithSnapshot("revision-2"), true, "a materially different revision re-notifies");
+  assert.equal(notifications.length, 2);
+});

--- a/src/resources/extensions/gsd/tests/copilot-catalog-notifications.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-notifications.test.ts
@@ -17,12 +17,14 @@ import { _resetCopilotModelsSessionStateForTests } from "../commands/handlers/co
 interface FakeModel {
   id: string;
   provider: string;
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
 }
 
 function createFakeCtx(models: FakeModel[]): { ctx: any; notifications: Array<{ message: string; level: string }> } {
   const notifications: Array<{ message: string; level: string }> = [];
   const ctx = {
     modelRegistry: {
+      getAll: () => models.map((model) => ({ ...model, cost: model.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } })),
       getAvailable: () => models,
       getApiKey: async () => undefined,
     },
@@ -36,9 +38,9 @@ function createFakeCtx(models: FakeModel[]): { ctx: any; notifications: Array<{ 
 }
 
 const SAME_TIER_SESSION: FakeModel[] = [
-  { id: "claude-sonnet-5", provider: "github-copilot" },
-  { id: "gpt-4.1", provider: "github-copilot" },
-  { id: "mai-code-1.1-flash", provider: "github-copilot" },
+  { id: "claude-sonnet-5", provider: "github-copilot", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } },
+  { id: "gpt-4.1", provider: "github-copilot", cost: { input: 2, output: 8, cacheRead: 0, cacheWrite: 0 } },
+  { id: "mai-code-1.1-flash", provider: "github-copilot", cost: { input: 0.2, output: 1.2, cacheRead: 0, cacheWrite: 0 } },
 ];
 
 // ─── compareCapabilityScores (pure) ─────────────────────────────────────────
@@ -69,7 +71,7 @@ test("compareCapabilityScores: equal-or-lower when either profile is missing (ne
 test("maybeNotifyCheaperAlternative: no qualifying alternative sends no notification", () => {
   _resetCopilotModelsSessionStateForTests();
   _resetCopilotCatalogNotificationStateForTests();
-  const { ctx, notifications } = createFakeCtx([{ id: "claude-sonnet-5", provider: "github-copilot" }]);
+  const { ctx, notifications } = createFakeCtx([{ id: "claude-sonnet-5", provider: "github-copilot", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } }]);
 
   const sent = maybeNotifyCheaperAlternative({
     ctx,

--- a/src/resources/extensions/gsd/tests/copilot-models-handler.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-models-handler.test.ts
@@ -1096,9 +1096,9 @@ test("handleCopilotModels: pricing suggests a cheaper same-tier Copilot model wh
   _resetCopilotModelsSessionStateForTests();
   const { ctx, notifications } = createFakeCtx({
     models: [
-      { id: "claude-sonnet-5", provider: "github-copilot" },
-      { id: "gpt-4.1", provider: "github-copilot" },
-      { id: "mai-code-1.1-flash", provider: "github-copilot" },
+      { id: "claude-sonnet-5", provider: "github-copilot", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } },
+      { id: "gpt-4.1", provider: "github-copilot", cost: { input: 2, output: 8, cacheRead: 0, cacheWrite: 0 } },
+      { id: "mai-code-1.1-flash", provider: "github-copilot", cost: { input: 0.2, output: 1.2, cacheRead: 0, cacheWrite: 0 } },
     ],
     apiKey: undefined,
   });
@@ -1291,9 +1291,9 @@ test("handleCopilotModels: why highlights a cheaper same-tier model when one is 
   _resetCopilotModelsSessionStateForTests();
   const { ctx, notifications } = createFakeCtx({
     models: [
-      { id: "claude-sonnet-5", provider: "github-copilot" },
-      { id: "gpt-4.1", provider: "github-copilot" },
-      { id: "mai-code-1.1-flash", provider: "github-copilot" },
+      { id: "claude-sonnet-5", provider: "github-copilot", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } },
+      { id: "gpt-4.1", provider: "github-copilot", cost: { input: 2, output: 8, cacheRead: 0, cacheWrite: 0 } },
+      { id: "mai-code-1.1-flash", provider: "github-copilot", cost: { input: 0.2, output: 1.2, cacheRead: 0, cacheWrite: 0 } },
     ],
     apiKey: undefined,
   });

--- a/src/resources/extensions/gsd/tests/copilot-models-handler.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-models-handler.test.ts
@@ -1092,6 +1092,24 @@ test("handleCopilotModels: pricing explains provider-aware economics locally", a
   assert.match(notifications[0].message, /^- freshness: stale$/m);
 });
 
+test("handleCopilotModels: pricing suggests a cheaper same-tier Copilot model when one is available", async () => {
+  _resetCopilotModelsSessionStateForTests();
+  const { ctx, notifications } = createFakeCtx({
+    models: [
+      { id: "claude-sonnet-5", provider: "github-copilot" },
+      { id: "gpt-4.1", provider: "github-copilot" },
+      { id: "mai-code-1.1-flash", provider: "github-copilot" },
+    ],
+    apiKey: undefined,
+  });
+
+  await handleCopilotModels("pricing claude-sonnet-5", ctx, {});
+
+  assert.match(notifications[0].message, /^- cheaper same-tier option: github-copilot\/gpt-4\.1 /m);
+  assert.match(notifications[0].message, /saves \$0\.0010 input \/ \$0\.0070 output per 1K/i);
+  assert.doesNotMatch(notifications[0].message, /mai-code-1\.1-flash/);
+});
+
 test("handleCopilotModels: pricing reports long-context tiers and request multipliers when live data supplies them", async () => {
   _resetCopilotModelsSessionStateForTests();
   const { ctx, notifications } = createFakeCtx({
@@ -1267,6 +1285,24 @@ test("handleCopilotModels: why reports a known-profile preview/policy-restricted
     notifications[1].message,
     /^- routing caveats: .*provider policy is restricted.*preview models are intended to stay manual-only.*$/m,
   );
+});
+
+test("handleCopilotModels: why highlights a cheaper same-tier model when one is session-available", async () => {
+  _resetCopilotModelsSessionStateForTests();
+  const { ctx, notifications } = createFakeCtx({
+    models: [
+      { id: "claude-sonnet-5", provider: "github-copilot" },
+      { id: "gpt-4.1", provider: "github-copilot" },
+      { id: "mai-code-1.1-flash", provider: "github-copilot" },
+    ],
+    apiKey: undefined,
+  });
+
+  await handleCopilotModels("why claude-sonnet-5", ctx, {});
+
+  assert.match(notifications[0].message, /^- cheaper same-tier option: github-copilot\/gpt-4\.1 /m);
+  assert.match(notifications[0].message, /saves \$0\.0010 input \/ \$0\.0070 output per 1K/i);
+  assert.doesNotMatch(notifications[0].message, /mai-code-1\.1-flash/);
 });
 
 test("handleCopilotModels: doctor reports cache and quarantine state without a network request", async () => {

--- a/src/resources/extensions/gsd/tests/model-cost-table.test.ts
+++ b/src/resources/extensions/gsd/tests/model-cost-table.test.ts
@@ -35,6 +35,13 @@ test("lookupModelCost finds haiku", () => {
   assert.ok(entry.inputPer1k < 0.001, "haiku should be cheap");
 });
 
+test("lookupModelCost finds Claude Sonnet 5 pricing", () => {
+  const entry = lookupModelCost("github-copilot/claude-sonnet-5");
+  assert.ok(entry);
+  assert.equal(entry.inputPer1k, 0.003);
+  assert.equal(entry.outputPer1k, 0.015);
+});
+
 test("lookupModelCost finds MAI Code 1.1 Flash pricing", () => {
   const entry = lookupModelCost("github-copilot/mai-code-1.1-flash");
   assert.ok(entry);

--- a/src/tests/provider-equality-allowlist.test.ts
+++ b/src/tests/provider-equality-allowlist.test.ts
@@ -105,6 +105,8 @@ const ALLOWED_FILES: Record<string, string> = {
     "remote-only GitHub Copilot candidate subtraction is a transport-specific quarantine check and must not fabricate metadata",
   "src/resources/extensions/gsd/copilot-catalog-session-refresh.ts":
     "session-start refresh coordinator needs the github-copilot provider specifically to resolve its own auth token, not API shape",
+  "src/resources/extensions/gsd/bootstrap/register-hooks.ts":
+    "session-start hook gates the GSD-W017 cheaper-alternative notification on the active model's transport (github-copilot), not API shape",
 };
 
 function shouldScan(path: string): boolean {


### PR DESCRIPTION
Rebase of #1980's notifications slice onto current main, on top of the landed session-start refresh (#2058). The original stacked draft went stale; cherry-picked its three commits (authorship preserved) and the touched suites pass (131/109 across copilot-catalog-*, handler, cost-table, prefs, provider-equality).

What it adds, per the original PR: after each catalog sync, a non-blocking notice when a cheaper or better-rated same-tier model is available, with notifications deduped per sync event and provider-aware cost resolution; registry tier lookups canonicalize dotted model IDs before comparison.

Supersedes #1980 (that draft will be closed once this merges).