### PR TITLE
fix(issue): [Bug]: reassess-roadmap metadataCorrections.completedSlices adopts slice lifecycle but skips task lifecycles

### DIFF
--- a/src/resources/extensions/gsd/tests/reassess-roadmap-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/reassess-roadmap-domain-operation.test.ts
@@ -279,6 +279,10 @@ test("reassessment corrects milestone and completed-slice evidence metadata with
     },
   });
   const beforeTask = getTask("M001", "S01", "T01");
+  assert.equal(db().prepare(`
+    SELECT lifecycle_status FROM workflow_item_lifecycles
+    WHERE item_kind = 'task' AND milestone_id = 'M001' AND slice_id = 'S01' AND task_id = 'T01'
+  `).get(), undefined, "fixture task must start without canonical lifecycle authority");
   const beforeMilestoneLifecycle = db().prepare(
     "SELECT lifecycle_status, state_version FROM workflow_item_lifecycles WHERE item_kind = 'milestone' AND milestone_id = 'M001'",
   ).get();
@@ -323,6 +327,10 @@ test("reassessment corrects milestone and completed-slice evidence metadata with
   assert.equal(completedSlice?.demo, "The corrected runtime acceptance policy is demonstrable.");
   assert.equal(completedSlice?.success_criteria, "Runtime acceptance evidence is recorded.");
   assert.deepEqual(getTask("M001", "S01", "T01"), beforeTask, "metadata correction must not mutate completed task rows");
+  assert.deepEqual(db().prepare(`
+    SELECT lifecycle_status, state_version FROM workflow_item_lifecycles
+    WHERE item_kind = 'task' AND milestone_id = 'M001' AND slice_id = 'S01' AND task_id = 'T01'
+  `).get(), { lifecycle_status: "completed", state_version: 0 }, "metadata correction must adopt completed task lifecycles");
   assert.deepEqual(db().prepare(
     "SELECT lifecycle_status, state_version FROM workflow_item_lifecycles WHERE item_kind = 'milestone' AND milestone_id = 'M001'",
   ).get(), beforeMilestoneLifecycle, "metadata correction must preserve completed milestone lifecycle state");

--- a/src/resources/extensions/gsd/tests/reassess-roadmap-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/reassess-roadmap-domain-operation.test.ts
@@ -278,11 +278,30 @@ test("reassessment corrects milestone and completed-slice evidence metadata with
       requiredWorkflowTools: [],
     },
   });
+  insertTask({
+    id: "T02",
+    milestoneId: "M001",
+    sliceId: "S01",
+    title: "Skipped evidence task",
+    status: "skipped",
+    planning: {
+      description: "Preserved skipped work.",
+      estimate: "15m",
+      files: [],
+      verify: "node --test",
+      inputs: [],
+      expectedOutput: [],
+      observabilityImpact: "No task evidence required.",
+      requiredWorkflowTools: [],
+    },
+  });
   const beforeTask = getTask("M001", "S01", "T01");
-  assert.equal(db().prepare(`
-    SELECT lifecycle_status FROM workflow_item_lifecycles
-    WHERE item_kind = 'task' AND milestone_id = 'M001' AND slice_id = 'S01' AND task_id = 'T01'
-  `).get(), undefined, "fixture task must start without canonical lifecycle authority");
+  const beforeSkippedTask = getTask("M001", "S01", "T02");
+  assert.deepEqual(db().prepare(`
+    SELECT task_id, lifecycle_status FROM workflow_item_lifecycles
+    WHERE item_kind = 'task' AND milestone_id = 'M001' AND slice_id = 'S01'
+    ORDER BY task_id
+  `).all(), [], "fixture tasks must start without canonical lifecycle authority");
   const beforeMilestoneLifecycle = db().prepare(
     "SELECT lifecycle_status, state_version FROM workflow_item_lifecycles WHERE item_kind = 'milestone' AND milestone_id = 'M001'",
   ).get();
