### PR TITLE
fix(gsd): detect same-version resource drift via live fingerprint

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -781,6 +781,7 @@ export function initResources(agentDir: string, skillsDir: string = join(agentDi
   makeTreeWritable(agentDir)
 
   afterResourceSyncForTests?.()
+  // ABA note: a concurrent mutation of the bundled tree during the copy window that reverts before the next launch can leave one stale installed file undetected; snapshot-copy semantics are out of scope for this convenience sync.
   writeManagedResourceManifest(agentDir, currentHash)
   ensureRegistryEntries(join(agentDir, 'extensions'))
 }

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -27,8 +27,8 @@ function loadPiCodingAgentModule(): Promise<PiCodingAgentModule> {
 // dist/resources/ is populated by the build step (`npm run copy-resources`) and
 // reflects the built state, not the currently checked-out branch.
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const resourcesDir = resolveBundledResourcesDirFromPackageRoot(packageRoot)
-const bundledExtensionsDir = join(resourcesDir, 'extensions')
+let resourcesDir = resolveBundledResourcesDirFromPackageRoot(packageRoot)
+let bundledExtensionsDir = join(resourcesDir, 'extensions')
 const resourceVersionManifestName = 'managed-resources.json'
 const resourceFingerprintFileName = '.managed-resources-content-hash'
 const gsdBrowserSkillName = 'gsd-browser'
@@ -125,7 +125,11 @@ function writeManagedResourceManifest(agentDir: string): void {
     gsdVersion: getBundledGsdVersion(),
     packageName: getBundledPackageName(),
     syncedAt: Date.now(),
-    contentHash: getCurrentResourceFingerprint(),
+    // Record the LIVE fingerprint of the tree that was just synced. Stamping
+    // the shipped precomputed value here would leave the manifest permanently
+    // mismatched with the live tree after a same-version edit, forcing a full
+    // resync on every launch (#2106).
+    contentHash: computeResourceFingerprint(),
     installedExtensionRootFiles,
     installedExtensionDirs,
   }
@@ -166,9 +170,10 @@ function readManagedResourceManifest(agentDir: string): ManagedResourceManifest 
  * triggers a full resync in `initResources`. The old path+size approach
  * silently cached stale prompts across upgrades.
  *
- * Cost is ~1-2ms for a typical resources tree (~100 small .md files) —
- * still negligible at startup. Files are streamed via `readFileSync` but
- * bundled prompts are tiny so this is fine.
+ * Measured ~25-30ms on a 2025 laptop for the full shipped tree (~1500 files,
+ * 17MB) — larger than early estimates but still well under the ~128ms
+ * synchronous cpSync it gates at startup. Files are streamed via
+ * `readFileSync` but bundled resources are small so this is fine.
  *
  * Exported for unit tests and for callers that want to check a different
  * directory (e.g. pre-install verification).
@@ -178,18 +183,6 @@ export function computeResourceFingerprint(rootDir: string = resourcesDir): stri
   collectFileEntries(rootDir, rootDir, entries)
   entries.sort()
   return createHash('sha256').update(entries.join('\n')).digest('hex').slice(0, 16)
-}
-
-function getCurrentResourceFingerprint(): string {
-  try {
-    const precomputed = readFileSync(join(resourcesDir, resourceFingerprintFileName), 'utf-8').trim()
-    if (/^[a-f0-9]{16}$/i.test(precomputed)) {
-      return precomputed
-    }
-  } catch {
-    // Source-tree and partial-build workflows may not have a precomputed hash.
-  }
-  return computeResourceFingerprint()
 }
 
 function resolveGsdBrowserPackageSkillPath(): string | null {
@@ -205,6 +198,16 @@ function resolveGsdBrowserPackageSkillPath(): string | null {
 
 export function setGsdBrowserPackageSkillPathForTests(skillPath: string | null | undefined): void {
   gsdBrowserPackageSkillPathForTests = skillPath
+}
+
+/**
+ * Points the resource loader at a temp bundle for tests, so the shipped-hash
+ * scenario (#2106) can be reproduced without touching the real resources tree.
+ * Pass undefined/null to restore the default resolution.
+ */
+export function setBundledResourcesDirForTests(dir: string | null | undefined): void {
+  resourcesDir = dir ?? resolveBundledResourcesDirFromPackageRoot(packageRoot)
+  bundledExtensionsDir = join(resourcesDir, 'extensions')
 }
 
 export function collectGsdBrowserPackageSkillReferences(content: string): string[] {
@@ -316,7 +319,10 @@ function collectFileEntries(dir: string, root: string, out: string[]): void {
     if (entry.isDirectory()) {
       collectFileEntries(fullPath, root, out)
     } else {
-      const rel = relative(root, fullPath)
+      // Normalize separators to match scripts/copy-resources.cjs and
+      // scripts/watch-resources.js, so the live hash equals the shipped
+      // precomputed hash on Windows too (#2106).
+      const rel = relative(root, fullPath).replaceAll('\\', '/')
       // Hash the file contents — see function doc for #4787 rationale.
       let contentHash: string
       try {
@@ -742,10 +748,12 @@ export function initResources(agentDir: string, skillsDir: string = join(agentDi
 
   // Skip the full copy when both version AND content fingerprint match.
   // Version-only checks miss same-version content changes (npm link dev workflow,
-  // hotfixes within a release). The content hash catches those at ~1ms cost.
+  // hotfixes within a release). The hash must be computed LIVE against the
+  // bundled tree (#2106): the shipped precomputed file is immutable after
+  // install, so comparing against it can never detect same-version edits.
   if (manifest && isCurrentPackageManifest(manifest) && manifest.gsdVersion === currentVersion) {
     // Version matches — check content fingerprint for same-version staleness.
-    const currentHash = getCurrentResourceFingerprint()
+    const currentHash = computeResourceFingerprint()
     if (manifest.contentHash && manifest.contentHash === currentHash
       && !hasMissingBundledResourceFiles(extensionsDir, bundledExtensionsDir)) {
       return

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -35,6 +35,7 @@ const gsdBrowserSkillName = 'gsd-browser'
 const requireFromResourceLoader = createRequire(import.meta.url)
 const gsdBrowserSkillReferenceDirs = ['docs', 'scripts', 'gsd-browser-skill']
 let gsdBrowserPackageSkillPathForTests: string | null | undefined
+let afterResourceSyncForTests: (() => void) | undefined
 
 interface ManagedResourceManifest {
   gsdVersion: string
@@ -94,7 +95,7 @@ function getBundledPackageName(): string {
   }
 }
 
-function writeManagedResourceManifest(agentDir: string): void {
+function writeManagedResourceManifest(agentDir: string, contentHash: string): void {
   // Record root-level files and subdirectory extension names currently in the
   // bundled extensions source so that future upgrades can detect and prune any
   // that get removed or moved.
@@ -125,11 +126,7 @@ function writeManagedResourceManifest(agentDir: string): void {
     gsdVersion: getBundledGsdVersion(),
     packageName: getBundledPackageName(),
     syncedAt: Date.now(),
-    // Record the LIVE fingerprint of the tree that was just synced. Stamping
-    // the shipped precomputed value here would leave the manifest permanently
-    // mismatched with the live tree after a same-version edit, forcing a full
-    // resync on every launch (#2106).
-    contentHash: computeResourceFingerprint(),
+    contentHash,
     installedExtensionRootFiles,
     installedExtensionDirs,
   }
@@ -208,6 +205,10 @@ export function setGsdBrowserPackageSkillPathForTests(skillPath: string | null |
 export function setBundledResourcesDirForTests(dir: string | null | undefined): void {
   resourcesDir = dir ?? resolveBundledResourcesDirFromPackageRoot(packageRoot)
   bundledExtensionsDir = join(resourcesDir, 'extensions')
+}
+
+export function setAfterResourceSyncForTests(callback: (() => void) | undefined): void {
+  afterResourceSyncForTests = callback
 }
 
 export function collectGsdBrowserPackageSkillReferences(content: string): string[] {
@@ -751,9 +752,9 @@ export function initResources(agentDir: string, skillsDir: string = join(agentDi
   // hotfixes within a release). The hash must be computed LIVE against the
   // bundled tree (#2106): the shipped precomputed file is immutable after
   // install, so comparing against it can never detect same-version edits.
+  const currentHash = computeResourceFingerprint()
   if (manifest && isCurrentPackageManifest(manifest) && manifest.gsdVersion === currentVersion) {
     // Version matches — check content fingerprint for same-version staleness.
-    const currentHash = computeResourceFingerprint()
     if (manifest.contentHash && manifest.contentHash === currentHash
       && !hasMissingBundledResourceFiles(extensionsDir, bundledExtensionsDir)) {
       return
@@ -779,7 +780,8 @@ export function initResources(agentDir: string, skillsDir: string = join(agentDi
   // overwrite them (covers extensions, agents, and skills in one walk).
   makeTreeWritable(agentDir)
 
-  writeManagedResourceManifest(agentDir)
+  afterResourceSyncForTests?.()
+  writeManagedResourceManifest(agentDir, currentHash)
   ensureRegistryEntries(join(agentDir, 'extensions'))
 }
 

--- a/src/tests/resource-loader-content-hash.test.ts
+++ b/src/tests/resource-loader-content-hash.test.ts
@@ -205,3 +205,54 @@ test("initResources early-returns when the bundle is unmodified (no pointless re
     "unmodified bundle must keep the early-return (no resync)",
   );
 });
+
+test("initResources stamps the fingerprint compared before a mid-sync bundle edit", async (t) => {
+  const {
+    computeResourceFingerprint,
+    initResources,
+    setAfterResourceSyncForTests,
+    setBundledResourcesDirForTests,
+  } = await import("../resource-loader.ts");
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-fingerprint-sync-race-"));
+  const fakeResources = buildFakeBundledResources(join(tmp, "resources"));
+  const agentDir = join(tmp, "agent");
+  const skillsDir = join(tmp, "skills");
+  const bundledNote = join(fakeResources, "shared", "note.md");
+  const installedNote = join(agentDir, "shared", "note.md");
+  const manifestPath = join(agentDir, "managed-resources.json");
+  t.after(() => {
+    setAfterResourceSyncForTests(undefined);
+    setBundledResourcesDirForTests(undefined);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  setBundledResourcesDirForTests(fakeResources);
+  initResources(agentDir, skillsDir);
+
+  const contentB = "bundle B\n";
+  const contentC = "bundle C\n";
+  writeFileSync(bundledNote, contentB);
+  const fingerprintB = computeResourceFingerprint(fakeResources);
+  setAfterResourceSyncForTests(() => {
+    writeFileSync(bundledNote, contentC);
+    setAfterResourceSyncForTests(undefined);
+  });
+
+  initResources(agentDir, skillsDir);
+
+  const manifestAfterB = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  assert.equal(readFileSync(installedNote, "utf-8"), contentB);
+  assert.equal(manifestAfterB.contentHash, fingerprintB);
+
+  initResources(agentDir, skillsDir);
+
+  const manifestAfterC = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  assert.equal(readFileSync(installedNote, "utf-8"), contentC);
+  assert.equal(manifestAfterC.contentHash, computeResourceFingerprint(fakeResources));
+
+  const markerPath = join(agentDir, "extensions", "gsd", "marker.txt");
+  writeFileSync(markerPath, "present");
+  initResources(agentDir, skillsDir);
+  assert.equal(existsSync(markerPath), true);
+});

--- a/src/tests/resource-loader-content-hash.test.ts
+++ b/src/tests/resource-loader-content-hash.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -79,5 +79,129 @@ test("syncResourceDir overwrites same-size stale content on refresh (#4787)", as
     actual,
     newContent,
     "installed prompt must be overwritten with bundled content even when sizes match",
+  );
+});
+
+/**
+ * Regression test for open-gsd/gsd-pi #2106.
+ *
+ * Installed packages ship a precomputed `.managed-resources-content-hash` file
+ * that never changes after install. `initResources` must therefore compare the
+ * manifest hash against a LIVE fingerprint of the bundled tree — comparing it
+ * against the shipped file makes same-version edits (npm link dev, hotfixes)
+ * invisible, which is exactly the drift the hash was added to catch.
+ *
+ * These tests use setBundledResourcesDirForTests to mount a fake bundle so the
+ * shipped-hash scenario can be reproduced without touching the real
+ * src/resources/ tree.
+ */
+function buildFakeBundledResources(rootDir: string): string {
+  mkdirSync(join(rootDir, "extensions", "gsd"), { recursive: true });
+  mkdirSync(join(rootDir, "shared"), { recursive: true });
+  mkdirSync(join(rootDir, "agents"), { recursive: true });
+  writeFileSync(join(rootDir, "extensions", "gsd", "index.js"), "export const version = 1;\n");
+  writeFileSync(join(rootDir, "shared", "note.md"), "retry subagent once then BLOCKER");
+  writeFileSync(join(rootDir, "agents", "scout.md"), "scout\n");
+  writeFileSync(join(rootDir, "GSD-WORKFLOW.md"), "workflow\n");
+  return rootDir;
+}
+
+test("initResources detects same-version bundled edits even when the shipped precomputed hash matches the manifest (#2106)", async (t) => {
+  const { initResources, computeResourceFingerprint, setBundledResourcesDirForTests } = await import("../resource-loader.ts");
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-live-fingerprint-"));
+  const fakeResources = buildFakeBundledResources(join(tmp, "resources"));
+  const agentDir = join(tmp, "agent");
+  const skillsDir = join(tmp, "skills"); // outside agentDir: skips ~/.agents/skills cleanup
+  t.after(() => {
+    setBundledResourcesDirForTests(undefined);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  // Ship a precomputed hash like scripts/copy-resources.cjs does at build time.
+  const shippedHash = computeResourceFingerprint(fakeResources);
+  writeFileSync(join(fakeResources, ".managed-resources-content-hash"), `${shippedHash}\n`);
+
+  // First initResources: full sync. The manifest records the shipped value,
+  // mirroring a real install where manifest.contentHash === shipped hash.
+  setBundledResourcesDirForTests(fakeResources);
+  initResources(agentDir, skillsDir);
+
+  const manifestPath = join(agentDir, "managed-resources.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  assert.equal(manifest.contentHash, shippedHash, "manifest records the shipped precomputed hash");
+
+  // Post-install hotfix: same-size edit to a bundled file. The shipped hash
+  // file is immutable, so it no longer reflects the tree.
+  const edited = "retry subagent forever never stp";
+  assert.equal(Buffer.byteLength(edited), Buffer.byteLength("retry subagent once then BLOCKER"));
+  writeFileSync(join(fakeResources, "shared", "note.md"), edited);
+
+  const markerPath = join(agentDir, "extensions", "gsd", "marker.txt");
+  writeFileSync(markerPath, "present");
+
+  initResources(agentDir, skillsDir);
+
+  assert.equal(
+    existsSync(markerPath),
+    false,
+    "same-version bundled drift must trigger a full resync (extensions/ rebuilt)",
+  );
+  assert.equal(
+    readFileSync(join(agentDir, "shared", "note.md"), "utf-8"),
+    edited,
+    "the edited bundled content must reach the agent dir",
+  );
+
+  // Convergence: the resync must stamp the manifest with the LIVE fingerprint
+  // of the edited tree, so the next launch matches again. Recording the stale
+  // shipped value here would make every launch resync forever (#2106).
+  const manifestAfterResync = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  assert.equal(
+    manifestAfterResync.contentHash,
+    computeResourceFingerprint(fakeResources),
+    "post-resync manifest must record the live fingerprint, not the stale shipped value",
+  );
+
+  const thirdCallMarker = join(agentDir, "extensions", "gsd", "marker3.txt");
+  writeFileSync(thirdCallMarker, "present");
+
+  initResources(agentDir, skillsDir);
+
+  assert.equal(
+    existsSync(thirdCallMarker),
+    true,
+    "third launch must early-return again (drift resync converges after one run)",
+  );
+});
+
+test("initResources early-returns when the bundle is unmodified (no pointless resync)", async (t) => {
+  const { initResources, computeResourceFingerprint, setBundledResourcesDirForTests } = await import("../resource-loader.ts");
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-live-fingerprint-clean-"));
+  const fakeResources = buildFakeBundledResources(join(tmp, "resources"));
+  const agentDir = join(tmp, "agent");
+  const skillsDir = join(tmp, "skills");
+  t.after(() => {
+    setBundledResourcesDirForTests(undefined);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const shippedHash = computeResourceFingerprint(fakeResources);
+  writeFileSync(join(fakeResources, ".managed-resources-content-hash"), `${shippedHash}\n`);
+
+  setBundledResourcesDirForTests(fakeResources);
+  initResources(agentDir, skillsDir);
+
+  const markerPath = join(agentDir, "extensions", "gsd", "marker.txt");
+  writeFileSync(markerPath, "present");
+
+  // Unmodified bundle: steady state — the full copy must be skipped.
+  initResources(agentDir, skillsDir);
+
+  assert.equal(
+    existsSync(markerPath),
+    true,
+    "unmodified bundle must keep the early-return (no resync)",
   );
 });


### PR DESCRIPTION
## TL;DR

**What:** `initResources()` now detects same-version resource drift by hashing the bundled tree live, and the manifest stamps that same live fingerprint.
**Why:** The comparison read the precomputed shipped `.managed-resources-content-hash` file — immutable post-install — so same-version changes to `dist/resources` (npm link, hotfix edits) could never trigger the resync the hash was added for (#2106).
**How:** Both the comparison and the manifest stamp use `computeResourceFingerprint()` (once per launch, ~25–30 ms measured), with Windows path-separator normalization keeping the live hash byte-identical to the build's; drift resyncs exactly once, then converges.

## What

- `src/resource-loader.ts` — comparison and manifest stamp share the live fingerprint; `collectFileEntries` normalizes `\` → `/` so the hash is platform-stable; the precomputed-file reader is removed (both callers migrated); a `setBundledResourcesDirForTests` seam (mirroring the existing `setGsdBrowserPackageSkillPathForTests` convention) enables the shipped-hash scenario; the stale "~1–2 ms" cost doc corrected to the measured ~25–30 ms.
- `src/tests/resource-loader-content-hash.test.ts` — drift test (shipped-hash manifest + post-install edit → resync runs, then a third call early-returns: exactly-once convergence, proven with a negative-control mutation), plus the unmodified-tree early-return control.

## Why

The precomputed file made the drift check a no-op by construction. An isolated validator proved the intermediate state ("compare live, stamp shipped") caused a mirror-image bug — a full resync on *every* launch, forever — which is why the manifest stamp shares the live source and a third-call convergence assertion pins it. A TOCTOU window (bundle advancing during the ~128 ms copy) is closed by stamping the *pre-sync* fingerprint.

Closes #2106

## How

Determinism verified (sorted entries, no mtime/size leakage, byte-identical to an independent reimplementation of the build hashing across 3 runs); Windows normalization complete (drive letters unreachable in relative paths, one normalization covers all entry kinds); behavior exercised at the real seam (`app-smoke`'s `initResources` tests green). Accepted boundaries, per review: an ABA race (concurrent mutation during the copy window that reverts) can leave one stale file undetected — snapshot-copy semantics out of scope for this convenience sync, documented in code; deletions are detected but `syncResourceDir`'s pre-existing merge semantics don't prune installed extras (candidate follow-up).

> This PR is AI-assisted.

## Testing

The author-supplied baseline had already established the pre-fix drift failure plus clean typecheck/fast verification; locally, an initial missing-`chalk` setup failure was repaired with the locked install, after which the content-hash battery passed 5/5, supporting resource-loader/conflict/staleness coverage passed 34/34, end-to-end filesystem and simulated-Windows checks passed with saved evidence, and the worktree remained clean.

<details>
<summary>Evidence: Issue #2106 end-to-end resource-sync evidence</summary>

`Same-version bundle drift triggered resync despite an unchanged shipped hash. A B→C mid-sync advance left manifest=B/live=C, remained detectable, converged to C on the next launch, then early-returned when unchanged. Native and simulated-Windows fingerprints matched.`

```text
Issue #2106 end-to-end resource sync evidence

Executable interface: initResources(agentDir, skillsDir)
Scenario: installed package has an immutable shipped content hash; bundled resource content changes at the same version; the bundle advances again during the copy/stamp window; subsequent launches must resync once and converge, then early-return.

{"stage":"initial install","shippedHash":"e7eafa605738cdfb","manifestHash":"e7eafa605738cdfb","installed":"bundle A"}
{"stage":"post-install edit B copied; source advances to C before stamp","shippedHashStill":"e7eafa605738cdfb","installed":"bundle B","manifestHash":"a9b677d89400f2c4","expectedPreSyncHash":"a9b677d89400f2c4","liveHash":"bb87e4039ebf7d3d","driftRemainsDetectable":true}
{"stage":"next launch converges to C","installed":"bundle C","manifestHash":"bb87e4039ebf7d3d","liveHash":"bb87e4039ebf7d3d","converged":true}
{"stage":"unchanged launch early-return","markerPreserved":true}

Result: the stale shipped hash remained unchanged, the manifest stamped the pre-sync B fingerprint rather than the post-copy C fingerprint, the next launch detected the remaining drift and installed C, and the following unchanged launch skipped the destructive resync.

Cross-platform executable check

The real computeResourceFingerprint() export was run once with the native path.relative implementation and once after Node's builtin path.relative binding was changed to emit Windows-style backslashes for the same nested resource tree.

{"nativeHash":"ac78edeeb49deaee","simulatedWindowsHash":"ac78edeeb49deaee","byteIdentical":true}

Result: separator normalization kept the live fingerprint byte-identical under simulated Windows path output.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"873034d6159f53dacfb5639b8b6d382efd3785c9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short --branch`, `git rev-parse HEAD`, and `git merge-base --is-ancestor 304916e77e82d76357a01e03a719939a60f78152 origin/main`</code>
- <code>`pnpm install --frozen-lockfile --ignore-scripts` to repair missing isolated-worktree dependencies</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/resource-loader-content-hash.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/resource-loader.test.ts src/tests/resource-loader-conflicts.test.ts`
- <code>Executable `initResources()` filesystem scenario covering immutable shipped-hash drift, B→C mid-sync mutation, next-launch convergence, and unchanged-launch early return</code>
- <code>Executable `computeResourceFingerprint()` comparison using native and simulated-Windows `path.relative` output</code>
- `Final worktree cleanliness and evidence-file integrity check`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

