### PR TITLE
feat(gsd): refresh models and pricing in session

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -39,7 +39,7 @@
 | `/gsd report` | Generate HTML reports for all milestones and open the reports index in a browser |
 | `/gsd report --html` | Generate self-contained HTML report for current or completed milestone |
 | `/gsd report --html --all` | Generate retrospective reports for all milestones at once |
-| `/gsd update` | Update GSD to the latest version in-session |
+| `/gsd update` | Update GSD in-session; `--models` refreshes models and pricing without a restart |
 | `/gsd upgrade` | Alias for `/gsd update` |
 | `/gsd knowledge` | Add persistent project knowledge. Rules remain manually maintained in `KNOWLEDGE.md`; patterns and lessons are memory-backed and projected into the file on the next session start. |
 | `/gsd memory` | Query and forget project memories |
@@ -589,6 +589,8 @@ When the `claude-code` provider is configured, update may also warn if the local
 ```
 
 If already up to date, it reports so and takes no action.
+
+Use `/gsd update --models` to fetch the published all-provider model catalog, atomically replace `~/.gsd/agent/models-catalog.json`, and reload the model registry in the current session. New models and pricing become available without an npm upgrade or restart. The command does not require provider authentication, and `/gsd upgrade --models` is an alias. See [Updating the Model Catalog](./custom-models.md#updating-the-model-catalog) for validation, precedence, and failure behavior.
 
 ## Report
 

--- a/docs/user-docs/custom-models.md
+++ b/docs/user-docs/custom-models.md
@@ -279,13 +279,15 @@ Behavior notes:
 
 ## Updating the Model Catalog
 
-Run `gsd update --models` to fetch the latest published model catalog without a full npm upgrade:
+Run `gsd update --models` from the shell, or `/gsd update --models` in a running session, to fetch the latest published model catalog without a full npm upgrade:
 
 ```bash
 gsd update --models
+# In a running GSD session:
+/gsd update --models
 ```
 
-The command downloads the current generated catalog snapshot from the gsd-pi repository's `main` branch and stores it as a versioned JSON overlay at `~/.gsd/agent/models-catalog.json`. The flag is standalone; a trailing value is rejected.
+The command downloads the current generated catalog snapshot from the gsd-pi repository's `main` branch and stores it as a versioned JSON overlay at `~/.gsd/agent/models-catalog.json`. The fetch is auth-free, uses only the published all-provider catalog, and is bounded by a 15-second timeout. The flag is standalone; a trailing value is rejected before any fetch. `/gsd upgrade --models` is an alias for the in-session form.
 
 At startup, models resolve in precedence order (lowest to highest):
 
@@ -293,7 +295,7 @@ At startup, models resolve in precedence order (lowest to highest):
 2. **Overlay** from `~/.gsd/agent/models-catalog.json` — replaces bundled entries with the same provider + model `id` and adds new models and providers.
 3. **`models.json`** (this file) — custom providers, custom models, and `modelOverrides` always take highest precedence and are never modified by the update.
 
-This delivers new models, pricing, and context-window updates as they are published, without upgrading GSD itself. The overlay is replaced atomically only after a complete catalog passes validation, so a download, validation, or write failure leaves an existing overlay unchanged. If the overlay is missing or malformed, it is ignored and startup continues with the bundled catalog and `models.json`.
+This delivers new models, pricing, and context-window updates as they are published, without upgrading GSD itself. The in-session form reloads the model registry after a successful update, so the new catalog is active immediately without a restart. The overlay is replaced atomically only after a complete catalog passes validation, so a download, HTTP, validation, or write failure leaves an existing overlay unchanged. If the overlay is missing or malformed, it is ignored and startup continues with the bundled catalog and `models.json`.
 
 ## GitHub Copilot Live Catalog Sync
 

--- a/docs/zh-CN/user-docs/commands.md
+++ b/docs/zh-CN/user-docs/commands.md
@@ -31,7 +31,7 @@
 | `/gsd brief <mode> [topic] [--slides]` | 生成自包含的可视化 HTML 简报。模式：`diagram`、`plan`、`diff`、`recap`、`table`、`slides`。 |
 | `/gsd export --html` | 为当前或已完成的 milestone 生成自包含 HTML 报告 |
 | `/gsd export --html --all` | 一次性为所有 milestones 生成回顾报告 |
-| `/gsd update` | 在会话内更新到最新版本 |
+| `/gsd update` | 在会话内更新 GSD；`--models` 可刷新 models 和定价且无需重启 |
 | `/gsd knowledge` | 添加持久化项目知识。Rules 仍手动维护在 `KNOWLEDGE.md` 中；patterns 和 lessons 由 memories 承载，并投影回文件。 |
 | `/gsd fast` | 为支持的模型切换 service tier（优先级 API 路由） |
 | `/gsd rate` | 评价上一个单元所用模型层级（over / ok / under），帮助改进自适应路由 |
@@ -392,6 +392,8 @@ MCP 模式也会暴露供 headless 和 MCP 客户端使用的 GSD workflow adapt
 ```
 
 如果已经是最新版本，它会给出提示且不做任何操作。
+
+运行 `/gsd update --models` 可获取已发布的全 provider model 目录，以原子方式替换 `~/.gsd/agent/models-catalog.json`，并重新加载当前会话中的 model registry。新的 models 和定价无需 npm 升级或重启即可使用。该命令不需要 provider 认证，`/gsd upgrade --models` 是它的别名。关于校验、优先级和失败行为，请参阅[更新 Model 目录](./custom-models.md#updating-the-model-catalog)。
 
 ## 导出
 

--- a/docs/zh-CN/user-docs/custom-models.md
+++ b/docs/zh-CN/user-docs/custom-models.md
@@ -282,13 +282,15 @@ export GSD_ALLOWED_COMMAND_PREFIXES="pass,op,sops,doppler"
 <a id="updating-the-model-catalog"></a>
 ## 更新 Model 目录
 
-运行 `gsd update --models` 即可在不进行完整 npm 升级的情况下获取最新发布的 model 目录：
+在 shell 中运行 `gsd update --models`，或在 GSD 会话中运行 `/gsd update --models`，即可在不进行完整 npm 升级的情况下获取最新发布的 model 目录：
 
 ```bash
 gsd update --models
+# 在正在运行的 GSD 会话中：
+/gsd update --models
 ```
 
-该命令会从 gsd-pi 仓库的 `main` 分支下载当前生成的目录快照，并将其存储为一个带版本号的 JSON 覆盖文件，位于 `~/.gsd/agent/models-catalog.json`。该参数是独立的，不接受附加值。
+该命令会从 gsd-pi 仓库的 `main` 分支下载当前生成的目录快照，并将其存储为一个带版本号的 JSON 覆盖文件，位于 `~/.gsd/agent/models-catalog.json`。获取过程无需认证，只使用已发布的全 provider 目录，超时时间为 15 秒。该参数是独立的；如果附加值，命令会在发起请求前拒绝执行。`/gsd upgrade --models` 是会话内命令的别名。
 
 启动时，models 按以下优先级解析（从低到高）：
 
@@ -296,7 +298,7 @@ gsd update --models
 2. **覆盖文件**：来自 `~/.gsd/agent/models-catalog.json`——会用相同 provider + model `id` 的条目替换内置条目，并新增 models 和 providers。
 3. **`models.json`**（本文件）——自定义 providers、自定义 models 和 `modelOverrides` 始终具有最高优先级，且更新过程永远不会修改它。
 
-这样就能在不升级 GSD 本身的情况下，随着新 model、定价和上下文窗口更新的发布而获得它们。只有在完整目录通过校验之后，覆盖文件才会被原子替换，因此下载、校验或写入失败都不会影响现有的覆盖文件。如果覆盖文件缺失或格式错误，会被忽略，启动过程会继续使用内置目录和 `models.json`。
+这样就能在不升级 GSD 本身的情况下，随着新 model、定价和上下文窗口更新的发布而获得它们。会话内命令成功后会重新加载 model registry，因此新目录会立即生效，无需重启。只有在完整目录通过校验之后，覆盖文件才会被原子替换，因此下载、HTTP、校验或写入失败都不会影响现有的覆盖文件。如果覆盖文件缺失或格式错误，会被忽略，启动过程会继续使用内置目录和 `models.json`。
 
 ## GitHub Copilot 实时目录同步
 

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -647,13 +647,43 @@ function resolveGsdBrowserPathVersionForCommand(env: NodeJS.ProcessEnv = process
   }
 }
 
