### PR TITLE
fix(ci): exempt generated artifacts from require-tests gate

### DIFF
--- a/scripts/require-tests.sh
+++ b/scripts/require-tests.sh
@@ -3,7 +3,8 @@
 # Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 #
 # Fails CI if a PR changes source files but includes no test file changes.
-# Exemptions: docs-only, CI/config, test-only, and chore branches.
+# Exemptions: docs-only, CI/config, test-only, chore branches, and generated
+# artifacts (*.generated.*) that are machine-regenerated.
 
 set -euo pipefail
 
@@ -35,10 +36,13 @@ if [[ "$BRANCH" =~ ^(docs|chore|ci)/ ]]; then
 fi
 
 # --- classify changed files ---
-# Source files: .ts/.mts/.mjs/.js in src/ or packages/, excluding tests and type declarations
+# Source files: .ts/.mts/.mjs/.js in src/ or packages/, excluding tests, type
+# declarations, and generated artifacts (machine-regenerated; bot PRs like
+# model-catalog refresh never carry hand-written tests)
 SRC_FILES=$(echo "$FILES" | grep -E '^(src|packages)/.*\.(ts|mts|mjs|js)$' \
   | grep -vE '\.(test|spec)\.' \
   | grep -vE '\.d\.ts$' \
+  | grep -vE '\.generated\.' \
   | grep -vE '__tests__/' \
   | grep -vE '/tests/' \
   || true)


### PR DESCRIPTION
## Problem

The scheduled `update-model-catalog` workflow opened [#2120](https://github.com/open-gsd/gsd-pi/pull/2120) (bot refresh of `packages/pi-ai/src/models.generated.ts`), but CI failed: `scripts/require-tests.sh` classifies the generated file as a source change and fails the PR because no test files changed. `ci-gate` then failed, so the PR is blocked from auto-merge.

A machine-regenerated artifact can never carry hand-written test changes, so this fails on every refresh PR.

## Fix

Exclude `*.generated.*` files from the source-file classification in `scripts/require-tests.sh` (the repo already follows this naming convention: `models.generated.ts`, `image-models.generated.ts`). The gate still enforces tests for hand-written source changes.

## Verification

Ran the gate locally against synthetic diffs:

| scenario | expected | result |
| --- | --- | --- |
| generated-only change (the #2120 diff) | pass | ✓ pass (pre-fix: fail, confirmed by CI on #2120) |
| hand-written src change, no tests | fail | ✓ fail |
| hand-written src change + test file | pass | ✓ pass |

AI-assisted: yes.