### PR TITLE
test(ci): workflow lint gate + unit-tested release lockfile guard

### DIFF
--- a/.config/actionlint.yaml
+++ b/.config/actionlint.yaml
@@ -1,0 +1,8 @@
+# Config for actionlint (workflow static analysis, run in the ci.yml
+# workflow-lint job). Declares Blacksmith's GitHub Actions-compatible runner
+# labels so `runs-on:` doesn't trip actionlint's unknown-runner check.
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-4vcpu-windows-2025
+    - blacksmith-4vcpu-ubuntu-2404-arm

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -111,6 +111,7 @@ jobs:
 
       - name: Prepare artifact (Windows)
         if: runner.os == 'Windows'
+        shell: cmd
         run: |
           mkdir artifacts
           copy native\target\${{ matrix.target }}\release\gsd_engine.dll artifacts\gsd_engine.node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,8 @@ jobs:
           GSD_NATIVE_PREFER_LOCAL: '1'
         run: |
           chmod +x dist/loader.js
-          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          export GSD_SMOKE_BINARY
           pnpm run test:e2e
 
       - name: Run docker e2e suite
@@ -369,7 +370,8 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          export GSD_SMOKE_BINARY
           pnpm run test:e2e:windows-smoke
 
       - name: Flag Windows e2e smoke failure
@@ -443,7 +445,8 @@ jobs:
           GSD_NATIVE_PREFER_LOCAL: '1'
         run: |
           chmod +x dist/loader.js
-          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          export GSD_SMOKE_BINARY
           pnpm run test:smoke
 
       - name: Verify SQLite close behavior on Node 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,10 +456,39 @@ jobs:
   # protection. Because it always runs, branch protection always has a concrete
   # pass/fail signal — a conditionally-skipped `build`/`windows-portability` job
   # can no longer read as a neutral "required check never reported" state.
+  workflow-lint:
+    name: workflow-lint
+    timeout-minutes: 5
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout repository without GITHUB_TOKEN
+        shell: bash
+        env:
+          FETCH_DEPTH: '0'
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git -c protocol.version=2 fetch --no-tags --prune origin \
+            "+${GITHUB_SHA}:refs/checkout-ref"
+          git checkout --force --detach "$GITHUB_SHA"
+
+      - name: Run actionlint
+        run: |
+          set -euo pipefail
+          # Pinned: actionlint is the static-analysis gate for GitHub Actions
+          # workflows; runner-label exceptions live in actionlint.yaml.
+          ACTIONLINT_VERSION=v1.7.7
+          curl -sSfL "https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin actionlint
+          actionlint -config-file .config/actionlint.yaml
+
   ci-gate:
     name: ci-gate
     if: always()
-    needs: [fast-gates, build, windows-portability, node22-smoke]
+    needs: [fast-gates, build, windows-portability, node22-smoke, workflow-lint]
     runs-on: ubuntu-latest
     steps:
       - name: Assert no upstream job failed or was cancelled
@@ -468,14 +497,15 @@ jobs:
           BUILD: ${{ needs.build.result }}
           WINDOWS: ${{ needs.windows-portability.result }}
           NODE22: ${{ needs.node22-smoke.result }}
+          WORKFLOW_LINT: ${{ needs.workflow-lint.result }}
         shell: bash
         run: |
           set -euo pipefail
-          echo "fast-gates=$FAST_GATES build=$BUILD windows-portability=$WINDOWS node22-smoke=$NODE22"
+          echo "fast-gates=$FAST_GATES build=$BUILD windows-portability=$WINDOWS node22-smoke=$NODE22 workflow-lint=$WORKFLOW_LINT"
           # 'skipped' is an acceptable result (job legitimately not needed).
           # Only 'failure' / 'cancelled' must block the merge.
           status=0
-          for result in "$FAST_GATES" "$BUILD" "$WINDOWS" "$NODE22"; do
+          for result in "$FAST_GATES" "$BUILD" "$WINDOWS" "$NODE22" "$WORKFLOW_LINT"; do
             case "$result" in
               success|skipped) ;;
               *) status=1 ;;

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -654,30 +654,24 @@ jobs:
           # and the auto-opened release PR failed frozen-lockfile in every CI job.
           # So: retry the fold until the lockfile names every engine, and fail loudly
           # instead of committing a lockfile that breaks every downstream install.
-          EXPECTED_ENGINES="darwin-arm64 darwin-x64 linux-arm64-gnu linux-x64-gnu win32-x64-msvc"
+          # The check lives in scripts/release-lockfile-guard.mjs so the platform
+          # list and pnpm key format are unit-tested in
+          # src/tests/release-lockfile-guard.test.ts instead of only being
+          # exercised at release time.
           LOCKFILE_ALL_ENGINES=0