@@ -327,10 +346,15 @@ test("reassessment corrects milestone and completed-slice evidence metadata with
   assert.equal(completedSlice?.demo, "The corrected runtime acceptance policy is demonstrable.");
   assert.equal(completedSlice?.success_criteria, "Runtime acceptance evidence is recorded.");
   assert.deepEqual(getTask("M001", "S01", "T01"), beforeTask, "metadata correction must not mutate completed task rows");
+  assert.deepEqual(getTask("M001", "S01", "T02"), beforeSkippedTask, "metadata correction must not mutate skipped task rows");
   assert.deepEqual(db().prepare(`
-    SELECT lifecycle_status, state_version FROM workflow_item_lifecycles
-    WHERE item_kind = 'task' AND milestone_id = 'M001' AND slice_id = 'S01' AND task_id = 'T01'
-  `).get(), { lifecycle_status: "completed", state_version: 0 }, "metadata correction must adopt completed task lifecycles");
+    SELECT task_id, lifecycle_status, state_version FROM workflow_item_lifecycles
+    WHERE item_kind = 'task' AND milestone_id = 'M001' AND slice_id = 'S01'
+    ORDER BY task_id
+  `).all(), [
+    { task_id: "T01", lifecycle_status: "completed", state_version: 0 },
+    { task_id: "T02", lifecycle_status: "cancelled", state_version: 0 },
+  ], "metadata correction must adopt terminal task lifecycles");
   assert.deepEqual(db().prepare(
     "SELECT lifecycle_status, state_version FROM workflow_item_lifecycles WHERE item_kind = 'milestone' AND milestone_id = 'M001'",
   ).get(), beforeMilestoneLifecycle, "metadata correction must preserve completed milestone lifecycle state");

--- a/src/resources/extensions/gsd/tools/reassess-roadmap.ts
+++ b/src/resources/extensions/gsd/tools/reassess-roadmap.ts
@@ -399,13 +399,14 @@ export async function handleReassessRoadmap(
             throw new PlanningGuardError(`metadata correction target ${correction.sliceId} is canonically ${lifecycle.lifecycleStatus}, not completed`);
           }
           for (const task of getSliceTasks(params.milestoneId, correction.sliceId)) {
-            if (normalizeLegacyLifecycleStatus(task.status) !== "completed") continue;
+            const taskLifecycleStatus = normalizeLegacyLifecycleStatus(task.status);
+            if (taskLifecycleStatus !== "completed" && taskLifecycleStatus !== "cancelled") continue;
             adoptLifecycleIfMissing(context, {
               itemKind: "task",
               milestoneId: params.milestoneId,
               sliceId: correction.sliceId,
               taskId: task.id,
-              lifecycleStatus: "completed",
+              lifecycleStatus: taskLifecycleStatus,
             });
           }
         }

--- a/src/resources/extensions/gsd/tools/reassess-roadmap.ts
+++ b/src/resources/extensions/gsd/tools/reassess-roadmap.ts
@@ -398,6 +398,16 @@ export async function handleReassessRoadmap(
           if (lifecycle.lifecycleStatus !== "completed") {
             throw new PlanningGuardError(`metadata correction target ${correction.sliceId} is canonically ${lifecycle.lifecycleStatus}, not completed`);
           }
+          for (const task of getSliceTasks(params.milestoneId, correction.sliceId)) {
+            if (normalizeLegacyLifecycleStatus(task.status) !== "completed") continue;
+            adoptLifecycleIfMissing(context, {
+              itemKind: "task",
+              milestoneId: params.milestoneId,
+              sliceId: correction.sliceId,
+              taskId: task.id,
+              lifecycleStatus: "completed",
+            });
+          }
         }
 
         for (const modifiedSlice of params.sliceChanges.modified) {


### PR DESCRIPTION
## Summary
- Adopted completed task lifecycles during completed-slice metadata correction and verified the regression, build, and typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2082
- [#2082 [Bug]: reassess-roadmap metadataCorrections.completedSlices adopts slice lifecycle but skips task lifecycles](https://github.com/open-gsd/gsd-pi/issues/2082)

## User
- @Jack11111eee

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2082-bug-reassess-roadmap-metadatacorrections-1788059023`