### PR TITLE
feat(vscode): show DB-authoritative project progress in sidebar (#2136)

### DIFF
--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -123,6 +123,7 @@ export interface ProjectProgress {
 		}>;
 	}>;
 	milestoneDetailsTruncated?: boolean;
+	milestoneDetailsTasksTruncated?: boolean;
 }
 
 export interface CompactionResult<T = unknown> {

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -12,6 +12,7 @@ export const RPC_COMMAND_TYPES = [
 	"abort",
 	"new_session",
 	"get_state",
+	"get_project_progress",
 	"set_model",
 	"cycle_model",
 	"get_available_models",
@@ -97,6 +98,33 @@ export interface BashResult {
 	fullOutputPath?: string;
 }
 
+export interface ProjectProgress {
+	activeMilestone: { id: string; title: string } | null;
+	activeSlice: { id: string; title: string } | null;
+	activeTask: { id: string; title: string } | null;
+	phase: string;
+	milestones: { total: number; done: number; active: number; pending: number; parked: number };
+	slices: { total: number; done: number; active: number; pending: number };
+	tasks: { total: number; done: number; pending: number };
+	requirements: { active: number; validated: number; deferred: number; outOfScope: number } | null;
+	blockers: string[];
+	nextAction: string;
+	milestoneDetails?: Array<{
+		id: string;
+		title: string;
+		status: string;
+		truncated: boolean;
+		slices: Array<{
+			id: string;
+			title: string;
+			status: string;
+			truncated: boolean;
+			tasks: Array<{ id: string; title: string; status: string }>;
+		}>;
+	}>;
+	milestoneDetailsTruncated?: boolean;
+}
+
 export interface CompactionResult<T = unknown> {
 	summary: string;
 	firstKeptEntryId: string;
@@ -113,6 +141,7 @@ export type RpcCommand =
 	| { id?: string; type: "abort" }
 	| { id?: string; type: "new_session"; parentSession?: string }
 	| { id?: string; type: "get_state" }
+	| { id?: string; type: "get_project_progress" }
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
 	| { id?: string; type: "cycle_model" }
 	| { id?: string; type: "get_available_models" }
@@ -176,6 +205,7 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "abort"; success: true }
 	| { id?: string; type: "response"; command: "new_session"; success: true; data: { cancelled: boolean } }
 	| { id?: string; type: "response"; command: "get_state"; success: true; data: RpcSessionState }
+	| { id?: string; type: "response"; command: "get_project_progress"; success: true; data: ProjectProgress | null }
 	| { id?: string; type: "response"; command: "set_model"; success: true; data: ModelInfo }
 	| {
 			id?: string;

--- a/packages/contracts/src/workflow.test.ts
+++ b/packages/contracts/src/workflow.test.ts
@@ -21,5 +21,6 @@ test("read-only workflow tools are classified correctly", () => {
   const readOnly = WORKFLOW_TOOL_CONTRACTS.filter((tool) => tool.writePolicy === "read");
   assert.ok(readOnly.some((tool) => tool.canonicalName === "gsd_milestone_status"));
   assert.ok(readOnly.some((tool) => tool.canonicalName === "gsd_checkpoint_db"));
+  assert.ok(readOnly.some((tool) => tool.canonicalName === "gsd_project_snapshot"));
   assert.ok(readOnly.every((tool) => tool.writePolicy === "read"));
 });

--- a/packages/contracts/src/workflow.ts
+++ b/packages/contracts/src/workflow.ts
@@ -336,6 +336,14 @@ export const WORKFLOW_TOOL_CONTRACTS = [
 		writePolicy: "read",
 		auditEvent: "workflow.decision.get",
 	},
+	{
+		canonicalName: "gsd_project_snapshot",
+		aliases: [],
+		schemaId: "workflow.project.snapshot",
+		executorId: "executeProjectSnapshot",
+		writePolicy: "read",
+		auditEvent: "workflow.project.snapshot",
+	},
 ] as const satisfies readonly WorkflowToolContractMetadata[];
 
 /** Literal union of canonical workflow tool names. Typing a name list with this union makes drift from WORKFLOW_TOOL_CONTRACTS a compile error. */

--- a/packages/gsd-agent-modes/src/modes/rpc/rpc-client.ts
+++ b/packages/gsd-agent-modes/src/modes/rpc/rpc-client.ts
@@ -11,7 +11,7 @@ import type { SessionStats } from "@gsd/agent-core";
 import type { BashResult } from "@gsd/agent-core";
 import type { CompactionResult } from "@gsd/agent-core/compaction/index.js";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
-import type { RpcCommand, RpcInitResult, RpcResponse, RpcSessionState, RpcSlashCommand } from "./rpc-types.js";
+import type { ProjectProgress, RpcCommand, RpcInitResult, RpcResponse, RpcSessionState, RpcSlashCommand } from "./rpc-types.js";
 
 // ============================================================================
 // Types
@@ -238,6 +238,11 @@ export class RpcClient {
 	 */
 	async getState(): Promise<RpcSessionState> {
 		const response = await this.send({ type: "get_state" });
+		return this.getData(response);
+	}
+
+	async getProjectProgress(): Promise<ProjectProgress | null> {
+		const response = await this.send({ type: "get_project_progress" });
 		return this.getData(response);
 	}
 

--- a/packages/gsd-agent-modes/src/modes/rpc/rpc-mode.ts
+++ b/packages/gsd-agent-modes/src/modes/rpc/rpc-mode.ts
@@ -30,6 +30,7 @@ import type {
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
 	RpcInitResult,
+	ProjectProgress,
 	RpcResponse,
 	RpcSessionState,
 	RpcSlashCommand,
@@ -46,6 +47,20 @@ export type {
 	RpcSessionState,
 	RpcV2Event,
 } from "./rpc-types.js";
+
+export async function invokeProjectProgressRead(
+	handler: (input: unknown) => Promise<unknown>,
+	id: string | undefined,
+	cwd: string,
+): Promise<RpcResponse> {
+	try {
+		const data = await handler({ cwd });
+		return { id, type: "response", command: "get_project_progress", success: true, data: data as ProjectProgress | null };
+	} catch (e) {
+		const message = e instanceof Error ? e.message : String(e);
+		return { id, type: "response", command: "get_project_progress", success: false, error: message };
+	}
+}
 
 /**
  * Run in RPC mode.
@@ -599,6 +614,17 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 					extensionsReady,
 				};
 				return success(id, "get_state", state);
+			}
+
+			case "get_project_progress": {
+				if (!extensionsReady) {
+					return error(id, "get_project_progress", "Extensions are still loading");
+				}
+				const handler = session.extensionRunner?.getRuntimeReadHandler("project_progress");
+				if (!handler) {
+					return error(id, "get_project_progress", "Project progress is unavailable");
+				}
+				return await invokeProjectProgressRead(handler, id, session.sessionManager.getCwd());
 			}
 
 			// =================================================================

--- a/packages/gsd-agent-modes/src/modes/rpc/rpc-project-progress.test.ts
+++ b/packages/gsd-agent-modes/src/modes/rpc/rpc-project-progress.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { invokeProjectProgressRead } from "./rpc-mode.js";
+
+test("project progress read forwards the active session CWD and request ID", async () => {
+	let receivedInput: unknown;
+	const response = await invokeProjectProgressRead(
+		async (input) => {
+			receivedInput = input;
+			return { phase: "execute" };
+		},
+		"request-123",
+		"/workspace/project",
+	);
+
+	assert.deepEqual(receivedInput, { cwd: "/workspace/project" });
+	assert.deepEqual(response, {
+		id: "request-123",
+		type: "response",
+		command: "get_project_progress",
+		success: true,
+		data: { phase: "execute" },
+	});
+});
+
+test("project progress reader failures preserve the request ID", async () => {
+	const response = await invokeProjectProgressRead(
+		async () => {
+			throw new Error("database unavailable");
+		},
+		"request-456",
+		"/workspace/project",
+	);
+
+	assert.deepEqual(response, {
+		id: "request-456",
+		type: "response",
+		command: "get_project_progress",
+		success: false,
+		error: "database unavailable",
+	});
+});

--- a/packages/gsd-agent-modes/src/modes/rpc/rpc-protocol-v2.test.ts
+++ b/packages/gsd-agent-modes/src/modes/rpc/rpc-protocol-v2.test.ts
@@ -22,6 +22,7 @@ import type {
 	RpcV2Event,
 	RpcProtocolVersion,
 	RpcSessionState,
+	ProjectProgress,
 } from "./rpc-types.js";
 
 // ============================================================================
@@ -329,6 +330,60 @@ describe("v2 type shapes", () => {
 		assert.equal(initResp.command, "init");
 		assert.equal(shutdownResp.command, "shutdown");
 		assert.equal(subscribeResp.command, "subscribe");
+	});
+
+	it("project progress command preserves the DB progress payload shape", () => {
+		const command: RpcCommand = { type: "get_project_progress" };
+		const progress: ProjectProgress = {
+			activeMilestone: { id: "M001", title: "Milestone" },
+			activeSlice: { id: "S001", title: "Slice" },
+			activeTask: { id: "T001", title: "Task" },
+			phase: "execute",
+			milestones: { total: 1, done: 0, active: 1, pending: 0, parked: 0 },
+			slices: { total: 1, done: 0, active: 1, pending: 0 },
+			tasks: { total: 1, done: 0, pending: 1 },
+			requirements: { active: 1, validated: 0, deferred: 0, outOfScope: 0 },
+			blockers: [],
+			nextAction: "Implement the task",
+			milestoneDetails: [{
+				id: "M001",
+				title: "Milestone",
+				status: "active",
+				truncated: false,
+				slices: [{
+					id: "S001",
+					title: "Slice",
+					status: "active",
+					truncated: false,
+					tasks: [{ id: "T001", title: "Task", status: "pending" }],
+				}],
+			}],
+			milestoneDetailsTruncated: false,
+		};
+		const response: RpcResponse = {
+			type: "response",
+			command: command.type,
+			success: true,
+			data: progress,
+		};
+
+		assert.equal(command.type, "get_project_progress");
+		assert.deepEqual(response.data, progress);
+		assert.equal(progress.milestoneDetails?.[0]?.slices[0]?.tasks[0]?.id, "T001");
+		assert.deepEqual(Object.keys(progress).sort(), [
+			"activeMilestone",
+			"activeSlice",
+			"activeTask",
+			"blockers",
+			"milestoneDetails",
+			"milestoneDetailsTruncated",
+			"milestones",
+			"nextAction",
+			"phase",
+			"requirements",
+			"slices",
+			"tasks",
+		].sort());
 	});
 });
 

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1359,7 +1359,12 @@ async function runSerializedCanonicalReadOperation(
 }
 
 function mapCanonicalReadError(
-  operation: "list_decisions" | "get_decision" | "list_requirements" | "get_requirement",
+  operation:
+    | "list_decisions"
+    | "get_decision"
+    | "list_requirements"
+    | "get_requirement"
+    | "read_project_snapshot",
   message: string,
   id?: string,
 ): unknown {
@@ -1377,9 +1382,11 @@ function mapCanonicalReadError(
     ? "listing decisions"
     : operation === "get_decision"
       ? "fetching decision"
-      : operation === "list_requirements"
-        ? "listing requirements"
-        : "fetching requirement";
+        : operation === "list_requirements"
+          ? "listing requirements"
+          : operation === "read_project_snapshot"
+            ? "reading project snapshot"
+            : "fetching requirement";
 
   return adaptExecutorResult({
     content: [{
@@ -2936,6 +2943,46 @@ export function registerWorkflowTools(
     milestoneId: z.string().optional(),
     limit: z.number().int().min(1).max(500).optional(),
   });
+
+  server.tool(
+    "gsd_project_snapshot",
+    "Read the full project snapshot from the GSD database (DB-authoritative, never projections). Returns requirements, decisions, milestones, and authority revision in one payload.",
+    {
+      projectDir: z
+        .string()
+        .optional()
+        .describe("Absolute path to the project directory (defaults to MCP server cwd)"),
+    },
+    async (args: Record<string, unknown>) => {
+      const { projectDir } = parseWorkflowArgs(
+        z.object({ projectDir: z.string().optional() }),
+        args,
+      );
+      try {
+        return await runSerializedCanonicalReadOperation(projectDir, async () => {
+          const snapshot = await (
+            await importWorkflowRuntimeModule<any>(
+              "../../../src/resources/extensions/gsd/state/project-snapshot.js",
+            )
+          ).readProjectSnapshotFromDb(projectDir);
+          if (!snapshot) {
+            throw new Error("Database adapter not available (db_unavailable)");
+          }
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(snapshot) }],
+            details: {
+              operation: "read_project_snapshot",
+              revision: snapshot.authority?.revision,
+              snapshot,
+            },
+          };
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return mapCanonicalReadError("read_project_snapshot", message);
+      }
+    },
+  );
 
   server.tool(
     "gsd_requirement_list",

--- a/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
@@ -1143,6 +1143,9 @@ export interface ResolvedCommand extends RegisteredCommand {
 	invocationName: string;
 }
 
+/** A typed read capability exposed by a loaded extension to an embedding host. */
+export type RuntimeReadHandler = (input: unknown) => Promise<unknown>;
+
 // ============================================================================
 // Extension API
 // ============================================================================
@@ -1243,6 +1246,9 @@ export interface ExtensionAPI {
 	registerTool<TParams extends TSchema = TSchema, TDetails = unknown, TState = any>(
 		tool: ToolDefinition<TParams, TDetails, TState>,
 	): void;
+
+	/** Register a host-only read capability. It is not advertised as an LLM tool. */
+	registerRuntimeRead(name: string, handler: RuntimeReadHandler): void;
 
 	// =========================================================================
 	// Command, Shortcut, Flag Registration
@@ -1696,6 +1702,7 @@ export interface Extension {
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;
 	shortcuts: Map<KeyId, ExtensionShortcut>;
+	runtimeReadHandlers: Map<string, RuntimeReadHandler>;
 	/** GSD: npm package lifecycle hooks registered by extensions. */
 	lifecycleHooks?: LifecycleHookMap;
 }

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -40,6 +40,7 @@ import type {
 	MessageRenderer,
 	ProviderConfig,
 	RegisteredCommand,
+	RuntimeReadHandler,
 	ToolDefinition,
 } from "./types.js";
 
@@ -248,6 +249,11 @@ function createExtensionAPI(
 				registerToolCompatibility(tool.name, tool.compatibility);
 			}
 			runtime.refreshTools();
+		},
+
+		registerRuntimeRead(name: string, handler: RuntimeReadHandler): void {
+			runtime.assertActive();
+			extension.runtimeReadHandlers.set(name, handler);
 		},
 
 		registerBeforeInstall(handler: LifecycleHookHandler): void {
@@ -465,6 +471,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		commands: new Map(),
 		flags: new Map(),
 		shortcuts: new Map(),
+		runtimeReadHandlers: new Map(),
 	};
 }
 

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -428,6 +428,15 @@ export class ExtensionRunner {
 		return undefined;
 	}
 
+	/** Get a host-only extension read capability by name. */
+	getRuntimeReadHandler(name: string): ((input: unknown) => Promise<unknown>) | undefined {
+		for (const ext of this.extensions) {
+			const handler = ext.runtimeReadHandlers.get(name);
+			if (handler) return handler;
+		}
+		return undefined;
+	}
+
 	getFlags(): Map<string, ExtensionFlag> {
 		const allFlags = new Map<string, ExtensionFlag>();
 		for (const ext of this.extensions) {

--- a/packages/pi-coding-agent/test/extensions-runner.test.ts
+++ b/packages/pi-coding-agent/test/extensions-runner.test.ts
@@ -876,4 +876,24 @@ describe("ExtensionRunner", () => {
 		expect(captured).toEqual(model);
 		delete (globalThis as unknown as { __bprEventModel?: unknown }).__bprEventModel;
 	});
+
+	it("exposes a host-only runtime read without registering an LLM tool", async () => {
+		const extCode = `
+			export default function(pi) {
+				pi.registerRuntimeRead("project_progress", async (input) => ({ input, source: "extension" }));
+			}
+		`;
+		fs.writeFileSync(path.join(extensionsDir, "runtime-read.ts"), extCode);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+		const handler = runner.getRuntimeReadHandler("project_progress");
+
+		expect(handler).toBeDefined();
+		expect(await handler?.({ cwd: tempDir })).toEqual({
+			input: { cwd: tempDir },
+			source: "extension",
+		});
+		expect(runner.getAllRegisteredTools()).toHaveLength(0);
+	});
 });

--- a/packages/rpc-client/src/rpc-client.ts
+++ b/packages/rpc-client/src/rpc-client.ts
@@ -439,6 +439,11 @@ export class RpcClient {
 		return this.getData(response);
 	}
 
+	async getProjectProgress(): Promise<import("@opengsd/contracts").ProjectProgress | null> {
+		const response = await this.send({ type: "get_project_progress" });
+		return this.getData(response);
+	}
+
 	/**
 	 * Export session to HTML.
 	 */

--- a/src/read-cli.ts
+++ b/src/read-cli.ts
@@ -4,6 +4,7 @@
  *   gsd read progress --json --project /path
  *   gsd read roadmap --json --project /path [--milestone M001]
  *   gsd read memory --json --project /path --query "auth"
+ *   gsd read snapshot --json --project /path
  */
 
 import { existsSync } from 'node:fs'
@@ -98,6 +99,47 @@ async function loadDbProgressReader(
 }
 
 /**
+ * Injectable DB snapshot reader — mirrors loadDbProgressReader: production
+ * jiti-loads state/project-snapshot.ts; tests inject the reader/importer.
+ */
+export type DbSnapshotReader = (projectDir: string) => Promise<unknown>
+export type DbSnapshotModuleImporter = (path: string) => Promise<unknown>
+
+async function loadDbSnapshotReader(
+  moduleImporter: DbSnapshotModuleImporter = (path) => jiti.import(path, {}),
+): Promise<DbSnapshotReader> {
+  let mod: any
+  try {
+    mod = await moduleImporter(gsdExtensionPath('state/project-snapshot.ts'))
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(
+      `selected GSD extensions do not support DB-backed snapshot reads; synchronize the extension bundle (${detail})`,
+    )
+  }
+  if (typeof mod.readProjectSnapshotFromDb !== 'function') {
+    throw new Error('selected GSD extensions do not support DB-backed snapshot reads; synchronize the extension bundle')
+  }
+  return (projectDir: string) => mod.readProjectSnapshotFromDb(projectDir)
+}
+
+/**
+ * DB-backed project snapshot (issue #2102), or null when there is no DB file.
+ * Unlike progress, snapshot has no projection fallback: a null result means
+ * the DB is missing and the caller must refuse loudly.
+ */
+async function tryReadSnapshotFromDb(
+  dbPath: string,
+  projectDir: string,
+  reader?: DbSnapshotReader,
+  moduleImporter?: DbSnapshotModuleImporter,
+): Promise<unknown | null> {
+  if (!existsSync(dbPath)) return null
+  const read = reader ?? await loadDbSnapshotReader(moduleImporter)
+  return await read(projectDir)
+}
+
+/**
  * DB-backed progress payload, or null when the projection fallback applies:
  * no DB file, or the DB cannot be opened (locked/unreadable). Schema skew
  * has already refused loudly via assertProjectDbSchemaSupported before this
@@ -155,7 +197,7 @@ async function assertProjectDbSchemaSupported(
   }
 }
 
-export type ReadKind = 'progress' | 'roadmap' | 'memory'
+export type ReadKind = 'progress' | 'roadmap' | 'memory' | 'snapshot'
 
 /** DB-backed progress reader — jiti-loaded in production, injected in tests. */
 export type DbProgressReader = (projectDir: string) => Promise<unknown>
@@ -182,7 +224,7 @@ function parseReadArgs(argv: string[]): ReadCliOptions | null {
   const args = argv.slice(readIndex + 1)
   if (args.length < 1) return null
   const kind = args[0] as ReadKind
-  if (!['progress', 'roadmap', 'memory'].includes(kind)) return null
+  if (!['progress', 'roadmap', 'memory', 'snapshot'].includes(kind)) return null
 
   let project: string | undefined
   let milestone: string | undefined
@@ -206,11 +248,13 @@ export async function runReadCli(
   preflight?: ReadCliSchemaPreflight,
   dbProgressReader?: DbProgressReader,
   dbProgressModuleImporter?: DbProgressModuleImporter,
+  dbSnapshotReader?: DbSnapshotReader,
+  dbSnapshotModuleImporter?: DbSnapshotModuleImporter,
 ): Promise<number> {
   const opts = parseReadArgs(argv)
   if (!opts) {
     process.stderr.write(
-      'Usage: gsd read <progress|roadmap|memory> --json --project <path> [--milestone M001] [--query text]\n',
+      'Usage: gsd read <progress|roadmap|memory|snapshot> --json --project <path> [--milestone M001] [--query text]\n',
     )
     return 1
   }
@@ -260,6 +304,32 @@ export async function runReadCli(
         return 1
       }
       data = fromDb ?? readProgress(projectDir)
+      break
+    }
+    case 'snapshot': {
+      // DB-only read (issue #2102): no projection fallback exists, so a
+      // missing DB or failed read refuses loudly with exit 1.
+      let snapshot: unknown | null
+      try {
+        snapshot = await tryReadSnapshotFromDb(
+          dbPath,
+          projectDir,
+          dbSnapshotReader,
+          dbSnapshotModuleImporter,
+        )
+      } catch (err) {
+        process.stderr.write(
+          `[gsd] DB-backed snapshot read failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        )
+        return 1
+      }
+      if (snapshot === null) {
+        process.stderr.write(
+          `[gsd] snapshot requires a GSD database; none found at ${dbPath}\n`,
+        )
+        return 1
+      }
+      data = snapshot
       break
     }
     case 'roadmap':

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -3336,6 +3336,134 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
 	registerWorkflowTool(pi, decisionListTool);
 
+	// ─── gsd_project_snapshot ────────────────────────────────────────────────
+	//
+	// Read-only: returns the DB-authoritative project snapshot (issue #2102) —
+	// progress, milestone, and slice/task state assembled from the canonical
+	// database in one payload. Use instead of stitching together multiple read
+	// tools or parsing markdown projections, which may lag the DB.
+
+	const projectSnapshotExecute = async (
+		_toolCallId: string,
+		params: any,
+		_signal: AbortSignal | undefined,
+		_onUpdate: unknown,
+		_ctx: unknown,
+	) => {
+		const basePath =
+			typeof params.projectDir === "string" && params.projectDir
+				? params.projectDir
+				: resolveCtxCwd(_ctx);
+		try {
+			const { readProjectSnapshotFromDb } = await import("../state/project-snapshot.js");
+
+			const snapshot = await withCanonicalReadAdapter(
+				basePath,
+				async () => readProjectSnapshotFromDb(basePath),
+			);
+
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: JSON.stringify(snapshot),
+					},
+				],
+				details: {
+					operation: "read_project_snapshot",
+					projectDir: basePath,
+					snapshot,
+				} as any,
+			};
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (msg.includes("db_unavailable")) {
+				logError("tool", `gsd_project_snapshot failed: ${msg}`, {
+					tool: "gsd_project_snapshot",
+					error: String(err),
+				});
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: "Error: GSD database is not available.",
+						},
+					],
+					details: {
+						operation: "read_project_snapshot",
+						error: "db_unavailable",
+					} as any,
+				};
+			}
+			logError("tool", `gsd_project_snapshot failed: ${msg}`, {
+				tool: "gsd_project_snapshot",
+				error: String(err),
+			});
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: `Error reading project snapshot: ${msg}`,
+					},
+				],
+				details: {
+					operation: "read_project_snapshot",
+					error: "query_error",
+					message: msg,
+				} as any,
+			};
+		}
+	};
+
+	const projectSnapshotTool = {
+		name: "gsd_project_snapshot",
+		label: "Read Project Snapshot",
+		description:
+			"Read the DB-authoritative project snapshot (issue #2102): progress, milestone, " +
+			"and slice/task state in one payload. Use instead of combining multiple read " +
+			"tools or parsing markdown projections.",
+		promptSnippet:
+			"Read the canonical GSD project snapshot from the database",
+		promptGuidelines: [
+			"Use gsd_project_snapshot for a one-shot view of project state — do not assemble it from markdown projections.",
+			"The snapshot is DB-authoritative; projections may be stale after migrations or failed regens.",
+			"Optionally pass projectDir to target a specific project root; defaults to the session working directory.",
+		],
+		parameters: Type.Object({
+			projectDir: Type.Optional(
+				Type.String({
+					description:
+						"Project root to read the snapshot for. Defaults to the current working directory.",
+				}),
+			),
+		}),
+		execute: projectSnapshotExecute,
+		renderCall(args: any, theme: any) {
+			let text = theme.fg("toolTitle", theme.bold("project_snapshot"));
+			if (args.projectDir) {
+				text += theme.fg("dim", ` [${args.projectDir}]`);
+			}
+			return new Text(text, 0, 0);
+		},
+		renderResult(result: any, _options: any, theme: any) {
+			const d = readDetails(result);
+			if (result.isError || d?.error) {
+				return new Text(
+					theme.fg("error", formatToolErrorText(result, d)),
+					0,
+					0,
+				);
+			}
+			return new Text(
+				theme.fg("success", "Project snapshot read"),
+				0,
+				0,
+			);
+		},
+	};
+
+	registerWorkflowTool(pi, projectSnapshotTool);
+
 	// ─── gsd_decision_get ────────────────────────────────────────────────────
 	//
 	// Point-lookup by stable D### ID. Sources from the canonical memories table

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -941,18 +941,24 @@ export interface ProgressHierarchyDetails {
     }>;
   }>;
   milestonesTruncated: boolean;
+  tasksTruncated: boolean;
 }
 
 /** Read a bounded project hierarchy for compact integration consumers. */
 export function getProgressHierarchyDetails(): ProgressHierarchyDetails {
   const db = getDbOrNull();
-  if (!db) return { milestones: [], milestonesTruncated: false };
+  if (!db) return { milestones: [], milestonesTruncated: false, tasksTruncated: false };
+
+  const maxMilestones = 50;
+  const maxSlicesPerMilestone = 50;
+  const maxTasksPerSlice = 50;
+  const maxTasks = 1_000;
 
   const milestones = db.prepare(
     "SELECT id, title, status FROM milestones ORDER BY CASE WHEN sequence > 0 THEN 0 ELSE 1 END, sequence, id LIMIT 51",
   ).all() as Array<{ id: string; title: string; status: string }>;
-  const selectedMilestones = milestones.slice(0, 50);
-  if (selectedMilestones.length === 0) return { milestones: [], milestonesTruncated: false };
+  const selectedMilestones = milestones.slice(0, maxMilestones);
+  if (selectedMilestones.length === 0) return { milestones: [], milestonesTruncated: false, tasksTruncated: false };
 
   const milestonePlaceholders = selectedMilestones.map((_, index) => `:mid${index}`).join(",");
   const milestoneParams: Record<string, string> = {};
@@ -970,13 +976,15 @@ export function getProgressHierarchyDetails(): ProgressHierarchyDetails {
       WHERE row_number <= 51
       ORDER BY milestone_id, sequence, id`,
   ).all(milestoneParams) as Array<Record<string, unknown>>;
-  const selectedSlices = slices.filter((slice) => Number(slice.row_number) <= 50);
+  const selectedSlices = slices.filter((slice) => Number(slice.row_number) <= maxSlicesPerMilestone);
   const sliceKeys = selectedSlices.map((slice) => ({
     milestoneId: String(slice.milestone_id),
     sliceId: String(slice.id),
   }));
   const tasks: Array<Record<string, unknown>> = [];
   for (let start = 0; start < sliceKeys.length; start += 400) {
+    const remainingTaskRows = maxTasks + 1 - tasks.length;
+    if (remainingTaskRows <= 0) break;
     const chunk = sliceKeys.slice(start, start + 400);
     const taskClauses = chunk.map((slice, index) => `(milestone_id = :taskMid${index} AND slice_id = :taskSid${index})`).join(" OR ");
     const taskParams: Record<string, string> = {};
@@ -992,28 +1000,46 @@ export function getProgressHierarchyDetails(): ProgressHierarchyDetails {
              FROM tasks
             WHERE ${taskClauses}
          )
-        WHERE row_number <= 51
-        ORDER BY milestone_id, slice_id, sequence, id`,
+        WHERE row_number <= ${maxTasksPerSlice + 1}
+        ORDER BY milestone_id, slice_id, sequence, id
+        LIMIT ${remainingTaskRows}`,
     ).all(taskParams) as Array<Record<string, unknown>>;
     tasks.push(...rows);
   }
 
+  const tasksTruncated = tasks.length > maxTasks;
+  const selectedTasks = tasks.slice(0, maxTasks);
+  const slicesByMilestone = new Map<string, Array<Record<string, unknown>>>();
+  for (const slice of slices) {
+    const key = String(slice.milestone_id);
+    const bucket = slicesByMilestone.get(key) ?? [];
+    bucket.push(slice);
+    slicesByMilestone.set(key, bucket);
+  }
+  const tasksBySlice = new Map<string, Array<Record<string, unknown>>>();
+  for (const task of selectedTasks) {
+    const key = `${String(task.milestone_id)}\0${String(task.slice_id)}`;
+    const bucket = tasksBySlice.get(key) ?? [];
+    bucket.push(task);
+    tasksBySlice.set(key, bucket);
+  }
+
   return {
     milestones: selectedMilestones.map((milestone) => {
-      const milestoneSlices = slices.filter((slice) => String(slice.milestone_id) === milestone.id);
+      const milestoneSlices = slicesByMilestone.get(milestone.id) ?? [];
       return {
         ...milestone,
-        truncated: milestoneSlices.some((slice) => Number(slice.row_number) > 50),
-        slices: milestoneSlices.filter((slice) => Number(slice.row_number) <= 50).map((slice) => {
+        truncated: milestoneSlices.some((slice) => Number(slice.row_number) > maxSlicesPerMilestone),
+        slices: milestoneSlices.filter((slice) => Number(slice.row_number) <= maxSlicesPerMilestone).map((slice) => {
           const milestoneId = String(slice.milestone_id);
           const sliceId = String(slice.id);
-          const sliceTasks = tasks.filter((task) => String(task.milestone_id) === milestoneId && String(task.slice_id) === sliceId);
+          const sliceTasks = tasksBySlice.get(`${milestoneId}\0${sliceId}`) ?? [];
           return {
             id: sliceId,
             title: String(slice.title ?? ""),
             status: String(slice.status ?? ""),
-            truncated: sliceTasks.some((task) => Number(task.row_number) > 50),
-            tasks: sliceTasks.filter((task) => Number(task.row_number) <= 50).map((task) => ({
+            truncated: sliceTasks.some((task) => Number(task.row_number) > maxTasksPerSlice),
+            tasks: sliceTasks.filter((task) => Number(task.row_number) <= maxTasksPerSlice).map((task) => ({
               id: String(task.id ?? ""),
               title: String(task.title ?? ""),
               status: String(task.status ?? ""),
@@ -1022,7 +1048,8 @@ export function getProgressHierarchyDetails(): ProgressHierarchyDetails {
         }),
       };
     }),
-    milestonesTruncated: milestones.length > 50,
+    milestonesTruncated: milestones.length > maxMilestones,
+    tasksTruncated,
   };
 }
 

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -125,6 +125,131 @@ export function getProjectAuthorityVersion(): ProjectAuthorityVersion {
   };
 }
 
+export interface ProjectAuthorityRow {
+  projectId: string;
+  revision: number;
+  authorityEpoch: number;
+}
+
+/** Full project_authority singleton read (null when no row / no DB open). */
+export function getProjectAuthorityRow(): ProjectAuthorityRow | null {
+  const db = getDbOrNull();
+  if (!db) return null;
+  const row = db.prepare(
+    "SELECT project_id, revision, authority_epoch FROM project_authority WHERE singleton = 1",
+  ).get();
+  if (!row) return null;
+  return {
+    projectId: String(row["project_id"] ?? ""),
+    revision: numberColumn(row, "revision"),
+    authorityEpoch: numberColumn(row, "authority_epoch"),
+  };
+}
+
+export interface OpenBlockerRow {
+  blockerId: string;
+  blockerKind: string;
+  resolutionOwner: string;
+  description: string;
+  requestedAction: string;
+  openedAt: string;
+  openedProjectRevision: number;
+}
+
+/** Open workflow blockers, oldest first (issue #2102 snapshot read). */
+export function getOpenBlockers(): OpenBlockerRow[] {
+  const db = getDbOrNull();
+  if (!db) return [];
+  const rows = db.prepare(
+    `SELECT blocker_id, blocker_kind, resolution_owner, description, requested_action,
+            opened_at, opened_project_revision
+       FROM workflow_blockers
+      WHERE blocker_status = 'open'
+      ORDER BY opened_project_revision, blocker_id`,
+  ).all();
+  return rows.map((row) => ({
+    blockerId: String(row["blocker_id"] ?? ""),
+    blockerKind: String(row["blocker_kind"] ?? ""),
+    resolutionOwner: String(row["resolution_owner"] ?? ""),
+    description: String(row["description"] ?? ""),
+    requestedAction: String(row["requested_action"] ?? ""),
+    openedAt: String(row["opened_at"] ?? ""),
+    openedProjectRevision: numberColumn(row, "opened_project_revision"),
+  }));
+}
+
+export interface OpenQuestionRow {
+  questionId: string;
+  questionText: string;
+  createdAt: string;
+}
+
+/** Open workflow questions, creation order (issue #2102 snapshot read). */
+export function getOpenQuestions(): OpenQuestionRow[] {
+  const db = getDbOrNull();
+  if (!db) return [];
+  const rows = db.prepare(
+    `SELECT question_id, question_text, created_at
+       FROM workflow_open_questions
+      WHERE question_status = 'open'
+      ORDER BY created_at, question_id`,
+  ).all();
+  return rows.map((row) => ({
+    questionId: String(row["question_id"] ?? ""),
+    questionText: String(row["question_text"] ?? ""),
+    createdAt: String(row["created_at"] ?? ""),
+  }));
+}
+
+/** Max applied migration version from the schema_version table (null when absent). */
+export function getSchemaVersion(): number | null {
+  const db = getDbOrNull();
+  if (!db) return null;
+  const row = db.prepare("SELECT MAX(version) AS version FROM schema_version").get();
+  if (!row || row["version"] === null || row["version"] === undefined) return null;
+  return numberColumn(row, "version");
+}
+
+export interface VerificationSummaryCounts {
+  assessments: { total: number; pass: number; fail: number };
+  evidence: { total: number; passed: number; failed: number };
+}
+
+/**
+ * Project-wide verification summary (issue #2102 snapshot read): assessment
+ * status counts plus verification_evidence verdict counts.
+ */
+export function getVerificationSummary(): VerificationSummaryCounts {
+  const db = getDbOrNull();
+  if (!db) return { assessments: { total: 0, pass: 0, fail: 0 }, evidence: { total: 0, passed: 0, failed: 0 } };
+
+  const assessmentRows = db.prepare(
+    "SELECT lower(status) AS status, COUNT(*) AS count FROM assessments GROUP BY lower(status)",
+  ).all();
+  const assessments = { total: 0, pass: 0, fail: 0 };
+  for (const row of assessmentRows) {
+    const count = numberColumn(row, "count");
+    assessments.total += count;
+    const status = String(row["status"] ?? "");
+    if (status === "pass" || status === "passed") assessments.pass += count;
+    else if (status === "fail" || status === "failed") assessments.fail += count;
+  }
+
+  const evidenceRows = db.prepare(
+    "SELECT lower(verdict) AS verdict, COUNT(*) AS count FROM verification_evidence GROUP BY lower(verdict)",
+  ).all();
+  const evidence = { total: 0, passed: 0, failed: 0 };
+  for (const row of evidenceRows) {
+    const count = numberColumn(row, "count");
+    evidence.total += count;
+    const verdict = String(row["verdict"] ?? "");
+    if (verdict === "passed" || verdict === "pass") evidence.passed += count;
+    else if (verdict === "failed" || verdict === "fail") evidence.failed += count;
+  }
+
+  return { assessments, evidence };
+}
+
 export function getHierarchyCompletionCounts(): HierarchyCompletionCounts {
   if (!getDbOrNull()!) {
     return { milestones: 0, milestonesTotal: 0, slices: 0, slicesTotal: 0, tasks: 0, tasksTotal: 0 };

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -926,6 +926,106 @@ export function getTasksBySliceIds(
   return bySlice;
 }
 
+export interface ProgressHierarchyDetails {
+  milestones: Array<{
+    id: string;
+    title: string;
+    status: string;
+    truncated: boolean;
+    slices: Array<{
+      id: string;
+      title: string;
+      status: string;
+      truncated: boolean;
+      tasks: Array<{ id: string; title: string; status: string }>;
+    }>;
+  }>;
+  milestonesTruncated: boolean;
+}
+
+/** Read a bounded project hierarchy for compact integration consumers. */
+export function getProgressHierarchyDetails(): ProgressHierarchyDetails {
+  const db = getDbOrNull();
+  if (!db) return { milestones: [], milestonesTruncated: false };
+
+  const milestones = db.prepare(
+    "SELECT id, title, status FROM milestones ORDER BY CASE WHEN sequence > 0 THEN 0 ELSE 1 END, sequence, id LIMIT 51",
+  ).all() as Array<{ id: string; title: string; status: string }>;
+  const selectedMilestones = milestones.slice(0, 50);
+  if (selectedMilestones.length === 0) return { milestones: [], milestonesTruncated: false };
+
+  const milestonePlaceholders = selectedMilestones.map((_, index) => `:mid${index}`).join(",");
+  const milestoneParams: Record<string, string> = {};
+  selectedMilestones.forEach((milestone, index) => {
+    milestoneParams[`:mid${index}`] = milestone.id;
+  });
+  const slices = db.prepare(
+    `SELECT milestone_id, id, title, status, sequence, row_number
+       FROM (
+         SELECT milestone_id, id, title, status, sequence,
+                ROW_NUMBER() OVER (PARTITION BY milestone_id ORDER BY sequence, id) AS row_number
+           FROM slices
+          WHERE milestone_id IN (${milestonePlaceholders})
+       )
+      WHERE row_number <= 51
+      ORDER BY milestone_id, sequence, id`,
+  ).all(milestoneParams) as Array<Record<string, unknown>>;
+  const selectedSlices = slices.filter((slice) => Number(slice.row_number) <= 50);
+  const sliceKeys = selectedSlices.map((slice) => ({
+    milestoneId: String(slice.milestone_id),
+    sliceId: String(slice.id),
+  }));
+  const tasks: Array<Record<string, unknown>> = [];
+  for (let start = 0; start < sliceKeys.length; start += 400) {
+    const chunk = sliceKeys.slice(start, start + 400);
+    const taskClauses = chunk.map((slice, index) => `(milestone_id = :taskMid${index} AND slice_id = :taskSid${index})`).join(" OR ");
+    const taskParams: Record<string, string> = {};
+    chunk.forEach((slice, index) => {
+      taskParams[`:taskMid${index}`] = slice.milestoneId;
+      taskParams[`:taskSid${index}`] = slice.sliceId;
+    });
+    const rows = db.prepare(
+      `SELECT milestone_id, slice_id, id, title, status, sequence, row_number
+         FROM (
+           SELECT milestone_id, slice_id, id, title, status, sequence,
+                  ROW_NUMBER() OVER (PARTITION BY milestone_id, slice_id ORDER BY sequence, id) AS row_number
+             FROM tasks
+            WHERE ${taskClauses}
+         )
+        WHERE row_number <= 51
+        ORDER BY milestone_id, slice_id, sequence, id`,
+    ).all(taskParams) as Array<Record<string, unknown>>;
+    tasks.push(...rows);
+  }
+
+  return {
+    milestones: selectedMilestones.map((milestone) => {
+      const milestoneSlices = slices.filter((slice) => String(slice.milestone_id) === milestone.id);
+      return {
+        ...milestone,
+        truncated: milestoneSlices.some((slice) => Number(slice.row_number) > 50),
+        slices: milestoneSlices.filter((slice) => Number(slice.row_number) <= 50).map((slice) => {
+          const milestoneId = String(slice.milestone_id);
+          const sliceId = String(slice.id);
+          const sliceTasks = tasks.filter((task) => String(task.milestone_id) === milestoneId && String(task.slice_id) === sliceId);
+          return {
+            id: sliceId,
+            title: String(slice.title ?? ""),
+            status: String(slice.status ?? ""),
+            truncated: sliceTasks.some((task) => Number(task.row_number) > 50),
+            tasks: sliceTasks.filter((task) => Number(task.row_number) <= 50).map((task) => ({
+              id: String(task.id ?? ""),
+              title: String(task.title ?? ""),
+              status: String(task.status ?? ""),
+            })),
+          };
+        }),
+      };
+    }),
+    milestonesTruncated: milestones.length > 50,
+  };
+}
+
 /** Dispatch-eligibility shape consumed by decision-path callers (ADR-017). */
 export interface MilestoneSliceSummary {
   id: string;

--- a/src/resources/extensions/gsd/ecosystem/gsd-extension-api.ts
+++ b/src/resources/extensions/gsd/ecosystem/gsd-extension-api.ts
@@ -208,6 +208,8 @@ export function createGSDExtensionAPI(
     setVisibleSkills: (...args: Parameters<ExtensionAPI["setVisibleSkills"]>) =>
       pi.setVisibleSkills(...args),
     getCommands: () => pi.getCommands(),
+  registerRuntimeRead: (...args: Parameters<ExtensionAPI["registerRuntimeRead"]>) =>
+    pi.registerRuntimeRead(...args),
 
     // ── Model & thinking ───────────────────────────────────────────────
     setModel: (...args: Parameters<ExtensionAPI["setModel"]>) => pi.setModel(...args),

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -23,12 +23,12 @@ export default async function registerExtension(pi: ExtensionAPI) {
   registerGSDCommand(pi);
 
   if (typeof pi.registerRuntimeRead === "function") {
-    const { readProgressFromDb } = await import("./mcp-bridge.js");
+    const { readProjectProgressFromDb } = await import("./mcp-bridge.js");
     pi.registerRuntimeRead("project_progress", async (input) => {
       if (!input || typeof input !== "object" || typeof (input as { cwd?: unknown }).cwd !== "string") {
         throw new Error("Project progress requires a session CWD");
       }
-      return readProgressFromDb((input as { cwd: string }).cwd);
+      return readProjectProgressFromDb((input as { cwd: string }).cwd);
     });
   }
 

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -22,6 +22,16 @@ export default async function registerExtension(pi: ExtensionAPI) {
   const { registerGSDCommand } = await import("./commands/index.js");
   registerGSDCommand(pi);
 
+  if (typeof pi.registerRuntimeRead === "function") {
+    const { readProgressFromDb } = await import("./mcp-bridge.js");
+    pi.registerRuntimeRead("project_progress", async (input) => {
+      if (!input || typeof input !== "object" || typeof (input as { cwd?: unknown }).cwd !== "string") {
+        throw new Error("Project progress requires a session CWD");
+      }
+      return readProgressFromDb((input as { cwd: string }).cwd);
+    });
+  }
+
   // Full setup (shortcuts, tools, hooks) in a separate try/catch so that
   // any platform-specific load failure doesn't take out the core command.
   try {

--- a/src/resources/extensions/gsd/mcp-bridge.ts
+++ b/src/resources/extensions/gsd/mcp-bridge.ts
@@ -7,6 +7,7 @@ export {
 export { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 export { openExistingWorkflowDatabase } from "./db-workspace.js";
 export { readProgressFromDb } from "./state/progress-from-db.js";
+export { readProjectSnapshotFromDb } from "./state/project-snapshot.js";
 export {
   _getAdapter,
   checkpointDatabase,

--- a/src/resources/extensions/gsd/mcp-bridge.ts
+++ b/src/resources/extensions/gsd/mcp-bridge.ts
@@ -6,7 +6,7 @@ export {
 } from "./bootstrap/write-gate.js";
 export { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 export { openExistingWorkflowDatabase } from "./db-workspace.js";
-export { readProgressFromDb } from "./state/progress-from-db.js";
+export { readProgressFromDb, readProjectProgressFromDb } from "./state/progress-from-db.js";
 export {
   _getAdapter,
   checkpointDatabase,

--- a/src/resources/extensions/gsd/state/derive/db-open.ts
+++ b/src/resources/extensions/gsd/state/derive/db-open.ts
@@ -17,7 +17,10 @@ export function syncQueueOrderProjectionToDb(basePath: string): void {
   setMilestoneQueueOrder(desiredIds);
 }
 
-export function ensureExistingWorkflowDbOpen(basePath: string): boolean {
+export function ensureExistingWorkflowDbOpen(
+  basePath: string,
+  options: { throwOnOpenFailure?: boolean } = {},
+): boolean {
   if (isDbAvailable()) {
     syncQueueOrderProjectionToDb(basePath);
     return true;
@@ -37,6 +40,9 @@ export function ensureExistingWorkflowDbOpen(basePath: string): boolean {
     // (exact engine message attached) so state-read surfaces refuse loudly
     // instead of emitting a degraded all-zero snapshot (T003 spike).
     throw result.error;
+  }
+  if (!result.ok && options.throwOnOpenFailure && result.reason !== "missing-database" && result.reason !== "missing-gsd-dir") {
+    throw result.error ?? new Error(`Unable to open the GSD database: ${result.reason}`);
   }
   if (result.ok) syncQueueOrderProjectionToDb(basePath);
   return result.ok;

--- a/src/resources/extensions/gsd/state/progress-from-db.ts
+++ b/src/resources/extensions/gsd/state/progress-from-db.ts
@@ -9,6 +9,7 @@ import { ensureExistingWorkflowDbOpen } from "./derive/db-open.js";
 import {
   getHierarchyCompletionCounts,
   getInFlightSliceCount,
+  getProgressHierarchyDetails,
   getMilestoneStatusCounts,
   getProjectAuthorityVersion,
   isDbAvailable,
@@ -36,6 +37,20 @@ export interface DbProgressResult {
   requirements: { active: number; validated: number; deferred: number; outOfScope: number } | null;
   blockers: string[];
   nextAction: string;
+  milestoneDetails?: Array<{
+    id: string;
+    title: string;
+    status: string;
+    truncated: boolean;
+    slices: Array<{
+      id: string;
+      title: string;
+      status: string;
+      truncated: boolean;
+      tasks: Array<{ id: string; title: string; status: string }>;
+    }>;
+  }>;
+  milestoneDetailsTruncated?: boolean;
 }
 
 function toRef(value: { id: string; title: string } | null): { id: string; title: string } | null {
@@ -84,6 +99,7 @@ function readProgressHierarchy(): ProgressHierarchy {
 function buildProgressResult(
   state: GSDState,
   hierarchy: ReturnType<typeof readProgressHierarchy>,
+  details: ReturnType<typeof getProgressHierarchyDetails>,
 ): DbProgressResult {
   const slicesDone = hierarchy.counts.slices;
   const slicesTotal = hierarchy.counts.slicesTotal;
@@ -118,6 +134,8 @@ function buildProgressResult(
         : null,
     blockers: [...state.blockers],
     nextAction: state.nextAction,
+    milestoneDetails: details.milestones,
+    milestoneDetailsTruncated: details.milestonesTruncated,
   };
 }
 
@@ -142,7 +160,7 @@ export async function readProgressFromDb(basePath: string): Promise<DbProgressRe
   for (let attempt = 1; ; attempt++) {
     const before = readProgressStabilityToken();
     const state = await deriveState(basePath);
-    const result = buildProgressResult(state, readProgressHierarchy());
+    const result = buildProgressResult(state, readProgressHierarchy(), getProgressHierarchyDetails());
     const after = readProgressStabilityToken();
 
     if (stabilityTokensMatch(before, after)) return result;

--- a/src/resources/extensions/gsd/state/progress-from-db.ts
+++ b/src/resources/extensions/gsd/state/progress-from-db.ts
@@ -37,6 +37,9 @@ export interface DbProgressResult {
   requirements: { active: number; validated: number; deferred: number; outOfScope: number } | null;
   blockers: string[];
   nextAction: string;
+}
+
+export interface DbProjectProgressResult extends DbProgressResult {
   milestoneDetails?: Array<{
     id: string;
     title: string;
@@ -51,6 +54,7 @@ export interface DbProgressResult {
     }>;
   }>;
   milestoneDetailsTruncated?: boolean;
+  milestoneDetailsTasksTruncated?: boolean;
 }
 
 function toRef(value: { id: string; title: string } | null): { id: string; title: string } | null {
@@ -99,7 +103,6 @@ function readProgressHierarchy(): ProgressHierarchy {
 function buildProgressResult(
   state: GSDState,
   hierarchy: ReturnType<typeof readProgressHierarchy>,
-  details: ReturnType<typeof getProgressHierarchyDetails>,
 ): DbProgressResult {
   const slicesDone = hierarchy.counts.slices;
   const slicesTotal = hierarchy.counts.slicesTotal;
@@ -134,9 +137,37 @@ function buildProgressResult(
         : null,
     blockers: [...state.blockers],
     nextAction: state.nextAction,
-    milestoneDetails: details.milestones,
-    milestoneDetailsTruncated: details.milestonesTruncated,
   };
+}
+
+async function readProgressFromDbInternal(
+  basePath: string,
+  includeHierarchyDetails: boolean,
+  throwOnOpenFailure: boolean,
+): Promise<DbProgressResult | DbProjectProgressResult | null> {
+  ensureExistingWorkflowDbOpen(basePath, { throwOnOpenFailure });
+  if (!isDbAvailable()) return null;
+
+  invalidateStateCache();
+  for (let attempt = 1; ; attempt++) {
+    const before = readProgressStabilityToken();
+    const state = await deriveState(basePath);
+    const progress = buildProgressResult(state, readProgressHierarchy());
+    const details = includeHierarchyDetails ? getProgressHierarchyDetails() : undefined;
+    const result: DbProgressResult | DbProjectProgressResult = details
+      ? {
+          ...progress,
+          milestoneDetails: details.milestones,
+          milestoneDetailsTruncated: details.milestonesTruncated,
+          milestoneDetailsTasksTruncated: details.tasksTruncated,
+        }
+      : progress;
+    const after = readProgressStabilityToken();
+
+    if (stabilityTokensMatch(before, after)) return result;
+    if (attempt === MAX_REVISION_ATTEMPTS) return result;
+    invalidateStateCache();
+  }
 }
 
 /**
@@ -153,19 +184,10 @@ function buildProgressResult(
  * may still straddle revisions.
  */
 export async function readProgressFromDb(basePath: string): Promise<DbProgressResult | null> {
-  ensureExistingWorkflowDbOpen(basePath);
-  if (!isDbAvailable()) return null;
+  return await readProgressFromDbInternal(basePath, false, false) as DbProgressResult | null;
+}
 
-  invalidateStateCache();
-  for (let attempt = 1; ; attempt++) {
-    const before = readProgressStabilityToken();
-    const state = await deriveState(basePath);
-    const result = buildProgressResult(state, readProgressHierarchy(), getProgressHierarchyDetails());
-    const after = readProgressStabilityToken();
-
-    if (stabilityTokensMatch(before, after)) return result;
-
-    if (attempt === MAX_REVISION_ATTEMPTS) return result;
-    invalidateStateCache();
-  }
+/** Detailed bounded progress is host-only; established CLI and MCP reads retain ProgressResult. */
+export async function readProjectProgressFromDb(basePath: string): Promise<DbProjectProgressResult | null> {
+  return await readProgressFromDbInternal(basePath, true, true) as DbProjectProgressResult | null;
 }

--- a/src/resources/extensions/gsd/state/project-snapshot.ts
+++ b/src/resources/extensions/gsd/state/project-snapshot.ts
@@ -1,0 +1,202 @@
+// Project/App: gsd-pi
+// File Purpose: DB-authoritative project snapshot read (issue #2102).
+// One compact, deterministic payload covering authority, current focus,
+// progress counts, blockers, open questions, verification, and the bounded
+// milestone registry — modeled on readProgressFromDb.
+
+import { deriveState, invalidateStateCache } from "./derive/index.js";
+import { ensureExistingWorkflowDbOpen } from "./derive/db-open.js";
+import {
+  _getAdapter,
+  getAllMilestones,
+  getHierarchyCompletionCounts,
+  getInFlightSliceCount,
+  getMilestoneStatusCounts,
+  getOpenBlockers,
+  getOpenQuestions,
+  getProjectAuthorityRow,
+  getProjectAuthorityVersion,
+  getSchemaVersion,
+  getVerificationSummary,
+  isDbAvailable,
+  readTransaction,
+  type OpenBlockerRow,
+  type OpenQuestionRow,
+  type VerificationSummaryCounts,
+} from "../gsd-db.js";
+import type { GSDState } from "../types.js";
+
+const MAX_REVISION_ATTEMPTS = 3;
+
+/** Registry cap: snapshots stay bounded for large projects (issue #2102). */
+export const MAX_SNAPSHOT_MILESTONES = 50;
+
+export interface DbProjectSnapshotAuthority {
+  projectId: string;
+  schemaVersion: number | null;
+  revision: number;
+  authorityEpoch: number;
+}
+
+export interface DbProjectSnapshotCurrent {
+  activeMilestone: { id: string; title: string } | null;
+  activeSlice: { id: string; title: string } | null;
+  activeTask: { id: string; title: string } | null;
+  phase: string;
+  nextAction: string;
+}
+
+export interface DbProjectSnapshotProgress {
+  milestones: { total: number; done: number; active: number; pending: number; parked: number };
+  slices: { total: number; done: number; active: number; pending: number };
+  tasks: { total: number; done: number; pending: number };
+}
+
+export interface DbProjectSnapshotMilestone {
+  id: string;
+  title: string;
+  status: string;
+  sequence: number;
+}
+
+export interface DbProjectSnapshot {
+  authority: DbProjectSnapshotAuthority;
+  current: DbProjectSnapshotCurrent;
+  progress: DbProjectSnapshotProgress;
+  blockers: OpenBlockerRow[];
+  openQuestions: OpenQuestionRow[];
+  verification: VerificationSummaryCounts;
+  milestones: { items: DbProjectSnapshotMilestone[]; truncated: boolean };
+  capturedAt: string;
+}
+
+interface SnapshotStabilityToken {
+  revision: number;
+  authorityEpoch: number;
+  dataVersion: number;
+}
+
+function readStabilityToken(): SnapshotStabilityToken {
+  const authority = getProjectAuthorityVersion();
+  const row = _getAdapter()?.prepare("PRAGMA data_version").get();
+  const dataVersion = Number(row?.["data_version"]);
+  if (!Number.isSafeInteger(dataVersion) || dataVersion < 0) {
+    throw new Error("GSD database data version is not available");
+  }
+  return { ...authority, dataVersion };
+}
+
+function stabilityTokensMatch(before: SnapshotStabilityToken, after: SnapshotStabilityToken): boolean {
+  return before.revision === after.revision
+    && before.authorityEpoch === after.authorityEpoch
+    && before.dataVersion === after.dataVersion;
+}
+
+interface SnapshotDbRead {
+  authority: DbProjectSnapshotAuthority;
+  progress: DbProjectSnapshotProgress;
+  blockers: OpenBlockerRow[];
+  openQuestions: OpenQuestionRow[];
+  verification: VerificationSummaryCounts;
+  milestones: DbProjectSnapshot["milestones"];
+}
+
+function readSnapshotDb(): SnapshotDbRead {
+  return readTransaction(() => {
+    const authorityRow = getProjectAuthorityRow();
+    if (!authorityRow) {
+      throw new Error("GSD project authority row is not available");
+    }
+    const authority: DbProjectSnapshotAuthority = {
+      projectId: authorityRow.projectId,
+      schemaVersion: getSchemaVersion(),
+      revision: authorityRow.revision,
+      authorityEpoch: authorityRow.authorityEpoch,
+    };
+
+    const counts = getHierarchyCompletionCounts();
+    const milestoneCounts = getMilestoneStatusCounts();
+    const slicesActive = getInFlightSliceCount();
+    const slicesPending = counts.slicesTotal - counts.slices - slicesActive;
+    const progress: DbProjectSnapshotProgress = {
+      milestones: milestoneCounts,
+      slices: {
+        total: counts.slicesTotal,
+        done: counts.slices,
+        active: slicesActive,
+        pending: slicesPending,
+      },
+      tasks: {
+        total: counts.tasksTotal,
+        done: counts.tasks,
+        pending: counts.tasksTotal - counts.tasks,
+      },
+    };
+
+    const all = getAllMilestones();
+    const truncated = all.length > MAX_SNAPSHOT_MILESTONES;
+    const milestones = {
+      items: all.slice(0, MAX_SNAPSHOT_MILESTONES).map((m) => ({
+        id: m.id,
+        title: m.title,
+        status: m.status,
+        sequence: m.sequence,
+      })),
+      truncated,
+    };
+
+    return {
+      authority,
+      progress,
+      blockers: getOpenBlockers(),
+      openQuestions: getOpenQuestions(),
+      verification: getVerificationSummary(),
+      milestones,
+    };
+  });
+}
+
+function toRef(value: { id: string; title: string } | null): { id: string; title: string } | null {
+  return value ? { id: value.id, title: value.title } : null;
+}
+
+function buildCurrent(state: GSDState): DbProjectSnapshotCurrent {
+  return {
+    activeMilestone: toRef(state.activeMilestone),
+    activeSlice: toRef(state.activeSlice),
+    activeTask: toRef(state.activeTask),
+    phase: state.phase,
+    nextAction: state.nextAction,
+  };
+}
+
+/**
+ * Read the compact DB-authoritative project snapshot. The DB-backed sections
+ * (authority, progress, blockers, questions, verification, milestones) are
+ * captured inside one read transaction; `deriveState` runs outside it and
+ * supplies current refs/phase/nextAction, so `capturedAt` reflects when the
+ * snapshot was assembled and the current section may tear relative to the
+ * transactional sections under concurrent commits — the stability-retry loop
+ * bounds but does not eliminate that (same contract as readProgressFromDb).
+ */
+export async function readProjectSnapshotFromDb(basePath: string): Promise<DbProjectSnapshot | null> {
+  ensureExistingWorkflowDbOpen(basePath);
+  if (!isDbAvailable()) return null;
+
+  invalidateStateCache();
+  for (let attempt = 1; ; attempt++) {
+    const before = readStabilityToken();
+    const dbRead = readSnapshotDb();
+    const state = await deriveState(basePath);
+    const after = readStabilityToken();
+
+    if (stabilityTokensMatch(before, after) || attempt === MAX_REVISION_ATTEMPTS) {
+      return {
+        ...dbRead,
+        current: buildCurrent(state),
+        capturedAt: new Date().toISOString(),
+      };
+    }
+    invalidateStateCache();
+  }
+}

--- a/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
@@ -17,7 +17,7 @@ import {
   getDb,
   openDatabase,
 } from "../mcp-bridge.ts";
-import { insertRequirement, getDbPath } from "../gsd-db.ts";
+import { insertRequirement, insertMilestone, insertSlice, insertTask, getDbPath } from "../gsd-db.ts";
 import { resolveProjectRootDbPath } from "../db-workspace.ts";
 import { invalidateAllCaches } from "../cache.ts";
 
@@ -329,6 +329,132 @@ test("canonical read parity: corrupt requirements table returns query_error for 
 
     assert.equal(readError(nativeReqList), "query_error");
     assert.equal(readError(mcpReqList), "query_error");
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read parity: gsd_project_snapshot returns the same payload for native and MCP", async () => {
+  const base = makeProjectBase("gsd-canonical-snapshot-parity");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+
+    openDatabase(resolveProjectRootDbPath(base));
+    insertMilestone({ id: "M001", title: "Parity milestone", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Parity slice",
+      status: "in_progress",
+      risk: "low",
+      depends: [],
+      sequence: 1,
+    });
+    insertTask({
+      id: "T01",
+      milestoneId: "M001",
+      sliceId: "S01",
+      title: "Parity task",
+      status: "pending",
+      sequence: 1,
+    });
+
+    const nativeSnapshotResult = await nativeTool(native, "gsd_project_snapshot").execute(
+      "call-8",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeDetails = (nativeSnapshotResult as {
+      details?: { error?: string; snapshot?: Record<string, unknown> };
+    }).details;
+
+    const mcpSnapshotResult = await mcpTool(mcp, "gsd_project_snapshot").handler({ projectDir: base });
+    const mcpDetails = (mcpSnapshotResult as {
+      structuredContent?: { error?: string; snapshot?: Record<string, unknown> };
+    }).structuredContent;
+
+    assert.equal(nativeDetails?.error, undefined);
+    assert.equal(mcpDetails?.error, undefined);
+
+    const nativeSnapshot = nativeDetails?.snapshot;
+    const mcpSnapshot = mcpDetails?.snapshot;
+    assert.ok(nativeSnapshot, "native result should carry details.snapshot");
+    assert.ok(mcpSnapshot, "MCP result should carry structuredContent.snapshot");
+
+    // capturedAt legitimately differs between the two executions; every other
+    // section must be identical across the native and MCP surfaces.
+    const stripCapturedAt = (snapshot: Record<string, unknown>) =>
+      JSON.parse(JSON.stringify({ ...snapshot, capturedAt: "<capturedAt>" }));
+    assert.deepEqual(stripCapturedAt(nativeSnapshot!), stripCapturedAt(mcpSnapshot!));
+
+    assert.equal(typeof nativeSnapshot!.authority, "object");
+    assert.ok(String((nativeSnapshot!.authority as { projectId?: unknown }).projectId ?? "").length > 0);
+    assert.deepEqual((nativeSnapshot!.milestones as { items?: unknown[] }).items?.length, 1);
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read parity: gsd_project_snapshot missing DB returns db_unavailable for native and MCP without creating gsd.db", async () => {
+  const base = makeProjectBase("gsd-canonical-snapshot-missing-db");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+    const dbPath = resolveProjectRootDbPath(base);
+
+    assert.equal(existsSync(dbPath), false, "fixture starts without gsd.db");
+
+    const nativeSnapshotResult = await nativeTool(native, "gsd_project_snapshot").execute(
+      "call-9",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeDetails = (nativeSnapshotResult as { details?: { error?: string } }).details;
+    assert.equal(nativeDetails?.error, "db_unavailable");
+    assert.equal(existsSync(dbPath), false, "native snapshot read should not create gsd.db as side effect");
+
+    const mcpSnapshotResult = await mcpTool(mcp, "gsd_project_snapshot").handler({ projectDir: base });
+    const mcpDetails = (mcpSnapshotResult as { structuredContent?: { error?: string } }).structuredContent;
+    assert.equal(mcpDetails?.error, "db_unavailable");
+    assert.equal(existsSync(dbPath), false, "MCP snapshot read should not create gsd.db as side effect");
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read parity: dropped workflow_blockers table returns query_error for native and MCP snapshot reads", async () => {
+  const base = makeProjectBase("gsd-canonical-snapshot-query-error");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+
+    openDatabase(resolveProjectRootDbPath(base));
+    getDb().prepare("DROP TABLE workflow_blockers").run();
+
+    const nativeSnapshotResult = await nativeTool(native, "gsd_project_snapshot").execute(
+      "call-10",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeDetails = (nativeSnapshotResult as { details?: { error?: string } }).details;
+    assert.equal(nativeDetails?.error, "query_error");
+
+    const mcpSnapshotResult = await mcpTool(mcp, "gsd_project_snapshot").handler({ projectDir: base });
+    const mcpDetails = (mcpSnapshotResult as { structuredContent?: { error?: string } }).structuredContent;
+    assert.equal(mcpDetails?.error, "query_error");
+
+    const isolated = (await import("../db-workspace.ts")).openWorkflowDatabaseIsolated(
+      resolveProjectRootDbPath(base),
+    );
+    assert.ok(isolated, "isolated open should still work after handled snapshot query_error");
+    isolated?.close();
   } finally {
     cleanup([base]);
   }

--- a/src/resources/extensions/gsd/tests/extension-bootstrap-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/extension-bootstrap-isolation.test.ts
@@ -38,6 +38,7 @@ function makePi(overrides: Partial<Record<string, unknown>> = {}) {
     registerTool: () => {},
     registerHook: () => {},
     registerShortcut: () => {},
+    registerRuntimeRead: () => {},
     events,
     ...overrides,
   };
@@ -73,6 +74,7 @@ describe("extension bootstrap isolation (#4168, #4172)", () => {
       registerTool: () => {},
       registerHook: () => {},
       registerShortcut: () => {},
+      registerRuntimeRead: () => {},
       events: { on: () => {}, off: () => {}, emit: () => {} },
     };
 
@@ -101,6 +103,7 @@ describe("extension bootstrap isolation (#4168, #4172)", () => {
       registerTool: () => {},
       registerHook: () => {},
       registerShortcut: () => {},
+      registerRuntimeRead: () => {},
       events: { on: () => {}, off: () => {}, emit: () => {} },
     };
     await registerExtension(pi as any);
@@ -136,6 +139,7 @@ describe("registerGsdExtension defensive registration", () => {
       registerShortcut: () => {
         throw new Error("simulated platform-specific shortcut failure");
       },
+      registerRuntimeRead: () => {},
       events: { on: () => {}, off: () => {}, emit: () => {} },
     };
     assert.doesNotThrow(() => registerGsdExtension(pi as any));
@@ -154,6 +158,7 @@ describe("registerGsdExtension defensive registration", () => {
       registerTool: () => {},
       registerHook: () => {},
       registerShortcut: () => {},
+      registerRuntimeRead: () => {},
       events: { on: () => {}, off: () => {}, emit: () => {} },
     };
     registerGsdExtension(pi as any);
@@ -183,6 +188,7 @@ describe("registerGsdExtension defensive registration", () => {
       },
       registerHook: () => {},
       registerShortcut: () => {},
+      registerRuntimeRead: () => {},
       events: { on: () => {}, off: () => {}, emit: () => {} },
       getAllTools: () => registeredTools.map((name) => ({ name })),
     };
@@ -211,6 +217,7 @@ describe("registerGsdExtension defensive registration", () => {
       registerTool: (tool: { name: string }) => { registeredTools.push(tool.name); },
       registerHook: () => {},
       registerShortcut: () => {},
+      registerRuntimeRead: () => {},
       events: { on: () => {}, off: () => {}, emit: () => {} },
       // Simulate the pre-bind throwing stub (loader.ts:182).
       getAllTools: () => {
@@ -238,6 +245,7 @@ describe("registerGsdExtension defensive registration", () => {
       },
       registerHook: () => {},
       registerShortcut: () => {},
+      registerRuntimeRead: () => {},
       events: { on: () => {}, off: () => {}, emit: () => {} },
       getAllTools: () => registeredTools.map((name) => ({ name })),
     };

--- a/src/resources/extensions/gsd/tests/progress-from-db.test.ts
+++ b/src/resources/extensions/gsd/tests/progress-from-db.test.ts
@@ -124,6 +124,8 @@ test("readProgressFromDb emits exactly the ProgressResult key set", async (t) =>
     "requirements",
     "blockers",
     "nextAction",
+    "milestoneDetails",
+    "milestoneDetailsTruncated",
   ]);
   assert.deepEqual(Object.keys(result.milestones), ["total", "done", "active", "pending", "parked"]);
   assert.deepEqual(Object.keys(result.slices), ["total", "done", "active", "pending"]);
@@ -154,6 +156,7 @@ test("readProgressFromDb derives refs, project-wide counts, and requirements fro
   assert.deepEqual(result.blockers, []);
   assert.equal(typeof result.nextAction, "string");
   assert.ok(result.nextAction.length > 0);
+  assert.equal(result.milestoneDetails?.[0]?.slices[0]?.tasks[0]?.id, "T01");
 });
 
 test("readProgressFromDb keeps milestone counts project-wide under a milestone lock", async (t) => {

--- a/src/resources/extensions/gsd/tests/progress-from-db.test.ts
+++ b/src/resources/extensions/gsd/tests/progress-from-db.test.ts
@@ -20,7 +20,7 @@ import {
   invalidateStateCache,
   resetDeriveTelemetry,
 } from "../state.ts";
-import { readProgressFromDb } from "../state/progress-from-db.ts";
+import { readProgressFromDb, readProjectProgressFromDb } from "../state/progress-from-db.ts";
 import {
   createWorkflowAuthorityFixture,
   type WorkflowAuthorityFixture,
@@ -124,8 +124,6 @@ test("readProgressFromDb emits exactly the ProgressResult key set", async (t) =>
     "requirements",
     "blockers",
     "nextAction",
-    "milestoneDetails",
-    "milestoneDetailsTruncated",
   ]);
   assert.deepEqual(Object.keys(result.milestones), ["total", "done", "active", "pending", "parked"]);
   assert.deepEqual(Object.keys(result.slices), ["total", "done", "active", "pending"]);
@@ -156,7 +154,8 @@ test("readProgressFromDb derives refs, project-wide counts, and requirements fro
   assert.deepEqual(result.blockers, []);
   assert.equal(typeof result.nextAction, "string");
   assert.ok(result.nextAction.length > 0);
-  assert.equal(result.milestoneDetails?.[0]?.slices[0]?.tasks[0]?.id, "T01");
+  const detailedResult = await readProjectProgressFromDb(fixture.root);
+  assert.equal(detailedResult?.milestoneDetails?.[0]?.slices[0]?.tasks[0]?.id, "T01");
 });
 
 test("readProgressFromDb keeps milestone counts project-wide under a milestone lock", async (t) => {

--- a/src/resources/extensions/gsd/tests/project-snapshot.test.ts
+++ b/src/resources/extensions/gsd/tests/project-snapshot.test.ts
@@ -1,0 +1,393 @@
+// Project/App: gsd-pi
+// File Purpose: readProjectSnapshotFromDb — DB-authoritative project snapshot
+// reads (#2102). Pins the exact DbProjectSnapshot key set, the seeded
+// authority/progress/blocker/question/verification/milestone sections, byte
+// determinism at a stable revision, milestone registry truncation, open-item
+// ordering, and the missing-DB null contract.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  _getAdapter,
+  closeDatabase,
+  getProjectAuthorityRow,
+  getSchemaVersion,
+  insertMilestone,
+  transaction,
+} from "../gsd-db.ts";
+import { deriveState } from "../state.ts";
+import {
+  MAX_SNAPSHOT_MILESTONES,
+  readProjectSnapshotFromDb,
+} from "../state/project-snapshot.ts";
+import {
+  createWorkflowAuthorityFixture,
+} from "./workflow-authority-fixture.ts";
+
+// Provenance seeds. workflow_blockers / workflow_open_questions reference
+// workflow_operations and workflow_item_lifecycles, so the snapshot seeds
+// must build that minimal provenance chain first (same shape the foundation
+// schema tests use). Revisions sit far above the fixture's authority revision
+// so the seed never collides with real writer operations.
+const SEED_REVISION_BASE = 910_001;
+
+function fixtureProjectId(): string {
+  const authority = getProjectAuthorityRow();
+  assert.ok(authority, "fixture project_authority row should exist");
+  return authority.projectId;
+}
+
+function seedOperation(operationId: string, revision: number): void {
+  _getAdapter()!.prepare(
+    `INSERT INTO workflow_operations (
+       operation_id, project_id, operation_type, idempotency_key,
+       expected_revision, resulting_revision,
+       expected_authority_epoch, resulting_authority_epoch,
+       actor_type, actor_id, source_transport, request_hash, created_at
+     ) VALUES (?, ?, 'snapshot-test', ?, ?, ?, 0, 0, 'agent', 'test', 'test', ?, '2026-09-05T00:00:00.000Z')`,
+  ).run(
+    operationId,
+    fixtureProjectId(),
+    `key-${operationId}`,
+    revision - 1,
+    revision,
+    `hash-${operationId}`,
+  );
+}
+
+function seedMilestoneLifecycle(
+  lifecycleId: string,
+  operationId: string,
+  revision: number,
+): void {
+  _getAdapter()!.prepare(
+    `INSERT INTO workflow_item_lifecycles (
+       lifecycle_id, project_id, item_kind, milestone_id, lifecycle_status,
+       created_at, updated_at,
+       last_operation_id, last_project_revision, last_authority_epoch
+     ) VALUES (?, ?, 'milestone', 'M001', 'in_progress', '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z', ?, ?, 0)`,
+  ).run(lifecycleId, fixtureProjectId(), operationId, revision);
+}
+
+function seedBlocker(input: {
+  blockerId: string;
+  lifecycleId: string;
+  operationId: string;
+  revision: number;
+  kind?: string;
+  openedAt?: string;
+}): void {
+  _getAdapter()!.prepare(
+    `INSERT INTO workflow_blockers (
+       blocker_id, project_id, lifecycle_id, blocker_kind, resolution_owner,
+       blocker_status, description, requested_action, opened_at,
+       opened_operation_id, opened_project_revision, opened_authority_epoch
+     ) VALUES (?, ?, ?, ?, 'user', 'open', ?, ?, ?, ?, ?, 0)`,
+  ).run(
+    input.blockerId,
+    fixtureProjectId(),
+    input.lifecycleId,
+    input.kind ?? "ambiguous_intent",
+    `${input.blockerId} description`,
+    `${input.blockerId} requested action`,
+    input.openedAt ?? "2026-09-05T00:00:00.000Z",
+    input.operationId,
+    input.revision,
+  );
+}
+
+function seedQuestion(input: {
+  questionId: string;
+  lifecycleId: string;
+  operationId: string;
+  revision: number;
+  text: string;
+  createdAt: string;
+}): void {
+  // The initial-state trigger requires created/last provenance to match and
+  // created_at == updated_at for a question that begins open.
+  _getAdapter()!.prepare(
+    `INSERT INTO workflow_open_questions (
+       question_id, project_id, lifecycle_id, question_text, question_status,
+       state_version, created_at, updated_at,
+       created_operation_id, created_project_revision, created_authority_epoch,
+       last_operation_id, last_project_revision, last_authority_epoch
+     ) VALUES (?, ?, ?, ?, 'open', 0, ?, ?, ?, ?, 0, ?, ?, 0)`,
+  ).run(
+    input.questionId,
+    fixtureProjectId(),
+    input.lifecycleId,
+    input.text,
+    input.createdAt,
+    input.createdAt,
+    input.operationId,
+    input.revision,
+    input.operationId,
+    input.revision,
+  );
+}
+
+function seedVerificationRows(): void {
+  const db = _getAdapter()!;
+  db.prepare(
+    `INSERT INTO assessments (path, milestone_id, status, scope, full_content, created_at)
+     VALUES
+       ('snapshot-assess-pass', 'M001', 'pass', 'slice', '', '2026-09-05T00:00:00.000Z'),
+       ('snapshot-assess-fail', 'M001', 'FAIL', 'slice', '', '2026-09-05T00:00:00.000Z')`,
+  ).run();
+  // Tasks (M001, S01, T01) and (M001, S02, T01) exist in the fixture; the
+  // verification_evidence FK targets that composite key.
+  db.prepare(
+    `INSERT INTO verification_evidence (
+       task_id, slice_id, milestone_id, command, exit_code, verdict, duration_ms, created_at
+     ) VALUES
+       ('T01', 'S01', 'M001', 'npm test', 0, 'passed', 12, '2026-09-05T00:00:00.000Z'),
+       ('T01', 'S02', 'M001', 'npm test', 1, 'failed', 34, '2026-09-05T00:00:00.000Z'),
+       ('T01', 'S02', 'M001', 'npm run check', 1, 'Failed', 56, '2026-09-05T00:00:00.000Z')`,
+  ).run();
+}
+
+/** Seeds blockers/questions with deliberately mixed insert order + revisions. */
+function seedSnapshotOpenItems(): void {
+  transaction(() => {
+    seedOperation("op-snap-a", SEED_REVISION_BASE);
+    seedOperation("op-snap-b", SEED_REVISION_BASE + 1);
+    seedMilestoneLifecycle("life-snap", "op-snap-a", SEED_REVISION_BASE);
+
+    // Blockers: inserted out of order; B-snap-zz carries the lower revision so
+    // ordering must come from (opened_project_revision, blocker_id), not
+    // insertion order or id alone.
+    seedBlocker({
+      blockerId: "B-snap-zz",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-a",
+      revision: SEED_REVISION_BASE,
+      openedAt: "2026-09-05T00:00:03.000Z",
+    });
+    seedBlocker({
+      blockerId: "B-snap-aa",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-b",
+      revision: SEED_REVISION_BASE + 1,
+      openedAt: "2026-09-05T00:00:01.000Z",
+    });
+    // Same revision as B-snap-aa: id is the tiebreaker.
+    seedBlocker({
+      blockerId: "B-snap-ab",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-b",
+      revision: SEED_REVISION_BASE + 1,
+      openedAt: "2026-09-05T00:00:02.000Z",
+    });
+
+    // Questions: inserted out of order; ordering must come from
+    // (created_at, question_id), not insertion order.
+    seedQuestion({
+      questionId: "Q-snap-later",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-a",
+      revision: SEED_REVISION_BASE,
+      text: "Which storage engine should back the queue?",
+      createdAt: "2026-09-05T00:00:09.000Z",
+    });
+    seedQuestion({
+      questionId: "Q-snap-b",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-a",
+      revision: SEED_REVISION_BASE,
+      text: "Same-timestamp question B",
+      createdAt: "2026-09-05T00:00:05.000Z",
+    });
+    seedQuestion({
+      questionId: "Q-snap-a",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-a",
+      revision: SEED_REVISION_BASE,
+      text: "Same-timestamp question A",
+      createdAt: "2026-09-05T00:00:05.000Z",
+    });
+  });
+}
+
+test("readProjectSnapshotFromDb emits exactly the DbProjectSnapshot key set", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+
+  const snapshot = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(snapshot);
+  assert.deepEqual(Object.keys(snapshot).sort(), [
+    "authority",
+    "blockers",
+    "capturedAt",
+    "current",
+    "milestones",
+    "openQuestions",
+    "progress",
+    "verification",
+  ]);
+  assert.deepEqual(Object.keys(snapshot.authority), ["projectId", "schemaVersion", "revision", "authorityEpoch"]);
+  assert.deepEqual(Object.keys(snapshot.current), [
+    "activeMilestone",
+    "activeSlice",
+    "activeTask",
+    "phase",
+    "nextAction",
+  ]);
+  assert.deepEqual(Object.keys(snapshot.progress), ["milestones", "slices", "tasks"]);
+  assert.deepEqual(Object.keys(snapshot.progress.milestones), ["total", "done", "active", "pending", "parked"]);
+  assert.deepEqual(Object.keys(snapshot.progress.slices), ["total", "done", "active", "pending"]);
+  assert.deepEqual(Object.keys(snapshot.progress.tasks), ["total", "done", "pending"]);
+  assert.deepEqual(Object.keys(snapshot.milestones), ["items", "truncated"]);
+  assert.deepEqual(Object.keys(snapshot.verification), ["assessments", "evidence"]);
+  assert.deepEqual(Object.keys(snapshot.verification.assessments), ["total", "pass", "fail"]);
+  assert.deepEqual(Object.keys(snapshot.verification.evidence), ["total", "passed", "failed"]);
+});
+
+test("readProjectSnapshotFromDb assembles authority, current, progress, open items, verification, and milestones", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  seedSnapshotOpenItems();
+  seedVerificationRows();
+
+  const snapshot = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(snapshot);
+  const state = await deriveState(fixture.root);
+
+  const authorityRow = getProjectAuthorityRow();
+  assert.ok(authorityRow);
+  assert.equal(snapshot.authority.projectId, authorityRow.projectId);
+  assert.ok(snapshot.authority.projectId.length > 0, "projectId should be the real authority id");
+  assert.equal(snapshot.authority.revision, authorityRow.revision);
+  assert.equal(snapshot.authority.authorityEpoch, authorityRow.authorityEpoch);
+  assert.equal(snapshot.authority.schemaVersion, getSchemaVersion());
+  assert.equal(typeof snapshot.authority.schemaVersion, "number");
+
+  assert.deepEqual(snapshot.current.activeMilestone, { id: "M001", title: "Authority Fixture" });
+  assert.deepEqual(snapshot.current.activeSlice, { id: "S02", title: "Ready dependent slice" });
+  assert.deepEqual(snapshot.current.activeTask, { id: "T01", title: "Ready task" });
+  // The current section must be the same derivation the canonical state
+  // reader serves, not a snapshot-specific re-implementation.
+  assert.deepEqual(snapshot.current.activeMilestone, state.activeMilestone
+    ? { id: state.activeMilestone.id, title: state.activeMilestone.title }
+    : null);
+  assert.deepEqual(snapshot.current.activeSlice, state.activeSlice
+    ? { id: state.activeSlice.id, title: state.activeSlice.title }
+    : null);
+  assert.deepEqual(snapshot.current.activeTask, state.activeTask
+    ? { id: state.activeTask.id, title: state.activeTask.title }
+    : null);
+  assert.equal(snapshot.current.phase, state.phase);
+  assert.equal(typeof snapshot.current.nextAction, "string");
+  assert.ok(snapshot.current.nextAction.length > 0);
+
+  assert.deepEqual(snapshot.progress.milestones, { total: 1, done: 0, active: 1, pending: 0, parked: 0 });
+  assert.deepEqual(snapshot.progress.slices, { total: 2, done: 1, active: 0, pending: 1 });
+  assert.deepEqual(snapshot.progress.tasks, { total: 2, done: 1, pending: 1 });
+
+  assert.equal(snapshot.blockers.length, 3);
+  assert.deepEqual(
+    snapshot.blockers.map((b) => b.blockerId),
+    ["B-snap-zz", "B-snap-aa", "B-snap-ab"],
+  );
+  assert.deepEqual(snapshot.blockers[0], {
+    blockerId: "B-snap-zz",
+    blockerKind: "ambiguous_intent",
+    resolutionOwner: "user",
+    description: "B-snap-zz description",
+    requestedAction: "B-snap-zz requested action",
+    openedAt: "2026-09-05T00:00:03.000Z",
+    openedProjectRevision: SEED_REVISION_BASE,
+  });
+
+  assert.equal(snapshot.openQuestions.length, 3);
+  assert.deepEqual(
+    snapshot.openQuestions.map((q) => q.questionId),
+    ["Q-snap-a", "Q-snap-b", "Q-snap-later"],
+  );
+  assert.deepEqual(snapshot.openQuestions[2], {
+    questionId: "Q-snap-later",
+    questionText: "Which storage engine should back the queue?",
+    createdAt: "2026-09-05T00:00:09.000Z",
+  });
+
+  assert.deepEqual(snapshot.verification, {
+    assessments: { total: 2, pass: 1, fail: 1 },
+    evidence: { total: 3, passed: 1, failed: 2 },
+  });
+
+  assert.equal(snapshot.milestones.truncated, false);
+  assert.deepEqual(snapshot.milestones.items, [
+    { id: "M001", title: "Authority Fixture", status: "active", sequence: 0 },
+  ]);
+
+  assert.equal(typeof snapshot.capturedAt, "string");
+  assert.ok(!Number.isNaN(Date.parse(snapshot.capturedAt)), "capturedAt should be an ISO timestamp");
+});
+
+test("readProjectSnapshotFromDb is byte-deterministic at a stable revision", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  seedSnapshotOpenItems();
+
+  const first = await readProjectSnapshotFromDb(fixture.root);
+  const second = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(first);
+  assert.ok(second);
+
+  // capturedAt legitimately moves between reads; everything else must not.
+  const firstPayload = JSON.stringify({ ...first, capturedAt: "<capturedAt>" });
+  const secondPayload = JSON.stringify({ ...second, capturedAt: "<capturedAt>" });
+  assert.equal(firstPayload, secondPayload);
+});
+
+test("readProjectSnapshotFromDb truncates the milestone registry beyond the cap", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+
+  // Fixture has M001; M002..M051 push the registry past the 50-item cap.
+  // Milestones default to sequence 0, so registry order is id-lexicographic
+  // and M051 is the row dropped by truncation.
+  transaction(() => {
+    for (let n = 2; n <= 51; n += 1) {
+      insertMilestone({
+        id: `M${String(n).padStart(3, "0")}`,
+        title: `Extra milestone ${n}`,
+        status: "pending",
+      });
+    }
+  });
+
+  const snapshot = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(snapshot);
+
+  assert.equal(MAX_SNAPSHOT_MILESTONES, 50);
+  assert.equal(snapshot.milestones.truncated, true);
+  assert.equal(snapshot.milestones.items.length, 50);
+  assert.equal(snapshot.milestones.items[0]?.id, "M001");
+  assert.equal(snapshot.milestones.items[49]?.id, "M050");
+  assert.equal(
+    snapshot.milestones.items.some((m) => m.id === "M051"),
+    false,
+    "the milestone past the cap must not appear in the registry",
+  );
+  // Counts stay project-wide even when the registry is truncated.
+  assert.deepEqual(snapshot.progress.milestones, { total: 51, done: 0, active: 1, pending: 50, parked: 0 });
+});
+
+test("readProjectSnapshotFromDb returns null when no database exists", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-snapshot-empty-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // The reader must not ride on a global handle left open by another test's
+  // fixture, and must not create the database as a side effect.
+  closeDatabase();
+
+  const snapshot = await readProjectSnapshotFromDb(root);
+
+  assert.equal(snapshot, null);
+  assert.equal(existsSync(join(root, ".gsd", "gsd.db")), false, "missing DB must not be created");
+});

--- a/src/tests/read-cli-args.test.ts
+++ b/src/tests/read-cli-args.test.ts
@@ -51,6 +51,45 @@ test("runReadCli handles global flags before read", async () => {
 	}
 });
 
+test("runReadCli accepts the snapshot kind and fails closed without a DB", async () => {
+	const stdout = captureWrite(process.stdout);
+	const stderr = captureWrite(process.stderr);
+	try {
+		// The hermes fixture has no gsd.db, so the accepted snapshot kind must
+		// refuse loudly instead of falling back to projections — arg parsing
+		// only, no DB opened, no reader reached.
+		const exitCode = await runReadCli(
+			["node", "gsd", "read", "snapshot", "--json", "--project", fixture],
+			probelessPreflight,
+		);
+
+		assert.equal(exitCode, 1);
+		assert.equal(stdout.output(), "");
+		assert.match(stderr.output(), /snapshot requires a GSD database/);
+	} finally {
+		stdout.restore();
+		stderr.restore();
+	}
+});
+
+test("runReadCli rejects unknown read kinds with usage on stderr", async () => {
+	const stdout = captureWrite(process.stdout);
+	const stderr = captureWrite(process.stderr);
+	try {
+		const exitCode = await runReadCli(
+			["node", "gsd", "read", "snapshott", "--json", "--project", fixture],
+			probelessPreflight,
+		);
+
+		assert.equal(exitCode, 1);
+		assert.equal(stdout.output(), "");
+		assert.match(stderr.output(), /^Usage: gsd read <progress\|roadmap\|memory\|snapshot>/);
+	} finally {
+		stdout.restore();
+		stderr.restore();
+	}
+});
+
 function captureWrite(stream: NodeJS.WriteStream): { output: () => string; restore: () => void } {
 	const chunks: string[] = [];
 	const original = stream.write.bind(stream);

--- a/src/tests/read-cli-snapshot-db.test.ts
+++ b/src/tests/read-cli-snapshot-db.test.ts
@@ -1,0 +1,230 @@
+/**
+ * `gsd read snapshot` DB-only wiring (#2102).
+ *
+ * Unlike progress, the snapshot kind has no projection fallback: a present
+ * and openable project DB must feed the envelope data through the injectable
+ * DB snapshot reader, while a missing DB or a failed read refuses loudly
+ * with exit 1 (fail closed — never a degraded payload). The reader is
+ * exercised through its injectable seam — the same pattern as the
+ * progress/snapshot wiring tests in read-cli-progress-db.test.ts — so these
+ * cases pin the wiring and fail-closed decisions, not the snapshot payload
+ * itself (pinned by tests/project-snapshot.test.ts in the extension).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  runReadCli,
+  type DbSnapshotModuleImporter,
+  type DbSnapshotReader,
+  type ReadCliSchemaPreflight,
+} from "../read-cli.ts";
+import { closeDatabase, openDatabase } from "../resources/extensions/gsd/gsd-db.ts";
+import {
+  openWorkflowDatabaseIsolated,
+  resolveProjectRootDbPath,
+} from "../resources/extensions/gsd/db-workspace.ts";
+import { SCHEMA_VERSION, SchemaTooNewError } from "../resources/extensions/gsd/db/engine.ts";
+
+const realPreflight: ReadCliSchemaPreflight = {
+  resolveProjectRootDbPath,
+  openIsolatedDatabase: (path) => openWorkflowDatabaseIsolated(path),
+  supportedSchemaVersion: SCHEMA_VERSION,
+  createSchemaTooNewError: (currentVersion, supportedVersion) =>
+    new SchemaTooNewError(currentVersion, supportedVersion),
+};
+
+interface CaptureOpts {
+  preflight?: ReadCliSchemaPreflight;
+  snapshotReader?: DbSnapshotReader;
+  moduleImporter?: DbSnapshotModuleImporter;
+}
+
+async function captureReadCli(argv: string[], opts: CaptureOpts = {}) {
+  let stdout = "";
+  let stderr = "";
+  const originalOut = process.stdout.write;
+  const originalErr = process.stderr.write;
+  process.stdout.write = ((chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const exitCode = await runReadCli(
+      argv,
+      opts.preflight ?? realPreflight,
+      undefined,
+      undefined,
+      opts.snapshotReader,
+      opts.moduleImporter,
+    );
+    return { exitCode, stdout, stderr };
+  } finally {
+    process.stdout.write = originalOut;
+    process.stderr.write = originalErr;
+  }
+}
+
+function readSnapshotArgv(base: string): string[] {
+  return ["node", "gsd", "read", "snapshot", "--json", "--project", base];
+}
+
+function makeProject(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-read-cli-snapshot-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "STATE.md"),
+    "# Project State\n\n**Phase:** planning\n",
+  );
+  return base;
+}
+
+function makeSnapshotSentinel(): Record<string, unknown> {
+  return {
+    authority: { projectId: "proj", schemaVersion: 48, revision: 7, authorityEpoch: 0 },
+    current: {
+      activeMilestone: { id: "M001", title: "From DB" },
+      activeSlice: null,
+      activeTask: null,
+      phase: "execute",
+      nextAction: "Keep going",
+    },
+    progress: {
+      milestones: { total: 1, done: 0, active: 1, pending: 0, parked: 0 },
+      slices: { total: 0, done: 0, active: 0, pending: 0 },
+      tasks: { total: 0, done: 0, pending: 0 },
+    },
+    blockers: [],
+    openQuestions: [],
+    verification: {
+      assessments: { total: 0, pass: 0, fail: 0 },
+      evidence: { total: 0, passed: 0, failed: 0 },
+    },
+    milestones: { items: [], truncated: false },
+    capturedAt: "2026-09-05T00:00:00.000Z",
+  };
+}
+
+test("gsd read snapshot serves the DB-backed envelope with the pinned snapshot key set when the DB is present", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const sentinel = makeSnapshotSentinel();
+  let calls = 0;
+  const run = await captureReadCli(readSnapshotArgv(base), {
+    snapshotReader: async (projectDir) => {
+      calls++;
+      assert.equal(projectDir, base);
+      return sentinel;
+    },
+  });
+
+  assert.equal(run.exitCode, 0);
+  const envelope = JSON.parse(run.stdout);
+  assert.equal(envelope.integration_version, 1);
+  assert.equal(envelope.kind, "snapshot");
+  assert.equal(envelope.projectDir, base);
+  assert.deepEqual(Object.keys(envelope.data).sort(), [
+    "authority",
+    "blockers",
+    "capturedAt",
+    "current",
+    "milestones",
+    "openQuestions",
+    "progress",
+    "verification",
+  ]);
+  assert.deepEqual(envelope.data, sentinel);
+  assert.equal(calls, 1);
+});
+
+test("gsd read snapshot uses the project DB from a canonical milestone worktree", async (t) => {
+  const base = makeProject();
+  const worktree = join(base, ".gsd-worktrees", "M001");
+  mkdirSync(join(worktree, ".gsd"), { recursive: true });
+  writeFileSync(join(worktree, ".gsd", "STATE.md"), "# Project State\n\n**Phase:** planning\n");
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readSnapshotArgv(worktree), {
+    snapshotReader: async (projectDir) => {
+      assert.equal(projectDir, worktree);
+      return makeSnapshotSentinel();
+    },
+  });
+
+  assert.equal(run.exitCode, 0);
+  const envelope = JSON.parse(run.stdout);
+  assert.equal(envelope.kind, "snapshot");
+  assert.equal(envelope.data.authority.projectId, "proj");
+});
+
+test("gsd read snapshot refuses loudly when the DB-backed read fails", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readSnapshotArgv(base), {
+    snapshotReader: async () => {
+      throw new Error("boom");
+    },
+  });
+
+  assert.equal(run.exitCode, 1);
+  assert.equal(run.stdout, "");
+  assert.ok(
+    run.stderr.includes("DB-backed snapshot read failed"),
+    `stderr should explain the failure, got: ${run.stderr}`,
+  );
+  assert.ok(run.stderr.includes("boom"), `stderr should carry the cause, got: ${run.stderr}`);
+});
+
+test("gsd read snapshot refuses loudly when no DB exists (fail closed, no fallback)", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  let calls = 0;
+  const run = await captureReadCli(readSnapshotArgv(base), {
+    snapshotReader: async () => {
+      calls++;
+      return makeSnapshotSentinel();
+    },
+  });
+
+  assert.equal(run.exitCode, 1);
+  assert.equal(run.stdout, "");
+  assert.ok(
+    run.stderr.includes("snapshot requires a GSD database"),
+    `stderr should explain the missing DB, got: ${run.stderr}`,
+  );
+  assert.equal(calls, 0, "reader must not be invoked when the DB file is absent");
+});
+
+test("gsd read snapshot explains how to repair a stale extension bundle", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readSnapshotArgv(base), {
+    moduleImporter: async () => {
+      throw new Error("Cannot find module state/project-snapshot.ts");
+    },
+  });
+
+  assert.equal(run.exitCode, 1);
+  assert.equal(run.stdout, "");
+  assert.match(run.stderr, /synchronize the extension bundle/);
+});

--- a/vscode-extension/src/gsd-client.ts
+++ b/vscode-extension/src/gsd-client.ts
@@ -8,6 +8,7 @@ import type {
 	ModelInfo,
 	RpcSessionState,
 	RpcSlashCommand,
+	ProjectProgress,
 	SessionStats,
 	ThinkingLevel,
 } from "@opengsd/contracts" with { "resolution-mode": "import" };
@@ -17,7 +18,7 @@ import { buildGsdClientSpawnPlan } from "./gsd-client-spawn.js";
  * Mirrors the RPC command/response protocol from the GSD agent.
  * Shared command and response payloads come from @opengsd/contracts.
  */
-export type { BashResult, ModelInfo, SessionStats, ThinkingLevel };
+export type { BashResult, ModelInfo, ProjectProgress, SessionStats, ThinkingLevel };
 export type SlashCommand = RpcSlashCommand;
 
 export interface RpcResponse {
@@ -395,6 +396,12 @@ export class GsdClient implements vscode.Disposable {
 		const response = await this.send({ type: "get_session_stats" });
 		this.assertSuccess(response);
 		return response.data as SessionStats;
+	}
+
+	async getProjectProgress(): Promise<ProjectProgress | null> {
+		const response = await this.send({ type: "get_project_progress" });
+		this.assertSuccess(response);
+		return response.data as ProjectProgress | null;
 	}
 
 	/**

--- a/vscode-extension/src/sidebar.ts
+++ b/vscode-extension/src/sidebar.ts
@@ -2,7 +2,7 @@
 // File Purpose: VS Code sidebar webview provider for GSD agent controls and status.
 
 import * as vscode from "vscode";
-import type { GsdClient, SessionStats, ThinkingLevel } from "./gsd-client.js";
+import type { GsdClient, ProjectProgress, SessionStats, ThinkingLevel } from "./gsd-client.js";
 import {
 	getContextUsageDisplay,
 	getSessionCacheReadTokens,
@@ -33,6 +33,7 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 	private view?: vscode.WebviewView;
 	private disposables: vscode.Disposable[] = [];
 	private refreshTimer: ReturnType<typeof setInterval> | undefined;
+	private refreshInFlight: Promise<void> | undefined;
 
 	constructor(
 		private readonly extensionUri: vscode.Uri,
@@ -102,6 +103,9 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 					break;
 				case "sessionStats":
 					await vscode.commands.executeCommand("gsd.sessionStats");
+					break;
+				case "refreshProgress":
+					await this.refresh();
 					break;
 				case "listCommands":
 					await vscode.commands.executeCommand("gsd.listCommands");
@@ -191,6 +195,19 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 	}
 
 	async refresh(): Promise<void> {
+		if (this.refreshInFlight) {
+			return this.refreshInFlight;
+		}
+
+		this.refreshInFlight = this.refreshInternal();
+		try {
+			await this.refreshInFlight;
+		} finally {
+			this.refreshInFlight = undefined;
+		}
+	}
+
+	private async refreshInternal(): Promise<void> {
 		if (!this.view) {
 			return;
 		}
@@ -207,6 +224,8 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		let autoCompaction = false;
 		let autoRetry = false;
 		let stats: SessionStats | null = null;
+		let projectProgress: ProjectProgress | null = null;
+		let projectProgressError: string | null = null;
 		let steeringMode: "all" | "one-at-a-time" = "all";
 		let followUpMode: "all" | "one-at-a-time" = "all";
 
@@ -237,6 +256,12 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			} catch {
 				// Stats fetch failed
 			}
+
+			try {
+				projectProgress = await this.client.getProjectProgress();
+			} catch (error) {
+				projectProgressError = error instanceof Error ? error.message : "Project progress request failed";
+			}
 		}
 
 		const connected = this.client.isConnected;
@@ -255,6 +280,8 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			autoCompaction,
 			autoRetry,
 			stats,
+			projectProgress,
+			projectProgressError,
 			steeringMode,
 			followUpMode,
 		});
@@ -283,6 +310,8 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		autoCompaction: boolean;
 		autoRetry: boolean;
 		stats: SessionStats | null;
+		projectProgress: ProjectProgress | null;
+		projectProgressError: string | null;
 		steeringMode: "all" | "one-at-a-time";
 		followUpMode: "all" | "one-at-a-time";
 	}): string {
@@ -307,6 +336,10 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 
 		// Only show stats that have real data
 		const hasStats = hasSessionTokenStats(info.stats);
+		const projectProgressHtml = this.getProjectProgressHtml(
+			info.projectProgress,
+			info.projectProgressError,
+		);
 
 		const nonce = getNonce();
 
@@ -490,6 +523,20 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		.section-body {
 			padding: 6px 10px 8px;
 		}
+		.progress-current {
+			display: grid;
+			gap: 3px;
+			font-size: 11px;
+		}
+		.progress-title { font-weight: 600; }
+		.progress-meta { opacity: 0.65; }
+		.progress-next { margin-top: 4px; opacity: 0.8; }
+		.progress-empty { opacity: 0.65; font-size: 11px; }
+			.progress-tree { margin-top: 8px; max-height: 320px; overflow-y: auto; font-size: 11px; }
+			.progress-milestone { margin-top: 6px; }
+			.progress-slice { margin: 3px 0 0 10px; opacity: 0.85; }
+			.progress-task { margin: 2px 0 0 22px; opacity: 0.7; }
+			.progress-status { opacity: 0.65; }
 
 		/* ---- Stats grid ---- */
 		.stats-grid {
@@ -619,6 +666,7 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			totalTokens,
 			hasStats: !!hasStats,
 			statRows,
+			projectProgressHtml,
 			nonce,
 		}) : `
 	<div class="header">
@@ -683,6 +731,8 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			autoCompaction: boolean;
 			autoRetry: boolean;
 			stats: SessionStats | null;
+			projectProgress: ProjectProgress | null;
+			projectProgressError: string | null;
 			steeringMode: "all" | "one-at-a-time";
 			followUpMode: "all" | "one-at-a-time";
 		},
@@ -695,6 +745,7 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			totalTokens: number;
 			hasStats: boolean;
 			statRows: string;
+			projectProgressHtml: string;
 			nonce: string;
 		},
 	): string {
@@ -735,6 +786,8 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		<button class="streaming-abort" data-command="abort">Stop</button>
 	</div>
 	` : ""}
+
+	${ui.projectProgressHtml}
 
 	<!-- Workflow -->
 	<div class="section" data-section="workflow">
@@ -801,6 +854,45 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 				<span class="toggle-label">Approval</span>
 				<span class="toggle-pill on" data-command="selectApprovalMode">change</span>
 			</div>
+		</div>
+	</div>`;
+	}
+
+	private getProjectProgressHtml(
+		progress: ProjectProgress | null,
+		errorMessage: string | null,
+	): string {
+		let body = "<div class=\"progress-empty\">No project progress available.</div>";
+		if (errorMessage) {
+			const isUnsupported = errorMessage.startsWith("Unknown command:");
+			body = `<div class="progress-empty">${isUnsupported ? "Unsupported GSD runtime." : "Project progress unavailable."}</div>`;
+		} else if (progress) {
+			const current = progress.activeTask?.title
+				?? progress.activeSlice?.title
+				?? progress.activeMilestone?.title
+				?? "No active work";
+			const counts = `${progress.tasks.done}/${progress.tasks.total} tasks done / ${progress.slices.done}/${progress.slices.total} slices done`;
+			body = `
+			<div class="progress-current">
+				<span class="progress-title">${escapeHtml(current)}</span>
+				<span class="progress-meta">${escapeHtml(progress.phase)} / ${escapeHtml(counts)}</span>
+				${progress.nextAction ? `<span class="progress-next">Next: ${escapeHtml(progress.nextAction)}</span>` : ""}
+			</div>`;
+						body += `<div class="progress-tree">${(progress.milestoneDetails ?? []).map((milestone) => `
+						<div class="progress-milestone"><span class="progress-status">${escapeHtml(milestone.status)}</span> <strong>${escapeHtml(milestone.id)} ${escapeHtml(milestone.title)}</strong>${milestone.truncated ? " ..." : ""}</div>
+						${milestone.slices.map((slice) => `
+						<div class="progress-slice"><span class="progress-status">${escapeHtml(slice.status)}</span> ${escapeHtml(slice.id)} ${escapeHtml(slice.title)}${slice.truncated ? " ..." : ""}</div>
+						${slice.tasks.map((task) => `<div class="progress-task"><span class="progress-status">${escapeHtml(task.status)}</span> ${escapeHtml(task.id)} ${escapeHtml(task.title)}</div>`).join("")}
+						`).join("")}
+						`).join("")}${progress.milestoneDetailsTruncated ? "<div class=\"progress-empty\">More milestones available.</div>" : ""}</div>`;
+		}
+
+		return `
+	<div class="section collapsed" data-section="project-progress">
+		<div class="section-header"><span class="chevron">&#9660;</span> Project Progress</div>
+		<div class="section-body">
+			${body}
+			<button class="action-btn" data-command="refreshProgress" style="margin-top:6px;width:100%">Refresh</button>
 		</div>
 	</div>`;
 	}

--- a/vscode-extension/src/sidebar.ts
+++ b/vscode-extension/src/sidebar.ts
@@ -34,13 +34,15 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 	private disposables: vscode.Disposable[] = [];
 	private refreshTimer: ReturnType<typeof setInterval> | undefined;
 	private refreshInFlight: Promise<void> | undefined;
+	private projectProgress: ProjectProgress | null = null;
+	private projectProgressError: string | null = null;
 
 	constructor(
 		private readonly extensionUri: vscode.Uri,
 		private readonly client: GsdClient,
 	) {
 		this.disposables.push(
-			client.onConnectionChange(() => this.refresh()),
+			client.onConnectionChange(() => this.refresh(true)),
 			client.onEvent((evt) => {
 				switch (evt.type) {
 					case "agent_start":
@@ -105,7 +107,7 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 					await vscode.commands.executeCommand("gsd.sessionStats");
 					break;
 				case "refreshProgress":
-					await this.refresh();
+					await this.refresh(true);
 					break;
 				case "listCommands":
 					await vscode.commands.executeCommand("gsd.listCommands");
@@ -191,15 +193,15 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			}
 		}, 10_000);
 
-		this.refresh();
+		this.refresh(true);
 	}
 
-	async refresh(): Promise<void> {
+	async refresh(refreshProjectProgress = false): Promise<void> {
 		if (this.refreshInFlight) {
 			return this.refreshInFlight;
 		}
 
-		this.refreshInFlight = this.refreshInternal();
+		this.refreshInFlight = this.refreshInternal(refreshProjectProgress);
 		try {
 			await this.refreshInFlight;
 		} finally {
@@ -207,7 +209,7 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		}
 	}
 
-	private async refreshInternal(): Promise<void> {
+	private async refreshInternal(refreshProjectProgress: boolean): Promise<void> {
 		if (!this.view) {
 			return;
 		}
@@ -224,8 +226,6 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		let autoCompaction = false;
 		let autoRetry = false;
 		let stats: SessionStats | null = null;
-		let projectProgress: ProjectProgress | null = null;
-		let projectProgressError: string | null = null;
 		let steeringMode: "all" | "one-at-a-time" = "all";
 		let followUpMode: "all" | "one-at-a-time" = "all";
 
@@ -257,10 +257,14 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 				// Stats fetch failed
 			}
 
-			try {
-				projectProgress = await this.client.getProjectProgress();
-			} catch (error) {
-				projectProgressError = error instanceof Error ? error.message : "Project progress request failed";
+			if (refreshProjectProgress) {
+				try {
+					this.projectProgress = await this.client.getProjectProgress();
+					this.projectProgressError = null;
+				} catch (error) {
+					this.projectProgress = null;
+					this.projectProgressError = error instanceof Error ? error.message : "Project progress request failed";
+				}
 			}
 		}
 
@@ -280,8 +284,8 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			autoCompaction,
 			autoRetry,
 			stats,
-			projectProgress,
-			projectProgressError,
+			projectProgress: this.projectProgress,
+			projectProgressError: this.projectProgressError,
 			steeringMode,
 			followUpMode,
 		});
@@ -685,10 +689,14 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		const vscode = acquireVsCodeApi();
 		const stored = vscode.getState() || {};
 
-		// Restore collapsed state
+		// Restore persisted section state after each WebView rerender.
 		document.querySelectorAll('.section').forEach(s => {
 			const id = s.dataset.section;
-			if (id && stored[id] === 'collapsed') s.classList.add('collapsed');
+			if (id && stored[id] === 'collapsed') {
+				s.classList.add('collapsed');
+			} else if (id && stored[id] === 'open') {
+				s.classList.remove('collapsed');
+			}
 		});
 
 		document.addEventListener('click', (e) => {
@@ -884,7 +892,7 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 						<div class="progress-slice"><span class="progress-status">${escapeHtml(slice.status)}</span> ${escapeHtml(slice.id)} ${escapeHtml(slice.title)}${slice.truncated ? " ..." : ""}</div>
 						${slice.tasks.map((task) => `<div class="progress-task"><span class="progress-status">${escapeHtml(task.status)}</span> ${escapeHtml(task.id)} ${escapeHtml(task.title)}</div>`).join("")}
 						`).join("")}
-						`).join("")}${progress.milestoneDetailsTruncated ? "<div class=\"progress-empty\">More milestones available.</div>" : ""}</div>`;
+						`).join("")}${progress.milestoneDetailsTruncated ? "<div class=\"progress-empty\">More milestones available.</div>" : ""}${progress.milestoneDetailsTasksTruncated ? "<div class=\"progress-empty\">More tasks available.</div>" : ""}</div>`;
 		}
 
 		return `

--- a/vscode-extension/test/manifest.test.ts
+++ b/vscode-extension/test/manifest.test.ts
@@ -109,6 +109,9 @@ test("project progress uses the existing RPC client and one sidebar refresh loop
 	assert.match(sidebarSource, /progress\.milestoneDetails \?\? \[\]\)\.map/);
 	assert.match(sidebarSource, /milestone\.slices\.map/);
 	assert.match(sidebarSource, /slice\.tasks\.map/);
+	assert.match(sidebarSource, /progress\.milestoneDetailsTasksTruncated/);
+	assert.match(sidebarSource, /this\.refresh\(true\)/);
+	assert.match(sidebarSource, /stored\[id\] === 'open'/);
 	assert.equal((sidebarSource.match(/setInterval\(/g) ?? []).length, 1);
 });
 

--- a/vscode-extension/test/manifest.test.ts
+++ b/vscode-extension/test/manifest.test.ts
@@ -33,6 +33,10 @@ function readPackage(): {
 	return JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
 }
 
+function readSource(fileName: string): string {
+	return readFileSync(join(root, "src", fileName), "utf8");
+}
+
 test("manifest contributes unique executable commands with titles", () => {
 	const pkg = readPackage();
 	const contributed = pkg.contributes.commands.map((entry) => entry.command);
@@ -87,6 +91,25 @@ test("checkpoint view is contributed in the extension manifest", () => {
 
 	assert.ok(pkg.contributes.views.gsd.some((view) => view.id === "gsd-checkpoints"));
 	assert.ok(pkg.contributes.commands.some((entry) => entry.command === "gsd.restoreCheckpoint"));
+});
+
+test("project progress uses the existing RPC client and one sidebar refresh loop", () => {
+	const clientSource = readSource("gsd-client.ts");
+	const sidebarSource = readSource("sidebar.ts");
+
+	assert.match(clientSource, /type: "get_project_progress"/);
+	assert.match(clientSource, /async getProjectProgress\(\): Promise<ProjectProgress \| null>/);
+	assert.match(sidebarSource, /case "refreshProgress":/);
+	assert.match(sidebarSource, /this\.client\.getProjectProgress\(\)/);
+	assert.match(sidebarSource, /data-section="project-progress"/);
+	assert.match(sidebarSource, /class="section collapsed" data-section="project-progress"/);
+	assert.match(sidebarSource, /Project progress unavailable/);
+	assert.match(sidebarSource, /escapeHtml\(current\)/);
+	assert.match(sidebarSource, /escapeHtml\(progress\.nextAction\)/);
+	assert.match(sidebarSource, /progress\.milestoneDetails \?\? \[\]\)\.map/);
+	assert.match(sidebarSource, /milestone\.slices\.map/);
+	assert.match(sidebarSource, /slice\.tasks\.map/);
+	assert.equal((sidebarSource.match(/setInterval\(/g) ?? []).length, 1);
 });
 
 test("agent git helpers scope git output to tracked agent files", () => {


### PR DESCRIPTION
Closes #2136

## Umbrella and traceability

This PR is the focused consumer step in the umbrella roadmap [#2099](https://github.com/open-gsd/gsd-pi/issues/2099):

```mermaid
flowchart LR
  A[#2099 consumer-led integration] --> B[#2105 DB-authoritative ProgressResult]
  B --> C[#2136 VS Code consumer]
  C --> D[#2143 this draft PR]
  C --> E{Named consumer fields still missing?}
  E -->|yes, broader aggregate| F[#2102 conditional snapshot]
  E -->|no| G[Keep ProgressResult baseline]
```

The original #2099 plan contains broader architectural evidence for `gsd_project_snapshot` across MCP hosts, IDEs, messaging adapters, profiles, events, resources, verification context, open questions, and authority metadata. That is a credible roadmap, but #2102 remains separate maintainer-owned, demand-gated scope. This PR records the concrete VS Code consumer evidence without silently implementing the full snapshot.

## TL;DR

**What:** Expose DB-authoritative GSD project progress through the existing VS Code RPC process and render milestones, slices, and tasks in the sidebar.

**Why:** Session state existed over RPC, but users could not inspect actual project milestones and steps without reading projection files or starting another process.

**How:** A host-only runtime-read capability delegates to the existing DB reader; additive `get_project_progress` RPC carries bounded, ordered details; the existing sidebar renders them with safe states and escaping.

## Implementation

- Added host-only `project_progress` runtime-read capability, not an LLM tool.
- Added additive RPC contract, server dispatch, built-in/public/VS Code client wrappers.
- Forwarded active session CWD and preserved request correlation on reader failures.
- Reused `readProgressFromDb()` and the DB-authoritative path. No `STATE.md` parsing, copied SQL, projection fallback, second child process, new MCP tool, or CLI surface.
- Added SQL-bounded milestone -> slice -> task details with SQLite-safe batches, deterministic ordering, and truncation flags.
- Added collapsed sidebar hierarchy rendering with legacy-response compatibility and escaped dynamic values.
- Updated ecosystem API delegation and bootstrap mocks for the additive API.

```mermaid
flowchart TD
  V[VS Code sidebar] --> R[Long-lived GSD RPC]
  R --> P[get_project_progress]
  P --> Q[DB-authoritative reader]
  Q --> M[Milestones <= 50]
  M --> S[Slices <= 50 per milestone]
  S --> T[Tasks <= 50 per slice]
  M --> X[truncated flags]
  S --> X
```

## Verification

### Local focused validation

- DB progress suite: **8/8 passed**
- Project-progress RPC tests: **2/2 passed**
- RPC protocol suite: **63/63 passed**
- Extension-runner tests: **30/30 passed**
- VS Code source-contract suite: **14/14 passed**
- VS Code extension TypeScript build: passed with local extension dependencies
- `pnpm run verify:fast`: passed, including strict matrix, package-boundary checks, and actionlint
- Fresh Edelman_Studio RPC probe: returned real DB data with **16 milestones** and nested slices/tasks
- Patched fork `build:core`: passed; fresh runtime returned `1.17.0`

### Independent review

Codex CLI performed multiple read-only reviews, including review of the CI regression fix and the bounded hierarchy implementation. Final verdict: **PASS_WITH_GAPS**, no blockers and no file changes. Remaining non-blocking gaps are no Extension Development Host harness, no stress fixtures for hierarchy boundaries, and no full DB-to-Extension Development Host integration test.

### Clean-runner verification

- Workflow: [sharded CI run 33794759473](https://github.com/pimmink/gsd-pi-ci/actions/runs/33794759473)
- Exact SHA: `00aa69a77aba0112819756c676b1c5d47bf20695`
- Build: passed
- Lifecycle shadow gate: passed
- All four test shards: passed
- Fail-closed aggregate: passed
- **Final totals: 14758 passed, 0 failed, 31 skipped**

## Known limitations

- Multi-root workspaces use the first workspace folder; aggregation is intentionally not inferred.
- Hierarchy output is bounded and reports truncation.
- Extension Development Host runtime coverage is not configured in this checkout.

## Related work

- Umbrella roadmap: [#2099](https://github.com/open-gsd/gsd-pi/issues/2099)
- DB-authoritative foundation: [#2105](https://github.com/open-gsd/gsd-pi/pull/2105)
- Focused consumer issue: [#2136](https://github.com/open-gsd/gsd-pi/issues/2136)
- Conditional broader aggregate: [#2102](https://github.com/open-gsd/gsd-pi/issues/2102)

## AI disclosure

This PR includes AI-assisted implementation and review support. All submitted changes were reviewed, locally verified, and tested by the contributor; Codex CLI also performed independent read-only reviews.