### PR TITLE
fix(gsd): make progress reads database-authoritative

### DIFF
--- a/docs/dev/ADR-046-database-authoritative-workflow-lifecycle.md
+++ b/docs/dev/ADR-046-database-authoritative-workflow-lifecycle.md
@@ -79,6 +79,13 @@ closeout from one consistent project-database snapshot. Missing or unreadable
 authority fails explicitly; runtime does not fall back to files or cached
 prose.
 
+Read-only progress integrations are a display-only compatibility boundary:
+`gsd read progress` and packaged MCP `gsd_progress` may serve the `STATE.md`
+projection only when the project database is missing or cannot be opened, or
+when the standalone MCP package has no GSD runtime bridge. Once the database
+opens, it remains authoritative and any later read failure is reported instead
+of falling back. This exception cannot drive lifecycle state.
+
 Only Domain Operations in the Single Writer layer mutate workflow state. A
 Domain Operation validates revision, dependencies, lifecycle, lease/fencing,
 evidence, and transport idempotency inside one transaction. That transaction

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -574,7 +574,9 @@ MCP mode also exposes the GSD workflow adapter tools used by headless runtimes:
 - Project state and read-only tools: `gsd_query`, `gsd_progress`, `gsd_roadmap`, `gsd_history`, `gsd_doctor`, `gsd_captures`, `gsd_knowledge`, `gsd_graph`
 - Interactive form tool: `ask_user_questions`
 
-For an auto-mode run, call `gsd_execute` first with an absolute `projectDir`. It returns a `sessionId`; poll `gsd_status` with that `sessionId` until the run finishes, then call `gsd_result` for accumulated output or `gsd_cancel` to stop it. If a client loses the `sessionId`, `gsd_status` can fall back to `projectDir`, or omit both fields only when this MCP server tracks exactly one session. The read-only project tools read `.gsd/` directly and do not require an active session.
+For an auto-mode run, call `gsd_execute` first with an absolute `projectDir`. It returns a `sessionId`; poll `gsd_status` with that `sessionId` until the run finishes, then call `gsd_result` for accumulated output or `gsd_cancel` to stop it. If a client loses the `sessionId`, `gsd_status` can fall back to `projectDir`, or omit both fields only when this MCP server tracks exactly one session. Read-only project tools do not require an active session. With the GSD runtime bridge available, `gsd_progress` reads the project-root database and may run pending migrations and synchronize milestone queue order, matching `gsd headless status`. It uses the `STATE.md` projection only when the database is missing or cannot be opened; failures after a successful open are returned as errors. Without the bridge, the standalone MCP package keeps its projection-reader behavior. The other read-only project tools continue to read `.gsd/` projections directly.
+
+The integration CLI `gsd read progress --json --project <path>` follows the same database-first and projection-fallback contract as `gsd_progress`.
 
 ## In-Session Update
 

--- a/docs/zh-CN/user-docs/commands.md
+++ b/docs/zh-CN/user-docs/commands.md
@@ -378,7 +378,7 @@ MCP 模式也会暴露供 headless 和 MCP 客户端使用的 GSD workflow adapt
 - 项目状态和只读工具：`gsd_query`、`gsd_progress`、`gsd_roadmap`、`gsd_history`、`gsd_doctor`、`gsd_captures`、`gsd_knowledge`、`gsd_graph`
 - 交互式表单工具：`ask_user_questions`
 
