### PR TITLE
fix(gsd): honor auto_push at closeout when git.isolation is none

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree-merge-already-merged.ts
+++ b/src/resources/extensions/gsd/auto-worktree-merge-already-merged.ts
@@ -13,6 +13,8 @@ import {
   nativeIsAncestor,
 } from "./native-git-bridge.js";
 import { cleanupMergedMilestoneWorktree } from "./auto-worktree-merge-cleanup.js";
+import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { pushIntegrationBranchIfAhead } from "./publication.js";
 import { logWarning } from "./workflow-logger.js";
 
 export interface AlreadyMergedMilestoneRequest {
@@ -26,7 +28,9 @@ export interface AlreadyMergedMilestoneRequest {
 
 export interface AlreadyMergedMilestoneResult {
   commitMessage: string;
-  pushed: false;
+  pushed: boolean;
+  /** Set when the closeout auto-push was attempted and failed (#2153). */
+  pushError?: string;
   prCreated: false;
   codeFilesChanged: true;
 }
@@ -68,7 +72,27 @@ export function finalizeAlreadyMergedMilestoneIfReachable(
     clearProjectRootState: true,
     chdirWarningContext: "after already-merged cleanup",
   });
-  return { commitMessage, pushed: false, prCreated: false, codeFilesChanged: true };
+  // #2153: the fast path skipped publication entirely, so a re-run after a
+  // manual merge never published. Push when auto_push is on and the
+  // integration branch is ahead of its upstream; failure is non-fatal.
+  const gitPrefs = loadEffectiveGSDPreferences(projectRoot)?.preferences?.git ?? {};
+  const publication = pushIntegrationBranchIfAhead({
+    basePath: projectRoot,
+    branch: mainBranch,
+    milestoneId,
+    prefs: {
+      autoPush: gitPrefs.auto_push === true,
+      autoPr: gitPrefs.auto_pr === true,
+      remote: gitPrefs.remote,
+    },
+  });
+  return {
+    commitMessage,
+    pushed: publication.pushed,
+    ...(publication.pushError ? { pushError: publication.pushError } : {}),
+    prCreated: false,
+    codeFilesChanged: true,
+  };
 }
 
 function assertNoUnanchoredRegularMergeCodeChanges(request: {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1,5 +1,5 @@
 // Project/App: gsd-pi
-// File Purpose: GSD single-writer barrel + write/read wrappers.
+// File Purpose: GSD single-writer barrel + write/read wrappers. Diagnostic-only branch (#2158 probe): comment to trip windows-portability classification.
 //
 // ─── Single-writer invariant ─────────────────────────────────────────────
 // Every write-SQL statement against `.gsd/gsd.db` lives behind a typed

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1,5 +1,5 @@
 // Project/App: gsd-pi
-// File Purpose: GSD single-writer barrel + write/read wrappers. Diagnostic-only branch (#2158 probe): comment to trip windows-portability classification.
+// File Purpose: GSD single-writer barrel + write/read wrappers.
 //
 // ─── Single-writer invariant ─────────────────────────────────────────────
 // Every write-SQL statement against `.gsd/gsd.db` lives behind a typed

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -66,6 +66,8 @@ export type JournalEventType =
   // #4765 — slice-cadence collapse
   | "slice-merged"
   | "milestone-resquash"
+  // #2153 — closeout auto-push for paths that skip the milestone merge
+  | "milestone-pushed"
   // dispatch telemetry — measure agent/subagent invocation frequency and shape
   | "subagent-invoked"
   | "subagent-completed"

--- a/src/resources/extensions/gsd/publication.ts
+++ b/src/resources/extensions/gsd/publication.ts
@@ -11,11 +11,13 @@
 // logged and reported in the result, never thrown.
 
 import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 
 import {
   buildPullRequestEvidence,
   createDraftPullRequestFromEvidence,
 } from "./pull-request-process.js";
+import { emitJournalEvent } from "./journal.js";
 import { logWarning } from "./workflow-logger.js";
 
 export interface PublicationPrefs {
@@ -118,5 +120,88 @@ export function publishMilestone(request: PublicationRequest): PublicationResult
     }
   }
 
+  return result;
+}
+
+export interface PushIfAheadRequest {
+  basePath: string;
+  /** The integration branch to push (e.g. main). Empty disables the push. */
+  branch: string;
+  /** Optional milestone id for the journal event payload. */
+  milestoneId?: string;
+  prefs: PublicationPrefs;
+}
+
+export interface PushIfAheadResult {
+  pushed: boolean;
+  /** Set when a push was attempted and failed. Absent when no push ran. */
+  pushError?: string;
+}
+
+/**
+ * True when HEAD has commits not on its upstream. A branch with no upstream
+ * was never pushed, so it counts as ahead; other rev-list failures
+ * conservatively report not-ahead so closeout never wedges on inspection
+ * errors (#2153).
+ */
+function isAheadOfUpstream(basePath: string): boolean {
+  try {
+    return execFileSync("git", ["rev-list", "--count", "@{upstream}..HEAD"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    }).trim() !== "0";
+  } catch (err) {
+    const errWithStderr = err as { stderr?: string | Buffer };
+    const stderr = errWithStderr.stderr?.toString() ?? "";
+    const message = err instanceof Error ? err.message : String(err);
+    return /no upstream configured/i.test(`${stderr}\n${message}`);
+  }
+}
+
+/**
+ * Auto-push tail-step for closeout paths that never reach `publishMilestone`
+ * (the isolation=none merge skip and the already-merged fast path — #2153).
+ * Mirrors publishMilestone's autoPush branch: `git push <remote> <branch>`
+ * with the same remote resolution (prefs.remote ?? "origin") and the same
+ * non-fatal failure contract. No-ops when auto-push is off (suppressed by
+ * auto-PR, as in publishMilestone), the branch is empty, the remote is
+ * missing, or the branch is not ahead of its upstream.
+ */
+export function pushIntegrationBranchIfAhead(
+  request: PushIfAheadRequest,
+): PushIfAheadResult {
+  const result: PushIfAheadResult = { pushed: false };
+  const { basePath, branch, prefs } = request;
+  if (!branch || !prefs.autoPush || prefs.autoPr) return result;
+  const remote = prefs.remote ?? "origin";
+  if (!gitRemoteExists(basePath, remote)) return result;
+  if (!isAheadOfUpstream(basePath)) return result;
+
+  try {
+    execFileSync("git", ["push", remote, branch], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    result.pushed = true;
+  } catch (err) {
+    // Push failure is non-fatal — closeout must not wedge on it (#2153)
+    result.pushError = err instanceof Error ? err.message : String(err);
+    logWarning("worktree", `git push failed: ${result.pushError}`);
+  }
+  emitJournalEvent(basePath, {
+    ts: new Date().toISOString(),
+    flowId: randomUUID(),
+    seq: 0,
+    eventType: "milestone-pushed",
+    data: {
+      milestoneId: request.milestoneId,
+      branch,
+      remote,
+      pushed: result.pushed,
+      error: result.pushError,
+    },
+  });
   return result;
 }

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -856,6 +856,7 @@ test("rerootCommandSession refreshes command workspace to project root", async (
 
 test("stopAuto foreground completion closeout reroots session and preserves the transcript surface", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-completion-stop-"));
+  runGit(["init"], base);
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
   const notifications: string[] = [];

--- a/src/resources/extensions/gsd/tests/auto-worktree-merge-already-merged.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-merge-already-merged.test.ts
@@ -81,6 +81,38 @@ function request(
   };
 }
 
+function createRepoWithBareRemote(): { repo: string; bare: string } {
+  const repo = createRepo();
+  const bare = join(
+    mkdtempSync(join(tmpdir(), "gsd-already-merged-remote-")),
+    "remote.git",
+  );
+  cleanupPaths.push(bare);
+  git(repo, ["init", "--bare", bare]);
+  git(repo, ["remote", "add", "origin", bare]);
+  return { repo, bare };
+}
+
+function enableAutoPush(repo: string): void {
+	mkdirSync(join(repo, ".gsd"), { recursive: true });
+	// Pin auto_pr and remote so machine-global preferences can't leak in and
+	// suppress or redirect the push this test asserts on.
+	writeFileSync(
+		join(repo, ".gsd", "preferences.md"),
+		["## Git", "- auto_push: true", "- auto_pr: false", "- remote: origin"].join("\n"),
+	);
+}
+
+function cleanupMocks(): void {
+  _setMilestoneCleanupDepsForTests({
+    removeWorktree: () => true,
+    nativeBranchDelete: () => {},
+    setActiveWorkspace: () => {},
+    nudgeGitBranchCache: () => {},
+    chdir: () => {},
+  });
+}
+
 describe("finalizeAlreadyMergedMilestoneIfReachable", () => {
   test("returns null when the milestone branch is not reachable from integration branch", () => {
     const repo = createRepo();
@@ -173,5 +205,68 @@ describe("finalizeAlreadyMergedMilestoneIfReachable", () => {
       realpathSync(previousCwd),
       "throws before cleanup but restores to the caller's previous cwd",
     );
+  });
+
+  test("pushes the integration branch when auto_push is on and main is ahead of upstream (#2153)", () => {
+    const { repo, bare } = createRepoWithBareRemote();
+    git(repo, ["push", "-u", "origin", "main"]); // upstream configured, in sync
+    enableAutoPush(repo);
+    const { milestoneBranch } = createRegularMergedMilestone(repo);
+    commitFile(repo, "hotfix.txt", "later main work\n", "fix: advance main");
+    cleanupMocks();
+
+    const result = finalizeAlreadyMergedMilestoneIfReachable(
+      request(repo, milestoneBranch, repo),
+    );
+
+    assert.equal(result?.pushed, true);
+    const remoteHeads = git(repo, ["ls-remote", "--heads", bare]);
+    assert.match(remoteHeads, /refs\/heads\/main/);
+    assert.ok(
+      remoteHeads.startsWith(git(repo, ["rev-parse", "HEAD"])),
+      `remote main should equal local HEAD, got: ${remoteHeads}`,
+    );
+  });
+
+  test("reports push failure without throwing when the remote is unreachable (#2153)", () => {
+    const { repo, bare } = createRepoWithBareRemote();
+    git(repo, ["remote", "set-url", "origin", join(bare, "..", "does-not-exist.git")]);
+    enableAutoPush(repo);
+    const { milestoneBranch } = createRegularMergedMilestone(repo);
+    cleanupMocks();
+
+    const result = finalizeAlreadyMergedMilestoneIfReachable(
+      request(repo, milestoneBranch, repo),
+    ); // must not throw
+
+    assert.equal(result?.pushed, false);
+    assert.ok(
+      typeof result?.pushError === "string" && result.pushError.length > 0,
+      `expected pushError to describe the failure, got: ${String(result?.pushError)}`,
+    );
+  });
+
+  test("does not push when auto_push is off even if main is ahead (#2153)", () => {
+    const { repo, bare } = createRepoWithBareRemote();
+    git(repo, ["push", "-u", "origin", "main"]); // upstream configured, in sync
+    // Pin auto_push: false explicitly — global prefs merge in per-key and this
+    // machine (or CI) may have auto_push: true globally.
+    mkdirSync(join(repo, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(repo, ".gsd", "preferences.md"),
+      ["## Git", "- auto_push: false", "- auto_pr: false", "- remote: origin"].join("\n"),
+    );
+    const { milestoneBranch } = createRegularMergedMilestone(repo);
+    commitFile(repo, "hotfix.txt", "later main work\n", "fix: advance main");
+    cleanupMocks();
+
+    const result = finalizeAlreadyMergedMilestoneIfReachable(
+      request(repo, milestoneBranch, repo),
+    );
+
+    assert.equal(result?.pushed, false);
+    assert.equal(result?.pushError, undefined);
+    const remoteHeads = git(repo, ["ls-remote", "--heads", bare]);
+    assert.doesNotMatch(remoteHeads, new RegExp(git(repo, ["rev-parse", "HEAD"])));
   });
 });

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -15,6 +15,7 @@ import {
   type NotifyCtx,
 } from "../worktree-lifecycle.js";
 import { WorktreeStateProjection } from "../worktree-state-projection.js";
+import { queryJournal } from "../journal.js";
 import { AutoSession } from "../auto/session.js";
 import { openDatabase, closeDatabase, insertMilestone, _getAdapter } from "../gsd-db.js";
 import { registerAutoWorker } from "../db/auto-workers.js";
@@ -1156,4 +1157,161 @@ test("adoptOrphanWorktree restores prior paths when callback throws", () => {
   );
   assert.equal(s.basePath, "/prior");
   assert.equal(s.originalBasePath, "/prior-original");
+});
+
+// ─── mergeMilestoneStandalone — isolation:none auto-push closeout (#2153) ─────
+
+function makeBareRemote(prefix: string): string {
+  const bare = join(
+    realpathSync(mkdtempSync(join(tmpdir(), prefix))),
+    "remote.git",
+  );
+  execFileSync("git", ["init", "--bare", bare], { stdio: "pipe" });
+  return bare;
+}
+
+function gitIn(repo: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: repo,
+    stdio: "pipe",
+    encoding: "utf-8",
+  }).trim();
+}
+
+function commitMilestoneWork(repo: string, milestoneId: string): void {
+  writeFileSync(join(repo, `${milestoneId}.txt`), "milestone work\n");
+  gitIn(repo, "add", ".");
+  gitIn(repo, "commit", "-m", `feat: ${milestoneId} work`);
+}
+
+function autoPushDeps(): LegacyTestDeps {
+  return makeDeps({
+    loadEffectiveGSDPreferences: () => ({
+      preferences: { git: { auto_push: true } },
+    }),
+  });
+}
+
+function runNoneModeMerge(deps: LegacyTestDeps, repo: string): ReturnType<typeof mergeMilestoneStandalone> {
+  // isolationModeOverride pins the guard hermetically — the real
+  // getIsolationMode would otherwise merge machine-global preferences.
+  return mergeMilestoneStandalone(deps, {
+    originalBasePath: repo,
+    worktreeBasePath: repo,
+    milestoneId: "M001",
+    isolationModeOverride: "none",
+    notify: () => {},
+  });
+}
+
+test("isolation:none merge skip pushes the integration branch when auto_push is on and ahead (#2153)", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase();
+  const bare = makeBareRemote("gsd-lifecycle-remote-");
+  t.after(() => {
+    cleanupRepoBase(base, previousCwd);
+    rmSync(bare, { recursive: true, force: true });
+  });
+  gitIn(base, "remote", "add", "origin", bare);
+  commitMilestoneWork(base, "M001"); // work lands directly on main in isolation:none
+
+  const result = runNoneModeMerge(autoPushDeps(), base);
+
+  assert.equal(result.mode, "skipped");
+  assert.equal(result.merged, false);
+  assert.equal(result.pushed, true);
+  assert.equal(result.pushError, undefined);
+  const remoteHeads = gitIn(base, "ls-remote", "--heads", bare);
+  assert.match(remoteHeads, /refs\/heads\/main/);
+  assert.ok(
+    remoteHeads.startsWith(gitIn(base, "rev-parse", "HEAD")),
+    `remote main should equal local HEAD, got: ${remoteHeads}`,
+  );
+  const [pushEvent] = queryJournal(base, { eventType: "milestone-pushed" });
+  assert.ok(pushEvent, "expected a milestone-pushed journal event");
+  assert.equal(pushEvent.data?.pushed, true);
+  assert.equal(pushEvent.data?.branch, "main");
+  assert.equal(pushEvent.data?.remote, "origin");
+});
+
+test("isolation:none merge skip does not push when the branch is not ahead of upstream (#2153)", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase();
+  const bare = makeBareRemote("gsd-lifecycle-remote-");
+  t.after(() => {
+    cleanupRepoBase(base, previousCwd);
+    rmSync(bare, { recursive: true, force: true });
+  });
+  gitIn(base, "remote", "add", "origin", bare);
+  gitIn(base, "push", "-u", "origin", "main"); // upstream configured, in sync
+  // Point origin at a dead path: an unwanted push attempt would fail loud
+  // instead of passing silently, so pushError staying undefined proves the
+  // ahead check suppressed the push.
+  gitIn(base, "remote", "set-url", "origin", join(bare, "..", "does-not-exist.git"));
+
+  const result = runNoneModeMerge(autoPushDeps(), base);
+
+  assert.equal(result.mode, "skipped");
+  assert.equal(result.merged, false);
+  assert.equal(result.pushed, false);
+  assert.equal(result.pushError, undefined);
+  assert.equal(
+    queryJournal(base, { eventType: "milestone-pushed" }).length,
+    0,
+    "no push attempt, no journal event",
+  );
+});
+
+test("isolation:none merge skip surfaces push failure without throwing (#2153)", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase();
+  const bare = makeBareRemote("gsd-lifecycle-remote-");
+  t.after(() => {
+    cleanupRepoBase(base, previousCwd);
+    rmSync(bare, { recursive: true, force: true });
+  });
+  gitIn(base, "remote", "add", "origin", bare);
+  gitIn(base, "remote", "set-url", "origin", join(bare, "..", "does-not-exist.git"));
+  commitMilestoneWork(base, "M001"); // ahead (no upstream) with an unwritable remote
+
+  const result = runNoneModeMerge(autoPushDeps(), base); // must not throw
+
+  assert.equal(result.mode, "skipped");
+  assert.equal(result.merged, false);
+  assert.equal(result.pushed, false);
+  assert.ok(
+    typeof result.pushError === "string" && result.pushError.length > 0,
+    `expected pushError to describe the failure, got: ${String(result.pushError)}`,
+  );
+  const [pushEvent] = queryJournal(base, { eventType: "milestone-pushed" });
+  assert.ok(pushEvent, "expected a milestone-pushed journal event");
+  assert.equal(pushEvent.data?.pushed, false);
+  assert.equal(typeof pushEvent.data?.error, "string");
+});
+
+test("isolation:none merge skip leaves everything unpushed when auto_push is off (#2153)", (t) => {
+  const previousCwd = process.cwd();
+  const base = makeGitRepoBase();
+  const bare = makeBareRemote("gsd-lifecycle-remote-");
+  t.after(() => {
+    cleanupRepoBase(base, previousCwd);
+    rmSync(bare, { recursive: true, force: true });
+  });
+  gitIn(base, "remote", "add", "origin", bare);
+  commitMilestoneWork(base, "M001");
+
+  // Explicit auto_push:false override — the real loader would merge this
+  // machine's global preferences, which may enable auto_push.
+  const result = runNoneModeMerge(
+    makeDeps({
+      loadEffectiveGSDPreferences: () => ({ preferences: { git: { auto_push: false } } }),
+    }),
+    base,
+  );
+
+  assert.equal(result.mode, "skipped");
+  assert.equal(result.merged, false);
+  assert.equal(result.pushed, false);
+  assert.equal(result.pushError, undefined);
+  assert.equal(gitIn(base, "ls-remote", "--heads", bare).trim(), "");
 });

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -86,6 +86,10 @@ import { teardownAutoWorktree } from "./auto-worktree-teardown.js";
 import { inspectUncommittedWorktreeState } from "./worktree-manager.js";
 import { resolveRoadmapForMilestoneMerge } from "./milestone-merge-roadmap.js";
 import type { MilestoneMergeTransactionRunner } from "./milestone-merge-transaction.js";
