### PR TITLE
fix(gsd): drop unfixable compat-marker keys instead of quarantining the marker

### DIFF
--- a/src/resources/extensions/gsd/compat/compat-marker.ts
+++ b/src/resources/extensions/gsd/compat/compat-marker.ts
@@ -194,6 +194,9 @@ export function recordCompatProjectionWrite(
   entities: string[],
 ): void {
   const projectionPath = deriveCompatProjectionKey(filePath, [join(basePath, ".gsd")]);
+  // An unsafe derived key (target resolving outside .gsd/) must never enter
+  // the marker: one poisoned key invalidates the whole marker on read (#2130).
+  if (!isSafeProjectionKey(projectionPath)) return;
   const marker = readCompatMarker(basePath);
   marker.projections[projectionPath] = {
     sha: computeProjectionSha(content),
@@ -301,9 +304,16 @@ function healProjectionMapKeys(
 
   for (const key of Object.keys(map)) {
     if (isSafeProjectionKey(key)) continue;
-    if (key.includes("\0") || isAbsolute(key) || /^[A-Za-z]:/.test(key)) continue;
-    const healedKey = rootRelativeKey(root, resolve(root, key));
-    if (!healedKey || !isSafeProjectionKey(healedKey)) continue;
+    // Unfixable key — control chars/absolute/drive-letter, or still escaping
+    // after canonicalization: drop it instead of leaving it in place, where it
+    // would invalidate the whole marker on every subsequent read (#2130).
+    const unfixable = key.includes("\0") || isAbsolute(key) || /^[A-Za-z]:/.test(key);
+    const healedKey = unfixable ? null : rootRelativeKey(root, resolve(root, key));
+    if (!healedKey || !isSafeProjectionKey(healedKey)) {
+      delete map[key];
+      changed = true;
+      continue;
+    }
 
     if (!map[healedKey]) {
       map[healedKey] = map[key]!;

--- a/src/resources/extensions/gsd/compat/compat-marker.ts
+++ b/src/resources/extensions/gsd/compat/compat-marker.ts
@@ -194,8 +194,8 @@ export function recordCompatProjectionWrite(
   entities: string[],
 ): void {
   const projectionPath = deriveCompatProjectionKey(filePath, [join(basePath, ".gsd")]);
-  // An unsafe derived key (target resolving outside .gsd/) must never enter
-  // the marker: one poisoned key invalidates the whole marker on read (#2130).
+  // Projection keys are resolved under .gsd; never persist one that escapes
+  // that root.
   if (!isSafeProjectionKey(projectionPath)) return;
   const marker = readCompatMarker(basePath);
   marker.projections[projectionPath] = {

--- a/src/resources/extensions/gsd/tests/compat-marker.test.ts
+++ b/src/resources/extensions/gsd/tests/compat-marker.test.ts
@@ -2,7 +2,7 @@
 // File Purpose: Unit tests for the gsd-core compat marker (`.gsd/.compat.json`).
 import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -10,6 +10,7 @@ import { randomUUID } from "node:crypto";
 import {
   readCompatMarker,
   writeCompatMarker,
+  recordCompatProjectionWrite,
   normalizeForHash,
   computeProjectionSha,
   pruneOrphanedProjectionEntries,
@@ -17,6 +18,7 @@ import {
   compatMarkerPath,
 } from "../compat/compat-marker.ts";
 import { externalMarkdownEditHandler } from "../state-reconciliation/drift/external-markdown-edit.ts";
+import { isSafeProjectionKey } from "../compat/compat-marker-validation.ts";
 import type { DriftContext } from "../state-reconciliation/types.ts";
 import type { GSDState } from "../types.ts";
 
@@ -192,12 +194,13 @@ test("pruneOrphanedProjectionEntries returns 0 and writes nothing when marker is
   assert.ok(!files.includes(".compat.json"), "must not create a marker where none existed");
 });
 
-// --- Path-traversal containment (plan 029) ---------------------------------
+// --- Path-traversal containment (plan 029, refined by #2130) ----------------
 //
 // The marker is repo-controlled content whose projection-map keys are joined
-// with basePath and readFileSync'd by the drift detectors. A key that escapes
-// .gsd/ must invalidate the whole marker so readCompatMarker fails safe to the
-// empty marker (detectors see no entries → nothing outside the repo is read).
+// with basePath and readFileSync'd by the drift detectors. Keys that escape
+// .gsd/ are never stored (record-time guard) and are dropped at read time by
+// the heal pass, so one poisoned key can no longer quarantine every stored
+// baseline.
 
 for (const badKey of ["../outside.md", "/etc/hosts", "C:/x.md", "..\\x.md"]) {
   test(`readCompatMarker rejects a projection key that escapes the root: ${JSON.stringify(badKey)}`, () => {
@@ -267,7 +270,75 @@ test("readCompatMarker heals invalid keys that canonicalize back under .gsd", ()
   );
 });
 
-test("an escaping key in planning.passthrough also invalidates the whole marker", () => {
+test("recordCompatProjectionWrite skips entries whose derived key escapes .gsd (#2130)", () => {
+  const base = makeTmpBase();
+  // Pre-existing safe baseline that must survive the unsafe write.
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-07-07T00:00:00.000Z",
+    projections: { "roadmap.md": { sha: "aaaaaaaaaaaaaaaa", entities: ["M001"] } },
+    planning: { active: false, layout: null, projections: {}, passthrough: {} },
+    piVersion: "1.8.1",
+  });
+  // Real escape path: the file resolves OUTSIDE .gsd/, so rootRelativeKey
+  // returns null and deriveCompatProjectionKey's fallback yields a
+  // ../-prefixed key.
+  const outside = join(base, "outside.md");
+  writeFileSync(outside, "# outside\n", "utf-8");
+  recordCompatProjectionWrite(base, outside, "# outside\n", []);
+
+  // Assert the RAW on-disk bytes BEFORE any read: readCompatMarker's heal
+  // rewrites the file, which would mask a regression of the write guard.
+  const raw = JSON.parse(readFileSync(compatMarkerPath(base), "utf-8")) as {
+    projections: Record<string, unknown>;
+  };
+  assert.equal(
+    Object.keys(raw.projections).some((k) => !isSafeProjectionKey(k)),
+    false,
+    "raw marker on disk must contain no unsafe keys (write guard, independent of heal)",
+  );
+
+  const marker = readCompatMarker(base);
+  assert.equal(marker.projections["../outside.md"], undefined, "unsafe key must never enter the marker");
+  assert.ok(marker.projections["roadmap.md"], "pre-existing baseline must survive (no quarantine)");
+  assert.ok(
+    !readdirSync(join(base, ".gsd")).some((f: string) => f.startsWith(".compat.json.bad-")),
+    "an unsafe record must not quarantine the marker",
+  );
+});
+
+test("readCompatMarker drops an unfixable ../ key and keeps the remaining baselines (#2130)", () => {
+  const base = makeTmpBase();
+  writeCompatMarker(base, {
+    schema: 2,
+    lastWriter: "gsd-pi",
+    lastProjectedAt: "2026-07-07T00:00:00.000Z",
+    projections: {
+      "roadmap.md": { sha: "aaaaaaaaaaaaaaaa", entities: ["M001"] },
+      "../outside.md": { sha: "deadbeefdeadbeef", entities: ["m1"] },
+    },
+    planning: { active: false, layout: null, projections: {}, passthrough: {} },
+    piVersion: "1.8.1",
+  });
+
+  const marker = readCompatMarker(base);
+  assert.ok(marker.projections["roadmap.md"], "safe baseline must survive the heal");
+  assert.equal(marker.projections["../outside.md"], undefined, "unfixable key must be dropped");
+  assert.ok(
+    !readdirSync(join(base, ".gsd")).some((f: string) => f.startsWith(".compat.json.bad-")),
+    "a single poisoned key must not quarantine the whole marker",
+  );
+  // The heal must persist: readCompatMarker rewrites the file without the
+  // dropped key, so the poison is gone from disk, not just from the view.
+  const raw = JSON.parse(readFileSync(compatMarkerPath(base), "utf-8")) as {
+    projections: Record<string, unknown>;
+  };
+  assert.equal(raw.projections["../outside.md"], undefined, "heal must be persisted to disk");
+  assert.ok(raw.projections["roadmap.md"], "healed rewrite must keep the safe baseline");
+});
+
+test("an unfixable escaping key in planning.passthrough is dropped, not quarantined (#2130)", () => {
   const base = makeTmpBase();
   writeCompatMarker(base, {
     schema: 2,
@@ -284,8 +355,12 @@ test("an escaping key in planning.passthrough also invalidates the whole marker"
   });
 
   const marker = readCompatMarker(base);
-  assert.equal(Object.keys(marker.projections).length, 0);
-  assert.equal(marker.planning!.active, false, "planning falls back to inactive default");
+  assert.equal(marker.planning!.passthrough["../../secret.md"], undefined, "unfixable key must be dropped");
+  assert.equal(marker.planning!.active, true, "rest of the marker must survive the heal");
+  assert.ok(
+    !readdirSync(join(base, ".gsd")).some((f: string) => f.startsWith(".compat.json.bad-")),
+    "healed marker must not be quarantined",
+  );
 });
 
 test("hostile marker makes the drift detector read nothing outside the project", async () => {


### PR DESCRIPTION
## TL;DR

**What:** The compat marker write path refuses unsafe projection keys, and the heal pass deletes unfixable keys instead of leaving them.
**Why:** One `../`-prefixed key (derivable when a target resolves outside the `.gsd` root) invalidated the whole `.gsd/.compat.json` marker, quarantining it and losing every baseline on every read (#2130).
**How:** `recordCompatProjectionWrite` skips keys failing `isSafeProjectionKey`; `healProjectionMapKeys` drops keys it cannot heal to a safe form. Dry-run previews keep the old fail-safe behavior; quarantine still applies to non-key corruption.

## What

- `src/resources/extensions/gsd/compat/compat-marker.ts` — two hunks: a write guard after `deriveCompatProjectionKey`, and a deletion path in `healProjectionMapKeys` for keys that are control-char/absolute/drive-letter or still escaping after canonicalization.
- `src/resources/extensions/gsd/tests/compat-marker.test.ts` — write-guard test asserting the **raw on-disk bytes before any read** (the heal rewrites the file, which would mask a guard regression — verified empirically: reverting only the guard fails exactly this test), a heal-drop test asserting the drop **persists to disk** with the safe baseline intact, and an updated passthrough test that previously pinned the removed whole-marker-invalidation behavior.

## Why

`readCompatMarker` quarantines any marker failing `isValidCompatMarker`, and `isValidProjectionMap` requires every key to be safe — so a single poisoned key lost all baselines. `healProjectionMapKeys` `continue`d over unfixable keys, so the poison survived and every read re-quarantined. Dropping unfixable keys is safe: their targets are outside the root, so the entries were inert poison; affected files re-detect as unseeded content.

Closes #2130

## How

Two hunks at the exact failure points, no new abstractions. Behavior preserved elsewhere: dry-run drift previews (`healInvalidKeys: false`) still get the empty-marker fail-safe with no rewrite or quarantine, and markers invalid for non-key reasons (bad `lastWriter`, non-string `sha`, malformed JSON) still quarantine — both probe-verified. A codex second-opinion review found no blocking bugs; its healed-key truthiness-collision observation targets a pre-existing line this PR does not touch, so it is left out of this one-concern change.

> This PR is AI-assisted.

## Testing

The author-supplied baseline reported 23 focused and 39 dependent tests passing; this phase independently reran the 23 focused cases, demonstrated persisted end-user marker behavior, verified both regressions through sabotage failures, restored the implementation, and finished with a clean worktree.

<details>
<summary>Evidence: Compat-marker behavior transcript</summary>

<code>Unsafe writes persisted only `roadmap.md`; default reads dropped and persisted removal of `../outside.md` without quarantine; dry-run remained non-mutating and fail-safe; malformed JSON, bad `lastWriter`, and non-string SHA still quarantined.</code>

```text
WRITE GUARD
{
  "persistedProjectionKeys": [
    "roadmap.md"
  ],
  "quarantineFiles": 0
}
DEFAULT READ HEALS AND PERSISTS
{
  "returnedProjectionKeys": [
    "roadmap.md"
  ],
  "persistedProjectionKeys": [
    "roadmap.md"
  ],
  "quarantineFiles": 0
}
DRY RUN REMAINS FAIL-SAFE AND NON-MUTATING
{
  "returnedProjectionKeys": [],
  "persistedProjectionKeys": [
    "roadmap.md",
    "../outside.md"
  ],
  "markerBytesUnchanged": true,
  "quarantineFiles": 0
}
NON-KEY INVALID MARKER: malformed JSON
{
  "returnedProjectionKeys": [],
  "originalMarkerExists": false,
  "quarantineFiles": 1
}
NON-KEY INVALID MARKER: bad lastWriter
{
  "returnedProjectionKeys": [],
  "originalMarkerExists": false,
  "quarantineFiles": 1
}
NON-KEY INVALID MARKER: non-string sha
{
  "returnedProjectionKeys": [],
  "originalMarkerExists": false,
  "quarantineFiles": 1
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"65ae1b135944d4f28709570f89cbf3f59df39c26","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --frozen-lockfile` followed by `pnpm run build:pi` and `pnpm run test:compile` to restore the repository test environment; the initial direct TypeScript runner was incompatible with emitted `.js` imports</code>
- <code>`GSD_NATIVE_DISABLE=1 node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/resources/extensions/gsd/tests/compat-marker.test.js dist-test/src/resources/extensions/gsd/tests/compat-marker-invalidation.test.js` — final result: 23 passed</code>
- <code>`GSD_NATIVE_DISABLE=1 node --input-type=module` executable API probe covering raw persisted write-guard state, persisted healing, dry-run rejection without mutation, and quarantine retention for malformed JSON, bad `lastWriter`, and non-string SHA</code>
- <code>Write-guard sabotage: temporarily disabled the safety return, recompiled, and ran `--test-name-pattern=&#39;recordCompatProjectionWrite skips entries whose derived key escapes&#39;`; it failed because unsafe raw bytes were persisted</code>
- <code>Heal-drop sabotage: temporarily disabled deletion of unhealable keys, recompiled, and ran `--test-name-pattern=&#39;readCompatMarker drops an unfixable ../ key and keeps the remaining baselines&#39;`; it failed because the safe baseline was lost</code>
- <code>Restored both hunks, reran the focused suites, removed generated test/build artifacts, and confirmed `git diff --exit-code 8550acceb10520538171f300eab93c3003e46d97`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ Configured extension typecheck requires workspace build outputs owned by another gate phase, so it could not complete. Both changed TypeScript files passed syntax checks and `git diff --check`.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

