### PR TITLE
fix(issue): [Bug]: milestone status 'cancelled' wedges auto-mode — roadmap-missing detector↔repairer asymmetry (#1651 class)

### DIFF
--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -842,7 +842,7 @@ export function getTasksBySliceIds(
 export interface MilestoneSliceSummary {
   id: string;
   title: string;
-  /** Closed per the canonical status vocabulary (complete/done/skipped/closed). */
+  /** Closed per the canonical status vocabulary (complete/done/skipped/closed/cancelled). */
   done: boolean;
   depends: string[];
 }

--- a/src/resources/extensions/gsd/db/sql-constants.ts
+++ b/src/resources/extensions/gsd/db/sql-constants.ts
@@ -69,5 +69,5 @@ export const CURRENT_TASK_RECOVERY_CAUSAL_AUTHORITY_SQL = `(
  *  prevent an upsert from reopening a completed slice/task. Derived from the
  *  single source `RAW_CLOSED_STATUSES` (ADR-030) so the SQL fragment cannot
  *  drift from `isClosedStatus()`. Renders as `'complete', 'done', 'skipped',
- *  'closed'`. */
+ *  'closed', 'cancelled'`. */
 export const TERMINAL_STATUS_SQL = RAW_CLOSED_STATUSES.map((s) => `'${s}'`).join(", ");

--- a/src/resources/extensions/gsd/status-guards.ts
+++ b/src/resources/extensions/gsd/status-guards.ts
@@ -2,10 +2,9 @@
  * Status predicates and the canonical status vocabulary for GSD state-machine
  * guards (ADR-030).
  *
- * The DB column is free-form `string` so legacy/imported rows still load. Three
- * raw values besides canonical "complete"/"skipped" indicate "closed": "done"
- * (legacy alias), "closed" (legacy/imported), and "skipped" (user-directed skip
- * via rethink or backtrack). `RAW_CLOSED_STATUSES` is the single source for both
+ * The DB column is free-form `string` so legacy/imported rows still load.
+ * Canonical "complete"/"skipped" and legacy/imported "done", "closed", and
+ * "cancelled" indicate closure. `RAW_CLOSED_STATUSES` is the single source for both
  * `isClosedStatus()` and the SQL terminal-status fragment
  * (`db/sql-constants.ts` derives `TERMINAL_STATUS_SQL` from it), replacing the
  * prior independent definitions.
@@ -29,28 +28,30 @@ const CANONICAL_STATUS_SET: ReadonlySet<string> = new Set(CANONICAL_STATUSES);
 
 /**
  * Raw status values that mean a unit is closed — the single source of truth.
- * Includes legacy/imported aliases ("done", "closed") alongside canonical
- * "complete"/"skipped" because the DB column is free-form and older rows /
- * imports still carry them. Order matters: `TERMINAL_STATUS_SQL` is derived
- * from this array verbatim.
+ * Includes legacy/imported aliases ("done", "closed", "cancelled") alongside
+ * canonical "complete"/"skipped" because the DB column is free-form and older
+ * rows / imports still carry them. Order matters: `TERMINAL_STATUS_SQL` is
+ * derived from this array verbatim.
  */
-export const RAW_CLOSED_STATUSES = ["complete", "done", "skipped", "closed"] as const;
+export const RAW_CLOSED_STATUSES = ["complete", "done", "skipped", "closed", "cancelled"] as const;
 const RAW_CLOSED_SET: ReadonlySet<string> = new Set(RAW_CLOSED_STATUSES);
 
 /** Free-form aliases mapped to their canonical Status on read. */
 const ALIAS_TO_CANONICAL: Readonly<Record<string, Status>> = {
   done: "complete",
   closed: "complete",
+  cancelled: "skipped",
   planned: "pending",
   "in-progress": "in_progress",
 };
 
 /**
  * Normalize a free-form DB status string into the canonical `Status`
- * vocabulary. Maps known aliases (done/closed → complete, planned → pending,
- * in-progress → in_progress). An unrecognized/legacy value is **quarantined** —
- * preserved verbatim rather than silently remapped to a wrong canonical state —
- * so reads never fail and reconciliation/telemetry can surface it.
+ * vocabulary. Maps known aliases (done/closed → complete, cancelled → skipped,
+ * planned → pending, in-progress → in_progress). An unrecognized/legacy value
+ * is **quarantined** — preserved verbatim rather than silently remapped to a
+ * wrong canonical state — so reads never fail and reconciliation/telemetry can
+ * surface it.
  */
 export function toStatus(raw: string): Status {
   const value = raw.trim();

--- a/src/resources/extensions/gsd/tests/roadmap-missing-drift-1634.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-missing-drift-1634.test.ts
@@ -145,7 +145,7 @@ test("#1634 (b): missing ROADMAP.md with DB planning rows emits roadmap-missing 
   );
 });
 
-test("#1634: unplanned bare milestone rows and closed milestones do not emit roadmap-missing drift", async (t) => {
+test("#1634/#2063: unplanned bare milestone rows and closed milestones do not emit roadmap-missing drift", async (t) => {
   const base = makeBase("gsd-1634-unplanned-");
   t.after(() => cleanup(base));
 
@@ -162,6 +162,15 @@ test("#1634: unplanned bare milestone rows and closed milestones do not emit roa
     status: "complete",
     planning: { vision: "Already shipped." },
   });
+  // Cancelled milestone: imported/externally-written terminal rows must stay
+  // out of reconciliation even when vision would otherwise make them renderable.
+  insertMilestone({
+    id: "M004",
+    title: "Cancelled",
+    status: "cancelled",
+    planning: { vision: "No longer planned." },
+  });
+  insertMilestone({ id: "M005", title: "Cancelled placeholder", status: "cancelled" });
 
   const records = detectRoadmapMissingDrift(makeState(), { basePath: base, state: makeState() });
   assert.equal(records.length, 0, "neither bare nor closed milestones may be flagged");

--- a/src/resources/extensions/gsd/tests/status-guards.test.ts
+++ b/src/resources/extensions/gsd/tests/status-guards.test.ts
@@ -30,6 +30,10 @@ test('isClosedStatus: "closed" returns true', () => {
   assert.equal(isClosedStatus('closed'), true);
 });
 
+test('isClosedStatus: "cancelled" returns true', () => {
+  assert.equal(isClosedStatus('cancelled'), true);
+});
+
 test('isClosedStatus: "pending" returns false', () => {
   assert.equal(isClosedStatus('pending'), false);
 });
@@ -70,7 +74,7 @@ test('isDeferredStatus is true only for "deferred"', () => {
 // ─── isInactiveStatus (closed OR deferred) ─────────────────────────────────
 
 test('isInactiveStatus covers every closed status', () => {
-  for (const s of ['complete', 'done', 'skipped', 'closed']) {
+  for (const s of RAW_CLOSED_STATUSES) {
     assert.equal(isInactiveStatus(s), true, `${s} should count as inactive`);
   }
 });
@@ -88,7 +92,7 @@ test('isInactiveStatus excludes runnable statuses', () => {
 // ─── isSkippedForDispatch (closed, parked, or deferred) ────────────────────
 
 test('isSkippedForDispatch covers closed, parked, and deferred', () => {
-  for (const s of ['complete', 'done', 'skipped', 'closed', 'parked', 'deferred']) {
+  for (const s of [...RAW_CLOSED_STATUSES, 'parked', 'deferred']) {
     assert.equal(isSkippedForDispatch(s), true, `${s} should be skipped for dispatch ordering`);
   }
 });
@@ -110,6 +114,7 @@ test('toStatus passes canonical values through unchanged', () => {
 test('toStatus maps known aliases to canonical', () => {
   assert.equal(toStatus('done'), 'complete');
   assert.equal(toStatus('closed'), 'complete');
+  assert.equal(toStatus('cancelled'), 'skipped');
   assert.equal(toStatus('planned'), 'pending');
   assert.equal(toStatus('in-progress'), 'in_progress');
 });
@@ -130,6 +135,6 @@ test('RAW_CLOSED_STATUSES is the single source: every member is closed', () => {
 });
 
 test('TERMINAL_STATUS_SQL is derived from RAW_CLOSED_STATUSES and renders identically', () => {
-  assert.equal(TERMINAL_STATUS_SQL, "'complete', 'done', 'skipped', 'closed'");
+  assert.equal(TERMINAL_STATUS_SQL, "'complete', 'done', 'skipped', 'closed', 'cancelled'");
   assert.equal(TERMINAL_STATUS_SQL, RAW_CLOSED_STATUSES.map((s) => `'${s}'`).join(', '));
 });


### PR DESCRIPTION
## Summary
- Added cancelled milestone terminal handling with passing focused status tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2063
- [#2063 [Bug]: milestone status 'cancelled' wedges auto-mode — roadmap-missing detector↔repairer asymmetry (#1651 class)](https://github.com/open-gsd/gsd-pi/issues/2063)

## User
- @Jack11111eee

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2063-bug-milestone-status-cancelled-wedges-au-1788019409`