### PR TITLE
chore(gsd): remove dead Copilot catalog classification

### DIFF
--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -1,14 +1,14 @@
 // Project/App: gsd-pi
 // File Purpose: GSD-W018 — session-start GitHub Copilot catalog refresh
-// coordinator and 3-tier runtime model classification.
+// coordinator.
 //
 // Extends the explicit, user-invoked `/gsd copilot-models sync` (GSD-W014)
 // with an OPT-IN automatic refresh at GSD session start, gated by
 // `copilot_catalog.refresh_on_session_start` (default "off"). Reuses the
 // same read-only fetch/sanitize/last-known-good pipeline from
 // `copilot-model-catalog.ts` — this module never duplicates network/auth
-// logic, it only coordinates *when* to call it and classifies the result for
-// safe runtime selection.
+// logic, it only coordinates *when* to call it and captures the result for
+// the W017 change notifications.
 //
 // Invariants:
 //   - Never blocks ordinary session startup: callers must fire-and-forget
@@ -20,11 +20,7 @@
 //     `ctx.modelRegistry.getApiKey()`, which only ever returns a token that
 //     is already available, and any thrown/missing token is treated as
 //     "auth unavailable, skip silently" — never surfaced as an error.
-//   - Bounded wall-clock timeout; a slow/hanging fetch never wedges startup
-//     or a caller awaiting the in-flight refresh (e.g. the model picker).
-//   - Classification never fabricates capability or pricing data: unknown
-//     stays unknown (manual-only), and structurally incomplete records are
-//     quarantined rather than silently defaulted.
+//   - Bounded wall-clock timeout; a slow/hanging fetch never wedges startup.
 //   - State here is session-scoped only (module-level, per basePath) —
 //     nothing is persisted to disk, mirroring the existing
 //     `commands/handlers/copilot-models.ts` session-scoped snapshot.
@@ -36,16 +32,8 @@ import {
 	applyLastKnownGood,
 	diffCatalogSnapshots,
 	fetchGitHubCopilotModels,
-	type CopilotModelRecord,
 	type CopilotModelSnapshot,
 } from "./copilot-model-catalog.js";
