### PR TITLE
fix(auto): register liveness identity on rejected unit-run claim (#2097)

### DIFF
--- a/src/resources/extensions/gsd/auto/lease-conflict-notice.ts
+++ b/src/resources/extensions/gsd/auto/lease-conflict-notice.ts
@@ -3,6 +3,28 @@
 
 const LEASE_HELD_RE = /^Milestone\s+(\S+)\s+is held by worker\s+(.+?)\s+until\s+(.+?)\.?$/;
 
+/**
+ * Normalize a unit-run claim rejection reason into a value that is stable
+ * across repeated identical rejections, for use as an ADR-047 liveness
+ * signature payload (which is hashed).
+ *
+ * Lease-held rejections embed the lease `expiresAt` timestamp (see
+ * `workflow-dispatch-claim.ts`: `Milestone ... is held by worker ... until
+ * <expiresAt>.`). That timestamp advances every time the holder heartbeats, so
+ * hashing the raw reason would produce a different signature on each otherwise
+ * identical "lease still held" rejection and never accumulate to the wedge
+ * threshold. Stripping the volatile `until <expiresAt>` clause keys the
+ * signature on the stable conflict identity (milestone + holder). All other
+ * reasons (e.g. `missing-worker`, `dispatch claim skipped: ...`) pass through
+ * unchanged.
+ */
+export function stableClaimSignature(reason: string): string {
+  const match = reason.match(LEASE_HELD_RE);
+  if (!match) return reason;
+  const [, milestoneId, workerId] = match;
+  return `Milestone ${milestoneId} is held by worker ${workerId}`;
+}
+
 export interface LeaseConflictNoticeInput {
   milestoneId?: string | null;
   unitType: string;

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -1535,8 +1535,29 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         : this.openUnitRun(decision.unitType, decision.unitId, reconciliation.stateSnapshot);
       if (typeof dispatchId !== "number") {
         this.clearPendingDispatch();
+        // ADR-047 (#2097): a rejected unit-run claim (lease held/blocked,
+        // degraded, or skip) is a non-advancing guard block just like every
+        // other blocked path above. It MUST register a stable liveness identity
+        // so adjudicateLiveness can record/trip the signature ledger. Without
+        // this, the blocked result reaches adjudicateLiveness with no
+        // pendingLivenessInput and degrades into the "semantic guard did not
+        // provide a stable identity" backstop-unavailable hard-stop — which
+        // /gsd doctor --fix cannot repair because nothing is corrupt.
+        if (dispatchId.kind === "blocked") {
+          this.journalTransition({
+            name: "advance-blocked",
+            reason: dispatchId.reason,
+            unitType: decision.unitType,
+            unitId: decision.unitId,
+          });
+        }
         this.postAdvanceRecord(dispatchId);
-        return dispatchId;
+        return this.withLivenessInput(dispatchId, {
+          guardId: "unit-run-claim",
+          inputPayload: dispatchId.kind === "blocked"
+            ? dispatchId.reason
+            : buildDispatchKey(decision.unitType, decision.unitId),
+        });
       }
 
       this.status.phase = "running";

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -1552,11 +1552,22 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
           });
         }
         this.postAdvanceRecord(dispatchId);
+        const claimInputPayload = dispatchId.kind === "blocked"
+          ? dispatchId.reason
+          : buildDispatchKey(decision.unitType, decision.unitId);
         return this.withLivenessInput(dispatchId, {
           guardId: "unit-run-claim",
-          inputPayload: dispatchId.kind === "blocked"
-            ? dispatchId.reason
-            : buildDispatchKey(decision.unitType, decision.unitId),
+          inputPayload: claimInputPayload,
+          // ADR-047 §5: a tripped wedge MUST carry a reachable recovery
+          // instruction. Without an explicit sanctionedExit the ledger falls
+          // back to the raw claim reason (e.g. `missing-worker`), which tells
+          // the operator nothing about how to clear the claim blocker.
+          sanctionedExit:
+            `Auto-mode could not claim a unit-run for ${decision.unitType} ${decision.unitId} ` +
+            `(${claimInputPayload}). Another live worker may hold the milestone lease, or the ` +
+            `owning worker is shutting down mid-retry. Inspect \`/gsd status\` for the active ` +
+            `UnitRun and lease holder, then re-run once the lease is released (or run ` +
+            `\`/gsd doctor\` if no worker is live).`,
         });
       }
 

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -66,6 +66,7 @@ import { normalizeRealPath } from "../paths.js";
 import { preserveProjectionChanges } from "../projection-worker.js";
 import { throwIfTransientProjectionLockError } from "../projection-root-errors.js";
 import { buildDispatchKey } from "./dispatch-key.js";