+// In-session counterpart of `gsd update --models`: refresh the
+// models-catalog.json overlay from the published catalog, then reload the
+// registry so the new models/pricing are active without a restart (same
+// seam as `copilot-models sync --register`).
+async function updateModelsCatalogInSession(ctx: ExtensionCommandContext): Promise<void> {
+  const { refreshModelsCatalogOverlay } = await import("./models-catalog-refresh.js");
+  ctx.ui.notify("Fetching model catalog...", "info");
+  const result = await refreshModelsCatalogOverlay();
+  if (!result.ok) {
+    ctx.ui.notify(result.message, "error");
+    return;
+  }
+  ctx.modelRegistry.refresh();
+  const previous = result.previous
+    ? ` (was ${result.previous.providers} providers, ${result.previous.models} models)`
+    : "";
+  ctx.ui.notify(
+    `Updated model catalog: ${result.providers} providers, ${result.models} models${previous}. Model registry refreshed.`,
+    "info",
+  );
+}
+
 export async function handleUpdate(ctx: ExtensionCommandContext, args = ""): Promise<void> {
   const { execSync } = await import("node:child_process");
 
   const target = args.trim();
+  if (target === "--models") {
+    await updateModelsCatalogInSession(ctx);
+    return;
+  }
+  if (target.includes("--models")) {
+    ctx.ui.notify("Usage: /gsd update [browser] [--models] — --models does not take a value", "warning");
+    return;
+  }
   const browserUpdate = target === "browser" || target === "gsd-browser";
   if (target && !browserUpdate) {
-    ctx.ui.notify("Usage: /gsd update [browser]", "warning");
+    ctx.ui.notify("Usage: /gsd update [browser] [--models]", "warning");
     return;
   }
 

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -83,7 +83,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "park", desc: "Park a milestone — skip without deleting" },
   { cmd: "unpark", desc: "Reactivate a parked milestone" },
   { cmd: "discard", desc: "Permanently discard one milestone (with confirmation)" },