-import { resolveModelEconomics } from "./model-cost-table.js";
-import {
-	canonicalizeModelId,
-	getModelProfileConfidence,
-	MODEL_CAPABILITY_TIER,
-	type CapabilityProfileConfidence,
-} from "./model-router.js";
 import type {
 	CopilotCatalogPreferences,
 	CopilotCatalogRefreshMode,
@@ -97,123 +85,6 @@ export function shouldTriggerCopilotCatalogRefresh(
 	return nowMs - lastRefreshedAtMs >= staleAfterMs;
 }
 
-// ─── Runtime model classification (Class A / B / C) ────────────────────────
-
-/**
- * - "trusted" (Class A): capability tier, profile confidence, and pricing are
- *   all known — exposed for manual selection AND eligible for automatic
- *   routing (subject to the existing routing confidence/economics gates in
- *   model-router.ts).
- * - "manual-only" (Class B): the live record is transport-valid
- *   (`tool_call: true`) but capability tier, profile confidence, or pricing
- *   is unknown — selectable manually, never auto-routed, never used for
- *   cheaper-model suggestions.
- * - "quarantined" (Class C): structurally incomplete (not tool-call capable)
- *   — not exposed as selectable, not routed, not suggested.
- */
-export type ModelRuntimeClass = "trusted" | "manual-only" | "quarantined";
-
-export interface ModelClassification {
-	modelClass: ModelRuntimeClass;
-	reasons: string[];
-	tier?: string;
-	profileConfidence?: CapabilityProfileConfidence;
-	hasKnownPricing: boolean;
-}
-
-/**
- * Classify a single live-catalog GitHub Copilot model for safe runtime
- * exposure (GSD-W018 Decision 6). Never invents capability or pricing data —
- * absence of evidence always resolves to "manual-only" or "quarantined",
- * never a synthesized "trusted" classification.
- */
-export function classifyRemoteCopilotModel(
-	record: CopilotModelRecord,
-): ModelClassification {
-	if (!record.execution.toolCalls) {
-		return {
-			modelClass: "quarantined",
-			reasons: ["missing required tool-call capability"],
-			hasKnownPricing: false,
-		};
-	}
-	if (record.availability.policyState === "disabled" || record.availability.policyState === "restricted") {
-		return {
-			modelClass: "quarantined",
-			reasons: [`policy state: ${record.availability.policyState}`],
-			hasKnownPricing: false,
-		};
-	}
-	if (record.availability.preview) {
-		return {
-			modelClass: "quarantined",
-			reasons: ["preview model — not yet stable for automatic exposure"],
-			hasKnownPricing: false,
-		};
-	}
-	if (record.conflicts.length > 0) {
-		return {
-			modelClass: "quarantined",
-			reasons: [`unresolved normalization conflict(s): ${record.conflicts.join(", ")}`],
-			hasKnownPricing: false,
-		};
-	}
-
-	const tier = MODEL_CAPABILITY_TIER[canonicalizeModelId(record.id)];
-	const profileConfidence = getModelProfileConfidence(record.id);
-	const hasKnownLimits =
-		typeof record.execution.contextWindow === "number" && typeof record.execution.maxTokens === "number";
-	const hasBillingOnRecord = record.billing.inputPer1k !== undefined && record.billing.outputPer1k !== undefined;
-	const economics = resolveModelEconomics({
-		provider: "github-copilot",
-		modelId: record.id,
-		fallbackEconomics: {
-			source: "bundled-fallback",
-			stale: false,
-			billingUnit: "tokens",
-		},
-		// BUNDLED_COST_TABLE entries are keyed by bare model ID and are not
-		// provider-qualified — without this, a same-named model priced by a
-		// different provider (e.g. OpenAI's "gpt-5.4") could silently be
-		// reported as this Copilot model's known price. See model-cost-table.ts.
-		disableImplicitFallback: true,
-	});
-	const fallbackPrices = economics.tokenPrices?.default;
-	const hasKnownPricing =
-		hasBillingOnRecord ||
-		economics.source !== "bundled-fallback" ||
-		Boolean(fallbackPrices && (fallbackPrices.inputPer1k > 0 || fallbackPrices.outputPer1k > 0));
-
-	if (tier && profileConfidence !== "unknown" && hasKnownPricing && hasKnownLimits) {
-		return {
-			modelClass: "trusted",
-			reasons: [
-				`capability tier known (${tier})`,
-				`profile confidence: ${profileConfidence}`,
-				"pricing known",
-				"context/token limits known",
-			],
-			tier,
-			profileConfidence,
-			hasKnownPricing,
-		};
-	}
-
-	const reasons: string[] = [];
-	if (!tier) reasons.push("no known capability tier");
-	if (profileConfidence === "unknown") reasons.push("no capability profile (unknown confidence)");
-	if (!hasKnownPricing) reasons.push("no known pricing");
-	if (!hasKnownLimits) reasons.push("no known context/token limits");
-
-	return {
-		modelClass: "manual-only",
-		reasons,
-		tier,
-		profileConfidence,
-		hasKnownPricing,
-	};
-}
-
 // ─── Session-start refresh coordinator ─────────────────────────────────────
 
 export interface CopilotCatalogSessionRefreshResult {
@@ -222,7 +93,6 @@ export interface CopilotCatalogSessionRefreshResult {
 	ok: boolean;
 	reason?: string;
 	snapshot: CopilotModelSnapshot | null;
-	classifications: Record<string, ModelClassification>;
 	changedModelIds: string[];
 }
 
@@ -230,7 +100,6 @@ const NOOP_RESULT: Readonly<CopilotCatalogSessionRefreshResult> = Object.freeze(
 	ran: false,
 	ok: false,
 	snapshot: null,
-	classifications: {},
 	changedModelIds: [],
 });
 
@@ -351,11 +220,6 @@ async function runCopilotCatalogRefresh(
 	lastSnapshotByBasePath.set(basePath, nextSnapshot);
 	lastRefreshedAtByBasePath.set(basePath, nowFn());
 
-	const classifications: Record<string, ModelClassification> = {};
-	for (const model of nextSnapshot.models) {
-		classifications[model.id] = classifyRemoteCopilotModel(model);
-	}
-
 	const changedModelIds = previousSnapshot
 		? (() => {
 				const diff = diffCatalogSnapshots(previousSnapshot, nextSnapshot);
@@ -367,7 +231,6 @@ async function runCopilotCatalogRefresh(
 		ran: true,
 		ok: true,
 		snapshot: nextSnapshot,
-		classifications,
 		changedModelIds,
 	};
 }
@@ -377,12 +240,10 @@ async function runCopilotCatalogRefresh(
  * refresh. Callers on the startup path MUST NOT `await` this synchronously —
  * fire it and let it resolve in the background (`void
  * startCopilotCatalogSessionRefresh(...)`), per the non-blocking-startup
- * invariant. `awaitCopilotCatalogSessionRefresh` is the bounded-wait join
- * point for callers (e.g. the model picker) that need the result.
+ * invariant.
  *
  * Returns `NOOP_RESULT` synchronously-resolved when the mode is "off" or
- * "if_stale" and the snapshot is not yet stale — no promise is stored in
- * that case, so `awaitCopilotCatalogSessionRefresh` has nothing to join.
+ * "if_stale" and the snapshot is not yet stale.
  */
 export function startCopilotCatalogSessionRefresh(
 	options: RefreshCopilotCatalogSessionOptions,
@@ -412,21 +273,6 @@ export function startCopilotCatalogSessionRefresh(
 
 	inFlightRefreshes.set(basePath, runPromise);
 	return runPromise;
-}
-
-/**
- * Await an in-flight refresh for `basePath`, bounded by `timeoutMs`. Used by
- * the model picker so a just-started refresh can populate newly available
- * models before the picker renders, without ever blocking indefinitely.
- * Resolves immediately with `NOOP_RESULT` when nothing is in flight.
- */
-export function awaitCopilotCatalogSessionRefresh(
-	basePath: string,
-	timeoutMs = DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS,
-): Promise<CopilotCatalogSessionRefreshResult> {
-	const pending = inFlightRefreshes.get(basePath);
-	if (!pending) return Promise.resolve(NOOP_RESULT);
-	return withTimeout(pending, timeoutMs, { ...NOOP_RESULT, ran: true, reason: "timeout" });
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/copilot-catalog-session-refresh.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-session-refresh.test.ts
@@ -1,24 +1,19 @@
 // Regression/behavior tests for GSD-W018: the session-start GitHub Copilot
-// catalog refresh coordinator and 3-tier runtime model classification.
-// Exercises the coordinator's dedup/timeout/auth-safety contract and the
-// classifier's refusal to fabricate capability or pricing data — as opposed
-// to the production command wiring covered by copilot-models-handler.test.ts.
+// catalog refresh coordinator. Exercises the coordinator's dedup/timeout/
+// auth-safety contract — as opposed to the production command wiring covered
+// by copilot-models-handler.test.ts.
 
 import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
 	_resetCopilotCatalogSessionRefreshStateForTests,
-	awaitCopilotCatalogSessionRefresh,
-	classifyRemoteCopilotModel,
 	resolveCopilotCatalogNotifyOnChanges,
 	resolveCopilotCatalogRefreshMode,
 	resolveCopilotCatalogStaleAfterMs,
 	shouldTriggerCopilotCatalogRefresh,
 	startCopilotCatalogSessionRefresh,
-	type CopilotCatalogSessionRefreshResult,
 } from "../copilot-catalog-session-refresh.js";
-import type { CopilotModelRecord } from "../copilot-model-catalog.js";
 
 interface FakeModel {
 	id: string;
@@ -55,38 +50,6 @@ function jsonResponse(data: Array<Record<string, unknown>>) {
 
 function neverResolves() {
 	return (async () => new Promise<Response>(() => {})) as unknown as typeof fetch;
-}
-
-function buildRecord(overrides: Partial<CopilotModelRecord> = {}): CopilotModelRecord {
-	return {
-		provider: "github-copilot",
-		id: "claude-sonnet-5",
-		registryId: "github-copilot/claude-sonnet-5",
-		name: "Claude Sonnet 5",
-		availability: { enabled: true, pickerEnabled: true, preview: false, policyState: "enabled" },
-		execution: {
-			toolCalls: true,
-			supportedEndpoints: [],
-			reasoningLevels: [],
-			contextWindow: 200_000,
-			maxTokens: 8_192,
-		},
-		billing: { billingUnit: "tokens", inputPer1k: 0.003, outputPer1k: 0.015 },
-		provenance: {
-			displayName: { source: "provider-live", freshness: "fresh" },
-			availability: { source: "provider-live", freshness: "fresh" },
-			endpoints: { source: "provider-live", freshness: "fresh" },
-			reasoning: { source: "provider-live", freshness: "fresh" },
-			limits: { source: "provider-live", freshness: "fresh" },
-			billingUnit: { source: "provider-live", freshness: "fresh" },
-			tokenPrices: { source: "provider-live", freshness: "fresh" },
-			requestMultiplier: { source: "unknown", freshness: "unknown" },
-			promotion: { source: "unknown", freshness: "unknown" },
-		},
-		conflicts: [],
-		hash: "test-hash",
-		...overrides,
-	} as CopilotModelRecord;
 }
 
 // ─── Config resolution ──────────────────────────────────────────────────────
@@ -143,63 +106,6 @@ test("shouldTriggerCopilotCatalogRefresh: if_stale triggers on first run and aft
 	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 1400, 500), false, "still fresh");
 	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 1500, 500), true, "exactly at threshold");
 	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 2000, 500), true, "past threshold");
-});
-
-// ─── classifyRemoteCopilotModel (pure) ──────────────────────────────────────
-
-test("classifyRemoteCopilotModel: trusted when tier, profile, pricing, and limits are all known", () => {
-	const result = classifyRemoteCopilotModel(buildRecord());
-	assert.equal(result.modelClass, "trusted");
-	assert.equal(result.tier, "standard");
-	assert.equal(result.hasKnownPricing, true);
-});
-
-test("classifyRemoteCopilotModel: manual-only when capability tier is unknown", () => {
-	const result = classifyRemoteCopilotModel(buildRecord({ id: "some-brand-new-unlisted-model" }));
-	assert.equal(result.modelClass, "manual-only");
-	assert.ok(result.reasons.some((reason) => reason.includes("capability tier")));
-});
-
-test("classifyRemoteCopilotModel: manual-only when pricing is unknown and tier/profile are unknown too", () => {
-	const result = classifyRemoteCopilotModel(
-		buildRecord({ id: "some-brand-new-unlisted-model-2", billing: { billingUnit: "unknown" } }),
-	);
-	assert.equal(result.modelClass, "manual-only");
-	assert.equal(result.hasKnownPricing, false);
-});
-
-test("classifyRemoteCopilotModel: quarantined when not tool-call capable", () => {
-	const result = classifyRemoteCopilotModel(
-		buildRecord({ execution: { ...buildRecord().execution, toolCalls: false } }),
-	);
-	assert.equal(result.modelClass, "quarantined");
-	assert.match(result.reasons[0]!, /tool-call/);
-});
-
-test("classifyRemoteCopilotModel: quarantined when policy-restricted or disabled", () => {
-	const restricted = classifyRemoteCopilotModel(
-		buildRecord({ availability: { ...buildRecord().availability, policyState: "restricted" } }),
-	);
-	assert.equal(restricted.modelClass, "quarantined");
-
-	const disabled = classifyRemoteCopilotModel(
-		buildRecord({ availability: { ...buildRecord().availability, policyState: "disabled" } }),
-	);
-	assert.equal(disabled.modelClass, "quarantined");
-});
-
-test("classifyRemoteCopilotModel: quarantined when preview", () => {
-	const result = classifyRemoteCopilotModel(
-		buildRecord({ availability: { ...buildRecord().availability, preview: true } }),
-	);
-	assert.equal(result.modelClass, "quarantined");
-	assert.match(result.reasons[0]!, /preview/);
-});
-
-test("classifyRemoteCopilotModel: quarantined when normalization reported conflicts", () => {
-	const result = classifyRemoteCopilotModel(buildRecord({ conflicts: ["endpoint mismatch"] }));
-	assert.equal(result.modelClass, "quarantined");
-	assert.match(result.reasons[0]!, /conflict/);
 });
 
 // ─── startCopilotCatalogSessionRefresh (coordinator) ────────────────────────