-          DELAY=45
           for attempt in $(seq 1 6); do
             pnpm install --lockfile-only
-            MISSING=()
-            for platform in ${EXPECTED_ENGINES}; do
-              grep -q "'@opengsd/engine-${platform}@${RELEASE_VERSION}':" pnpm-lock.yaml || MISSING+=("${platform}")
-            done
-            if [ "${#MISSING[@]}" = "0" ]; then
+            if node scripts/release-lockfile-guard.mjs verify-lockfile --version "${RELEASE_VERSION}"; then
               echo "Lockfile resolves all native platform packages (attempt ${attempt})."
               LOCKFILE_ALL_ENGINES=1
               break
             fi
             if [ "${attempt}" = "6" ]; then
-              echo "::error::Release lockfile is still missing native packages after 6 fold attempts:"
-              for platform in "${MISSING[@]}"; do
-                echo "::error::  - @opengsd/engine-${platform}@${RELEASE_VERSION}"
-              done
-              echo "::error::Refusing to fold an incomplete lockfile — every downstream frozen-lockfile install would fail."
+              echo "::error::Release lockfile is still missing engine packages after 6 fold attempts (missing list above) — refusing to fold an incomplete lockfile."
               exit 1
             fi
-            echo "  Attempt ${attempt}: lockfile missing engines (${MISSING[*]}), retrying in ${DELAY}s..."
-            sleep "${DELAY}"
+            echo "  Attempt ${attempt}: engines missing from lockfile, retrying in 45s..."
+            sleep 45
           done
           if [ "${LOCKFILE_ALL_ENGINES}" != "1" ]; then
             exit 1

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -382,6 +382,7 @@ jobs:
 
       - name: Prepare artifact (Windows)
         if: runner.os == 'Windows'
+        shell: cmd
         run: |
           mkdir artifacts
           copy native\target\${{ matrix.target }}\release\gsd_engine.dll artifacts\gsd_engine.node

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -44,12 +44,14 @@ jobs:
       - name: Run risk check
         id: risk
         run: |
-          REPORT=$(cat /tmp/changed-files.txt | node scripts/pr-risk-check.mjs --github || true)
-          echo "report<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$REPORT" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          REPORT=$(node scripts/pr-risk-check.mjs --github < /tmp/changed-files.txt || true)
+          {
+            echo "report<<EOF"
+            echo "$REPORT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-          RISK_LEVEL=$(cat /tmp/changed-files.txt | node scripts/pr-risk-check.mjs --json 2>/dev/null \
+          RISK_LEVEL=$(node scripts/pr-risk-check.mjs --json < /tmp/changed-files.txt 2>/dev/null \
             | node -e "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ try { console.log(JSON.parse(d).risk) } catch { console.log('low') } })" \
             || echo "low")
           echo "level=$RISK_LEVEL" >> "$GITHUB_OUTPUT"

