### PR TITLE
fix(issue): [Bug]: Legacy completed slices can't be lifecycle-adopted — reopen guard dead-locks milestone closeout

### DIFF
--- a/src/resources/extensions/gsd/db/milestone-closeout-readiness.ts
+++ b/src/resources/extensions/gsd/db/milestone-closeout-readiness.ts
@@ -647,16 +647,7 @@ export function readMilestoneCloseoutReadiness(
     });
   }
 
-  const descendant = getDb().prepare(`
-    SELECT COALESCE(MAX(lifecycle.last_project_revision), 0) AS revision
-    FROM workflow_item_lifecycles lifecycle
-    JOIN project_authority authority
-      ON authority.project_id = lifecycle.project_id
-     AND authority.singleton = 1
-    WHERE lifecycle.milestone_id = :milestone_id
-      AND lifecycle.item_kind IN ('slice', 'task')
-  `).get({ ":milestone_id": input.milestoneId });
-  const descendantRevision = Number(descendant?.["revision"] ?? 0);
+  const descendantRevision = closeoutRelevantDescendantRevision(input.milestoneId);
   if (descendantRevision >= validation.project_revision) {
     blockers.push({
       kind: "validation-stale",
@@ -756,15 +747,26 @@ function waiverSourceRevision(payloadJson: string): string | null {
   }
 }
 
-function descendantRevision(milestoneId: string): number {
+// milestone.complete may adopt legacy completed descendants after authorizing
+// validation. Those state-version-zero rows record compatibility, not newer
+// work; any later lifecycle transition increments the version and counts again.
+function closeoutRelevantDescendantRevision(milestoneId: string): number {
   const descendant = getDb().prepare(`
     SELECT COALESCE(MAX(lifecycle.last_project_revision), 0) AS revision
     FROM workflow_item_lifecycles lifecycle
     JOIN project_authority authority
       ON authority.project_id = lifecycle.project_id
      AND authority.singleton = 1
+    LEFT JOIN workflow_operations lifecycle_operation
+      ON lifecycle_operation.project_id = lifecycle.project_id
+     AND lifecycle_operation.operation_id = lifecycle.last_operation_id
     WHERE lifecycle.milestone_id = :milestone_id
       AND lifecycle.item_kind IN ('slice', 'task')
+      AND NOT (
+        lifecycle.lifecycle_status = 'completed'
+        AND lifecycle.state_version = 0
+        AND COALESCE(lifecycle_operation.operation_type, '') = 'milestone.complete'
+      )
   `).get({ ":milestone_id": milestoneId });
   return Number(descendant?.["revision"] ?? 0);
 }
@@ -822,7 +824,7 @@ export function readMilestoneCloseoutAuthorization(
         }],
       };
     }
