### PR TITLE
Fix/recover legacy summary files

### DIFF
--- a/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
+++ b/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
@@ -730,6 +730,23 @@ function interpretFlatArtifact(
     return;
   }
   if (/-SUMMARY\.md$/u.test(path)) {
+    const summaryId = frontmatterField(file, "id")?.value;
+    const summarySlice = frontmatterField(file, "slice")?.value;
+    const summaryTask = frontmatterField(file, "task")?.value;
+    if (summaryId !== undefined && /^(?:S\d+|M\d+)/u.test(summaryId)) {
+      preserveHeading(file, candidates, "flat-non-task-summary-preserved", {
+        reason: "non-task-summary",
+        id: summaryId,
+      });
+      return;
+    }
+    if (summaryId === undefined && summaryTask === undefined && summarySlice !== undefined && /^S\d+$/u.test(summarySlice)) {
+      preserveHeading(file, candidates, "flat-non-task-summary-preserved", {
+        reason: "non-task-summary",
+        id: summarySlice,
+      });
+      return;
+    }
     const parent = selectFlatParent(file, expectedFlatParent(file, claimsByDirectory));
     const status = frontmatterField(file, "status");
     if (parent.selected === undefined) {

--- a/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
+++ b/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
@@ -680,6 +680,118 @@ describe("legacy .gsd captured-byte interpretation", () => {
     );
   });
 
+  test("preserves flat slice and milestone summaries", (t) => {
+    const interpretation = interpretLegacyGsdCapture(captureFiles(t, {
+      "phases/09-team/09-ROADMAP.md": [
+        "# M009-rfuh2h: Team milestone",
+        "",
+        "- [x] **S01: First slice** `risk:low` `depends:[]`",
+        "",
+      ].join("\n"),
+      "phases/09-team/09-SUMMARY.md": [
+        "---",
+        "id: M009-rfuh2h",
+        "status: complete",
+        "---",
+        "",
+        "# M009: Must not map as a task",
+        "",
+      ].join("\n"),
+      "phases/09-team/09-01-SUMMARY.md": [
+        "---",
+        "id: S01",
+        "parent: M009-rfuh2h",
+        "milestone: M009-rfuh2h",
+        "status: complete",
+        "---",
+        "",
+        "# S01: Must not map as a task",
+        "",
+      ].join("\n"),
+      "phases/09-team/S01-T01-SUMMARY.md": [
+        "---",
+        "id: T01",
+        "parent: S01",
+        "milestone: M009-rfuh2h",
+        "---",
+        "",
+        "# T01: Must map as a task status refinement",
+        "",
+      ].join("\n"),
+    }));
+
+    assert.deepEqual(interpretation.diagnoses, []);
+
+    assert.deepEqual(
+      interpretation.candidates
+        .filter((candidate) => candidate.reason_code === "flat-non-task-summary-preserved")
+        .map((candidate) => [candidate.classification, candidate.target.kind, candidate.target.key, candidate.normalized]),
+      [
+        ["preserve", "artifact", ".gsd/phases/09-team/09-01-SUMMARY.md", { reason: "non-task-summary", id: "S01" }],
+        ["preserve", "artifact", ".gsd/phases/09-team/09-SUMMARY.md", { reason: "non-task-summary", id: "M009-rfuh2h" }],
+      ],
+    );
+
+    assert.deepEqual(
+      interpretation.candidates
+        .filter((candidate) => candidate.target.kind === "task")
+        .map((candidate) => [candidate.target.key, candidate.target.field, candidate.normalized]),
+      [["M009-rfuh2h/S01/T01", "status", "complete"]],
+    );
+  });
+
+  test("preserves flat slice summaries with no id field", (t) => {
+    const interpretation = interpretLegacyGsdCapture(captureFiles(t, {
+      "phases/09-team/09-ROADMAP.md": [
+        "# M009-rfuh2h: Team milestone",
+        "",
+        "- [x] **S02: Second slice** `risk:low` `depends:[]`",
+        "",
+      ].join("\n"),
+      "phases/09-team/09-02-PLAN.md": [
+        "# S02: Second slice",
+        "",
+        "**Milestone:** M009-rfuh2h",
+        "**Slice:** S02",
+        "",
+        "## Tasks",
+        "",
+        "- [x] **T01**: Must map as the only real task",
+        "",
+      ].join("\n"),
+      "phases/09-team/09-02-SUMMARY.md": [
+        "---",
+        "slice: S02",
+        "status: complete",
+        "---",
+        "",
+        "# S02 Summary: Old format must not fabricate S02/T02",
+        "",
+      ].join("\n"),
+    }));
+
+    assert.deepEqual(interpretation.diagnoses, []);
+    assert.deepEqual(
+      interpretation.candidates
+        .filter((candidate) => candidate.target.kind === "task")
+        .map((candidate) => [candidate.target.key, candidate.target.field, candidate.normalized]),
+      [["M009-rfuh2h/S02/T01", undefined, {
+        id: "T01",
+        milestone_id: "M009-rfuh2h",
+        slice_id: "S02",
+        status: "complete",
+        title: "Must map as the only real task",
+      }]],
+    );
+
+    assert.deepEqual(
+      interpretation.candidates
+        .filter((candidate) => candidate.reason_code === "flat-non-task-summary-preserved")
+        .map((candidate) => [candidate.classification, candidate.target.kind, candidate.target.key, candidate.normalized]),
+      [["preserve", "artifact", ".gsd/phases/09-team/09-02-SUMMARY.md", { reason: "non-task-summary", id: "S02" }]],
+    );
+  });
+
   test("emits action-matrix decision candidates and complete anchors for present collections", (t) => {
     const base = temporaryDirectory(t);
     const physicalRoot = join(base, ".gsd");


### PR DESCRIPTION
## Linked issue

<!--
PRs without a linked issue will be closed.
Open or find an issue first: https://github.com/open-gsd/gsd-pi/issues
-->

Closes #2137 

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** legacy import handle legacy SUMMARY files
**Why:** gsd recover can import legacy SUMMARY files
**How:** `legacy-import-preview-gsd-hierarchy.ts`, recognize both non-task-summary frontmatter shapes (`id: S##`/`id: M###`, and the older `slice: S##` with no `id:`/`task:`)

## What

<!-- Detailed description of the change. What files, modules, or systems are affected? -->
Changed files:
  - `src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts` — the `-SUMMARY.md` branch of `interpretFlatArtifact` now recognizes two legitimate non-task-summary frontmatter shapes and preserves both as history (`reason_code: flat-non-task-summary-preserved`) instead of forcing them through task-parent selection:
  - newer shape: frontmatter `id` matching `^(S\d+|M\d+)`
  - older shape: frontmatter `slice: S##` with no `id:` and no `task:` field (the `task:` exclusion keeps a genuinely misplaced task summary routed through task-parent selection, so it still correctly surfaces as `unparsed` - verified against the existing wrong-parent corpus fixture)
  - `src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts` - two new regression tests, one per frontmatter shape.


## Why

<!-- The motivation. What problem does this solve? -->
`gsd recover` is the only path to rebuild the database from on-disk markdown projections when the DB is lost or corrupt or working in teams. Two distinct frontmatter eras exist in real GSD projects:

1. Newer shape (`id: S##`/`id: M###` + `parent:`) → recover aborts closed with `task-summary-parent-conflict` before writing anything. Regressed (I think...) by [c58b8d93](https://github.com/lcostantini/gsd-pi/commit/c58b8d93), which rewired `gsd recover` from the structural `migrateHierarchyToDb` importer to the current legacy-import preview engine that classifies every `*-SUMMARY.md` by filename as a task summary.
2. Older shape (`slice: S##`, no `id:` at all) → the filename-derived fallback parser misreads the slice's own numeric suffix as a task number, fabricating a phantom task that doesn't exist in any PLAN. This phantom task later crashes the classifier with `legacy import canonical lifecycle has no hierarchy row` instead of failing closed with a normal diagnosis.

No data loss in either case - recover aborts/crashes before mutating - but there is no path to recovery.


## How

<!-- The approach. How does the implementation work? Key decisions and alternatives considered? -->
Both non-task-summary shapes are detected before the file is routed through `selectFlatParent` (task-parent selection), mirroring how the ROADMAP checkboxes/heading already carry slice and milestone completion status (so re-deriving it from the summary as a "task" duplicates and corrupts that signal). Only genuine `T##` task summaries proceed to task logic in either case, restoring parity with the pre-[c58b8d93](https://github.com/lcostantini/gsd-pi/commit/c58b8d93) structural importer for both frontmatter eras.

Key decision: the older `slice:` shape guard explicitly excludes files that also carry a `task:` field, so a genuinely misplaced task summary (real regression case in the existing corpus fixture, `flat-wrong-parent-summary`) still correctly surfaces as `unparsed` instead of being silently preserved as history.


## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code. Root cause investigation, fix implementation and partial tests. Verification and tests were executed manually  <!-- If so, note the tool and what was tested -->
