### PR TITLE
release: v1.17.0

### DIFF
--- a/extensions/google-search/package.json
+++ b/extensions/google-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-extensions/google-search",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Web search via Google with AI-synthesized answers and source citations",
   "type": "module",
   "keywords": [

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -215,7 +215,7 @@ class GsdMcpClient:
                 "params": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.16.2"},
+                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.17.0"},
                 },
             }
         )

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-gsd-hermes"
-version = "1.16.2"
+version = "1.17.0"
 description = "Hermes Agent plugin — GSD structured delivery engine integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-ast"
-version = "1.16.2"
+version = "1.17.0"
 dependencies = [
  "ast-grep-core",
  "globset",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-engine"
-version = "1.16.2"
+version = "1.17.0"
 dependencies = [
  "arboard",
  "dashmap",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-grep"
-version = "1.16.2"
+version = "1.17.0"
 dependencies = [
  "grep-matcher",
  "grep-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "1.16.2"
+version = "1.17.0"
 edition = "2021"
 license = "MIT"
 authors = ["GSD Contributors"]

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-arm64",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-x64",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-arm64-gnu",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-x64-gnu",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-win32-x64-msvc",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
   "repository": {
@@ -209,11 +209,11 @@
   },
   "optionalDependencies": {
     "@mariozechner/clipboard": "0.3.6",
-    "@opengsd/engine-darwin-arm64": "1.16.2",
-    "@opengsd/engine-darwin-x64": "1.16.2",
-    "@opengsd/engine-linux-arm64-gnu": "1.16.2",
-    "@opengsd/engine-linux-x64-gnu": "1.16.2",
-    "@opengsd/engine-win32-x64-msvc": "1.16.2",
+    "@opengsd/engine-darwin-arm64": "1.17.0",
+    "@opengsd/engine-darwin-x64": "1.17.0",
+    "@opengsd/engine-linux-arm64-gnu": "1.17.0",
+    "@opengsd/engine-linux-x64-gnu": "1.17.0",
+    "@opengsd/engine-win32-x64-msvc": "1.17.0",
     "fsevents": "~2.3.3",
     "koffi": "^2.9.0",
     "node-pty": "^1.1.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/contracts",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Shared public contracts for GSD workspace boundaries",
   "license": "MIT",
   "gsd": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/daemon",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD daemon — background process for project monitoring and Discord integration",
   "license": "MIT",
   "repository": {

--- a/packages/gsd-agent-core/package.json
+++ b/packages/gsd-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-core",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD session orchestration layer on top of @gsd/pi-coding-agent",
   "type": "module",
   "gsd": {

--- a/packages/gsd-agent-modes/package.json
+++ b/packages/gsd-agent-modes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-modes",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "GSD run modes and CLI layer",
   "type": "module",
   "gsd": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/mcp-server",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "MCP server exposing GSD orchestration tools for compatible clients",
   "license": "MIT",
   "gsd": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/native",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Native Rust bindings for GSD — high-performance native modules via N-API",
   "type": "commonjs",
   "gsd": {

--- a/packages/pi-agent-core/package.json
+++ b/packages/pi-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-agent-core",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "General-purpose agent with transport abstraction, state management, and attachment support",
   "type": "module",
   "gsd": {

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-ai",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Unified LLM API with automatic model discovery and provider configuration",
   "type": "module",
   "gsd": {

--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-coding-agent",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Coding agent CLI (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-tui",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Terminal UI library (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/rpc-client/package.json
+++ b/packages/rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/rpc-client",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Standalone RPC client SDK for GSD — zero internal dependencies",
   "license": "MIT",
   "gsd": {

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glittercowboy/gsd",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "piConfig": {
     "name": "gsd",
     "configDir": ".gsd"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,20 +169,20 @@ importers:
         specifier: 0.3.6
         version: 0.3.6
       '@opengsd/engine-darwin-arm64':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: 1.17.0
+        version: 1.17.0
       '@opengsd/engine-darwin-x64':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: 1.17.0
+        version: 1.17.0
       '@opengsd/engine-linux-arm64-gnu':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: 1.17.0
+        version: 1.17.0
       '@opengsd/engine-linux-x64-gnu':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: 1.17.0
+        version: 1.17.0
       '@opengsd/engine-win32-x64-msvc':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: 1.17.0
+        version: 1.17.0
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -2007,28 +2007,28 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@opengsd/engine-darwin-arm64@1.16.2':
-    resolution: {integrity: sha512-EQ90IR+6XTSJXXf9Ni1qTzcWXRbBbOabP43ooT2nLcGTCvA4HYoGYWSI07Xppo/lAiylPizetU1PN+IGieZkzA==}
+  '@opengsd/engine-darwin-arm64@1.17.0':
+    resolution: {integrity: sha512-vn6QzUm63/HyLuMFKS0bV/Vuvu8G0R+hfHv2gn0Hb5n6xakBBRxVoc0fUFbhk7W2U/FsQu5NbLsN3Ig+fwDonA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@opengsd/engine-darwin-x64@1.16.2':
-    resolution: {integrity: sha512-Gz6NVngtNslezpyCIEGOfseCviZc0z2CeA3JiFMxfn5qXiJ/xKwPwH4wQpglP/JGB8Hx6eaBzMf0wC5F/AzuvQ==}
+  '@opengsd/engine-darwin-x64@1.17.0':
+    resolution: {integrity: sha512-gbVIlw1PJwhijvpmlu+zB7Ny7dD8PRizddqbAJD4YzIIBg3RxLuy0y674AHSQlOdcLXT13+Uj3Ni/7ZELUXgTA==}
     cpu: [x64]
     os: [darwin]
 
-  '@opengsd/engine-linux-arm64-gnu@1.16.2':
-    resolution: {integrity: sha512-O9ATcKSmeHtJS2Ln6yYiA3hhz3+EPEA2bbBdw5bBeMWtUdRLYbrtgIrkTZ1On99265AmsUxbfGB1WR513ntJhw==}
+  '@opengsd/engine-linux-arm64-gnu@1.17.0':
+    resolution: {integrity: sha512-xcvobjgl3HOYPf4eSiEe6WHf7aH+MRY7bvPpx65As+SoslbAxgsYeaOXh+hLXzULoCN3b+e1YRyWuSbAkqCIpQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@opengsd/engine-linux-x64-gnu@1.16.2':
-    resolution: {integrity: sha512-Fl65dtTn/qBhDAqTR/RjiySkl+PodphizX8TphKqF18ESm1JoqU4X51N5QJ/vqZfxHXN5Y8t7E0C8671lKquUw==}
+  '@opengsd/engine-linux-x64-gnu@1.17.0':
+    resolution: {integrity: sha512-oiDsmWHjoZsjaAywEdxE8W+9eW30WmXKwFFMYZ5hzuHlUU/JW4MAMXuoXFlAlaZj28dh4Xk+TANIyrJy5c0FUQ==}
     cpu: [x64]
     os: [linux]
 
-  '@opengsd/engine-win32-x64-msvc@1.16.2':
-    resolution: {integrity: sha512-2CyRxZznHKDZn+JCuw/i97+PqnxvCXNARV0b6bzb5td6DomblyTSNJr5GNIkRt1uevDdmRqnimN3eEeGwmNINA==}
+  '@opengsd/engine-win32-x64-msvc@1.17.0':
+    resolution: {integrity: sha512-NqeWoZaK8Fp3doM/LpGFkM7LmUYH/ssy9jM9M8WSuTb7ZJO2Wa0ZyRUNP7JEgNw18vK2PxGNfXdyU+vHWfNK4w==}
     cpu: [x64]
     os: [win32]
 
@@ -7724,19 +7724,19 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@opengsd/engine-darwin-arm64@1.16.2':
+  '@opengsd/engine-darwin-arm64@1.17.0':
     optional: true
 
-  '@opengsd/engine-darwin-x64@1.16.2':
+  '@opengsd/engine-darwin-x64@1.17.0':
     optional: true
 
-  '@opengsd/engine-linux-arm64-gnu@1.16.2':
+  '@opengsd/engine-linux-arm64-gnu@1.17.0':
     optional: true
 
-  '@opengsd/engine-linux-x64-gnu@1.16.2':
+  '@opengsd/engine-linux-x64-gnu@1.17.0':
     optional: true
 
-  '@opengsd/engine-win32-x64-msvc@1.16.2':
+  '@opengsd/engine-win32-x64-msvc@1.17.0':
     optional: true
 
   '@opengsd/gsd-browser@0.2.2': {}


### PR DESCRIPTION
Lands the 1.17.0 version bump on main to match the published release (tag `v1.17.0`, npm `latest`). The NPM Publish workflow created the release commit + tag off-main and published `@opengsd/engine-*@1.17.0` first, so the regenerated lockfile resolves cleanly — this is the same post-release sync as #2013 for 1.16.2.