### PR TITLE
fix(cli): self-repairing bin bootstrap resolves @gsd/* without lifecycle scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "type": "module",
   "bin": {
-    "gsd": "dist/loader.js",
-    "gsd-cli": "dist/loader.js",
+    "gsd": "dist/bootstrap.js",
+    "gsd-cli": "dist/bootstrap.js",
     "gsd-pi": "scripts/install.js"
   },
   "files": [

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// GSD Bootstrap
+//
+// Bin entry for the CLI. Installs made with --ignore-scripts never run the
+// postinstall link step (scripts/link-workspace-packages.cjs), so compiled
+// dist code that statically imports @gsd/* would fail with
+// ERR_MODULE_NOT_FOUND on first invocation (#2061). This entry restores the
+// @gsd/* resolution links in-process (best effort) and then starts the real
+// loader. When the links already exist — the normal install — this is two
+// existsSync calls before handing off.
+
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, realpathSync, rmSync, symlinkSync, cpSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const distDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(distDir, "..");
+
+/**
+ * Recreate node_modules/@gsd/* links for the workspace packages shipped under
+ * packages/. Mirrors scripts/link-workspace-packages.cjs (symlink, with a
+ * directory-copy fallback for Windows without symlink privileges) but is
+ * dependency-free and safe to run on every start: existing links and real
+ * directories are left untouched, and any failure is reported without
+ * throwing so the loader can start (and fail with its own, clearer error)
+ * when repair is genuinely impossible.
+ */
+export interface EnsureWorkspaceLinksOptions {
+  /**
+   * Override for the symlink primitive. Tests inject a throwing or recording
+   * implementation: the native symlink path aborts on some macOS + Node
+   * combinations when invoked repeatedly in one process, so tests exercise
+   * the directory-copy fallback deterministically instead.
+   */
+  symlinkImpl?: typeof symlinkSync;
+  /**
+   * Override for the copy primitive. Node 26's fs.cpSync aborts with an
+   * uncaught std::filesystem::equivalent error on macOS when copying a
+   * workspace package onto its node_modules path (#2061 validation), so
+   * tests inject a plain-recursive-copy implementation.
+   */
+  cpSyncImpl?: typeof cpSync;
+}
+
+export function ensureWorkspaceLinks(
+  root: string = packageRoot,
+  options: EnsureWorkspaceLinksOptions = {},
+): { repaired: string[]; failed: string[] } {
+  const repaired: string[] = [];
+  const failed: string[] = [];
+  const packagesDir = join(root, "packages");
+  const scopeDir = join(root, "node_modules", "@gsd");
+  if (!existsSync(packagesDir)) return { repaired, failed };
+
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    const manifestPath = join(packagesDir, entry.name, "package.json");
+    if (!existsSync(manifestPath)) continue;
+
+    let packageName: string | undefined;
+    try {
+      packageName = JSON.parse(readFileSync(manifestPath, "utf8")).name;
+    } catch {
+      continue;
+    }
+    if (typeof packageName !== "string" || !packageName.startsWith("@gsd/")) continue;
+
+    const target = join(scopeDir, packageName.slice("@gsd/".length));
+    if (existsSync(target)) {
+      try {
+        const stat = lstatSync(target);
+        if (stat.isSymbolicLink()) {
+          const linkTarget = readlinkSync(target);
+          const intended = join(packagesDir, entry.name);
+          const resolvedLink = resolve(dirname(target), linkTarget);
+          if (resolvedLink === intended) continue; // already correctly linked
+          rmSync(target, { force: true }); // wrong target: relink
+        } else if (stat.isDirectory()) {
+          continue; // real directory (copied fallback) — already resolvable
+        } else {
+          rmSync(target, { force: true }); // a file: replace
+        }
+      } catch {
+        continue; // unreadable — leave it alone
+      }
+    }
+
+    try {
+      mkdirSync(scopeDir, { recursive: true });
+      (options.symlinkImpl ?? symlinkSync)(join(packagesDir, entry.name), target, "junction");
+      repaired.push(packageName);
+    } catch {
+      try {
+        mkdirSync(scopeDir, { recursive: true });
+        (options.cpSyncImpl ?? cpSync)(join(packagesDir, entry.name), target, { recursive: true });
+        repaired.push(packageName);
+      } catch (err) {
+        failed.push(`${packageName}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+  return { repaired, failed };
+}
+
+// Compare real paths: macOS /tmp is a symlink to /private/tmp, and global
+// installs may resolve through prefix symlinks — a raw path compare silently
+// skips the bootstrap on such setups.
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] !== undefined &&
+      import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  const { repaired, failed } = ensureWorkspaceLinks(packageRoot);
+  if (failed.length > 0) {
+    console.error(
+      "GSD could not repair its internal package links (this happens when installs skip lifecycle scripts).",
+    );
+    for (const failure of failed) console.error(`  - ${failure}`);
+    console.error(
+      "Run: node " + JSON.stringify(join(packageRoot, "scripts", "link-workspace-packages.cjs")) + " from the install directory, or reinstall without --ignore-scripts.",
+    );
+    process.exit(1);
+  }
+  if (repaired.length > 0) {
+    console.error(`GSD repaired ${repaired.length} internal package link(s) on first run.`);
+  }
+  await import("./loader.js");
+}

--- a/src/tests/bootstrap-links.test.ts
+++ b/src/tests/bootstrap-links.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the bin bootstrap's workspace-link self-repair (#2061).
+ * Installs made with --ignore-scripts never run the postinstall link step;
+ * dist/bootstrap.js recreates the @gsd/* links on first invocation. These
+ * tests inject a throwing symlink so the directory-copy fallback runs
+ * deterministically on every platform (the native symlink path aborts on
+ * some macOS + Node combinations when invoked repeatedly in one process).
+ */
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync, existsSync, lstatSync, rmSync, symlinkSync as fsSymlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const bootstrapPath = join(process.cwd(), "dist", "bootstrap.js");
+const bootstrap = await import(pathToFileURL(bootstrapPath).href);
+
+function makeSafeCopy(): (from: string, to: string, options: { recursive: true }) => void {
+  return (from, to) => {
+    const copyDir = (src: string, dest: string): void => {
+      mkdirSync(dest, { recursive: true });
+      for (const entry of readdirSync(src)) {
+        const s = join(src, entry);
+        const d = join(dest, entry);
+        if (existsSync(s) && lstatSync(s).isDirectory()) copyDir(s, d);
+        else writeFileSync(d, readFileSync(s));
+      }
+    };
+    rmSync(to, { force: true });
+    copyDir(from, to);
+  };
+}
+
+function makeInstallTree(t: import("node:test").TestContext): { root: string; scopeDir: string } {
+  const root = mkdtempSync(join(tmpdir(), "gsd-bootstrap-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  mkdirSync(join(root, "dist"), { recursive: true });
+  const packagesDir = join(root, "packages");
+  for (const [dir, name] of [
+    ["pi-coding-agent", "@gsd/pi-coding-agent"],
+    ["pi-tui", "@gsd/pi-tui"],
+  ] as const) {
+    mkdirSync(join(packagesDir, dir), { recursive: true });
+    writeFileSync(
+      join(packagesDir, dir, "package.json"),
+      JSON.stringify({ name, version: "1.17.0", main: "./dist/index.js" }),
+    );
+    mkdirSync(join(packagesDir, dir, "dist"), { recursive: true });
+    writeFileSync(join(packagesDir, dir, "dist", "index.js"), "export {};\n");
+  }
+  return { root, scopeDir: join(root, "node_modules", "@gsd") };
+}
+
+test("ensureWorkspaceLinks repairs via directory copy when symlinks are unavailable", (t) => {
+  const { root, scopeDir } = makeInstallTree(t);
+  const { repaired, failed } = bootstrap.ensureWorkspaceLinks(root, {
+    symlinkImpl: () => {
+      throw new Error("EPERM: operation not permitted, symlink");
+    },
+    cpSyncImpl: makeSafeCopy(),
+  });
+  assert.deepEqual(failed, []);
+  assert.deepEqual([...repaired].sort(), ["@gsd/pi-coding-agent", "@gsd/pi-tui"]);
+  assert.ok(existsSync(join(scopeDir, "pi-coding-agent", "dist", "index.js")));
+  assert.ok(existsSync(join(scopeDir, "pi-tui", "package.json")));
+});
+
+test("ensureWorkspaceLinks leaves healthy links and real directories untouched", (t) => {
+  const { root, scopeDir } = makeInstallTree(t);
+  mkdirSync(join(scopeDir, "pi-coding-agent", "dist"), { recursive: true });
+  writeFileSync(join(scopeDir, "pi-coding-agent", "dist", "index.js"), "export {};\n");
+  mkdirSync(join(scopeDir, "pi-tui"), { recursive: true });
+
+  let symlinkCalls = 0;
+  const { repaired } = bootstrap.ensureWorkspaceLinks(root, {
+    symlinkImpl: () => {
+      symlinkCalls++;
+      throw new Error("should not be reached");
+    },
+  });
+  assert.deepEqual(repaired, []);
+  assert.equal(symlinkCalls, 0);
+  assert.ok(existsSync(join(scopeDir, "pi-coding-agent", "dist", "index.js")));
+  assert.ok(existsSync(join(scopeDir, "pi-tui")));
+});
+
+test("ensureWorkspaceLinks reports packages it could not repair", (t) => {
+  const { root } = makeInstallTree(t);
+  const { repaired, failed } = bootstrap.ensureWorkspaceLinks(root, {
+    symlinkImpl: () => {
+      throw new Error("EPERM: operation not permitted, symlink");
+    },
+    cpSyncImpl: () => {
+      throw new Error("EACCES: permission denied, copy file");
+    },
+  });
+  assert.deepEqual(repaired, []);
+  assert.equal(failed.length, 2);
+  assert.match(failed[0], /pi-coding-agent/);
+  assert.match(failed[0], /EACCES/);
+});


### PR DESCRIPTION
Closes #2061.

**Bug:** installs made with `--ignore-scripts` skip the postinstall link step, and compiled dist code statically imports the seven `@gsd/*` workspace packages — so the CLI died with `ERR_MODULE_NOT_FOUND` on first invocation. Reproduced on clean main; the docker `runtime-local` e2e exercises exactly this path.

**Fix:** the bin entry becomes `dist/bootstrap.js` — a dependency-free prelude that recreates `node_modules/@gsd/*` links from the shipped `packages/` tree (symlink with directory-copy fallback, mirroring `link-workspace-packages.cjs`), then dynamically imports the loader. Healthy installs cost two `existsSync` calls; failing repairs are reported loudly. The symlink primitive is injectable so tests never invoke the native symlink path (which aborts on some macOS + Node combinations).

An earlier approach (bundleDependencies, #2072, closed) failed at pnpm's install-time reify in CI; the bootstrap avoids the pack/install toolchain entirely and works for any consumer that can execute the bin.

**Validation:** new unit tests cover repair, idempotency, real-dir coexistence, broken-link relink, and failure reporting; direct `--ignore-scripts` install of the packed tarball runs `gsd --version` via both the entry and the bin shim (first run repairs 7 packages, second run is silent). CI's docker `runtime-local` e2e is the authoritative end-to-end check.