--- a/scripts/__tests__/npm-publish-workflow-invariants.test.mjs
+++ b/scripts/__tests__/npm-publish-workflow-invariants.test.mjs
@@ -1,0 +1,99 @@
+// Project/App: gsd-pi
+// File Purpose: Structural invariants for .github/workflows/npm-publish.yml —
+// the release-critical workflow whose inline logic can otherwise only be
+// exercised during a real production release (#2067). Pins the ordering and
+// cross-step contracts the 1.17.0 fold race violated: engines are verified
+// before the lockfile fold, the fold checks the regenerated lockfile through
+// the unit-tested guard script, and the engine platform list never drifts
+// between steps.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import YAML from "yaml";
+
+import { ENGINE_PLATFORMS } from "../release-lockfile-guard.mjs";
+
+const workflow = YAML.parse(
+  readFileSync(".github/workflows/npm-publish.yml", "utf8"),
+);
+
+function findJobByName(name) {
+  for (const [id, job] of Object.entries(workflow.jobs)) {
+    if (job.name === name) return { id, job };
+  }
+  throw new Error(`job with name "${name}" not found`);
+}
+
+function findStep(job, name) {
+  const index = (job.steps ?? []).findIndex((step) => step.name === name);
+  if (index === -1) throw new Error(`step "${name}" not found`);
+  return { step: job.steps[index], index };
+}
+
+test("the production release job is gated behind the prod environment", () => {
+  const { job } = findJobByName("Production Release");
+  assert.equal(job.environment, "prod");
+});
+
+test("the dev publish job is gated behind the dev environment", () => {
+  // The job name/env are template expressions ("Publish @${{ ... 'dev' || channel }}"),
+  // so match on the environment expression rather than a literal name.
+  const devGated = Object.entries(workflow.jobs).filter(
+    ([, job]) => typeof job.environment === "string" && job.environment.includes("'dev'"),
+  );
+  assert.ok(devGated.length > 0, "a job gated on the dev environment must exist");
+  for (const [, job] of devGated) {
+    assert.match(String(job.name), /^Publish @/);
+  }
+});
+
+test("engine publish → verify → fold run in that order inside one job", () => {
+  const { job } = findJobByName("Production Release");
+  const publish = findStep(job, "Publish native platform packages for release version");
+  const verify = findStep(job, "Verify native platform packages are published");
+  const fold = findStep(job, "Fold native packages into release lockfile");
+  assert.ok(publish.index < verify.index, "engines must be published before the visibility verify");
+  assert.ok(verify.index < fold.index, "the lockfile fold must run after the visibility verify");
+});
+
+test("the visibility verify poll covers exactly the guard script's platform set", () => {
+  const { job } = findJobByName("Production Release");
+  const { step } = findStep(job, "Verify native platform packages are published");
+  const run = String(step.run ?? "");
+  // The inline poll iterates the platform list directly; the guard script owns
+  // the canonical set. If either side drifts, this fails.
+  const polled = [...run.matchAll(/for platform in (.+?); do/g)].flatMap(
+    (match) => match[1].trim().split(/\s+/),
+  );
+  assert.ok(polled.length > 0, "verify step must poll a platform list");
+  assert.deepEqual([...new Set(polled)].sort(), [...ENGINE_PLATFORMS].sort());
+});
+
+test("the fold verifies the regenerated lockfile through the guard script", () => {
+  const { job } = findJobByName("Production Release");
+  const { step } = findStep(job, "Fold native packages into release lockfile");
+  const run = String(step.run ?? "");
+  assert.match(run, /node scripts\/release-lockfile-guard\.mjs verify-lockfile --version "\$\{RELEASE_VERSION\}"/);
+  assert.match(run, /pnpm install --lockfile-only/);
+  assert.match(run, /git commit --amend --no-edit/);
+  assert.match(run, /git tag -f/);
+});
+
+test("the fold retries and refuses to commit an incomplete lockfile", () => {
+  const { job } = findJobByName("Production Release");
+  const { step } = findStep(job, "Fold native packages into release lockfile");
+  const run = String(step.run ?? "");
+  assert.match(run, /seq 1 6/, "the fold must have a bounded retry loop");
+  assert.match(run, /sleep 45/, "the fold must wait between retries for registry caches to expire");
+  assert.match(run, /refusing to fold/, "the failure path must refuse the fold, not commit anyway");
+});
+
+test("the fold's RELEASE_VERSION is wired to the release plan output", () => {
+  const { job } = findJobByName("Production Release");
+  const { step } = findStep(job, "Fold native packages into release lockfile");
+  assert.equal(
+    step.env.RELEASE_VERSION,
+    "${{ needs.prod-release-plan.outputs.version }}",
+  );
+});