+import { stableClaimSignature } from "./lease-conflict-notice.js";
 import {
   COMPLETED_NO_ADVANCE_GUARD_ID,
   formatWedgeRefusalNotice,
@@ -1552,8 +1553,11 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
           });
         }
         this.postAdvanceRecord(dispatchId);
+        // Use a stable signature payload: lease-held reasons embed a volatile
+        // `until <expiresAt>` timestamp that advances on every holder
+        // heartbeat, which would defeat the ADR-047 occurrence-2 wedge trip.
         const claimInputPayload = dispatchId.kind === "blocked"
-          ? dispatchId.reason
+          ? stableClaimSignature(dispatchId.reason)
           : buildDispatchKey(decision.unitType, decision.unitId);
         return this.withLivenessInput(dispatchId, {
           guardId: "unit-run-claim",

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -944,6 +944,42 @@ test("ADR-047: unavailable liveness storage fails the advance boundary closed", 
   assert.match(result.reason, /liveness backstop unavailable/i);
 });
 
+test("ADR-047: a rejected unit-run claim blocks with a stable identity, not backstop-unavailable", async (t) => {
+  const f = makeFixture();
+  t.after(() => f.cleanup());
+
+  // Force the unit-run claim (openUnitRun -> claimUnitRun) to be rejected:
+  // clearing the session worker id yields a "degraded: missing-worker" claim,
+  // which openUnitRun maps to a blocked AutoAdvanceResult before any dispatch
+  // opens. This is the #2097 shape: the claim-block path used to return without
+  // registering a liveness identity, degrading into "semantic guard did not
+  // provide a stable identity" backstop-unavailable — an unrecoverable stop
+  // that no DB repair (/gsd doctor --fix) could clear.
+  f.session.workerId = null;
+
+  const first = await f.orchestrator.advance();
+  assert.equal(first.kind, "blocked");
+  if (first.kind !== "blocked") throw new Error("expected a blocked claim");
+  assert.equal(first.action, "stop");
+  // The block carries the real claim reason and a stable identity ...
+  assert.match(first.reason, /missing-worker/);
+  // ... and MUST NOT degrade into the no-stable-identity backstop failure.
+  assert.doesNotMatch(first.reason, /semantic guard did not provide a stable identity/);
+  assert.doesNotMatch(first.reason, /liveness backstop unavailable/i);
+
+  // Because the claim block now registers a stable "unit-run-claim" signature,
+  // a second identical rejection trips the liveness wedge (threshold 2) instead
+  // of hard-failing the backstop boundary.
+  const second = await f.orchestrator.advance();
+  assert.equal(second.kind, "blocked");
+  if (second.kind !== "blocked") throw new Error("expected a second blocked claim");
+  assert.match(second.reason, /liveness backstop tripped/);
+  const wedge = getOpenWedge(normalizeRealPath(f.base));
+  assert.equal(wedge.ok, true);
+  assert.equal(wedge.ok ? wedge.wedge?.guardId : null, "unit-run-claim");
+  assert.equal(wedge.ok ? wedge.wedge?.occurrenceCount : null, 2);
+});
+
 test("completeActiveUnit allows a different next unit to advance", async (t) => {
   let nextTaskId = "M001/S01/T01";
   const f = makeFixture({

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -978,6 +978,14 @@ test("ADR-047: a rejected unit-run claim blocks with a stable identity, not back
   assert.equal(wedge.ok, true);
   assert.equal(wedge.ok ? wedge.wedge?.guardId : null, "unit-run-claim");
   assert.equal(wedge.ok ? wedge.wedge?.occurrenceCount : null, 2);
+  // ADR-047 §5: the wedge MUST carry an actionable recovery instruction, not
+  // just the raw claim reason. Guards against regressing to the
+  // `sanctionedExit ?? inputPayload` fallback (which would only store
+  // `missing-worker`).
+  const sanctionedExit = wedge.ok ? wedge.wedge?.sanctionedExit ?? "" : "";
+  assert.notEqual(sanctionedExit, "missing-worker");
+  assert.match(sanctionedExit, /could not claim a unit-run/i);
+  assert.match(sanctionedExit, /\/gsd status/);
 });
 
 test("completeActiveUnit allows a different next unit to advance", async (t) => {

--- a/src/resources/extensions/gsd/tests/lease-conflict-notice.test.ts
+++ b/src/resources/extensions/gsd/tests/lease-conflict-notice.test.ts
@@ -4,7 +4,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { formatLeaseConflictNotice } from "../auto/lease-conflict-notice.ts";
+import { formatLeaseConflictNotice, stableClaimSignature } from "../auto/lease-conflict-notice.ts";
 
 test("lease conflict notice explains the retry action before worker details", () => {
   const message = formatLeaseConflictNotice({
@@ -35,4 +35,25 @@ test("lease conflict notice keeps unknown reasons as details", () => {
   assert.match(message, /^Blocked: M012 is already active in another GSD worker\./);
   assert.match(message, /Try \/gsd status/);
   assert.match(message, /Details: stale_lease/);
+});
+
+test("stableClaimSignature strips the volatile lease expiresAt so identical rejections hash the same (Copilot #2098)", () => {
+  // Two "lease still held" rejections that differ ONLY in the expiresAt
+  // timestamp (advanced by a holder heartbeat) must normalize to the same
+  // signature, otherwise the ADR-047 wedge never trips at occurrence 2.
+  const a = "Milestone M012 is held by worker auto-host-34036-ee4ef385 until 2026-05-20T18:58:59.275Z.";
+  const b = "Milestone M012 is held by worker auto-host-34036-ee4ef385 until 2026-05-20T18:59:44.900Z.";
+  const sigA = stableClaimSignature(a);
+  const sigB = stableClaimSignature(b);
+  assert.equal(sigA, sigB);
+  assert.equal(sigA, "Milestone M012 is held by worker auto-host-34036-ee4ef385");
+  assert.doesNotMatch(sigA, /until|\d{4}-\d{2}-\d{2}T/);
+});
+
+test("stableClaimSignature passes non-lease reasons through unchanged", () => {
+  assert.equal(stableClaimSignature("missing-worker"), "missing-worker");
+  assert.equal(
+    stableClaimSignature("dispatch claim skipped: stale-lease"),
+    "dispatch claim skipped: stale-lease",
+  );
 });


### PR DESCRIPTION
## What

Fixes the auto-mode hard-stop `liveness backstop unavailable: semantic guard did not provide a stable identity` (#2097).

`advanceInner()` returned the blocked `AutoAdvanceResult` from `openUnitRun()` **directly, without `withLivenessInput(...)`**. When a unit-run claim is rejected (milestone lease held/`blocked`, `degraded`, or `skip`), `adjudicateLiveness()` then saw a `blocked` result with a `null` `pendingLivenessInput` and fell through to `backstopFailure("semantic guard did not provide a stable identity")`, hard-stopping auto-mode.

Because nothing in the workflow DB is actually corrupt, the recommended `/gsd doctor --fix` can never clear it. The stop recurs whenever a unit-run claim is rejected mid-retry (e.g. the owning worker is shutting down or another live worker holds the milestone lease).

## Fix

Wrap the claim-rejection return in `withLivenessInput` with a stable `unit-run-claim` guard identity keyed on the rejection reason, and journal `advance-blocked` for parity with the sibling guard paths (`resource-version-guard`, `pre-dispatch-health-gate`, `state-reconciliation:*`, `prior-slice-completion`, `unit-tool-contract`, `unit-worktree-preparation`, …). Repeated identical claim rejections now record/trip the ADR-047 signature ledger (wedge at threshold 2) with an actionable sanctioned exit, instead of failing the backstop **closed**.

Same family as the ADR-047 coverage gaps fixed in #1672 / #1805, but at the `orchestrator.ts` `openUnitRun` claim-rejection seam.

## Test

Adds `ADR-047: a rejected unit-run claim blocks with a stable identity, not backstop-unavailable`, which forces a `degraded: missing-worker` claim and asserts:
- the advance blocks with the real claim reason and **not** the `semantic guard did not provide a stable identity` / `backstop unavailable` message, and
- a second identical rejection trips the `unit-run-claim` wedge (occurrence 2).

## Verification

Cumulative across all three commits (`eafa13d6` + review follow-ups `4bad9779`, `d279fcba`):

- `auto-orchestrator.test.ts`: 58/58 pass (incl. the ADR-047 rejected-claim regression test, which also asserts the persisted `sanctionedExit`).
- `lease-conflict-notice.test.ts`: 4/4 pass (incl. two `stableClaimSignature` regression tests).
- `pnpm run typecheck:extensions`: clean.

Each follow-up diff is minimal and applied by hand (no biome wholesale reformat); see the Review evidence section below for the per-commit breakdown.

Closes #2097



---

## Review evidence (added 2026-08-30)

### Automated PR risk report (Auto Engine, critical)

The risk report asked for a scope / root-cause assessment of auto-mode trigger conditions and loop termination. Verified against the code (not from memory):

- **Root cause, not symptom.** In `advanceInner`, every blocked/skip return routes through `withLivenessInput(...)`. The single exception was the `openUnitRun` claim-rejection return, which never set `pendingLivenessInput` — so `adjudicateLiveness` fell to `backstopFailure("semantic guard did not provide a stable identity")`. Exactly one missing instrumentation.
- **Other call sites / duplicated logic.** `openUnitRun` has a single caller (`advanceInner`); no duplication. The two other raw `return blocked;` are legitimately terminal (the outer `advance()` open-wedge short-circuit before `adjudicateLiveness` runs, and inside `backstopFailure()` itself). `loop.ts` has a separate liveness seam already hardened in #1672/#1805 — untouched.
- **Loop termination.** No path converts a stop into a continue. Both post-fix outcomes are `action:"stop"`: a one-off rejection returns the real claim reason; a repeated identical rejection trips the wedge at occurrence 2. Termination is preserved and strengthened (prevents silent retry churn). Auto-mode trigger conditions are unchanged.
- **Contract/downstream.** `AutoAdvanceResult` shape unchanged; only `reason`/wedge metadata become more informative. No signature change.

### Independent Codex review (`codex review`, adversarial prompt)

Codex CLI 0.145.0 (note: the risk report's `codex review --adversarial` CTA is stale — that flag no longer exists; filed as open-gsd/gsd-pi#2100). Ran `codex review` with an adversarial prompt against this commit. It surfaced one actionable finding:

> **[P2] Persist an actionable recovery for claim wedges** — `orchestrator.ts` (unit-run-claim seam). When the new `unit-run-claim` signature trips, no `sanctionedExit` is supplied, so the wedge persists only the raw reason (e.g. `missing-worker`, `dispatch claim skipped: stale-lease`). The resulting notice does not tell the operator how to resolve the claim blocker, contrary to ADR-047 §5's requirement that every wedge carry a reachable recovery instruction.

**Resolved in `4bad9779`.** The claim-rejection path now supplies a claim-specific `sanctionedExit` (names the unit, the reason, and the recovery path: `/gsd status` for the lease holder, re-run once released, or `/gsd doctor` if no worker is live) — mirroring the `COMPLETED_NO_ADVANCE_GUARD_ID` and `orphaned-active-unit` siblings. The ADR-047 regression test now asserts the wedge's `sanctionedExit` is the actionable message, not the raw `missing-worker` reason.

- `auto-orchestrator.test.ts`: 58/58 pass.
- `pnpm run typecheck:extensions`: clean.
- Follow-up diff is minimal (+22/-3); no unrelated reformatting.


### Copilot code review (2026-08-30)

Copilot's second review raised one actionable inline comment (a duplicate of the codex [P2] was already resolved in `4bad9779`):

> **Signature stability** — the `unit-run-claim` signature used the raw claim reason as `inputPayload`. For lease-held rejections that reason embeds the lease `expiresAt` timestamp (`workflow-dispatch-claim.ts`: `Milestone ... is held by worker ... until <expiresAt>.`), which advances on every holder heartbeat. Hashing it would produce a different signature on each identical "lease still held" rejection, so the ADR-047 wedge would never trip at occurrence 2.

**Resolved in `d279fcba`.** Added `stableClaimSignature()` which strips the volatile `until <expiresAt>` clause and keys the signature on the stable conflict identity (milestone + holder); non-lease reasons (`missing-worker`, `dispatch claim skipped: …`) pass through unchanged. Wired into the orchestrator `inputPayload`. Two regression tests assert identical lease-held rejections differing only in `expiresAt` normalize to the same signature.

- `lease-conflict-notice.test.ts`: 4/4 pass.
- `auto-orchestrator.test.ts`: 58/58 pass.
- `pnpm run typecheck:extensions`: clean.

Both Copilot inline threads resolved (the sanctioned-exit comment was already covered by `4bad9779`).

