### PR TITLE
fix(gsd): route Copilot Kimi, Gemini 3.x, Grok 4.6, MAI Flash Picker, and GPT-5.4 Nano

### DIFF
--- a/packages/pi-ai/test/generated-models.test.ts
+++ b/packages/pi-ai/test/generated-models.test.ts
@@ -308,6 +308,38 @@ describe("models.generated.ts", () => {
 		}
 	});
 
+	test("includes Copilot Kimi models on the GitHub Copilot OpenAI-compatible transport", () => {
+		for (const [id, contextWindow, maxTokens] of [
+			["kimi-k2.7-code", 256000, 32000],
+			["kimi-k3", 1048576, 131072],
+		] as const) {
+			const model = MODELS["github-copilot"][id];
+
+			expect(model).toBeDefined();
+			expect(model).toMatchObject({
+				id,
+				api: "openai-completions",
+				provider: "github-copilot",
+				baseUrl: "https://api.individual.githubcopilot.com",
+				reasoning: true,
+				input: ["text", "image"],
+				contextWindow,
+				maxTokens,
+				headers: {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat",
+				},
+				compat: {
+					supportsStore: false,
+					supportsDeveloperRole: false,
+					supportsReasoningEffort: false,
+				},
+			});
+			expect(model.cost.input).toBeGreaterThan(0);
+			expect(model.cost.output).toBeGreaterThan(0);
+		}
+	});
+
 	test("supplements the ZAI catalog with the GLM models missing from models.dev", () => {
 		// models.dev's "zai-coding-plan" provider lags the live z.ai endpoint, so
 		// the generator pins these known-available GLM models. Guard that they stay

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -148,10 +148,15 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "gpt-5-mini": "light",
   "gpt-5-nano": "light",
   "gpt-5-4-mini": "light",
+  "gpt-5-4-nano": "light",
   "gpt-5-1-codex-mini": "light",
   "gpt-5-3-codex-spark": "light",
+  "mai-code-1-flash-picker": "light",
   "mai-code-1-1-flash": "light",
   "gemini-2-0-flash": "light",
+  "gemini-3-5-flash": "light",
+  "gemini-3-6-flash": "light",
+  "gemini-3-7-flash": "light",
 
   // Standard-tier models
   "claude-sonnet-4": "standard",
@@ -164,6 +169,8 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "gpt-4-1": "standard",
   "gpt-5-1-codex-max": "standard",
   "gemini-2-5-pro": "standard",
+  "gemini-3-1-pro-preview": "standard",
+  "kimi-k2-7-code": "standard",
   "deepseek-chat": "standard",
 
   // Heavy-tier models (most capable)
@@ -191,6 +198,8 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "o4-mini": "heavy",
   "o4-mini-deep-research": "heavy",
   "grok-4-5": "heavy",
+  "grok-4-6": "heavy",
+  "kimi-k3": "heavy",
 };
 
 // ─── Cost Table (per 1K input tokens, approximate USD) ───────────────────────
@@ -220,6 +229,7 @@ const MODEL_COST_PER_1K_INPUT: Record<string, number> = {
   "gpt-5-mini": 0.0003,
   "gpt-5-nano": 0.0001,
   "gpt-5-4-mini": 0.00075,
+  "gpt-5-4-nano": 0.0002,
   "gpt-5-pro": 0.015,
   "gpt-5-1": 0.005,
   "gpt-5-1-codex-max": 0.003,
@@ -228,6 +238,7 @@ const MODEL_COST_PER_1K_INPUT: Record<string, number> = {
   "gpt-5-2-codex": 0.005,
   "gpt-5-3-codex": 0.005,
   "gpt-5-3-codex-spark": 0.0003,
+  "mai-code-1-flash-picker": 0.00075,
   "mai-code-1-1-flash": 0.0002,
   "gpt-5-4": 0.005,
   "gpt-5-5": 0.005,
@@ -238,8 +249,15 @@ const MODEL_COST_PER_1K_INPUT: Record<string, number> = {
   "o4-mini-deep-research": 0.005,
   "gemini-2-0-flash": 0.0001,
   "gemini-2-5-pro": 0.00125,
+  "gemini-3-1-pro-preview": 0.002,
+  "gemini-3-5-flash": 0.0015,
+  "gemini-3-6-flash": 0.00075,
+  "gemini-3-7-flash": 0.00075,
   "deepseek-chat": 0.00014,
   "grok-4-5": 0.002,
+  "grok-4-6": 0.002,
+  "kimi-k2-7-code": 0.00095,
+  "kimi-k3": 0.003,
 };
 
 // ─── Capability Profiles Data Table ──────────────────────────────────────────
@@ -276,6 +294,7 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   "gpt-5-mini":                   { coding: 62, debugging: 52, research: 48, reasoning: 52, speed: 88, longContext: 52, instruction: 74 },
   "gpt-5-nano":                   { coding: 42, debugging: 32, research: 28, reasoning: 32, speed: 95, longContext: 32, instruction: 62 },
   "gpt-5-4-mini":                 { coding: 70, debugging: 60, research: 55, reasoning: 60, speed: 84, longContext: 60, instruction: 78 },
+  "gpt-5-4-nano":                 { coding: 50, debugging: 40, research: 35, reasoning: 42, speed: 94, longContext: 55, instruction: 66 },
   "gpt-5-pro":                    { coding: 94, debugging: 90, research: 88, reasoning: 94, speed: 35, longContext: 88, instruction: 92 },
   "gpt-5-1":                      { coding: 93, debugging: 89, research: 86, reasoning: 93, speed: 42, longContext: 86, instruction: 91 },
   "gpt-5-1-codex-max":            { coding: 90, debugging: 85, research: 70, reasoning: 85, speed: 55, longContext: 75, instruction: 85 },
@@ -284,6 +303,7 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   "gpt-5-2-codex":                { coding: 93, debugging: 90, research: 72, reasoning: 88, speed: 50, longContext: 78, instruction: 88 },
   "gpt-5-3-codex":                { coding: 94, debugging: 91, research: 74, reasoning: 89, speed: 50, longContext: 80, instruction: 89 },
   "gpt-5-3-codex-spark":          { coding: 68, debugging: 58, research: 42, reasoning: 52, speed: 90, longContext: 50, instruction: 74 },
+  "mai-code-1-flash-picker":      { coding: 74, debugging: 64, research: 42, reasoning: 58, speed: 96, longContext: 68, instruction: 76 },
   "mai-code-1-1-flash":           { coding: 78, debugging: 68, research: 45, reasoning: 62, speed: 96, longContext: 70, instruction: 78 },
   "gpt-5-4":                      { coding: 95, debugging: 92, research: 88, reasoning: 94, speed: 42, longContext: 88, instruction: 92 },
   // GPT-5.5 scores are relative to the existing gpt-5.4 profile and backed by
@@ -304,14 +324,23 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   // ── Google ─────────────────────────────────────────────────────────────────
   "gemini-2-5-pro":               { coding: 75, debugging: 70, research: 85, reasoning: 75, speed: 55, longContext: 90, instruction: 75 },
   "gemini-2-0-flash":             { coding: 50, debugging: 40, research: 50, reasoning: 40, speed: 95, longContext: 60, instruction: 65 },
+  "gemini-3-1-pro-preview":       { coding: 80, debugging: 75, research: 88, reasoning: 82, speed: 55, longContext: 95, instruction: 78 },
+  "gemini-3-5-flash":             { coding: 62, debugging: 55, research: 60, reasoning: 58, speed: 92, longContext: 75, instruction: 72 },
+  "gemini-3-6-flash":             { coding: 66, debugging: 58, research: 64, reasoning: 62, speed: 93, longContext: 88, instruction: 74 },
+  "gemini-3-7-flash":             { coding: 68, debugging: 60, research: 66, reasoning: 64, speed: 93, longContext: 88, instruction: 75 },
 
   // ── DeepSeek ───────────────────────────────────────────────────────────────
   "deepseek-chat":                { coding: 75, debugging: 65, research: 55, reasoning: 70, speed: 70, longContext: 55, instruction: 65 },
+
+  // ── Moonshot/Kimi ─────────────────────────────────────────────────────────
+  "kimi-k2-7-code":               { coding: 82, debugging: 76, research: 62, reasoning: 78, speed: 70, longContext: 78, instruction: 80 },
+  "kimi-k3":                      { coding: 90, debugging: 84, research: 78, reasoning: 88, speed: 55, longContext: 95, instruction: 86 },
 
   // ── xAI ────────────────────────────────────────────────────────────────────
   // Grok 4.5 (2026-07): Opus-class frontier model tuned for coding and agentic
   // work; notably faster and more token-efficient than peer heavy models.
   "grok-4-5":                     { coding: 95, debugging: 90, research: 82, reasoning: 93, speed: 55, longContext: 80, instruction: 90 },
+  "grok-4-6":                     { coding: 96, debugging: 91, research: 83, reasoning: 94, speed: 55, longContext: 82, instruction: 91 },
 };
 
 // ─── Base Task Requirements Data Table ───────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -1644,6 +1644,18 @@ describe("model-router registry keys", () => {
       ["gemini-2.5-pro", "claude-sonnet-5"],
     );
   });
