### PR TITLE
fix(issue): unmerged-milestone-guard ignores prefs.main_branch when milestone has no <MID>-META.json, falsely blocks /gsd auto against master

### DIFF
--- a/src/resources/extensions/gsd/tests/unmerged-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/unmerged-milestone-guard.test.ts
@@ -53,6 +53,27 @@ test("findUnmergedCompletedMilestones blocks completed milestone branch product 
   }
 });
 
+test("findUnmergedCompletedMilestones honors configured main branch without milestone metadata", async (t) => {
+  const base = makeTempRepo("gsd-unmerged-guard-");
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+  seedMilestone(base, "M013");
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    ["---", "git:", "  main_branch: devel", "---", ""].join("\n"),
+  );
+  git(base, "checkout", "-b", "devel");
+  commitBranchFile(base, "milestone/M013", "index.html", "<h1>M013</h1>\n");
+  git(base, "checkout", "devel");
+  git(base, "merge", "--ff-only", "milestone/M013");
+
+  const blockers = await findUnmergedCompletedMilestones(base);
+
+  assert.equal(blockers.length, 0);
+});
+
 test("findUnmergedCompletedMilestones does not block after a --no-ff merge that diverges from the branch tip", async () => {
   const base = makeTempRepo("gsd-unmerged-guard-");
   try {

--- a/src/resources/extensions/gsd/unmerged-milestone-guard.ts
+++ b/src/resources/extensions/gsd/unmerged-milestone-guard.ts
@@ -12,7 +12,7 @@ import {
 import { autoWorktreeBranch } from "./auto-worktree-branch-lifecycle.js";
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 import { getAllMilestones } from "./gsd-db.js";
-import { resolveMilestoneIntegrationBranch } from "./git-service.js";
+import { resolveMilestoneIntegrationBranch, VALID_BRANCH_NAME } from "./git-service.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { isClosedStatus } from "./status-guards.js";
 
@@ -121,6 +121,9 @@ function resolveIntegrationBranch(base: string, milestoneId: string): string | n
   const resolution = resolveMilestoneIntegrationBranch(base, milestoneId, prefs);
   if (resolution.effectiveBranch && nativeBranchExists(base, resolution.effectiveBranch)) {
     return resolution.effectiveBranch;
+  }
+  if (prefs.main_branch && VALID_BRANCH_NAME.test(prefs.main_branch) && nativeBranchExists(base, prefs.main_branch)) {
+    return prefs.main_branch;
   }
 
   try {


### PR DESCRIPTION
## Summary
- Fixed integration-branch resolution for metadata-less milestones and added regression coverage; static checks passed.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2110
- [#2110 unmerged-milestone-guard ignores prefs.main_branch when milestone has no <MID>-META.json, falsely blocks /gsd auto against master](https://github.com/open-gsd/gsd-pi/issues/2110)

## User
- @splichy

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2110-unmerged-milestone-guard-ignores-prefs-m-1788194349`