### PR TITLE
fix(pi-agent-core): continue and surface max_tokens truncation instead of ending silently

### DIFF
--- a/packages/gsd-agent-core/src/session/agent-session-compaction.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-compaction.ts
@@ -23,6 +23,17 @@ export function resolveThresholdContextTokens(assistantMessage: AssistantMessage
 export class AgentSessionCompactionModule {
 	constructor(readonly host: AgentSessionHost) {}
 
+	private removeTrailingAssistantMessages(): void {
+		const messages = this.host.agent.state.messages;
+		let keepCount = messages.length;
+		while (keepCount > 0 && messages[keepCount - 1]?.role === "assistant") {
+			keepCount--;
+		}
+		if (keepCount !== messages.length) {
+			this.host.agent.state.messages = messages.slice(0, keepCount);
+		}
+	}
+
 	async compact(customInstructions?: string): Promise<CompactionResult> {
 		this.host.disconnectFromAgent();
 		await this.host.abort();
@@ -205,12 +216,7 @@ export class AgentSessionCompactionModule {
 			}
 
 			this.host._overflowRecoveryAttempted = true;
-			// Remove the error message from agent state (it IS saved to session for history,
-			// but we don't want it in context for the retry)
-			const messages = this.host.agent.state.messages;
-			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
-				this.host.agent.state.messages = messages.slice(0, -1);
-			}
+			this.removeTrailingAssistantMessages();
 			return await this.runAutoCompaction("overflow", true);
 		}
 
@@ -318,11 +324,7 @@ export class AgentSessionCompactionModule {
 						willRetry,
 					});
 					if (willRetry) {
-						const messages = this.host.agent.state.messages;
-						const lastMsg = messages[messages.length - 1];
-						if (lastMsg?.role === "assistant" && (lastMsg as AssistantMessage).stopReason === "error") {
-							this.host.agent.state.messages = messages.slice(0, -1);
-						}
+						this.removeTrailingAssistantMessages();
 						return true;
 					}
 					return this.host.agent.hasQueuedMessages();
