### PR TITLE
fix(gsd): reconcile the shadow-repair gate with milestone completion's legacy adoption

### DIFF
--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -212,6 +212,13 @@ export interface LifecycleShadowRepairCandidate extends LifecycleShadowRepairIde
   targetStatus: "completed" | null;
   evidence: LifecycleShadowRepairEvidence | null;
   reason: string | null;
+  /**
+   * Raw legacy verification_result for tasks (null for slices/milestones or
+   * when unrecorded). Distinguishes "never verified" bare legacy completions —
+   * completion's adoption territory (#2070) — from rows with a recorded failed
+   * verification, which the shadow gate must never silently repair (#2002).
+   */
+  legacyVerificationResult: string | null;
 }
 
 function validCompletedAt(value: unknown): string | null {
@@ -253,7 +260,7 @@ interface RepairEvidenceFacts {
   digestFacts: unknown;
 }
 
-function isPassingVerificationResult(verificationResult: string): boolean {
+export function isPassingVerificationResult(verificationResult: string): boolean {
   return verificationResult.trim().toLowerCase() === "passed";
 }
 
@@ -381,6 +388,7 @@ export function getLifecycleShadowRepairCandidate(
         comparison: compareLifecycleShadow(null, canonicalStatus),
         targetStatus: null,
         evidence: null,
+        legacyVerificationResult: null,
         reason: "legacy hierarchy row is missing; extra canonical shadow remains unresolved",
       };
     }
@@ -420,6 +428,7 @@ export function getLifecycleShadowRepairCandidate(
     return {
       ...identity,
       legacyStatus,
+      legacyVerificationResult: identity.itemKind === "task" ? (verificationResult || null) : null,
       canonicalStatus,
       canonicalLastOperationId,
       comparison: compareLifecycleShadow(legacyStatus, canonicalStatus),

--- a/src/resources/extensions/gsd/lifecycle-shadow-repair-domain-operation.ts
+++ b/src/resources/extensions/gsd/lifecycle-shadow-repair-domain-operation.ts
@@ -12,6 +12,7 @@ import {
 import { getDb } from "./db/engine.js";
 import {
   getLifecycleShadowRepairCandidate,
+  isPassingVerificationResult,
   type LifecycleShadowRepairCandidate,
   type LifecycleShadowRepairEvidence,
   type LifecycleShadowRepairIdentity,
@@ -461,6 +462,25 @@ export function repairMilestoneLifecycleShadowsForward(input: {
     if (!candidate || candidate.canonicalStatus === "completed") continue;
     const legacyComplete = candidate.comparison.normalizedLegacyStatus === "completed";
     if (!legacyComplete) continue;
+
+    // Tri-state rule for pure legacy-complete descendants with no canonical
+    // lifecycle row (#2002 x #2070):
+    //   - recorded failed verification  → unresolved (never silently repair)
+    //   - no verification recorded      → completion's adoption territory:
+    //     skip it here and let milestone completion adopt it (#2070)
+    //   - recorded passing verification → falls through: the shadow repair
+    //     adopts it now (#2002)
+    if (candidate.canonicalStatus === null) {
+      const failedVerification =
+        typeof candidate.legacyVerificationResult === "string" &&
+        candidate.legacyVerificationResult !== "" &&
+        !isPassingVerificationResult(candidate.legacyVerificationResult);
+      if (failedVerification) {
+        unresolved.push(entityId(item));
+        continue;
+      }
+      if (!candidate.evidence) continue;
+    }
 
     const identity = entityId(item);
     if (candidate.targetStatus !== "completed" || !candidate.evidence) {

--- a/src/resources/extensions/gsd/tests/lifecycle-shadow-forward-repair.test.ts
+++ b/src/resources/extensions/gsd/tests/lifecycle-shadow-forward-repair.test.ts
@@ -724,3 +724,76 @@ test("repairMilestoneLifecycleShadowsForward runs task repairs before slice repa
 
   assert.deepEqual(result.repaired, ["M011/S01/T01", "M011/S01"]);
 });
+
+// ── Tri-state rule for pure legacy-complete descendants with no canonical
+// row (#2002 x #2070 reconciliation): recorded failed verification blocks,
+// nothing recorded is left to milestone completion's adoption, recorded
+// passed is repaired here. ──
+
+function insertLegacyCompleteTask(t: import("node:test").TestContext, opts: {
+  milestoneId: string;
+  sliceId: string;
+  taskId: string;
+  verificationResult: string | null;
+}): void {
+  openFixture(t);
+  db().exec(`
+    INSERT INTO milestones (id, title, status, created_at)
+    VALUES ('${opts.milestoneId}', 'Tri-state milestone', 'active', '2026-07-01T00:00:00.000Z');
+    INSERT INTO slices (milestone_id, id, title, status, created_at)
+    VALUES ('${opts.milestoneId}', '${opts.sliceId}', 'Tri-state slice', 'active', '2026-07-01T00:00:00.000Z');
+    INSERT INTO tasks (
+      milestone_id, slice_id, id, title, status, completed_at,
+      one_liner, narrative, verification_result, full_summary_md
+    ) VALUES (
+      '${opts.milestoneId}', '${opts.sliceId}', '${opts.taskId}', 'Tri-state task', 'complete',
+      '2026-07-02T00:00:00.000Z', 'Finished', 'Historical completion',
+      '${opts.verificationResult ?? ""}', '# Task summary'
+    );
+  `);
+}
+
+test("a recorded failed verification on a canonical-less legacy task blocks repair as unresolved", (t) => {
+  insertLegacyCompleteTask(t, {
+    milestoneId: "M010", sliceId: "S01", taskId: "T01", verificationResult: "failed",
+  });
+  const result = repairMilestoneLifecycleShadowsForward({
+    invocation: invocation("shadow-repair/tri-state/failed"),
+    milestoneId: "M010",
+  });
+  assert.deepEqual(result.repaired, []);
+  assert.deepEqual(result.unresolved, ["M010/S01/T01"]);
+  assert.equal(db().prepare(`
+    SELECT COUNT(*) AS count FROM workflow_item_lifecycles WHERE milestone_id = 'M010'
+  `).get()?.["count"], 0);
+});
+
+test("an unverified canonical-less legacy task is left for milestone completion to adopt", (t) => {
+  insertLegacyCompleteTask(t, {
+    milestoneId: "M011", sliceId: "S01", taskId: "T01", verificationResult: null,
+  });
+  const result = repairMilestoneLifecycleShadowsForward({
+    invocation: invocation("shadow-repair/tri-state/unverified"),
+    milestoneId: "M011",
+  });
+  assert.deepEqual(result.repaired, []);
+  assert.deepEqual(result.unresolved, []);
+  assert.equal(db().prepare(`
+    SELECT COUNT(*) AS count FROM workflow_item_lifecycles WHERE milestone_id = 'M011'
+  `).get()?.["count"], 0, "the shadow gate must not adopt — milestone completion does");
+});
+
+test("a passing-verified canonical-less legacy task is repaired by the shadow gate", (t) => {
+  insertLegacyCompleteTask(t, {
+    milestoneId: "M012", sliceId: "S01", taskId: "T01", verificationResult: "passed",
+  });
+  const result = repairMilestoneLifecycleShadowsForward({
+    invocation: invocation("shadow-repair/tri-state/passed"),
+    milestoneId: "M012",
+  });
+  assert.deepEqual(result.unresolved, []);
+  assert.deepEqual(result.repaired, ["M012/S01/T01"]);
+  assert.equal(db().prepare(`
+    SELECT lifecycle_status FROM workflow_item_lifecycles WHERE milestone_id = 'M012'
+  `).get()?.["lifecycle_status"], "completed");
+});


### PR DESCRIPTION
Unblocks main: #2002 and #2070 merged hours apart with contradictory semantics for the same descendant shape (legacy rows marked `complete` with no canonical `workflow_item_lifecycles` row):

- #2002's gate classified them unresolved (no passing verification evidence) and refused validation
- #2070's completion feature — and its test — requires completion itself to adopt exactly that shape

Main's unit suite has been red since they landed (14732 passed / 1 failed, first seen on #2072's build).

**Resolution (tri-state by the raw legacy verification result):**
| recorded verification | canonical row | disposition |
|---|---|---|
| failed | none | unresolved — never silently repair (#2002 intact) |
| none | none | completion adopts (#2070) |
| passed | none | shadow repair adopts (#2002 intact) |

Rows with a canonical row keep the full evidence gate unchanged.

Both suites pass together: milestone-completion 23/23, lifecycle-shadow-forward-repair 53/53. Unblocks #2072.