@@ -277,7 +183,7 @@ test("startCopilotCatalogSessionRefresh: a throwing getApiKey never triggers a l
 	assert.equal(result.reason, "auth-unavailable");
 });
 
-test("startCopilotCatalogSessionRefresh: successful refresh classifies models and reports changes", async () => {
+test("startCopilotCatalogSessionRefresh: successful refresh reports changed models", async () => {
 	_resetCopilotCatalogSessionRefreshStateForTests();
 	const { ctx } = createFakeCtx({
 		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
@@ -294,7 +200,6 @@ test("startCopilotCatalogSessionRefresh: successful refresh classifies models an
 	assert.equal(result.ok, true);
 	assert.ok(result.snapshot);
 	assert.equal(result.changedModelIds.length, 1, "first-ever snapshot reports every model as changed");
-	assert.ok(result.classifications["claude-sonnet-5"]);
 });
 
 test("startCopilotCatalogSessionRefresh: no-diff second refresh reports zero changes", async () => {
@@ -380,30 +285,4 @@ test("startCopilotCatalogSessionRefresh: a hanging fetch resolves via the bounde
 	});
 
 	assert.equal(result.reason, "timeout");
-});
-
-test("awaitCopilotCatalogSessionRefresh: resolves immediately when nothing is in flight", async () => {
-	_resetCopilotCatalogSessionRefreshStateForTests();
-	const result = await awaitCopilotCatalogSessionRefresh("/no-such-project", 50);
-	assert.equal(result.ran, false);
-});
-
-test("awaitCopilotCatalogSessionRefresh: joins an in-flight refresh started elsewhere", async () => {
-	_resetCopilotCatalogSessionRefreshStateForTests();
-	const { ctx } = createFakeCtx({
-		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
-		apiKey: "token-abc",
-	});
-
-	const started: Promise<CopilotCatalogSessionRefreshResult> = startCopilotCatalogSessionRefresh({
-		ctx,
-		basePath: "/project-6",
-		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
-		fetchImpl: jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]),
-	});
-
-	const joined = await awaitCopilotCatalogSessionRefresh("/project-6", 1000);
-	const original = await started;
-	assert.equal(joined.ok, original.ok);
-	assert.deepEqual(joined.snapshot, original.snapshot);
 });


### PR DESCRIPTION
## Intent

Walk back issue #2088's per-model catalog machinery: remove the diagnostic-only 3-tier runtime model classification (trusted/manual-only/quarantined) from the W018 session-start Copilot catalog refresh. It is dead code: classifyRemoteCopilotModel had zero consumers outside its own module and tests, and awaitCopilotCatalogSessionRefresh (the intended bounded-wait join for the model picker) had no callers. Runtime safety is already enforced where it belongs, at write time: copilot-models sync --register only writes complete models (authoritative API mapping, tool calls, context window, max tokens, reasoning flag, all four price fields) into the models-catalog.json overlay, so incomplete models can never become selectable; RFC #2091 proposing per-model runtime gating was closed as wontfix by the maintainer for exactly this reason. Deliberate decisions: the refresh coordinator itself STAYS - register-hooks still fires it on session start and the W017 cheaper-alternative notifications still consume changedModelIds/snapshot via getLastKnownCopilotCatalogSnapshot; the classifications field on CopilotCatalogSessionRefreshResult is removed along with the classifier; the provider-equality allowlist entry for the file stays (the coordinator still needs the github-copilot provider for auth resolution); this must be a pure removal with zero behavior change. Verified locally: typecheck:extensions clean, session-refresh tests 16/16, notifications + prefs + provider-equality-allowlist 19/19, manual-selection tests pass, pnpm run verify:fast green, GitHub CI already 11/11 green on PR #2094.

## What Changed

- Remove the unused trusted/manual-only/quarantined model classifier and classification data from Copilot catalog refresh results.
- Remove the unused bounded-wait refresh join and its classifier/join-specific tests.
- Update coordinator comments and tests to reflect its remaining refresh and change-notification responsibilities.

## Risk Assessment

✅ Low: The change is a bounded removal of unconsumed classification and join machinery while preserving the refresh coordinator, notification data flow, snapshot access, and provider allowlist.

## Testing

The supplied baseline already reported clean typecheck, verify:fast, and CI; after fixing missing local dependencies, all targeted automated checks and direct session-start/CLI evidence passed, persisted state confirmed write-time safety, transient files were removed, and no screenshot was applicable because this is lifecycle and CLI behavior rather than a visual change.

<details>
<summary>Evidence: End-to-end session-start and CLI transcript</summary>

```text
{
  "sessionStartRefresh": {
    "resultFields": [
      "changedModelIds",
      "ok",
      "ran",
      "snapshot"
    ],
    "ok": true,
    "changedModelIds": [
      "brand-new-complete",
      "gpt-5.4",
      "incomplete-model"
    ],
    "secondRefreshChangedModelIds": [],
    "lastKnownSnapshotModelIds": [
      "brand-new-complete",
      "gpt-5.4",
      "incomplete-model"
    ]
  },
  "actualSessionStartHook": {
    "handlerRegistered": true,
    "notifications": [
      {
        "level": "info",
        "message": "GitHub Copilot model catalog: 3 model(s) changed since the last check. Run /gsd copilot-models changes for details."
      }
    ],
    "capturedSnapshotModelIds": [
      "brand-new-complete",
      "gpt-5.4",
      "incomplete-model"
    ]
  },
  "userCommand": "/gsd copilot-models sync --register",
  "notifications": [
    {
      "level": "info",
      "message": "GitHub Copilot model catalog: 3 model(s) available.\n= github-copilot/brand-new-complete registered into /Users/jeremymcspadden/.no-mistakes/evidence/01M19RJEAB47TM6CDBPG1WGVX5/models-catalog.json\n! github-copilot/incomplete-model quarantined — missing authoritative runtime API/endpoint mapping; missing authoritative context window; missing authoritative max output tokens; missing authoritative reasoning support flag; missing authoritative input token price; missing authoritative output token price; missing authoritative cache-read token price; missing authoritative cache-write token price"
    }
  ],
  "registryRefreshCalls": 1,
  "persistedModelIds": [
    "brand-new-complete"
  ],
  "incompleteModelPersisted": false,
  "persistedCompleteModel": {
    "id": "brand-new-complete",
    "name": "Brand New Complete",
    "api": "openai-responses",
    "provider": "github-copilot",
    "baseUrl": "https://api.individual.githubcopilot.com",
    "reasoning": true,
    "input": [
      "text"
    ],
    "cost": {
      "input": 0.2,
      "output": 1.2,
      "cacheRead": 0,
      "cacheWrite": 0
    },
    "contextWindow": 400000,
    "maxTokens": 128000,
    "headers": {
      "User-Agent": "GitHubCopilotChat/0.35.0",
      "Editor-Version": "vscode/1.107.0",
      "Editor-Plugin-Version": "copilot-chat/0.35.0",
      "Copilot-Integration-Id": "vscode-chat"
    }
  }
}
```
</details>
<details>
<summary>Evidence: Persisted models catalog overlay</summary>

```text
{
  "version": 1,
  "fetchedAt": "2026-08-30T16:46:35.186Z",
  "source": "gsd:copilot-models --register",
  "models": {
    "github-copilot": {
      "brand-new-complete": {
        "id": "brand-new-complete",
        "name": "Brand New Complete",
        "api": "openai-responses",
        "provider": "github-copilot",
        "baseUrl": "https://api.individual.githubcopilot.com",
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0.2,
          "output": 1.2,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 400000,
        "maxTokens": 128000,
        "headers": {
          "User-Agent": "GitHubCopilotChat/0.35.0",
          "Editor-Version": "vscode/1.107.0",
          "Editor-Plugin-Version": "copilot-chat/0.35.0",
          "Copilot-Integration-Id": "vscode-chat"
        }
      }
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d0782be3cdaba94a17ff15b28c7d6dff159fcfdf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --frozen-lockfile --ignore-scripts` (restored missing isolated-worktree dependencies; removed afterward)</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/copilot-catalog-session-refresh.test.ts src/resources/extensions/gsd/tests/copilot-catalog-notifications.test.ts src/resources/extensions/gsd/tests/copilot-catalog-preferences-validation.test.ts src/resources/extensions/gsd/tests/copilot-catalog-manual-selection.test.ts src/tests/provider-equality-allowlist.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern='synthesizeCopilotOverlayEntry produces|registerCopilotModelsInOverlay' src/resources/extensions/gsd/tests/copilot-overlay-writer.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern='--register quarantines remote-only|--register on a first run writes complete|--register calls modelRegistry.refresh' src/resources/extensions/gsd/tests/copilot-models-handler.test.ts`
- <code>Executed the real registered `session_start` handler with opt-in catalog preferences and captured its notification and snapshot</code>
- <code>Executed `handleCopilotModels(&#34;sync --register&#34;, ...)`, inspected the persisted overlay, quarantine message, and registry refresh side effect</code>
- `Parsed the generated evidence and asserted the lifecycle notification, quarantine result, and registry refresh contract`
- <code>`git status --short --branch` after removing transient dependencies and Memtrace data</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
