### PR TITLE
fix(gsd): browser daemon warm-up burns its full timeout on an inherited stdio pipe

### DIFF
--- a/src/resources/extensions/gsd/browser-daemon-auto-prep.ts
+++ b/src/resources/extensions/gsd/browser-daemon-auto-prep.ts
@@ -1,5 +1,7 @@
 import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
+import { closeSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 import {
   resolveAmbientBrowserEngineResolution,
@@ -10,11 +12,15 @@ import {
   resolveGsdBrowserCliAvailability,
   resolveGsdBrowserDaemonStartInvocation,
   resolveGsdBrowserDaemonStopInvocation,
+  type GsdBrowserMcpLaunchConfig,
 } from "../shared/gsd-browser-cli.js";
 import { uatTypeIncludesBrowser, type UatType } from "./uat-policy.js";
 
 const DEFAULT_DAEMON_START_TIMEOUT_MS = 30_000;
 const DEFAULT_DAEMON_STOP_TIMEOUT_MS = 15_000;
+
+/** Maximum bytes of daemon stderr folded into an error message (4 KB). */
+const MAX_DAEMON_STDERR_BYTES = 4 * 1024;
 
 /**
  * Project roots whose gsd-browser daemon this process warmed via
@@ -65,6 +71,83 @@ export function shouldWarmBrowserDaemonForUat(ctx: BrowserDaemonWarmContext): bo
   return resolveActiveBrowserEngine(projectRoot, env) === "gsd-browser";
 }
 
+/** Truncate to maxBytes, appending the marker used by verification-gate.ts. */
+function truncateDaemonStderr(value: string): string {
+  if (Buffer.byteLength(value, "utf-8") <= MAX_DAEMON_STDERR_BYTES) return value;
+  // Slice conservatively then trim to last full character
+  const buf = Buffer.from(value, "utf-8").subarray(0, MAX_DAEMON_STDERR_BYTES);
+  return buf.toString("utf-8") + "\n…[truncated]";
+}
+
+function readDaemonStderr(stderrPath: string): string {
+  try {
+    return truncateDaemonStderr(readFileSync(stderrPath, "utf-8").trim());
+  } catch {
+    // Diagnostics are best-effort — never let stderr recovery mask the real failure.
+    return "";
+  }
+}
+
+/**
+ * Run a `gsd-browser daemon <action>` invocation without ever handing the child an
+ * stdio *pipe* (#2103).
+ *
+ * `daemon start` exits 0 but leaves a detached daemon (and Chrome) behind that inherits
+ * the pipe's write handle. execFileSync unblocks on stdio EOF, not on child exit, so the
+ * surviving grandchild held the pipe open and warm-up burned its full timeout — reporting
+ * ETIMEDOUT even though the daemon had started cleanly.
+ *
+ * stderr is captured to a file descriptor instead, mirroring verification-gate.ts: a file
+ * is not a pipe, so spawnSync never waits on it. Capturing rather than discarding keeps the
+ * daemon's own failure text inside the user-facing "daemon failed to start (...)" message,
+ * which stdio "ignore" would reduce to a bare "Command failed: <cmd>".
+ */
+function runDaemonCommand(
+  invocation: Pick<GsdBrowserMcpLaunchConfig, "command" | "args" | "cwd" | "env">,
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+): { ok: true } | { ok: false; error: string } {
+  // Capture setup is best-effort: this module must stay incapable of throwing, because the
+  // dispatch-rule loop that reaches it does not guard rule.match(). If the temp file cannot
+  // be created we discard stderr rather than fail the warm-up.
+  let capture: { dir: string; path: string; fd: number } | null = null;
+  try {
+    const dir = mkdtempSync(join(tmpdir(), "gsd-browser-daemon-"));
+    const path = join(dir, "stderr");
+    capture = { dir, path, fd: openSync(path, "w") };
+  } catch {
+    capture = null;
+  }
+
+  try {
+    execFileSync(invocation.command, invocation.args, {
+      cwd: invocation.cwd,
+      env: { ...process.env, ...env, ...(invocation.env ?? {}) },
+      stdio: ["ignore", "ignore", capture ? capture.fd : "ignore"],
+      timeout: timeoutMs,
+      windowsHide: true,
+    });
+    return { ok: true };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const stderrText = capture ? readDaemonStderr(capture.path) : "";
+    return { ok: false, error: stderrText ? `${detail}: ${stderrText}` : detail };
+  } finally {
+    if (capture) {
+      try {
+        closeSync(capture.fd);
+      } catch {
+        /* already closed */
+      }
+      try {
+        rmSync(capture.dir, { recursive: true, force: true });
+      } catch {
+        /* best-effort temp cleanup */
+      }
+    }
+  }
+}
+
 export function ensureBrowserDaemonStarted(
   projectRoot: string,
   options: { env?: NodeJS.ProcessEnv; timeoutMs?: number } = {},
@@ -85,21 +168,7 @@ export function ensureBrowserDaemonStarted(
     };
   }
 
-  try {
-    execFileSync(invocation.command, invocation.args, {
-      cwd: invocation.cwd,
-      env: { ...process.env, ...env, ...(invocation.env ?? {}) },
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: options.timeoutMs ?? DEFAULT_DAEMON_START_TIMEOUT_MS,
-      encoding: "utf-8",
-    });
-    return { ok: true };
-  } catch (error) {
-    return {
-      ok: false,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
+  return runDaemonCommand(invocation, env, options.timeoutMs ?? DEFAULT_DAEMON_START_TIMEOUT_MS);
 }
 
 /**
@@ -144,21 +213,7 @@ export function stopBrowserDaemon(
     };
   }
 
-  try {
-    execFileSync(invocation.command, invocation.args, {
-      cwd: invocation.cwd,
-      env: { ...process.env, ...env, ...(invocation.env ?? {}) },
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: options.timeoutMs ?? DEFAULT_DAEMON_STOP_TIMEOUT_MS,
-      encoding: "utf-8",
-    });
-    return { ok: true };
-  } catch (error) {
-    return {
-      ok: false,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
+  return runDaemonCommand(invocation, env, options.timeoutMs ?? DEFAULT_DAEMON_STOP_TIMEOUT_MS);
 }
 
 /**

--- a/src/resources/extensions/gsd/browser-daemon-auto-prep.ts
+++ b/src/resources/extensions/gsd/browser-daemon-auto-prep.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { closeSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
+import { closeSync, fstatSync, mkdtempSync, openSync, readFileSync, readSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -71,20 +71,41 @@ export function shouldWarmBrowserDaemonForUat(ctx: BrowserDaemonWarmContext): bo
   return resolveActiveBrowserEngine(projectRoot, env) === "gsd-browser";
 }
 
-/** Truncate to maxBytes, appending the marker used by verification-gate.ts. */
-function truncateDaemonStderr(value: string): string {
-  if (Buffer.byteLength(value, "utf-8") <= MAX_DAEMON_STDERR_BYTES) return value;
-  // Slice conservatively then trim to last full character
-  const buf = Buffer.from(value, "utf-8").subarray(0, MAX_DAEMON_STDERR_BYTES);
-  return buf.toString("utf-8") + "\n…[truncated]";
-}
-
+/**
+ * Read at most {@link MAX_DAEMON_STDERR_BYTES} from the capture file, keeping the head and
+ * the tail around a marker. Mirrors readBoundedCommandOutput in verification-gate.ts, so a
+ * daemon that floods stderr cannot pull an unbounded file into memory here.
+ */
 function readDaemonStderr(stderrPath: string): string {
+  let fd: number;
   try {
-    return truncateDaemonStderr(readFileSync(stderrPath, "utf-8").trim());
+    fd = openSync(stderrPath, "r");
   } catch {
     // Diagnostics are best-effort — never let stderr recovery mask the real failure.
     return "";
+  }
+
+  try {
+    const size = fstatSync(fd).size;
+    if (size <= MAX_DAEMON_STDERR_BYTES) return readFileSync(stderrPath, "utf-8").trim();
+
+    const marker = Buffer.from("\n…[truncated]\n", "utf-8");
+    const retainedBytes = MAX_DAEMON_STDERR_BYTES - marker.byteLength;
+    const headBytes = Math.floor(retainedBytes / 2);
+    const tailBytes = retainedBytes - headBytes;
+    const head = Buffer.allocUnsafe(headBytes);
+    const tail = Buffer.allocUnsafe(tailBytes);
+    readSync(fd, head, 0, headBytes, 0);
+    readSync(fd, tail, 0, tailBytes, size - tailBytes);
+    return Buffer.concat([head, marker, tail]).toString("utf-8").trim();
+  } catch {
+    return "";
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      /* already closed */
+    }
   }
 }
 
@@ -110,11 +131,14 @@ function runDaemonCommand(
   // Capture setup is best-effort: this module must stay incapable of throwing, because the
   // dispatch-rule loop that reaches it does not guard rule.match(). If the temp file cannot
   // be created we discard stderr rather than fail the warm-up.
-  let capture: { dir: string; path: string; fd: number } | null = null;
+  // The directory is tracked separately from the descriptor so that a partial setup —
+  // mkdtempSync succeeds, openSync then fails — still gets cleaned up below.
+  let captureDir: string | null = null;
+  let capture: { path: string; fd: number } | null = null;
   try {
-    const dir = mkdtempSync(join(tmpdir(), "gsd-browser-daemon-"));
-    const path = join(dir, "stderr");
-    capture = { dir, path, fd: openSync(path, "w") };
+    captureDir = mkdtempSync(join(tmpdir(), "gsd-browser-daemon-"));
+    const path = join(captureDir, "stderr");
+    capture = { path, fd: openSync(path, "w") };
   } catch {
     capture = null;
   }
@@ -139,8 +163,10 @@ function runDaemonCommand(
       } catch {
         /* already closed */
       }
+    }
+    if (captureDir) {
       try {
-        rmSync(capture.dir, { recursive: true, force: true });
+        rmSync(captureDir, { recursive: true, force: true });
       } catch {
         /* best-effort temp cleanup */
       }

--- a/src/resources/extensions/gsd/tests/browser-daemon-auto-prep.test.ts
+++ b/src/resources/extensions/gsd/tests/browser-daemon-auto-prep.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
+  ensureBrowserDaemonStarted,
   prepareBrowserDaemonForUat,
   shouldWarmBrowserDaemonForUat,
   stopBrowserDaemon,
@@ -143,6 +147,94 @@ test("stopBrowserDaemon reports failure when the gsd-browser CLI is missing", ()
   });
 
   assert.equal(result.ok, false);
+});
+
+/**
+ * Stand-in for the gsd-browser CLI, wired in through GSD_BROWSER_MCP_COMMAND, which
+ * resolveGsdBrowserMcpLaunchConfig splits into command + prefix args and the daemon
+ * invocation forwards ahead of `daemon <action>`.
+ */
+function writeFakeGsdBrowser(dir: string, lines: string[]): string {
+  const scriptPath = join(dir, "fake-gsd-browser.mjs");
+  writeFileSync(scriptPath, `${lines.join("\n")}\n`, "utf-8");
+  return scriptPath;
+}
+
+function fakeCliEnv(scriptPath: string): NodeJS.ProcessEnv {
+  // splitCommandLine() honours double quotes, so paths with spaces still resolve.
+  return { GSD_BROWSER_MCP_COMMAND: `"${process.execPath}" "${scriptPath.replace(/\\/g, "/")}"` };
+}
+
+test("ensureBrowserDaemonStarted does not hang when the daemon leaves a child holding stdio", (t) => {
+  // Regression guard for #2103: `daemon start` exits 0 but leaves a detached daemon that
+  // inherits the parent's stdio. With a *pipe* the parent blocks on EOF - not on child exit -
+  // and burns the whole timeout. The timeout here is deliberately far above the assertion
+  // threshold so a slow runner cannot masquerade as the bug returning.
+  const dir = mkdtempSync(join(tmpdir(), "gsd-daemon-hang-"));
+  const pidPath = join(dir, "grandchild.pid").replace(/\\/g, "/");
+  t.after(() => {
+    try {
+      process.kill(Number(readFileSync(pidPath, "utf-8").trim()));
+    } catch {
+      /* already exited, or never recorded */
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort temp cleanup */
+    }
+  });
+
+  const scriptPath = writeFakeGsdBrowser(dir, [
+    `import { spawn } from "node:child_process";`,
+    `import { writeFileSync } from "node:fs";`,
+    `process.stdout.write("Daemon started.\\n");`,
+    `const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 10000)"], {`,
+    `  stdio: "inherit",`,
+    `  detached: true,`,
+    `});`,
+    `writeFileSync(${JSON.stringify(pidPath)}, String(child.pid), "utf-8");`,
+    `child.unref();`,
+    `process.exit(0);`,
+  ]);
+
+  const startedAt = Date.now();
+  // dir doubles as projectRoot so the invocation gets a cwd that exists.
+  const result = ensureBrowserDaemonStarted(dir, { env: fakeCliEnv(scriptPath), timeoutMs: 20_000 });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(result.ok, true, `expected a clean start, got ${JSON.stringify(result)}`);
+  assert.ok(elapsedMs < 5_000, `warm-up should return promptly, took ${elapsedMs}ms`);
+});
+
+test("ensureBrowserDaemonStarted keeps daemon stderr in the failure detail", (t) => {
+  // Guards the file-capture path added with runDaemonCommand rather than the original bug:
+  // dropping the stdio pipes must not cost the actionable cause. This also passes against
+  // the pre-fix code, where execFileSync folded piped stderr into error.message - it exists
+  // to stop a future simplification to stdio "ignore", which would silently degrade the
+  // user-facing message to a bare "Command failed: <cmd>".
+  const dir = mkdtempSync(join(tmpdir(), "gsd-daemon-stderr-"));
+  t.after(() => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort temp cleanup */
+    }
+  });
+
+  const scriptPath = writeFakeGsdBrowser(dir, [
+    `process.stderr.write("chrome not found: set GSD_BROWSER_PATH\\n");`,
+    `process.exit(1);`,
+  ]);
+
+  const result = ensureBrowserDaemonStarted(dir, { env: fakeCliEnv(scriptPath), timeoutMs: 20_000 });
+
+  assert.equal(result.ok, false);
+  assert.match(
+    result.ok ? "" : result.error,
+    /chrome not found/,
+    "daemon stderr must survive into the actionable error message",
+  );
 });
 
 test("teardownWarmedBrowserDaemons is a no-op when nothing was warmed", () => {

--- a/src/resources/extensions/gsd/tests/browser-daemon-auto-prep.test.ts
+++ b/src/resources/extensions/gsd/tests/browser-daemon-auto-prep.test.ts
@@ -237,6 +237,40 @@ test("ensureBrowserDaemonStarted keeps daemon stderr in the failure detail", (t)
   );
 });
 