+import {
+  pushIntegrationBranchIfAhead,
+  type PushIfAheadResult,
+} from "./publication.js";
 
 const recentWorktreeMergeFailures = new Map<string, number>();
 const MERGE_FAILURE_DEDUPE_MS = 60_000;
@@ -388,6 +392,11 @@ export interface MergeStandaloneResult {
    * `merged === true`.
    */
   commitMessage?: string;
+  /**
+   * Set when an auto-push attempt at closeout failed (isolation=none skip
+   * path, #2153). Absent when no push ran or the push succeeded.
+   */
+  pushError?: string;
 }
 
 // ─── Validation ──────────────────────────────────────────────────────────
@@ -1379,6 +1388,31 @@ function _mergeBranchModeImpl(
 }
 
 /**
+ * Closeout auto-push for the isolation=none merge skip (#2153). Resolves the
+ * integration branch (the current branch at the project root — isolation:none
+ * commits land there directly) and git preferences through the lifecycle
+ * seams, then delegates to the Publication module.
+ */
+function pushIfAheadAtCloseout(
+  deps: WorktreeLifecycleDeps,
+  basePath: string | undefined,
+  milestoneId: string,
+): PushIfAheadResult {
+  if (!basePath) return { pushed: false };
+  const gitPrefs = lifecycleLoadPreferences(deps, basePath)?.preferences?.git ?? {};
+  return pushIntegrationBranchIfAhead({
+    basePath,
+    branch: currentLifecycleBranch(deps, basePath),
+    milestoneId,
+    prefs: {
+      autoPush: gitPrefs.auto_push === true,
+      autoPr: gitPrefs.auto_pr === true,
+      remote: typeof gitPrefs.remote === "string" ? gitPrefs.remote : undefined,
+    },
+  });
+}
+
+/**
  * Session-less merge entry (ADR-016 phase 2 / A1, issue #5618).
  *
  * Runs the worktree-mode or branch-mode merge body without touching session
@@ -1482,11 +1516,17 @@ export function mergeMilestoneStandalone(
         /* best-effort */
       }
     }
