### PR TITLE
fix(packaging): bundle @gsd/* workspace packages so --ignore-scripts installs work

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,13 @@
     "@aws-sdk/client-bedrock-runtime": "^3.983.0",
     "@clack/prompts": "^1.1.0",
     "@google/genai": "^1.40.0",
+    "@gsd/agent-core": "workspace:*",
+    "@gsd/agent-modes": "workspace:*",
+    "@gsd/native": "workspace:*",
+    "@gsd/pi-agent-core": "workspace:*",
+    "@gsd/pi-ai": "workspace:*",
+    "@gsd/pi-coding-agent": "workspace:*",
+    "@gsd/pi-tui": "workspace:*",
     "@mariozechner/jiti": "^2.6.2",
     "@mistralai/mistralai": "2.2.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
@@ -226,5 +233,14 @@
     "c8": {
       "yargs": "^18.0.0"
     }
-  }
+  },
+  "bundleDependencies": [
+    "@gsd/agent-core",
+    "@gsd/agent-modes",
+    "@gsd/native",
+    "@gsd/pi-agent-core",
+    "@gsd/pi-ai",
+    "@gsd/pi-coding-agent",
+    "@gsd/pi-tui"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,27 @@ importers:
       '@google/genai':
         specifier: ^1.40.0
         version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@gsd/agent-core':
+        specifier: workspace:*
+        version: link:packages/gsd-agent-core
+      '@gsd/agent-modes':
+        specifier: workspace:*
+        version: link:packages/gsd-agent-modes
+      '@gsd/native':
+        specifier: workspace:*
+        version: link:packages/native
+      '@gsd/pi-agent-core':
+        specifier: workspace:*
+        version: link:packages/pi-agent-core
+      '@gsd/pi-ai':
+        specifier: workspace:*
+        version: link:packages/pi-ai
+      '@gsd/pi-coding-agent':
+        specifier: workspace:*
+        version: link:packages/pi-coding-agent
+      '@gsd/pi-tui':
+        specifier: workspace:*
+        version: link:packages/pi-tui
       '@mariozechner/jiti':
         specifier: ^2.6.2
         version: 2.6.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,10 @@ packages:
   - 'web'
 
 autoInstallPeers: true
+# Root declares @gsd/* internal packages with real ranges so the published
+# manifest lists them (satisfied by bundledDependencies in the tarball).
+# pnpm links them to the workspace copies instead of hitting the registry.
+linkWorkspacePackages: true
 strictPeerDependencies: false
 engineStrict: true
 

--- a/scripts/__tests__/validate-pack.test.mjs
+++ b/scripts/__tests__/validate-pack.test.mjs
@@ -22,8 +22,10 @@ async function importValidatePackWithRootPackage(rootPackageJson) {
       buildApi.onLoad({ filter: /.*/, namespace: "validate-pack-stub" }, (args) => {
         const stubs = {
           "node:child_process": `
-            export function execFileSync() {
-              throw new Error("npm commands must not run after an early package guard failure");
+            export function execFileSync(command, args) {
+              globalThis.__validatePackStubCalls = globalThis.__validatePackStubCalls || [];
+              globalThis.__validatePackStubCalls.push(String(args?.[1] ?? command));
+              return "";
             }
           `,
           "node:fs": `
@@ -83,18 +85,24 @@ async function importValidatePackWithRootPackage(rootPackageJson) {
   } finally {
     console.log = originalLog;
     process.exit = originalExit;
+    delete globalThis.__validatePackStubCalls;
   }
 }
 
-test("validate-pack fails before npm pack when publishable dependencies contain workspace ranges", async () => {
+test("validate-pack resolves workspace ranges first, then fails when they survive the rewrite", async () => {
+  // The stubbed readFileSync always returns the same manifest, simulating a
+  // prepack resolve that failed to rewrite the workspace range.
   const logs = await importValidatePackWithRootPackage({
     dependencies: {
       "@gsd/pi-ai": "workspace:*",
     },
   });
   const output = logs.join("\n");
-  assert.match(output, /Checking for workspace: protocol leaks/);
-  assert.match(output, /dependencies\.@gsd\/pi-ai=workspace:\*/);
-  assert.match(output, /Remove internal workspace packages/);
+  // The resolve must run BEFORE the leak guard (publish snapshot order).
+  assert.match(output, /Resolving workspace:\* ranges for publishable manifest/);
+  const resolveAt = output.indexOf("Resolving workspace:");
+  const leakAt = output.indexOf("dependencies.@gsd/pi-ai=workspace:*");
+  assert.ok(resolveAt !== -1 && leakAt > resolveAt, "leak check must observe the resolved state");
+  assert.match(output, /check prepack-resolve-workspace\.cjs/);
   assert.doesNotMatch(output, /Packing tarball/);
 });

--- a/scripts/prepack-resolve-workspace.cjs
+++ b/scripts/prepack-resolve-workspace.cjs
@@ -20,9 +20,14 @@ const TARGET_PACKAGE_JSONS = [
   ...RELEASE_WORKSPACE_PACKAGE_DIRS.map((dir) => path.join(ROOT, dir, 'package.json')),
 ];
 const DROP_INTERNAL_DEPS_PACKAGE_JSONS = new Set([
-  ROOT_PACKAGE_JSON,
   STANDALONE_WEB_PACKAGE_JSON,
 ]);
+
+// Root internal deps are resolved to ^version (not dropped) so the published
+// manifest lists them — npm then satisfies those ranges from the
+// bundleDependencies copies packed under node_modules/@gsd (see
+// materializeBundleCopies below), which also makes --ignore-scripts installs
+// work without the postinstall link step (#2061).
 
 // Recover from a backup left behind by a previous prepack that was hard-killed
 // before postpack could restore (SIGKILL skips the EXIT trap). The manifests on
@@ -135,3 +140,94 @@ for (const filePath of TARGET_PACKAGE_JSONS) {
 if (!resolvedAny && fs.existsSync(BACKUP_DIR)) {
   fs.rmSync(BACKUP_DIR, { recursive: true, force: true });
 }
+
+// Materialize clean (symlink-free) copies of the workspace packages that
+// compiled dist code imports as @gsd/*. npm's bundleDependencies walker packs
+// whatever sits in node_modules, and pnpm's node_modules/@gsd entries are
+// symlinks whose nested node_modules drag in the pnpm virtual store — the
+// 537MB-tarball failure that validate-pack's bloat guard exists for. Copying
+// package.json + dist (excluding node_modules) gives the bundler real, lean
+// directories, and link-workspace-packages.cjs already leaves real directories
+// alone, so postinstall coexists with these copies.
+const BUNDLED_GSD_PACKAGES = [
+  'agent-core',
+  'agent-modes',
+  'native',
+  'pi-agent-core',
+  'pi-ai',
+  'pi-coding-agent',
+  'pi-tui',
+];
+const BUNDLE_COPY_ENTRIES = ['package.json', 'dist'];
+
+// Package directory names do not all match their @gsd/* import names
+// (@gsd/agent-core lives in packages/gsd-agent-core), so resolve by reading
+// each candidate's package.json name.
+function findPackageDirFor(name) {
+  for (const dir of RELEASE_WORKSPACE_PACKAGE_DIRS) {
+    const manifestPath = path.join(ROOT, dir, 'package.json');
+    if (!fs.existsSync(manifestPath)) continue;
+    try {
+      if (readJson(manifestPath).name === `@gsd/${name}`) return path.join(ROOT, dir);
+    } catch {
+      // unreadable manifest — not our package
+    }
+  }
+  return null;
+}
+
+function materializeBundleCopies() {
+  const scopeDir = path.join(ROOT, 'node_modules', '@gsd');
+  fs.mkdirSync(scopeDir, { recursive: true });
+  const failures = [];
+  let materialized = 0;
+  for (const name of BUNDLED_GSD_PACKAGES) {
+    const sourceDir = findPackageDirFor(name);
+    if (sourceDir === null || !fs.existsSync(path.join(sourceDir, 'package.json'))) {
+      failures.push(`@gsd/${name}: no packages/* directory declares this package name`);
+      continue;
+    }
+    const targetDir = path.join(scopeDir, name);
+    fs.rmSync(targetDir, { recursive: true, force: true });
+    fs.mkdirSync(targetDir, { recursive: true });
+    for (const entry of BUNDLE_COPY_ENTRIES) {
+      const from = path.join(sourceDir, entry);
+      if (!fs.existsSync(from)) continue;
+      fs.cpSync(from, path.join(targetDir, entry), { recursive: true, verbatimSymlinks: false });
+    }
+    // Strip dependency fields from the bundled manifest: npm's bundler resolves
+    // and packs each declared dep, which under pnpm means dragging the virtual
+    // store into the tarball. Bundled copies resolve externals by walking up to
+    // the root node_modules — the same mechanism the linked install uses — so
+    // the fields are unnecessary and harmful here.
+    const bundledPkgPath = path.join(targetDir, 'package.json');
+    const bundledPkg = readJson(bundledPkgPath);
+    for (const field of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
+      delete bundledPkg[field];
+    }
+    writeJson(bundledPkgPath, bundledPkg);
+    materialized++;
+  }
+  // A leftover symlink here makes npm's bundle walker dereference the pnpm
+  // virtual store — the 537MB tarball failure. Never pack without real dirs.
+  for (const name of BUNDLED_GSD_PACKAGES) {
+    const target = path.join(scopeDir, name);
+    if (!existsSyncF(target)) failures.push(`@gsd/${name}: bundle copy missing under node_modules/@gsd`);
+  }
+  if (failures.length > 0) {
+    console.error('[prepack] ERROR: could not materialize bundle copies:');
+    for (const failure of failures) console.error(`  - ${failure}`);
+    process.exit(1);
+  }
+  console.log(`[prepack] Materialized ${materialized} bundled @gsd/* copies under node_modules/@gsd for --ignore-scripts installs.`);
+}
+
+function existsSyncF(target) {
+  try {
+    return fs.existsSync(target) && fs.lstatSync(target).isDirectory() && !fs.lstatSync(target).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+materializeBundleCopies();

--- a/scripts/validate-pack.js
+++ b/scripts/validate-pack.js
@@ -135,20 +135,29 @@ try {
   npmCacheDir = mkdtempSync(join(tmpdir(), 'validate-pack-npm-cache-'));
   mkdirSync(npmCacheDir, { recursive: true });
 
-  const rootPkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+  let rootPkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
 
   function isInternalWorkspaceDep(dep) {
     return dep.startsWith('@gsd/') || dep.startsWith('@opengsd/') || dep.startsWith('@earendil-works/');
   }
 
+  // Resolve workspace:* ranges FIRST: the publish flow rewrites them before
+  // `npm publish` snapshots the registry manifest, so this check must observe
+  // the same post-rewrite state (and the pack below reuses it).
+  console.log('==> Resolving workspace:* ranges for publishable manifest...');
+  execFileSync(process.execPath, [join(__dirname, 'prepack-resolve-workspace.cjs')], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  rootPkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+
   // --- Guard: no `workspace:` protocol in the published dependency fields ---
-  // `npm publish` builds the registry manifest (packument) from package.json read
-  // BEFORE the `prepack` hook runs, so a `prepack`-time rewrite/strip lands in the
-  // TARBALL but NOT in the published metadata that consumers resolve against. Any
-  // `workspace:` range left in dependencies/optionalDependencies/peerDependencies
-  // therefore leaks to the registry and breaks `npm install` with EUNSUPPORTEDPROTOCOL.
-  // Internal @gsd/@opengsd packages must NOT appear in these fields at all — they ship
-  // under packages/*/dist and are symlinked at postinstall (link-workspace-packages.cjs).
+  // The published manifest is snapshotted from the rewritten package.json, and
+  // internal @gsd/* deps now ship as bundledDependencies copies under
+  // node_modules/@gsd (satisfying their ^version ranges without registry
+  // access, including for --ignore-scripts installs). Any leftover
+  // `workspace:` range would leak to the registry and break `npm install`
+  // with EUNSUPPORTEDPROTOCOL.
   console.log('==> Checking for workspace: protocol leaks in published dependency fields...');
   const workspaceLeaks = [];
   for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
@@ -159,7 +168,7 @@ try {
   if (workspaceLeaks.length) {
     console.log('ERROR: root package.json has workspace: ranges that will leak to the published registry manifest:');
     for (const leak of workspaceLeaks) console.log(`    ${leak}`);
-    console.log('    Remove internal workspace packages from these fields (they ship via files + postinstall link).');
+    console.log('    The prepack resolve should have rewritten these — check prepack-resolve-workspace.cjs.');
     process.exit(1);
   }
   console.log('    No workspace: protocol leaks in published dependency fields.');
@@ -218,11 +227,8 @@ try {
   console.log('    Packaged workspace external dependency coverage is complete.');
 
   // --- Pack tarball ---
-  // npm pack --ignore-scripts skips prepack; resolve workspace:* for publishable tarballs.
-  execFileSync(process.execPath, [join(__dirname, 'prepack-resolve-workspace.cjs')], {
-    cwd: ROOT,
-    stdio: 'inherit',
-  });
+  // (workspace:* ranges were resolved above, before the manifest guards, so the
+  // published metadata and the tarball see the same state.)
 
   console.log('==> Packing tarball...');
   const packOutput = runNpm(['pack', '--json', '--ignore-scripts']);
@@ -298,6 +304,11 @@ try {
   }
   console.log(`    Size guard OK: ${entryCount} entries, ${formatBytes(unpackedSize)} unpacked, ${pnpmStorePaths.length} .pnpm entries.`);
 
+  // --- Guard: bundled @gsd/* workspace packages must be in the tarball ---
+  // Compiled dist code statically imports @gsd/*; installs with
+  // --ignore-scripts never run the postinstall link step, so resolution
+  // depends entirely on these bundled copies (#2061).
+
   // npm install can consume/delete a cwd-local tarball; keep a temp copy for later smoke tests.
   const packedTarballPath = tarball;
   tarball = join(mkdtempSync(join(tmpdir(), 'validate-pack-tarball-')), tarballName);
@@ -310,8 +321,26 @@ try {
   });
 
   // --- Check critical files using npm pack metadata ---
-  console.log('==> Checking critical files...');
+  console.log('==> Checking critical files using npm pack metadata...');
   const packedFiles = new Set(packEntry.files.map((entry) => entry.path));
+
+  const missingBundled = [];
+  for (const platform of [
+    'agent-core', 'agent-modes', 'native', 'pi-agent-core', 'pi-ai', 'pi-coding-agent', 'pi-tui',
+  ]) {
+    for (const required of [
+      `node_modules/@gsd/${platform}/package.json`,
+      `node_modules/@gsd/${platform}/dist/index.js`,
+    ]) {
+      if (!packedFiles.has(required)) missingBundled.push(required);
+    }
+  }
+  if (missingBundled.length > 0) {
+    console.log('ERROR: bundled @gsd/* copies missing from the tarball — --ignore-scripts installs would break (#2061):');
+    for (const required of missingBundled) console.log(`    ${required}`);
+    process.exit(1);
+  }
+  console.log('    Bundled @gsd/* copies present for --ignore-scripts installs.');
 
   const requiredFiles = [
     'dist/loader.js',


### PR DESCRIPTION
Closes #2061.

**Bug:** `npm install -g --ignore-scripts` of the packed tarball produced a CLI that died on first run — compiled dist code statically imports the seven `@gsd/*` workspace packages, which only resolved after the postinstall link step that `--ignore-scripts` skips. Reproduced on clean main (and by the docker `runtime-local` e2e).

**Fix:** declare the seven runtime packages as root dependencies (`workspace:*`, which version-sync already normalizes) plus `bundleDependencies`, so the tarball ships real copies under `node_modules/@gsd` and resolution no longer depends on lifecycle scripts.

- `pnpm-workspace.yaml` gains `linkWorkspacePackages: true` — pnpm links the declared packages in-repo instead of trying to resolve them from the registry (they aren't published).
- prepack materializes clean (symlink-free, dependency-stripped) copies into `node_modules/@gsd`. Stripping the dep fields is what keeps npm's bundle walker from dereferencing the pnpm virtual store — the 537MB-tarball failure mode validate-pack's bloat guard was built for; bundled dist content adds only ~11MB. Package dirs resolve by manifest name, not directory name (`@gsd/agent-core` lives in `packages/gsd-agent-core`) — the first attempt skipped those two, left their pnpm symlinks in place, and the bloat guard correctly rejected the resulting 542MB tarball.
- The publish flow's resolve step now also applies to the root manifest, so the published manifest lists `@gsd/*` at `^version` and npm satisfies those ranges from the bundled copies without registry access.
- validate-pack: prepack runs before the manifest guards (they must observe the resolved state), and a new guard asserts all seven bundled copies (`package.json` + `dist/index.js`) are present in the tarball.
- `link-workspace-packages.cjs` already leaves real directories untouched ("copied or from bundleDependencies"), so postinstall coexists with bundled copies.

**Validation:** validate-pack end-to-end passes (pack, all guards, `--ignore-scripts` global install + repair simulation, `@gsd/*` import resolution); 246 scripts tests pass; direct `--ignore-scripts` global install of the packed tarball runs `gsd --version` successfully (previously ERR_MODULE_NOT_FOUND). The docker e2e could not complete locally (Docker Hub timeouts pulling the base image) — CI's run is the authoritative check.