### PR TITLE
fix(hermes): link gsd-mcp-server and emit version bounds in generated config

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "bin": {
     "gsd": "dist/bootstrap.js",
     "gsd-cli": "dist/bootstrap.js",
+    "gsd-mcp-server": "packages/mcp-server/bin/gsd-mcp-server.js",
     "gsd-pi": "scripts/install.js"
   },
   "files": [

--- a/src/hermes-integration-install.ts
+++ b/src/hermes-integration-install.ts
@@ -170,9 +170,22 @@ function quoteYamlScalar(value: string): string {
   return `'${value.replace(/'/g, "''")}'`
 }
 
-function renderGsdYaml(project: string | undefined): string {
+// Same package.json-relative read as loader.ts; resolves from src/ in dev and
+// dist/ in an installed package.
+function readGsdVersion(): string {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8')) as { version: string }
+  return pkg.version
+}
+
+function nextMajorVersion(version: string): string {
+  return `${Number(version.split('.')[0]) + 1}.0.0`
+}
+
+export function renderGsdYaml(project: string | undefined): string {
   const defaultProject = project ?? '~/code/myapp'
-  return `# open-gsd-hermes configuration. Edit paths for your machine.\ngsd:\n  cli_path: gsd\n  mcp_server_path: gsd-mcp-server\n  credential_source: gsd\n  default_project: ${quoteYamlScalar(defaultProject)}\n  poll_interval_seconds: 12\n  cache_ttl_seconds: 45\n  notification_level: normal\n  bindings: {}\n`
+  const version = readGsdVersion()
+  return `# open-gsd-hermes configuration. Edit paths for your machine.\ngsd:\n  cli_path: gsd\n  mcp_server_path: gsd-mcp-server\n  credential_source: gsd\n  default_project: ${quoteYamlScalar(defaultProject)}\n  poll_interval_seconds: 12\n  cache_ttl_seconds: 45\n  notification_level: normal\n  gsd_version_min: ${quoteYamlScalar(version)}\n  gsd_version_max: ${quoteYamlScalar(nextMajorVersion(version))}\n  bindings: {}\n`
 }
 
 function findHermesPython(hermesHome: string): string {

--- a/src/tests/hermes-integration-install.test.ts
+++ b/src/tests/hermes-integration-install.test.ts
@@ -2,9 +2,12 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-import { installHermesPlugin, parseHermesInstallArgs } from '../hermes-integration-install.ts'
+import { installHermesPlugin, parseHermesInstallArgs, renderGsdYaml } from '../hermes-integration-install.ts'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
 test('parseHermesInstallArgs resolves Hermes home and project paths', () => {
   const opts = parseHermesInstallArgs([
@@ -67,4 +70,33 @@ test('installHermesPlugin leaves existing config unchanged', () => {
 
   assert.equal(readFileSync(result.configPath, 'utf8'), 'gsd:\n  default_project: /existing\n')
   assert.ok(result.actions.some((action) => action.includes('Left existing')))
+})
+
+test('renderGsdYaml writes a version gate covering the installed gsd-pi version', () => {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as { version: string }
+  const nextMajor = `${Number(pkg.version.split('.')[0]) + 1}.0.0`
+
+  const config = renderGsdYaml(undefined)
+
+  assert.ok(
+    config.includes(`gsd_version_min: '${pkg.version}'`),
+    `expected gsd_version_min: '${pkg.version}' in:\n${config}`,
+  )
+  assert.ok(
+    config.includes(`gsd_version_max: '${nextMajor}'`),
+    `expected gsd_version_max: '${nextMajor}' in:\n${config}`,
+  )
+})
+
+test('renderGsdYaml mcp_server_path matches a bin entry shipped in the package', () => {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as {
+    bin: Record<string, string>
+  }
+  const binTarget = pkg.bin['gsd-mcp-server']
+
+  const config = renderGsdYaml(undefined)
+
+  assert.ok(config.includes('mcp_server_path: gsd-mcp-server'))
+  assert.equal(binTarget, 'packages/mcp-server/bin/gsd-mcp-server.js')
+  assert.equal(existsSync(join(repoRoot, binTarget)), true)
 })

--- a/src/tests/hermes-integration-install.test.ts
+++ b/src/tests/hermes-integration-install.test.ts
@@ -8,7 +8,15 @@ import { parse as parseYaml } from 'yaml'
 
 import { installHermesPlugin, parseHermesInstallArgs, renderGsdYaml } from '../hermes-integration-install.ts'
 
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+// Walk up to the real worktree root: the compiled unit runner executes this
+// file from dist-test, where a static relative path would resolve to the wrong
+// tree (dist-test has no packages/*/bin).
+let repoRoot = resolve(dirname(fileURLToPath(import.meta.url)))
+while (!existsSync(join(repoRoot, '.git'))) {
+  const parent = dirname(repoRoot)
+  if (parent === repoRoot) throw new Error('could not locate worktree root from test file')
+  repoRoot = parent
+}
 
 test('parseHermesInstallArgs resolves Hermes home and project paths', () => {
   const opts = parseHermesInstallArgs([

--- a/src/tests/hermes-integration-install.test.ts
+++ b/src/tests/hermes-integration-install.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 
 import { tmpdir } from 'node:os'
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
 
 import { installHermesPlugin, parseHermesInstallArgs, renderGsdYaml } from '../hermes-integration-install.ts'
 
@@ -76,27 +77,25 @@ test('renderGsdYaml writes a version gate covering the installed gsd-pi version'
   const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as { version: string }
   const nextMajor = `${Number(pkg.version.split('.')[0]) + 1}.0.0`
 
-  const config = renderGsdYaml(undefined)
+  const config = parseYaml(renderGsdYaml(undefined)) as {
+    gsd: { gsd_version_min: string; gsd_version_max: string }
+  }
 
-  assert.ok(
-    config.includes(`gsd_version_min: '${pkg.version}'`),
-    `expected gsd_version_min: '${pkg.version}' in:\n${config}`,
-  )
-  assert.ok(
-    config.includes(`gsd_version_max: '${nextMajor}'`),
-    `expected gsd_version_max: '${nextMajor}' in:\n${config}`,
-  )
+  assert.equal(config.gsd.gsd_version_min, pkg.version)
+  assert.equal(config.gsd.gsd_version_max, nextMajor)
 })
 
 test('renderGsdYaml mcp_server_path matches a bin entry shipped in the package', () => {
   const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as {
     bin: Record<string, string>
   }
-  const binTarget = pkg.bin['gsd-mcp-server']
+  const config = parseYaml(renderGsdYaml(undefined)) as {
+    gsd: { mcp_server_path: string }
+  }
+  const mcpServerPath = config.gsd.mcp_server_path
+  const binTarget = pkg.bin[mcpServerPath]
 
-  const config = renderGsdYaml(undefined)
-
-  assert.ok(config.includes('mcp_server_path: gsd-mcp-server'))
+  assert.equal(mcpServerPath, 'gsd-mcp-server')
   assert.equal(binTarget, 'packages/mcp-server/bin/gsd-mcp-server.js')
   assert.equal(existsSync(join(repoRoot, binTarget)), true)
 })


### PR DESCRIPTION
## TL;DR

**What:** `gsd hermes install` now provisions the `gsd-mcp-server` binary link and writes explicit version bounds into the generated `~/.hermes/gsd.yaml`.
**Why:** The generated config pointed at a binary npm never installed (preflight PATH check failed) and wrote no version keys, so the plugin fell back to Python-side defaults (`min 2.53`) that reject every current gsd-pi release including 1.17.0 (#2142).
**How:** Add `gsd-mcp-server` to the root bin map (the target already ships in the tarball), and emit `gsd_version_min`/`gsd_version_max` derived from the real package version.

## What

- `package.json` — bin map gains `"gsd-mcp-server": "packages/mcp-server/bin/gsd-mcp-server.js"`. The file already ships (`files` glob `packages/*/bin/**`, already in `validate-pack.js` requiredFiles); only the link was missing, so `npm i -g` now puts it on PATH and preflight step 2 passes. No version fields touched.
- `src/hermes-integration-install.ts` — `renderGsdYaml` (now exported for tests) emits `gsd_version_min` = the real package version and `gsd_version_max` = next major (exclusive), read at runtime from `package.json` relative to the module — verified to resolve identically in `src`, `dist`, and `dist-test` layouts.
- `src/tests/hermes-integration-install.test.ts` — new tests parse the generated YAML **structurally** with the `yaml` dependency and assert `config.gsd.gsd_version_min`/`gsd_version_max`/`mcp_server_path` (substring checks would miss keys moved outside the `gsd:` mapping); the bin-mapping assertion derives from the parsed MCP path, and the target-existence check resolves the worktree root by walking up to `.git` so it holds under the compiled `dist-test` runner too.

## Why

`ensure_version()` in `integrations/hermes/open_gsd_hermes/gsd_client.py` rejects when the detected CLI version is outside `[gsd_version_min, gsd_version_max)`; `config.py` defaults those to `2.53`/`3.0` when the YAML omits them. Every stock install of gsd-pi 1.17.0 therefore failed the plugin's version gate immediately after a successful-looking install. An isolated verification ran the **real** rendered YAML through the **real** `GsdConfig` + `ensure_version`: 1.17.0 passes, 1.16.9 is rejected below min, 2.0.0 is rejected at the exclusive max, and the unfixed default config rejects 1.17.0.

Closes #2142

## How

Two mechanisms, no new abstractions. Known limitations, accepted during triage: re-running install intentionally leaves an existing `gsd.yaml` untouched, so configs generated before this fix keep the broken defaults until regenerated; prerelease version stamps that are not PEP-440-valid would fail `packaging.version` on the Python side (pre-existing, independent of this change); `readGsdVersion` fails loud if `package.json` is missing — a silent fallback would mint a gate that rejects the running version.

Verified: node tests 5/5 (both new tests confirmed failing before the fix), `python3 -m pytest integrations/hermes/tests -q` 98 passed (1 pre-existing SIGKILL failure reproducing on the clean tree), `tsc` clean, `verify:fast` green.

> This PR is AI-assisted.
