### PR TITLE
release: v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,69 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-08-29
+
+### Added
+- **gsd**: non-blocking cheaper/better same-tier Copilot notifications (GSD-W017) (#2060)
+- **gsd**: session-start GitHub Copilot catalog refresh (GSD-W018) (#2058)
+- **copilot-models**: add safe registration and provider-aware diagnostics
+- **copilot-models**: explain provider-aware routing and pricing
+- **gsd**: add profile-confidence routing safety
+- **copilot-models**: add opt-in --register overlay writer (Phase H slice 1)
+- **gsd**: annotate Copilot catalog drift with registry ID and capability tier
+- **copilot-models**: add live catalog sync command and tests
+
+### Fixed
+- **test**: raise baseline invariant timeout to cover slower machines (#2057)
+- **issue**: [Bug]: recover  fails with LEGACY_IMPORT_APPLICATION_PREVIEW_UNRESOLVED - filename pattern mismatch (#2049)
+- **issue**: [Bug]: stalled-tool watchdog aborts a legitimately long-running subagent (parallel reviewer dispatch), so validate-milestone is killed before it can persist and the liveness backstop wedges auto-mode (#2053)
+- **gsd**: address 6 fresh Copilot automated-review findings on PR #1978
+- **gsd**: fully adopt canonicalizeModelId after rebasing past upstream #2035
+- **copilot-models**: scope account keys and notification dedup to the actual sync event
+- address 7 new GitHub Copilot review findings on PR #1978
+- implement documented user-override precedence, fix getApiKey-throws regression
+- correct 4 regressions found by an independent codex review
+- address Copilot automated review findings on PR #1978
+- **gsd**: reject wrong-provider pricing targets before resolving auth
+- **gsd**: harden copilot catalog state and economics coverage
+- **gsd**: describe expanded copilot-models command surface
+- **gsd**: complete Copilot model explanation contract
+- **gsd**: make Copilot model explanation local and truthful
+- **gsd**: align overlay-writer test typing with dynamic model ids
+- **gsd**: quarantine incomplete Copilot catalog models
+- **copilot-models**: prove manual-selection claim, drop unlinkable plan refs
+- **gsd**: include copilot-models in full help
+- **issue**: [Bug]: `gsd install` (shell) never writes an extensions registry entry, making installed extensions invisible to `/gsd extensions list`/`update` (#2012)
+- **mcp-server**: mirror canonical read payloads into structuredContent (#2039)
+- **extensions**: parse pinned specifiers on update-all, harden temp cleanups, unique registry staging (#2044)
+- **daemon**: port mcp-server's PATH lookup and empty-sessionId guards (#2043)
+- **update-check**: sort prereleases below the same release in compareSemver (#2045)
+- **pi-agent-core**: end the loop stream with an error message when runAgentLoop throws (#2041)
+- **pi-coding-agent**: make execCommand's SIGKILL escalation actually fire (#2040)
+- **mcp-server**: validate projectDir and verify the recorded PID before gsd_cancel signals it (#2038)
+- **daemon**: don't dereference cleared pendingBlocker in relay success log (#2037)
+- **issue**: [Bug] plan-slice timeout writes invalid canonical PLAN then enters finalize-retry wedge (#1996)
+- **pi-ai**: map unknown and paused Anthropic stop reasons to the error terminal instead of throwing (#2042)
+- **issue**: [Bug]: `gsd list` (shell) never reads the extensions registry, so extensions installed via `/gsd extensions install` show as "No packages installed." (#2009)
+- **issue**: [Bug]: `/gsd extensions list` shows a duplicated `npm:` prefix in "installed from" (`npm:npm:<pkg>@<version>`) (#2010)
+- **gsd**: allow repeated successful requirement saves (#2000)
+- **issue**: plan-milestone prompt mentions forbidden gsd_resume, then recovery marks failed planning as completed S00-blocker (#2023)
+- **issue**: Authorized recovery prompt becomes stale after auto claims successor Attempt (#1989)
+- **issue**: [Bug]: task reopened to ready with NO attempt lineage after a failed completion wedges on orphaned SUMMARY artifact — taskHasAttemptHistory=false defeats #1771 skip-guard, rebuild/doctor give 0 auto-fixable (1.16.1) (#1984)
+- **issue**: Windows: projection-lock transient wedges auto-mode after 2 strikes — loop re-detects transience from taxonomy-labeled reason string, regex no longer matches (defeats #1690/#1856 backoff budget) (#2003)
+- **issue**: [Bug]: gsd_task_settle --reconcileLifecycle cannot reconcile orphaned in_progress lifecycle row whose latest Attempt outcome is succeeded (variant of #1983) (#2019)
+- **issue**: Terminal deadlock: agent-owned `abort` + `lifecycle=ready` + reopen restricted to `status=complete` → execute-task is undispatchable (#2022)
+- **issue**: [Bug]: plan-slice content validator counts 0 tasks when task ids are slice-qualified (S07-T01) — unrecoverable finalize-retry wedge, sanctioned exit cannot fix it (#2027)
+- **issue**: [Bug]: initResources() never inspects the destination, so a torn ~/.gsd/agent/ copy is never repaired — and hasMissingBundledResourceFiles() has no caller (#2030)
+- **issue**: [Bug]: 503 no_available_providers never reaches model fallback — core-retry hand-off keys on a display-only string (#2032)
+- **issue**: [Bug]: Extensions installed via `/gsd extensions install` are registered but never loaded at runtime (#2011)
+- **issue**: [bug] model router ignores dotted Copilot model IDs and pins all phases to the ceiling model (#2035)
+
+### Changed
+- **gsd**: remove dead lastActiveAccountKey write-only variable
+- ignore generated GSD working state (#2036)
+- **verify-merge**: heavy-gate classifier and compile-once optimization (#1990)
+
 ## [1.16.2] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ See [CHANGELOG.md](./CHANGELOG.md) for release-by-release fixes and [Legacy Rele
 ## Latest Release Highlights
 
 <!-- release-highlights:start -->
-Latest release: **v1.16.2**
+Latest release: **v1.17.0**
 
-- **tui:** Hide completed project sentinel.
-- **headless:** Classify live workflow outcomes structurally.
-- **gsd:** Recover failed UAT closeout.
-- **legacy-import:** Take only the code span of a Verification bullet as the verify command (#1982).
-- **auto:** Abort the live host turn on permanent provider-error pause; completion gate names its recovery lever and admits blocker reports (#1977).
-- **state-reconciliation:** Stop mapping remediation slice ids onto other slices' plan files (#1976).
-- **auto:** Keep the verification auto-fix retry bound attempt-independent and pause loudly on durable abort (#1972).
-- **legacy-import:** Carry Verification/Inputs/Expected Output from a task's ### section into its import claim (#1970).
+- **gsd:** Non-blocking cheaper/better same-tier Copilot notifications (GSD-W017) (#2060).
+- **gsd:** Session-start GitHub Copilot catalog refresh (GSD-W018) (#2058).
+- **copilot-models:** Add safe registration and provider-aware diagnostics.
+- **copilot-models:** Explain provider-aware routing and pricing.
+- **gsd:** Add profile-confidence routing safety.
+- **copilot-models:** Add opt-in --register overlay writer (Phase H slice 1).
+- **gsd:** Annotate Copilot catalog drift with registry ID and capability tier.
+- **copilot-models:** Add live catalog sync command and tests.
 
 <!-- release-highlights:end -->
 

--- a/extensions/google-search/package.json
+++ b/extensions/google-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-extensions/google-search",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Web search via Google with AI-synthesized answers and source citations",
   "type": "module",
   "keywords": [

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -215,7 +215,7 @@ class GsdMcpClient:
                 "params": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.16.2"},
+                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.17.0"},
                 },
             }
         )

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-gsd-hermes"
-version = "1.16.2"
+version = "1.17.0"
 description = "Hermes Agent plugin — GSD structured delivery engine integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-ast"
-version = "1.16.2"
+version = "1.17.0"
 dependencies = [
  "ast-grep-core",
  "globset",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-engine"
-version = "1.16.2"
+version = "1.17.0"
 dependencies = [
  "arboard",
  "dashmap",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-grep"
-version = "1.16.2"
+version = "1.17.0"
 dependencies = [
  "grep-matcher",
  "grep-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "1.16.2"
+version = "1.17.0"
 edition = "2021"
 license = "MIT"
 authors = ["GSD Contributors"]

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-arm64",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-x64",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-arm64-gnu",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-x64-gnu",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-win32-x64-msvc",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
   "repository": {
@@ -209,11 +209,11 @@
   },
   "optionalDependencies": {
     "@mariozechner/clipboard": "0.3.6",
-    "@opengsd/engine-darwin-arm64": "1.16.2",
-    "@opengsd/engine-darwin-x64": "1.16.2",
-    "@opengsd/engine-linux-arm64-gnu": "1.16.2",
-    "@opengsd/engine-linux-x64-gnu": "1.16.2",
-    "@opengsd/engine-win32-x64-msvc": "1.16.2",
+    "@opengsd/engine-darwin-arm64": "1.17.0",
+    "@opengsd/engine-darwin-x64": "1.17.0",
+    "@opengsd/engine-linux-arm64-gnu": "1.17.0",
+    "@opengsd/engine-linux-x64-gnu": "1.17.0",
+    "@opengsd/engine-win32-x64-msvc": "1.17.0",
     "fsevents": "~2.3.3",
     "koffi": "^2.9.0",
     "node-pty": "^1.1.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/contracts",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Shared public contracts for GSD workspace boundaries",
   "license": "MIT",
   "gsd": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/daemon",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD daemon — background process for project monitoring and Discord integration",
   "license": "MIT",
   "repository": {

--- a/packages/gsd-agent-core/package.json
+++ b/packages/gsd-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-core",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD session orchestration layer on top of @gsd/pi-coding-agent",
   "type": "module",
   "gsd": {

--- a/packages/gsd-agent-modes/package.json
+++ b/packages/gsd-agent-modes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-modes",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD run modes and CLI layer",
   "type": "module",
   "gsd": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/mcp-server",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "MCP server exposing GSD orchestration tools for compatible clients",
   "license": "MIT",
   "gsd": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/native",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Native Rust bindings for GSD — high-performance native modules via N-API",
   "type": "commonjs",
   "gsd": {

--- a/packages/pi-agent-core/package.json
+++ b/packages/pi-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-agent-core",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "General-purpose agent with transport abstraction, state management, and attachment support",
   "type": "module",
   "gsd": {

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-ai",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Unified LLM API with automatic model discovery and provider configuration",
   "type": "module",
   "gsd": {

--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-coding-agent",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Coding agent CLI (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-tui",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Terminal UI library (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/rpc-client/package.json
+++ b/packages/rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/rpc-client",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Standalone RPC client SDK for GSD — zero internal dependencies",
   "license": "MIT",
   "gsd": {

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glittercowboy/gsd",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "piConfig": {
     "name": "gsd",
     "configDir": ".gsd"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,20 +169,17 @@ importers:
         specifier: 0.3.6
         version: 0.3.6
       '@opengsd/engine-darwin-arm64':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: 1.17.0
+        version: 1.17.0
       '@opengsd/engine-darwin-x64':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: 1.17.0
+        version: 1.17.0
       '@opengsd/engine-linux-arm64-gnu':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: 1.17.0
+        version: 1.17.0
       '@opengsd/engine-linux-x64-gnu':
-        specifier: 1.16.2
-        version: 1.16.2
-      '@opengsd/engine-win32-x64-msvc':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: 1.17.0
+        version: 1.17.0
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -2007,30 +2004,25 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@opengsd/engine-darwin-arm64@1.16.2':
-    resolution: {integrity: sha512-EQ90IR+6XTSJXXf9Ni1qTzcWXRbBbOabP43ooT2nLcGTCvA4HYoGYWSI07Xppo/lAiylPizetU1PN+IGieZkzA==}
+  '@opengsd/engine-darwin-arm64@1.17.0':
+    resolution: {integrity: sha512-vn6QzUm63/HyLuMFKS0bV/Vuvu8G0R+hfHv2gn0Hb5n6xakBBRxVoc0fUFbhk7W2U/FsQu5NbLsN3Ig+fwDonA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@opengsd/engine-darwin-x64@1.16.2':
-    resolution: {integrity: sha512-Gz6NVngtNslezpyCIEGOfseCviZc0z2CeA3JiFMxfn5qXiJ/xKwPwH4wQpglP/JGB8Hx6eaBzMf0wC5F/AzuvQ==}
+  '@opengsd/engine-darwin-x64@1.17.0':
+    resolution: {integrity: sha512-gbVIlw1PJwhijvpmlu+zB7Ny7dD8PRizddqbAJD4YzIIBg3RxLuy0y674AHSQlOdcLXT13+Uj3Ni/7ZELUXgTA==}
     cpu: [x64]
     os: [darwin]
 
-  '@opengsd/engine-linux-arm64-gnu@1.16.2':
-    resolution: {integrity: sha512-O9ATcKSmeHtJS2Ln6yYiA3hhz3+EPEA2bbBdw5bBeMWtUdRLYbrtgIrkTZ1On99265AmsUxbfGB1WR513ntJhw==}
+  '@opengsd/engine-linux-arm64-gnu@1.17.0':
+    resolution: {integrity: sha512-xcvobjgl3HOYPf4eSiEe6WHf7aH+MRY7bvPpx65As+SoslbAxgsYeaOXh+hLXzULoCN3b+e1YRyWuSbAkqCIpQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@opengsd/engine-linux-x64-gnu@1.16.2':
-    resolution: {integrity: sha512-Fl65dtTn/qBhDAqTR/RjiySkl+PodphizX8TphKqF18ESm1JoqU4X51N5QJ/vqZfxHXN5Y8t7E0C8671lKquUw==}
+  '@opengsd/engine-linux-x64-gnu@1.17.0':
+    resolution: {integrity: sha512-oiDsmWHjoZsjaAywEdxE8W+9eW30WmXKwFFMYZ5hzuHlUU/JW4MAMXuoXFlAlaZj28dh4Xk+TANIyrJy5c0FUQ==}
     cpu: [x64]
     os: [linux]
-
-  '@opengsd/engine-win32-x64-msvc@1.16.2':
-    resolution: {integrity: sha512-2CyRxZznHKDZn+JCuw/i97+PqnxvCXNARV0b6bzb5td6DomblyTSNJr5GNIkRt1uevDdmRqnimN3eEeGwmNINA==}
-    cpu: [x64]
-    os: [win32]
 
   '@opengsd/gsd-browser@0.2.2':
     resolution: {integrity: sha512-ld4TOZKcXJF3v0KVlUqrOfHC+rYG8l00Dw0GkEuHtQTIYq7+blYO2acnGHN+P2Owod0xlq/2k1UQDaYgrRSKgw==}
@@ -7724,19 +7716,16 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@opengsd/engine-darwin-arm64@1.16.2':
+  '@opengsd/engine-darwin-arm64@1.17.0':
     optional: true
 
-  '@opengsd/engine-darwin-x64@1.16.2':
+  '@opengsd/engine-darwin-x64@1.17.0':
     optional: true
 
-  '@opengsd/engine-linux-arm64-gnu@1.16.2':
+  '@opengsd/engine-linux-arm64-gnu@1.17.0':
     optional: true
 
-  '@opengsd/engine-linux-x64-gnu@1.16.2':
-    optional: true
-
-  '@opengsd/engine-win32-x64-msvc@1.16.2':
+  '@opengsd/engine-linux-x64-gnu@1.17.0':
     optional: true
 
   '@opengsd/gsd-browser@0.2.2': {}


### PR DESCRIPTION
Version bump for v1.17.0. Direct push to main was rejected by branch rules, so the release commit lands through the merge queue. npm, the `v1.17.0` tag and the GitHub release are already published.