-    const currentDescendantRevision = descendantRevision(input.milestoneId);
+    const currentDescendantRevision = closeoutRelevantDescendantRevision(input.milestoneId);
     if (currentDescendantRevision >= waiver.project_revision) {
       return {
         authorized: false,

--- a/src/resources/extensions/gsd/db/writers/milestone-lifecycle.ts
+++ b/src/resources/extensions/gsd/db/writers/milestone-lifecycle.ts
@@ -13,6 +13,7 @@ import {
 } from "../lifecycle-shadow-comparison.js";
 import { getDb } from "../engine.js";
 import {
+  adoptLifecycleIfMissing,
   adoptOrTransitionLifecycle,
   readLifecycleShadowComparison,
   requireActiveDomainOperationContext,
@@ -539,6 +540,19 @@ export function completeMilestoneHierarchy(
     );
   }
 
+  // Closeout is the compatibility adoption path for work completed before
+  // canonical lifecycle authority existed. Existing lifecycles are preserved,
+  // and every non-completed or mismatched descendant still fails below.
+  for (const row of [...loadSlices(context, milestoneId), ...loadTasks(context, milestoneId)]) {
+    if (row.lifecycleId || normalizeLegacyLifecycleStatus(row.legacyStatus) !== "completed") continue;
+    adoptLifecycleIfMissing(context, {
+      itemKind: row.itemKind,
+      milestoneId,
+      ...(row.sliceId ? { sliceId: row.sliceId } : {}),
+      ...(row.taskId ? { taskId: row.taskId } : {}),
+      lifecycleStatus: "completed",
+    });
+  }
   const slices = loadSlices(context, milestoneId);
   if (slices.length === 0) {
     throw new MilestoneLifecycleValidationError(`no slices found for Milestone ${milestoneId}`);

--- a/src/resources/extensions/gsd/tests/milestone-completion-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-completion-domain-operation.test.ts
@@ -33,6 +33,7 @@ import {
   grantTaskWaiver,
   recordTaskRequirementDisposition,
 } from "../task-recovery-domain-operation.ts";
+import { handleCompleteMilestone } from "../tools/complete-milestone.ts";
 import {
   handleValidateMilestone,
   type ValidateMilestoneParams,
@@ -687,6 +688,53 @@ test("Milestone completion commits one receipt and preserves every descendant fa
     projection_kind: "milestone-lifecycle",
   });
   assert.deepEqual(descendantSnapshot(), descendantsBefore, "completion must verify descendants without rewriting them");
+});
+
+test("Milestone completion adopts missing completed legacy descendant lifecycles", async () => {
+  const basePath = await prepareFixture(() => {
+    insertSlice({ id: "S00", milestoneId: "M001", status: "complete" });
+    insertTask({ id: "T00", sliceId: "S00", milestoneId: "M001", status: "complete" });
+    db().prepare(`
+      UPDATE slices SET depends = '["S00"]'
+      WHERE milestone_id = 'M001' AND id = 'S01'
+    `).run();
+  });
+  assert.equal(row(`
+    SELECT COUNT(*) AS count FROM workflow_item_lifecycles
+    WHERE milestone_id = 'M001' AND slice_id = 'S00'
+  `).count, 0);
+
+  const result = await handleCompleteMilestone({
+    milestoneId: "M001",
+    verificationPassed: true,
+    ...closeout(),
+  }, basePath, invocation("milestone-complete/public/legacy-descendants"));
+
+  assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+  assert.ok(result.operationId);
+  const payload = JSON.parse(String(row(`
+    SELECT payload_json FROM workflow_domain_events
+    WHERE operation_id = '${result.operationId}' AND event_type = 'milestone.completed'
+  `).payload_json)) as Record<string, unknown>;
+  assert.ok((payload["completedSliceIds"] as string[]).includes("S00"));
+  assert.ok((payload["completedTaskIds"] as string[]).includes("S00/T00"));
+  assert.deepEqual(rows(`
+    SELECT item_kind, lifecycle_status, state_version, last_operation_id
+    FROM workflow_item_lifecycles
+    WHERE milestone_id = 'M001' AND slice_id = 'S00'
+    ORDER BY item_kind
+  `), [{
+    item_kind: "slice",
+    lifecycle_status: "completed",
+    state_version: 0,
+    last_operation_id: result.operationId,
+  }, {
+    item_kind: "task",
+    lifecycle_status: "completed",
+    state_version: 0,
+    last_operation_id: result.operationId,
+  }]);
+  assert.deepEqual(proveMilestoneCloseout("M001", { summaryArtifactBasePath: basePath }), { ok: true });
 });
 
 test("Milestone completion replays its receipt and conflicts on changed closeout", async () => {


### PR DESCRIPTION
## Summary
- Added transactional legacy lifecycle adoption during milestone closeout with regression coverage and static verification.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2069
- [#2069 [Bug]: Legacy completed slices can't be lifecycle-adopted — reopen guard dead-locks milestone closeout](https://github.com/open-gsd/gsd-pi/issues/2069)

## User
- @Jack11111eee

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2069-bug-legacy-completed-slices-can-t-be-lif-1788027930`