-运行自动模式时，先用绝对路径 `projectDir` 调用 `gsd_execute`。它会返回 `sessionId`；之后用这个 `sessionId` 轮询 `gsd_status`，直到运行结束，再调用 `gsd_result` 获取累积输出，或调用 `gsd_cancel` 停止运行。如果客户端丢失了 `sessionId`，`gsd_status` 可以回退到 `projectDir`；只有当这个 MCP server 只跟踪一个会话时，才可以同时省略这两个字段。项目只读工具会直接读取 `.gsd/`，不需要活跃会话。
+运行自动模式时，先用绝对路径 `projectDir` 调用 `gsd_execute`。它会返回 `sessionId`；之后用这个 `sessionId` 轮询 `gsd_status`，直到运行结束，再调用 `gsd_result` 获取累积输出，或调用 `gsd_cancel` 停止运行。如果客户端丢失了 `sessionId`，`gsd_status` 可以回退到 `projectDir`；只有当这个 MCP server 只跟踪一个会话时，才可以同时省略这两个字段。项目只读工具不需要活跃会话；当前数据库与 projection 的读取规则请以[英文命令文档](../../user-docs/commands.md#mcp-server-mode)为准。
 
 ## 会话内更新
 

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -27,7 +27,6 @@ import {
   formatAskUserQuestionsElicitResult,
   isLocalElicitClientAbortError,
   isLocalElicitTimeoutError,
-  registerProgressTool,
   withElicitTimeout,
 } from './server.js';
 import {
@@ -893,22 +892,21 @@ describe('createMcpServer tool registration', () => {
       ].join('\n'),
     );
 
-    let handler: ((args: Record<string, unknown>) => Promise<any>) | undefined;
-    registerProgressTool({
-      tool(name, _description, _params, registeredHandler) {
-        if (name === 'gsd_progress') handler = registeredHandler;
+    const { server } = await createMcpServer(sm, {
+      includeWorkflowTools: false,
+      progressToolDependencies: {
+        hasWorkflowBridge: () => true,
+        readFromDb: async () => ({
+          activeMilestone: { id: 'M001', title: 'Database Authority' },
+          phase: 'executing',
+        }),
+        readProjection: readProgress,
       },
-    }, {
-      hasWorkflowBridge: () => true,
-      readFromDb: async () => ({
-        activeMilestone: { id: 'M001', title: 'Database Authority' },
-        phase: 'executing',
-      }),
-      readProjection: readProgress,
     });
-    assert.ok(handler);
+    const progressTool = (server as any)._registeredTools?.gsd_progress;
+    assert.ok(progressTool, 'gsd_progress should be registered');
 
-    const result = await handler({ projectDir });
+    const result = await progressTool.handler({ projectDir });
     assert.deepEqual(JSON.parse(result.content[0].text), {
       activeMilestone: { id: 'M001', title: 'Database Authority' },
       phase: 'executing',
@@ -929,21 +927,20 @@ describe('createMcpServer tool registration', () => {
       ].join('\n'),
     );
 
-    let handler: ((args: Record<string, unknown>) => Promise<any>) | undefined;
-    registerProgressTool({
-      tool(name, _description, _params, registeredHandler) {
-        if (name === 'gsd_progress') handler = registeredHandler;
+    const { server } = await createMcpServer(sm, {
+      includeWorkflowTools: false,
+      progressToolDependencies: {
+        hasWorkflowBridge: () => false,
+        readFromDb: async () => {
+          throw new Error('DB reader must not run without a bridge');
+        },
+        readProjection: readProgress,
       },
-    }, {
-      hasWorkflowBridge: () => false,
-      readFromDb: async () => {
-        throw new Error('DB reader must not run without a bridge');
-      },
-      readProjection: readProgress,
     });
-    assert.ok(handler);
+    const progressTool = (server as any)._registeredTools?.gsd_progress;
+    assert.ok(progressTool, 'gsd_progress should be registered');
 
-    const result = await handler({ projectDir });
+    const result = await progressTool.handler({ projectDir });
     const progress = JSON.parse(result.content[0].text);
     assert.deepEqual(progress.activeMilestone, { id: 'M999', title: 'Projection Only' });
     assert.equal(progress.phase, 'plan');

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -866,6 +866,17 @@ describe('createMcpServer tool registration', () => {
     assert.ok(typeof server.close === 'function');
   });
 
+  it('gsd_progress returns validation failures in the MCP error envelope', async () => {
+    const { server } = await createMcpServer(sm, { includeWorkflowTools: false });
+    const progressTool = (server as any)._registeredTools?.gsd_progress;
+    assert.ok(progressTool, 'gsd_progress should be registered');
+
+    const result = await progressTool.handler({ projectDir: 'relative/path' });
+
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /projectDir must be an absolute path/);
+  });
+
   it('ask_user_questions passes the declared elicitation timeout and signal to the MCP SDK request', async () => {
     const { server } = await createMcpServer(sm, { includeWorkflowTools: false });
     const askTool = (server as any)._registeredTools?.ask_user_questions;

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -12,11 +12,11 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { delimiter, join, resolve } from 'node:path';
+import { delimiter, dirname, join, resolve } from 'node:path';
 import { EventEmitter } from 'node:events';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { SessionManager } from './session-manager.js';
 import { installGlobalErrorHandlers } from './cli-errors.js';
@@ -36,7 +36,43 @@ import {
 import { MAX_EVENTS } from './types.js';
 import type { ManagedSession, CostAccumulator, PendingBlocker } from './types.js';
 import { WORKFLOW_TOOL_ALIAS_NAMES } from '@opengsd/contracts';
-import { readProgress } from './readers/state.js';
+
+interface WorkflowBridgeFixtureModule {
+  closeDatabase(): void;
+  insertMilestone(milestone: { id: string; title: string; status: string }): boolean;
+  insertSlice(slice: {
+    id: string;
+    milestoneId: string;
+    title: string;
+    status: string;
+    risk: string;
+    depends: string[];
+    sequence: number;
+  }): void;
+  openDatabase(path: string): boolean;
+}
+
+async function importWorkflowBridgeFixture(): Promise<WorkflowBridgeFixtureModule> {
+  const candidates = [
+    '../../../src/resources/extensions/gsd/mcp-bridge.js',
+    '../../../src/resources/extensions/gsd/mcp-bridge.ts',
+    '../../../dist/resources/extensions/gsd/mcp-bridge.js',
+  ];
+  let lastError: unknown;
+  for (const candidate of candidates) {
+    try {
+      return await import(new URL(candidate, import.meta.url).href) as WorkflowBridgeFixtureModule;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+function restoreEnvironmentValue(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 describe('installGlobalErrorHandlers', () => {
   it('logs uncaught exceptions and unhandled rejections to stderr, then terminates (#783)', () => {
@@ -880,7 +916,11 @@ describe('createMcpServer tool registration', () => {
 
   it('registered gsd_progress prefers the DB payload when the bridge is configured', async (t) => {
     const projectDir = mkdtempSync(join(tmpdir(), 'gsd-progress-handler-'));
-    t.after(() => rmSync(projectDir, { recursive: true, force: true }));
+    const bridge = await importWorkflowBridgeFixture();
+    t.after(() => {
+      bridge.closeDatabase();
+      rmSync(projectDir, { recursive: true, force: true });
+    });
     mkdirSync(join(projectDir, '.gsd'));
     writeFileSync(
       join(projectDir, '.gsd', 'STATE.md'),
@@ -891,26 +931,30 @@ describe('createMcpServer tool registration', () => {
         '**Phase:** planning',
       ].join('\n'),
     );
-
-    const { server } = await createMcpServer(sm, {
-      includeWorkflowTools: false,
-      progressToolDependencies: {
-        hasWorkflowBridge: () => true,
-        readFromDb: async () => ({
-          activeMilestone: { id: 'M001', title: 'Database Authority' },
-          phase: 'executing',
-        }),
-        readProjection: readProgress,
-      },
+    assert.equal(bridge.openDatabase(join(projectDir, '.gsd', 'gsd.db')), true);
+    assert.equal(
+      bridge.insertMilestone({ id: 'M001', title: 'Database Authority', status: 'active' }),
+      true,
+    );
+    bridge.insertSlice({
+      id: 'S01',
+      milestoneId: 'M001',
+      title: 'Database Slice',
+      status: 'pending',
+      risk: 'low',
+      depends: [],
+      sequence: 1,
     });
+    bridge.closeDatabase();
+
+    const { server } = await createMcpServer(sm, { includeWorkflowTools: false });
     const progressTool = (server as any)._registeredTools?.gsd_progress;
     assert.ok(progressTool, 'gsd_progress should be registered');
 
     const result = await progressTool.handler({ projectDir });
-    assert.deepEqual(JSON.parse(result.content[0].text), {
-      activeMilestone: { id: 'M001', title: 'Database Authority' },
-      phase: 'executing',
-    });
+    const progress = JSON.parse(result.content[0].text);
+    assert.deepEqual(progress.activeMilestone, { id: 'M001', title: 'Database Authority' });
+    assert.equal(progress.milestones.total, 1);
   });
 
   it('registered gsd_progress uses projections without a workflow bridge', async (t) => {
@@ -927,16 +971,28 @@ describe('createMcpServer tool registration', () => {
       ].join('\n'),
     );
 
-    const { server } = await createMcpServer(sm, {
-      includeWorkflowTools: false,
-      progressToolDependencies: {
-        hasWorkflowBridge: () => false,
-        readFromDb: async () => {
-          throw new Error('DB reader must not run without a bridge');
-        },
-        readProjection: readProgress,
-      },
+    const previousExecutors = process.env.GSD_WORKFLOW_EXECUTORS_MODULE;
+    const previousWriteGate = process.env.GSD_WORKFLOW_WRITE_GATE_MODULE;
+    delete process.env.GSD_WORKFLOW_EXECUTORS_MODULE;
+    delete process.env.GSD_WORKFLOW_WRITE_GATE_MODULE;
+    t.after(() => {
+      restoreEnvironmentValue('GSD_WORKFLOW_EXECUTORS_MODULE', previousExecutors);
+      restoreEnvironmentValue('GSD_WORKFLOW_WRITE_GATE_MODULE', previousWriteGate);
     });
+
+    const moduleDir = dirname(fileURLToPath(import.meta.url));
+    const standaloneRoot = mkdtempSync(join(dirname(moduleDir), 'standalone-mcp-'));
+    const standaloneModuleDir = join(standaloneRoot, 'runtime');
+    cpSync(moduleDir, standaloneModuleDir, { recursive: true });
+    t.after(() => rmSync(standaloneRoot, { recursive: true, force: true }));
+    const serverExtension = import.meta.url.endsWith('.ts') ? '.ts' : '.js';
+    const standaloneServerModule = await import(pathToFileURL(
+      join(standaloneModuleDir, `server${serverExtension}`),
+    ).href) as typeof import('./server.js');
+    const { server } = await standaloneServerModule.createMcpServer(
+      sm,
+      { includeWorkflowTools: false },
+    );
     const progressTool = (server as any)._registeredTools?.gsd_progress;
     assert.ok(progressTool, 'gsd_progress should be registered');
 

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, join, resolve } from 'node:path';
 import { EventEmitter } from 'node:events';
@@ -27,6 +27,7 @@ import {
   formatAskUserQuestionsElicitResult,
   isLocalElicitClientAbortError,
   isLocalElicitTimeoutError,
+  registerProgressTool,
   withElicitTimeout,
 } from './server.js';
 import {
@@ -36,6 +37,7 @@ import {
 import { MAX_EVENTS } from './types.js';
 import type { ManagedSession, CostAccumulator, PendingBlocker } from './types.js';
 import { WORKFLOW_TOOL_ALIAS_NAMES } from '@opengsd/contracts';
+import { readProgress } from './readers/state.js';
 
 describe('installGlobalErrorHandlers', () => {
   it('logs uncaught exceptions and unhandled rejections to stderr, then terminates (#783)', () => {
@@ -875,6 +877,76 @@ describe('createMcpServer tool registration', () => {
 
     assert.equal(result.isError, true);
     assert.match(result.content[0].text, /projectDir must be an absolute path/);
+  });
+
+  it('registered gsd_progress prefers the DB payload when the bridge is configured', async (t) => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'gsd-progress-handler-'));
+    t.after(() => rmSync(projectDir, { recursive: true, force: true }));
+    mkdirSync(join(projectDir, '.gsd'));
+    writeFileSync(
+      join(projectDir, '.gsd', 'STATE.md'),
+      [
+        '# Project State',
+        '',
+        '**Active Milestone:** M999: Stale Projection',
+        '**Phase:** planning',
+      ].join('\n'),
+    );
+
+    let handler: ((args: Record<string, unknown>) => Promise<any>) | undefined;
+    registerProgressTool({
+      tool(name, _description, _params, registeredHandler) {
+        if (name === 'gsd_progress') handler = registeredHandler;
+      },
+    }, {
+      hasWorkflowBridge: () => true,
+      readFromDb: async () => ({
+        activeMilestone: { id: 'M001', title: 'Database Authority' },
+        phase: 'executing',
+      }),
+      readProjection: readProgress,
+    });
+    assert.ok(handler);
+
+    const result = await handler({ projectDir });
+    assert.deepEqual(JSON.parse(result.content[0].text), {
+      activeMilestone: { id: 'M001', title: 'Database Authority' },
+      phase: 'executing',
+    });
+  });
+
+  it('registered gsd_progress uses projections without a workflow bridge', async (t) => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'gsd-progress-handler-'));
+    t.after(() => rmSync(projectDir, { recursive: true, force: true }));
+    mkdirSync(join(projectDir, '.gsd'));
+    writeFileSync(
+      join(projectDir, '.gsd', 'STATE.md'),
+      [
+        '# Project State',
+        '',
+        '**Active Milestone:** M999: Projection Only',
+        '**Phase:** planning',
+      ].join('\n'),
+    );
+
+    let handler: ((args: Record<string, unknown>) => Promise<any>) | undefined;
+    registerProgressTool({
+      tool(name, _description, _params, registeredHandler) {
+        if (name === 'gsd_progress') handler = registeredHandler;
+      },
+    }, {
+      hasWorkflowBridge: () => false,
+      readFromDb: async () => {
+        throw new Error('DB reader must not run without a bridge');
+      },
+      readProjection: readProgress,
+    });
+    assert.ok(handler);
+
+    const result = await handler({ projectDir });
+    const progress = JSON.parse(result.content[0].text);
+    assert.deepEqual(progress.activeMilestone, { id: 'M999', title: 'Projection Only' });
+    assert.equal(progress.phase, 'plan');
   });
 
   it('ask_user_questions passes the declared elicitation timeout and signal to the MCP SDK request', async () => {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -34,6 +34,7 @@ import { resolveGsdRoot, resolveMilestoneFile } from './readers/paths.js';
 import { runDoctorLite } from './readers/doctor-lite.js';
 import {
   hasWorkflowToolBridgeConfiguration,
+  readProjectProgressViaBridge,
   registerWorkflowTools,
   validateProjectDir,
   warmWorkflowToolBridges,
@@ -1374,14 +1375,24 @@ export async function createMcpServer(
   // -----------------------------------------------------------------------
   server.tool(
     'gsd_progress',
-    'Get structured project progress: active milestone/slice/task, phase, completion counts, blockers, and next action. No session required — reads directly from .gsd/ on disk.',
+    'Get structured project progress: active milestone/slice/task, phase, completion counts, blockers, and next action. No session required — reads the workflow database (the workflow authority) when the GSD runtime is available, .gsd/ projections otherwise.',
     {
       projectDir: z.string().describe('Absolute path to the project directory'),
     },
     async (args: Record<string, unknown>) => {
       const { projectDir } = args as { projectDir: string };
+      const dir = validateProjectDir(projectDir);
       try {
-        return jsonContent(readProgress(validateProjectDir(projectDir)));
+        if (hasWorkflowToolBridgeConfiguration()) {
+          // ADR-046: DB-authoritative when the runtime bridge exists. DB
+          // errors fail loud; null (no DB) falls back to the projection
+          // reader, matching `gsd read progress`.
+          const fromDb = await readProjectProgressViaBridge(dir);
+          if (fromDb !== null) {
+            return jsonContent(fromDb);
+          }
+        }
+        return jsonContent(readProgress(dir));
       } catch (err) {
         return errorContent(err instanceof Error ? err.message : String(err));
       }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1134,7 +1134,10 @@ export async function secureEnvCollectHandler(
  */
 export async function createMcpServer(
   sessionManager: SessionManager,
-  options: { includeWorkflowTools?: boolean } = {},
+  options: {
+    includeWorkflowTools?: boolean;
+    progressToolDependencies?: ProgressToolDependencies;
+  } = {},
 ): Promise<{
   server: McpServerInstance;
 }> {
@@ -1413,7 +1416,7 @@ export async function createMcpServer(
   // -----------------------------------------------------------------------
   // gsd_progress — structured project progress metrics
   // -----------------------------------------------------------------------
-  registerProgressTool(server);
+  registerProgressTool(server, options.progressToolDependencies);
 
   // -----------------------------------------------------------------------
   // gsd_roadmap — milestone/slice/task structure with status

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1134,10 +1134,7 @@ export async function secureEnvCollectHandler(
  */
 export async function createMcpServer(
   sessionManager: SessionManager,
-  options: {
-    includeWorkflowTools?: boolean;
-    progressToolDependencies?: ProgressToolDependencies;
-  } = {},
+  options: { includeWorkflowTools?: boolean } = {},
 ): Promise<{
   server: McpServerInstance;
 }> {
@@ -1416,7 +1413,7 @@ export async function createMcpServer(
   // -----------------------------------------------------------------------
   // gsd_progress — structured project progress metrics
   // -----------------------------------------------------------------------
-  registerProgressTool(server, options.progressToolDependencies);
+  registerProgressTool(server);
 
   // -----------------------------------------------------------------------
   // gsd_roadmap — milestone/slice/task structure with status

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -382,22 +382,7 @@ interface McpServerInstance {
   close(): Promise<void>;
 }
 
-interface ProgressToolDependencies {
-  hasWorkflowBridge: () => boolean;
-  readFromDb: (projectDir: string) => Promise<unknown | null>;
-  readProjection: (projectDir: string) => unknown;
-}
-
-const progressToolDependencies: ProgressToolDependencies = {
-  hasWorkflowBridge: hasWorkflowToolBridgeConfiguration,
-  readFromDb: readProjectProgressViaBridge,
-  readProjection: readProgress,
-};
-
-export function registerProgressTool(
-  server: Pick<McpServerInstance, 'tool'>,
-  dependencies: ProgressToolDependencies = progressToolDependencies,
-): void {
+function registerProgressTool(server: Pick<McpServerInstance, 'tool'>): void {
   server.tool(
     'gsd_progress',
     'Get structured project progress: active milestone/slice/task, phase, completion counts, blockers, and next action. No session required — reads the workflow database (the workflow authority) when the GSD runtime is available, .gsd/ projections otherwise.',
@@ -408,13 +393,13 @@ export function registerProgressTool(
       const { projectDir } = args as { projectDir: string };
       try {
         const dir = validateProjectDir(projectDir);
-        if (dependencies.hasWorkflowBridge()) {
-          const fromDb = await dependencies.readFromDb(dir);
+        if (hasWorkflowToolBridgeConfiguration()) {
+          const fromDb = await readProjectProgressViaBridge(dir);
           if (fromDb !== null) {
             return jsonContent(fromDb);
           }
         }
-        return jsonContent(dependencies.readProjection(dir));
+        return jsonContent(readProgress(dir));
       } catch (err) {
         return errorContent(err instanceof Error ? err.message : String(err));
       }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1381,8 +1381,8 @@ export async function createMcpServer(
     },
     async (args: Record<string, unknown>) => {
       const { projectDir } = args as { projectDir: string };
-      const dir = validateProjectDir(projectDir);
       try {
+        const dir = validateProjectDir(projectDir);
         if (hasWorkflowToolBridgeConfiguration()) {
           // ADR-046: DB-authoritative when the runtime bridge exists. DB
           // errors fail loud; null (no DB) falls back to the projection

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -382,6 +382,46 @@ interface McpServerInstance {
   close(): Promise<void>;
 }
 
+interface ProgressToolDependencies {
+  hasWorkflowBridge: () => boolean;
+  readFromDb: (projectDir: string) => Promise<unknown | null>;
+  readProjection: (projectDir: string) => unknown;
+}
+
+const progressToolDependencies: ProgressToolDependencies = {
+  hasWorkflowBridge: hasWorkflowToolBridgeConfiguration,
+  readFromDb: readProjectProgressViaBridge,
+  readProjection: readProgress,
+};
+
+export function registerProgressTool(
+  server: Pick<McpServerInstance, 'tool'>,
+  dependencies: ProgressToolDependencies = progressToolDependencies,
+): void {
+  server.tool(
+    'gsd_progress',
+    'Get structured project progress: active milestone/slice/task, phase, completion counts, blockers, and next action. No session required — reads the workflow database (the workflow authority) when the GSD runtime is available, .gsd/ projections otherwise.',
+    {
+      projectDir: z.string().describe('Absolute path to the project directory'),
+    },
+    async (args: Record<string, unknown>) => {
+      const { projectDir } = args as { projectDir: string };
+      try {
+        const dir = validateProjectDir(projectDir);
+        if (dependencies.hasWorkflowBridge()) {
+          const fromDb = await dependencies.readFromDb(dir);
+          if (fromDb !== null) {
+            return jsonContent(fromDb);
+          }
+        }
+        return jsonContent(dependencies.readProjection(dir));
+      } catch (err) {
+        return errorContent(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+}
+
 interface AskUserQuestionOption {
   label: string;
   description: string;
@@ -1373,31 +1413,7 @@ export async function createMcpServer(
   // -----------------------------------------------------------------------
   // gsd_progress — structured project progress metrics
   // -----------------------------------------------------------------------
-  server.tool(
-    'gsd_progress',
-    'Get structured project progress: active milestone/slice/task, phase, completion counts, blockers, and next action. No session required — reads the workflow database (the workflow authority) when the GSD runtime is available, .gsd/ projections otherwise.',
-    {
-      projectDir: z.string().describe('Absolute path to the project directory'),
-    },
-    async (args: Record<string, unknown>) => {
-      const { projectDir } = args as { projectDir: string };
-      try {
-        const dir = validateProjectDir(projectDir);
-        if (hasWorkflowToolBridgeConfiguration()) {
-          // ADR-046: DB-authoritative when the runtime bridge exists. DB
-          // errors fail loud; null (no DB) falls back to the projection
-          // reader, matching `gsd read progress`.
-          const fromDb = await readProjectProgressViaBridge(dir);
-          if (fromDb !== null) {
-            return jsonContent(fromDb);
-          }
-        }
-        return jsonContent(readProgress(dir));
-      } catch (err) {
-        return errorContent(err instanceof Error ? err.message : String(err));
-      }
-    },
-  );
+  registerProgressTool(server);
 
   // -----------------------------------------------------------------------
   // gsd_roadmap — milestone/slice/task structure with status

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1392,7 +1392,7 @@ export async function createMcpServer(
   );
 
   // =======================================================================
-  // READ-ONLY TOOLS — no session required, pure filesystem reads
+  // READ-ONLY TOOLS — no session required
   // =======================================================================
 
   // -----------------------------------------------------------------------

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -31,6 +31,7 @@ import { invalidateAllCaches } from "../../../src/resources/extensions/gsd/cache
 import { resolveToolPresentationPlan } from "../../../src/resources/extensions/gsd/tool-presentation-plan.ts";
 import { claimTaskAttempt } from "../../../src/resources/extensions/gsd/task-execution-domain-operation.ts";
 import { seedSliceCompletionAuthority } from "../../../src/resources/extensions/gsd/tests/slice-completion-fixture.ts";
+import { _setDatabaseOpenBeforeRawForTest } from "../../../src/resources/extensions/gsd/db/engine.ts";
 import {
   _buildBridgeImportCandidates,
   _buildImportCandidates,
@@ -3745,41 +3746,50 @@ describe("validateProjectDir", () => {
 });
 
 describe("readProjectProgressViaBridge", () => {
-  it("serves each project's own state across back-to-back calls (no wrong-handle leakage)", async () => {
+  it("serves each project's own state across back-to-back calls (no wrong-handle leakage)", async (t) => {
     const baseA = makeTmpBase();
     const baseB = makeTmpBase();
-    try {
-      openDatabase(join(baseA, ".gsd", "gsd.db"));
-      insertMilestone({ id: "M001", title: "Project A milestone", status: "active" });
-      insertSlice({ id: "S01", milestoneId: "M001", title: "A slice", status: "complete", risk: "low", depends: [], sequence: 1 });
-      closeDatabase();
+    t.after(() => cleanup(baseA));
+    t.after(() => cleanup(baseB));
+    openDatabase(join(baseA, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Project A milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "A slice", status: "complete", risk: "low", depends: [], sequence: 1 });
+    closeDatabase();
 
-      openDatabase(join(baseB, ".gsd", "gsd.db"));
-      insertMilestone({ id: "M002", title: "Project B milestone", status: "active" });
-      insertSlice({ id: "S01", milestoneId: "M002", title: "B slice", status: "complete", risk: "low", depends: [], sequence: 1 });
-      closeDatabase();
+    openDatabase(join(baseB, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M002", title: "Project B milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M002", title: "B slice", status: "complete", risk: "low", depends: [], sequence: 1 });
+    closeDatabase();
 
-      const a = await readProjectProgressViaBridge(baseA) as { activeMilestone?: { id?: string; title?: string } };
-      assert.equal(a.activeMilestone?.id, "M001");
-      assert.equal(a.activeMilestone?.title, "Project A milestone");
+    const a = await readProjectProgressViaBridge(baseA) as { activeMilestone?: { id?: string; title?: string } };
+    assert.equal(a.activeMilestone?.id, "M001");
+    assert.equal(a.activeMilestone?.title, "Project A milestone");
 
-      const b = await readProjectProgressViaBridge(baseB) as { activeMilestone?: { id?: string; title?: string } };
-      assert.equal(b.activeMilestone?.id, "M002");
-      assert.equal(b.activeMilestone?.title, "Project B milestone");
-    } finally {
-      cleanup(baseA);
-      cleanup(baseB);
-    }
+    const b = await readProjectProgressViaBridge(baseB) as { activeMilestone?: { id?: string; title?: string } };
+    assert.equal(b.activeMilestone?.id, "M002");
+    assert.equal(b.activeMilestone?.title, "Project B milestone");
   });
 
-  it("returns null when the project DB is missing (no DB created as a read side effect)", async () => {
+  it("returns null when the project DB is missing (no DB created as a read side effect)", async (t) => {
     const base = makeTmpBase();
-    try {
-      const result = await readProjectProgressViaBridge(base);
-      assert.equal(result, null);
-      assert.equal(existsSync(join(base, ".gsd", "gsd.db")), false, "a read must not create gsd.db");
-    } finally {
-      cleanup(base);
-    }
+    t.after(() => cleanup(base));
+    const result = await readProjectProgressViaBridge(base);
+    assert.equal(result, null);
+    assert.equal(existsSync(join(base, ".gsd", "gsd.db")), false, "a read must not create gsd.db");
+  });
+
+  it("returns null without recreating a DB removed at the open boundary", async (t) => {
+    const base = makeTmpBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    t.after(() => cleanup(base));
+    t.after(() => _setDatabaseOpenBeforeRawForTest(null));
+    assert.equal(openDatabase(dbPath), true);
+    closeDatabase();
+    _setDatabaseOpenBeforeRawForTest((path) => rmSync(path, { force: true }));
+
+    const result = await readProjectProgressViaBridge(base);
+
+    assert.equal(result, null);
+    assert.equal(existsSync(dbPath), false, "a read must not recreate gsd.db");
   });
 });

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -34,6 +34,7 @@ import { seedSliceCompletionAuthority } from "../../../src/resources/extensions/
 import {
   _buildBridgeImportCandidates,
   _buildImportCandidates,
+  readProjectProgressViaBridge,
   registerWorkflowTools,
   resolveRecoveryActionProjectDir,
   WORKFLOW_TOOL_NAMES,
@@ -3737,6 +3738,46 @@ describe("validateProjectDir", () => {
       assert.match(result.content?.[0]?.text ?? "", /Error/);
       assert.ok(result.structuredContent, "error details must ride on structuredContent");
       assert.equal(result.structuredContent.error, "db_unavailable");
+    } finally {
+      cleanup(base);
+    }
+  });
+});
+
+describe("readProjectProgressViaBridge", () => {
+  it("serves each project's own state across back-to-back calls (no wrong-handle leakage)", async () => {
+    const baseA = makeTmpBase();
+    const baseB = makeTmpBase();
+    try {
+      openDatabase(join(baseA, ".gsd", "gsd.db"));
+      insertMilestone({ id: "M001", title: "Project A milestone", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "A slice", status: "complete", risk: "low", depends: [], sequence: 1 });
+      closeDatabase();
+
+      openDatabase(join(baseB, ".gsd", "gsd.db"));
+      insertMilestone({ id: "M002", title: "Project B milestone", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M002", title: "B slice", status: "complete", risk: "low", depends: [], sequence: 1 });
+      closeDatabase();
+
+      const a = await readProjectProgressViaBridge(baseA) as { activeMilestone?: { id?: string; title?: string } };
+      assert.equal(a.activeMilestone?.id, "M001");
+      assert.equal(a.activeMilestone?.title, "Project A milestone");
+
+      const b = await readProjectProgressViaBridge(baseB) as { activeMilestone?: { id?: string; title?: string } };
+      assert.equal(b.activeMilestone?.id, "M002");
+      assert.equal(b.activeMilestone?.title, "Project B milestone");
+    } finally {
+      cleanup(baseA);
+      cleanup(baseB);
+    }
+  });
+
+  it("returns null when the project DB is missing (no DB created as a read side effect)", async () => {
+    const base = makeTmpBase();
+    try {
+      const result = await readProjectProgressViaBridge(base);
+      assert.equal(result, null);
+      assert.equal(existsSync(join(base, ".gsd", "gsd.db")), false, "a read must not create gsd.db");
     } finally {
       cleanup(base);
     }

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -31,7 +31,10 @@ import { invalidateAllCaches } from "../../../src/resources/extensions/gsd/cache
 import { resolveToolPresentationPlan } from "../../../src/resources/extensions/gsd/tool-presentation-plan.ts";
 import { claimTaskAttempt } from "../../../src/resources/extensions/gsd/task-execution-domain-operation.ts";
 import { seedSliceCompletionAuthority } from "../../../src/resources/extensions/gsd/tests/slice-completion-fixture.ts";
-import { _setDatabaseOpenBeforeRawForTest } from "../../../src/resources/extensions/gsd/db/engine.ts";
+import {
+  _setDatabaseOpenBeforeRawForTest,
+  _setStartupSchemaDetectionForTest,
+} from "../../../src/resources/extensions/gsd/db/engine.ts";
 import {
   _buildBridgeImportCandidates,
   _buildImportCandidates,
@@ -3791,5 +3794,22 @@ describe("readProjectProgressViaBridge", () => {
 
     assert.equal(result, null);
     assert.equal(existsSync(dbPath), false, "a read must not recreate gsd.db");
+  });
+
+  it("returns null when the existing project DB is locked", async (t) => {
+    const base = makeTmpBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    t.after(() => cleanup(base));
+    t.after(() => _setStartupSchemaDetectionForTest(null));
+    assert.equal(openDatabase(dbPath), true);
+    closeDatabase();
+    _setStartupSchemaDetectionForTest(() => {
+      throw Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY", errcode: 5 });
+    });
+
+    const result = await readProjectProgressViaBridge(base);
+
+    assert.equal(result, null);
+    assert.equal(existsSync(dbPath), true, "a locked read must preserve the existing DB");
   });
 });

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -29,7 +29,7 @@ interface GsdMcpBridge {
   shouldBlockPendingGateInSnapshot: (...args: any[]) => any;
   shouldBlockQueueExecutionInSnapshot: (...args: any[]) => any;
   ensureDbOpen: (...args: any[]) => any;
-  ensureExistingDbOpen: (...args: any[]) => any;
+  openExistingWorkflowDatabase: (projectDir: string) => WorkflowDatabaseOpenResult;
   _getAdapter: (...args: any[]) => any;
   checkpointDatabase: (...args: any[]) => any;
   closeDatabase: (...args: any[]) => any;
@@ -59,6 +59,15 @@ interface GsdMcpBridge {
   milestoneIdSort: (...args: any[]) => any;
   nextMilestoneId: (...args: any[]) => any;
 }
+
+type WorkflowDatabaseOpenResult =
+  | { ok: true; reason: "opened-existing" | "created-empty" }
+  | {
+      ok: false;
+      reason: "missing-database" | "missing-gsd-dir" | "locked" | "open-failed";
+      error?: Error;
+    }
+  | { ok: false; reason: "schema-too-new"; error: Error };
 
 async function importBridgeModule(): Promise<GsdMcpBridge> {
   return importLocalModule<GsdMcpBridge>("../../../src/resources/extensions/gsd/mcp-bridge.js");
@@ -1307,22 +1316,17 @@ async function runSerializedWorkflowDbOperation<T>(
  * project-scoped DB open, so back-to-back calls for different projects
  * cannot serve one project's state for another.
  *
- * Returns null when the project has no database — the caller falls back to
- * the projection reader, matching `gsd read progress`. A missing DB must not
- * be created as a side effect of a read (`ensureDbOpen` would happily create
- * an empty one). Any other failure throws — callers must fail loud, not
- * degrade to projection data that can lag the database.
+ * Returns null when the project database is missing or cannot be opened, so
+ * the caller falls back to the projection reader, matching `gsd read progress`.
+ * Schema-version errors and failures after a successful open remain loud.
  */
 export async function readProjectProgressViaBridge(projectDir: string): Promise<unknown | null> {
   return runSerializedWorkflowOperation(async () => {
-    const { resolveProjectRootDbPath } = await importWorkflowRuntimeModule<any>(
-      "../../../src/resources/extensions/gsd/db-workspace.js",
-    );
     const bridge = await importBridgeModule();
-    const dbAvailable = await bridge.ensureExistingDbOpen(projectDir);
-    if (!dbAvailable) {
-      if (!existsSync(resolveProjectRootDbPath(projectDir))) return null;
-      throw new Error("GSD database is not available");
+    const opened = bridge.openExistingWorkflowDatabase(projectDir);
+    if (!opened.ok) {
+      if (opened.reason === "schema-too-new") throw opened.error;
+      return null;
     }
     return bridge.readProgressFromDb(projectDir);
   });

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -29,6 +29,7 @@ interface GsdMcpBridge {
   shouldBlockPendingGateInSnapshot: (...args: any[]) => any;
   shouldBlockQueueExecutionInSnapshot: (...args: any[]) => any;
   ensureDbOpen: (...args: any[]) => any;
+  ensureExistingDbOpen: (...args: any[]) => any;
   _getAdapter: (...args: any[]) => any;
   checkpointDatabase: (...args: any[]) => any;
   closeDatabase: (...args: any[]) => any;
@@ -1317,12 +1318,10 @@ export async function readProjectProgressViaBridge(projectDir: string): Promise<
     const { resolveProjectRootDbPath } = await importWorkflowRuntimeModule<any>(
       "../../../src/resources/extensions/gsd/db-workspace.js",
     );
-    if (!existsSync(resolveProjectRootDbPath(projectDir))) {
-      return null;
-    }
     const bridge = await importBridgeModule();
-    const dbAvailable = await bridge.ensureDbOpen(projectDir);
+    const dbAvailable = await bridge.ensureExistingDbOpen(projectDir);
     if (!dbAvailable) {
+      if (!existsSync(resolveProjectRootDbPath(projectDir))) return null;
       throw new Error("GSD database is not available");
     }
     return bridge.readProgressFromDb(projectDir);

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -45,6 +45,7 @@ interface GsdMcpBridge {
   upsertMilestonePlanning: (...args: any[]) => any;
   invalidateStateCache: (...args: any[]) => any;
   isReusableGhostMilestone: (...args: any[]) => any;
+  readProgressFromDb: (...args: any[]) => any;
   loadEffectiveGSDPreferences: (...args: any[]) => any;
   saveDecisionToDb: (...args: any[]) => any;
   saveRequirementToDb: (...args: any[]) => any;
@@ -1296,6 +1297,35 @@ async function runSerializedWorkflowDbOperation<T>(
       throw new Error("GSD database is not available");
     }
     return fn();
+  });
+}
+
+/**
+ * DB-authoritative progress payload for the `gsd_progress` tool
+ * (ADR-046). Runs inside the workflow serialization queue with the bridge's
+ * project-scoped DB open, so back-to-back calls for different projects
+ * cannot serve one project's state for another.
+ *
+ * Returns null when the project has no database — the caller falls back to
+ * the projection reader, matching `gsd read progress`. A missing DB must not
+ * be created as a side effect of a read (`ensureDbOpen` would happily create
+ * an empty one). Any other failure throws — callers must fail loud, not
+ * degrade to projection data that can lag the database.
+ */
+export async function readProjectProgressViaBridge(projectDir: string): Promise<unknown | null> {
+  return runSerializedWorkflowOperation(async () => {
+    const { resolveProjectRootDbPath } = await importWorkflowRuntimeModule<any>(
+      "../../../src/resources/extensions/gsd/db-workspace.js",
+    );
+    if (!existsSync(resolveProjectRootDbPath(projectDir))) {
+      return null;
+    }
+    const bridge = await importBridgeModule();
+    const dbAvailable = await bridge.ensureDbOpen(projectDir);
+    if (!dbAvailable) {
+      throw new Error("GSD database is not available");
+    }
+    return bridge.readProgressFromDb(projectDir);
   });
 }
 

--- a/src/read-cli.ts
+++ b/src/read-cli.ts
@@ -52,6 +52,7 @@ function isSchemaTooNewErrorLike(err: unknown): err is Error {
  * through their own module graph.
  */
 export interface ReadCliSchemaPreflight {
+  resolveProjectRootDbPath: (basePath: string) => string
   openIsolatedDatabase: (path: string) => {
     prepare(sql: string): { get(): Record<string, unknown> | undefined }
     close(): void
@@ -63,12 +64,14 @@ export interface ReadCliSchemaPreflight {
 async function loadSchemaPreflight(): Promise<ReadCliSchemaPreflight> {
   const dbWorkspaceModule = await jiti.import(gsdExtensionPath('db-workspace.ts'), {}) as any
   const engineModule = await jiti.import(gsdExtensionPath('db/engine.ts'), {}) as any
-  if (typeof dbWorkspaceModule.openWorkflowDatabaseIsolated !== 'function'
+  if (typeof dbWorkspaceModule.resolveProjectRootDbPath !== 'function'
+    || typeof dbWorkspaceModule.openWorkflowDatabaseIsolated !== 'function'
     || typeof engineModule.SCHEMA_VERSION !== 'number'
     || typeof engineModule.SchemaTooNewError !== 'function') {
     throw new Error('selected GSD extensions do not support schema-version preflight; synchronize the extension bundle')
   }
   return {
+    resolveProjectRootDbPath: dbWorkspaceModule.resolveProjectRootDbPath,
     openIsolatedDatabase: dbWorkspaceModule.openWorkflowDatabaseIsolated,
     supportedSchemaVersion: engineModule.SCHEMA_VERSION,
     createSchemaTooNewError: (currentVersion, supportedVersion) =>
@@ -223,8 +226,10 @@ export async function runReadCli(
     return 1
   }
 
+  const schemaPreflight = preflight ?? await loadSchemaPreflight()
+  const dbPath = schemaPreflight.resolveProjectRootDbPath(projectDir)
   try {
-    await assertProjectDbSchemaSupported(join(gsdRoot, 'gsd.db'), preflight)
+    await assertProjectDbSchemaSupported(dbPath, schemaPreflight)
   } catch (err) {
     if (isSchemaTooNewErrorLike(err)) {
       // Version skew must refuse loudly: exact engine message, non-zero exit —
@@ -243,7 +248,7 @@ export async function runReadCli(
       let fromDb: unknown | null
       try {
         fromDb = await tryReadProgressFromDb(
-          join(gsdRoot, 'gsd.db'),
+          dbPath,
           projectDir,
           dbProgressReader,
           dbProgressModuleImporter,

--- a/src/read-cli.ts
+++ b/src/read-cli.ts
@@ -76,8 +76,18 @@ async function loadSchemaPreflight(): Promise<ReadCliSchemaPreflight> {
   }
 }
 
-async function loadDbProgressReader(): Promise<DbProgressReader> {
-  const mod = await jiti.import(gsdExtensionPath('state/progress-from-db.ts'), {}) as any
+async function loadDbProgressReader(
+  moduleImporter: DbProgressModuleImporter = (path) => jiti.import(path, {}),
+): Promise<DbProgressReader> {
+  let mod: any
+  try {
+    mod = await moduleImporter(gsdExtensionPath('state/progress-from-db.ts'))
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(
+      `selected GSD extensions do not support DB-backed progress reads; synchronize the extension bundle (${detail})`,
+    )
+  }
   if (typeof mod.readProgressFromDb !== 'function') {
     throw new Error('selected GSD extensions do not support DB-backed progress reads; synchronize the extension bundle')
   }
@@ -95,15 +105,11 @@ async function loadDbProgressReader(): Promise<DbProgressReader> {
 async function tryReadProgressFromDb(
   dbPath: string,
   projectDir: string,
-  preflight?: ReadCliSchemaPreflight,
   reader?: DbProgressReader,
+  moduleImporter?: DbProgressModuleImporter,
 ): Promise<unknown | null> {
   if (!existsSync(dbPath)) return null
-  const pf = preflight ?? await loadSchemaPreflight()
-  const probe = pf.openIsolatedDatabase(dbPath)
-  if (!probe) return null
-  probe.close()
-  const read = reader ?? await loadDbProgressReader()
+  const read = reader ?? await loadDbProgressReader(moduleImporter)
   return await read(projectDir)
 }
 
@@ -150,6 +156,7 @@ export type ReadKind = 'progress' | 'roadmap' | 'memory'
 
 /** DB-backed progress reader — jiti-loaded in production, injected in tests. */
 export type DbProgressReader = (projectDir: string) => Promise<unknown>
+export type DbProgressModuleImporter = (path: string) => Promise<unknown>
 
 export interface ReadEnvelope<T = unknown> {
   integration_version: number
@@ -195,6 +202,7 @@ export async function runReadCli(
   argv: string[],
   preflight?: ReadCliSchemaPreflight,
   dbProgressReader?: DbProgressReader,
+  dbProgressModuleImporter?: DbProgressModuleImporter,
 ): Promise<number> {
   const opts = parseReadArgs(argv)
   if (!opts) {
@@ -234,7 +242,12 @@ export async function runReadCli(
       // the projection reader is the fallback for missing/locked DBs only.
       let fromDb: unknown | null
       try {
-        fromDb = await tryReadProgressFromDb(join(gsdRoot, 'gsd.db'), projectDir, preflight, dbProgressReader)
+        fromDb = await tryReadProgressFromDb(
+          join(gsdRoot, 'gsd.db'),
+          projectDir,
+          dbProgressReader,
+          dbProgressModuleImporter,
+        )
       } catch (err) {
         process.stderr.write(
           `[gsd] DB-backed progress read failed: ${err instanceof Error ? err.message : String(err)}\n`,

--- a/src/read-cli.ts
+++ b/src/read-cli.ts
@@ -76,6 +76,37 @@ async function loadSchemaPreflight(): Promise<ReadCliSchemaPreflight> {
   }
 }
 
+async function loadDbProgressReader(): Promise<DbProgressReader> {
+  const mod = await jiti.import(gsdExtensionPath('state/progress-from-db.ts'), {}) as any
+  if (typeof mod.readProgressFromDb !== 'function') {
+    throw new Error('selected GSD extensions do not support DB-backed progress reads; synchronize the extension bundle')
+  }
+  return (projectDir: string) => mod.readProgressFromDb(projectDir)
+}
+
+/**
+ * DB-backed progress payload, or null when the projection fallback applies:
+ * no DB file, or the DB cannot be opened (locked/unreadable). Schema skew
+ * has already refused loudly via assertProjectDbSchemaSupported before this
+ * runs. When the DB is usable but the read itself fails, the error propagates
+ * — it must never be swallowed into a projection fallback, which would serve
+ * exactly the stale data this path exists to prevent.
+ */
+async function tryReadProgressFromDb(
+  dbPath: string,
+  projectDir: string,
+  preflight?: ReadCliSchemaPreflight,
+  reader?: DbProgressReader,
+): Promise<unknown | null> {
+  if (!existsSync(dbPath)) return null
+  const pf = preflight ?? await loadSchemaPreflight()
+  const probe = pf.openIsolatedDatabase(dbPath)
+  if (!probe) return null
+  probe.close()
+  const read = reader ?? await loadDbProgressReader()
+  return await read(projectDir)
+}
+
 /**
  * Read-only schema-version preflight. The markdown readers below never open
  * gsd.db, so without this guard `gsd read` would silently serve stale/empty
@@ -84,6 +115,13 @@ async function loadSchemaPreflight(): Promise<ReadCliSchemaPreflight> {
  * no migration, no global-handle side effects — and throws SchemaTooNewError
  * when the recorded schema version is newer than this binary supports. A
  * missing or unreadable DB keeps the existing degraded markdown behavior.
+ *
+ * After this guard, `gsd read progress` prefers a DB-derived payload
+ * (state/progress-from-db.ts via the extension runtime). Unlike the
+ * preflight, that read opens the DB through the engine's normal path: it
+ * runs pending migrations and syncs the milestone queue-order projection —
+ * the same contract as `gsd headless status`. A locked or unreadable DB
+ * falls back to markdown; a failed DB-backed read refuses loudly instead.
  */
 async function assertProjectDbSchemaSupported(
   dbPath: string,
@@ -109,6 +147,9 @@ async function assertProjectDbSchemaSupported(
 }
 
 export type ReadKind = 'progress' | 'roadmap' | 'memory'
+
+/** DB-backed progress reader — jiti-loaded in production, injected in tests. */
+export type DbProgressReader = (projectDir: string) => Promise<unknown>
 
 export interface ReadEnvelope<T = unknown> {
   integration_version: number
@@ -150,7 +191,11 @@ function parseReadArgs(argv: string[]): ReadCliOptions | null {
   return { kind, project, milestone, query, json }
 }
 
-export async function runReadCli(argv: string[], preflight?: ReadCliSchemaPreflight): Promise<number> {
+export async function runReadCli(
+  argv: string[],
+  preflight?: ReadCliSchemaPreflight,
+  dbProgressReader?: DbProgressReader,
+): Promise<number> {
   const opts = parseReadArgs(argv)
   if (!opts) {
     process.stderr.write(
@@ -184,9 +229,21 @@ export async function runReadCli(argv: string[], preflight?: ReadCliSchemaPrefli
 
   let data: unknown
   switch (opts.kind) {
-    case 'progress':
-      data = readProgress(projectDir)
+    case 'progress': {
+      // ADR-046: when the DB is present and openable, serve DB-derived state;
+      // the projection reader is the fallback for missing/locked DBs only.
+      let fromDb: unknown | null
+      try {
+        fromDb = await tryReadProgressFromDb(join(gsdRoot, 'gsd.db'), projectDir, preflight, dbProgressReader)
+      } catch (err) {
+        process.stderr.write(
+          `[gsd] DB-backed progress read failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        )
+        return 1
+      }
+      data = fromDb ?? readProgress(projectDir)
       break
+    }
     case 'roadmap':
       data = readRoadmap(projectDir, opts.milestone)
       break

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -11,7 +11,6 @@ import { logWarning } from "../workflow-logger.js";
 import {
   getWorkflowDatabaseStatus,
   openWorkflowDatabaseIsolated,
-  openExistingWorkflowDatabase,
   openWorkflowDatabase,
   resolveProjectRootDbPath,
   type WorkflowDatabaseOpenResult,
@@ -166,15 +165,6 @@ export async function ensureDbOpen(basePath: string = safeWorkspaceCwd()): Promi
   if (result.ok) return true;
 
   logWarning("bootstrap", formatWorkflowDatabaseOpenFailure(result));
-  return false;
-}
-
-export async function ensureExistingDbOpen(basePath: string = safeWorkspaceCwd()): Promise<boolean> {
-  const result = openExistingWorkflowDatabase(basePath);
-  if (result.ok) return true;
-  if (result.reason !== "missing-database") {
-    logWarning("bootstrap", formatWorkflowDatabaseOpenFailure(result));
-  }
   return false;
 }
 

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -11,6 +11,7 @@ import { logWarning } from "../workflow-logger.js";
 import {
   getWorkflowDatabaseStatus,
   openWorkflowDatabaseIsolated,
+  openExistingWorkflowDatabase,
   openWorkflowDatabase,
   resolveProjectRootDbPath,
   type WorkflowDatabaseOpenResult,
@@ -165,6 +166,15 @@ export async function ensureDbOpen(basePath: string = safeWorkspaceCwd()): Promi
   if (result.ok) return true;
 
   logWarning("bootstrap", formatWorkflowDatabaseOpenFailure(result));
+  return false;
+}
+
+export async function ensureExistingDbOpen(basePath: string = safeWorkspaceCwd()): Promise<boolean> {
+  const result = openExistingWorkflowDatabase(basePath);
+  if (result.ok) return true;
+  if (result.reason !== "missing-database") {
+    logWarning("bootstrap", formatWorkflowDatabaseOpenFailure(result));
+  }
   return false;
 }
 

--- a/src/resources/extensions/gsd/db-provider.ts
+++ b/src/resources/extensions/gsd/db-provider.ts
@@ -2,6 +2,7 @@
 // File Purpose: SQLite provider loading and lifecycle helpers for the GSD database facade.
 
 import { closeSync, openSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 export type DbProviderName = "node:sqlite";
 
@@ -25,8 +26,12 @@ type RawDatabase = {
 };
 
 type NodeSqliteModule = {
-  DatabaseSync?: new (path: string, options?: { readOnly?: boolean }) => RawDatabase;
+  DatabaseSync?: new (path: string | URL, options?: { readOnly?: boolean }) => RawDatabase;
 };
+
+export interface SqliteRawOpenOptions {
+  createIfMissing?: boolean;
+}
 
 function isClosedDatabaseError(error: unknown): boolean {
   return /database (?:is )?not open|database is closed/iu.test(String(error));
@@ -146,16 +151,22 @@ export class SqliteProviderLoader {
     return this.providerModule ? "node:sqlite" : null;
   }
 
-  openRaw(path: string): unknown {
+  openRaw(path: string, options: SqliteRawOpenOptions = {}): unknown {
     this.load();
     const DatabaseSync = this.providerModule?.DatabaseSync;
     if (!DatabaseSync) return null;
     if (path === ":memory:") return new DatabaseSync(path);
 
-    closeSync(openSync(path, "a"));
+    const createIfMissing = options.createIfMissing !== false;
+    if (createIfMissing) closeSync(openSync(path, "a"));
     const readOnlyGuard = new DatabaseSync(path, { readOnly: true });
     try {
-      return withReadOnlyCloseGuard(new DatabaseSync(path), readOnlyGuard);
+      let writablePath: string | URL = path;
+      if (!createIfMissing) {
+        writablePath = pathToFileURL(path);
+        writablePath.searchParams.set("mode", "rw");
+      }
+      return withReadOnlyCloseGuard(new DatabaseSync(writablePath), readOnlyGuard);
     } catch (error) {
       readOnlyGuard.close();
       throw error;

--- a/src/resources/extensions/gsd/db-workspace.ts
+++ b/src/resources/extensions/gsd/db-workspace.ts
@@ -21,6 +21,7 @@ import {
   isSchemaTooNewError,
   _getAdapter,
   openDatabase,
+  openExistingDatabase,
   openDatabaseByScope,
   openDatabaseByWorkspace,
   openIsolatedDatabase,
@@ -153,15 +154,23 @@ export function resolveProjectRootDbPath(basePath: string): string {
   return resolveWorkflowDatabaseLocation(basePath).projectDb;
 }
 
-export function openWorkflowDatabase(basePath: string): WorkflowDatabaseOpenResult {
+function openWorkflowDatabaseWithMode(
+  basePath: string,
+  createIfMissing: boolean,
+): WorkflowDatabaseOpenResult {
   const location = resolveWorkflowDatabaseLocation(basePath);
   if (!existsSync(location.projectGsd)) {
     return { ok: false, reason: "missing-gsd-dir", location };
   }
 
   const existed = existsSync(location.projectDb);
+  if (!createIfMissing && !existed) {
+    return { ok: false, reason: "missing-database", location };
+  }
   try {
-    const opened = openDatabase(location.projectDb);
+    const opened = createIfMissing
+      ? openDatabase(location.projectDb)
+      : openExistingDatabase(location.projectDb);
     if (!opened) {
       return { ok: false, reason: "open-failed", location };
     }
@@ -191,6 +200,9 @@ export function openWorkflowDatabase(basePath: string): WorkflowDatabaseOpenResu
         error,
       };
     }
+    if (!createIfMissing && !existsSync(location.projectDb)) {
+      return { ok: false, reason: "missing-database", location, error };
+    }
     return {
       ok: false,
       reason: "open-failed",
@@ -200,12 +212,12 @@ export function openWorkflowDatabase(basePath: string): WorkflowDatabaseOpenResu
   }
 }
 
+export function openWorkflowDatabase(basePath: string): WorkflowDatabaseOpenResult {
+  return openWorkflowDatabaseWithMode(basePath, true);
+}
+
 export function openExistingWorkflowDatabase(basePath: string): WorkflowDatabaseOpenResult {
-  const location = resolveWorkflowDatabaseLocation(basePath);
-  if (!existsSync(location.projectDb)) {
-    return { ok: false, reason: "missing-database", location };
-  }
-  return openWorkflowDatabase(basePath);
+  return openWorkflowDatabaseWithMode(basePath, false);
 }
 
 export function openWorkflowDatabasePath(path: string): boolean {

--- a/src/resources/extensions/gsd/db/engine.ts
+++ b/src/resources/extensions/gsd/db/engine.ts
@@ -1038,9 +1038,13 @@ function createFileBoundDatabaseAdapter(rawDb: unknown, databasePath: string, ex
   return fileBoundAdapter;
 }
 
-function openCorrelatedRawDatabase(path: string, open: () => unknown): { raw: unknown; identity?: FileIdentity } {
+function openCorrelatedRawDatabase(
+  path: string,
+  open: () => unknown,
+  createIfMissing = true,
+): { raw: unknown; identity?: FileIdentity } {
   if (path === ":memory:") return { raw: open() };
-  const capture = captureSqliteOpenIdentity(path, true);
+  const capture = captureSqliteOpenIdentity(path, createIfMissing);
   _databaseOpenBeforeRawForTest?.(path);
   let raw: unknown;
   try {
@@ -2288,7 +2292,7 @@ function retainOrCloseFailedOpen(
   }
 }
 
-function openDatabaseInternal(path: string, allowReplacementWrite: boolean): boolean {
+function openDatabaseInternal(path: string, allowReplacementWrite: boolean, createIfMissing = true): boolean {
   _dbOpenState.markAttempted();
   cleanupPendingDatabaseMaintenance();
   cleanupPendingStartup();
@@ -2335,7 +2339,11 @@ function openDatabaseInternal(path: string, allowReplacementWrite: boolean): boo
     }
   } else {
     try {
-      ({ raw: rawDb, identity: openedIdentity } = openCorrelatedRawDatabase(path, () => providerLoader.openRaw(path)));
+      ({ raw: rawDb, identity: openedIdentity } = openCorrelatedRawDatabase(
+        path,
+        () => providerLoader.openRaw(path, { createIfMissing }),
+        createIfMissing,
+      ));
     } catch (error) {
       _dbOpenState.recordError(isSqliteBusyError(error) ? "locked" : "open", error);
       throw error;
@@ -2394,7 +2402,11 @@ function openDatabaseInternal(path: string, allowReplacementWrite: boolean): boo
 
     let runtimeAdapterOpened = false;
     try {
-      ({ raw: rawDb, identity: openedIdentity } = openCorrelatedRawDatabase(path, () => providerLoader.openRaw(path)));
+      ({ raw: rawDb, identity: openedIdentity } = openCorrelatedRawDatabase(
+        path,
+        () => providerLoader.openRaw(path, { createIfMissing }),
+        createIfMissing,
+      ));
       if (!rawDb) {
         completeDatabaseMaintenanceCleanup(startupMaintenance);
         startupMaintenance = undefined;
@@ -2422,16 +2434,24 @@ function openDatabaseInternal(path: string, allowReplacementWrite: boolean): boo
   return true;
 }
 
-export function openDatabase(path: string): boolean {
+function openDatabaseWithMode(path: string, createIfMissing: boolean): boolean {
   for (let attempt = 0; ; attempt += 1) {
     try {
-      return openDatabaseInternal(path, false);
+      return openDatabaseInternal(path, false, createIfMissing);
     } catch (error) {
       const backoffMs = DB_OPEN_BUSY_BACKOFF_MS[attempt];
       if (!isSqliteBusyError(error) || backoffMs === undefined) throw error;
       Atomics.wait(DB_OPEN_BUSY_SLEEP, 0, 0, backoffMs);
     }
   }
+}
+
+export function openDatabase(path: string): boolean {
+  return openDatabaseWithMode(path, true);
+}
+
+export function openExistingDatabase(path: string): boolean {
+  return openDatabaseWithMode(path, false);
 }
 
 export function promoteDatabaseForReplacementRecovery(): void {

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -80,6 +80,11 @@ export interface MilestoneStatusCounts {
   parked: number;
 }
 
+export interface ProjectAuthorityVersion {
+  revision: number;
+  authorityEpoch: number;
+}
+
 function numberColumn(row: Record<string, unknown> | undefined, column: string): number {
   const value = row?.[column];
   if (typeof value === "number") return value;
@@ -102,6 +107,21 @@ function getCompletionCount(table: "milestones" | "slices" | "tasks"): { complet
   return {
     completed: numberColumn(row, "completed"),
     total: numberColumn(row, "total"),
+  };
+}
+
+export function getProjectAuthorityVersion(): ProjectAuthorityVersion {
+  const db = getDbOrNull();
+  if (!db) throw new Error("GSD database is not available");
+
+  const row = db.prepare(
+    "SELECT revision, authority_epoch FROM project_authority WHERE singleton = 1",
+  ).get();
+  if (!row) throw new Error("GSD project authority row is not available");
+
+  return {
+    revision: numberColumn(row, "revision"),
+    authorityEpoch: numberColumn(row, "authority_epoch"),
   };
 }
 

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -72,6 +72,14 @@ export interface HierarchyCompletionCounts {
   tasksTotal: number;
 }
 
+export interface MilestoneStatusCounts {
+  total: number;
+  done: number;
+  active: number;
+  pending: number;
+  parked: number;
+}
+
 function numberColumn(row: Record<string, unknown> | undefined, column: string): number {
   const value = row?.[column];
   if (typeof value === "number") return value;
@@ -113,6 +121,34 @@ export function getHierarchyCompletionCounts(): HierarchyCompletionCounts {
     slicesTotal: slices.total,
     tasks: tasks.completed,
     tasksTotal: tasks.total,
+  };
+}
+
+export function getMilestoneStatusCounts(): MilestoneStatusCounts {
+  const db = getDbOrNull();
+  if (!db) {
+    return { total: 0, done: 0, active: 0, pending: 0, parked: 0 };
+  }
+
+  const row = db.prepare(
+    `SELECT
+       COUNT(*) AS total,
+       COALESCE(SUM(CASE WHEN status IN (${TERMINAL_STATUS_SQL}) THEN 1 ELSE 0 END), 0) AS done,
+       COALESCE(SUM(CASE WHEN status IN ('active', 'in_progress', 'in-progress') THEN 1 ELSE 0 END), 0) AS active,
+       COALESCE(SUM(CASE WHEN status = 'parked' THEN 1 ELSE 0 END), 0) AS parked
+     FROM milestones`,
+  ).get();
+  const total = numberColumn(row, "total");
+  const done = numberColumn(row, "done");
+  const active = numberColumn(row, "active");
+  const parked = numberColumn(row, "parked");
+
+  return {
+    total,
+    done,
+    active,
+    pending: total - done - active - parked,
+    parked,
   };
 }
 

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -116,6 +116,24 @@ export function getHierarchyCompletionCounts(): HierarchyCompletionCounts {
   };
 }
 
+/**
+ * Slices currently in flight, for progress reads that expose an "active"
+ * bucket (integration ProgressResult). Canonical in-flight statuses plus the
+ * legacy 'in-progress' alias — the DB column is free-form
+ * (status-guards.ts). Deferred/blocked/queued slices are NOT in flight; they
+ * land in the caller's "pending" bucket, matching the projection reader's
+ * buckets, which have no deferred field.
+ */
+export function getInFlightSliceCount(): number {
+  if (!getDbOrNull()!) return 0;
+  const row = getDbOrNull()!
+    .prepare(
+      "SELECT COUNT(*) AS n FROM slices WHERE status IN ('in_progress', 'in-progress', 'active')",
+    )
+    .get();
+  return numberColumn(row, "n");
+}
+
 export function getDecisionById(id: string): Decision | null {
   if (!getDbOrNull()!) return null;
   const row = getDbOrNull()!.prepare("SELECT * FROM decisions WHERE id = ?").get(id);

--- a/src/resources/extensions/gsd/mcp-bridge.ts
+++ b/src/resources/extensions/gsd/mcp-bridge.ts
@@ -5,6 +5,7 @@ export {
   shouldBlockQueueExecutionInSnapshot,
 } from "./bootstrap/write-gate.js";
 export { ensureDbOpen, ensureExistingDbOpen } from "./bootstrap/dynamic-tools.js";
+export { openExistingWorkflowDatabase } from "./db-workspace.js";
 export { readProgressFromDb } from "./state/progress-from-db.js";
 export {
   _getAdapter,

--- a/src/resources/extensions/gsd/mcp-bridge.ts
+++ b/src/resources/extensions/gsd/mcp-bridge.ts
@@ -4,7 +4,7 @@ export {
   shouldBlockPendingGateInSnapshot,
   shouldBlockQueueExecutionInSnapshot,
 } from "./bootstrap/write-gate.js";
-export { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
+export { ensureDbOpen, ensureExistingDbOpen } from "./bootstrap/dynamic-tools.js";
 export { readProgressFromDb } from "./state/progress-from-db.js";
 export {
   _getAdapter,

--- a/src/resources/extensions/gsd/mcp-bridge.ts
+++ b/src/resources/extensions/gsd/mcp-bridge.ts
@@ -4,7 +4,7 @@ export {
   shouldBlockPendingGateInSnapshot,
   shouldBlockQueueExecutionInSnapshot,
 } from "./bootstrap/write-gate.js";
-export { ensureDbOpen, ensureExistingDbOpen } from "./bootstrap/dynamic-tools.js";
+export { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 export { openExistingWorkflowDatabase } from "./db-workspace.js";
 export { readProgressFromDb } from "./state/progress-from-db.js";
 export {

--- a/src/resources/extensions/gsd/mcp-bridge.ts
+++ b/src/resources/extensions/gsd/mcp-bridge.ts
@@ -5,6 +5,7 @@ export {
   shouldBlockQueueExecutionInSnapshot,
 } from "./bootstrap/write-gate.js";
 export { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
+export { readProgressFromDb } from "./state/progress-from-db.js";
 export {
   _getAdapter,
   checkpointDatabase,

--- a/src/resources/extensions/gsd/state/progress-from-db.ts
+++ b/src/resources/extensions/gsd/state/progress-from-db.ts
@@ -5,7 +5,13 @@
 // projection data that can lag it.
 
 import { deriveState } from "./derive/index.js";
-import { getHierarchyCompletionCounts, getInFlightSliceCount, readTransaction } from "../gsd-db.js";
+import {
+  getHierarchyCompletionCounts,
+  getInFlightSliceCount,
+  getMilestoneStatusCounts,
+  isDbAvailable,
+  readTransaction,
+} from "../gsd-db.js";
 import type { GSDState } from "../types.js";
 
 /**
@@ -34,26 +40,22 @@ function toRef(value: { id: string; title: string } | null): { id: string; title
 /**
  * Derive the integration progress payload from the database. `deriveState`
  * supplies current refs, phase, blockers, and next action (the same source
- * the runtime and auto-mode use); project-wide slice/task counts come from
- * the read seam, since `GSDState.progress` is scoped to the active
- * milestone/slice while `ProgressResult` buckets are project-wide.
+ * the runtime and auto-mode use); project-wide milestone/slice/task counts
+ * come from the read seam, since `deriveState` may be execution-scoped while
+ * `ProgressResult` buckets are project-wide.
  *
  * Note: the derive open path runs pending migrations and syncs the
  * milestone queue-order projection (same behavior as `gsd headless status`).
- * Callers must have already decided the DB is present and schema-supported;
- * a locked or unreadable DB should fall back at the call site, not here.
  */
-export async function readProgressFromDb(basePath: string): Promise<DbProgressResult> {
+export async function readProgressFromDb(basePath: string): Promise<DbProgressResult | null> {
   const state: GSDState = await deriveState(basePath);
+  if (!isDbAvailable()) return null;
+
   const hierarchy = readTransaction(() => ({
     counts: getHierarchyCompletionCounts(),
+    milestones: getMilestoneStatusCounts(),
     slicesActive: getInFlightSliceCount(),
   }));
-
-  const registry = state.registry ?? [];
-  const milestonesDone = registry.filter((m) => m.status === "complete").length;
-  const milestonesActive = registry.filter((m) => m.status === "active").length;
-  const milestonesParked = registry.filter((m) => m.status === "parked").length;
 
   const slicesDone = hierarchy.counts.slices;
   const slicesTotal = hierarchy.counts.slicesTotal;
@@ -65,13 +67,7 @@ export async function readProgressFromDb(basePath: string): Promise<DbProgressRe
     activeSlice: toRef(state.activeSlice),
     activeTask: toRef(state.activeTask),
     phase: state.phase,
-    milestones: {
-      total: registry.length,
-      done: milestonesDone,
-      active: milestonesActive,
-      pending: registry.length - milestonesDone - milestonesActive - milestonesParked,
-      parked: milestonesParked,
-    },
+    milestones: hierarchy.milestones,
     slices: {
       total: slicesTotal,
       done: slicesDone,

--- a/src/resources/extensions/gsd/state/progress-from-db.ts
+++ b/src/resources/extensions/gsd/state/progress-from-db.ts
@@ -4,15 +4,19 @@
 // is the sole workflow authority, so integration reads must not serve
 // projection data that can lag it.
 
-import { deriveState } from "./derive/index.js";
+import { deriveState, invalidateStateCache } from "./derive/index.js";
+import { ensureExistingWorkflowDbOpen } from "./derive/db-open.js";
 import {
   getHierarchyCompletionCounts,
   getInFlightSliceCount,
   getMilestoneStatusCounts,
+  getProjectAuthorityVersion,
   isDbAvailable,
   readTransaction,
 } from "../gsd-db.js";
 import type { GSDState } from "../types.js";
+
+const MAX_REVISION_ATTEMPTS = 3;
 
 /**
  * Structural mirror of `ProgressResult`
@@ -37,26 +41,24 @@ function toRef(value: { id: string; title: string } | null): { id: string; title
   return value ? { id: value.id, title: value.title } : null;
 }
 
-/**
- * Derive the integration progress payload from the database. `deriveState`
- * supplies current refs, phase, blockers, and next action (the same source
- * the runtime and auto-mode use); project-wide milestone/slice/task counts
- * come from the read seam, since `deriveState` may be execution-scoped while
- * `ProgressResult` buckets are project-wide.
- *
- * Note: the derive open path runs pending migrations and syncs the
- * milestone queue-order projection (same behavior as `gsd headless status`).
- */
-export async function readProgressFromDb(basePath: string): Promise<DbProgressResult | null> {
-  const state: GSDState = await deriveState(basePath);
-  if (!isDbAvailable()) return null;
+interface ProgressHierarchy {
+  counts: ReturnType<typeof getHierarchyCompletionCounts>;
+  milestones: ReturnType<typeof getMilestoneStatusCounts>;
+  slicesActive: number;
+}
 
-  const hierarchy = readTransaction(() => ({
+function readProgressHierarchy(): ProgressHierarchy {
+  return readTransaction(() => ({
     counts: getHierarchyCompletionCounts(),
     milestones: getMilestoneStatusCounts(),
     slicesActive: getInFlightSliceCount(),
   }));
+}
 
+function buildProgressResult(
+  state: GSDState,
+  hierarchy: ReturnType<typeof readProgressHierarchy>,
+): DbProgressResult {
   const slicesDone = hierarchy.counts.slices;
   const slicesTotal = hierarchy.counts.slicesTotal;
   const tasksDone = hierarchy.counts.tasks;
@@ -91,4 +93,38 @@ export async function readProgressFromDb(basePath: string): Promise<DbProgressRe
     blockers: [...state.blockers],
     nextAction: state.nextAction,
   };
+}
+
+/**
+ * Derive the integration progress payload from the database. `deriveState`
+ * supplies current refs, phase, blockers, and next action (the same source
+ * the runtime and auto-mode use); project-wide milestone/slice/task counts
+ * come from the read seam, since `deriveState` may be execution-scoped while
+ * `ProgressResult` buckets are project-wide.
+ *
+ * Note: the derive open path runs pending migrations and syncs the
+ * milestone queue-order projection (same behavior as `gsd headless status`).
+ * Results are bound to a stable authority revision; under sustained concurrent
+ * commits a snapshot may still straddle revisions.
+ */
+export async function readProgressFromDb(basePath: string): Promise<DbProgressResult | null> {
+  ensureExistingWorkflowDbOpen(basePath);
+  if (!isDbAvailable()) return null;
+
+  for (let attempt = 1; ; attempt++) {
+    const before = getProjectAuthorityVersion();
+    const state = await deriveState(basePath);
+    const result = buildProgressResult(state, readProgressHierarchy());
+    const after = getProjectAuthorityVersion();
+
+    if (
+      before.revision === after.revision
+      && before.authorityEpoch === after.authorityEpoch
+    ) {
+      return result;
+    }
+
+    invalidateStateCache();
+    if (attempt === MAX_REVISION_ATTEMPTS) return result;
+  }
 }

--- a/src/resources/extensions/gsd/state/progress-from-db.ts
+++ b/src/resources/extensions/gsd/state/progress-from-db.ts
@@ -12,6 +12,7 @@ import {
   getMilestoneStatusCounts,
   getProjectAuthorityVersion,
   isDbAvailable,
+  _getAdapter,
   readTransaction,
 } from "../gsd-db.js";
 import type { GSDState } from "../types.js";
@@ -45,6 +46,31 @@ interface ProgressHierarchy {
   counts: ReturnType<typeof getHierarchyCompletionCounts>;
   milestones: ReturnType<typeof getMilestoneStatusCounts>;
   slicesActive: number;
+}
+
+interface ProgressStabilityToken {
+  revision: number;
+  authorityEpoch: number;
+  dataVersion: number;
+}
+
+function readProgressStabilityToken(): ProgressStabilityToken {
+  const authority = getProjectAuthorityVersion();
+  const row = _getAdapter()?.prepare("PRAGMA data_version").get();
+  const dataVersion = Number(row?.["data_version"]);
+  if (!Number.isSafeInteger(dataVersion) || dataVersion < 0) {
+    throw new Error("GSD database data version is not available");
+  }
+  return { ...authority, dataVersion };
+}
+
+function stabilityTokensMatch(
+  before: ProgressStabilityToken,
+  after: ProgressStabilityToken,
+): boolean {
+  return before.revision === after.revision
+    && before.authorityEpoch === after.authorityEpoch
+    && before.dataVersion === after.dataVersion;
 }
 
 function readProgressHierarchy(): ProgressHierarchy {
@@ -104,27 +130,24 @@ function buildProgressResult(
  *
  * Note: the derive open path runs pending migrations and syncs the
  * milestone queue-order projection (same behavior as `gsd headless status`).
- * Results are bound to a stable authority revision; under sustained concurrent
- * commits a snapshot may still straddle revisions.
+ * Results are bound to stable authority and data-version tokens; under
+ * sustained concurrent commits or same-process interleaved writes, a snapshot
+ * may still straddle revisions.
  */
 export async function readProgressFromDb(basePath: string): Promise<DbProgressResult | null> {
   ensureExistingWorkflowDbOpen(basePath);
   if (!isDbAvailable()) return null;
 
+  invalidateStateCache();
   for (let attempt = 1; ; attempt++) {
-    const before = getProjectAuthorityVersion();
+    const before = readProgressStabilityToken();
     const state = await deriveState(basePath);
     const result = buildProgressResult(state, readProgressHierarchy());
-    const after = getProjectAuthorityVersion();
+    const after = readProgressStabilityToken();
 
-    if (
-      before.revision === after.revision
-      && before.authorityEpoch === after.authorityEpoch
-    ) {
-      return result;
-    }
+    if (stabilityTokensMatch(before, after)) return result;
 
-    invalidateStateCache();
     if (attempt === MAX_REVISION_ATTEMPTS) return result;
+    invalidateStateCache();
   }
 }

--- a/src/resources/extensions/gsd/state/progress-from-db.ts
+++ b/src/resources/extensions/gsd/state/progress-from-db.ts
@@ -1,0 +1,98 @@
+// Project/App: gsd-pi
+// File Purpose: DB-authoritative progress reads for integration surfaces
+// (`gsd read progress`, packaged MCP `gsd_progress`). ADR-046: the database
+// is the sole workflow authority, so integration reads must not serve
+// projection data that can lag it.
+
+import { deriveState } from "./derive/index.js";
+import { getHierarchyCompletionCounts, getInFlightSliceCount, readTransaction } from "../gsd-db.js";
+import type { GSDState } from "../types.js";
+
+/**
+ * Structural mirror of `ProgressResult`
+ * (packages/mcp-server/src/readers/state.ts). Kept local so the extension
+ * bundle does not import from packages/; the exact key set is pinned by
+ * tests/progress-from-db.test.ts.
+ */
+export interface DbProgressResult {
+  activeMilestone: { id: string; title: string } | null;
+  activeSlice: { id: string; title: string } | null;
+  activeTask: { id: string; title: string } | null;
+  phase: string;
+  milestones: { total: number; done: number; active: number; pending: number; parked: number };
+  slices: { total: number; done: number; active: number; pending: number };
+  tasks: { total: number; done: number; pending: number };
+  requirements: { active: number; validated: number; deferred: number; outOfScope: number } | null;
+  blockers: string[];
+  nextAction: string;
+}
+
+function toRef(value: { id: string; title: string } | null): { id: string; title: string } | null {
+  return value ? { id: value.id, title: value.title } : null;
+}
+
+/**
+ * Derive the integration progress payload from the database. `deriveState`
+ * supplies current refs, phase, blockers, and next action (the same source
+ * the runtime and auto-mode use); project-wide slice/task counts come from
+ * the read seam, since `GSDState.progress` is scoped to the active
+ * milestone/slice while `ProgressResult` buckets are project-wide.
+ *
+ * Note: the derive open path runs pending migrations and syncs the
+ * milestone queue-order projection (same behavior as `gsd headless status`).
+ * Callers must have already decided the DB is present and schema-supported;
+ * a locked or unreadable DB should fall back at the call site, not here.
+ */
+export async function readProgressFromDb(basePath: string): Promise<DbProgressResult> {
+  const state: GSDState = await deriveState(basePath);
+  const hierarchy = readTransaction(() => ({
+    counts: getHierarchyCompletionCounts(),
+    slicesActive: getInFlightSliceCount(),
+  }));
+
+  const registry = state.registry ?? [];
+  const milestonesDone = registry.filter((m) => m.status === "complete").length;
+  const milestonesActive = registry.filter((m) => m.status === "active").length;
+  const milestonesParked = registry.filter((m) => m.status === "parked").length;
+
+  const slicesDone = hierarchy.counts.slices;
+  const slicesTotal = hierarchy.counts.slicesTotal;
+  const tasksDone = hierarchy.counts.tasks;
+  const tasksTotal = hierarchy.counts.tasksTotal;
+
+  return {
+    activeMilestone: toRef(state.activeMilestone),
+    activeSlice: toRef(state.activeSlice),
+    activeTask: toRef(state.activeTask),
+    phase: state.phase,
+    milestones: {
+      total: registry.length,
+      done: milestonesDone,
+      active: milestonesActive,
+      pending: registry.length - milestonesDone - milestonesActive - milestonesParked,
+      parked: milestonesParked,
+    },
+    slices: {
+      total: slicesTotal,
+      done: slicesDone,
+      active: hierarchy.slicesActive,
+      pending: slicesTotal - slicesDone - hierarchy.slicesActive,
+    },
+    tasks: {
+      total: tasksTotal,
+      done: tasksDone,
+      pending: tasksTotal - tasksDone,
+    },
+    requirements:
+      state.requirements && state.requirements.total > 0
+        ? {
+            active: state.requirements.active,
+            validated: state.requirements.validated,
+            deferred: state.requirements.deferred,
+            outOfScope: state.requirements.outOfScope,
+          }
+        : null,
+    blockers: [...state.blockers],
+    nextAction: state.nextAction,
+  };
+}

--- a/src/resources/extensions/gsd/tests/progress-from-db.test.ts
+++ b/src/resources/extensions/gsd/tests/progress-from-db.test.ts
@@ -1,0 +1,105 @@
+// Project/App: gsd-pi
+// File Purpose: readProgressFromDb — DB-authoritative integration progress
+// reads (#2101). Pins both the values derived from the DB and the exact
+// ProgressResult key set the Hermes contract depends on.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  insertMilestone,
+  insertSlice,
+} from "../gsd-db.ts";
+import { deriveState } from "../state.ts";
+import { readProgressFromDb } from "../state/progress-from-db.ts";
+import {
+  createWorkflowAuthorityFixture,
+  type WorkflowAuthorityFixture,
+} from "./workflow-authority-fixture.ts";
+
+function seedSecondMilestone(fixture: WorkflowAuthorityFixture): void {
+  insertMilestone({ id: "M002", title: "Later milestone", status: "pending" });
+  insertSlice({
+    id: "S03",
+    milestoneId: "M002",
+    title: "In-flight slice",
+    status: "in_progress",
+    risk: "low",
+    depends: [],
+    sequence: 1,
+  });
+}
+
+test("readProgressFromDb emits exactly the ProgressResult key set", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+
+  const result = await readProgressFromDb(fixture.root);
+  assert.deepEqual(Object.keys(result), [
+    "activeMilestone",
+    "activeSlice",
+    "activeTask",
+    "phase",
+    "milestones",
+    "slices",
+    "tasks",
+    "requirements",
+    "blockers",
+    "nextAction",
+  ]);
+  assert.deepEqual(Object.keys(result.milestones), ["total", "done", "active", "pending", "parked"]);
+  assert.deepEqual(Object.keys(result.slices), ["total", "done", "active", "pending"]);
+  assert.deepEqual(Object.keys(result.tasks), ["total", "done", "pending"]);
+  assert.deepEqual(
+    Object.keys(result.requirements ?? {}),
+    ["active", "validated", "deferred", "outOfScope"],
+  );
+});
+
+test("readProgressFromDb derives refs, project-wide counts, and requirements from the DB", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  seedSecondMilestone(fixture);
+
+  const result = await readProgressFromDb(fixture.root);
+  const state = await deriveState(fixture.root);
+
+  assert.deepEqual(result.activeMilestone, { id: "M001", title: "Authority Fixture" });
+  assert.deepEqual(result.activeSlice, { id: "S02", title: "Ready dependent slice" });
+  assert.deepEqual(result.activeTask, { id: "T01", title: "Ready task" });
+  assert.equal(result.phase, state.phase);
+  assert.deepEqual(result.milestones, { total: 2, done: 0, active: 1, pending: 1, parked: 0 });
+  assert.deepEqual(result.slices, { total: 3, done: 1, active: 1, pending: 1 });
+  assert.deepEqual(result.tasks, { total: 2, done: 1, pending: 1 });
+  assert.deepEqual(result.requirements, { active: 1, validated: 0, deferred: 0, outOfScope: 0 });
+  assert.deepEqual(result.blockers, []);
+  assert.equal(typeof result.nextAction, "string");
+  assert.ok(result.nextAction.length > 0);
+});
+
+test("readProgressFromDb reflects DB state, never stale projection files", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+
+  writeFileSync(
+    join(fixture.root, ".gsd", "STATE.md"),
+    [
+      "# Project State",
+      "",
+      "**Phase:** planning",
+      "**Active Milestone:** M999: Stale Projection",
+      "",
+      "## Next Action",
+      "",
+      "Stale action from projection",
+      "",
+    ].join("\n"),
+  );
+
+  const result = await readProgressFromDb(fixture.root);
+  assert.equal(result.activeMilestone?.id, "M001");
+  assert.notEqual(result.activeMilestone?.title, "Stale Projection");
+  assert.notEqual(result.nextAction, "Stale action from projection");
+});

--- a/src/resources/extensions/gsd/tests/progress-from-db.test.ts
+++ b/src/resources/extensions/gsd/tests/progress-from-db.test.ts
@@ -3,16 +3,22 @@
 // reads (#2101). Pins both the values derived from the DB and the exact
 // ProgressResult key set the Hermes contract depends on.
 
-import { test } from "node:test";
+import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
+  _getAdapter,
   insertMilestone,
   insertSlice,
 } from "../gsd-db.ts";
-import { deriveState } from "../state.ts";
+import {
+  deriveState,
+  getDeriveTelemetry,
+  invalidateStateCache,
+  resetDeriveTelemetry,
+} from "../state.ts";
 import { readProgressFromDb } from "../state/progress-from-db.ts";
 import {
   createWorkflowAuthorityFixture,
@@ -30,6 +36,38 @@ function seedSecondMilestone(fixture: WorkflowAuthorityFixture): void {
     depends: [],
     sequence: 1,
   });
+}
+
+function changeAuthorityDuringCounts(
+  t: TestContext,
+  limit: number,
+): () => number {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  const originalPrepare = adapter.prepare.bind(adapter);
+  let changes = 0;
+
+  adapter.prepare = (sql: string) => {
+    const statement = originalPrepare(sql);
+    if (!sql.includes("AS completed") || !sql.includes("FROM milestones")) return statement;
+    return {
+      ...statement,
+      get(...params: unknown[]) {
+        if (changes < limit) {
+          changes++;
+          originalPrepare("UPDATE milestones SET title = ? WHERE id = 'M001'")
+            .run(`Authority revision ${changes}`);
+          originalPrepare("UPDATE project_authority SET revision = revision + 1 WHERE singleton = 1")
+            .run();
+        }
+        return statement.get(...params);
+      },
+    };
+  };
+  t.after(() => {
+    adapter.prepare = originalPrepare;
+  });
+  return () => changes;
 }
 
 test("readProgressFromDb emits exactly the ProgressResult key set", async (t) => {
@@ -124,4 +162,34 @@ test("readProgressFromDb reflects DB state, never stale projection files", async
   assert.equal(result.activeMilestone?.id, "M001");
   assert.notEqual(result.activeMilestone?.title, "Stale Projection");
   assert.notEqual(result.nextAction, "Stale action from projection");
+});
+
+test("readProgressFromDb retries when the authority revision moves", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  const getChanges = changeAuthorityDuringCounts(t, 1);
+  invalidateStateCache();
+  resetDeriveTelemetry();
+
+  const result = await readProgressFromDb(fixture.root);
+
+  assert.ok(result);
+  assert.equal(result.activeMilestone?.title, "Authority revision 1");
+  assert.equal(getChanges(), 1);
+  assert.equal(getDeriveTelemetry().dbDeriveCount, 2);
+});
+
+test("readProgressFromDb returns the last attempt during sustained revision movement", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  const getChanges = changeAuthorityDuringCounts(t, 3);
+  invalidateStateCache();
+  resetDeriveTelemetry();
+
+  const result = await readProgressFromDb(fixture.root);
+
+  assert.ok(result);
+  assert.equal(result.activeMilestone?.title, "Authority revision 2");
+  assert.equal(getChanges(), 3);
+  assert.equal(getDeriveTelemetry().dbDeriveCount, 3);
 });

--- a/src/resources/extensions/gsd/tests/progress-from-db.test.ts
+++ b/src/resources/extensions/gsd/tests/progress-from-db.test.ts
@@ -71,6 +71,13 @@ function changeAuthorityDuringCounts(
   return () => changes;
 }
 
+function updateMilestoneFromExternalConnection(dbPath: string): void {
+  const external = new DatabaseSync(dbPath);
+  external.prepare("UPDATE milestones SET title = ? WHERE id = 'M001'")
+    .run("External hierarchy commit");
+  external.close();
+}
+
 function changeHierarchyFromAnotherConnectionDuringCounts(
   t: TestContext,
   dbPath: string,
@@ -88,13 +95,7 @@ function changeHierarchyFromAnotherConnectionDuringCounts(
       get(...params: unknown[]) {
         if (changes === 0) {
           changes++;
-          const external = new DatabaseSync(dbPath);
-          try {
-            external.prepare("UPDATE milestones SET title = ? WHERE id = 'M001'")
-              .run("External hierarchy commit");
-          } finally {
-            external.close();
-          }
+          updateMilestoneFromExternalConnection(dbPath);
         }
         return statement.get(...params);
       },

--- a/src/resources/extensions/gsd/tests/progress-from-db.test.ts
+++ b/src/resources/extensions/gsd/tests/progress-from-db.test.ts
@@ -7,6 +7,7 @@ import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 
 import {
   _getAdapter,
@@ -59,6 +60,41 @@ function changeAuthorityDuringCounts(
             .run(`Authority revision ${changes}`);
           originalPrepare("UPDATE project_authority SET revision = revision + 1 WHERE singleton = 1")
             .run();
+        }
+        return statement.get(...params);
+      },
+    };
+  };
+  t.after(() => {
+    adapter.prepare = originalPrepare;
+  });
+  return () => changes;
+}
+
+function changeHierarchyFromAnotherConnectionDuringCounts(
+  t: TestContext,
+  dbPath: string,
+): () => number {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  const originalPrepare = adapter.prepare.bind(adapter);
+  let changes = 0;
+
+  adapter.prepare = (sql: string) => {
+    const statement = originalPrepare(sql);
+    if (!sql.includes("AS completed") || !sql.includes("FROM milestones")) return statement;
+    return {
+      ...statement,
+      get(...params: unknown[]) {
+        if (changes === 0) {
+          changes++;
+          const external = new DatabaseSync(dbPath);
+          try {
+            external.prepare("UPDATE milestones SET title = ? WHERE id = 'M001'")
+              .run("External hierarchy commit");
+          } finally {
+            external.close();
+          }
         }
         return statement.get(...params);
       },
@@ -177,6 +213,40 @@ test("readProgressFromDb retries when the authority revision moves", async (t) =
   assert.equal(result.activeMilestone?.title, "Authority revision 1");
   assert.equal(getChanges(), 1);
   assert.equal(getDeriveTelemetry().dbDeriveCount, 2);
+});
+
+test("readProgressFromDb retries when another connection changes hierarchy data", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  const getChanges = changeHierarchyFromAnotherConnectionDuringCounts(t, fixture.dbPath);
+  invalidateStateCache();
+  resetDeriveTelemetry();
+
+  const result = await readProgressFromDb(fixture.root);
+
+  assert.ok(result);
+  assert.equal(result.activeMilestone?.title, "External hierarchy commit");
+  assert.equal(getChanges(), 1);
+  assert.equal(getDeriveTelemetry().dbDeriveCount, 2);
+});
+
+test("readProgressFromDb rejects a pre-existing stale derive cache", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  t.mock.method(Date, "now", () => 42_000);
+  invalidateStateCache();
+  const cached = await deriveState(fixture.root);
+  assert.equal(cached.activeMilestone?.title, "Authority Fixture");
+
+  _getAdapter()?.prepare("UPDATE milestones SET title = ? WHERE id = 'M001'")
+    .run("Current hierarchy title");
+  resetDeriveTelemetry();
+
+  const result = await readProgressFromDb(fixture.root);
+
+  assert.ok(result);
+  assert.equal(result.activeMilestone?.title, "Current hierarchy title");
+  assert.equal(getDeriveTelemetry().dbDeriveCount, 1);
 });
 
 test("readProgressFromDb returns the last attempt during sustained revision movement", async (t) => {

--- a/src/resources/extensions/gsd/tests/progress-from-db.test.ts
+++ b/src/resources/extensions/gsd/tests/progress-from-db.test.ts
@@ -37,6 +37,7 @@ test("readProgressFromDb emits exactly the ProgressResult key set", async (t) =>
   t.after(() => fixture.cleanup());
 
   const result = await readProgressFromDb(fixture.root);
+  assert.ok(result);
   assert.deepEqual(Object.keys(result), [
     "activeMilestone",
     "activeSlice",
@@ -64,6 +65,7 @@ test("readProgressFromDb derives refs, project-wide counts, and requirements fro
   seedSecondMilestone(fixture);
 
   const result = await readProgressFromDb(fixture.root);
+  assert.ok(result);
   const state = await deriveState(fixture.root);
 
   assert.deepEqual(result.activeMilestone, { id: "M001", title: "Authority Fixture" });
@@ -77,6 +79,25 @@ test("readProgressFromDb derives refs, project-wide counts, and requirements fro
   assert.deepEqual(result.blockers, []);
   assert.equal(typeof result.nextAction, "string");
   assert.ok(result.nextAction.length > 0);
+});
+
+test("readProgressFromDb keeps milestone counts project-wide under a milestone lock", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  seedSecondMilestone(fixture);
+
+  const previousLock = process.env.GSD_MILESTONE_LOCK;
+  process.env.GSD_MILESTONE_LOCK = "M002";
+  t.after(() => {
+    if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
+    else process.env.GSD_MILESTONE_LOCK = previousLock;
+  });
+
+  const result = await readProgressFromDb(fixture.root);
+  assert.ok(result);
+
+  assert.equal(result.activeMilestone?.id, "M002");
+  assert.deepEqual(result.milestones, { total: 2, done: 0, active: 1, pending: 1, parked: 0 });
 });
 
 test("readProgressFromDb reflects DB state, never stale projection files", async (t) => {
@@ -99,6 +120,7 @@ test("readProgressFromDb reflects DB state, never stale projection files", async
   );
 
   const result = await readProgressFromDb(fixture.root);
+  assert.ok(result);
   assert.equal(result.activeMilestone?.id, "M001");
   assert.notEqual(result.activeMilestone?.title, "Stale Projection");
   assert.notEqual(result.nextAction, "Stale action from projection");

--- a/src/tests/read-cli-args.test.ts
+++ b/src/tests/read-cli-args.test.ts
@@ -14,6 +14,7 @@ const fixture = resolve(__dirname, "../../integrations/hermes/tests/fixtures/min
 // hermes fixture is not copied into dist-test) and would depend on the
 // developer machine's extension bundle state.
 const probelessPreflight: ReadCliSchemaPreflight = {
+	resolveProjectRootDbPath: (basePath) => resolve(basePath, ".gsd", "gsd.db"),
 	openIsolatedDatabase: () => null,
 	supportedSchemaVersion: Number.MAX_SAFE_INTEGER,
 	createSchemaTooNewError: (currentVersion, supportedVersion) =>
@@ -37,6 +38,7 @@ test("runReadCli handles global flags before read", async () => {
 				fixture,
 			],
 			probelessPreflight,
+			async () => null,
 		);
 
 		assert.equal(exitCode, 0, stderr.output());

--- a/src/tests/read-cli-args.test.ts
+++ b/src/tests/read-cli-args.test.ts
@@ -3,26 +3,41 @@ import assert from "node:assert/strict";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { runReadCli } from "../read-cli.ts";
+import { runReadCli, type ReadCliSchemaPreflight } from "../read-cli.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixture = resolve(__dirname, "../../integrations/hermes/tests/fixtures/minimal-project");
+
+// Hermetic probe: never opens a DB, so the DB-backed progress path stays
+// disengaged and this test pins argument parsing only. Without this, a
+// dist-test run resolves gsdRoot by walking up to the repo's own .gsd (the
+// hermes fixture is not copied into dist-test) and would depend on the
+// developer machine's extension bundle state.
+const probelessPreflight: ReadCliSchemaPreflight = {
+	openIsolatedDatabase: () => null,
+	supportedSchemaVersion: Number.MAX_SAFE_INTEGER,
+	createSchemaTooNewError: (currentVersion, supportedVersion) =>
+		new Error(`schema ${currentVersion} > ${supportedVersion}`),
+};
 
 test("runReadCli handles global flags before read", async () => {
 	const stdout = captureWrite(process.stdout);
 	const stderr = captureWrite(process.stderr);
 	try {
-		const exitCode = await runReadCli([
-			"node",
-			"gsd",
-			"--model",
-			"claude-sonnet",
-			"read",
-			"progress",
-			"--json",
-			"--project",
-			fixture,
-		]);
+		const exitCode = await runReadCli(
+			[
+				"node",
+				"gsd",
+				"--model",
+				"claude-sonnet",
+				"read",
+				"progress",
+				"--json",
+				"--project",
+				fixture,
+			],
+			probelessPreflight,
+		);
 
 		assert.equal(exitCode, 0, stderr.output());
 		const envelope = JSON.parse(stdout.output());

--- a/src/tests/read-cli-progress-db.test.ts
+++ b/src/tests/read-cli-progress-db.test.ts
@@ -1,0 +1,159 @@
+/**
+ * `gsd read progress` DB-authoritative wiring (#2101).
+ *
+ * When a project DB is present and openable, the envelope data must come
+ * from the DB-backed reader (ADR-046: the DB is the workflow authority, a
+ * projection can lag it). A missing or unopenable DB keeps the projection
+ * fallback; a failing DB-backed read refuses loudly instead of degrading
+ * to projections. The reader is exercised through its injectable seam —
+ * the same pattern as the schema-version preflight tests — so these cases
+ * pin the wiring and fallback decisions, not the derivation itself (pinned
+ * by tests/progress-from-db.test.ts in the extension).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runReadCli, type ReadCliSchemaPreflight, type DbProgressReader } from "../read-cli.ts";
+import { closeDatabase, openDatabase } from "../resources/extensions/gsd/gsd-db.ts";
+import { openWorkflowDatabaseIsolated } from "../resources/extensions/gsd/db-workspace.ts";
+import { SCHEMA_VERSION, SchemaTooNewError } from "../resources/extensions/gsd/db/engine.ts";
+
+const realPreflight: ReadCliSchemaPreflight = {
+  openIsolatedDatabase: (path) => openWorkflowDatabaseIsolated(path),
+  supportedSchemaVersion: SCHEMA_VERSION,
+  createSchemaTooNewError: (currentVersion, supportedVersion) =>
+    new SchemaTooNewError(currentVersion, supportedVersion),
+};
+
+// Probe that never opens — simulates a locked/unreadable DB at the seam
+// where tryReadProgressFromDb decides the projection fallback.
+const lockedPreflight: ReadCliSchemaPreflight = {
+  openIsolatedDatabase: () => null,
+  supportedSchemaVersion: SCHEMA_VERSION,
+  createSchemaTooNewError: (currentVersion, supportedVersion) =>
+    new SchemaTooNewError(currentVersion, supportedVersion),
+};
+
+interface CaptureOpts {
+  preflight?: ReadCliSchemaPreflight;
+  reader?: DbProgressReader;
+}
+
+async function captureReadCli(argv: string[], opts: CaptureOpts = {}) {
+  let stdout = "";
+  let stderr = "";
+  const originalOut = process.stdout.write;
+  const originalErr = process.stderr.write;
+  process.stdout.write = ((chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const exitCode = await runReadCli(argv, opts.preflight ?? realPreflight, opts.reader);
+    return { exitCode, stdout, stderr };
+  } finally {
+    process.stdout.write = originalOut;
+    process.stderr.write = originalErr;
+  }
+}
+
+function readProgressArgv(base: string): string[] {
+  return ["node", "gsd", "read", "progress", "--json", "--project", base];
+}
+
+function makeProject(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-read-cli-progress-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "STATE.md"),
+    "# Project State\n\n**Phase:** planning\n",
+  );
+  return base;
+}
+
+test("gsd read progress serves the DB-backed payload when the project DB is present and openable", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const sentinel = { phase: "db-derived", activeMilestone: { id: "M001", title: "From DB" } };
+  let calls = 0;
+  const run = await captureReadCli(readProgressArgv(base), {
+    reader: async (projectDir) => {
+      calls++;
+      assert.equal(projectDir, base);
+      return sentinel;
+    },
+  });
+  assert.equal(run.exitCode, 0);
+  const envelope = JSON.parse(run.stdout);
+  assert.equal(envelope.kind, "progress");
+  assert.deepEqual(envelope.data, sentinel);
+  assert.equal(calls, 1);
+});
+
+test("gsd read progress falls back to the projection reader when the DB cannot be opened", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readProgressArgv(base), {
+    preflight: lockedPreflight,
+    reader: async () => {
+      throw new Error("reader must not be called when the probe cannot open the DB");
+    },
+  });
+  assert.equal(run.exitCode, 0);
+  const envelope = JSON.parse(run.stdout);
+  assert.equal(envelope.kind, "progress");
+  // Parsed from STATE.md — the documented degraded fallback.
+  assert.equal(envelope.data.phase, "plan");
+});
+
+test("gsd read progress refuses loudly when the DB-backed read fails", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readProgressArgv(base), {
+    reader: async () => {
+      throw new Error("boom");
+    },
+  });
+  assert.equal(run.exitCode, 1);
+  assert.equal(run.stdout, "");
+  assert.ok(
+    run.stderr.includes("DB-backed progress read failed"),
+    `stderr should explain the failure, got: ${run.stderr}`,
+  );
+  assert.ok(run.stderr.includes("boom"), `stderr should carry the cause, got: ${run.stderr}`);
+});
+
+test("gsd read progress does not invoke the DB reader when no DB exists", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  let calls = 0;
+  const run = await captureReadCli(readProgressArgv(base), {
+    reader: async () => {
+      calls++;
+      return { phase: "should-not-appear" };
+    },
+  });
+  assert.equal(run.exitCode, 0);
+  assert.equal(calls, 0);
+  const envelope = JSON.parse(run.stdout);
+  assert.equal(envelope.kind, "progress");
+  assert.equal(envelope.data.phase, "plan");
+});

--- a/src/tests/read-cli-progress-db.test.ts
+++ b/src/tests/read-cli-progress-db.test.ts
@@ -24,11 +24,15 @@ import {
   type ReadCliSchemaPreflight,
 } from "../read-cli.ts";
 import { closeDatabase, openDatabase } from "../resources/extensions/gsd/gsd-db.ts";
-import { openWorkflowDatabaseIsolated } from "../resources/extensions/gsd/db-workspace.ts";
+import {
+  openWorkflowDatabaseIsolated,
+  resolveProjectRootDbPath,
+} from "../resources/extensions/gsd/db-workspace.ts";
 import { SCHEMA_VERSION, SchemaTooNewError } from "../resources/extensions/gsd/db/engine.ts";
 import { readProgressFromDb } from "../resources/extensions/gsd/state/progress-from-db.ts";
 
 const realPreflight: ReadCliSchemaPreflight = {
+  resolveProjectRootDbPath,
   openIsolatedDatabase: (path) => openWorkflowDatabaseIsolated(path),
   supportedSchemaVersion: SCHEMA_VERSION,
   createSchemaTooNewError: (currentVersion, supportedVersion) =>
@@ -38,6 +42,7 @@ const realPreflight: ReadCliSchemaPreflight = {
 // Probe that never opens — simulates a locked/unreadable DB during the
 // read-only schema check before the DB-backed reader reaches its own open.
 const lockedPreflight: ReadCliSchemaPreflight = {
+  resolveProjectRootDbPath,
   openIsolatedDatabase: () => null,
   supportedSchemaVersion: SCHEMA_VERSION,
   createSchemaTooNewError: (currentVersion, supportedVersion) =>
@@ -111,6 +116,27 @@ test("gsd read progress serves the DB-backed payload when the project DB is pres
   assert.equal(envelope.kind, "progress");
   assert.deepEqual(envelope.data, sentinel);
   assert.equal(calls, 1);
+});
+
+test("gsd read progress uses the project DB from a canonical milestone worktree", async (t) => {
+  const base = makeProject();
+  const worktree = join(base, ".gsd-worktrees", "M001");
+  mkdirSync(join(worktree, ".gsd"), { recursive: true });
+  writeFileSync(join(worktree, ".gsd", "STATE.md"), "# Project State\n\n**Phase:** planning\n");
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const sentinel = { phase: "project-db-derived" };
+  const run = await captureReadCli(readProgressArgv(worktree), {
+    reader: async (projectDir) => {
+      assert.equal(projectDir, worktree);
+      return sentinel;
+    },
+  });
+
+  assert.equal(run.exitCode, 0);
+  assert.deepEqual(JSON.parse(run.stdout).data, sentinel);
 });
 
 test("gsd read progress lets the DB reader decide availability after schema preflight", async (t) => {

--- a/src/tests/read-cli-progress-db.test.ts
+++ b/src/tests/read-cli-progress-db.test.ts
@@ -17,10 +17,16 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { runReadCli, type ReadCliSchemaPreflight, type DbProgressReader } from "../read-cli.ts";
+import {
+  runReadCli,
+  type DbProgressModuleImporter,
+  type DbProgressReader,
+  type ReadCliSchemaPreflight,
+} from "../read-cli.ts";
 import { closeDatabase, openDatabase } from "../resources/extensions/gsd/gsd-db.ts";
 import { openWorkflowDatabaseIsolated } from "../resources/extensions/gsd/db-workspace.ts";
 import { SCHEMA_VERSION, SchemaTooNewError } from "../resources/extensions/gsd/db/engine.ts";
+import { readProgressFromDb } from "../resources/extensions/gsd/state/progress-from-db.ts";
 
 const realPreflight: ReadCliSchemaPreflight = {
   openIsolatedDatabase: (path) => openWorkflowDatabaseIsolated(path),
@@ -29,8 +35,8 @@ const realPreflight: ReadCliSchemaPreflight = {
     new SchemaTooNewError(currentVersion, supportedVersion),
 };
 
-// Probe that never opens — simulates a locked/unreadable DB at the seam
-// where tryReadProgressFromDb decides the projection fallback.
+// Probe that never opens — simulates a locked/unreadable DB during the
+// read-only schema check before the DB-backed reader reaches its own open.
 const lockedPreflight: ReadCliSchemaPreflight = {
   openIsolatedDatabase: () => null,
   supportedSchemaVersion: SCHEMA_VERSION,
@@ -41,6 +47,7 @@ const lockedPreflight: ReadCliSchemaPreflight = {
 interface CaptureOpts {
   preflight?: ReadCliSchemaPreflight;
   reader?: DbProgressReader;
+  moduleImporter?: DbProgressModuleImporter;
 }
 
 async function captureReadCli(argv: string[], opts: CaptureOpts = {}) {
@@ -57,7 +64,12 @@ async function captureReadCli(argv: string[], opts: CaptureOpts = {}) {
     return true;
   }) as typeof process.stderr.write;
   try {
-    const exitCode = await runReadCli(argv, opts.preflight ?? realPreflight, opts.reader);
+    const exitCode = await runReadCli(
+      argv,
+      opts.preflight ?? realPreflight,
+      opts.reader,
+      opts.moduleImporter,
+    );
     return { exitCode, stdout, stderr };
   } finally {
     process.stdout.write = originalOut;
@@ -101,22 +113,38 @@ test("gsd read progress serves the DB-backed payload when the project DB is pres
   assert.equal(calls, 1);
 });
 
-test("gsd read progress falls back to the projection reader when the DB cannot be opened", async (t) => {
+test("gsd read progress lets the DB reader decide availability after schema preflight", async (t) => {
   const base = makeProject();
   t.after(() => rmSync(base, { recursive: true, force: true }));
   assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
   closeDatabase();
 
+  const sentinel = { phase: "db-derived-after-preflight" };
   const run = await captureReadCli(readProgressArgv(base), {
     preflight: lockedPreflight,
-    reader: async () => {
-      throw new Error("reader must not be called when the probe cannot open the DB");
-    },
+    reader: async () => sentinel,
   });
   assert.equal(run.exitCode, 0);
   const envelope = JSON.parse(run.stdout);
-  assert.equal(envelope.kind, "progress");
-  // Parsed from STATE.md — the documented degraded fallback.
+  assert.deepEqual(envelope.data, sentinel);
+});
+
+test("gsd read progress falls back when the DB disappears before the DB reader opens it", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const dbPath = join(base, ".gsd", "gsd.db");
+  assert.equal(openDatabase(dbPath), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readProgressArgv(base), {
+    reader: async (projectDir) => {
+      rmSync(dbPath, { force: true });
+      return readProgressFromDb(projectDir);
+    },
+  });
+
+  assert.equal(run.exitCode, 0);
+  const envelope = JSON.parse(run.stdout);
   assert.equal(envelope.data.phase, "plan");
 });
 
@@ -138,6 +166,23 @@ test("gsd read progress refuses loudly when the DB-backed read fails", async (t)
     `stderr should explain the failure, got: ${run.stderr}`,
   );
   assert.ok(run.stderr.includes("boom"), `stderr should carry the cause, got: ${run.stderr}`);
+});
+
+test("gsd read progress explains how to repair a stale extension bundle", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readProgressArgv(base), {
+    moduleImporter: async () => {
+      throw new Error("Cannot find module state/progress-from-db.ts");
+    },
+  });
+
+  assert.equal(run.exitCode, 1);
+  assert.equal(run.stdout, "");
+  assert.match(run.stderr, /synchronize the extension bundle/);
 });
 
 test("gsd read progress does not invoke the DB reader when no DB exists", async (t) => {

--- a/src/tests/read-cli-schema-too-new.test.ts
+++ b/src/tests/read-cli-schema-too-new.test.ts
@@ -41,7 +41,7 @@ const realPreflight: ReadCliSchemaPreflight = {
     new SchemaTooNewError(currentVersion, supportedVersion),
 };
 
-async function captureReadCli(argv: string[]) {
+async function captureReadCli(argv: string[], reader?: (projectDir: string) => Promise<unknown>) {
   let stdout = "";
   let stderr = "";
   const originalOut = process.stdout.write;
@@ -55,7 +55,7 @@ async function captureReadCli(argv: string[]) {
     return true;
   }) as typeof process.stderr.write;
   try {
-    const exitCode = await runReadCli(argv, realPreflight);
+    const exitCode = await runReadCli(argv, realPreflight, reader);
     return { exitCode, stdout, stderr };
   } finally {
     process.stdout.write = originalOut;
@@ -98,17 +98,20 @@ test("gsd read progress --json on a newer-schema project exits non-zero with the
   }
 });
 
-test("gsd read progress --json on a current-schema project keeps the exit-0 read path", async () => {
+test("gsd read progress --json on a current-schema project serves the DB-backed payload", async () => {
   const base = makeProject();
   try {
     assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
     closeDatabase();
 
-    const run = await captureReadCli(readProgressArgv(base));
+    // DB present + schema OK now prefers the DB-backed reader (#2101); the
+    // injected sentinel proves the envelope carried DB data, not STATE.md.
+    const sentinel = { phase: "db-derived" };
+    const run = await captureReadCli(readProgressArgv(base), async () => sentinel);
     assert.equal(run.exitCode, 0);
     const envelope = JSON.parse(run.stdout);
     assert.equal(envelope.kind, "progress");
-    assert.equal(envelope.data.phase, "plan");
+    assert.deepEqual(envelope.data, sentinel);
   } finally {
     rmSync(base, { recursive: true, force: true });
   }

--- a/src/tests/read-cli-schema-too-new.test.ts
+++ b/src/tests/read-cli-schema-too-new.test.ts
@@ -25,8 +25,12 @@ import { join } from "node:path";
 import { runReadCli, type ReadCliSchemaPreflight } from "../read-cli.ts";
 import { closeDatabase, openDatabase, _getAdapter } from "../resources/extensions/gsd/gsd-db.ts";
 import { recordSchemaVersion } from "../resources/extensions/gsd/db-schema-metadata.ts";
-import { openWorkflowDatabaseIsolated } from "../resources/extensions/gsd/db-workspace.ts";
+import {
+  openWorkflowDatabaseIsolated,
+  resolveProjectRootDbPath,
+} from "../resources/extensions/gsd/db-workspace.ts";
 import { SCHEMA_VERSION, SchemaTooNewError } from "../resources/extensions/gsd/db/engine.ts";
+import { readProgressFromDb } from "../resources/extensions/gsd/state/progress-from-db.ts";
 
 const V49_MESSAGE =
   "gsd.db schema is v49, newer than the v48 this gsd-pi supports. " +
@@ -35,6 +39,7 @@ const V49_MESSAGE =
 // Real preflight probe: the same pieces the production jiti loader wires up,
 // loaded through this test process's module graph.
 const realPreflight: ReadCliSchemaPreflight = {
+  resolveProjectRootDbPath,
   openIsolatedDatabase: (path) => openWorkflowDatabaseIsolated(path),
   supportedSchemaVersion: SCHEMA_VERSION,
   createSchemaTooNewError: (currentVersion, supportedVersion) =>
@@ -98,6 +103,24 @@ test("gsd read progress --json on a newer-schema project exits non-zero with the
   }
 });
 
+test("gsd read progress checks the project DB schema from a canonical milestone worktree", async (t) => {
+  const base = makeProject();
+  const worktree = join(base, ".gsd-worktrees", "M001");
+  mkdirSync(join(worktree, ".gsd"), { recursive: true });
+  writeFileSync(join(worktree, ".gsd", "STATE.md"), "# Project State\n\n**Phase:** planning\n");
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  const db = _getAdapter();
+  assert.ok(db);
+  recordSchemaVersion(db, 49);
+  closeDatabase();
+
+  const run = await captureReadCli(readProgressArgv(worktree));
+
+  assert.notEqual(run.exitCode, 0);
+  assert.match(run.stderr, new RegExp(V49_MESSAGE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
 test("gsd read progress --json on a current-schema project serves the DB-backed payload", async () => {
   const base = makeProject();
   try {
@@ -134,7 +157,7 @@ test("gsd read progress --json with an unreadable gsd.db keeps the existing degr
   try {
     writeFileSync(join(base, ".gsd", "gsd.db"), "not a sqlite database");
 
-    const run = await captureReadCli(readProgressArgv(base));
+    const run = await captureReadCli(readProgressArgv(base), readProgressFromDb);
     assert.equal(run.exitCode, 0);
     const envelope = JSON.parse(run.stdout);
     assert.equal(envelope.kind, "progress");


### PR DESCRIPTION
## Intent

Fix issue #2101 (split from the #2099 review): make 'gsd read progress' and the packaged MCP 'gsd_progress' tool DB-authoritative per ADR-046 instead of serving STATE.md projections that can lag gsd.db. The branch carries three approved review-fix commits (4929e665..6921ec5b): project-wide milestone counts from DB status rather than the possibly lock-narrowed registry; availability judged at the actual DB-open boundary with markdown fallback for missing/locked DBs and loud exit-1 for failing DB-backed reads; worktree-authoritative DB paths via the project-root DB path contract; sync-hint when the extension module is missing from a stale synced bundle; atomic existing-only MCP reads (a DB removed mid-flight must not be recreated nor yield empty success — null fallback instead); validation inside the isError envelope so standalone installs are unchanged; the revision-bind consistency the maintainer explicitly chose (project_authority revision read before/after deriveState plus counts, bounded retry with derive-cache invalidation, last attempt wins under sustained movement, residual tearing documented); and handler-level tests through the registered gsd_progress tool where DB and STATE.md disagree. Maintainer-approved tradeoffs to treat as deliberate: migrate-on-read and milestone queue-order sync on this path (same contract as gsd headless status, documented); fine-grained DB phases (executing, evaluating-gates, ...) replace the parser's coarse plan/execute buckets, display-only for Hermes; stale synced agent extension bundle fails loud with a synchronize hint; DB terminal status wins over SUMMARY.md heuristics; envelope stays integration_version: 1; exact ProgressResult key set pinned by test and covered by the Hermes contract test. The adapter-injected single-snapshot deriveState refactor was explicitly REJECTED — do not request it.

## What Changed

- Make `gsd read progress` and packaged MCP `gsd_progress` derive progress and project-wide counts from the project-root workflow database.
- Fall back to `STATE.md` only when the database is missing or cannot be opened, while surfacing failures after a successful open and preventing existing-only reads from recreating a removed database.
- Add revision-bound consistency checks, CLI and MCP coverage, and documentation for the database-first progress contract.

## Risk Assessment

✅ Low: The change is focused, matches the required DB-authoritative behavior, preserves documented fallbacks, and includes behavior-level regression coverage for the affected CLI, MCP, consistency, and database-open paths.

## Testing

After resolving initial missing-dependency and generated-artifact setup failures, focused automated tests passed and product-level CLI/MCP transcripts showed the DB payload winning over stale STATE.md; an intentional reader-removal sabotage proved the check detects the regression. Text transcripts are the appropriate reviewer-visible artifacts because this change affects CLI JSON and MCP API output, not UI.

<details>
<summary>Evidence: CLI DB-authoritative transcript</summary>

```text
Projection file before command:
# Project State

**Active Milestone:** M999: Stale Projection
**Phase:** planning

CLI response:
{
  "integration_version": 1,
  "kind": "progress",
  "projectDir": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-progress-evidence-2wb604",
  "data": {
    "activeMilestone": {
      "id": "M001",
      "title": "Database Authority"
    },
    "activeSlice": {
      "id": "S01",
      "title": "Database Slice"
    },
    "activeTask": null,
    "phase": "planning",
    "milestones": {
      "total": 1,
      "done": 0,
      "active": 1,
      "pending": 0,
      "parked": 0
    },
    "slices": {
      "total": 1,
      "done": 0,
      "active": 0,
      "pending": 1
    },
    "tasks": {
      "total": 0,
      "done": 0,
      "pending": 0
    },
    "requirements": null,
    "blockers": [],
    "nextAction": "Slice S01 has no DB tasks. Plan slice tasks before execution."
  }
}
CLI exit code: 0
```
</details>
<details>
<summary>Evidence: Registered MCP DB-authoritative response</summary>

```text
Projection file before tool call:
# Project State

**Active Milestone:** M999: Stale Projection
**Phase:** planning

Registered gsd_progress response:
{
  "content": [
    {
      "type": "text",
      "text": "{\n  \"activeMilestone\": {\n    \"id\": \"M001\",\n    \"title\": \"Database Authority\"\n  },\n  \"activeSlice\": {\n    \"id\": \"S01\",\n    \"title\": \"Database Slice\"\n  },\n  \"activeTask\": null,\n  \"phase\": \"planning\",\n  \"milestones\": {\n    \"total\": 1,\n    \"done\": 0,\n    \"active\": 1,\n    \"pending\": 0,\n    \"parked\": 0\n  },\n  \"slices\": {\n    \"total\": 1,\n    \"done\": 0,\n    \"active\": 0,\n    \"pending\": 1\n  },\n  \"tasks\": {\n    \"total\": 0,\n    \"done\": 0,\n    \"pending\": 0\n  },\n  \"requirements\": null,\n  \"blockers\": [],\n  \"nextAction\": \"Slice S01 has no DB tasks. Plan slice tasks before execution.\"\n}"
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"28b7d423cd7b0ac65921e7eed59e0c66293664a5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `src/resources/extensions/gsd/state/progress-from-db.ts:115` - Intent requires results to be bound to a stable authority revision, with tearing limited to sustained concurrent commits. However, `project_authority.revision` does not cover every input: existing writer contracts state slice status/depends/sequence writes do not bump it. A concurrent `updateSliceStatus()` between `deriveState()` and the count transaction can therefore return active S01 alongside `done: 1, active: 0` while both revision reads remain equal. Bind against a read token covering all hierarchy writes at the shared DB boundary.
- 🚨 `src/resources/extensions/gsd/state/progress-from-db.ts:116` - The revision check accepts a pre-existing stale derive cache. Call 1 can cache state at revision R; another process commits R+1; call 2 within the 100 ms TTL reads R+1 before and after but receives cached state from R here, silently combining stale refs/phase with R+1 counts. Bind cache entries to the authority token or invalidate before the first derivation attempt.
- 🚨 `packages/mcp-server/src/mcp-server.test.ts:897` - The required handler-level regression test bypasses the shipping `createMcpServer` registration by directly invoking `registerProgressTool` with injected dependencies. Restoring projection-only registration inside `createMcpServer` would leave this test green, so it does not catch the original packaged-MCP defect. Invoke `_registeredTools.gsd_progress` from `createMcpServer` with disagreeing DB and STATE.md data.

🔧 Fix: Strengthen progress consistency and production registration coverage
2 errors still open:

- 🚨 `packages/mcp-server/src/workflow-tools.ts:1322` - Intent requires markdown fallback for a missing or locked DB. When an existing DB is locked, `ensureExistingDbOpen()` returns false but the path still exists, so this path throws and `gsd_progress` returns an MCP error instead of `STATE.md`. Preserve the open result’s reason so missing/locked failures return null while post-open query failures remain loud.
- 🚨 `packages/mcp-server/src/mcp-server.test.ts:895` - The required production-registration regression test injects `hasWorkflowBridge` and `readFromDb` and never creates a disagreeing `gsd.db`. Production bridge detection or `readProjectProgressViaBridge` wiring can regress while this remains green. Use a real DB/STATE.md disagreement through `createMcpServer` with its default progress dependencies.

🔧 Fix: Handle locked MCP reads and test production wiring
3 issues (1 warning, 2 infos) still open:

- ⚠️ `src/resources/extensions/gsd/tests/progress-from-db.test.ts:92` - This new test helper receives `TestContext` but uses `try/finally` for cleanup, contrary to CONTRIBUTING.md. Extract the immediate external-DB operation into a helper without `t`; keep adapter restoration registered with `t.after()`.
- ℹ️ `packages/mcp-server/src/server.ts:385` - The dependency interface, default object, and exported registration helper now have only one production caller, while tests exercise `createMcpServer` directly. Remove the unused injection layer and keep registration private or inline.
- ℹ️ `src/resources/extensions/gsd/bootstrap/dynamic-tools.ts:172` - `ensureExistingDbOpen` has no callers after MCP progress switched to `openExistingWorkflowDatabase`; remove this orphan helper and its bridge re-export.

🔧 Fix: Remove obsolete progress seams and normalize test cleanup
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --frozen-lockfile` to restore missing isolated-worktree dependencies</code>
- <code>`node … --test src/tests/read-cli-progress-db.test.ts src/tests/read-cli-schema-too-new.test.ts src/resources/extensions/gsd/tests/progress-from-db.test.ts` — focused CLI, schema, counts, cache, revision, and DB-authority cases</code>
- <code>`node … --test --test-name-pattern=&#39;gsd_progress|registered gsd_progress&#39; packages/mcp-server/src/mcp-server.test.ts` — production registration, DB preference, projection fallback, and validation envelope</code>
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern=&#39;readProjectProgressViaBridge&#39; packages/mcp-server/src/workflow-tools.test.ts` — project isolation and missing/removed/locked DB behavior</code>
- <code>Invoked `runReadCli` against a real disagreeing DB/STATE fixture and captured `cli-db-authoritative.txt`</code>
- <code>Invoked `createMcpServer`’s registered `gsd_progress` handler against a real disagreeing DB/STATE fixture and captured `mcp-db-authoritative.txt`</code>
- <code>Sabotaged the CLI DB reader to return `null`; the authority assertion failed as expected with `M999 !== M001`</code>
- <code>Removed generated `node_modules`, `dist-test`, and native package build output; confirmed the worktree is clean</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