+    // #2153: in isolation:none the milestone work is already committed to the
+    // current branch, so skipping the merge also skipped publication and
+    // auto_push silently never pushed. Honor it here when the branch is ahead
+    // of its upstream; push failure is non-fatal to the closeout.
+    const publication = pushIfAheadAtCloseout(deps, originalBasePath, milestoneId);
     return {
       merged: false,
       mode: "skipped",
       codeFilesChanged: false,
-      pushed: false,
+      pushed: publication.pushed,
+      ...(publication.pushError ? { pushError: publication.pushError } : {}),
     };
   }
 


### PR DESCRIPTION
## TL;DR

**What:** The `git.isolation: none` closeout and the already-merged fast path now honor `auto_push` by pushing the integration branch when it is ahead of its upstream.
**Why:** With `isolation: none` the closeout guard returned before any publication ran, so `auto_push` silently never pushed — the documented solo preset recommends exactly that combo, and commits piled up indefinitely (#2153).
**How:** A shared `pushIntegrationBranchIfAhead` helper (same gates and invocation as `publishMilestone`'s autoPush branch: `auto_push` on, `auto_pr` off, remote exists, ahead of `@{upstream}`), wired into both closeout paths, with failures surfaced as `pushError` + a `milestone-pushed` journal event instead of silence.

## What

- `src/resources/extensions/gsd/publication.ts` — `pushIntegrationBranchIfAhead` next to `publishMilestone` (ADR-034 seam); non-fatal failures; `milestone-pushed` journal event.
- `src/resources/extensions/gsd/journal.ts` — `"milestone-pushed"` event type.
- `src/resources/extensions/gsd/worktree-lifecycle.ts` — the `isolation: none` skip path pushes when ahead; `MergeStandaloneResult` gains optional `pushError`.
- `src/resources/extensions/gsd/auto-worktree-merge-already-merged.ts` — the already-merged fast path pushes when ahead; `pushed` widened to `boolean`.
- Tests: 6 new cases across `worktree-lifecycle.test.ts` and `auto-worktree-merge-already-merged.test.ts` (temp repos with local bare remotes, prefs pinned project-locally so global config can't leak in): pushes when ahead (asserted against the bare remote), no push when in-sync (a spurious push would fail loud against a dead URL), no push when `auto_push` off, push failure surfaces without throwing, journal event emitted. One CI-only test-fixture fix: the completion-stop UI test's directory is now an actual git repo (the closeout path consults git state, and the fixture previously relied on ambient non-repo behavior).

## Why

`auto_push` is documented as "automatically push commits to the remote after committing", and `preferences-reference.md`'s solo preset recommends `auto_push: true` with `git.isolation: none` — a combination that silently did nothing: the only `publishMilestone` call runs after a worktree merge, which never happens in this mode.

Closes #2153

## How

The helper mirrors `publishMilestone`'s autoPush ownership rule exactly (`auto_push && !auto_pr`) and is strictly more gated (adds the ahead check). No-upstream counts as ahead (nothing was ever pushed); other upstream-resolution failures are conservatively treated as not-ahead. Push failures never wedge closeout — they surface via `pushError`, `logWarning`, and the journal. Known limitation, consistent with `publishMilestone`'s existing behavior: the ahead check compares against the branch's configured upstream while the push targets `git.remote ?? origin`; a user with a custom `git.remote` and a tracking config pointing elsewhere may see skips (a remote-target comparison is a possible follow-up). The doctor "N commits ahead" check discussed in the issue is deliberately left out of this one-concern change.

> This PR is AI-assisted.

## Testing

The supplied baseline had already reported revert sensitivity, touched/consumer suites, typecheck, and verify:fast; locally, after restoring missing dependencies, all seven focused #2153 tests passed. Manual Git-level checks demonstrated both closeout routes pushing local HEAD to real bare remotes, journal persistence, and every required no-op gate; an intentional disabled-auto-push sabotage failed the positive assertion as expected. No UI evidence applies because this is a Git closeout behavior change.

<details>
<summary>Evidence: Isolation-none auto-push transcript</summary>

`isolation:none closeout returned pushed=true; remote main exactly matched local HEAD; milestone-pushed journal event persisted.`

```text
{
  "scenario": "documented solo preset closeout (git.isolation=none, auto_push=true)",
  "closeoutResult": {
    "merged": false,
    "mode": "skipped",
    "codeFilesChanged": false,
    "pushed": true
  },
  "localHead": "6eea12d4ef22bff95f47e21bd92a12c6f5275205",
  "remoteMain": "6eea12d4ef22bff95f47e21bd92a12c6f5275205",
  "remoteMatchesLocal": true,
  "journalEvent": {
    "milestoneId": "M001",
    "branch": "main",
    "remote": "origin",
    "pushed": true
  }
}
```
</details>
<details>
<summary>Evidence: Already-merged auto-push transcript</summary>

`Already-merged fast path returned pushed=true; remote main exactly matched local HEAD; milestone-pushed journal event persisted.`

```text
{
  "scenario": "already-merged milestone fast path",
  "closeoutResult": {
    "commitMessage": "merge M001",
    "pushed": true,
    "prCreated": false,
    "codeFilesChanged": true
  },
  "localHead": "b55c369c5749ad23e03a141ffbc98a2336210b4d",
  "remoteMain": "b55c369c5749ad23e03a141ffbc98a2336210b4d",
  "remoteMatchesLocal": true,
  "journalEvent": {
    "milestoneId": "M001",
    "branch": "main",
    "remote": "origin",
    "pushed": true
  }
}
```
</details>
<details>
<summary>Evidence: Push gate transcript</summary>

`Empty branch, auto-PR ownership, missing remote, and invalid upstream all remained unpushed with no journal attempt.`

```text
{
  "emptyBranch": {
    "pushed": false
  },
  "autoPrOwnsPublication": {
    "pushed": false
  },
  "missingRemote": {
    "pushed": false
  },
  "invalidUpstream": {
    "pushed": false
  },
  "remoteHeads": "(none)",
  "journalAttempts": 0
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ca2dafcee727ba6a4c83767ef59e65c4756a8733","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `src/resources/extensions/gsd/publication.ts:149` - The ahead gate compares `@{upstream}..HEAD`, but the push targets `prefs.remote` and `branch`. If `main` tracks an in-sync `origin/main` while `git.remote` is `backup`, a missing or stale `backup/main` is silently skipped, leaving auto-push broken for the documented custom-remote setting. A successful no-upstream push also does not establish tracking, so later unchanged closeouts keep attempting pushes. The intent explicitly requires the upstream rule, so confirm the intended semantics; the shared helper should compare against the selected remote target, including a missing target ref, with behavioral coverage for both sequences.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern=&#39;#2153&#39; src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts src/resources/extensions/gsd/tests/auto-worktree-merge-already-merged.test.ts` — initial dependency-loading failure, then all seven selected cases passed after setup.</code>
- <code>`pnpm install --frozen-lockfile` — restored missing test dependencies; its silent postinstall was interrupted after no active child remained, but the required runtime dependencies loaded successfully.</code>
- <code>Manual `mergeMilestoneStandalone` isolation:none closeout against a temporary bare `origin` — verified result, remote SHA, and journal state.</code>
- <code>Manual `finalizeAlreadyMergedMilestoneIfReachable` closeout against a temporary bare `origin` — verified result, remote SHA, and journal state.</code>
- <code>Manual `pushIntegrationBranchIfAhead` gate harness — verified empty branch, auto-PR, missing remote, and invalid upstream do not push.</code>
- <code>Inline sabotage check through `mergeMilestoneStandalone` with `auto_push:false` while asserting `pushed:true` — failed as expected with `false !== true`.</code>
- `Confirmed tracked and staged diffs remained empty; removed generated dependency trees and test caches. Evidence files were retained in the required directory.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

