### PR TITLE
fix(gsd): keep blank lines truly empty in pushIndented PLAN.md output

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -234,7 +234,10 @@ function renderGateFindings(gate: GateRow): string {
 
 function pushIndented(lines: string[], value: string, indent = "  "): void {
   for (const line of value.split("\n")) {
-    lines.push(`${indent}${line}`);
+    // Blank (empty or whitespace-only, incl. a stray \r from CRLF input) lines
+    // stay truly empty — indent-only lines are trailing whitespace that fails
+    // git's whitespace checks (#2128).
+    lines.push(line.trim() ? `${indent}${line}` : "");
   }
 }
 

--- a/src/resources/extensions/gsd/tests/markdown-renderer-whitespace.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer-whitespace.test.ts
@@ -1,0 +1,82 @@
+// Project/App: gsd-pi
+// File Purpose: Regression test for #2128 — pushIndented must not emit
+// indent-only (trailing whitespace) lines for blank description lines.
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { renderPlanFromDb } from "../markdown-renderer.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask } from "../gsd-db.ts";
+
+const tmpDirs: string[] = [];
+function makeTmp(descriptionLines: string[] = [
+  "First paragraph of the task.",
+  "",
+  "Second paragraph of the task.",
+]): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-ws-${randomUUID()}`));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  insertSlice({
+    milestoneId: "M001", id: "S01", title: "Set up tooling", status: "pending",
+    risk: "low", depends: [], demo: "build runs", sequence: 1,
+  });
+  insertTask({
+    milestoneId: "M001", sliceId: "S01", id: "T01", title: "Init repo",
+    status: "pending", sequence: 1,
+    planning: {
+      description: descriptionLines.join("\n"),
+    },
+  });
+  tmpDirs.push(base);
+  return base;
+}
+
+describe("markdown-renderer whitespace (#2128)", () => {
+  afterEach(() => {
+    closeDatabase();
+    for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* */ } }
+    tmpDirs.length = 0;
+  });
+
+  test("plan <tasks> block keeps blank description lines truly empty", async () => {
+    const base = makeTmp();
+    const result = await renderPlanFromDb(base, "M001", "S01");
+    const lines = result.content.split("\n");
+
+    const whitespaceOnly = lines.filter((line) => /^\s+$/.test(line));
+    assert.deepEqual(whitespaceOnly, [], "no rendered line may be whitespace-only");
+
+    const first = lines.indexOf("  First paragraph of the task.");
+    const second = lines.indexOf("  Second paragraph of the task.");
+    assert.notEqual(first, -1, "indented first paragraph must survive");
+    assert.notEqual(second, -1, "indented second paragraph must survive");
+    assert.equal(second - first, 2, "exactly one blank separator line between paragraphs");
+    assert.equal(lines[first + 1], "", "paragraph-break line must be empty, not indent-only");
+  });
+
+  test("whitespace-only and CRLF blank separators render truly empty", async () => {
+    const base = makeTmp([
+      "Para A.",
+      "   ",
+      "\r",
+      "Para B.",
+    ]);
+    const result = await renderPlanFromDb(base, "M001", "S01");
+    const lines = result.content.split("\n");
+
+    const whitespaceOnly = lines.filter((line) => /^\s+$/.test(line));
+    assert.deepEqual(whitespaceOnly, [], "space-only and \\r-only separators must not emit trailing whitespace");
+
+    const first = lines.indexOf("  Para A.");
+    const second = lines.indexOf("  Para B.");
+    assert.notEqual(first, -1, "indented Para A must survive");
+    assert.notEqual(second, -1, "indented Para B must survive");
+    assert.equal(second - first, 3, "two blank separators between the paragraphs");
+    assert.deepEqual(lines.slice(first + 1, second), ["", ""], "every separator line must be truly empty");
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** `pushIndented` no longer emits indent-only (trailing-whitespace) lines for blank description separators in rendered flat-phase `PLAN.md`.
**Why:** Blank paragraph-break lines in task descriptions rendered as `"  "`, tripping git's whitespace check (#2128).
**How:** Blank lines — empty, whitespace-only, or a stray `\r` from CRLF input — pass through un-indented via a `line.trim()` guard; a DB-backed regression test pins the rendered bytes.

## What

- `src/resources/extensions/gsd/markdown-renderer.ts` — `pushIndented` keeps empty, whitespace-only, and stray-CR separator lines truly empty. Non-blank lines are byte-identical to before. Sole caller: `renderSlicePlanMarkdown`'s `<tasks>` block.
- `src/resources/extensions/gsd/tests/markdown-renderer-whitespace.test.ts` (new) — regression coverage through the public `renderPlanFromDb` path for paragraph breaks, whitespace-only separators, and CRLF-derived blank lines.

## Why

`pushIndented` indented every line of `value.split("\n")` unconditionally, so interior blank lines in task descriptions rendered as trailing whitespace in the flat-phase `<tasks>` block and failed `git diff --check`.

Closes #2128

## How

One-line change at the emission point — the cause — not a post-hoc trim of rendered output. A codex second-opinion review flagged whitespace-only and CRLF blank separators as the same failure class; both are folded into the same guard. Stripping `\r` from non-blank text lines was considered and ruled out of scope.

Reviewer note: existing `PLAN.md` files that contain the old indent-only blank lines will flag a one-time content drift and be re-rendered clean by the existing stale-render repair — expected self-healing, not a regression.

> This PR is AI-assisted.

## Testing

After repairing the isolated worktree’s missing dependencies, targeted renderer tests passed, old-behavior sabotage failed for the intended reason, and a real DB-rendered PLAN.md demonstrated clean separator bytes and no Git whitespace errors. Generated dependencies and caches were removed, leaving the worktree clean; the Markdown artifact is the direct end-user output, so no UI screenshot applies.

<details>
<summary>Evidence: Generated flat-phase PLAN.md</summary>

```text
# S01: Render PLAN

**Milestone:** M001
**Slice:** S01

**Goal:** Render task descriptions without whitespace-only separator lines.
**Demo:** PLAN has clean blank lines

## Must-Haves

- Complete the planned slice outcomes.

## Verification

- Run the task and slice verification checks for this slice.

<tasks>
- [ ] **T01**: Preserve description
  First paragraph.



    Nested detail.
  Second paragraph.
</tasks>
<!-- gsd:state-version=0:0 -->
```
</details>
<details>
<summary>Evidence: Public-render and Git whitespace verification</summary>

```text
{
  "publicInterface": "renderPlanFromDb",
  "generatedPlanPath": "/Users/jeremymcspadden/.no-mistakes/evidence/01M1N65BP7EHZNWK4Q4WDKKZTK/issue-2128-clean-CErMHN/.gsd/phases/01-whitespace-evidence/01-01-PLAN.md",
  "inputSeparatorKinds": [
    "empty",
    "spaces-only",
    "stray-CR from CRLF"
  ],
  "whitespaceOnlyLines": [],
  "expectedLinesBetweenParagraphs": [
    "",
    "",
    "",
    "    Nested detail."
  ],
  "actualLinesBetweenParagraphs": [
    "",
    "",
    "",
    "    Nested detail."
  ],
  "nonBlankIndentedLinePreservedExactly": true,
  "gitWhitespaceCheck": {
    "command": "git diff --no-index --check -- /dev/null /Users/jeremymcspadden/.no-mistakes/evidence/01M1N65BP7EHZNWK4Q4WDKKZTK/issue-2128-clean-CErMHN/.gsd/phases/01-whitespace-evidence/01-01-PLAN.md",
    "exitStatus": 1,
    "note": "git diff --no-index returns 1 for a clean non-empty added file; whitespace errors return 3 and emit diagnostics",
    "diagnostics": "",
    "passed": true
  },
  "passed": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"dcb1ed76e4aac2cdbc4d1e8ec1febccc7bc51602","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git merge-base --is-ancestor dcb1ed76e4aac2cdbc4d1e8ec1febccc7bc51602 origin/main` and worktree-status preflight</code>
- <code>`pnpm install --frozen-lockfile --ignore-scripts` to repair the initially missing test dependencies</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/markdown-renderer-whitespace.test.ts`
- `Temporarily restored unconditional indentation and reran the focused test; both cases failed on whitespace-only output, then restored the committed guard`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/markdown-renderer-whitespace.test.ts src/resources/extensions/gsd/tests/flat-phase-renderer.test.ts`
- <code>Generated a DB-backed flat-phase PLAN.md through public `renderPlanFromDb` using empty, spaces-only, and stray-CR separators</code>
- `git diff --no-index --check -- /dev/null <generated 01-01-PLAN.md>`
- `git diff --check e34e7d7d0ef27a0381d7f16619fee5a4e4a78171..dcb1ed76e4aac2cdbc4d1e8ec1febccc7bc51602`
- `Removed generated dependency/cache directories and confirmed the worktree matches the target commit`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

