### PR TITLE
fix(gsd): stop doctor env_git_remote false 'unreachable' on healthy repos

### DIFF
--- a/src/resources/extensions/gsd/doctor-environment.ts
+++ b/src/resources/extensions/gsd/doctor-environment.ts
@@ -442,7 +442,7 @@ function checkGitRemote(basePath: string): EnvironmentCheckResult | null {
   if (!remote) return null;
 
   // Quick connectivity check with short timeout
-  const result = tryExec("git ls-remote --exit-code -h origin HEAD", basePath);
+  const result = tryExec("git ls-remote --exit-code origin HEAD", basePath);
   if (result === null) {
     return {
       name: "git_remote",

--- a/src/resources/extensions/gsd/tests/integration/doctor-environment.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-environment.test.ts
@@ -2,17 +2,6 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 /**
  * doctor-environment.test.ts — Tests for environment health checks (#1221).
- *
- * Tests:
- *   - Node version detection
- *   - Dependencies installed check
- *   - Env file detection
- *   - Port conflict detection
- *   - Disk space check
- *   - Docker detection
- *   - Project tool detection
- *   - Doctor issue conversion
- *   - Report formatting
  */
 
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
@@ -367,8 +356,6 @@ describe('doctor-environment', async () => {
 
     // ── Full environment checks include git remote ─────────────────────
     test('env: runFullEnvironmentChecks includes git remote', () => {
-      // runFullEnvironmentChecks adds git remote check
-      // We can't easily test this without a real git repo, but verify it doesn't throw
       const dir = createProjectDir();
       cleanups.push(dir);
       const results = runFullEnvironmentChecks(dir);

--- a/src/resources/extensions/gsd/tests/integration/doctor-environment.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-environment.test.ts
@@ -16,6 +16,7 @@ import assert from 'node:assert/strict';
  */
 
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -400,4 +401,34 @@ describe('doctor-environment', async () => {
       try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
     }
   }
+});
+
+// ── Git Remote Check: healthy repo reports ok (#2129) ──────────────────────
+test('env: git_remote reports ok on a healthy repo with origin (#2129)', (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-env-git-remote-"));
+  t.after(() => { rmSync(base, { recursive: true, force: true }); });
+
+  const git = (cwd: string, ...args: string[]): void => {
+    execFileSync("git", args, { cwd, stdio: "pipe" });
+  };
+
+  // Local project repo plus a local bare "origin" — no network needed.
+  const project = join(base, "project");
+  const origin = join(base, "origin.git");
+  mkdirSync(project);
+  git(project, "init", "-b", "main");
+  git(project, "config", "user.email", "test@test.com");
+  git(project, "config", "user.name", "Test");
+  writeFileSync(join(project, "README.md"), "# init\n");
+  git(project, "add", "-A");
+  // -c commit.gpgsign=false keeps the fixture hermetic against global git config.
+  git(project, "-c", "commit.gpgsign=false", "commit", "-m", "init");
+  git(base, "init", "--bare", "-b", "main", origin);
+  git(project, "remote", "add", "origin", origin);
+  git(project, "push", "origin", "main");
+
+  const results = runFullEnvironmentChecks(project);
+  const remoteCheck = results.find(r => r.name === "git_remote");
+  assert.ok(remoteCheck, "git remote check runs when origin exists");
+  assert.equal(remoteCheck!.status, "ok", "healthy origin is reachable");
 });


### PR DESCRIPTION
## TL;DR

**What:** The doctor `env_git_remote` probe drops `-h` from `git ls-remote --exit-code origin HEAD`.
**Why:** `-h` restricts the listing to `refs/heads/*`, so the `HEAD` refspec never matches and `--exit-code` exits 2 on fully healthy repos — every repo warned "unreachable" (#2129).
**How:** Remove `-h` so the probe resolves `HEAD` (exit 0 when healthy); unreachable remotes still warn. Regression test wires a fully local bare repo as `origin` and asserts status `ok`.

## What

- `src/resources/extensions/gsd/doctor-environment.ts` — `checkGitRemote` now runs `git ls-remote --exit-code origin HEAD`. `tryExec` semantics unchanged: any non-zero exit still yields the "unreachable" warning.
- `src/resources/extensions/gsd/tests/integration/doctor-environment.test.ts` — new regression test: local project repo + local bare `origin.git` (no network), asserts `git_remote` status `ok`.

## Why

`git ls-remote --exit-code -h origin HEAD` exits 2 on every healthy repo because `-h` filters the symbolic `HEAD` refspec out of the listing, so the doctor's reachability check false-alarmed unconditionally. Dropping `-h` makes exit 0 the healthy-repo outcome while preserving the warning for genuinely unreachable remotes.

Closes #2129

## How

One deleted flag at the probe site — the cause — with no exit-code disambiguation added (the issue scopes that as separate follow-up hardening, e.g. distinguishing an empty remote from a network failure). Codex second-opinion review found no correctness bugs; its hermeticity finding was accepted: the fixture's commit passes `-c commit.gpgsign=false` so global git config can't break it.

> This PR is AI-assisted.

## Testing

The author-supplied baseline reported the doctor suite, build, and fast verification passing; this phase independently passed the focused 18-test doctor environment suite, proved the regression catches the old `-h` behavior, and captured direct CLI evidence that a healthy local origin reports reachable with zero false remote warnings. This is a CLI change, so a text transcript is the appropriate reviewer-visible artifact.

<details>
<summary>Evidence: Healthy local-origin doctor transcript</summary>

<code>$ git ls-remote --exit-code -h origin HEAD&#10;exit: 2&#10;&#10;$ git ls-remote --exit-code origin HEAD&#10;fdff7f48a1ca918d2fb0338dd916baa595cdeabb HEAD&#10;exit: 0&#10;&#10;$ /gsd doctor environment result&#10;Environment Health:&#10;✅ Git remote reachable&#10;env_git_remote warnings emitted: 0</code>

```text
$ git ls-remote --exit-code -h origin HEAD
exit: 2

$ git ls-remote --exit-code origin HEAD
fdff7f48a1ca918d2fb0338dd916baa595cdeabb	HEAD
exit: 0

$ /gsd doctor environment result
Environment Health:
  ✅ Git remote reachable
env_git_remote warnings emitted: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"914b70a99a5a08e9e0f3370991659a78b279c001","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-timeout=180000 src/resources/extensions/gsd/tests/integration/doctor-environment.test.ts`
- <code>Temporarily restored `git ls-remote --exit-code -h origin HEAD` and ran `--test-name-pattern=&#39;git_remote reports ok&#39;`; it failed for the expected reason, then the source was restored.</code>
- <code>Re-ran `--test-name-pattern=&#39;git_remote reports ok&#39;` after restoration; it passed.</code>
- <code>Created a local project and bare origin, pushed `main`, compared both Git probes, and executed `runFullEnvironmentChecks`, `checkEnvironmentHealth`, and `formatEnvironmentReport` to capture the CLI transcript.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