-  { cmd: "update", desc: "Update GSD to the latest version" },
+  { cmd: "update", desc: "Update GSD to the latest version; --models refreshes the model catalog" },
   { cmd: "upgrade", desc: "Alias for update; installs the latest @opengsd package" },
   { cmd: "start", desc: "Start a workflow template (bugfix, spike, feature, etc.)" },
   { cmd: "templates", desc: "List available workflow templates" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -177,7 +177,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd migrate        Migrate .planning/ (v1) to DB-backed .gsd/ with backup + audit",
     "  /gsd remote         Control remote auto-mode  [slack|discord|status|disconnect]",
     "  /gsd inspect        Show SQLite DB diagnostics (schema, row counts, recent entries)",
-    "  /gsd update         Update GSD to the latest version via npm",
+    "  /gsd update         Update GSD to the latest version via npm  [--models refreshes the model catalog]",
     "  /gsd upgrade        Alias for /gsd update",
     "  /gsd language       Set or clear the global response language  [off|clear|<language>]",
     "",

--- a/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
+++ b/src/resources/extensions/gsd/copilot-catalog-session-refresh.ts
@@ -1,14 +1,14 @@
 // Project/App: gsd-pi
 // File Purpose: GSD-W018 — session-start GitHub Copilot catalog refresh
-// coordinator and 3-tier runtime model classification.
+// coordinator.
 //
 // Extends the explicit, user-invoked `/gsd copilot-models sync` (GSD-W014)
 // with an OPT-IN automatic refresh at GSD session start, gated by
 // `copilot_catalog.refresh_on_session_start` (default "off"). Reuses the
 // same read-only fetch/sanitize/last-known-good pipeline from
 // `copilot-model-catalog.ts` — this module never duplicates network/auth
-// logic, it only coordinates *when* to call it and classifies the result for
-// safe runtime selection.
+// logic, it only coordinates *when* to call it and captures the result for
+// the W017 change notifications.
 //
 // Invariants:
 //   - Never blocks ordinary session startup: callers must fire-and-forget
@@ -20,11 +20,7 @@
 //     `ctx.modelRegistry.getApiKey()`, which only ever returns a token that
 //     is already available, and any thrown/missing token is treated as
 //     "auth unavailable, skip silently" — never surfaced as an error.
-//   - Bounded wall-clock timeout; a slow/hanging fetch never wedges startup
-//     or a caller awaiting the in-flight refresh (e.g. the model picker).
-//   - Classification never fabricates capability or pricing data: unknown
-//     stays unknown (manual-only), and structurally incomplete records are
-//     quarantined rather than silently defaulted.
+//   - Bounded wall-clock timeout; a slow/hanging fetch never wedges startup.
 //   - State here is session-scoped only (module-level, per basePath) —
 //     nothing is persisted to disk, mirroring the existing
 //     `commands/handlers/copilot-models.ts` session-scoped snapshot.
@@ -36,16 +32,8 @@ import {
 	applyLastKnownGood,
 	diffCatalogSnapshots,
 	fetchGitHubCopilotModels,
-	type CopilotModelRecord,
 	type CopilotModelSnapshot,
 } from "./copilot-model-catalog.js";
-import { resolveModelEconomics } from "./model-cost-table.js";
-import {
-	canonicalizeModelId,
-	getModelProfileConfidence,
-	MODEL_CAPABILITY_TIER,
-	type CapabilityProfileConfidence,
-} from "./model-router.js";
 import type {
 	CopilotCatalogPreferences,
 	CopilotCatalogRefreshMode,
@@ -97,123 +85,6 @@ export function shouldTriggerCopilotCatalogRefresh(
 	return nowMs - lastRefreshedAtMs >= staleAfterMs;
 }
 
-// ─── Runtime model classification (Class A / B / C) ────────────────────────
-
-/**
- * - "trusted" (Class A): capability tier, profile confidence, and pricing are
- *   all known — exposed for manual selection AND eligible for automatic
- *   routing (subject to the existing routing confidence/economics gates in
- *   model-router.ts).
- * - "manual-only" (Class B): the live record is transport-valid
- *   (`tool_call: true`) but capability tier, profile confidence, or pricing
- *   is unknown — selectable manually, never auto-routed, never used for
- *   cheaper-model suggestions.
- * - "quarantined" (Class C): structurally incomplete (not tool-call capable)
- *   — not exposed as selectable, not routed, not suggested.
- */
-export type ModelRuntimeClass = "trusted" | "manual-only" | "quarantined";
-
-export interface ModelClassification {
-	modelClass: ModelRuntimeClass;
-	reasons: string[];
-	tier?: string;
-	profileConfidence?: CapabilityProfileConfidence;
-	hasKnownPricing: boolean;
-}
-
-/**
- * Classify a single live-catalog GitHub Copilot model for safe runtime
- * exposure (GSD-W018 Decision 6). Never invents capability or pricing data —
- * absence of evidence always resolves to "manual-only" or "quarantined",
- * never a synthesized "trusted" classification.
- */
-export function classifyRemoteCopilotModel(
-	record: CopilotModelRecord,
-): ModelClassification {
-	if (!record.execution.toolCalls) {
-		return {
-			modelClass: "quarantined",
-			reasons: ["missing required tool-call capability"],
-			hasKnownPricing: false,
-		};
-	}
-	if (record.availability.policyState === "disabled" || record.availability.policyState === "restricted") {
-		return {
-			modelClass: "quarantined",
-			reasons: [`policy state: ${record.availability.policyState}`],
-			hasKnownPricing: false,
-		};
-	}
-	if (record.availability.preview) {
-		return {
-			modelClass: "quarantined",
-			reasons: ["preview model — not yet stable for automatic exposure"],
-			hasKnownPricing: false,
-		};
-	}
-	if (record.conflicts.length > 0) {
-		return {
-			modelClass: "quarantined",
-			reasons: [`unresolved normalization conflict(s): ${record.conflicts.join(", ")}`],
-			hasKnownPricing: false,
-		};
-	}
-
-	const tier = MODEL_CAPABILITY_TIER[canonicalizeModelId(record.id)];
-	const profileConfidence = getModelProfileConfidence(record.id);
-	const hasKnownLimits =
-		typeof record.execution.contextWindow === "number" && typeof record.execution.maxTokens === "number";
-	const hasBillingOnRecord = record.billing.inputPer1k !== undefined && record.billing.outputPer1k !== undefined;
-	const economics = resolveModelEconomics({
-		provider: "github-copilot",
-		modelId: record.id,
-		fallbackEconomics: {
-			source: "bundled-fallback",
-			stale: false,
-			billingUnit: "tokens",
-		},
-		// BUNDLED_COST_TABLE entries are keyed by bare model ID and are not
-		// provider-qualified — without this, a same-named model priced by a
-		// different provider (e.g. OpenAI's "gpt-5.4") could silently be
-		// reported as this Copilot model's known price. See model-cost-table.ts.
-		disableImplicitFallback: true,
-	});
-	const fallbackPrices = economics.tokenPrices?.default;
-	const hasKnownPricing =
-		hasBillingOnRecord ||
-		economics.source !== "bundled-fallback" ||
-		Boolean(fallbackPrices && (fallbackPrices.inputPer1k > 0 || fallbackPrices.outputPer1k > 0));
-
-	if (tier && profileConfidence !== "unknown" && hasKnownPricing && hasKnownLimits) {
-		return {
-			modelClass: "trusted",
-			reasons: [
-				`capability tier known (${tier})`,
-				`profile confidence: ${profileConfidence}`,
-				"pricing known",
-				"context/token limits known",
-			],
-			tier,
-			profileConfidence,
-			hasKnownPricing,
-		};
-	}
-
-	const reasons: string[] = [];
-	if (!tier) reasons.push("no known capability tier");
-	if (profileConfidence === "unknown") reasons.push("no capability profile (unknown confidence)");
-	if (!hasKnownPricing) reasons.push("no known pricing");
-	if (!hasKnownLimits) reasons.push("no known context/token limits");
-
-	return {
-		modelClass: "manual-only",
-		reasons,
-		tier,
-		profileConfidence,
-		hasKnownPricing,
-	};
-}
-
 // ─── Session-start refresh coordinator ─────────────────────────────────────
 
 export interface CopilotCatalogSessionRefreshResult {
@@ -222,7 +93,6 @@ export interface CopilotCatalogSessionRefreshResult {
 	ok: boolean;
 	reason?: string;
 	snapshot: CopilotModelSnapshot | null;
-	classifications: Record<string, ModelClassification>;
 	changedModelIds: string[];
 }
 
@@ -230,7 +100,6 @@ const NOOP_RESULT: Readonly<CopilotCatalogSessionRefreshResult> = Object.freeze(
 	ran: false,
 	ok: false,
 	snapshot: null,
-	classifications: {},
 	changedModelIds: [],
 });
 
@@ -351,11 +220,6 @@ async function runCopilotCatalogRefresh(
 	lastSnapshotByBasePath.set(basePath, nextSnapshot);
 	lastRefreshedAtByBasePath.set(basePath, nowFn());
 
-	const classifications: Record<string, ModelClassification> = {};
-	for (const model of nextSnapshot.models) {
-		classifications[model.id] = classifyRemoteCopilotModel(model);
-	}
-
 	const changedModelIds = previousSnapshot
 		? (() => {
 				const diff = diffCatalogSnapshots(previousSnapshot, nextSnapshot);
@@ -367,7 +231,6 @@ async function runCopilotCatalogRefresh(
 		ran: true,
 		ok: true,
 		snapshot: nextSnapshot,
-		classifications,
 		changedModelIds,
 	};
 }
@@ -377,12 +240,10 @@ async function runCopilotCatalogRefresh(
  * refresh. Callers on the startup path MUST NOT `await` this synchronously —
  * fire it and let it resolve in the background (`void
  * startCopilotCatalogSessionRefresh(...)`), per the non-blocking-startup
- * invariant. `awaitCopilotCatalogSessionRefresh` is the bounded-wait join
- * point for callers (e.g. the model picker) that need the result.
+ * invariant.
  *
  * Returns `NOOP_RESULT` synchronously-resolved when the mode is "off" or
- * "if_stale" and the snapshot is not yet stale — no promise is stored in
- * that case, so `awaitCopilotCatalogSessionRefresh` has nothing to join.
+ * "if_stale" and the snapshot is not yet stale.
  */
 export function startCopilotCatalogSessionRefresh(
 	options: RefreshCopilotCatalogSessionOptions,
@@ -412,21 +273,6 @@ export function startCopilotCatalogSessionRefresh(
 
 	inFlightRefreshes.set(basePath, runPromise);
 	return runPromise;
-}
-
-/**
- * Await an in-flight refresh for `basePath`, bounded by `timeoutMs`. Used by
- * the model picker so a just-started refresh can populate newly available
- * models before the picker renders, without ever blocking indefinitely.
- * Resolves immediately with `NOOP_RESULT` when nothing is in flight.
- */
-export function awaitCopilotCatalogSessionRefresh(
-	basePath: string,
-	timeoutMs = DEFAULT_COPILOT_CATALOG_REFRESH_TIMEOUT_MS,
-): Promise<CopilotCatalogSessionRefreshResult> {
-	const pending = inFlightRefreshes.get(basePath);
-	if (!pending) return Promise.resolve(NOOP_RESULT);
-	return withTimeout(pending, timeoutMs, { ...NOOP_RESULT, ran: true, reason: "timeout" });
 }
 
 /**

--- a/src/resources/extensions/gsd/models-catalog-refresh.ts
+++ b/src/resources/extensions/gsd/models-catalog-refresh.ts
@@ -1,0 +1,158 @@
+// In-session `gsd update --models` — refresh the models-catalog.json overlay
+// from the published all-provider catalog (every provider, models + pricing),
+// without a full CLI upgrade.
+//
+// Mirrors the fetch/validate/write path of `runModelsUpdate` in
+// `src/update-cmd.ts`. Duplicated rather than imported because
+// tsconfig.resources.json rootDir prevents importing from src/ (see
+// `resolveGsdBrowserPathVersionForCommand` in commands-handlers.ts for the
+// same convention). After a successful write the caller must invoke
+// `ctx.modelRegistry.refresh()` so the new catalog is active in the running
+// session — the same seam `copilot-models sync --register` uses.
+//
+// Failure never clobbers an existing overlay: the write happens only after a
+// full fetch + validate, to the exact location `ModelRegistry` reads
+// (resolveGsdModelsCatalogPath).
+
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { isModelsCatalog, isModelsCatalogOverlay, type ModelsCatalog } from "@gsd/pi-ai";
+
+import { resolveGsdModelsCatalogPath } from "./copilot-overlay-writer.js";
+
+export const GSD_MODELS_CATALOG_URL =
+	"https://raw.githubusercontent.com/open-gsd/gsd-pi/main/packages/pi-ai/src/models.generated.json";
+
+const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
+
+export type ModelsCatalogRefreshResult =
+	| {
+			ok: true;
+			path: string;
+			providers: number;
+			models: number;
+			previous: { providers: number; models: number } | null;
+	  }
+	| { ok: false; reason: "network" | "invalid" | "http" | "write"; message: string };
+
+interface CatalogCounts {
+	providers: number;
+	models: number;
+}
+
+function countCatalogModels(catalog: ModelsCatalog): CatalogCounts {
+	let models = 0;
+	for (const provider of Object.keys(catalog)) {
+		models += Object.keys(catalog[provider] ?? {}).length;
+	}
+	return { providers: Object.keys(catalog).length, models };
+}
+
+/** Best-effort read of an existing overlay for before/after counts. */
+function readExistingCatalogCounts(catalogPath: string): CatalogCounts | null {
+	try {
+		if (!existsSync(catalogPath)) return null;
+		const parsed: unknown = JSON.parse(readFileSync(catalogPath, "utf-8"));
+		if (!isModelsCatalogOverlay(parsed)) return null;
+		return countCatalogModels(parsed.models);
+	} catch {
+		// Missing/malformed overlay must never break the update
+		return null;
+	}
+}
+
+export interface RefreshModelsCatalogOptions {
+	/** Override for tests; defaults to the real models-catalog.json overlay path. */
+	catalogPath?: string;
+	/** Injectable fetch for tests. */
+	fetchImpl?: typeof fetch;
+	/** Injectable timeout for tests. Defaults to 15s, matching the CLI command. */
+	timeoutMs?: number;
+}
+
+/**
+ * Fetch the published catalog, validate it, and atomically replace the
+ * models-catalog.json overlay. In-session counterpart of `gsd update
+ * --models`.
+ */
+export async function refreshModelsCatalogOverlay(
+	options: RefreshModelsCatalogOptions = {},
+): Promise<ModelsCatalogRefreshResult> {
+	const catalogPath = options.catalogPath ?? resolveGsdModelsCatalogPath();
+	const fetchImpl = options.fetchImpl ?? fetch;
+
+	let data: unknown;
+	try {
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS);
+		try {
+			const res = await fetchImpl(GSD_MODELS_CATALOG_URL, { signal: controller.signal });
+			// A non-2xx response reached the server; report the status instead
+			// of a generic network message.
+			if (!res.ok) {
+				const statusText = res.statusText ? ` ${res.statusText}` : "";
+				return {
+					ok: false,
+					reason: "http",
+					message: `Failed to fetch model catalog: server responded with HTTP ${res.status}${statusText}. Existing catalog left unchanged.`,
+				};
+			}
+			data = await res.json();
+		} finally {
+			clearTimeout(timeout);
+		}
+	} catch (err) {
+		// res.json() throws a SyntaxError on malformed JSON — that is an
+		// invalid payload, not a network error.
+		if (err instanceof SyntaxError) {
+			return {
+				ok: false,
+				reason: "invalid",
+				message: "Fetched model catalog is invalid: expected a provider → model map. Existing catalog left unchanged.",
+			};
+		}
+		return {
+			ok: false,
+			reason: "network",
+			message: "Failed to fetch model catalog. Check your network connection. Existing catalog left unchanged.",
+		};
+	}
+
+	if (!isModelsCatalog(data)) {
+		return {
+			ok: false,
+			reason: "invalid",
+			message: "Fetched model catalog is invalid: expected a provider → model map. Existing catalog left unchanged.",
+		};
+	}
+
+	const previous = readExistingCatalogCounts(catalogPath);
+	const after = countCatalogModels(data);
+
+	const overlay = {
+		version: 1,
+		fetchedAt: new Date().toISOString(),
+		source: GSD_MODELS_CATALOG_URL,
+		models: data,
+	};
+
+	// Atomic write: temp file in the same directory, then rename — same
+	// convention as `src/update-cmd.ts` and `copilot-overlay-writer.ts`.
+	const tmpPath = `${catalogPath}.tmp-${process.pid}`;
+	try {
+		mkdirSync(dirname(catalogPath), { recursive: true });
+		writeFileSync(tmpPath, `${JSON.stringify(overlay, null, 2)}\n`);
+		renameSync(tmpPath, catalogPath);
+	} catch (err) {
+		rmSync(tmpPath, { force: true });
+		const detail = err instanceof Error ? err.message : String(err);
+		return {
+			ok: false,
+			reason: "write",
+			message: `Failed to write model catalog: ${detail}. Existing catalog left unchanged.`,
+		};
+	}
+
+	return { ok: true, path: catalogPath, providers: after.providers, models: after.models, previous };
+}

--- a/src/resources/extensions/gsd/tests/copilot-catalog-session-refresh.test.ts
+++ b/src/resources/extensions/gsd/tests/copilot-catalog-session-refresh.test.ts
@@ -1,24 +1,19 @@
 // Regression/behavior tests for GSD-W018: the session-start GitHub Copilot
-// catalog refresh coordinator and 3-tier runtime model classification.
-// Exercises the coordinator's dedup/timeout/auth-safety contract and the
-// classifier's refusal to fabricate capability or pricing data — as opposed
-// to the production command wiring covered by copilot-models-handler.test.ts.
+// catalog refresh coordinator. Exercises the coordinator's dedup/timeout/
+// auth-safety contract — as opposed to the production command wiring covered
+// by copilot-models-handler.test.ts.
 
 import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
 	_resetCopilotCatalogSessionRefreshStateForTests,
-	awaitCopilotCatalogSessionRefresh,
-	classifyRemoteCopilotModel,
 	resolveCopilotCatalogNotifyOnChanges,
 	resolveCopilotCatalogRefreshMode,
 	resolveCopilotCatalogStaleAfterMs,
 	shouldTriggerCopilotCatalogRefresh,
 	startCopilotCatalogSessionRefresh,
-	type CopilotCatalogSessionRefreshResult,
 } from "../copilot-catalog-session-refresh.js";
-import type { CopilotModelRecord } from "../copilot-model-catalog.js";
 
 interface FakeModel {
 	id: string;
@@ -55,38 +50,6 @@ function jsonResponse(data: Array<Record<string, unknown>>) {
 
 function neverResolves() {
 	return (async () => new Promise<Response>(() => {})) as unknown as typeof fetch;
-}
-
-function buildRecord(overrides: Partial<CopilotModelRecord> = {}): CopilotModelRecord {
-	return {
-		provider: "github-copilot",
-		id: "claude-sonnet-5",
-		registryId: "github-copilot/claude-sonnet-5",
-		name: "Claude Sonnet 5",
-		availability: { enabled: true, pickerEnabled: true, preview: false, policyState: "enabled" },
-		execution: {
-			toolCalls: true,
-			supportedEndpoints: [],
-			reasoningLevels: [],
-			contextWindow: 200_000,
-			maxTokens: 8_192,
-		},
-		billing: { billingUnit: "tokens", inputPer1k: 0.003, outputPer1k: 0.015 },
-		provenance: {
-			displayName: { source: "provider-live", freshness: "fresh" },
-			availability: { source: "provider-live", freshness: "fresh" },
-			endpoints: { source: "provider-live", freshness: "fresh" },
-			reasoning: { source: "provider-live", freshness: "fresh" },
-			limits: { source: "provider-live", freshness: "fresh" },
-			billingUnit: { source: "provider-live", freshness: "fresh" },
-			tokenPrices: { source: "provider-live", freshness: "fresh" },
-			requestMultiplier: { source: "unknown", freshness: "unknown" },
-			promotion: { source: "unknown", freshness: "unknown" },
-		},
-		conflicts: [],
-		hash: "test-hash",
-		...overrides,
-	} as CopilotModelRecord;
 }
 
 // ─── Config resolution ──────────────────────────────────────────────────────
@@ -143,63 +106,6 @@ test("shouldTriggerCopilotCatalogRefresh: if_stale triggers on first run and aft
 	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 1400, 500), false, "still fresh");
 	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 1500, 500), true, "exactly at threshold");
 	assert.equal(shouldTriggerCopilotCatalogRefresh("if_stale", 1000, 2000, 500), true, "past threshold");
-});
-
-// ─── classifyRemoteCopilotModel (pure) ──────────────────────────────────────
-
-test("classifyRemoteCopilotModel: trusted when tier, profile, pricing, and limits are all known", () => {
-	const result = classifyRemoteCopilotModel(buildRecord());
-	assert.equal(result.modelClass, "trusted");
-	assert.equal(result.tier, "standard");
-	assert.equal(result.hasKnownPricing, true);
-});
-
-test("classifyRemoteCopilotModel: manual-only when capability tier is unknown", () => {
-	const result = classifyRemoteCopilotModel(buildRecord({ id: "some-brand-new-unlisted-model" }));
-	assert.equal(result.modelClass, "manual-only");
-	assert.ok(result.reasons.some((reason) => reason.includes("capability tier")));
-});
-
-test("classifyRemoteCopilotModel: manual-only when pricing is unknown and tier/profile are unknown too", () => {
-	const result = classifyRemoteCopilotModel(
-		buildRecord({ id: "some-brand-new-unlisted-model-2", billing: { billingUnit: "unknown" } }),
-	);
-	assert.equal(result.modelClass, "manual-only");
-	assert.equal(result.hasKnownPricing, false);
-});
-
-test("classifyRemoteCopilotModel: quarantined when not tool-call capable", () => {
-	const result = classifyRemoteCopilotModel(
-		buildRecord({ execution: { ...buildRecord().execution, toolCalls: false } }),
-	);
-	assert.equal(result.modelClass, "quarantined");
-	assert.match(result.reasons[0]!, /tool-call/);
-});
-
-test("classifyRemoteCopilotModel: quarantined when policy-restricted or disabled", () => {
-	const restricted = classifyRemoteCopilotModel(
-		buildRecord({ availability: { ...buildRecord().availability, policyState: "restricted" } }),
-	);
-	assert.equal(restricted.modelClass, "quarantined");
-
-	const disabled = classifyRemoteCopilotModel(
-		buildRecord({ availability: { ...buildRecord().availability, policyState: "disabled" } }),
-	);
-	assert.equal(disabled.modelClass, "quarantined");
-});
-
-test("classifyRemoteCopilotModel: quarantined when preview", () => {
-	const result = classifyRemoteCopilotModel(
-		buildRecord({ availability: { ...buildRecord().availability, preview: true } }),
-	);
-	assert.equal(result.modelClass, "quarantined");
-	assert.match(result.reasons[0]!, /preview/);
-});
-
-test("classifyRemoteCopilotModel: quarantined when normalization reported conflicts", () => {
-	const result = classifyRemoteCopilotModel(buildRecord({ conflicts: ["endpoint mismatch"] }));
-	assert.equal(result.modelClass, "quarantined");
-	assert.match(result.reasons[0]!, /conflict/);
 });
 
 // ─── startCopilotCatalogSessionRefresh (coordinator) ────────────────────────
@@ -277,7 +183,7 @@ test("startCopilotCatalogSessionRefresh: a throwing getApiKey never triggers a l
 	assert.equal(result.reason, "auth-unavailable");
 });
 