@@ -401,11 +403,7 @@ export class AgentSessionCompactionModule {
 			this.host.emit({ type: "compaction_end", reason, result, aborted: false, willRetry });
 
 			if (willRetry) {
-				const messages = this.host.agent.state.messages;
-				const lastMsg = messages[messages.length - 1];
-				if (lastMsg?.role === "assistant" && (lastMsg as AssistantMessage).stopReason === "error") {
-					this.host.agent.state.messages = messages.slice(0, -1);
-				}
+				this.removeTrailingAssistantMessages();
 				return true;
 			}
 

--- a/packages/gsd-agent-core/src/session/agent-session-prompt.ts
+++ b/packages/gsd-agent-core/src/session/agent-session-prompt.ts
@@ -484,6 +484,7 @@ export class AgentSessionPromptModule {
 
 	isRetryableError(message: AssistantMessage): boolean {
 		if (message.stopReason !== "error" || !message.errorMessage) return false;
+		if (message.errorMessage.startsWith("[length-halt]")) return false;
 
 		// Context overflow is handled by compaction, not retry
 		const contextWindow = this.host.model?.contextWindow ?? 0;

--- a/packages/pi-agent-core/README.md
+++ b/packages/pi-agent-core/README.md
@@ -112,6 +112,12 @@ The `beforeToolCall` hook runs after `tool_execution_start` and validated argume
 
 Tools can also return `terminate: true` to hint that the automatic follow-up LLM call should be skipped. The loop only stops early when every finalized tool result in that batch sets `terminate: true`. Mixed batches continue normally.
 
+### Output Limit Continuation
+
+When a provider returns `stopReason: "length"` after producing output and without an error, the loop treats the response as incomplete. It executes any complete tool calls, emits their results, then adds a user continuation message and requests the rest of the response. The loop allows up to three continuations per run so a provider that repeatedly reaches its output limit cannot run forever.
+
+A `length` response with no output or with an `errorMessage` is not continued. If continuation is unsafe, explicitly stopped, or exhausts the continuation cap, the loop appends a terminal assistant message with `stopReason: "error"` instead of presenting the truncated response as a clean completion.
+
 Low-level loop callers can set `shouldStopAfterTurn` to stop gracefully after the current turn completes:
 
 ```typescript
@@ -124,7 +130,7 @@ const stream = agentLoop(prompts, context, {
 });
 ```
 
-`shouldStopAfterTurn` runs after `turn_end` is emitted and after the assistant response and any tool executions have completed normally. If it returns `true`, the loop emits `agent_end` and exits before polling steering or follow-up queues, and before starting another LLM call. It does not abort the provider stream, does not cancel running tools, and does not alter the assistant message stop reason.
+`shouldStopAfterTurn` runs after `turn_end` is emitted and after the assistant response and any tool executions finish. If it returns `true`, the loop exits before polling steering or follow-up queues or starting another LLM call. See `AgentLoopConfig.shouldStopAfterTurn` for the precise terminal-message contract when an output-limit continuation is pending.
 
 When you use the `Agent` class, assistant `message_end` processing is treated as a barrier before tool preflight begins. That means `beforeToolCall` sees agent state that already includes the assistant message that requested the tool call.
 

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -45,7 +45,7 @@ export const MAX_CONSECUTIVE_VALIDATION_FAILURES = 3;
  * cap (stopReason "length"), so a provider that always truncates cannot spin
  * the loop (and its cost) forever.
  */
-export const MAX_LENGTH_CONTINUATIONS = 3;
+const MAX_LENGTH_CONTINUATIONS = 3;
 
 /** Prompt injected after a length-truncated assistant turn so the model resumes. */
 const LENGTH_CONTINUATION_PROMPT =
@@ -59,6 +59,25 @@ const ZERO_USAGE = {
 	totalTokens: 0,
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 } as const;
+
+function createLengthStopMessage(config: AgentLoopConfig, haltedBecause: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{
+				type: "text",
+				text: `Agent stopped: provider returned stop_reason "length" and continuation was halted (${haltedBecause}).`,
+			},
+		],
+		api: config.model.api,
+		provider: config.model.provider,
+		model: config.model.id,
+		usage: ZERO_USAGE,
+		stopReason: "error",
+		errorMessage: `Provider stop_reason: length (${haltedBecause}; continuing was halted)`,
+		timestamp: Date.now(),
+	};
+}
 
 /**
  * Close a loop stream after `runAgentLoop*` threw outside the per-turn error
@@ -302,23 +321,8 @@ async function runLoop(
 						? message.errorMessage
 							? `provider error: ${message.errorMessage}`
 							: "no output was generated (context overflow, not output truncation)"
-						: `output cap hit ${MAX_LENGTH_CONTINUATIONS} times`;
-					const stopMessage: AssistantMessage = {
-						role: "assistant",
-						content: [
-							{
-								type: "text",
-								text: `Agent stopped: provider returned stop_reason "length" and continuation was halted (${haltedBecause}).`,
-							},
-						],
-						api: config.model.api,
-						provider: config.model.provider,
-						model: config.model.id,
-						usage: ZERO_USAGE,
-						stopReason: "error",
-						errorMessage: `Provider stop_reason: length (${haltedBecause}; continuing was halted)`,
-						timestamp: Date.now(),
-					};
+						: `continuation cap (${MAX_LENGTH_CONTINUATIONS}) exhausted`;
+					const stopMessage = createLengthStopMessage(config, haltedBecause);
 					await emit({ type: "turn_end", message, toolResults: [] });
 					await emit({ type: "message_start", message: stopMessage });
 					await emit({ type: "message_end", message: stopMessage });
@@ -411,6 +415,8 @@ async function runLoop(
 				}
 			}
 
+			await emit({ type: "turn_end", message, toolResults });
+
 			if (continueAfterTruncation) {
 				// Injected after the tool results so providers that require toolResult
 				// messages to directly follow the assistant toolCall message accept the
@@ -424,11 +430,10 @@ async function runLoop(
 				newMessages.push(continuationMessage);
 				await emit({ type: "message_start", message: continuationMessage });
 				await emit({ type: "message_end", message: continuationMessage });
-				// A truncated turn without tool calls would otherwise end the loop here.
-				hasMoreToolCalls = true;
+				if (toolCalls.length === 0) {
+					hasMoreToolCalls = true;
+				}
 			}
-
-			await emit({ type: "turn_end", message, toolResults });
 
 			const nextTurnContext = {
 				message,
@@ -451,14 +456,21 @@ async function runLoop(
 				};
 			}
 
-			if (
-				await config.shouldStopAfterTurn?.({
-					message,
-					toolResults,
-					context: currentContext,
-					newMessages,
-				})
-			) {
+			const shouldStopAfterTurn = await config.shouldStopAfterTurn?.({
+				message,
+				toolResults,
+				context: currentContext,
+				newMessages,
+			});
+			if (shouldStopAfterTurn) {
+				if (continueAfterTruncation) {
+					const stopMessage = createLengthStopMessage(config, "stop hook halted the continuation");
+					await emit({ type: "message_start", message: stopMessage });
+					await emit({ type: "message_end", message: stopMessage });
+					newMessages.push(stopMessage);
+					currentContext.messages.push(stopMessage);
+					await emit({ type: "turn_end", message: stopMessage, toolResults: [] });
+				}
 				await emit({ type: "agent_end", messages: newMessages });
 				return;
 			}

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -323,9 +323,13 @@ async function runLoop(
 				const isOutputTruncation = !message.errorMessage && message.usage.output > 0;
 				if (!isOutputTruncation) {
 					lengthHaltIsContextOverflow = isContextOverflow(message, config.model.contextWindow);
-					lengthHaltReason = message.errorMessage
-						? `provider error: ${message.errorMessage}`
-						: "no output was generated (context overflow, not output truncation)";
+					if (message.errorMessage) {
+						lengthHaltReason = `provider error: ${message.errorMessage}`;
+					} else if (lengthHaltIsContextOverflow) {
+						lengthHaltReason = "no output was generated (context overflow, not output truncation)";
+					} else {
+						lengthHaltReason = "no output was generated";
+					}
 				} else if (lengthContinuations < MAX_LENGTH_CONTINUATIONS) {
 					continueAfterTruncation = true;
 				} else {

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -74,7 +74,7 @@ function createLengthStopMessage(sourceMessage: AssistantMessage, haltedBecause:
 		model: sourceMessage.model,
 		usage: ZERO_USAGE,
 		stopReason: "error",
-		errorMessage: `Provider stop_reason: length (${haltedBecause}; continuing was halted)`,
+		errorMessage: `[length-halt] Provider stop_reason: length (${haltedBecause}; continuing was halted)`,
 		timestamp: Date.now(),
 	};
 }

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -381,6 +381,8 @@ async function runLoop(
 					await emit({ type: "message_start", message: retryMessage });
 					await emit({ type: "message_end", message: retryMessage });
 				} else if (overload.trip && lengthHaltReason === undefined) {
+					// A length stop after repeated preparation errors is surfaced by the
+					// schema breaker—loud, not silent—so no continuation is injected here.
 					const stopMessage: AssistantMessage = {
 						role: "assistant",
 						content: [
@@ -425,25 +427,6 @@ async function runLoop(
 				return;
 			}
 
-			if (continueAfterTruncation) {
-				lengthContinuations++;
-				// Injected after the tool results so providers that require toolResult
-				// messages to directly follow the assistant toolCall message accept the
-				// context on the next stream call.
-				const continuationMessage: AgentMessage = {
-					role: "user",
-					content: [{ type: "text", text: LENGTH_CONTINUATION_PROMPT }],
-					timestamp: Date.now(),
-				};
-				currentContext.messages.push(continuationMessage);
-				newMessages.push(continuationMessage);
-				await emit({ type: "message_start", message: continuationMessage });
-				await emit({ type: "message_end", message: continuationMessage });
-				if (toolCalls.length === 0) {
-					hasMoreToolCalls = true;
-				}
-			}
-
 			const nextTurnContext = {
 				message,
 				toolResults,
@@ -463,6 +446,25 @@ async function runLoop(
 								? undefined
 								: nextTurnSnapshot.thinkingLevel,
 				};
+			}
+
+			if (continueAfterTruncation) {
+				lengthContinuations++;
+				// Injected after the tool results so providers that require toolResult
+				// messages to directly follow the assistant toolCall message accept the
+				// context on the next stream call.
+				const continuationMessage: AgentMessage = {
+					role: "user",
+					content: [{ type: "text", text: LENGTH_CONTINUATION_PROMPT }],
+					timestamp: Date.now(),
+				};
+				currentContext.messages.push(continuationMessage);
+				newMessages.push(continuationMessage);
+				await emit({ type: "message_start", message: continuationMessage });
+				await emit({ type: "message_end", message: continuationMessage });
+				if (toolCalls.length === 0) {
+					hasMoreToolCalls = true;
+				}
 			}
 
 			const shouldStopAfterTurn = await config.shouldStopAfterTurn?.({

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -10,6 +10,7 @@ import {
 	createToolSearchShimResult,
 	EventStream,
 	isAgentToolName,
+	isContextOverflow,
 	isEmptyPathToolArguments,
 	isToolSearchToolName,
 	normalizeToolResultContent,
@@ -60,7 +61,12 @@ const ZERO_USAGE = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 } as const;
 
-function createLengthStopMessage(sourceMessage: AssistantMessage, haltedBecause: string): AssistantMessage {
+function createLengthStopMessage(
+	sourceMessage: AssistantMessage,
+	haltedBecause: string,
+	contextOverflow = false,
+): AssistantMessage {
+	const overflowMarker = contextOverflow ? " [context_length_exceeded]" : "";
 	return {
 		role: "assistant",
 		content: [
@@ -74,7 +80,7 @@ function createLengthStopMessage(sourceMessage: AssistantMessage, haltedBecause:
 		model: sourceMessage.model,
 		usage: ZERO_USAGE,
 		stopReason: "error",
-		errorMessage: `[length-halt] Provider stop_reason: length (${haltedBecause}; continuing was halted)`,
+		errorMessage: `[length-halt]${overflowMarker} Provider stop_reason: length (${haltedBecause}; continuing was halted)`,
 		timestamp: Date.now(),
 	};
 }
@@ -307,6 +313,7 @@ async function runLoop(
 			// error instead of presenting the truncation as a clean stop.
 			let continueAfterTruncation = false;
 			let lengthHaltReason: string | undefined;
+			let lengthHaltIsContextOverflow = false;
 			if (message.stopReason === "length") {
 				// Only a pure truncation is continuable. A zero-output length stop is
 				// silent context overflow (pi-ai isContextOverflow case 3), and a length
@@ -315,6 +322,7 @@ async function runLoop(
 				// cap message.
 				const isOutputTruncation = !message.errorMessage && message.usage.output > 0;
 				if (!isOutputTruncation) {
+					lengthHaltIsContextOverflow = isContextOverflow(message, config.model.contextWindow);
 					lengthHaltReason = message.errorMessage
 						? `provider error: ${message.errorMessage}`
 						: "no output was generated (context overflow, not output truncation)";
@@ -417,7 +425,7 @@ async function runLoop(
 
 			await emit({ type: "turn_end", message, toolResults });
 			if (lengthHaltReason !== undefined) {
-				const stopMessage = createLengthStopMessage(message, lengthHaltReason);
+				const stopMessage = createLengthStopMessage(message, lengthHaltReason, lengthHaltIsContextOverflow);
 				await emit({ type: "message_start", message: stopMessage });
 				await emit({ type: "message_end", message: stopMessage });
 				newMessages.push(stopMessage);

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -40,6 +40,17 @@ export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
 /** Cap consecutive turns where every tool call fails preparation (schema / not-found). */
 export const MAX_CONSECUTIVE_VALIDATION_FAILURES = 3;
 
+/**
+ * Cap continuations injected when the provider truncates output at the token
+ * cap (stopReason "length"), so a provider that always truncates cannot spin
+ * the loop (and its cost) forever.
+ */
+export const MAX_LENGTH_CONTINUATIONS = 3;
+
+/** Prompt injected after a length-truncated assistant turn so the model resumes. */
+const LENGTH_CONTINUATION_PROMPT =
+	"Your previous response was cut off at the output limit. Continue exactly where you left off.";
+
 const ZERO_USAGE = {
 	input: 0,
 	output: 0,
@@ -234,6 +245,7 @@ async function runLoop(
 	// Check for steering messages at start (user may have typed while waiting)
 	let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
 	let consecutiveAllToolErrorTurns = 0;
+	let lengthContinuations = 0;
 	let previousValidationFields: string[] = [];
 	let narrowedSchemaRetryGranted = false;
 
@@ -268,6 +280,54 @@ async function runLoop(
 				await emit({ type: "turn_end", message, toolResults: [] });
 				await emit({ type: "agent_end", messages: newMessages });
 				return;
+			}
+
+			// The provider cut the output at the token cap: the turn is incomplete
+			// (text orphaned mid-sentence, possibly mid-tool-call). Either continue
+			// the output (bounded by MAX_LENGTH_CONTINUATIONS) or surface a terminal
+			// error instead of presenting the truncation as a clean stop.
+			let continueAfterTruncation = false;
+			if (message.stopReason === "length") {
+				// Only a pure truncation is continuable. A zero-output length stop is
+				// silent context overflow (pi-ai isContextOverflow case 3), and a length
+				// stop carrying an errorMessage is a provider failure — continuing
+				// either would re-feed an unusable context and halt with a misreported
+				// cap message.
+				const isOutputTruncation = !message.errorMessage && message.usage.output > 0;
+				if (isOutputTruncation && lengthContinuations < MAX_LENGTH_CONTINUATIONS) {
+					lengthContinuations++;
+					continueAfterTruncation = true;
+				} else {
+					const haltedBecause = !isOutputTruncation
+						? message.errorMessage
+							? `provider error: ${message.errorMessage}`
+							: "no output was generated (context overflow, not output truncation)"
+						: `output cap hit ${MAX_LENGTH_CONTINUATIONS} times`;
+					const stopMessage: AssistantMessage = {
+						role: "assistant",
+						content: [
+							{
+								type: "text",
+								text: `Agent stopped: provider returned stop_reason "length" and continuation was halted (${haltedBecause}).`,
+							},
+						],
+						api: config.model.api,
+						provider: config.model.provider,
+						model: config.model.id,
+						usage: ZERO_USAGE,
+						stopReason: "error",
+						errorMessage: `Provider stop_reason: length (${haltedBecause}; continuing was halted)`,
+						timestamp: Date.now(),
+					};
+					await emit({ type: "turn_end", message, toolResults: [] });
+					await emit({ type: "message_start", message: stopMessage });
+					await emit({ type: "message_end", message: stopMessage });
+					newMessages.push(stopMessage);
+					currentContext.messages.push(stopMessage);
+					await emit({ type: "turn_end", message: stopMessage, toolResults: [] });
+					await emit({ type: "agent_end", messages: newMessages });
+					return;
+				}
 			}
 
 			// Check for tool calls
@@ -349,6 +409,23 @@ async function runLoop(
 					await emit({ type: "agent_end", messages: newMessages });
 					return;
 				}
+			}
+
+			if (continueAfterTruncation) {
+				// Injected after the tool results so providers that require toolResult
+				// messages to directly follow the assistant toolCall message accept the
+				// context on the next stream call.
+				const continuationMessage: AgentMessage = {
+					role: "user",
+					content: [{ type: "text", text: LENGTH_CONTINUATION_PROMPT }],
+					timestamp: Date.now(),
+				};
+				currentContext.messages.push(continuationMessage);
+				newMessages.push(continuationMessage);
+				await emit({ type: "message_start", message: continuationMessage });
+				await emit({ type: "message_end", message: continuationMessage });
+				// A truncated turn without tool calls would otherwise end the loop here.
+				hasMoreToolCalls = true;
 			}
 
 			await emit({ type: "turn_end", message, toolResults });

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -60,7 +60,7 @@ const ZERO_USAGE = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 } as const;
 
-function createLengthStopMessage(config: AgentLoopConfig, haltedBecause: string): AssistantMessage {
+function createLengthStopMessage(sourceMessage: AssistantMessage, haltedBecause: string): AssistantMessage {
 	return {
 		role: "assistant",
 		content: [
@@ -69,9 +69,9 @@ function createLengthStopMessage(config: AgentLoopConfig, haltedBecause: string)
 				text: `Agent stopped: provider returned stop_reason "length" and continuation was halted (${haltedBecause}).`,
 			},
 		],
-		api: config.model.api,
-		provider: config.model.provider,
-		model: config.model.id,
+		api: sourceMessage.api,
+		provider: sourceMessage.provider,
+		model: sourceMessage.model,
 		usage: ZERO_USAGE,
 		stopReason: "error",
 		errorMessage: `Provider stop_reason: length (${haltedBecause}; continuing was halted)`,
@@ -306,6 +306,7 @@ async function runLoop(
 			// the output (bounded by MAX_LENGTH_CONTINUATIONS) or surface a terminal
 			// error instead of presenting the truncation as a clean stop.
 			let continueAfterTruncation = false;
+			let lengthHaltReason: string | undefined;
 			if (message.stopReason === "length") {
 				// Only a pure truncation is continuable. A zero-output length stop is
 				// silent context overflow (pi-ai isContextOverflow case 3), and a length
@@ -313,24 +314,14 @@ async function runLoop(
 				// either would re-feed an unusable context and halt with a misreported
 				// cap message.
 				const isOutputTruncation = !message.errorMessage && message.usage.output > 0;
-				if (isOutputTruncation && lengthContinuations < MAX_LENGTH_CONTINUATIONS) {
-					lengthContinuations++;
+				if (!isOutputTruncation) {
+					lengthHaltReason = message.errorMessage
+						? `provider error: ${message.errorMessage}`
+						: "no output was generated (context overflow, not output truncation)";
+				} else if (lengthContinuations < MAX_LENGTH_CONTINUATIONS) {
 					continueAfterTruncation = true;
 				} else {
-					const haltedBecause = !isOutputTruncation
-						? message.errorMessage
-							? `provider error: ${message.errorMessage}`
-							: "no output was generated (context overflow, not output truncation)"
-						: `continuation cap (${MAX_LENGTH_CONTINUATIONS}) exhausted`;
-					const stopMessage = createLengthStopMessage(config, haltedBecause);
-					await emit({ type: "turn_end", message, toolResults: [] });
-					await emit({ type: "message_start", message: stopMessage });
-					await emit({ type: "message_end", message: stopMessage });
-					newMessages.push(stopMessage);
-					currentContext.messages.push(stopMessage);
-					await emit({ type: "turn_end", message: stopMessage, toolResults: [] });
-					await emit({ type: "agent_end", messages: newMessages });
-					return;
+					lengthHaltReason = `continuation cap (${MAX_LENGTH_CONTINUATIONS}) exhausted`;
 				}
 			}
 
@@ -338,10 +329,12 @@ async function runLoop(
 			const toolCalls = message.content.filter((c) => c.type === "toolCall");
 
 			const toolResults: ToolResultMessage[] = [];
+			let toolBatchTerminated = false;
 			hasMoreToolCalls = false;
 			if (toolCalls.length > 0) {
 				const executedToolBatch = await executeToolCalls(currentContext, message, config, signal, emit);
 				toolResults.push(...executedToolBatch.messages);
+				toolBatchTerminated = executedToolBatch.terminate;
 				hasMoreToolCalls = !executedToolBatch.terminate;
 
 				for (const result of toolResults) {
@@ -375,7 +368,7 @@ async function runLoop(
 					previousValidationFields = currentValidationFields;
 				}
 
-				if (overload.grantNarrowedRetry) {
+				if (overload.grantNarrowedRetry && lengthHaltReason === undefined) {
 					narrowedSchemaRetryGranted = true;
 					consecutiveAllToolErrorTurns = MAX_CONSECUTIVE_VALIDATION_FAILURES - 1;
 					const retryMessage: AgentMessage = {
@@ -387,7 +380,7 @@ async function runLoop(
 					newMessages.push(retryMessage);
 					await emit({ type: "message_start", message: retryMessage });
 					await emit({ type: "message_end", message: retryMessage });
-				} else if (overload.trip) {
+				} else if (overload.trip && lengthHaltReason === undefined) {
 					const stopMessage: AssistantMessage = {
 						role: "assistant",
 						content: [
@@ -415,9 +408,25 @@ async function runLoop(
 				}
 			}
 
+			if (continueAfterTruncation && toolBatchTerminated) {
+				continueAfterTruncation = false;
+				lengthHaltReason = "tool termination requested";
+			}
+
 			await emit({ type: "turn_end", message, toolResults });
+			if (lengthHaltReason !== undefined) {
+				const stopMessage = createLengthStopMessage(message, lengthHaltReason);
+				await emit({ type: "message_start", message: stopMessage });
+				await emit({ type: "message_end", message: stopMessage });
+				newMessages.push(stopMessage);
+				currentContext.messages.push(stopMessage);
+				await emit({ type: "turn_end", message: stopMessage, toolResults: [] });
+				await emit({ type: "agent_end", messages: newMessages });
+				return;
+			}
 
 			if (continueAfterTruncation) {
+				lengthContinuations++;
 				// Injected after the tool results so providers that require toolResult
 				// messages to directly follow the assistant toolCall message accept the
 				// context on the next stream call.
@@ -464,7 +473,7 @@ async function runLoop(
 			});
 			if (shouldStopAfterTurn) {
 				if (continueAfterTruncation) {
-					const stopMessage = createLengthStopMessage(config, "stop hook halted the continuation");
+					const stopMessage = createLengthStopMessage(message, "stop hook halted the continuation");
 					await emit({ type: "message_start", message: stopMessage });
 					await emit({ type: "message_end", message: stopMessage });
 					newMessages.push(stopMessage);

--- a/packages/pi-agent-core/src/types.ts
+++ b/packages/pi-agent-core/src/types.ts
@@ -116,9 +116,9 @@ export interface ShouldStopAfterTurnContext {
 	message: AssistantMessage;
 	/** Tool result messages passed to the preceding `turn_end` event. */
 	toolResults: ToolResultMessage[];
-	/** Current agent context after the turn's assistant message and tool results have been appended. */
+	/** Current agent context after the turn and any output-limit continuation have been appended. */
 	context: AgentContext;
-	/** Messages that this loop invocation will return if it exits at this point. Prompt runs include the initial prompt messages; continuation runs do not include pre-existing context messages. */
+	/** Messages this loop invocation will return if it exits, including any output-limit continuation. Prompt runs include the initial prompt messages; continuation runs omit pre-existing context messages. */
 	newMessages: AgentMessage[];
 }
 
@@ -207,6 +207,8 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 *
 	 * If it returns true, the loop emits `agent_end` and exits before polling steering or follow-up queues,
 	 * without starting another LLM call. The current assistant response and any tool executions finish normally.
+	 * When a provider output-limit continuation has already been queued, the loop first appends a terminal
+	 * assistant error so the transcript does not end with an unanswered continuation message.
 	 *
 	 * Use this to request a graceful stop after the current turn, e.g. before context gets too full.
 	 *

--- a/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
+++ b/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
-import { MAX_LENGTH_CONTINUATIONS, agentLoop } from "../src/agent-loop.ts";
+import { agentLoop } from "../src/agent-loop.ts";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
 
 const CONTINUATION_TEXT = "Your previous response was cut off at the output limit. Continue exactly where you left off.";
@@ -81,7 +81,7 @@ function identityConverter(messages: AgentMessage[]): Message[] {
 	return messages.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
 }
 
-function createEchoTool(executed: string[]): AgentTool<any, { value: string }> {
+function createEchoTool(executed: string[], terminate = false): AgentTool<any, { value: string }> {
 	const toolSchema = Type.Object({ value: Type.String() });
 	return {
 		name: "echo",
@@ -93,6 +93,7 @@ function createEchoTool(executed: string[]): AgentTool<any, { value: string }> {
 			return {
 				content: [{ type: "text", text: `echoed: ${params.value}` }],
 				details: { value: params.value },
+				terminate,
 			};
 		},
 	};
@@ -177,6 +178,17 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 
 		// Continuation message was emitted to consumers.
 		expect(continuations(events)).toHaveLength(1);
+		const truncatedTurnEndIndex = events.findIndex(
+			(event) => event.type === "turn_end" && event.message.role === "assistant" && event.message.stopReason === "length",
+		);
+		const continuationStartIndex = events.findIndex(
+			(event) =>
+				event.type === "message_start" &&
+				event.message.role === "user" &&
+				JSON.stringify(event.message.content).includes(CONTINUATION_TEXT),
+		);
+		expect(truncatedTurnEndIndex).toBeGreaterThan(-1);
+		expect(continuationStartIndex).toBeGreaterThan(truncatedTurnEndIndex);
 
 		// The run ended with the model's clean completion, not the truncation.
 		const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant");
@@ -220,19 +232,104 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 		const messages = await stream.result();
 
 		// Initial call + one per injected continuation, then halt.
-		expect(streamCallCount).toBe(MAX_LENGTH_CONTINUATIONS + 1);
+		expect(streamCallCount).toBe(4);
 
-		// Exactly MAX_LENGTH_CONTINUATIONS continuation messages were injected.
-		expect(continuations(events)).toHaveLength(MAX_LENGTH_CONTINUATIONS);
+		// Exactly three continuation messages were injected.
+		expect(continuations(events)).toHaveLength(3);
 
 		// The loop surfaced a terminal error instead of ending cleanly.
 		const lastMessage = messages[messages.length - 1];
 		expect(lastMessage.role).toBe("assistant");
 		expect(lastMessage.stopReason).toBe("error");
 		expect(lastMessage.errorMessage).toContain("Provider stop_reason: length");
+		expect(lastMessage.errorMessage).toContain("continuation cap (3) exhausted");
 		expect(lastMessage.errorMessage).toContain("continuing was halted");
 
 		// The stream ended with agent_end (clean drain, no hang).
+		expect(events[events.length - 1].type).toBe("agent_end");
+	});
+
+	it("surfaces a terminal error when the stop hook halts an injected continuation", async () => {
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			shouldStopAfterTurn: () => true,
+		};
+
+		let streamCallCount = 0;
+		const streamFn = () => {
+			streamCallCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				stream.push({
+					type: "done",
+					reason: "length",
+					message: createAssistantMessage([{ type: "text", text: "partial" }], "length", createUsage(5)),
+				});
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("hello")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		const lastMessage = messages[messages.length - 1];
+		expect(streamCallCount).toBe(1);
+		expect(continuations(events)).toHaveLength(1);
+		expect(lastMessage.role).toBe("assistant");
+		expect(lastMessage.stopReason).toBe("error");
+		expect(lastMessage.errorMessage).toContain("stop hook halted the continuation");
+		expect(events[events.length - 1].type).toBe("agent_end");
+	});
+
+	it("honors tool termination after a length-truncated tool-call turn", async () => {
+		const executed: string[] = [];
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [createEchoTool(executed, true)],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let streamCallCount = 0;
+		const streamFn = () => {
+			streamCallCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				stream.push({
+					type: "done",
+					reason: "length",
+					message: createAssistantMessage(
+						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+						"length",
+						createUsage(5),
+					),
+				});
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("hello")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		await stream.result();
+		expect(streamCallCount).toBe(1);
+		expect(executed).toEqual(["hello"]);
 		expect(events[events.length - 1].type).toBe("agent_end");
 	});
 

--- a/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
+++ b/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
@@ -1,0 +1,375 @@
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	type Message,
+	type Model,
+	type UserMessage,
+} from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { MAX_LENGTH_CONTINUATIONS, agentLoop } from "../src/agent-loop.ts";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
+
+const CONTINUATION_TEXT = "Your previous response was cut off at the output limit. Continue exactly where you left off.";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createUsage(output = 0) {
+	return {
+		input: 0,
+		output,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: output,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "mock",
+		name: "mock",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"] = "stop",
+	usage: AssistantMessage["usage"] = createUsage(),
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage,
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function createUserMessage(text: string): UserMessage {
+	return {
+		role: "user",
+		content: text,
+		timestamp: Date.now(),
+	};
+}
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+function createEchoTool(executed: string[]): AgentTool<any, { value: string }> {
+	const toolSchema = Type.Object({ value: Type.String() });
+	return {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+			executed.push(params.value);
+			return {
+				content: [{ type: "text", text: `echoed: ${params.value}` }],
+				details: { value: params.value },
+			};
+		},
+	};
+}
+
+describe("agent loop stopReason=length (max_tokens truncation)", () => {
+	it("injects a continuation message and completes the truncated turn", async () => {
+		const executed: string[] = [];
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [createEchoTool(executed)],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let callIndex = 0;
+		const contextsSeen: AgentMessage[][] = [];
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					// Truncated turn: tool call issued, narration cut mid-sentence.
+					stream.push({
+						type: "done",
+						reason: "length",
+						message: createAssistantMessage(
+							[
+								{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } },
+								{ type: "text", text: "Both aud" },
+							],
+							"length",
+							createUsage(24),
+						),
+					});
+				} else {
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "both audits finished" }]),
+					});
+				}
+				callIndex++;
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("run both audits")], context, config, undefined, (_model, ctx) => {
+			contextsSeen.push([...ctx.messages]);
+			return streamFn();
+		});
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+
+		// Second stream call happened (continuation re-streamed).
+		expect(callIndex).toBe(2);
+
+		// Tool call from the truncated turn still executed.
+		expect(executed).toEqual(["hello"]);
+
+		// The continuation user message was injected into the context the second
+		// stream call reads, after the truncated assistant message and its tool result.
+		const secondCallContext = contextsSeen[1];
+		const continuationIndex = secondCallContext.findIndex(
+			(m) => m.role === "user" && JSON.stringify(m.content).includes(CONTINUATION_TEXT),
+		);
+		expect(continuationIndex).toBeGreaterThan(-1);
+		const truncatedIndex = secondCallContext.findIndex(
+			(m) => m.role === "assistant" && m.stopReason === "length",
+		);
+		const toolResultIndex = secondCallContext.findIndex((m) => m.role === "toolResult");
+		expect(truncatedIndex).toBeGreaterThan(-1);
+		expect(toolResultIndex).toBeGreaterThan(truncatedIndex);
+		expect(continuationIndex).toBeGreaterThan(toolResultIndex);
+
+		// Continuation message was emitted to consumers.
+		expect(continuations(events)).toHaveLength(1);
+
+		// The run ended with the model's clean completion, not the truncation.
+		const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant");
+		expect(lastAssistant?.stopReason).toBe("stop");
+		expect(lastAssistant?.content).toEqual([{ type: "text", text: "both audits finished" }]);
+	});
+
+	it("halts with a terminal error after the continuation cap is exhausted", async () => {
+		const executed: string[] = [];
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [createEchoTool(executed)],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let streamCallCount = 0;
+		const streamFn = () => {
+			streamCallCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				// Provider always truncates: the loop must not spin forever.
+				stream.push({
+					type: "done",
+					reason: "length",
+					message: createAssistantMessage([{ type: "text", text: "partial narrati" }], "length", createUsage(12)),
+				});
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("narrate forever")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+
+		// Initial call + one per injected continuation, then halt.
+		expect(streamCallCount).toBe(MAX_LENGTH_CONTINUATIONS + 1);
+
+		// Exactly MAX_LENGTH_CONTINUATIONS continuation messages were injected.
+		expect(continuations(events)).toHaveLength(MAX_LENGTH_CONTINUATIONS);
+
+		// The loop surfaced a terminal error instead of ending cleanly.
+		const lastMessage = messages[messages.length - 1];
+		expect(lastMessage.role).toBe("assistant");
+		expect(lastMessage.stopReason).toBe("error");
+		expect(lastMessage.errorMessage).toContain("Provider stop_reason: length");
+		expect(lastMessage.errorMessage).toContain("continuing was halted");
+
+		// The stream ended with agent_end (clean drain, no hang).
+		expect(events[events.length - 1].type).toBe("agent_end");
+	});
+
+	it("does not continue a length stop carrying an errorMessage (provider failure, not truncation)", async () => {
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let streamCallCount = 0;
+		const streamFn = () => {
+			streamCallCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const message = {
+					...createAssistantMessage([{ type: "text", text: "partial" }], "length", createUsage(5)),
+					errorMessage: "prompt is too long: 213462 tokens > 200000 maximum",
+				};
+				stream.push({ type: "done", reason: "length", message });
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("hello")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+
+		// No continuation injected: the provider flagged a failure, not a truncation.
+		expect(streamCallCount).toBe(1);
+		expect(continuations(events)).toHaveLength(0);
+
+		// Surfaced as a terminal error carrying the provider's message.
+		const lastMessage = messages[messages.length - 1];
+		expect(lastMessage.role).toBe("assistant");
+		expect(lastMessage.stopReason).toBe("error");
+		expect(lastMessage.errorMessage).toContain("prompt is too long");
+		expect(lastMessage.errorMessage).toContain("continuing was halted");
+		expect(events[events.length - 1].type).toBe("agent_end");
+	});
+
+	it("does not continue a zero-output length stop (silent context overflow)", async () => {
+		// pi-ai classifies length + output=0 as context overflow (isContextOverflow
+		// case 3): the provider truncated the INPUT, leaving no room to generate.
+		// Continuing would grow the context further, so halt with a terminal error.
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let streamCallCount = 0;
+		const streamFn = () => {
+			streamCallCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage([{ type: "text", text: "" }], "length", createUsage(0));
+				stream.push({ type: "done", reason: "length", message });
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("hello")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+
+		expect(streamCallCount).toBe(1);
+		expect(continuations(events)).toHaveLength(0);
+
+		const lastMessage = messages[messages.length - 1];
+		expect(lastMessage.role).toBe("assistant");
+		expect(lastMessage.stopReason).toBe("error");
+		expect(lastMessage.errorMessage).toContain("no output was generated");
+		expect(lastMessage.errorMessage).toContain("continuing was halted");
+		expect(events[events.length - 1].type).toBe("agent_end");
+	});
+
+	it("does not inject a continuation when the turn stops normally", async () => {
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let streamCallCount = 0;
+		const streamFn = () => {
+			streamCallCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				stream.push({
+					type: "done",
+					reason: "stop",
+					message: createAssistantMessage([{ type: "text", text: "done" }]),
+				});
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("hello")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+
+		expect(streamCallCount).toBe(1);
+		expect(continuations(events)).toHaveLength(0);
+		expect(messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+	});
+});
+
+function continuations(events: AgentEvent[]) {
+	return events.filter(
+		(event): event is Extract<AgentEvent, { type: "message_start" }> =>
+			event.type === "message_start" &&
+			event.message.role === "user" &&
+			JSON.stringify(event.message.content).includes(CONTINUATION_TEXT),
+	);
+}

--- a/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
+++ b/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
@@ -37,12 +37,12 @@ function createUsage(output = 0) {
 	};
 }
 
-function createModel(): Model<"openai-responses"> {
+function createModel(id = "mock", provider = "openai"): Model<"openai-responses"> {
 	return {
-		id: "mock",
-		name: "mock",
+		id,
+		name: id,
 		api: "openai-responses",
-		provider: "openai",
+		provider,
 		baseUrl: "https://example.invalid",
 		reasoning: false,
 		input: ["text"],
@@ -214,10 +214,14 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 			const stream = new MockAssistantStream();
 			queueMicrotask(() => {
 				// Provider always truncates: the loop must not spin forever.
+				const content: AssistantMessage["content"] =
+					streamCallCount === 4
+						? [{ type: "toolCall", id: "tool-at-cap", name: "echo", arguments: { value: "at-cap" } }]
+						: [{ type: "text", text: "partial narrati" }];
 				stream.push({
 					type: "done",
 					reason: "length",
-					message: createAssistantMessage([{ type: "text", text: "partial narrati" }], "length", createUsage(12)),
+					message: createAssistantMessage(content, "length", createUsage(12)),
 				});
 			});
 			return stream;
@@ -236,6 +240,8 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 
 		// Exactly three continuation messages were injected.
 		expect(continuations(events)).toHaveLength(3);
+		expect(executed).toEqual(["at-cap"]);
+		expect(messages.slice(-3).map((message) => message.role)).toEqual(["assistant", "toolResult", "assistant"]);
 
 		// The loop surfaced a terminal error instead of ending cleanly.
 		const lastMessage = messages[messages.length - 1];
@@ -250,14 +256,16 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 	});
 
 	it("surfaces a terminal error when the stop hook halts an injected continuation", async () => {
+		const sourceModel = createModel("source-model", "source-provider");
 		const context: AgentContext = {
 			systemPrompt: "",
 			messages: [],
 			tools: [],
 		};
 		const config: AgentLoopConfig = {
-			model: createModel(),
+			model: sourceModel,
 			convertToLlm: identityConverter,
+			prepareNextTurn: () => ({ model: createModel("next-model", "next-provider") }),
 			shouldStopAfterTurn: () => true,
 		};
 
@@ -269,7 +277,11 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 				stream.push({
 					type: "done",
 					reason: "length",
-					message: createAssistantMessage([{ type: "text", text: "partial" }], "length", createUsage(5)),
+					message: {
+						...createAssistantMessage([{ type: "text", text: "partial" }], "length", createUsage(5)),
+						model: sourceModel.id,
+						provider: sourceModel.provider,
+					},
 				});
 			});
 			return stream;
@@ -288,6 +300,9 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 		expect(lastMessage.role).toBe("assistant");
 		expect(lastMessage.stopReason).toBe("error");
 		expect(lastMessage.errorMessage).toContain("stop hook halted the continuation");
+		expect(lastMessage.api).toBe(sourceModel.api);
+		expect(lastMessage.provider).toBe(sourceModel.provider);
+		expect(lastMessage.model).toBe(sourceModel.id);
 		expect(events[events.length - 1].type).toBe("agent_end");
 	});
 
@@ -327,9 +342,15 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 			events.push(event);
 		}
 
-		await stream.result();
+		const messages = await stream.result();
+		const lastMessage = messages[messages.length - 1];
 		expect(streamCallCount).toBe(1);
 		expect(executed).toEqual(["hello"]);
+		expect(continuations(events)).toHaveLength(0);
+		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult", "assistant"]);
+		expect(lastMessage.role).toBe("assistant");
+		expect(lastMessage.stopReason).toBe("error");
+		expect(lastMessage.errorMessage).toContain("tool termination requested");
 		expect(events[events.length - 1].type).toBe("agent_end");
 	});
 

--- a/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
+++ b/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
@@ -458,10 +458,7 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 		expect(events[events.length - 1].type).toBe("agent_end");
 	});
 
-	it("does not continue a zero-output length stop (silent context overflow)", async () => {
-		// pi-ai classifies length + output=0 as context overflow (isContextOverflow
-		// case 3): the provider truncated the INPUT, leaving no room to generate.
-		// Continuing would grow the context further, so halt with a terminal error.
+	it("does not label an unclassified zero-output length stop as context overflow", async () => {
 		const context: AgentContext = {
 			systemPrompt: "",
 			messages: [],
@@ -498,6 +495,9 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 		expect(lastMessage.role).toBe("assistant");
 		expect(lastMessage.stopReason).toBe("error");
 		expect(lastMessage.errorMessage).toContain("no output was generated");
+		expect(lastMessage.errorMessage).not.toContain("context overflow");
+		const terminalText = lastMessage.content.find((content) => content.type === "text");
+		expect(terminalText?.text).not.toContain("context overflow");
 		expect(lastMessage.errorMessage).toContain("continuing was halted");
 		expect(events[events.length - 1].type).toBe("agent_end");
 	});

--- a/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
+++ b/packages/pi-agent-core/test/agent-loop-max-tokens.test.ts
@@ -107,9 +107,20 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 			messages: [],
 			tools: [createEchoTool(executed)],
 		};
+		let replacedContext = false;
 		const config: AgentLoopConfig = {
 			model: createModel(),
 			convertToLlm: identityConverter,
+			prepareNextTurn: ({ context: currentContext }) => {
+				if (replacedContext) return undefined;
+				replacedContext = true;
+				return {
+					context: {
+						...currentContext,
+						messages: currentContext.messages.filter((message) => message.role !== "user"),
+					},
+				};
+			},
 		};
 
 		let callIndex = 0;
@@ -351,6 +362,53 @@ describe("agent loop stopReason=length (max_tokens truncation)", () => {
 		expect(lastMessage.role).toBe("assistant");
 		expect(lastMessage.stopReason).toBe("error");
 		expect(lastMessage.errorMessage).toContain("tool termination requested");
+		expect(events[events.length - 1].type).toBe("agent_end");
+	});
+
+	it("lets the schema breaker stop repeated truncated validation failures", async () => {
+		const executed: string[] = [];
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [createEchoTool(executed)],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let streamCallCount = 0;
+		const streamFn = () => {
+			streamCallCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				stream.push({
+					type: "done",
+					reason: "length",
+					message: createAssistantMessage(
+						[{ type: "toolCall", id: `invalid-${streamCallCount}`, name: "echo", arguments: {} }],
+						"length",
+						createUsage(5),
+					),
+				});
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("hello")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		const lastMessage = messages[messages.length - 1];
+		expect(streamCallCount).toBe(3);
+		expect(executed).toHaveLength(0);
+		expect(continuations(events)).toHaveLength(2);
+		expect(lastMessage.role).toBe("assistant");
+		expect(lastMessage.stopReason).toBe("error");
+		expect(lastMessage.errorMessage).toContain("Schema overload");
 		expect(events[events.length - 1].type).toBe("agent_end");
 	});
 

--- a/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -202,6 +202,27 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
 	});
 
+	it("does not retry a terminal length halt with retryable provider text", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("partial", { stopReason: "length", errorMessage: "rate limit" }),
+			fauxAssistantMessage("unexpected retry"),
+		]);
+
+		await harness.session.prompt("test");
+
+		const lastMessage = harness.session.messages[harness.session.messages.length - 1];
+		expect(lastMessage?.role).toBe("assistant");
+		if (lastMessage?.role !== "assistant") throw new Error("Expected a terminal assistant message");
+		expect(lastMessage.stopReason).toBe("error");
+		expect(lastMessage.errorMessage).toContain("[length-halt] Provider stop_reason: length");
+		expect(lastMessage.errorMessage).toContain("provider error: rate limit");
+		expect(harness.session.isRetryableError(lastMessage)).toBe(false);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.faux.state.callCount).toBe(1);
+	});
+
 	it("cancels retry sleep when abortRetry is called", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 100 } } });
 		harnesses.push(harness);