+test("ensureBrowserDaemonStarted degrades instead of throwing when stderr capture cannot be set up", (t) => {
+  // The module must stay incapable of throwing: the dispatch-rule loop that reaches it does
+  // not wrap rule.match(), so an escaped exception from a best-effort *warm-up* would take
+  // down dispatch. Point the temp dir at a path that cannot be created, so mkdtempSync fails.
+  const dir = mkdtempSync(join(tmpdir(), "gsd-daemon-nocapture-"));
+  const saved = { TMPDIR: process.env.TMPDIR, TEMP: process.env.TEMP, TMP: process.env.TMP };
+  t.after(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort temp cleanup */
+    }
+  });
+
+  const scriptPath = writeFakeGsdBrowser(dir, [
+    `process.stderr.write("chrome not found\\n");`,
+    `process.exit(1);`,
+  ]);
+
+  const unusable = join(dir, "does-not-exist", "nor-does-this");
+  process.env.TMPDIR = unusable;
+  process.env.TEMP = unusable;
+  process.env.TMP = unusable;
+
+  const result = ensureBrowserDaemonStarted(dir, { env: fakeCliEnv(scriptPath), timeoutMs: 20_000 });
+
+  // Still a normal failure result, just without the captured stderr detail.
+  assert.equal(result.ok, false);
+});
+
 test("teardownWarmedBrowserDaemons is a no-op when nothing was warmed", () => {
   // A failed warm-up must not register a project root for teardown.
   prepareBrowserDaemonForUat({


### PR DESCRIPTION
## Linked issue

Closes #2103

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** `ensureBrowserDaemonStarted` / `stopBrowserDaemon` no longer hand the `gsd-browser daemon` child an stdio pipe, so warm-up stops hanging until timeout and reporting a false `ETIMEDOUT`.
**Why:** The detached daemon inherits the pipe, the pipe never reaches EOF, and `execFileSync` blocks on EOF rather than on child exit — so auto-mode refuses to dispatch browser-backed `run-uat` even though the daemon started cleanly.
**How:** One shared `runDaemonCommand()` replaces the two copy-pasted `execFileSync` blocks and captures daemon stderr to a temp **file descriptor** instead of a pipe, following `verification-gate.ts`.

## What

Two files:

- `src/resources/extensions/gsd/browser-daemon-auto-prep.ts` — the two duplicated `execFileSync` blocks collapse into one private `runDaemonCommand()`.
- `src/resources/extensions/gsd/tests/browser-daemon-auto-prep.test.ts` — two added tests.

Blast radius is browser-backed `run-uat` dispatch in auto-mode. `ensureBrowserDaemonStarted`, `stopBrowserDaemon`, and `teardownWarmedBrowserDaemons` keep their exact signatures, stay **synchronous**, and stay **total** — they still return `{ok:false,error}` rather than throwing. No caller changes, no new dependency.

## Why

Users hit this as a browser-backed `run-uat` unit that refuses to dispatch, after a 30-second stall:

```
Cannot dispatch browser-backed run-uat: gsd-browser daemon failed to start
(spawnSync <node> ETIMEDOUT). Ensure Chrome/Chromium is installed, run
`gsd-browser daemon health` ...
```

The advice is unfollowable, because `gsd-browser daemon health` reports the daemon **up**. Nothing is wrong with it.

Root cause: both call sites passed `stdio: ["ignore", "pipe", "pipe"]`. `gsd-browser daemon start` deliberately leaves a **detached** daemon (and Chrome) behind, and that grandchild inherits the pipe's write handle. `execFileSync` returns when the child's stdio reaches **EOF**, not merely when the child exits — and a pipe whose write end is still held by a live grandchild never reaches EOF. The sync loop kept spinning after the child had already exited 0, until `timeout` fired.

The raw `spawnSync` result contains the discriminating fingerprint — three fields that look mutually contradictory:

| stdio | elapsed | `status` | `signal` | `error` | stdout |
|---|---|---|---|---|---|
| `["ignore","pipe","pipe"]` (before) | 4014 ms | **0** | null | **ETIMEDOUT** | `"Daemon started.\n"` |
| `["ignore","pipe","ignore"]` | 4016 ms | 0 | null | ETIMEDOUT | — |
| `["ignore","ignore",fd]` (this PR) | **60 ms** | 0 | null | none | — |
| `"ignore"` | 65 ms | 0 | null | none | — |

Node takes `status` from the child's exit callback and `error` from the timer independently, so `status: 0` + fully-collected stdout + `ETIMEDOUT` is only explicable by a held-open stdio pipe. It also rules out the alternatives: a genuinely slow daemon would fail at a fixed wall time independent of `timeout` (this burns exactly whatever `timeout` is set to), and a `maxBuffer` overflow yields `ENOBUFS`, not `ETIMEDOUT`. Row 2 shows that dropping only one pipe is not enough.

**Not strictly Windows-specific.** Pipe-EOF semantics are the same on POSIX; a grandchild inheriting the pipe blocks EOF there too. It stays latent on POSIX only because daemons conventionally redirect their stdio on fork. The fix is platform-independent.

## How

`runDaemonCommand(invocation, env, timeoutMs)` runs the invocation with `stdio: ["ignore", "ignore", stderrFd]`, where `stderrFd` is an `openSync` handle inside a per-call `mkdtempSync(join(tmpdir(), "gsd-browser-daemon-"))` directory, removed in `finally`. A file is not a pipe — `spawnSync` never waits on one — so the hang is gone regardless of what the daemon leaves running.

**Why a file rather than `stdio: "ignore"`.** `execFileSync` folds piped stderr into `error.message`, and that message is interpolated straight into the user-facing `daemon failed to start (...)` text. Verified against a daemon that writes to stderr and exits 1:

- with pipes: `Command failed: <cmd>` + `chrome not found: set GSD_BROWSER_PATH`
- with `stdio: "ignore"`: `Command failed: <cmd>` — the actionable cause is gone

That text is the only diagnostic users get for genuine daemon startup failures, so a one-line `stdio: "ignore"` would fix the hang by destroying the diagnostics. stderr is captured instead, byte-capped with the same `…[truncated]` marker `verification-gate.ts` uses.

**Capture setup is itself guarded.** `mkdtempSync`/`openSync` can fail (`EACCES`, `EMFILE`, `ENOSPC`), and this module must remain incapable of throwing — the dispatch-rule loop that reaches it does not wrap `rule.match()`. On capture-setup failure it degrades to discarded stderr and still returns `{ok:false,error}`. There is a test for this.

**Why one helper rather than two edits.** This is deduplication of the defect, not a refactor: the same fatal `stdio` line existed verbatim in both functions and both had to change identically. Nothing but the stdio handling changes.

**Precedent, not invention.** `verification-gate.ts:890-912` already solves this class of problem the same way — `mkdtempSync` → `openSync` → `stdio: ["ignore", stdoutFd, stderrFd]` → read back → `rmSync` in `finally`.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Two tests added to the existing suite:

1. **`does not hang when the daemon leaves a child holding stdio`** — a fake CLI announces readiness, spawns a `detached` child that inherits stdio, and exits 0. Asserts warm-up returns `ok` in well under the timeout. `timeoutMs` is 20 s while the assertion threshold is 5 s, so a slow runner cannot masquerade as the bug returning. This is the actual regression guard: it fails on the pre-fix code.
2. **`keeps daemon stderr in the failure detail`** — a fake CLI writes to stderr and exits 1; asserts the cause survives into the error. To be precise, **this one also passes on the pre-fix code** (piped stderr was already folded into `error.message`); it exists to stop a future simplification to `stdio: "ignore"` from silently degrading the message.

Verified by hand on Windows 11 / Node 22.22.0 against the installed package, including a control run that re-imports the unpatched module to confirm it still reproduces:

```
CONTROL - unpatched:  ok=false, elapsed=4018ms, error=spawnSync <node> ETIMEDOUT
PATCHED:              ok=true,  elapsed=70ms
```

Also verified: an unusable `tmpdir` makes capture setup fail without throwing, and per-call temp directories leave no residue.

**What I have not verified:** upstream CI. I did not run `pnpm run verify:pr` or the compiled unit suite locally — the change was developed and measured against an installed package, then applied to a clean checkout of `main`. The new tests spawn a short-lived detached child (10 s ceiling, killed in `t.after()`); if that is unwelcome in CI I am happy to rework them.

## AI disclosure

- [x] This PR includes AI-assisted code

Investigated, drafted, and reviewed with Claude (Anthropic). Every claim above was reproduced on a real host before submitting: the failure was measured before and after with a control run against the unpatched module, and the stderr-degradation comparison was run rather than assumed. Per CONTRIBUTING.md the tool is not credited as an author or co-author.