-test("startCopilotCatalogSessionRefresh: successful refresh classifies models and reports changes", async () => {
+test("startCopilotCatalogSessionRefresh: successful refresh reports changed models", async () => {
 	_resetCopilotCatalogSessionRefreshStateForTests();
 	const { ctx } = createFakeCtx({
 		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
@@ -294,7 +200,6 @@ test("startCopilotCatalogSessionRefresh: successful refresh classifies models an
 	assert.equal(result.ok, true);
 	assert.ok(result.snapshot);
 	assert.equal(result.changedModelIds.length, 1, "first-ever snapshot reports every model as changed");
-	assert.ok(result.classifications["claude-sonnet-5"]);
 });
 
 test("startCopilotCatalogSessionRefresh: no-diff second refresh reports zero changes", async () => {
@@ -380,30 +285,4 @@ test("startCopilotCatalogSessionRefresh: a hanging fetch resolves via the bounde
 	});
 
 	assert.equal(result.reason, "timeout");
-});
-
-test("awaitCopilotCatalogSessionRefresh: resolves immediately when nothing is in flight", async () => {
-	_resetCopilotCatalogSessionRefreshStateForTests();
-	const result = await awaitCopilotCatalogSessionRefresh("/no-such-project", 50);
-	assert.equal(result.ran, false);
-});
-
-test("awaitCopilotCatalogSessionRefresh: joins an in-flight refresh started elsewhere", async () => {
-	_resetCopilotCatalogSessionRefreshStateForTests();
-	const { ctx } = createFakeCtx({
-		models: [{ id: "claude-sonnet-5", provider: "github-copilot" }],
-		apiKey: "token-abc",
-	});
-
-	const started: Promise<CopilotCatalogSessionRefreshResult> = startCopilotCatalogSessionRefresh({
-		ctx,
-		basePath: "/project-6",
-		preferences: { copilot_catalog: { refresh_on_session_start: "always" } },
-		fetchImpl: jsonResponse([{ id: "claude-sonnet-5", name: "Claude Sonnet 5", tool_call: true }]),
-	});
-
-	const joined = await awaitCopilotCatalogSessionRefresh("/project-6", 1000);
-	const original = await started;
-	assert.equal(joined.ok, original.ok);
-	assert.deepEqual(joined.snapshot, original.snapshot);
 });

--- a/src/resources/extensions/gsd/tests/models-catalog-refresh.test.ts
+++ b/src/resources/extensions/gsd/tests/models-catalog-refresh.test.ts
@@ -1,0 +1,250 @@
+// Tests for the in-session `gsd update --models` path:
+// refreshModelsCatalogOverlay (fetch/validate/atomic-write of the
+// models-catalog.json overlay, failure must never clobber an existing
+// overlay) and the /gsd update --models handler wiring (registry refresh,
+// usage errors).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+	GSD_MODELS_CATALOG_URL,
+	refreshModelsCatalogOverlay,
+} from "../models-catalog-refresh.js";
+import { handleUpdate } from "../commands-handlers.js";
+
+function validModelEntry(provider: string, id: string) {
+	return {
+		id,
+		name: `Test ${id}`,
+		api: "openai-completions",
+		provider,
+		baseUrl: "https://api.example.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+	};
+}
+
+function validCatalogBody() {
+	return {
+		"github-copilot": { "claude-sonnet-5": validModelEntry("github-copilot", "claude-sonnet-5") },
+		anthropic: { "claude-opus-5": validModelEntry("anthropic", "claude-opus-5") },
+	};
+}
+
+function jsonResponse(body: unknown) {
+	return (async () => ({ ok: true, status: 200, statusText: "OK", json: async () => body }) as unknown as Response) as unknown as typeof fetch;
+}
+
+function tmpOverlayPath(t: { after: (fn: () => void) => void }): string {
+	const dir = mkdtempSync(join(tmpdir(), "gsd-models-catalog-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	return join(dir, "agent", "models-catalog.json");
+}
+
+function writeExistingOverlay(catalogPath: string, content: unknown): void {
+	mkdirSync(dirname(catalogPath), { recursive: true });
+	writeFileSync(catalogPath, typeof content === "string" ? content : JSON.stringify(content));
+}
+
+// ─── refreshModelsCatalogOverlay ────────────────────────────────────────────
+
+test("refreshModelsCatalogOverlay writes the overlay and reports counts", async (t) => {
+	const catalogPath = tmpOverlayPath(t);
+	let fetchedUrl: string | undefined;
+	const result = await refreshModelsCatalogOverlay({
+		catalogPath,
+		fetchImpl: (async (input: string | URL | Request) => {
+			fetchedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return ({ ok: true, status: 200, statusText: "OK", json: async () => validCatalogBody() }) as unknown as Response;
+		}) as unknown as typeof fetch,
+	});
+
+	assert.equal(fetchedUrl, GSD_MODELS_CATALOG_URL);
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	assert.equal(result.providers, 2);
+	assert.equal(result.models, 2);
+	assert.equal(result.previous, null, "no existing overlay yet");
+
+	const written = JSON.parse(readFileSync(catalogPath, "utf-8"));
+	assert.equal(written.version, 1);
+	assert.equal(written.source, GSD_MODELS_CATALOG_URL);
+	assert.ok(typeof written.fetchedAt === "string");
+	assert.deepEqual(Object.keys(written.models).sort(), ["anthropic", "github-copilot"]);
+	assert.equal(existsSync(`${catalogPath}.tmp-${process.pid}`), false, "temp file must be renamed away");
+});
+
+test("refreshModelsCatalogOverlay reports previous counts when an overlay already exists", async (t) => {
+	const catalogPath = tmpOverlayPath(t);
+	writeExistingOverlay(catalogPath, {
+		version: 1,
+		fetchedAt: "2026-01-01T00:00:00.000Z",
+		source: "old",
+		models: validCatalogBody(),
+	});
+
+	const result = await refreshModelsCatalogOverlay({
+		catalogPath,
+		fetchImpl: jsonResponse({ anthropic: { "claude-opus-5": validModelEntry("anthropic", "claude-opus-5") } }),
+	});
+
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	assert.deepEqual(result.previous, { providers: 2, models: 2 });
+	assert.equal(result.providers, 1);
+	assert.equal(result.models, 1);
+});
+
+test("refreshModelsCatalogOverlay rejects an invalid payload and leaves the existing overlay untouched", async (t) => {
+	const catalogPath = tmpOverlayPath(t);
+	const existing = JSON.stringify({
+		version: 1,
+		fetchedAt: "2026-01-01T00:00:00.000Z",
+		source: "old",
+		models: validCatalogBody(),
+	});
+	writeExistingOverlay(catalogPath, existing);
+
+	const result = await refreshModelsCatalogOverlay({
+		catalogPath,
+		fetchImpl: jsonResponse({ "not-a-catalog": true }),
+	});
+
+	assert.equal(result.ok, false);
+	if (result.ok) return;
+	assert.equal(result.reason, "invalid");
+	assert.equal(readFileSync(catalogPath, "utf-8"), existing, "existing overlay must not be clobbered");
+});
+
+test("refreshModelsCatalogOverlay distinguishes an HTTP error from a network failure", async (t) => {
+	const catalogPath = tmpOverlayPath(t);
+	const existing = "{}-sentinel-not-valid-json-but-byte-compared";
+	writeExistingOverlay(catalogPath, existing);
+
+	const httpResult = await refreshModelsCatalogOverlay({
+		catalogPath,
+		fetchImpl: (async () =>
+			({ ok: false, status: 503, statusText: "Service Unavailable", json: async () => ({}) }) as unknown as Response) as unknown as typeof fetch,
+	});
+	assert.equal(httpResult.ok, false);
+	if (!httpResult.ok) {
+		assert.equal(httpResult.reason, "http");
+		assert.match(httpResult.message, /HTTP 503 Service Unavailable/);
+	}
+
+	const networkResult = await refreshModelsCatalogOverlay({
+		catalogPath,
+		fetchImpl: (async () => {
+			throw new Error("ECONNREFUSED");
+		}) as unknown as typeof fetch,
+	});
+	assert.equal(networkResult.ok, false);
+	if (!networkResult.ok) assert.equal(networkResult.reason, "network");
+
+	assert.equal(readFileSync(catalogPath, "utf-8"), existing, "failures must never write");
+});
+
+// ─── /gsd update --models handler wiring ────────────────────────────────────
+
+function commandCtx(overrides: {
+	notify: (message: string, level?: string) => void;
+	refresh: () => void;
+}): any {
+	return {
+		ui: { notify: overrides.notify },
+		modelRegistry: { refresh: overrides.refresh },
+	} as any;
+}
+
+test("/gsd update --models refreshes the overlay into the real GSD_HOME path and reloads the registry", async (t) => {
+	const dir = mkdtempSync(join(tmpdir(), "gsd-models-catalog-e2e-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const previousHome = process.env.GSD_HOME;
+	const previousFetch = globalThis.fetch;
+	t.after(() => {
+		if (previousHome === undefined) delete process.env.GSD_HOME;
+		else process.env.GSD_HOME = previousHome;
+		globalThis.fetch = previousFetch;
+	});
+
+	process.env.GSD_HOME = dir;
+	globalThis.fetch = jsonResponse(validCatalogBody());
+
+	const notifications: string[] = [];
+	let refreshCalls = 0;
+	await handleUpdate(
+		commandCtx({
+			notify: (message: string) => notifications.push(message),
+			refresh: () => {
+				refreshCalls += 1;
+			},
+		}),
+		"--models",
+	);
+
+	assert.equal(refreshCalls, 1, "modelRegistry.refresh() must run after a successful write");
+	const writtenPath = join(dir, "agent", "models-catalog.json");
+	const written = JSON.parse(readFileSync(writtenPath, "utf-8"));
+	assert.equal(written.version, 1);
+	assert.ok(
+		notifications.some((message) => message.includes("Updated model catalog: 2 providers, 2 models")),
+		`unexpected notifications: ${JSON.stringify(notifications)}`,
+	);
+	assert.ok(notifications.some((message) => message.includes("Model registry refreshed")));
+});
+
+test("/gsd update --models reports failure without touching the registry", async (t) => {
+	const previousFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = previousFetch;
+	});
+	globalThis.fetch = (async () => {
+		throw new Error("network down");
+	}) as unknown as typeof fetch;
+
+	const notifications: Array<{ message: string; level?: string }> = [];
+	let refreshCalls = 0;
+	await handleUpdate(
+		commandCtx({
+			notify: (message: string, level?: string) => notifications.push({ message, level }),
+			refresh: () => {
+				refreshCalls += 1;
+			},
+		}),
+		"--models",
+	);
+
+	assert.equal(refreshCalls, 0, "a failed fetch must not reload the registry");
+	assert.ok(notifications.some((n) => n.level === "error" && n.message.includes("Existing catalog left unchanged")));
+});
+
+test("/gsd update --models with an extra value shows usage and never fetches", async (t) => {
+	const previousFetch = globalThis.fetch;
+	let fetchCalled = false;
+	t.after(() => {
+		globalThis.fetch = previousFetch;
+	});
+	globalThis.fetch = (async () => {
+		fetchCalled = true;
+		return ({ ok: true, json: async () => validCatalogBody() }) as unknown as Response;
+	}) as unknown as typeof fetch;
+
+	const notifications: Array<{ message: string; level?: string }> = [];
+	await handleUpdate(
+		commandCtx({
+			notify: (message: string, level?: string) => notifications.push({ message, level }),
+			refresh: () => {},
+		}),
+		"--models newest",
+	);
+
+	assert.equal(fetchCalled, false);
+	assert.ok(notifications.some((n) => n.level === "warning" && n.message.includes("Usage: /gsd update [browser] [--models]")));
+});


### PR DESCRIPTION
## Intent

Make the single update command the canonical way to refresh all models and pricing (part of walking back issue #2088's per-model catalog machinery; RFC #2091 was closed as wontfix). Wire a --models flag into the in-session /gsd update command (and the /gsd upgrade alias): refresh the ~/.gsd/agent/models-catalog.json overlay from the published all-provider catalog (same URL, 15s timeout, and isModelsCatalog validation as the existing CLI 'gsd update --models' in src/update-cmd.ts), then call ctx.modelRegistry.refresh() so new models and pricing are live in the running session without a restart - the same activation seam copilot-models sync --register uses. Deliberate constraints from the maintainer: the logic is duplicated into the extension (models-catalog-refresh.ts) rather than imported from src/ because tsconfig.resources.json rootDir forbids importing from src/ - that duplication matches the existing resolveGsdBrowserPathVersionForCommand convention; any failure (network, HTTP, invalid payload, write error) must leave an existing overlay untouched, never clobber it; HTTP errors must be distinguished from network failures; 'update --models' stays auth-free and deterministic (published catalog only - remote-only Copilot models still flow through the opt-in copilot-models sync --register completeness gate); --models with an extra value shows usage and never fetches. Verified locally: typecheck:extensions clean, 7 new tests in models-catalog-refresh.test.ts pass, all 25 existing update-cmd-diagnostics.test.ts cases pass, pnpm run verify:fast green.

## What Changed

- Add `/gsd update --models` and `/gsd upgrade --models` to fetch the published all-provider catalog, atomically update the overlay, and refresh models and pricing in the current session.
- Preserve existing overlays on network, HTTP, validation, or write failures, and reject extra flag values before fetching.
- Remove Copilot session-refresh model classification and picker-join APIs, with updated English/Chinese docs and focused tests.

## Risk Assessment

✅ Low: The change is well-bounded and directly satisfies the required URL, timeout, validation, failure-preservation, alias routing, and in-session registry refresh behavior without material source risks.

## Testing

Author-reported `typecheck:extensions` and `verify:fast` baselines were already green; independent targeted tests and product-level command evidence also passed. No screenshot was captured because this is a terminal notification flow with no visual layout—the transcript records the exact user-facing messages and persisted state.

<details>
<summary>Evidence: End-user command and failure-mode transcript</summary>

```text

=== published catalog activated through /gsd upgrade --models ===
{
  "command": "/gsd upgrade --models",
  "handled": true,
  "authConfigured": false,
  "catalogSource": "https://raw.githubusercontent.com/open-gsd/gsd-pi/main/packages/pi-ai/src/models.generated.json",
  "persistedOverlay": "/Users/jeremymcspadden/.no-mistakes/evidence/01M19PH5SRHKMFB79S6B5RBSTB/live-gsd-home/agent/models-catalog.json",
  "providerCount": 33,
  "modelCount": 992,
  "sampleProviders": [
    "amazon-bedrock",
    "anthropic",
    "anthropic-vertex",
    "azure-openai-responses",
    "cerebras",
    "cloudflare-ai-gateway",
    "cloudflare-workers-ai",
    "deepseek"
  ],
  "registryRefreshCalls": 1,
  "notifications": [
    {
      "message": "Fetching model catalog...",
      "level": "info"
    },
    {
      "message": "Updated model catalog: 33 providers, 992 models (was 1 providers, 1 models). Model registry refreshed.",
      "level": "info"
    }
  ]
}

=== extra value is rejected before fetch ===
{
  "command": "/gsd update --models newest",
  "handled": true,
  "fetchCalls": 0,
  "registryRefreshCalls": 0,
  "notifications": [
    {
      "message": "Usage: /gsd update [browser] [--models] — --models does not take a value",
      "level": "warning"
    }
  ]
}

=== http failure preserves existing overlay ===
{
  "command": "/gsd update --models",
  "handled": true,
  "registryRefreshCalls": 0,
  "overlayUnchanged": true,
  "overlaySha256": "9d93626faec8f98db6728b3ee17ee7c6ae4371991b06a16970c8197c2e3a5fe6",
  "notifications": [
    {
      "message": "Fetching model catalog...",
      "level": "info"
    },
    {
      "message": "Failed to fetch model catalog: server responded with HTTP 503 Service Unavailable. Existing catalog left unchanged.",
      "level": "error"
    }
  ]
}

=== network failure preserves existing overlay ===
{
  "command": "/gsd update --models",
  "handled": true,
  "registryRefreshCalls": 0,
  "overlayUnchanged": true,
  "overlaySha256": "9d93626faec8f98db6728b3ee17ee7c6ae4371991b06a16970c8197c2e3a5fe6",
  "notifications": [
    {
      "message": "Fetching model catalog...",
      "level": "info"
    },
    {
      "message": "Failed to fetch model catalog. Check your network connection. Existing catalog left unchanged.",
      "level": "error"
    }
  ]
}

=== invalid failure preserves existing overlay ===
{
  "command": "/gsd update --models",
  "handled": true,
  "registryRefreshCalls": 0,
  "overlayUnchanged": true,
  "overlaySha256": "9d93626faec8f98db6728b3ee17ee7c6ae4371991b06a16970c8197c2e3a5fe6",
  "notifications": [
    {
      "message": "Fetching model catalog...",
      "level": "info"
    },
    {
      "message": "Fetched model catalog is invalid: expected a provider → model map. Existing catalog left unchanged.",
      "level": "error"
    }
  ]
}

=== write failure preserves existing overlay ===
{
  "command": "/gsd update --models",
  "registryRefreshCalls": 0,
  "overlayUnchanged": true,
  "overlaySha256": "9d93626faec8f98db6728b3ee17ee7c6ae4371991b06a16970c8197c2e3a5fe6",
  "notifications": [
    {
      "message": "Fetching model catalog...",
      "level": "info"
    },
    {
      "message": "Failed to write model catalog: EACCES: permission denied, open '/Users/jeremymcspadden/.no-mistakes/evidence/01M19PH5SRHKMFB79S6B5RBSTB/failure-write/agent/models-catalog.json.tmp-82959'. Existing catalog left unchanged.",
      "level": "error"
    }
  ]
}

=== default fetch timeout aborts and preserves overlay ===
{
  "command": "/gsd update --models",
  "fetchAborted": true,
  "elapsedMs": 15008,
  "result": {
    "ok": false,
    "reason": "network",
    "message": "Failed to fetch model catalog. Check your network connection. Existing catalog left unchanged."
  },
  "overlayUnchanged": true
}

RESULT: PASS — published refresh, live activation, usage rejection, timeout, and all failure-preservation paths behaved as required.
```
</details>
<details>
<summary>Evidence: Published catalog overlay persisted by `/gsd upgrade --models`</summary>

```text
{
  "version": 1,
  "fetchedAt": "2026-08-30T16:11:43.832Z",
  "source": "https://raw.githubusercontent.com/open-gsd/gsd-pi/main/packages/pi-ai/src/models.generated.json",
  "models": {
    "amazon-bedrock": {
      "amazon.nova-2-lite-v1:0": {
        "id": "amazon.nova-2-lite-v1:0",
        "name": "Nova 2 Lite",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 0.33,
          "output": 2.75,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 128000,
        "maxTokens": 4096
      },
      "amazon.nova-lite-v1:0": {
        "id": "amazon.nova-lite-v1:0",
        "name": "Nova Lite",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": false,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 0.06,
          "output": 0.24,
          "cacheRead": 0.015,
          "cacheWrite": 0
        },
        "contextWindow": 300000,
        "maxTokens": 8192
      },
      "amazon.nova-micro-v1:0": {
        "id": "amazon.nova-micro-v1:0",
        "name": "Nova Micro",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": false,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0.035,
          "output": 0.14,
          "cacheRead": 0.00875,
          "cacheWrite": 0
        },
        "contextWindow": 128000,
        "maxTokens": 8192
      },
      "amazon.nova-pro-v1:0": {
        "id": "amazon.nova-pro-v1:0",
        "name": "Nova Pro",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": false,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 0.8,
          "output": 3.2,
          "cacheRead": 0.2,
          "cacheWrite": 0
        },
        "contextWindow": 300000,
        "maxTokens": 8192
      },
      "anthropic.claude-fable-5": {
        "id": "anthropic.claude-fable-5",
        "name": "Claude Fable 5",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "thinkingLevelMap": {
          "xhigh": "xhigh"
        },
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 10,
          "output": 50,
          "cacheRead": 1,
          "cacheWrite": 12.5
        },
        "contextWindow": 1000000,
        "maxTokens": 128000
      },
      "anthropic.claude-haiku-4-5-20251001-v1:0": {
        "id": "anthropic.claude-haiku-4-5-20251001-v1:0",
        "name": "Claude Haiku 4.5",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 1,
          "output": 5,
          "cacheRead": 0.1,
          "cacheWrite": 1.25
        },
        "contextWindow": 200000,
        "maxTokens": 64000
      },
      "anthropic.claude-opus-4-1-20250805-v1:0": {
        "id": "anthropic.claude-opus-4-1-20250805-v1:0",
        "name": "Claude Opus 4.1",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 15,
          "output": 75,
          "cacheRead": 1.5,
          "cacheWrite": 18.75
        },
        "contextWindow": 200000,
        "maxTokens": 32000
      },
      "anthropic.claude-opus-4-5-20251101-v1:0": {
        "id": "anthropic.claude-opus-4-5-20251101-v1:0",
        "name": "Claude Opus 4.5",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 5,
          "output": 25,
          "cacheRead": 0.5,
          "cacheWrite": 6.25
        },
        "contextWindow": 200000,
        "maxTokens": 64000
      },
      "anthropic.claude-opus-4-6-v1": {
        "id": "anthropic.claude-opus-4-6-v1",
        "name": "Claude Opus 4.6",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "thinkingLevelMap": {
          "xhigh": "max"
        },
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 5,
          "output": 25,
          "cacheRead": 0.5,
          "cacheWrite": 6.25
        },
        "contextWindow": 1000000,
        "maxTokens": 128000
      },
      "anthropic.claude-opus-4-7": {
        "id": "anthropic.claude-opus-4-7",
        "name": "Claude Opus 4.7",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "thinkingLevelMap": {
          "xhigh": "xhigh"
        },
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 5,
          "output": 25,
          "cacheRead": 0.5,
          "cacheWrite": 6.25
        },
        "contextWindow": 1000000,
        "maxTokens": 128000
      },
      "anthropic.claude-opus-4-8": {
        "id": "anthropic.claude-opus-4-8",
        "name": "Claude Opus 4.8",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "thinkingLevelMap": {
          "xhigh": "xhigh"
        },
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 5,
          "output": 25,
          "cacheRead": 0.5,
          "cacheWrite": 6.25
        },
        "contextWindow": 1000000,
        "maxTokens": 128000
      },
      "anthropic.claude-opus-5": {
        "id": "anthropic.claude-opus-5",
        "name": "Claude Opus 5",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "thinkingLevelMap": {
          "xhigh": "xhigh"
        },
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 5,
          "output": 25,
          "cacheRead": 0.5,
          "cacheWrite": 6.25
        },
        "contextWindow": 1000000,
        "maxTokens": 128000
      },
      "anthropic.claude-sonnet-4-5-20250929-v1:0": {
        "id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
        "name": "Claude Sonnet 4.5",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 3,
          "output": 15,
          "cacheRead": 0.3,
          "cacheWrite": 3.75
        },
        "contextWindow": 200000,
        "maxTokens": 64000
      },
      "anthropic.claude-sonnet-4-6": {
        "id": "anthropic.claude-sonnet-4-6",
        "name": "Claude Sonnet 4.6",
        "api": "bedrock-converse-stream",
        "provider": "amazon-bedrock",
        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "reasoning": true,
        "i

... [555884 bytes truncated] ...

t": 0.1,
          "output": 0.3,
          "cacheRead": 0.01,
          "cacheWrite": 0
        },
        "contextWindow": 262144,
        "maxTokens": 65536
      },
      "mimo-v2-omni": {
        "id": "mimo-v2-omni",
        "name": "MiMo-V2-Omni",
        "api": "openai-completions",
        "provider": "xiaomi-token-plan-sgp",
        "baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
        "compat": {
          "requiresReasoningContentOnAssistantMessages": true,
          "thinkingFormat": "deepseek"
        },
        "reasoning": true,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 0.4,
          "output": 2,
          "cacheRead": 0.08,
          "cacheWrite": 0
        },
        "contextWindow": 262144,
        "maxTokens": 131072
      },
      "mimo-v2-pro": {
        "id": "mimo-v2-pro",
        "name": "MiMo-V2-Pro",
        "api": "openai-completions",
        "provider": "xiaomi-token-plan-sgp",
        "baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
        "compat": {
          "requiresReasoningContentOnAssistantMessages": true,
          "thinkingFormat": "deepseek"
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 1,
          "output": 3,
          "cacheRead": 0.2,
          "cacheWrite": 0
        },
        "contextWindow": 1048576,
        "maxTokens": 131072
      },
      "mimo-v2.5": {
        "id": "mimo-v2.5",
        "name": "MiMo-V2.5",
        "api": "openai-completions",
        "provider": "xiaomi-token-plan-sgp",
        "baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
        "compat": {
          "requiresReasoningContentOnAssistantMessages": true,
          "thinkingFormat": "deepseek"
        },
        "reasoning": true,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 0.4,
          "output": 2,
          "cacheRead": 0.08,
          "cacheWrite": 0
        },
        "contextWindow": 1048576,
        "maxTokens": 131072
      },
      "mimo-v2.5-pro": {
        "id": "mimo-v2.5-pro",
        "name": "MiMo-V2.5-Pro",
        "api": "openai-completions",
        "provider": "xiaomi-token-plan-sgp",
        "baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
        "compat": {
          "requiresReasoningContentOnAssistantMessages": true,
          "thinkingFormat": "deepseek"
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 1,
          "output": 3,
          "cacheRead": 0.2,
          "cacheWrite": 0
        },
        "contextWindow": 1048576,
        "maxTokens": 131072
      }
    },
    "zai": {
      "glm-4.5": {
        "id": "glm-4.5",
        "name": "GLM-4.5",
        "api": "openai-completions",
        "provider": "zai",
        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
        "compat": {
          "supportsDeveloperRole": false,
          "thinkingFormat": "zai"
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 131072,
        "maxTokens": 98304
      },
      "glm-4.5-air": {
        "id": "glm-4.5-air",
        "name": "GLM-4.5-Air",
        "api": "openai-completions",
        "provider": "zai",
        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
        "compat": {
          "supportsDeveloperRole": false,
          "thinkingFormat": "zai"
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 131072,
        "maxTokens": 98304
      },
      "glm-4.6": {
        "id": "glm-4.6",
        "name": "GLM-4.6",
        "api": "openai-completions",
        "provider": "zai",
        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
        "compat": {
          "supportsDeveloperRole": false,
          "thinkingFormat": "zai",
          "zaiToolStream": true
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 204800,
        "maxTokens": 131072
      },
      "glm-4.7": {
        "id": "glm-4.7",
        "name": "GLM-4.7",
        "api": "openai-completions",
        "provider": "zai",
        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
        "compat": {
          "supportsDeveloperRole": false,
          "thinkingFormat": "zai",
          "zaiToolStream": true
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 204800,
        "maxTokens": 131072
      },
      "glm-5": {
        "id": "glm-5",
        "name": "GLM-5",
        "api": "openai-completions",
        "provider": "zai",
        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
        "compat": {
          "supportsDeveloperRole": false,
          "thinkingFormat": "zai",
          "zaiToolStream": true
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 200000,
        "maxTokens": 131072
      },
      "glm-5-turbo": {
        "id": "glm-5-turbo",
        "name": "GLM-5-Turbo",
        "api": "openai-completions",
        "provider": "zai",
        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
        "compat": {
          "supportsDeveloperRole": false,
          "thinkingFormat": "zai",
          "zaiToolStream": true
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 200000,
        "maxTokens": 131072
      },
      "glm-5.1": {
        "id": "glm-5.1",
        "name": "GLM-5.1",
        "api": "openai-completions",
        "provider": "zai",
        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
        "compat": {
          "supportsDeveloperRole": false,
          "thinkingFormat": "zai",
          "zaiToolStream": true
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 200000,
        "maxTokens": 131072
      },
      "glm-5.2": {
        "id": "glm-5.2",
        "name": "GLM-5.2",
        "api": "openai-completions",
        "provider": "zai",
        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
        "compat": {
          "supportsDeveloperRole": false,
          "thinkingFormat": "zai",
          "zaiToolStream": true
        },
        "reasoning": true,
        "input": [
          "text"
        ],
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 200000,
        "maxTokens": 131072
      },
      "glm-5v-turbo": {
        "id": "glm-5v-turbo",
        "name": "GLM-5V-Turbo",
        "api": "openai-completions",
        "provider": "zai",
        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
        "compat": {
          "supportsDeveloperRole": false,
          "thinkingFormat": "zai",
          "zaiToolStream": true
        },
        "reasoning": true,
        "input": [
          "text",
          "image"
        ],
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0
        },
        "contextWindow": 200000,
        "maxTokens": 131072
      }
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f17204cb0de0b93abb237fae6ac192f8ea69129c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch && git branch --show-current && git log -1 --format='%H %s'`
- <code>Initial focused test command was setup-blocked by missing dependencies; repaired with `pnpm install --frozen-lockfile --ignore-scripts`.</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/models-catalog-refresh.test.ts src/resources/extensions/gsd/tests/update-command.test.ts src/tests/update-cmd-diagnostics.test.ts`
- <code>Executed `verify-models-update.mts` through the real command router against the published catalog, then fault-injected argument, HTTP, network, invalid-payload, filesystem-write, and default-timeout scenarios.</code>
- <code>Removed test-installed dependency directories and confirmed `git status --short --untracked-files=all` remained clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