--- a/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -223,6 +223,42 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.faux.state.callCount).toBe(1);
 	});
 
+	it("compacts and retries a zero-output length overflow", async () => {
+		const harness = await createHarness({
+			models: [{ id: "xiaomi", contextWindow: 100 }],
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "overflow context compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "length" }),
+			fauxAssistantMessage("recovered after compaction"),
+		]);
+
+		await harness.session.prompt("x".repeat(800));
+
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({ reason: "overflow", willRetry: true }),
+		);
+		expect(harness.faux.state.callCount).toBe(2);
+		const lastMessage = harness.session.messages[harness.session.messages.length - 1];
+		expect(lastMessage?.role).toBe("assistant");
+		if (lastMessage?.role === "assistant") {
+			expect(lastMessage.stopReason).toBe("stop");
+			expect(lastMessage.content).toEqual([{ type: "text", text: "recovered after compaction" }]);
+		}
+	});
+
 	it("cancels retry sleep when abortRetry is called", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 100 } } });
 		harnesses.push(harness);


### PR DESCRIPTION
## TL;DR

**What:** The agent loop now recognizes `stopReason: "length"` (max_tokens truncation): it injects a bounded continuation and keeps streaming instead of presenting a truncated turn as a clean completion.
**Why:** `runLoop` only reacted to `"error"`/`"aborted"`, so a turn cut off mid-sentence ("Both aud…") left orphaned narration, executed the truncated turn's tools, and never continued or signaled the cut (#2157).
**How:** Pure output-truncation stops inject a continuation user message (max 3) and re-stream; non-pure length stops and cap exhaustion surface a terminal error with the reason. Context-overflow length stops keep flowing through the existing overflow compaction/retry machinery.

