### PR TITLE
fix(issue): [Bug]: auto-mode setModel persist:false is ignored — every unit dispatch rewrites the global settings.json default model

### DIFF
--- a/packages/gsd-agent-core/src/agent-session.test.ts
+++ b/packages/gsd-agent-core/src/agent-session.test.ts
@@ -4,6 +4,7 @@ import { SessionManager } from "@gsd/pi-coding-agent/core/session-manager.js";
 import { resolvePath } from "@gsd/pi-coding-agent/utils/paths.js";
 import { parseSkillBlock } from "./agent-session.ts";
 import { AgentSessionExtensionsModule } from "./session/agent-session-extensions.ts";
+import { AgentSessionModelModule } from "./session/agent-session-model.ts";
 import { AgentSessionNavigationModule } from "./session/agent-session-navigation.ts";
 import { AgentSessionPromptModule } from "./session/agent-session-prompt.ts";
 
@@ -85,6 +86,52 @@ describe("AgentSessionExtensionsModule", () => {
     assert.doesNotMatch(prompt, /<name>Review-Skill<\/name>/);
     assert.doesNotMatch(prompt, /<name>other-skill<\/name>/);
     assert.doesNotMatch(prompt, /<available_skills>/);
+  });
+
+  test("forwards setModel persistence options to the session", async () => {
+    const model = { provider: "test-provider", id: "test-model" };
+    let receivedOptions: { persist?: boolean } | undefined;
+    let boundSetModel:
+      | ((selectedModel: typeof model, options?: { persist?: boolean }) => Promise<boolean>)
+      | undefined;
+    const host = {
+      modelRegistry: { hasConfiguredAuth: () => true },
+      setModel: async (_selectedModel: typeof model, options?: { persist?: boolean }) => {
+        receivedOptions = options;
+      },
+      promptTemplates: [],
+      resourceLoader: { getSkills: () => ({ skills: [] }) },
+    };
+    const runner = {
+      bindCore: (actions: { setModel: typeof boundSetModel }) => {
+        boundSetModel = actions.setModel;
+      },
+    };
+
+    new AgentSessionExtensionsModule(host as any).bindExtensionCore(runner as any);
+    assert.ok(boundSetModel);
+    assert.equal(await boundSetModel(model, { persist: false }), true);
+    assert.deepEqual(receivedOptions, { persist: false });
+  });
+});
+
+describe("AgentSessionModelModule", () => {
+  test("switches models without changing the default when persist is false", async () => {
+    const { host, model, persistedModels, sessionModels } = makeModelModuleHost();
+
+    await new AgentSessionModelModule(host as any).setModel(model as any, { persist: false });
+
+    assert.equal(host.agent.state.model, model);
+    assert.deepEqual(sessionModels, [[model.provider, model.id]]);
+    assert.deepEqual(persistedModels, []);
+  });
+
+  test("persists the default model when persistence options are omitted", async () => {
+    const { host, model, persistedModels } = makeModelModuleHost();
+
+    await new AgentSessionModelModule(host as any).setModel(model as any);
+
+    assert.deepEqual(persistedModels, [[model.provider, model.id]]);
   });
 });
 
@@ -193,6 +240,29 @@ function makeSkill(name: string) {
     source: "test",
     disableModelInvocation: false,
   };
+}
+
+function makeModelModuleHost() {
+  const model = { provider: "test-provider", id: "test-model", reasoning: false };
+  const persistedModels: string[][] = [];
+  const sessionModels: string[][] = [];
+  const host = {
+    model: undefined,
+    thinkingLevel: "off",
+    agent: { state: { model: undefined, thinkingLevel: "off" } },
+    modelRegistry: { hasConfiguredAuth: () => true },
+    sessionManager: {
+      appendModelChange: (provider: string, id: string) => sessionModels.push([provider, id]),
+    },
+    settingsManager: {
+      getDefaultThinkingLevel: () => "off",
+      setDefaultModelAndProvider: (provider: string, id: string) => persistedModels.push([provider, id]),
+    },
+    setThinkingLevel: () => {},
+    _extensionRunner: { emit: async () => {} },
+  };
+
+  return { host, model, persistedModels, sessionModels };
 }
 
 function makeAssistantError(errorMessage: string) {

--- a/packages/gsd-agent-core/src/agent-session.ts
+++ b/packages/gsd-agent-core/src/agent-session.ts
@@ -477,8 +477,8 @@ export class AgentSession implements AgentSessionHost {
 		this._prompt.abortRetry();
 	}
 
-	setModel(model: Model<any>): Promise<void> {
-		return this._model.setModel(model);
+	setModel(model: Model<any>, options?: { persist?: boolean }): Promise<void> {
+		return this._model.setModel(model, options);
 	}
 
 	cycleModel(direction?: "forward" | "backward"): Promise<ModelCycleResult | undefined> {

--- a/packages/gsd-agent-core/src/session/agent-session-extensions.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-extensions.ts
@@ -262,8 +262,7 @@ export class AgentSessionExtensionsModule {
 				getCommands,
 				setModel: async (model, options) => {
 					if (!this.host.modelRegistry.hasConfiguredAuth(model)) return false;
-					await this.host.setModel(model);
-					if (options?.persist === false) return true;
+					await this.host.setModel(model, options);
 					return true;
 				},
 				getThinkingLevel: () => this.host.thinkingLevel,

--- a/packages/gsd-agent-core/src/session/agent-session-host.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-host.ts
@@ -183,6 +183,6 @@ export interface AgentSessionHost {
 	createReplacedSessionContext(): ReplacedSessionContext;
 
 	// Public methods modules delegate to
-	setModel(model: Model<any>): Promise<void>;
+	setModel(model: Model<any>, options?: { persist?: boolean }): Promise<void>;
 	cycleModel(direction?: "forward" | "backward"): Promise<ModelCycleResult | undefined>;
 }

--- a/packages/gsd-agent-core/src/session/agent-session-model.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-model.ts
@@ -62,7 +62,7 @@ export class AgentSessionModelModule {
 		});
 	}
 
-	async setModel(model: Model<any>): Promise<void> {
+	async setModel(model: Model<any>, options?: { persist?: boolean }): Promise<void> {
 		if (!this.host.modelRegistry.hasConfiguredAuth(model)) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
@@ -71,7 +71,9 @@ export class AgentSessionModelModule {
 		const thinkingLevel = this.getThinkingLevelForModelSwitch();
 		this.host.agent.state.model = model;
 		this.host.sessionManager.appendModelChange(model.provider, model.id);
-		this.host.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		if (options?.persist !== false) {
+			this.host.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		}
 
 		// Re-clamp thinking level for new model's capabilities
 		this.host.setThinkingLevel(thinkingLevel);


### PR DESCRIPTION
## Summary
- Fixed non-persistent model selection and verified it with builds, tests, type-checking, and fast gates.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2076
- [#2076 [Bug]: auto-mode setModel persist:false is ignored — every unit dispatch rewrites the global settings.json default model](https://github.com/open-gsd/gsd-pi/issues/2076)

## User
- @Jack11111eee

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2076-bug-auto-mode-setmodel-persist-false-is--1788053619`