### PR TITLE
fix(scripts): suggest a valid Codex review command in pr-risk-check

### DIFF
--- a/scripts/__tests__/pr-risk-check.test.mjs
+++ b/scripts/__tests__/pr-risk-check.test.mjs
@@ -1,0 +1,40 @@
+// Project/App: gsd-pi
+// File Purpose: Regression tests for the PR risk checker CLI output.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+const script = join(repoRoot, "scripts/pr-risk-check.mjs");
+
+// `codex review` has no --adversarial flag, and --base cannot be combined
+// with a custom [PROMPT] (clap conflict). `--base main` reviews the PR diff
+// against the repo's default base, matching this script's own default.
+const expectedCommand = "codex review --base main";
+
+// src/project-sessions.ts maps to State Machine (critical) in
+// docs/dev/FILE-SYSTEM-MAP.md, which triggers the Codex suggestion.
+function runRiskCheck(extraArgs) {
+  return spawnSync(process.execPath, [script, "--files", "src/project-sessions.ts", ...extraArgs], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+  });
+}
+
+test("console report suggests a valid codex review command", () => {
+  const result = runRiskCheck([]);
+
+  assert.match(result.stdout, /Have a Codex subscription\? Run: /);
+  assert.ok(result.stdout.includes(expectedCommand), result.stdout);
+  assert.doesNotMatch(result.stdout, /--adversarial/);
+});
+
+test("github summary suggests a valid codex review command", () => {
+  const result = runRiskCheck(["--github"]);
+
+  assert.match(result.stdout, /Have a Codex subscription\?/);
+  assert.ok(result.stdout.includes(`\`${expectedCommand}\``), result.stdout);
+  assert.doesNotMatch(result.stdout, /--adversarial/);
+});

--- a/scripts/pr-risk-check.mjs
+++ b/scripts/pr-risk-check.mjs
@@ -317,7 +317,7 @@ function renderConsole(report) {
       console.log('  Ask your coding agent before submitting:');
       console.log(`  "${prompt}"`);
       console.log('');
-      console.log('  Have a Codex subscription? Run: codex review --adversarial');
+      console.log('  Have a Codex subscription? Run: codex review --base main');
     }
   }
 
@@ -410,7 +410,7 @@ function renderGitHubSummary(report) {
       lines.push('> Report findings first. Then propose a fix scoped to the actual root cause, and wait for confirmation before applying changes outside the originally reported location.');
       lines.push('> ```');
       lines.push('>');
-      lines.push('> 💡 **Have a Codex subscription?** Get an independent second opinion: `codex review --adversarial`');
+      lines.push('> 💡 **Have a Codex subscription?** Get an independent second opinion: `codex review --base main`');
     }
   }
 


### PR DESCRIPTION
## TL;DR

