### PR TITLE
fix(issue): [Bug] gsd_save_gate_result mislabels a successful gate write as failed for skipped slices

### DIFF
--- a/src/resources/extensions/gsd/tests/milestone-completion-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-completion-domain-operation.test.ts
@@ -541,6 +541,44 @@ test("Milestone completion rejects unresolved pending quality gates without resi
   );
 });
 
+test("Milestone completion repairs every pending gate for a skipped slice in one call", async () => {
+  const basePath = await prepareFixture();
+  for (const gate of [
+    { gateId: "Q3", scope: "slice" },
+    { gateId: "Q4", scope: "slice" },
+    { gateId: "Q5", scope: "task", taskId: "T02" },
+    { gateId: "Q6", scope: "task", taskId: "T02" },
+    { gateId: "Q7", scope: "task", taskId: "T02" },
+    { gateId: "Q8", scope: "slice" },
+  ] as const) {
+    insertGateRow({
+      milestoneId: "M001",
+      sliceId: "S02",
+      gateId: gate.gateId,
+      scope: gate.scope,
+      taskId: "taskId" in gate ? gate.taskId : undefined,
+    });
+  }
+
+  const result = await handleCompleteMilestone({
+    milestoneId: "M001",
+    verificationPassed: true,
+    ...closeout(),
+  }, basePath, invocation("milestone-complete/skipped-slice-gates"));
+
+  assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+  assert.deepEqual(rows(`
+    SELECT gate_id, status, verdict
+    FROM quality_gates
+    WHERE milestone_id = 'M001' AND slice_id = 'S02'
+    ORDER BY gate_id
+  `), ["Q3", "Q4", "Q5", "Q6", "Q7", "Q8"].map((gateId) => ({
+    gate_id: gateId,
+    status: "complete",
+    verdict: "omitted",
+  })));
+});
+
 test("Milestone completion ignores completed unregistered legacy quality gates", async () => {
   await prepareFixture();
   insertGateRow({

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -2670,6 +2670,99 @@ test("executeSaveGateResult validates inputs and persists verdicts", async () =>
   }
 });
 
+test("executeSaveGateResult succeeds after committing a gate for a skipped slice", async (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+  openTestDb(base);
+  seedMilestone("M005", "Milestone Five");
+  seedSlice("M005", "S05", "skipped");
+  _getAdapter()!.prepare(
+    "INSERT OR REPLACE INTO tasks (milestone_id, slice_id, id, title, status) VALUES (?, ?, ?, ?, ?)",
+  ).run("M005", "S05", "T01", "Skipped task", "skipped");
+  insertGateRow({ milestoneId: "M005", sliceId: "S05", gateId: "Q3", scope: "slice" });
+
+  const result = await inProjectDir(base, () => executeSaveGateResult({
+    milestoneId: "M005",
+    sliceId: "S05",
+    gateId: "Q3",
+    verdict: "omitted",
+    rationale: "Slice was intentionally skipped.",
+    findings: "",
+  }, base));
+
+  assert.equal(result.isError, undefined);
+  assert.equal(result.details.operation, "save_gate_result");
+  assert.equal(result.details.stale, undefined);
+  assert.deepEqual(_getAdapter()!.prepare(
+    `SELECT status, verdict, rationale FROM quality_gates
+     WHERE milestone_id = ? AND slice_id = ? AND gate_id = ? AND task_id = ''`,
+  ).get("M005", "S05", "Q3"), {
+    status: "complete",
+    verdict: "omitted",
+    rationale: "Slice was intentionally skipped.",
+  });
+});
+
+test("executeSaveGateResult reports a post-commit projection failure as stale success", async (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    _setManagedProjectionWriteFaultForTest(null);
+    closeDatabase();
+    cleanup(base);
+  });
+  openTestDb(base);
+  seedMilestone("M005", "Milestone Five");
+  seedSlice("M005", "S05", "pending");
+  mkdirSync(join(base, "src"), { recursive: true });
+  writeFileSync(join(base, "src", "gate.ts"), "export const gate = true;\n", "utf-8");
+  await inProjectDir(base, () => executePlanSlice({
+    milestoneId: "M005",
+    sliceId: "S05",
+    goal: "Exercise a failed post-save plan projection.",
+    tasks: [{
+      taskId: "T01",
+      title: "Keep one active task",
+      description: "Keep the plan render path active.",
+      estimate: "5m",
+      files: ["src/gate.ts"],
+      verify: "node --test",
+      inputs: [],
+      expectedOutput: ["src/gate.ts"],
+    }],
+  }, base));
+  const obstructedWrites: string[] = [];
+  _setManagedProjectionWriteFaultForTest((logicalPath) => {
+    if (!logicalPath.endsWith("-PLAN.md")) return;
+    obstructedWrites.push(logicalPath);
+    throw new Error("simulated gate plan projection failure");
+  });
+
+  const result = await inProjectDir(base, () => executeSaveGateResult({
+    milestoneId: "M005",
+    sliceId: "S05",
+    gateId: "Q3",
+    verdict: "pass",
+    rationale: "The gate itself passed.",
+    findings: "No gate findings.",
+  }, base));
+
+  assert.equal(result.isError, undefined);
+  assert.equal(result.details.operation, "save_gate_result");
+  assert.equal(result.details.stale, true);
+  assert.match(String(result.content[0]?.text), /saved.*readable plan update is pending repair/i);
+  assert.ok(obstructedWrites.length > 0, "fixture must obstruct the post-save PLAN write");
+  assert.deepEqual(_getAdapter()!.prepare(
+    `SELECT status, verdict FROM quality_gates
+     WHERE milestone_id = ? AND slice_id = ? AND gate_id = ? AND task_id = ''`,
+  ).get("M005", "S05", "Q3"), {
+    status: "complete",
+    verdict: "pass",
+  });
+});
+
 test("executeSaveGateResult leaves quality gates pending after a retryable tool error", async () => {
   const base = makeTmpBase();
   const startedAt = Date.now();

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -32,7 +32,9 @@ import { appendEvent } from "../workflow-events.js";
 import { logWarning, logError } from "../workflow-logger.js";
 import {
   isMilestoneLifecycleAdopted,
+  readMilestoneCloseoutAuthorization,
 } from "../db/milestone-closeout-readiness.js";
+import { closeQualityGatesFromEvidence } from "../quality-gate-closure.js";
 import type { ExecutionInvocation } from "../execution-invocation.js";
 import {
   completeMilestone,
@@ -249,6 +251,17 @@ export async function handleCompleteMilestone(
       return { error: "adopted Milestone completion requires canonical invocation identity" };
     }
     try {
+      const authorization = readMilestoneCloseoutAuthorization({
+        milestoneId: params.milestoneId,
+        sourceRevision: currentSourceRevision!,
+      });
+      if (authorization.authorized) {
+        closeQualityGatesFromEvidence(params.milestoneId, {
+          artifactBasePath,
+          milestoneValidationPassed: authorization.kind === "validated",
+          milestoneValidationAuthorization: authorization,
+        });
+      }
       canonicalReceipt = completeMilestone({
         invocation,
         milestoneId: params.milestoneId,

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -90,7 +90,7 @@ import { flushWorkflowProjections } from "../projection-flush.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { parseProject } from "../schemas/parsers.js";
 import { autoSession, getAutoRuntimeSnapshot, isAutoActive } from "../auto-runtime-state.js";
-import { renderPlanFromDb, writeTaskSummaryProjection } from "../markdown-renderer.js";
+import { renderPlanCheckboxes, renderPlanFromDb, writeTaskSummaryProjection } from "../markdown-renderer.js";
 import { readUnitHarnessAbort, type UnitHarnessAbortRecord } from "../unit-runtime.js";
 import {
   prepareUatRun,
@@ -1851,21 +1851,39 @@ export async function executeSaveGateResult(
       rationale: params.rationale,
       findings: params.findings ?? "",
     });
-    await renderPlanFromDb(basePath, params.milestoneId, params.sliceId);
-    invalidateStateCache();
-    return {
-      content: [{ type: "text", text: `Gate ${params.gateId} result saved: verdict=${params.verdict}` }],
-      details: { operation: "save_gate_result", gateId: params.gateId, verdict: params.verdict },
-    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    logError("tool", `gsd_save_gate_result failed: ${msg}`, { tool: "gsd_save_gate_result", error: String(err) });
+    logError("tool", `gsd_save_gate_result database write failed: ${msg}`, { tool: "gsd_save_gate_result", error: String(err) });
     return {
       content: [{ type: "text", text: `Error saving gate result: ${msg}` }],
       details: { operation: "save_gate_result", error: msg },
-    isError: true,
-      };
+      isError: true,
+    };
   }
+
+  let projectionStale = false;
+  try {
+    await renderPlanCheckboxes(basePath, params.milestoneId, params.sliceId);
+  } catch (err) {
+    projectionStale = true;
+    logWarning(
+      "projection",
+      `gsd_save_gate_result plan projection failed for ${params.milestoneId}/${params.sliceId}; DB gate result remains committed`,
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+  }
+  invalidateStateCache();
+
+  const projectionNotice = projectionStale ? ". The readable plan update is pending repair." : "";
+  return {
+    content: [{ type: "text", text: `Gate ${params.gateId} result saved: verdict=${params.verdict}${projectionNotice}` }],
+    details: {
+      operation: "save_gate_result",
+      gateId: params.gateId,
+      verdict: params.verdict,
+      ...(projectionStale ? { stale: true } : {}),
+    },
+  };
 }
 
 function errorResult(operation: string, message: string, error: string): ToolExecutionResult {


### PR DESCRIPTION
## Summary
- Fixed skipped-slice gate save reporting and one-call milestone gate repair, with regression tests and passing static verification.

## Bugs Addressed
- [x] **Gate save reports failure after a successful database commit**
- [x] **Milestone completion repairs only one pending gate per retry**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #2116
- [#2116 [Bug] gsd_save_gate_result mislabels a successful gate write as failed for skipped slices](https://github.com/open-gsd/gsd-pi/issues/2116)

## User
- @affligem2001

## Repo
- `open-gsd/gsd-pi`

## Branch
- `issue/2116-bug-gsd-save-gate-result-mislabels-a-suc-1788238046`