### PR TITLE
fix(pi-ai): round catalog costs before writing JSON snapshot

### DIFF
--- a/packages/pi-ai/scripts/generate-models.ts
+++ b/packages/pi-ai/scripts/generate-models.ts
@@ -10,6 +10,7 @@ import {
 	CLOUDFLARE_WORKERS_AI_BASE_URL,
 } from "../src/providers/cloudflare.ts";
 import type { AnthropicMessagesCompat, Api, KnownProvider, Model, OpenAICompletionsCompat } from "../src/types.ts";
+import { formatCost, roundCost } from "./lib/model-cost.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -318,18 +319,6 @@ function getBedrockBaseUrl(modelId: string): string {
 	return modelId.startsWith("eu.")
 		? "https://bedrock-runtime.eu-central-1.amazonaws.com"
 		: "https://bedrock-runtime.us-east-1.amazonaws.com";
-}
-
-function roundCost(value: number): number {
-	if (!Number.isFinite(value)) {
-		throw new Error("Model costs must be finite numbers.");
-	}
-	const rounded = Number(value.toFixed(12));
-	return Object.is(rounded, -0) ? 0 : rounded;
-}
-
-function formatCost(value: number): string {
-	return String(roundCost(value));
 }
 
 function formatFiniteNumber(value: unknown, field: string, modelId: string): string {

--- a/packages/pi-ai/scripts/generate-models.ts
+++ b/packages/pi-ai/scripts/generate-models.ts
@@ -320,12 +320,16 @@ function getBedrockBaseUrl(modelId: string): string {
 		: "https://bedrock-runtime.us-east-1.amazonaws.com";
 }
 
-function formatCost(value: number): string {
+function roundCost(value: number): number {
 	if (!Number.isFinite(value)) {
 		throw new Error("Model costs must be finite numbers.");
 	}
 	const rounded = Number(value.toFixed(12));
-	return Object.is(rounded, -0) ? "0" : String(rounded);
+	return Object.is(rounded, -0) ? 0 : rounded;
+}
+
+function formatCost(value: number): string {
+	return String(roundCost(value));
 }
 
 function formatFiniteNumber(value: unknown, field: string, modelId: string): string {
@@ -2407,6 +2411,24 @@ async function generateModels() {
 		// Only add if not already present (models.dev takes priority over OpenRouter)
 		if (!providers[model.provider][model.id]) {
 			providers[model.provider][model.id] = model;
+		}
+	}
+
+	// Round costs in place so the JSON snapshot mirrors the TypeScript catalog
+	// exactly; raw floats carry binary noise that formatCost only strips from
+	// the .ts output.
+	for (const models of Object.values(providers)) {
+		for (const model of Object.values(models)) {
+			model.cost.input = roundCost(model.cost.input);
+			model.cost.output = roundCost(model.cost.output);
+			model.cost.cacheRead = roundCost(model.cost.cacheRead);
+			model.cost.cacheWrite = roundCost(model.cost.cacheWrite);
+			for (const tier of model.cost.tiers ?? []) {
+				if (tier.input !== undefined) tier.input = roundCost(tier.input);
+				if (tier.output !== undefined) tier.output = roundCost(tier.output);
+				if (tier.cacheRead !== undefined) tier.cacheRead = roundCost(tier.cacheRead);
+				if (tier.cacheWrite !== undefined) tier.cacheWrite = roundCost(tier.cacheWrite);
+			}
 		}
 	}
 

--- a/packages/pi-ai/scripts/lib/model-cost.ts
+++ b/packages/pi-ai/scripts/lib/model-cost.ts
@@ -1,0 +1,16 @@
+// Shared cost rounding for the generated catalog writers. The TypeScript
+// writer (formatCost) and the JSON snapshot must emit identical values, so
+// both go through roundCost; raw floats carry binary noise that would
+// otherwise desynchronize the two outputs.
+
+export function roundCost(value: number): number {
+	if (!Number.isFinite(value)) {
+		throw new Error("Model costs must be finite numbers.");
+	}
+	const rounded = Number(value.toFixed(12));
+	return Object.is(rounded, -0) ? 0 : rounded;
+}
+
+export function formatCost(value: number): string {
+	return String(roundCost(value));
+}

--- a/packages/pi-ai/test/model-cost.test.ts
+++ b/packages/pi-ai/test/model-cost.test.ts
@@ -1,0 +1,51 @@
+// Project/App: gsd-pi
+// File Purpose: Tests for the shared cost rounding used by the generated
+// catalog writers (scripts/lib/model-cost.ts).
+
+import { describe, expect, test } from "vitest";
+import { formatCost, roundCost } from "../scripts/lib/model-cost.ts";
+
+describe("roundCost", () => {
+	test("strips binary float noise from upstream prices", () => {
+		// Real values observed in upstream provider data (see #2120).
+		expect(roundCost(0.7999999999999999)).toBe(0.8);
+		expect(roundCost(1.5999999999999999)).toBe(1.6);
+		expect(roundCost(3.1999999999999997)).toBe(3.2);
+		expect(roundCost(0.049999999999999996)).toBe(0.05);
+		expect(roundCost(0.09999999999999999)).toBe(0.1);
+	});
+
+	test("leaves clean values unchanged", () => {
+		expect(roundCost(0.8)).toBe(0.8);
+		expect(roundCost(0.05)).toBe(0.05);
+		expect(roundCost(2)).toBe(2);
+	});
+
+	test("normalizes negative zero to zero", () => {
+		expect(Object.is(roundCost(-0), 0)).toBe(true);
+	});
+
+	test("rejects non-finite costs", () => {
+		expect(() => roundCost(Number.NaN)).toThrow(/finite/);
+		expect(() => roundCost(Number.POSITIVE_INFINITY)).toThrow(/finite/);
+	});
+
+	test("is idempotent", () => {
+		const once = roundCost(0.7999999999999999);
+		expect(roundCost(once)).toBe(once);
+	});
+});
+
+describe("formatCost / roundCost contract", () => {
+	// The regression behind #2120: the TypeScript writer formats costs while
+	// the JSON snapshot serialized raw floats, so the two outputs diverged.
+	// Both writers now share roundCost; these assertions pin that the TS
+	// literal and the JSON-serialized value are the same number.
+	test("TS literal and JSON-serialized value agree for noisy floats", () => {
+		for (const value of [0.7999999999999999, 1.5999999999999999, 3.1999999999999997, 0.049999999999999996]) {
+			const tsLiteral = Number(formatCost(value));
+			const jsonValue = JSON.parse(JSON.stringify(roundCost(value))) as number;
+			expect(jsonValue).toBe(tsLiteral);
+		}
+	});
+});


### PR DESCRIPTION
## Problem

The model-catalog refresh PR [#2120](https://github.com/open-gsd/gsd-pi/pull/2120) fails `build > Run pi-ai vitest suite` with:

```
models.generated.json mirrors the complete generated catalog
AssertionError: expected { 'amazon-bedrock': { …(119) }, …(32) } to deeply equal { … }
```

Root cause: `generate-models.ts` formats costs through `formatCost` (`toFixed(12)`) when writing the TypeScript catalog, but `JSON.stringify`s the raw in-memory values for the JSON snapshot. Upstream prices now include binary float noise (`0.7999999999999999`), so the JSON no longer mirrors `MODELS`. 303 divergent fields, all in `cost.input/output/cacheRead/cacheWrite` (verified by deep-diff).

## Fix

Round costs in place (`input`, `output`, `cacheRead`, `cacheWrite`, and pricing tiers) before either file is written, using a shared `roundCost` helper; `formatCost` delegates to it.

## Verification

- Ran the generator against live upstream (which has float noise): the mirror test now passes, and the existing TS floating-point literal guard still passes.
- Regenerated the TS catalog with main's script and the fixed script on the same upstream data: byte-identical output, proving the TS path is unaltered.
- `tsc --noEmit` clean on the script.

AI-assisted: yes.