### PR TITLE
fix(gsd): pause with cause on schema-rejected completions in the durable path

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -99,7 +99,7 @@ import { writeTurnGitTransaction } from "./uok/gitops.js";
 import { isClosedStatus } from "./status-guards.js";
 import { detectAbandonMilestone } from "./abandon-detect.js";
 import { getPendingGate } from "./bootstrap/write-gate.js";
-import { isDeterministicPolicyError, isToolUnavailableError } from "./auto-tool-tracking.js";
+import { isDeterministicPolicyError, isToolInvocationError, isToolUnavailableError } from "./auto-tool-tracking.js";
 import { formatConnectedStepStack, formatPostUnitStatusCard } from "./auto-status-message.js";
 import {
   clearProjectResearchInflightMarker,
@@ -449,6 +449,14 @@ function persistGitActionFailure(basePath: string, action: TurnGitActionMode, me
 
 function gitCommitRemediationRetryKey(unitType: string, unitId: string): string {
   return `git-commit:${verificationRetryKey(unitType, unitId)}`;
+}
+
+/**
+ * Shared by the legacy artifact ladder and the durable-authority branch so both
+ * pause sites emit byte-identical messaging (#2883/#2131).
+ */
+function toolInvocationPauseMessage(unitType: string, errorMsg: string): string {
+  return `Tool invocation/runtime failed for ${unitType}: ${errorMsg}. Retrying cannot resolve this deterministic failure — pausing auto-mode.`;
 }
 
 /**
@@ -2296,12 +2304,35 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       //   user message — retry will produce the same failure.
       // - DB-backed Tasks: Attempt, Result, Verdict, and Recovery rows own the
       //   recovery decision; this legacy artifact ladder must not compete.
+      //   Exception (#2131): the durable authority never sees the tool
+      //   invocation record, so a deterministic failure (e.g. a schema-rejected
+      //   gsd_task_complete) would be cleared and retried with unchanged inputs
+      //   until the liveness backstop wedges. The recorded #2883 classification
+      //   fires before the clear; transient tool-unavailable errors still defer.
       //
       // User-driven deep setup prompts may ask for approval before the final
       // root artifact write. If a premature write hits the write gate in the
       // same turn, the user wait is the meaningful state; pause instead of
       // writing a placeholder over PROJECT/REQUIREMENTS.
       if (!triggerArtifactVerified && isDurableVerificationTask(s.currentUnit.type)) {
+        // #2131: the durable authority never receives the invocation record, so
+        // a deterministic failure recorded here must pause before the clear
+        // below — otherwise it is retried with unchanged inputs until the
+        // liveness backstop wedges. Non-deterministic records (transient
+        // tool-unavailable, policy gates, queued-user skips) keep the deferral.
+        const invocationError = s.lastToolInvocationError;
+        if (
+          invocationError
+          && isToolInvocationError(invocationError)
+          && !isDeterministicPolicyError(invocationError)
+          && !isToolUnavailableError(invocationError)
+        ) {
+          debugLog("postUnit", { phase: "tool-invocation-error-pause", unitType: s.currentUnit.type, unitId: s.currentUnit.id, error: invocationError });
+          ctx.ui.notify(toolInvocationPauseMessage(s.currentUnit.type, invocationError), "error");
+          s.lastToolInvocationError = null;
+          await pauseAuto(ctx, pi);
+          return "dispatched";
+        }
         const retryKey = verificationRetryKey(s.currentUnit.type, s.currentUnit.id);
         if (s.pendingVerificationRetry?.unitId === s.currentUnit.id) {
           s.pendingVerificationRetry = null;
@@ -2473,7 +2504,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           const isUserSkip = /queued user message/i.test(s.lastToolInvocationError);
           const errMsg = isUserSkip
             ? `Tool skipped for ${s.currentUnit.type}: ${s.lastToolInvocationError}. Queued user message interrupted the turn — pausing auto-mode.`
-            : `Tool invocation/runtime failed for ${s.currentUnit.type}: ${s.lastToolInvocationError}. Retrying cannot resolve this deterministic failure — pausing auto-mode.`;
+            : toolInvocationPauseMessage(s.currentUnit.type, s.lastToolInvocationError);
           debugLog("postUnit", { phase: "tool-invocation-error-pause", unitType: s.currentUnit.type, unitId: s.currentUnit.id, error: s.lastToolInvocationError });
           ctx.ui.notify(errMsg, "error");
           s.lastToolInvocationError = null;

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -2318,8 +2318,9 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         // #2131: the durable authority never receives the invocation record, so
         // a deterministic failure recorded here must pause before the clear
         // below — otherwise it is retried with unchanged inputs until the
-        // liveness backstop wedges. Non-deterministic records (transient
-        // tool-unavailable, policy gates, queued-user skips) keep the deferral.
+        // liveness backstop wedges. Other recorded classes (transient
+        // tool-unavailable, deterministic policy gates, queued-user skips)
+        // keep the deferral.
         const invocationError = s.lastToolInvocationError;
         if (
           invocationError

--- a/src/resources/extensions/gsd/tests/post-unit-task-recovery-authority.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-task-recovery-authority.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../task-execution-domain-operation.ts";
 import { cleanup, makeTempRepo } from "./test-utils.ts";
 
-function createTaskContext(basePath: string, pauseCalls: string[]): PostUnitContext {
+function createTaskContext(basePath: string, pauseCalls: string[], notifyCalls: string[] = []): PostUnitContext {
   const session = new AutoSession();
   session.active = true;
   session.basePath = basePath;
@@ -36,7 +36,13 @@ function createTaskContext(basePath: string, pauseCalls: string[]): PostUnitCont
 
   return {
     s: session,
-    ctx: { ui: { notify: () => {} } } as unknown as PostUnitContext["ctx"],
+    ctx: {
+      ui: {
+        notify: (message: string) => {
+          notifyCalls.push(message);
+        },
+      },
+    } as unknown as PostUnitContext["ctx"],
     pi: {} as PostUnitContext["pi"],
     buildSnapshotOpts: () => ({}),
     lockBase: () => basePath,
@@ -135,6 +141,62 @@ test("DB-backed execute-task deterministic errors cannot write an artifact place
   assert.equal(pctx.s.pendingVerificationRetry, null);
   assert.equal(pctx.s.lastToolInvocationError, null);
   assert.deepEqual(pauseCalls, []);
+});
+
+// ── #2131: a schema-rejected gsd_task_complete records a deterministic
+// invocation error. The durable-authority branch used to clear it before any
+// classification could act, so the unit was re-dispatched with unchanged
+// inputs, failed host verification with a cause-agnostic throw, and wedged via
+// the ADR-047 liveness backstop. The deterministic record must survive the
+// durable path so the existing #2883 pause fires with the actual cause.
+test("schema-rejected gsd_task_complete pauses with the deterministic cause (#2131)", async (t) => {
+  const basePath = scaffoldDbBackedTask();
+  t.after(() => {
+    closeDatabase();
+    cleanup(basePath);
+  });
+  const pauseCalls: string[] = [];
+  const notifyCalls: string[] = [];
+  const pctx = createTaskContext(basePath, pauseCalls, notifyCalls);
+  pctx.s.lastToolInvocationError =
+    'gsd_task_complete: Validation failed for tool "gsd_task_complete": sliceId: must have required properties sliceId';
+
+  const result = await postUnitPreVerification(pctx, {
+    skipSettleDelay: true,
+    skipWorktreeSync: true,
+  });
+
+  assert.equal(result, "dispatched");
+  assert.equal(pauseCalls.length, 1, "auto-mode must pause instead of re-dispatching the unit");
+  assert.equal(pctx.s.lastToolInvocationError, null);
+  assert.deepEqual(notifyCalls, [
+    'Tool invocation/runtime failed for execute-task: gsd_task_complete: Validation failed for tool "gsd_task_complete": sliceId: must have required properties sliceId. Retrying cannot resolve this deterministic failure — pausing auto-mode.',
+  ]);
+});
+
+test("durable execute-task transient tool-unavailable error keeps deferring to durable authority", async (t) => {
+  const basePath = scaffoldDbBackedTask();
+  t.after(() => {
+    closeDatabase();
+    cleanup(basePath);
+  });
+  const pauseCalls: string[] = [];
+  const notifyCalls: string[] = [];
+  const pctx = createTaskContext(basePath, pauseCalls, notifyCalls);
+  pctx.s.lastToolInvocationError =
+    "No such tool available: mcp__gsd-workflow__gsd_task_complete";
+
+  const result = await postUnitPreVerification(pctx, {
+    skipSettleDelay: true,
+    skipWorktreeSync: true,
+  });
+
+  // Transient MCP startup race: still cleared for the durable authority's own
+  // bounded retry — no pause, no reclassification.
+  assert.equal(result, "continue");
+  assert.equal(pctx.s.lastToolInvocationError, null);
+  assert.deepEqual(pauseCalls, []);
+  assert.deepEqual(notifyCalls, []);
 });
 
 // ── #1971: a staged Attempt awaiting host verification must not reset the


### PR DESCRIPTION
## TL;DR

**What:** The durable-authority branch of `postUnitPreVerification` now pauses with the deterministic cause when the recorded tool-invocation error is a validation failure, instead of discarding it.
**Why:** The branch unconditionally cleared `lastToolInvocationError` before the deterministic classifier could act, so a schema-rejected `gsd_task_complete` (missing identity scalars) was retried blind, hit the cause-agnostic verification throw, and wedged auto-mode through the liveness backstop (#2131).
**How:** The recorded error is checked before the clear: deterministic validation failures fire the existing pause (legacy ladder's exact message via a shared helper); transient/policy/queued-skip records keep the old clear-and-defer.

## What

- `src/resources/extensions/gsd/auto-post-unit.ts` — the durable branch gates on `isToolInvocationError && !isDeterministicPolicyError && !isToolUnavailableError`, pauses via `pauseAuto` with a shared `toolInvocationPauseMessage` helper (byte-identical to the legacy ladder's text), then clears the record and returns `"dispatched"`. The non-durable ladder is untouched except the message-literal → helper swap.
- `src/resources/extensions/gsd/tests/post-unit-task-recovery-authority.test.ts` — regression test (schema-rejected completion pauses with the deterministic cause; failed pre-fix with `continue` — the wedge path) and a transient-unchanged guard (tool-unavailable still clears and defers).

## Why

The record's discard orphaned the #2883 doctrine: deterministic failures must stop-and-surface, not retry. An isolated validator compared the new gate to the legacy ladder term by term — it fires on exactly `invocation ∧ ¬policy ∧ ¬unavailable`, so no other error class changes behavior; the record-writer census confirms stale records can't leak (cleared at unit start and on tool success); resume semantics match the legacy ladder's (re-pauses with cause on an identical deterministic failure — the intended stop-and-surface behavior).

Closes #2131

## How

232 tests green across the post-unit/liveness/workflow-kernel/verification-retry battery; revert-sensitivity proven (the regression fails with the fix stashed); typecheck clean apart from 2 pre-existing unrelated errors. Known boundaries: ScheduleWakeup-continuation and queued-user-skip records still clear-and-defer on the durable path (identical to pre-fix, outside this issue's class), and the pause leaves retry bookkeeping one cycle stale (benign).

> This PR is AI-assisted.

## Testing

The supplied baseline reported its 232-test battery and `verify:fast` green; this phase independently ran the focused five-test recovery-authority suite, proved revert sensitivity against the old `continue` path, and exercised the real post-unit interface for deterministic and excluded error classes. No screenshot was captured because this is auto-loop control logic without a rendered test surface; the exact user-facing notification is preserved in the evidence transcript.

<details>
<summary>Evidence: Issue #2131 end-user behavior transcript</summary>

<code>Rejected completion:&#10;gsd_task_complete: Validation failed for tool &#34;gsd_task_complete&#34;: sliceId: must have required properties sliceId&#10;Post-unit outcome: dispatched&#10;Auto-mode pause calls: 1&#10;Invocation error record cleared: true&#10;UI error notification:&#10;Tool invocation/runtime failed for execute-task: gsd_task_complete: Validation failed for tool &#34;gsd_task_complete&#34;: sliceId: must have required properties sliceId. Retrying cannot resolve this deterministic failure — pausing auto-mode.&#10;Excluded durable records preserve clear-and-defer:&#10;tool unavailable: outcome=continue, pauses=0, notifications=0, recordCleared=true&#10;policy error: outcome=continue, pauses=0, notifications=0, recordCleared=true&#10;queued user skip: outcome=continue, pauses=0, notifications=0, recordCleared=true</code>

```text
import assert from "node:assert/strict";
import { mkdirSync } from "node:fs";
import { join } from "node:path";

import { postUnitPreVerification } from "../../worktrees/c2f4d848183f/01M1Q95C1T56ZD48K3R4SBXNDK/src/resources/extensions/gsd/auto-post-unit.ts";
import { AutoSession } from "../../worktrees/c2f4d848183f/01M1Q95C1T56ZD48K3R4SBXNDK/src/resources/extensions/gsd/auto/session.ts";
import {
  closeDatabase,
  insertMilestone,
  insertSlice,
  insertTask,
  openDatabase,
} from "../../worktrees/c2f4d848183f/01M1Q95C1T56ZD48K3R4SBXNDK/src/resources/extensions/gsd/gsd-db.ts";
import {
  cleanup,
  makeTempRepo,
} from "../../worktrees/c2f4d848183f/01M1Q95C1T56ZD48K3R4SBXNDK/src/resources/extensions/gsd/tests/test-utils.ts";

closeDatabase();
const basePath = makeTempRepo("gsd-issue-2131-evidence-");

try {
  mkdirSync(join(basePath, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), {
    recursive: true,
  });
  openDatabase(":memory:");
  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active" });
  insertTask({
    id: "T01",
    milestoneId: "M001",
    sliceId: "S01",
    title: "Task",
    status: "in_progress",
  });

  const error =
    'gsd_task_complete: Validation failed for tool "gsd_task_complete": sliceId: must have required properties sliceId';
  const pauseCalls = [];
  const notifications = [];
  const session = new AutoSession();
  session.active = true;
  session.basePath = basePath;
  session.currentUnit = {
    type: "execute-task",
    id: "M001/S01/T01",
    startedAt: Date.now(),
  };
  session.lastToolInvocationError = error;

  const outcome = await postUnitPreVerification(
    {
      s: session,
      ctx: {
        ui: {
          notify: (message, level) => notifications.push({ level, message }),
        },
      },
      pi: {},
      buildSnapshotOpts: () => ({}),
      lockBase: () => basePath,
      stopAuto: async () => {},
      pauseAuto: async () => pauseCalls.push("pause"),
      updateProgressWidget: () => {},
    },
    {
      skipSettleDelay: true,
      skipWorktreeSync: true,
    },
  );

  assert.equal(outcome, "dispatched");
  assert.equal(pauseCalls.length, 1);
  assert.equal(session.lastToolInvocationError, null);
  assert.deepEqual(notifications, [{
    level: "error",
    message:
      'Tool invocation/runtime failed for execute-task: gsd_task_complete: Validation failed for tool "gsd_task_complete": sliceId: must have required properties sliceId. Retrying cannot resolve this deterministic failure — pausing auto-mode.',
  }]);

  console.log("Rejected completion:");
  console.log(error);
  console.log(`Post-unit outcome: ${outcome}`);
  console.log(`Auto-mode pause calls: ${pauseCalls.length}`);
  console.log(`Invocation error record cleared: ${session.lastToolInvocationError === null}`);
  console.log(`UI ${notifications[0].level} notification:`);
  console.log(notifications[0].message);
} finally {
  closeDatabase();
  cleanup(basePath);
}

async function exerciseDeferredRecord(error) {
  closeDatabase();
  const scenarioPath = makeTempRepo("gsd-issue-2131-exclusion-");

  try {
    mkdirSync(join(scenarioPath, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), {
      recursive: true,
    });
    openDatabase(":memory:");
    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active" });
    insertTask({
      id: "T01",
      milestoneId: "M001",
      sliceId: "S01",
      title: "Task",
      status: "in_progress",
    });

    const pauses = [];
    const notices = [];
    const session = new AutoSession();
    session.active = true;
    session.basePath = scenarioPath;
    session.currentUnit = {
      type: "execute-task",
      id: "M001/S01/T01",
      startedAt: Date.now(),
    };
    session.lastToolInvocationError = error;

    const outcome = await postUnitPreVerification(
      {
        s: session,
        ctx: {
          ui: {
            notify: (message, level) => notices.push({ level, message }),
          },
        },
        pi: {},
        buildSnapshotOpts: () => ({}),
        lockBase: () => scenarioPath,
        stopAuto: async () => {},
        pauseAuto: async () => pauses.push("pause"),
        updateProgressWidget: () => {},
      },
      {
        skipSettleDelay: true,
        skipWorktreeSync: true,
      },
    );

    assert.equal(outcome, "continue");
    assert.equal(pauses.length, 0);
    assert.equal(notices.length, 0);
    assert.equal(session.lastToolInvocationError, null);
    return {
      outcome,
      pauses: pauses.length,
      notifications: notices.length,
      recordCleared: session.lastToolInvocationError === null,
    };
  } finally {
    closeDatabase();
    cleanup(scenarioPath);
  }
}

console.log("Excluded durable records preserve clear-and-defer:");
for (const [label, error] of [
  ["tool unavailable", "No such tool available: mcp__gsd-workflow__gsd_task_complete"],
  ["policy error", "gsd_task_complete: This is a mechanical gate: completion is blocked"],
  ["queued user skip", "gsd_task_complete: Skipped due to queued user message."],
]) {
  const observed = await exerciseDeferredRecord(error);
  console.log(
    `${label}: outcome=${observed.outcome}, pauses=${observed.pauses}, notifications=${observed.notifications}, recordCleared=${observed.recordCleared}`,
  );
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9f3b51d18232f8dbbd242cf2a8982df80dca3784","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short --branch`; `git rev-parse HEAD`; scoped base-to-target diff inspection</code>
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/post-unit-task-recovery-authority.test.ts` (initial setup failure: missing dependency)</code>
- `pnpm install --frozen-lockfile --ignore-scripts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/post-unit-task-recovery-authority.test.ts`
- <code>Sabotage/RED: temporarily disabled the durable pause predicate and ran `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern=&#39;schema-rejected gsd_task_complete&#39; src/resources/extensions/gsd/tests/post-unit-task-recovery-authority.test.ts`; failed as expected with `continue` instead of `dispatched`</code>
- `Restored/GREEN: reran the same named regression test successfully`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types /Users/jeremymcspadden/.no-mistakes/evidence/01M1Q95C1T56ZD48K3R4SBXNDK/issue-2131-e2e.mjs`
- <code>Final `git diff --exit-code`, worktree status, and generated `node_modules` cleanup check</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