+
+  test("all bundled GitHub Copilot chat models have router tier and capability profiles", () => {
+    const catalogPath = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..", "..", "packages", "pi-ai", "src", "models.generated.json");
+    const catalog = JSON.parse(readFileSync(catalogPath, "utf8"))["github-copilot"] as Record<string, Model<Api>>;
+    const missing = Object.values(catalog)
+      .filter((model) => model.api === "openai-completions" || model.api === "openai-responses" || model.api === "anthropic-messages")
+      .map((model) => canonicalizeModelId(model.id))
+      .filter((modelId) => MODEL_CAPABILITY_TIER[modelId] === undefined || MODEL_CAPABILITY_PROFILES[modelId] === undefined)
+      .sort();
+
+    assert.deepEqual(missing, []);
+  });
 });
 
 describe("Phase J routing safety", () => {


### PR DESCRIPTION
## Linked issue

Closes #2132

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds GSD router tier/cost/profile coverage for bundled GitHub Copilot Kimi, Gemini 3.x, Grok 4.6, MAI Flash Picker, and GPT-5.4 Nano models.
**Why:** These models are already in the published Copilot catalog, but the older router tables still treated them as unknown for dynamic routing.
**How:** Populate the router’s static tier/cost/profile tables and add regression coverage against the generated Copilot catalog plus Copilot Kimi transport metadata.

## What

This PR updates the GSD extension model router for bundled `github-copilot` chat models that were already present in `packages/pi-ai/src/models.generated.json` but missing from routing metadata:

- `gemini-3.1-pro-preview`
- `gemini-3.5-flash`
- `gemini-3.6-flash`
- `gemini-3.7-flash`
- `gpt-5.4-nano`
- `grok-4.6`
- `kimi-k2.7-code`
- `kimi-k3`
- `mai-code-1-flash-picker`

Files changed:

- `src/resources/extensions/gsd/model-router.ts`
- `src/resources/extensions/gsd/tests/model-router.test.ts`
- `packages/pi-ai/test/generated-models.test.ts`

## Why

`/gsd update --models` and the published catalog can make these model records available with static pricing and limits. Automatic routing still depends on the extension router’s tier, cost, and capability-profile tables. Without those rows, known bundled Copilot models could still be treated as unknown by dynamic routing.

## How

- Adds tier rows for the affected Copilot model IDs.
- Adds matching router cost rows using the generated catalog’s per-million prices converted to per-1K input pricing.
- Adds capability profiles consistent with existing model family profiles.
- Adds a router regression that asserts every bundled GitHub Copilot chat model has tier/profile coverage.
- Adds a generated-catalog regression proving Copilot Kimi models use the existing `github-copilot` OpenAI-compatible transport and Copilot headers, not a new Kimi provider/auth path.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — focused checks described below
- [ ] No tests needed — explained above

Validation completed before opening:

- Router completeness scan: no bundled GitHub Copilot chat models missing tier/profile coverage after the patch.
- `pnpm --filter @gsd/pi-ai exec vitest run test/generated-models.test.ts test/openai-completions-tool-choice.test.ts test/tool-call-without-result.test.ts`: 40 passed, 26 env-gated live tests skipped.
- `pnpm exec tsx --test src/resources/extensions/gsd/tests/model-router.test.ts`: 130 passed.
- `pnpm exec tsc --noEmit --project tsconfig.extensions.json`: passed.
- `pnpm run verify:fast`: passed, 250 passed plus strict audits.
- Remote clean-runner: `pimmink/gsd-pi-ci` sharded run 33664264464 passed for exact SHA `85dd3513f35eb418a57db8448949291b6bc7da76`: build, shards 1-4, lifecycle gate, and aggregate all green; aggregate totals 14759 passed, 0 failed, 31 skipped.

## AI disclosure

- [x] This PR includes AI-assisted code. GitHub Copilot was used to inspect existing model catalog/router behavior and prepare the scoped patch; the resulting changes were reviewed and validated with local and remote checks.