## What

- `packages/pi-agent-core/src/agent-loop.ts` — `MAX_LENGTH_CONTINUATIONS` (module-private, 3): on a pure truncation (`stopReason: "length"`, no `errorMessage`, `usage.output > 0`), a continuation user message is injected **after** the truncated turn's tool results — into the post-`prepareNextTurn` context so hook replacements can't drop it — and the loop re-streams; cap exhaustion, stop-hook halts, and non-pure length stops emit a synthetic terminal error (non-retryable, model-attributed to the message that truncated); zero-output length stops preserve the machine-recognizable overflow signal so compaction/retry still engages.
- `packages/pi-agent-core/test/agent-loop-max-tokens.test.ts` (new) — pure truncation with tool calls (continuation visible in the next stream's context, tools executed, loop ends on stop), cap exhaustion, stop-hook halt, non-pure length variants, overflow preservation, retry-classification.

## Why

`mapStopReason` maps `max_tokens` → `"length"` while the adjacent `pause_turn` is deliberately promoted to a terminal error; `"length"` fell through as a completed turn. Truncation is transient — a follow-up "continue" recovered it — so the loop should do that recovery itself, bounded.

Closes #2157

## How

RFC: blanket maintainer pre-approval for agent-implemented bug fixes in this subsystem (owner decision 2026-09-04, recorded on the issue); minimal bug fix, no public API changes (the cap constant is module-private). The continuation is injected after tool results — the issue's literal before-order would break Anthropic's consecutive-toolResult grouping — and applied post-`prepareNextTurn` so context-replacing hooks preserve it. The schema-overload breaker keeps precedence over length continuation in the repeated-preparation-error corner (its terminal error is loud, satisfying the "never silent" requirement). Synthetic length-halt errors are explicitly non-retryable so interpolated provider text (e.g. "rate limit") can't trigger auto-retry.

**Test framework note:** this package's established suite runs on Vitest (`agent-loop.test.ts` et al.), so the new tests match it; the node:test preference in CONTRIBUTING is applied in the extension/repo-level suites, and introducing a parallel node:test harness for this one file would have split the package's runner.

> This PR is AI-assisted.

## Testing

The supplied pre-fix and revert-sensitivity baseline established the intended regression failures; focused core tests, correctly configured retry/overflow integration tests, and a manual agent event transcript now demonstrate tool-result ordering, continuation visibility in the next provider request, successful resumed output, non-retryable terminal handling, preserved overflow recovery, and the three-continuation bound. Initial harness/configuration mistakes were diagnosed and retried successfully; the known #2140 package-harness failure set remained unchanged.

<details>
<summary>Evidence: Issue #2157 agent-loop event transcript</summary>

`Reproduces the reported “Both aud” truncation and shows tool execution, ordered continuation injection, successful completion, and the bounded terminal halt.`

```text
{
  "scenario": "Issue #2157 max_tokens/length behavior through agentLoop",
  "continuationRecovery": {
    "providerRequests": 2,
    "executedTools": [
      "hello"
    ],
    "secondRequestRoles": [
      "user",
      "assistant",
      "toolResult",
      "user"
    ],
    "secondRequestContainsContinuation": true,
    "eventOrder": [
      "agent_start",
      "turn_start",
      "message_start:user:run both audits",
      "message_end:user:run both audits",
      "message_start:assistant:toolCall | Both aud",
      "message_end:assistant:toolCall | Both aud",
      "tool_execution_start:echo",
      "tool_execution_end:echo",
      "message_start:toolResult:echoed: hello",
      "message_end:toolResult:echoed: hello",
      "turn_end:length",
      "message_start:user:Your previous response was cut off at the output limit. Continue exactly where you left off.",
      "message_end:user:Your previous response was cut off at the output limit. Continue exactly where you left off.",
      "turn_start",
      "message_start:assistant:both audits finished",
      "message_end:assistant:both audits finished",
      "turn_end:stop",
      "agent_end"
    ],
    "finalAssistant": {
      "role": "assistant",
      "content": [
        {
          "type": "text",
          "text": "both audits finished"
        }
      ],
      "api": "openai-responses",
      "provider": "evidence-provider",
      "model": "evidence-model",
      "usage": {
        "input": 0,
        "output": 8,
        "cacheRead": 0,
        "cacheWrite": 0,
        "totalTokens": 8,
        "cost": {
          "input": 0,
          "output": 0,
          "cacheRead": 0,
          "cacheWrite": 0,
          "total": 0
        }
      },
      "stopReason": "stop",
      "timestamp": 1788535388715
    }
  },
  "boundedFailure": {
    "providerRequests": 4,
    "continuationsInjected": 3,
    "finalStopReason": "error",
    "finalError": "[length-halt] Provider stop_reason: length (continuation cap (3) exhausted; continuing was halted)",
    "lastEvent": "agent_end"
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a059a6104cab2461efc8e7fd47b2506e3bc12d9b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (6) ✅</summary>

- 🚨 `packages/pi-agent-core/src/agent-loop.ts:425` - The continuation’s user events are emitted before the truncated turn’s `turn_end`. The transcript reducer resets the active turn on a user `message_start`, discarding accumulated tool segments; the following `turn_end` then clears the pending continuation. Emit `turn_end` before the continuation events so tool output and the continuation remain visible.
- 🚨 `packages/pi-agent-core/src/agent-loop.ts:428` - The intent requires pure truncations to re-stream, but `shouldStopAfterTurn()` can return true immediately after the continuation is appended, producing `agent_end` with an unanswered user continuation and no terminal error. Decide whether truncation continuation overrides this hook or whether the hook should produce the required terminal error.
- 🚨 `packages/pi-agent-core/src/agent-loop.ts:428` - Unconditionally setting `hasMoreToolCalls = true` overrides the documented early-termination result from a tool batch. A pure-length response containing tool calls whose results all set `terminate: true` now makes an unwanted extra provider request; only force this flag for text-only truncations, since non-terminating tool batches already set it.
- 🚨 `packages/pi-agent-core/src/agent-loop.ts:48` - The authoritative criterion says “no API changes,” but `export const MAX_LENGTH_CONTINUATIONS` becomes a public package export through `src/index.ts`’s wildcard export. Keep the constant module-private and assert the required three continuations directly in the behavioral test.
- ⚠️ `packages/pi-agent-core/src/agent-loop.ts:305` - Cap exhaustion happens on the fourth length-stopped response—the initial response plus three continuations—but the terminal reason reports that the output cap was hit three times. Report that the three-continuation cap was exhausted instead of giving an incorrect hit count.

🔧 Fix: Fix truncation continuation sequencing and termination handling
3 issues (2 errors, 1 warning) still open:

- 🚨 `packages/pi-agent-core/src/agent-loop.ts:326` - The fourth pure length-truncated response enters this terminal branch before tool-call handling. If it contains a complete tool call, the tool is skipped and history becomes `assistant(toolCall) -&gt; assistant(error)` without a matching tool result, which can make the next provider request invalid. Process tool calls/results before emitting the cap-exhaustion error.
- 🚨 `packages/pi-agent-core/src/agent-loop.ts:433` - For a pure length response whose tool batch returns `terminate:true`, the continuation is appended but no further provider call occurs. The loop then emits clean `agent_end`; the transcript hides the pending continuation while session state retains it, recreating a silent truncated completion. Preserve tool termination but emit the synthetic terminal length error instead of leaving an unanswered continuation.
- ⚠️ `packages/pi-agent-core/src/agent-loop.ts:467` - The stop-hook error is created after `prepareNextTurn` may switch models. If model A returned `length` and preparation selects model B, the terminal message is incorrectly attributed to B even though B was never called. Populate its API/provider/model fields from the truncated message.

🔧 Fix: Fix truncation terminal sequencing and attribution
2 errors still open:

- 🚨 `packages/pi-agent-core/src/agent-loop.ts:455` - Intent requires the prompt in `currentContext.messages` “so the next streamAssistantResponse sees it,” but `prepareNextTurn` runs afterward and can replace that context. A supported hook returning a fresh or pruned context without the synthetic message makes the forced next request run without the continuation while `newMessages` still claims it was sent. Apply the continuation to the post-prepare context, or explicitly require replacement contexts to preserve it.
- 🚨 `packages/pi-agent-core/src/agent-loop.ts:383` - Intent requires a continuation for a pure `length` stop within the cap, but the schema-overload branch can return first. After two all-preparation-error turns, a pure `length`/output&gt;0 response with another invalid tool call trips this branch and never reaches continuation injection. Decide precedence explicitly; if length continuation wins, defer the schema breaker for that incomplete turn.

🔧 Fix: Preserve prepared continuations and schema-breaker precedence
1 error still open:

- 🚨 `packages/pi-agent-core/src/agent-loop.ts:77` - Intent requires the synthetic length terminal not to match `isRetryableError`, but interpolating the provider error allows that. For example, `stopReason: &#34;length&#34;` with `errorMessage: &#34;rate limit&#34;` creates an error that the retry regex matches. Without tool results, retry then leaves the original assistant message last and fails with `Cannot continue from message role: assistant`; with tool results, it makes an unintended provider retry. Explicitly classify synthetic length-halt errors as non-retryable at the shared retry-policy boundary.

🔧 Fix: Prevent retries after terminal length halts
1 error still open:

- 🚨 `packages/pi-agent-core/src/agent-loop.ts:320` - A concrete overflow path still regresses: a Xiaomi-style response with `stopReason: &#34;length&#34;`, `usage.output === 0`, and input at least 99% of the context window previously reached `isContextOverflow` case 3, triggering overflow compaction and an automatic retry. This branch replaces it with a synthetic `stopReason: &#34;error&#34;` message using `ZERO_USAGE`; its bare “context overflow” wording matches none of the error overflow patterns, so only threshold compaction may run and it does not retry. Preserve a machine-recognizable overflow signal at the shared overflow-detection boundary while keeping the required loud terminal error.

🔧 Fix: Preserve overflow recovery for zero-output length stops
2 issues (1 error, 1 warning) still open:

- 🚨 `packages/pi-agent-core/test/agent-loop-max-tokens.test.ts:10` - CONTRIBUTING requires all new tests to use `node:test` and explicitly forbids introducing Vitest, while this added test imports Vitest. The authoritative intent deliberately selects Vitest for package-suite coherence, and the package test script itself runs Vitest, so these requirements conflict; obtain an explicit maintainer waiver or define a runnable `node:test` path before merging.
- ⚠️ `packages/pi-agent-core/src/agent-loop.ts:328` - For `stopReason: &#34;length&#34;`, zero output, and input far below the context window, `isContextOverflow` returns false but this reason still tells the user that context overflow occurred. Make the parenthetical conditional on `lengthHaltIsContextOverflow`, otherwise report only that no output was generated.

🔧 Fix: Correct zero-output length halt messaging
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec vitest run --config packages/pi-agent-core/vitest.config.ts packages/pi-agent-core/test/agent-loop-max-tokens.test.ts --reporter=verbose`
- `pnpm exec vitest run --config packages/pi-coding-agent/vitest.config.ts packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts --reporter=verbose`
- <code>Evidence harness: `pnpm exec vitest run --config …/packages/pi-agent-core/vitest.config.ts --root …/evidence/01M1PAQTBD6XHTB0HY4G02GT92 length-stop-evidence.test.ts --reporter=dot`</code>
- <code>Validated the generated transcript using `JSON.parse`</code>
- <code>`pnpm --filter @gsd/pi-agent-core test -- agent-loop-max-tokens.test.ts --reporter=verbose` (forwarded filter was ignored; reproduced the supplied unchanged #2140 package-harness failure set)</code>
- <code>`pnpm exec vitest run packages/pi-agent-core/test/agent-loop-max-tokens.test.ts packages/pi-coding-agent/test/suite/agent-session-retry-events.test.ts --reporter=verbose` (identified missing coding-agent configuration, then retried correctly)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

