### PR TITLE
fix(gsd): sibling-corroborated adoption for bare legacy-complete shadow descendants

### DIFF
--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -212,6 +212,14 @@ export interface LifecycleShadowRepairCandidate extends LifecycleShadowRepairIde
   targetStatus: "completed" | null;
   evidence: LifecycleShadowRepairEvidence | null;
   reason: string | null;
+  /**
+   * Raw legacy verification_result for tasks (null for slices/milestones or
+   * when unrecorded). Distinguishes "never verified" bare legacy completions —
+   * completion's adoption territory when a canonically-completed sibling
+   * establishes the adoption pattern (#2070) — from rows with a recorded
+   * failed verification, which must never be silently repaired (#2002).
+   */
+  legacyVerificationResult: string | null;
 }
 
 function validCompletedAt(value: unknown): string | null {
@@ -253,7 +261,7 @@ interface RepairEvidenceFacts {
   digestFacts: unknown;
 }
 
-function isPassingVerificationResult(verificationResult: string): boolean {
+export function isPassingVerificationResult(verificationResult: string): boolean {
   return verificationResult.trim().toLowerCase() === "passed";
 }
 
@@ -376,6 +384,7 @@ export function getLifecycleShadowRepairCandidate(
       return {
         ...identity,
         legacyStatus: null,
+        legacyVerificationResult: null,
         canonicalStatus,
         canonicalLastOperationId,
         comparison: compareLifecycleShadow(null, canonicalStatus),
@@ -420,6 +429,7 @@ export function getLifecycleShadowRepairCandidate(
     return {
       ...identity,
       legacyStatus,
+      legacyVerificationResult: identity.itemKind === "task" ? (verificationResult || null) : null,
       canonicalStatus,
       canonicalLastOperationId,
       comparison: compareLifecycleShadow(legacyStatus, canonicalStatus),

--- a/src/resources/extensions/gsd/lifecycle-shadow-repair-domain-operation.ts
+++ b/src/resources/extensions/gsd/lifecycle-shadow-repair-domain-operation.ts
@@ -12,6 +12,7 @@ import {
 import { getDb } from "./db/engine.js";
 import {
   getLifecycleShadowRepairCandidate,
+  isPassingVerificationResult,
   type LifecycleShadowRepairCandidate,
   type LifecycleShadowRepairEvidence,
   type LifecycleShadowRepairIdentity,
@@ -453,16 +454,41 @@ export function repairMilestoneLifecycleShadowsForward(input: {
     return { repaired: [], unresolved: [] };
   }
 
+  // A canonically-completed sibling descendant proves the adoption pattern is
+  // established for this milestone (e.g. a partially-applied legacy import):
+  // bare legacy-complete stragglers are then swept in by milestone completion
+  // rather than blocking validation (#2070). Without that corroboration, an
+  // adopted milestone claiming readiness on unsubstantiated descendants is
+  // refused (#2002).
+  const repairItems = milestoneRepairItems(milestoneId);
+  const corroborated = repairItems.some(
+    (item) => getLifecycleShadowRepairCandidate(item)?.canonicalStatus === "completed",
+  );
+
   const inScope: MilestoneRepairEntry[] = [];
   const unresolved: string[] = [];
 
-  for (const item of milestoneRepairItems(milestoneId)) {
+  for (const item of repairItems) {
     const candidate = getLifecycleShadowRepairCandidate(item);
     if (!candidate || candidate.canonicalStatus === "completed") continue;
     const legacyComplete = candidate.comparison.normalizedLegacyStatus === "completed";
     if (!legacyComplete) continue;
 
     const identity = entityId(item);
+    const failedVerification =
+      item.itemKind === "task" &&
+      typeof candidate.legacyVerificationResult === "string" &&
+      candidate.legacyVerificationResult !== "" &&
+      !isPassingVerificationResult(candidate.legacyVerificationResult);
+    if (failedVerification) {
+      // Recorded failed verification must never be silently repaired (#2002).
+      unresolved.push(identity);
+      continue;
+    }
+    if (corroborated && candidate.canonicalStatus === null) {
+      // Adoption pattern established: completion sweeps this straggler in.
+      continue;
+    }
     if (candidate.targetStatus !== "completed" || !candidate.evidence) {
       unresolved.push(identity);
       continue;

--- a/src/resources/extensions/gsd/tests/lifecycle-shadow-forward-repair.test.ts
+++ b/src/resources/extensions/gsd/tests/lifecycle-shadow-forward-repair.test.ts
@@ -724,3 +724,108 @@ test("repairMilestoneLifecycleShadowsForward runs task repairs before slice repa
 
   assert.deepEqual(result.repaired, ["M011/S01/T01", "M011/S01"]);
 });
+
+// ── Sibling corroboration (#2002 x #2070): a canonically-completed sibling
+// establishes the adoption pattern, deferring bare legacy-complete
+// stragglers to milestone completion; without it the strict gate applies. ──
+
+function insertCanonicalCompletedSibling(milestoneId: string, sliceId: string, taskId: string): void {
+  // The corroboration sibling is a canonical shadow row; FK targets
+  // (project_authority / workflow_operations) are not the subject here.
+  db().exec("PRAGMA foreign_keys = OFF");
+  db().prepare(`
+    INSERT INTO workflow_item_lifecycles (
+      lifecycle_id, project_id, item_kind, milestone_id, slice_id, task_id,
+      lifecycle_status, state_version, created_at, updated_at,
+      last_operation_id, last_project_revision, last_authority_epoch
+    ) VALUES (
+      'corroboration-' || :task_id, 'test-project', 'task', :milestone_id, :slice_id, :task_id,
+      'completed', 1, '2026-07-02T00:00:00.000Z', '2026-07-02T00:00:00.000Z',
+      'fixture-adopt', 1, 0
+    )
+  `).run({ ":milestone_id": milestoneId, ":slice_id": sliceId, ":task_id": taskId });
+  db().exec("PRAGMA foreign_keys = ON");
+}
+
+test("a bare legacy-complete straggler is deferred to completion when a sibling is canonically complete", (t) => {
+  openFixture(t);
+  insertCanonicalCompletedSibling("M001", "S01", "T01");
+  // T02 here: legacy complete, no durable evidence, canonical row absent —
+  // the exact straggler shape from #2070.
+  db().exec(`
+    INSERT INTO tasks (
+      milestone_id, slice_id, id, title, status, completed_at,
+      one_liner, narrative, verification_result, full_summary_md
+    ) VALUES (
+      'M001', 'S01', 'T04', 'Bare straggler', 'complete',
+      '2026-07-04T00:00:00.000Z', 'Finished', 'Historical completion', '', ''
+    );
+  `);
+
+  const result = repairMilestoneLifecycleShadowsForward({
+    invocation: invocation("shadow-repair/corroboration/deferred"),
+    milestoneId: "M001",
+  });
+
+  // Neither repaired by the gate nor treated as unresolved — completion adopts it.
+  assert.deepEqual(result.repaired, []);
+  assert.deepEqual(result.unresolved, []);
+  assert.equal(db().prepare(`
+    SELECT COUNT(*) AS count FROM workflow_item_lifecycles WHERE milestone_id = 'M001'
+  `).get()?.["count"], 1, "the gate must not adopt the straggler itself");
+});
+
+test("a bare straggler with recorded failed verification blocks even with sibling corroboration", (t) => {
+  openFixture(t);
+  insertCanonicalCompletedSibling("M001", "S01", "T01");
+  db().exec(`
+    INSERT INTO tasks (
+      milestone_id, slice_id, id, title, status, completed_at,
+      one_liner, narrative, verification_result, full_summary_md
+    ) VALUES (
+      'M001', 'S01', 'T05', 'Failed-verification straggler', 'complete',
+      '2026-07-04T00:00:00.000Z', 'Finished', 'Historical completion', 'failed', '# T05 summary'
+    );
+  `);
+
+  const result = repairMilestoneLifecycleShadowsForward({
+    invocation: invocation("shadow-repair/corroboration/failed"),
+    milestoneId: "M001",
+  });
+
+  assert.deepEqual(result.repaired, []);
+  assert.deepEqual(result.unresolved, ["M001/S01/T05"]);
+  assert.equal(db().prepare(`
+    SELECT COUNT(*) AS count FROM workflow_item_lifecycles WHERE milestone_id = 'M001'
+  `).get()?.["count"], 1, "only the corroborating sibling's own row exists");
+});
+
+test("without sibling corroboration a bare legacy-complete descendant is unresolved", (t) => {
+  openFixture(t);
+  db().exec(`
+    INSERT INTO tasks (
+      milestone_id, slice_id, id, title, status, completed_at,
+      one_liner, narrative, verification_result, full_summary_md
+    ) VALUES (
+      'M001', 'S01', 'T06', 'Unsubstantiated straggler', 'complete',
+      '2026-07-04T00:00:00.000Z', 'Finished', 'Historical completion', '', ''
+    );
+  `);
+
+  const result = repairMilestoneLifecycleShadowsForward({
+    invocation: invocation("shadow-repair/corroboration/unsubstantiated"),
+    milestoneId: "M001",
+  });
+
+  assert.deepEqual(result.repaired, []);
+  // #2002's atomicity: T03 (unsupported evidence) and T06 (bare, unverified)
+  // are unresolved, so the evidence-backed T01/T02 are reported unresolved
+  // too and nothing is written.
+  assert.deepEqual(
+    [...result.unresolved].sort(),
+    ["M001/S01/T01", "M001/S01/T02", "M001/S01/T03", "M001/S01/T06"],
+  );
+  assert.equal(db().prepare(`
+    SELECT COUNT(*) AS count FROM workflow_item_lifecycles WHERE milestone_id = 'M001'
+  `).get()?.["count"], 0);
+});


### PR DESCRIPTION
Closes #2074 (the #2002 × #2070 blocker filed earlier today). Main's unit suite is red because the two changes give contradictory answers for the same descendant state; this resolves it by the one discriminator both authors' tests actually agree on.

**Rule:** the shadow gate's strictness scales with sibling corroboration —
- a canonically-completed sibling descendant proves the adoption pattern is established (a partially-applied legacy import, i.e. #2070's exact scenario): bare legacy-complete stragglers are deferred so milestone completion sweeps them in;
- without corroboration (#2002's scenario: an adopted milestone claiming readiness on unsubstantiated descendants), the gate keeps the merged refusal + evidence-gated repair unchanged;
- a recorded **failed** verification blocks in both worlds (#2002's core invariant intact).

**Validation:** all three previously-conflicting suites pass together — lifecycle-shadow-forward-repair 56/56 (3 new tests pin the corroboration/failed/unverified rows), milestone-completion 23/23, milestone-validation — plus 52 lifecycle/recover and 246 scripts tests. Unblocks #2072 and the queued dependency work.