**What:** The PR-risk report now suggests `codex review --base main` instead of the invalid `codex review --adversarial`.
**Why:** The Codex CLI has no `--adversarial` flag — the pasted suggestion always failed with "unexpected argument" (#2100).
**How:** Two one-line string changes (console + GitHub summary outputs), pinned by a new test that spawns the script and asserts the corrected command in both output modes.

## What

- `scripts/pr-risk-check.mjs` — both suggestion sites corrected.
- `scripts/__tests__/pr-risk-check.test.mjs` (new) — spawns the script with `--files src/project-sessions.ts` (critical per FILE-SYSTEM-MAP.md, which triggers the suggestion branch) and asserts the corrected command is present and `--adversarial` is absent in console and `--github` outputs.

## Why

The suggestion is meant to be copy-pasted; on codex-cli 0.153.0 it exits 2 with `unexpected argument '--adversarial' found`. `--base main` is valid and matches the script's own diff base (`getChangedFilesFromGit` defaults to `main`).

Note: the issue's proposed alternative — `codex review --base <branch> "Adversarial review: ..."` — is *also* invalid (`--base` cannot be combined with a positional prompt), so the adversarial framing intentionally stays in the surrounding checklist text.

Closes #2100

## How

Verified empirically against the installed CLI (invalid flag rejected; `--base main` parses and starts a review). New test confirmed failing pre-fix (2/2) and passing post-fix. No other invalid codex suggestion strings remain in the repo.

> This PR is AI-assisted.

## Testing

The exact pre-fix implementation failed both focused regression cases, while the target passed; direct console and GitHub-summary runs emitted and persisted the corrected command for a critical file, and codex-cli 0.153.0 accepted `--base main` while rejecting both invalid forms. Reviewer-visible CLI and generated-Markdown artifacts were captured, so a UI screenshot was not applicable.

<details>
<summary>Evidence: Critical-risk console transcript</summary>

```text

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 gsd-pi PR Risk Report
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Overall Risk: 🔴 CRITICAL
Files changed: 1  |  Systems affected: 2

Affected Systems:
  🔴 State Machine
  🟡 CLI

File Breakdown:
  🔴 src/project-sessions.ts
     → State Machine, CLI

⚠️  Reviewer checklist for CRITICAL changes:
  • [State Machine] test state persistence across a session restart

  Ask your coding agent before submitting:
  "Review this PR for risks in: State Machine. Verify: 1) test state persistence across a session restart. Report all findings before I merge."

  Have a Codex subscription? Run: codex review --base main
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
</details>
<details>
<summary>Evidence: Persisted GitHub step summary</summary>

```text
## 🔴 PR Risk Report — CRITICAL

| | |
|---|---|
| **Files changed** | 1 |
| **Systems affected** | 2 |
| **Overall risk** | 🔴 CRITICAL |

\### Affected Systems

| Risk | System |
|------|--------|
| 🔴 critical | State Machine |
| 🟡 medium | CLI |

\<details>
<summary>File Breakdown</summary>

| Risk | File | Systems |
|------|------|---------|
| 🔴 | `src/project-sessions.ts` | State Machine, CLI |

</details>

> ⚠️ **🔴 Critical risk** — the following systems require verification before merge:
>
> - 🔴 **State Machine**: test state persistence across a session restart
>
> **⛔ This PR should not be merged without executing this follow-up prompt.**
>
> **Ask your coding agent to verify before submitting:**
>
> `` `
> Review this PR for risks in: State Machine. Verify:
>
> 1. test state persistence across a session restart
>
> Before modifying any code, assess the scope of this fix:
>
> - Identify the root cause, not just the reported symptom.
> - Search the codebase for other call sites, similar patterns, or duplicated logic that may share the same bug.
> - List affected tests, documentation, and any downstream consumers that depend on the current behavior.
> - Flag any changes that extend beyond the immediate file or function.
>
> Report findings first. Then propose a fix scoped to the actual root cause, and wait for confirmation before applying changes outside the originally reported location.
> `` `
>
> 💡 **Have a Codex subscription?** Get an independent second opinion: `codex review --base main`
```
</details>
<details>
<summary>Evidence: GitHub-mode stdout transcript</summary>

```text
## 🔴 PR Risk Report — CRITICAL

| | |
|---|---|
| **Files changed** | 1 |
| **Systems affected** | 2 |
| **Overall risk** | 🔴 CRITICAL |

\### Affected Systems

| Risk | System |
|------|--------|
| 🔴 critical | State Machine |
| 🟡 medium | CLI |

\<details>
<summary>File Breakdown</summary>

| Risk | File | Systems |
|------|------|---------|
| 🔴 | `src/project-sessions.ts` | State Machine, CLI |

</details>

> ⚠️ **🔴 Critical risk** — the following systems require verification before merge:
>
> - 🔴 **State Machine**: test state persistence across a session restart
>
> **⛔ This PR should not be merged without executing this follow-up prompt.**
>
> **Ask your coding agent to verify before submitting:**
>
> `` `
> Review this PR for risks in: State Machine. Verify:
>
> 1. test state persistence across a session restart
>
> Before modifying any code, assess the scope of this fix:
>
> - Identify the root cause, not just the reported symptom.
> - Search the codebase for other call sites, similar patterns, or duplicated logic that may share the same bug.
> - List affected tests, documentation, and any downstream consumers that depend on the current behavior.
> - Flag any changes that extend beyond the immediate file or function.
>
> Report findings first. Then propose a fix scoped to the actual root cause, and wait for confirmation before applying changes outside the originally reported location.
> `` `
>
> 💡 **Have a Codex subscription?** Get an independent second opinion: `codex review --base main`
```
</details>
<details>
<summary>Evidence: Codex CLI parser validation</summary>

```text
codex-cli 0.153.0; `codex review --base main --help` exited 0; `codex review --adversarial` exited 2 as an unexpected argument; combining `--base main` with a positional prompt exited 2 as a conflict.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cf98fd25863223b4938101771227a89a4e3b446e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test scripts/__tests__/pr-risk-check.test.mjs`
- <code>Extracted base-commit `scripts/pr-risk-check.mjs` with `git show e34e7d7d0ef27a0381d7f16619fee5a4e4a78171:scripts/pr-risk-check.mjs` and ran the target regression test against it; both cases failed for the old suggestion</code>
- `node scripts/pr-risk-check.mjs --files src/project-sessions.ts`
- `GITHUB_STEP_SUMMARY=… node scripts/pr-risk-check.mjs --files src/project-sessions.ts --github`
- `cmp -s …/pr-risk-github-stdout-cf98fd2.md …/pr-risk-github-step-summary-cf98fd2.md`
- `codex --version`
- `codex review --base main --help`
- `codex review --adversarial`
- `codex review --base main "Adversarial review for critical systems"`
- <code>`git status --short` after testing</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