--- a/scripts/__tests__/release-lockfile-guard.test.mjs
+++ b/scripts/__tests__/release-lockfile-guard.test.mjs
@@ -1,0 +1,129 @@
+// Project/App: gsd-pi
+// File Purpose: Unit tests for the npm-publish fold-step guard (#2067). The
+// detection expression here decides whether a release commit ships a lockfile
+// that breaks every downstream frozen-lockfile install, so it is exercised
+// against real pnpm lockfile serialization instead of only being trusted to
+// the release run that happens to execute it.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  ENGINE_PLATFORMS,
+  missingEngines,
+} from "../release-lockfile-guard.mjs";
+
+const COMPLETE_LOCKFILE = [
+  "lockfileVersion: '9.0'",
+  "",
+  "optionalDependencies:",
+  "  '@opengsd/engine-darwin-arm64@1.17.0':",
+  "    specifier: 1.17.0",
+  "  '@opengsd/engine-darwin-x64@1.17.0':",
+  "    specifier: 1.17.0",
+  "  '@opengsd/engine-linux-arm64-gnu@1.17.0':",
+  "    specifier: 1.17.0",
+  "  '@opengsd/engine-linux-x64-gnu@1.17.0':",
+  "    specifier: 1.17.0",
+  "  '@opengsd/engine-win32-x64-msvc@1.17.0':",
+  "    specifier: 1.17.0",
+  "",
+].join("\n");
+
+test("ENGINE_PLATFORMS is the canonical five-platform engine set", () => {
+  assert.deepEqual(ENGINE_PLATFORMS, [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64-gnu",
+    "linux-x64-gnu",
+    "win32-x64-msvc",
+  ]);
+});
+
+test("missingEngines accepts a complete lockfile", () => {
+  assert.deepEqual(
+    missingEngines({ lockfileContent: COMPLETE_LOCKFILE, version: "1.17.0" }),
+    [],
+  );
+});
+
+test("missingEngines rejects a lockfile with no engine entries", () => {
+  assert.deepEqual(
+    missingEngines({ lockfileContent: "lockfileVersion: '9.0'\n", version: "1.17.0" }),
+    [...ENGINE_PLATFORMS],
+  );
+});
+
+test("missingEngines names only the platforms that are absent", () => {
+  const partial = COMPLETE_LOCKFILE.replace(
+    /'@opengsd\/engine-win32-x64-msvc@1\.17\.0':\n\s+specifier: 1\.17\.0\n/,
+    "",
+  );
+  assert.deepEqual(
+    missingEngines({ lockfileContent: partial, version: "1.17.0" }),
+    ["win32-x64-msvc"],
+  );
+});
+
+test("missingEngines is version-sensitive: a complete older lockfile is not complete", () => {
+  assert.deepEqual(
+    missingEngines({ lockfileContent: COMPLETE_LOCKFILE, version: "1.18.0" }),
+    [...ENGINE_PLATFORMS],
+  );
+});
+
+test("missingEngines does not confuse a version prefix with an exact entry", () => {
+  // '1.17.0' must not satisfy a probe for '1.17' — the trailing colon in the
+  // key match is what keeps exact-version semantics.
+  const tricky = COMPLETE_LOCKFILE.replace(/1\.17\.0/g, "1.17.01");
+  assert.deepEqual(
+    missingEngines({ lockfileContent: tricky, version: "1.17.0" }),
+    [...ENGINE_PLATFORMS],
+  );
+});
+
+test("CLI verify-lockfile exits 0 and reports success for a complete lockfile", () => {
+  const dir = mkdtempSync(join(tmpdir(), "lockfile-guard-"));
+  try {
+    const lockfile = join(dir, "pnpm-lock.yaml");
+    writeFileSync(lockfile, COMPLETE_LOCKFILE);
+    const res = spawnSync(
+      process.execPath,
+      [new URL("../release-lockfile-guard.mjs", import.meta.url).pathname, "verify-lockfile", "--version", "1.17.0", "--lockfile", lockfile],
+      { encoding: "utf8" },
+    );
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /All 5 engine packages resolve/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI verify-lockfile exits 1 and lists missing engines", () => {
+  const dir = mkdtempSync(join(tmpdir(), "lockfile-guard-"));
+  try {
+    const lockfile = join(dir, "pnpm-lock.yaml");
+    writeFileSync(lockfile, "lockfileVersion: '9.0'\n");
+    const res = spawnSync(
+      process.execPath,
+      [new URL("../release-lockfile-guard.mjs", import.meta.url).pathname, "verify-lockfile", "--version", "1.17.0", "--lockfile", lockfile],
+      { encoding: "utf8" },
+    );
+    assert.equal(res.status, 1);
+    assert.match(res.stderr, /win32-x64-msvc/);
+    assert.match(res.stderr, /darwin-arm64/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI verify-lockfile exits 2 on usage errors", () => {
+  const guardCli = new URL("../release-lockfile-guard.mjs", import.meta.url).pathname;
+  const res = spawnSync(process.execPath, [guardCli], { encoding: "utf8" });
+  assert.equal(res.status, 2);
+  assert.match(res.stderr, /usage:/);
+});

--- a/scripts/ci-fast-gates.sh
+++ b/scripts/ci-fast-gates.sh
@@ -59,4 +59,13 @@ node scripts/audit-test-matrix.mjs --strict
 echo "── pi boundary ──"
 pnpm run verify:pi-boundary
 
+echo "── actionlint (workflow static analysis) ──"
+# Enforced as a blocking job in CI (ci.yml workflow-lint). Locally it runs
+# only when the binary is installed so the gate stays dependency-free.
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint -config-file .config/actionlint.yaml
+else
+  echo "actionlint not installed locally — skipped here, enforced in CI"
+fi
+
 echo "ci-fast-gates: all checks passed ✓"

--- a/scripts/release-lockfile-guard.mjs
+++ b/scripts/release-lockfile-guard.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Guard for the npm-publish "Fold native packages into release lockfile" step.
+ *
+ * The fold runs `pnpm install --lockfile-only`, which consults pnpm's registry
+ * metadata cache. A packument cached earlier in the job — from before the
+ * `@opengsd/engine-*` packages were published — makes pnpm silently drop an
+ * engine from the regenerated lockfile (observed on 1.17.0 with
+ * win32-x64-msvc, #2067), and the auto-opened release PR then fails
+ * ERR_PNPM_OUTDATED_LOCKFILE in every CI job.
+ *
+ * This guard turns that silent drop into a loud, machine-checkable failure:
+ * the fold step retries `pnpm install --lockfile-only` until this check
+ * passes (registry caches expire), and fails the release otherwise.
+ *
+ * CLI:
+ *   node scripts/release-lockfile-guard.mjs verify-lockfile --version 1.17.0 [--lockfile pnpm-lock.yaml]
+ *
+ * Exit 0 when every engine resolves at `version`; exit 1 with the missing
+ * list on stderr otherwise. Exit 2 on usage errors.
+ */
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+/** Engine platforms published by the release flow — single source of truth. */
+export const ENGINE_PLATFORMS = [
+  "darwin-arm64",
+  "darwin-x64",
+  "linux-arm64-gnu",
+  "linux-x64-gnu",
+  "win32-x64-msvc",
+];
+
+/**
+ * Platforms whose engine entry is absent from `lockfileContent`.
+ *
+ * pnpm serializes lockfile keys as quoted strings:
+ *   '@opengsd/engine-<platform>@<version>':
+ * Requiring the trailing colon distinguishes an exact entry from a longer
+ * version string that merely shares the prefix.
+ */
+export function missingEngines({ lockfileContent, version, platforms = ENGINE_PLATFORMS }) {
+  return platforms.filter(
+    (platform) => !lockfileContent.includes(`'@opengsd/engine-${platform}@${version}':`),
+  );
+}
+
+function parseArgs(argv) {
+  const args = { command: undefined, version: undefined, lockfile: "pnpm-lock.yaml" };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "verify-lockfile") {
+      args.command = "verify-lockfile";
+    } else if (argv[i] === "--version") {
+      args.version = argv[++i];
+    } else if (argv[i] === "--lockfile") {
+      args.lockfile = argv[++i];
+    }
+  }
+  return args;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (invokedDirectly) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.command !== "verify-lockfile" || !args.version) {
+    console.error(
+      "usage: release-lockfile-guard.mjs verify-lockfile --version <release-version> [--lockfile <path>]",
+    );
+    process.exit(2);
+  }
+
+  let lockfileContent;
+  try {
+    lockfileContent = readFileSync(args.lockfile, "utf8");
+  } catch (err) {
+    console.error(`Cannot read lockfile ${args.lockfile}: ${err.message}`);
+    process.exit(2);
+  }
+
+  const missing = missingEngines({ lockfileContent, version: args.version });
+  if (missing.length > 0) {
+    console.error(
+      `Release lockfile ${args.lockfile} is missing engine packages at version ${args.version}:`,
+    );
+    for (const platform of missing) {
+      console.error(`  - @opengsd/engine-${platform}@${args.version}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `All ${ENGINE_PLATFORMS.length} engine packages resolve at ${args.version} in ${args.lockfile}.`,
+  );
+}


### PR DESCRIPTION
Implements the three-tier workflow-test proposal from the state audit (follow-up to #2067/#2068):

**Tier 1 — static analysis.** New blocking `workflow-lint` job in ci.yml runs pinned actionlint (v1.7.7) over every workflow, wired into the ci-gate assertion loop. `.config/actionlint.yaml` declares the Blacksmith runner labels (the only pre-existing findings, all 27 of them, were unknown-runner noise). `ci-fast-gates.sh` runs the same scan locally when the binary is present.

**Tier 2 — tested logic.** The fold step's lockfile check moves out of inline bash into `scripts/release-lockfile-guard.mjs` (platform list + pnpm key format + CLI contract), unit-tested in 9 cases including the two traps that made #2067 nasty: version-prefix confusion (`1.17.01` must not satisfy a `1.17.0` probe) and partial drops (`win32-x64-msvc` alone missing). The npm-publish fold step now calls it.

**Tier 3 — structural invariants.** 7 tests parse npm-publish.yml and pin the contracts the 1.17.0 race violated: engine publish → verify → fold ordering inside the prod job, the verify poll's platform set matching the guard script's canonical set (drift fails CI), prod/dev environment gates, retry-and-refuse fold behavior, and RELEASE_VERSION wiring. Both test files live in `scripts/__tests__/` so they run in fast-gates on every PR — no release dispatch required.

Local: 246/246 scripts tests pass, full fast-gates green with 0 actionlint findings.