### PR TITLE
feat(gsd): add gsd_project_snapshot canonical DB read tool

### DIFF
--- a/packages/contracts/src/workflow.test.ts
+++ b/packages/contracts/src/workflow.test.ts
@@ -21,5 +21,6 @@ test("read-only workflow tools are classified correctly", () => {
   const readOnly = WORKFLOW_TOOL_CONTRACTS.filter((tool) => tool.writePolicy === "read");
   assert.ok(readOnly.some((tool) => tool.canonicalName === "gsd_milestone_status"));
   assert.ok(readOnly.some((tool) => tool.canonicalName === "gsd_checkpoint_db"));
+  assert.ok(readOnly.some((tool) => tool.canonicalName === "gsd_project_snapshot"));
   assert.ok(readOnly.every((tool) => tool.writePolicy === "read"));
 });

--- a/packages/contracts/src/workflow.ts
+++ b/packages/contracts/src/workflow.ts
@@ -336,6 +336,14 @@ export const WORKFLOW_TOOL_CONTRACTS = [
 		writePolicy: "read",
 		auditEvent: "workflow.decision.get",
 	},
+	{
+		canonicalName: "gsd_project_snapshot",
+		aliases: [],
+		schemaId: "workflow.project.snapshot",
+		executorId: "executeProjectSnapshot",
+		writePolicy: "read",
+		auditEvent: "workflow.project.snapshot",
+	},
 ] as const satisfies readonly WorkflowToolContractMetadata[];
 
 /** Literal union of canonical workflow tool names. Typing a name list with this union makes drift from WORKFLOW_TOOL_CONTRACTS a compile error. */

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1359,7 +1359,12 @@ async function runSerializedCanonicalReadOperation(
 }
 
 function mapCanonicalReadError(
-  operation: "list_decisions" | "get_decision" | "list_requirements" | "get_requirement",
+  operation:
+    | "list_decisions"
+    | "get_decision"
+    | "list_requirements"
+    | "get_requirement"
+    | "read_project_snapshot",
   message: string,
   id?: string,
 ): unknown {
@@ -1377,9 +1382,11 @@ function mapCanonicalReadError(
     ? "listing decisions"
     : operation === "get_decision"
       ? "fetching decision"
-      : operation === "list_requirements"
-        ? "listing requirements"
-        : "fetching requirement";
+        : operation === "list_requirements"
+          ? "listing requirements"
+          : operation === "read_project_snapshot"
+            ? "reading project snapshot"
+            : "fetching requirement";
 
   return adaptExecutorResult({
     content: [{
@@ -2936,6 +2943,46 @@ export function registerWorkflowTools(
     milestoneId: z.string().optional(),
     limit: z.number().int().min(1).max(500).optional(),
   });
+
+  server.tool(
+    "gsd_project_snapshot",
+    "Read the full project snapshot from the GSD database (DB-authoritative, never projections). Returns requirements, decisions, milestones, and authority revision in one payload.",
+    {
+      projectDir: z
+        .string()
+        .optional()
+        .describe("Absolute path to the project directory (defaults to MCP server cwd)"),
+    },
+    async (args: Record<string, unknown>) => {
+      const { projectDir } = parseWorkflowArgs(
+        z.object({ projectDir: z.string().optional() }),
+        args,
+      );
+      try {
+        return await runSerializedCanonicalReadOperation(projectDir, async () => {
+          const snapshot = await (
+            await importWorkflowRuntimeModule<any>(
+              "../../../src/resources/extensions/gsd/state/project-snapshot.js",
+            )
+          ).readProjectSnapshotFromDb(projectDir);
+          if (!snapshot) {
+            throw new Error("Database adapter not available (db_unavailable)");
+          }
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(snapshot) }],
+            details: {
+              operation: "read_project_snapshot",
+              revision: snapshot.authority?.revision,
+              snapshot,
+            },
+          };
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return mapCanonicalReadError("read_project_snapshot", message);
+      }
+    },
+  );
 
   server.tool(
     "gsd_requirement_list",

--- a/src/read-cli.ts
+++ b/src/read-cli.ts
@@ -4,6 +4,7 @@
  *   gsd read progress --json --project /path
  *   gsd read roadmap --json --project /path [--milestone M001]
  *   gsd read memory --json --project /path --query "auth"
+ *   gsd read snapshot --json --project /path
  */
 
 import { existsSync } from 'node:fs'
@@ -98,6 +99,47 @@ async function loadDbProgressReader(
 }
 
 /**
+ * Injectable DB snapshot reader — mirrors loadDbProgressReader: production
+ * jiti-loads state/project-snapshot.ts; tests inject the reader/importer.
+ */
+export type DbSnapshotReader = (projectDir: string) => Promise<unknown>
+export type DbSnapshotModuleImporter = (path: string) => Promise<unknown>
+
+async function loadDbSnapshotReader(
+  moduleImporter: DbSnapshotModuleImporter = (path) => jiti.import(path, {}),
+): Promise<DbSnapshotReader> {
+  let mod: any
+  try {
+    mod = await moduleImporter(gsdExtensionPath('state/project-snapshot.ts'))
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(
+      `selected GSD extensions do not support DB-backed snapshot reads; synchronize the extension bundle (${detail})`,
+    )
+  }
+  if (typeof mod.readProjectSnapshotFromDb !== 'function') {
+    throw new Error('selected GSD extensions do not support DB-backed snapshot reads; synchronize the extension bundle')
+  }
+  return (projectDir: string) => mod.readProjectSnapshotFromDb(projectDir)
+}
+
+/**
+ * DB-backed project snapshot (issue #2102), or null when there is no DB file.
+ * Unlike progress, snapshot has no projection fallback: a null result means
+ * the DB is missing and the caller must refuse loudly.
+ */
+async function tryReadSnapshotFromDb(
+  dbPath: string,
+  projectDir: string,
+  reader?: DbSnapshotReader,
+  moduleImporter?: DbSnapshotModuleImporter,
+): Promise<unknown | null> {
+  if (!existsSync(dbPath)) return null
+  const read = reader ?? await loadDbSnapshotReader(moduleImporter)
+  return await read(projectDir)
+}
+
+/**
  * DB-backed progress payload, or null when the projection fallback applies:
  * no DB file, or the DB cannot be opened (locked/unreadable). Schema skew
  * has already refused loudly via assertProjectDbSchemaSupported before this
@@ -155,7 +197,7 @@ async function assertProjectDbSchemaSupported(
   }
 }
 
-export type ReadKind = 'progress' | 'roadmap' | 'memory'
+export type ReadKind = 'progress' | 'roadmap' | 'memory' | 'snapshot'
 
 /** DB-backed progress reader — jiti-loaded in production, injected in tests. */
 export type DbProgressReader = (projectDir: string) => Promise<unknown>
@@ -182,7 +224,7 @@ function parseReadArgs(argv: string[]): ReadCliOptions | null {
   const args = argv.slice(readIndex + 1)
   if (args.length < 1) return null
   const kind = args[0] as ReadKind
-  if (!['progress', 'roadmap', 'memory'].includes(kind)) return null
+  if (!['progress', 'roadmap', 'memory', 'snapshot'].includes(kind)) return null
 
   let project: string | undefined
   let milestone: string | undefined
@@ -206,11 +248,13 @@ export async function runReadCli(
   preflight?: ReadCliSchemaPreflight,
   dbProgressReader?: DbProgressReader,
   dbProgressModuleImporter?: DbProgressModuleImporter,
+  dbSnapshotReader?: DbSnapshotReader,
+  dbSnapshotModuleImporter?: DbSnapshotModuleImporter,
 ): Promise<number> {
   const opts = parseReadArgs(argv)
   if (!opts) {
     process.stderr.write(
-      'Usage: gsd read <progress|roadmap|memory> --json --project <path> [--milestone M001] [--query text]\n',
+      'Usage: gsd read <progress|roadmap|memory|snapshot> --json --project <path> [--milestone M001] [--query text]\n',
     )
     return 1
   }
@@ -260,6 +304,32 @@ export async function runReadCli(
         return 1
       }
       data = fromDb ?? readProgress(projectDir)
+      break
+    }
+    case 'snapshot': {
+      // DB-only read (issue #2102): no projection fallback exists, so a
+      // missing DB or failed read refuses loudly with exit 1.
+      let snapshot: unknown | null
+      try {
+        snapshot = await tryReadSnapshotFromDb(
+          dbPath,
+          projectDir,
+          dbSnapshotReader,
+          dbSnapshotModuleImporter,
+        )
+      } catch (err) {
+        process.stderr.write(
+          `[gsd] DB-backed snapshot read failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        )
+        return 1
+      }
+      if (snapshot === null) {
+        process.stderr.write(
+          `[gsd] snapshot requires a GSD database; none found at ${dbPath}\n`,
+        )
+        return 1
+      }
+      data = snapshot
       break
     }
     case 'roadmap':

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -3336,6 +3336,134 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
 	registerWorkflowTool(pi, decisionListTool);
 
+	// ─── gsd_project_snapshot ────────────────────────────────────────────────
+	//
+	// Read-only: returns the DB-authoritative project snapshot (issue #2102) —
+	// progress, milestone, and slice/task state assembled from the canonical
+	// database in one payload. Use instead of stitching together multiple read
+	// tools or parsing markdown projections, which may lag the DB.
+
+	const projectSnapshotExecute = async (
+		_toolCallId: string,
+		params: any,
+		_signal: AbortSignal | undefined,
+		_onUpdate: unknown,
+		_ctx: unknown,
+	) => {
+		const basePath =
+			typeof params.projectDir === "string" && params.projectDir
+				? params.projectDir
+				: resolveCtxCwd(_ctx);
+		try {
+			const { readProjectSnapshotFromDb } = await import("../state/project-snapshot.js");
+
+			const snapshot = await withCanonicalReadAdapter(
+				basePath,
+				async () => readProjectSnapshotFromDb(basePath),
+			);
+
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: JSON.stringify(snapshot),
+					},
+				],
+				details: {
+					operation: "read_project_snapshot",
+					projectDir: basePath,
+					snapshot,
+				} as any,
+			};
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (msg.includes("db_unavailable")) {
+				logError("tool", `gsd_project_snapshot failed: ${msg}`, {
+					tool: "gsd_project_snapshot",
+					error: String(err),
+				});
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: "Error: GSD database is not available.",
+						},
+					],
+					details: {
+						operation: "read_project_snapshot",
+						error: "db_unavailable",
+					} as any,
+				};
+			}
+			logError("tool", `gsd_project_snapshot failed: ${msg}`, {
+				tool: "gsd_project_snapshot",
+				error: String(err),
+			});
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: `Error reading project snapshot: ${msg}`,
+					},
+				],
+				details: {
+					operation: "read_project_snapshot",
+					error: "query_error",
+					message: msg,
+				} as any,
+			};
+		}
+	};
+
+	const projectSnapshotTool = {
+		name: "gsd_project_snapshot",
+		label: "Read Project Snapshot",
+		description:
+			"Read the DB-authoritative project snapshot (issue #2102): progress, milestone, " +
+			"and slice/task state in one payload. Use instead of combining multiple read " +
+			"tools or parsing markdown projections.",
+		promptSnippet:
+			"Read the canonical GSD project snapshot from the database",
+		promptGuidelines: [
+			"Use gsd_project_snapshot for a one-shot view of project state — do not assemble it from markdown projections.",
+			"The snapshot is DB-authoritative; projections may be stale after migrations or failed regens.",
+			"Optionally pass projectDir to target a specific project root; defaults to the session working directory.",
+		],
+		parameters: Type.Object({
+			projectDir: Type.Optional(
+				Type.String({
+					description:
+						"Project root to read the snapshot for. Defaults to the current working directory.",
+				}),
+			),
+		}),
+		execute: projectSnapshotExecute,
+		renderCall(args: any, theme: any) {
+			let text = theme.fg("toolTitle", theme.bold("project_snapshot"));
+			if (args.projectDir) {
+				text += theme.fg("dim", ` [${args.projectDir}]`);
+			}
+			return new Text(text, 0, 0);
+		},
+		renderResult(result: any, _options: any, theme: any) {
+			const d = readDetails(result);
+			if (result.isError || d?.error) {
+				return new Text(
+					theme.fg("error", formatToolErrorText(result, d)),
+					0,
+					0,
+				);
+			}
+			return new Text(
+				theme.fg("success", "Project snapshot read"),
+				0,
+				0,
+			);
+		},
+	};
+
+	registerWorkflowTool(pi, projectSnapshotTool);
+
 	// ─── gsd_decision_get ────────────────────────────────────────────────────
 	//
 	// Point-lookup by stable D### ID. Sources from the canonical memories table

--- a/src/resources/extensions/gsd/db/queries.ts
+++ b/src/resources/extensions/gsd/db/queries.ts
@@ -125,6 +125,131 @@ export function getProjectAuthorityVersion(): ProjectAuthorityVersion {
   };
 }
 
+export interface ProjectAuthorityRow {
+  projectId: string;
+  revision: number;
+  authorityEpoch: number;
+}
+
+/** Full project_authority singleton read (null when no row / no DB open). */
+export function getProjectAuthorityRow(): ProjectAuthorityRow | null {
+  const db = getDbOrNull();
+  if (!db) return null;
+  const row = db.prepare(
+    "SELECT project_id, revision, authority_epoch FROM project_authority WHERE singleton = 1",
+  ).get();
+  if (!row) return null;
+  return {
+    projectId: String(row["project_id"] ?? ""),
+    revision: numberColumn(row, "revision"),
+    authorityEpoch: numberColumn(row, "authority_epoch"),
+  };
+}
+
+export interface OpenBlockerRow {
+  blockerId: string;
+  blockerKind: string;
+  resolutionOwner: string;
+  description: string;
+  requestedAction: string;
+  openedAt: string;
+  openedProjectRevision: number;
+}
+
+/** Open workflow blockers, oldest first (issue #2102 snapshot read). */
+export function getOpenBlockers(): OpenBlockerRow[] {
+  const db = getDbOrNull();
+  if (!db) return [];
+  const rows = db.prepare(
+    `SELECT blocker_id, blocker_kind, resolution_owner, description, requested_action,
+            opened_at, opened_project_revision
+       FROM workflow_blockers
+      WHERE blocker_status = 'open'
+      ORDER BY opened_project_revision, blocker_id`,
+  ).all();
+  return rows.map((row) => ({
+    blockerId: String(row["blocker_id"] ?? ""),
+    blockerKind: String(row["blocker_kind"] ?? ""),
+    resolutionOwner: String(row["resolution_owner"] ?? ""),
+    description: String(row["description"] ?? ""),
+    requestedAction: String(row["requested_action"] ?? ""),
+    openedAt: String(row["opened_at"] ?? ""),
+    openedProjectRevision: numberColumn(row, "opened_project_revision"),
+  }));
+}
+
+export interface OpenQuestionRow {
+  questionId: string;
+  questionText: string;
+  createdAt: string;
+}
+
+/** Open workflow questions, creation order (issue #2102 snapshot read). */
+export function getOpenQuestions(): OpenQuestionRow[] {
+  const db = getDbOrNull();
+  if (!db) return [];
+  const rows = db.prepare(
+    `SELECT question_id, question_text, created_at
+       FROM workflow_open_questions
+      WHERE question_status = 'open'
+      ORDER BY created_at, question_id`,
+  ).all();
+  return rows.map((row) => ({
+    questionId: String(row["question_id"] ?? ""),
+    questionText: String(row["question_text"] ?? ""),
+    createdAt: String(row["created_at"] ?? ""),
+  }));
+}
+
+/** Max applied migration version from the schema_version table (null when absent). */
+export function getSchemaVersion(): number | null {
+  const db = getDbOrNull();
+  if (!db) return null;
+  const row = db.prepare("SELECT MAX(version) AS version FROM schema_version").get();
+  if (!row || row["version"] === null || row["version"] === undefined) return null;
+  return numberColumn(row, "version");
+}
+
+export interface VerificationSummaryCounts {
+  assessments: { total: number; pass: number; fail: number };
+  evidence: { total: number; passed: number; failed: number };
+}
+
+/**
+ * Project-wide verification summary (issue #2102 snapshot read): assessment
+ * status counts plus verification_evidence verdict counts.
+ */
+export function getVerificationSummary(): VerificationSummaryCounts {
+  const db = getDbOrNull();
+  if (!db) return { assessments: { total: 0, pass: 0, fail: 0 }, evidence: { total: 0, passed: 0, failed: 0 } };
+
+  const assessmentRows = db.prepare(
+    "SELECT lower(status) AS status, COUNT(*) AS count FROM assessments GROUP BY lower(status)",
+  ).all();
+  const assessments = { total: 0, pass: 0, fail: 0 };
+  for (const row of assessmentRows) {
+    const count = numberColumn(row, "count");
+    assessments.total += count;
+    const status = String(row["status"] ?? "");
+    if (status === "pass" || status === "passed") assessments.pass += count;
+    else if (status === "fail" || status === "failed") assessments.fail += count;
+  }
+
+  const evidenceRows = db.prepare(
+    "SELECT lower(verdict) AS verdict, COUNT(*) AS count FROM verification_evidence GROUP BY lower(verdict)",
+  ).all();
+  const evidence = { total: 0, passed: 0, failed: 0 };
+  for (const row of evidenceRows) {
+    const count = numberColumn(row, "count");
+    evidence.total += count;
+    const verdict = String(row["verdict"] ?? "");
+    if (verdict === "passed" || verdict === "pass") evidence.passed += count;
+    else if (verdict === "failed" || verdict === "fail") evidence.failed += count;
+  }
+
+  return { assessments, evidence };
+}
+
 export function getHierarchyCompletionCounts(): HierarchyCompletionCounts {
   if (!getDbOrNull()!) {
     return { milestones: 0, milestonesTotal: 0, slices: 0, slicesTotal: 0, tasks: 0, tasksTotal: 0 };

--- a/src/resources/extensions/gsd/mcp-bridge.ts
+++ b/src/resources/extensions/gsd/mcp-bridge.ts
@@ -7,6 +7,7 @@ export {
 export { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 export { openExistingWorkflowDatabase } from "./db-workspace.js";
 export { readProgressFromDb } from "./state/progress-from-db.js";
+export { readProjectSnapshotFromDb } from "./state/project-snapshot.js";
 export {
   _getAdapter,
   checkpointDatabase,

--- a/src/resources/extensions/gsd/state/project-snapshot.ts
+++ b/src/resources/extensions/gsd/state/project-snapshot.ts
@@ -1,0 +1,202 @@
+// Project/App: gsd-pi
+// File Purpose: DB-authoritative project snapshot read (issue #2102).
+// One compact, deterministic payload covering authority, current focus,
+// progress counts, blockers, open questions, verification, and the bounded
+// milestone registry — modeled on readProgressFromDb.
+
+import { deriveState, invalidateStateCache } from "./derive/index.js";
+import { ensureExistingWorkflowDbOpen } from "./derive/db-open.js";
+import {
+  _getAdapter,
+  getAllMilestones,
+  getHierarchyCompletionCounts,
+  getInFlightSliceCount,
+  getMilestoneStatusCounts,
+  getOpenBlockers,
+  getOpenQuestions,
+  getProjectAuthorityRow,
+  getProjectAuthorityVersion,
+  getSchemaVersion,
+  getVerificationSummary,
+  isDbAvailable,
+  readTransaction,
+  type OpenBlockerRow,
+  type OpenQuestionRow,
+  type VerificationSummaryCounts,
+} from "../gsd-db.js";
+import type { GSDState } from "../types.js";
+
+const MAX_REVISION_ATTEMPTS = 3;
+
+/** Registry cap: snapshots stay bounded for large projects (issue #2102). */
+export const MAX_SNAPSHOT_MILESTONES = 50;
+
+export interface DbProjectSnapshotAuthority {
+  projectId: string;
+  schemaVersion: number | null;
+  revision: number;
+  authorityEpoch: number;
+}
+
+export interface DbProjectSnapshotCurrent {
+  activeMilestone: { id: string; title: string } | null;
+  activeSlice: { id: string; title: string } | null;
+  activeTask: { id: string; title: string } | null;
+  phase: string;
+  nextAction: string;
+}
+
+export interface DbProjectSnapshotProgress {
+  milestones: { total: number; done: number; active: number; pending: number; parked: number };
+  slices: { total: number; done: number; active: number; pending: number };
+  tasks: { total: number; done: number; pending: number };
+}
+
+export interface DbProjectSnapshotMilestone {
+  id: string;
+  title: string;
+  status: string;
+  sequence: number;
+}
+
+export interface DbProjectSnapshot {
+  authority: DbProjectSnapshotAuthority;
+  current: DbProjectSnapshotCurrent;
+  progress: DbProjectSnapshotProgress;
+  blockers: OpenBlockerRow[];
+  openQuestions: OpenQuestionRow[];
+  verification: VerificationSummaryCounts;
+  milestones: { items: DbProjectSnapshotMilestone[]; truncated: boolean };
+  capturedAt: string;
+}
+
+interface SnapshotStabilityToken {
+  revision: number;
+  authorityEpoch: number;
+  dataVersion: number;
+}
+
+function readStabilityToken(): SnapshotStabilityToken {
+  const authority = getProjectAuthorityVersion();
+  const row = _getAdapter()?.prepare("PRAGMA data_version").get();
+  const dataVersion = Number(row?.["data_version"]);
+  if (!Number.isSafeInteger(dataVersion) || dataVersion < 0) {
+    throw new Error("GSD database data version is not available");
+  }
+  return { ...authority, dataVersion };
+}
+
+function stabilityTokensMatch(before: SnapshotStabilityToken, after: SnapshotStabilityToken): boolean {
+  return before.revision === after.revision
+    && before.authorityEpoch === after.authorityEpoch
+    && before.dataVersion === after.dataVersion;
+}
+
+interface SnapshotDbRead {
+  authority: DbProjectSnapshotAuthority;
+  progress: DbProjectSnapshotProgress;
+  blockers: OpenBlockerRow[];
+  openQuestions: OpenQuestionRow[];
+  verification: VerificationSummaryCounts;
+  milestones: DbProjectSnapshot["milestones"];
+}
+
+function readSnapshotDb(): SnapshotDbRead {
+  return readTransaction(() => {
+    const authorityRow = getProjectAuthorityRow();
+    if (!authorityRow) {
+      throw new Error("GSD project authority row is not available");
+    }
+    const authority: DbProjectSnapshotAuthority = {
+      projectId: authorityRow.projectId,
+      schemaVersion: getSchemaVersion(),
+      revision: authorityRow.revision,
+      authorityEpoch: authorityRow.authorityEpoch,
+    };
+
+    const counts = getHierarchyCompletionCounts();
+    const milestoneCounts = getMilestoneStatusCounts();
+    const slicesActive = getInFlightSliceCount();
+    const slicesPending = counts.slicesTotal - counts.slices - slicesActive;
+    const progress: DbProjectSnapshotProgress = {
+      milestones: milestoneCounts,
+      slices: {
+        total: counts.slicesTotal,
+        done: counts.slices,
+        active: slicesActive,
+        pending: slicesPending,
+      },
+      tasks: {
+        total: counts.tasksTotal,
+        done: counts.tasks,
+        pending: counts.tasksTotal - counts.tasks,
+      },
+    };
+
+    const all = getAllMilestones();
+    const truncated = all.length > MAX_SNAPSHOT_MILESTONES;
+    const milestones = {
+      items: all.slice(0, MAX_SNAPSHOT_MILESTONES).map((m) => ({
+        id: m.id,
+        title: m.title,
+        status: m.status,
+        sequence: m.sequence,
+      })),
+      truncated,
+    };
+
+    return {
+      authority,
+      progress,
+      blockers: getOpenBlockers(),
+      openQuestions: getOpenQuestions(),
+      verification: getVerificationSummary(),
+      milestones,
+    };
+  });
+}
+
+function toRef(value: { id: string; title: string } | null): { id: string; title: string } | null {
+  return value ? { id: value.id, title: value.title } : null;
+}
+
+function buildCurrent(state: GSDState): DbProjectSnapshotCurrent {
+  return {
+    activeMilestone: toRef(state.activeMilestone),
+    activeSlice: toRef(state.activeSlice),
+    activeTask: toRef(state.activeTask),
+    phase: state.phase,
+    nextAction: state.nextAction,
+  };
+}
+
+/**
+ * Read the compact DB-authoritative project snapshot. The DB-backed sections
+ * (authority, progress, blockers, questions, verification, milestones) are
+ * captured inside one read transaction; `deriveState` runs outside it and
+ * supplies current refs/phase/nextAction, so `capturedAt` reflects when the
+ * snapshot was assembled and the current section may tear relative to the
+ * transactional sections under concurrent commits — the stability-retry loop
+ * bounds but does not eliminate that (same contract as readProgressFromDb).
+ */
+export async function readProjectSnapshotFromDb(basePath: string): Promise<DbProjectSnapshot | null> {
+  ensureExistingWorkflowDbOpen(basePath);
+  if (!isDbAvailable()) return null;
+
+  invalidateStateCache();
+  for (let attempt = 1; ; attempt++) {
+    const before = readStabilityToken();
+    const dbRead = readSnapshotDb();
+    const state = await deriveState(basePath);
+    const after = readStabilityToken();
+
+    if (stabilityTokensMatch(before, after) || attempt === MAX_REVISION_ATTEMPTS) {
+      return {
+        ...dbRead,
+        current: buildCurrent(state),
+        capturedAt: new Date().toISOString(),
+      };
+    }
+    invalidateStateCache();
+  }
+}

--- a/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
@@ -17,7 +17,7 @@ import {
   getDb,
   openDatabase,
 } from "../mcp-bridge.ts";
-import { insertRequirement, getDbPath } from "../gsd-db.ts";
+import { insertRequirement, insertMilestone, insertSlice, insertTask, getDbPath } from "../gsd-db.ts";
 import { resolveProjectRootDbPath } from "../db-workspace.ts";
 import { invalidateAllCaches } from "../cache.ts";
 
@@ -329,6 +329,132 @@ test("canonical read parity: corrupt requirements table returns query_error for 
 
     assert.equal(readError(nativeReqList), "query_error");
     assert.equal(readError(mcpReqList), "query_error");
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read parity: gsd_project_snapshot returns the same payload for native and MCP", async () => {
+  const base = makeProjectBase("gsd-canonical-snapshot-parity");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+
+    openDatabase(resolveProjectRootDbPath(base));
+    insertMilestone({ id: "M001", title: "Parity milestone", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Parity slice",
+      status: "in_progress",
+      risk: "low",
+      depends: [],
+      sequence: 1,
+    });
+    insertTask({
+      id: "T01",
+      milestoneId: "M001",
+      sliceId: "S01",
+      title: "Parity task",
+      status: "pending",
+      sequence: 1,
+    });
+
+    const nativeSnapshotResult = await nativeTool(native, "gsd_project_snapshot").execute(
+      "call-8",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeDetails = (nativeSnapshotResult as {
+      details?: { error?: string; snapshot?: Record<string, unknown> };
+    }).details;
+
+    const mcpSnapshotResult = await mcpTool(mcp, "gsd_project_snapshot").handler({ projectDir: base });
+    const mcpDetails = (mcpSnapshotResult as {
+      structuredContent?: { error?: string; snapshot?: Record<string, unknown> };
+    }).structuredContent;
+
+    assert.equal(nativeDetails?.error, undefined);
+    assert.equal(mcpDetails?.error, undefined);
+
+    const nativeSnapshot = nativeDetails?.snapshot;
+    const mcpSnapshot = mcpDetails?.snapshot;
+    assert.ok(nativeSnapshot, "native result should carry details.snapshot");
+    assert.ok(mcpSnapshot, "MCP result should carry structuredContent.snapshot");
+
+    // capturedAt legitimately differs between the two executions; every other
+    // section must be identical across the native and MCP surfaces.
+    const stripCapturedAt = (snapshot: Record<string, unknown>) =>
+      JSON.parse(JSON.stringify({ ...snapshot, capturedAt: "<capturedAt>" }));
+    assert.deepEqual(stripCapturedAt(nativeSnapshot!), stripCapturedAt(mcpSnapshot!));
+
+    assert.equal(typeof nativeSnapshot!.authority, "object");
+    assert.ok(String((nativeSnapshot!.authority as { projectId?: unknown }).projectId ?? "").length > 0);
+    assert.deepEqual((nativeSnapshot!.milestones as { items?: unknown[] }).items?.length, 1);
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read parity: gsd_project_snapshot missing DB returns db_unavailable for native and MCP without creating gsd.db", async () => {
+  const base = makeProjectBase("gsd-canonical-snapshot-missing-db");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+    const dbPath = resolveProjectRootDbPath(base);
+
+    assert.equal(existsSync(dbPath), false, "fixture starts without gsd.db");
+
+    const nativeSnapshotResult = await nativeTool(native, "gsd_project_snapshot").execute(
+      "call-9",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeDetails = (nativeSnapshotResult as { details?: { error?: string } }).details;
+    assert.equal(nativeDetails?.error, "db_unavailable");
+    assert.equal(existsSync(dbPath), false, "native snapshot read should not create gsd.db as side effect");
+
+    const mcpSnapshotResult = await mcpTool(mcp, "gsd_project_snapshot").handler({ projectDir: base });
+    const mcpDetails = (mcpSnapshotResult as { structuredContent?: { error?: string } }).structuredContent;
+    assert.equal(mcpDetails?.error, "db_unavailable");
+    assert.equal(existsSync(dbPath), false, "MCP snapshot read should not create gsd.db as side effect");
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read parity: dropped workflow_blockers table returns query_error for native and MCP snapshot reads", async () => {
+  const base = makeProjectBase("gsd-canonical-snapshot-query-error");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+
+    openDatabase(resolveProjectRootDbPath(base));
+    getDb().prepare("DROP TABLE workflow_blockers").run();
+
+    const nativeSnapshotResult = await nativeTool(native, "gsd_project_snapshot").execute(
+      "call-10",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeDetails = (nativeSnapshotResult as { details?: { error?: string } }).details;
+    assert.equal(nativeDetails?.error, "query_error");
+
+    const mcpSnapshotResult = await mcpTool(mcp, "gsd_project_snapshot").handler({ projectDir: base });
+    const mcpDetails = (mcpSnapshotResult as { structuredContent?: { error?: string } }).structuredContent;
+    assert.equal(mcpDetails?.error, "query_error");
+
+    const isolated = (await import("../db-workspace.ts")).openWorkflowDatabaseIsolated(
+      resolveProjectRootDbPath(base),
+    );
+    assert.ok(isolated, "isolated open should still work after handled snapshot query_error");
+    isolated?.close();
   } finally {
     cleanup([base]);
   }

--- a/src/resources/extensions/gsd/tests/project-snapshot.test.ts
+++ b/src/resources/extensions/gsd/tests/project-snapshot.test.ts
@@ -1,0 +1,393 @@
+// Project/App: gsd-pi
+// File Purpose: readProjectSnapshotFromDb — DB-authoritative project snapshot
+// reads (#2102). Pins the exact DbProjectSnapshot key set, the seeded
+// authority/progress/blocker/question/verification/milestone sections, byte
+// determinism at a stable revision, milestone registry truncation, open-item
+// ordering, and the missing-DB null contract.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  _getAdapter,
+  closeDatabase,
+  getProjectAuthorityRow,
+  getSchemaVersion,
+  insertMilestone,
+  transaction,
+} from "../gsd-db.ts";
+import { deriveState } from "../state.ts";
+import {
+  MAX_SNAPSHOT_MILESTONES,
+  readProjectSnapshotFromDb,
+} from "../state/project-snapshot.ts";
+import {
+  createWorkflowAuthorityFixture,
+} from "./workflow-authority-fixture.ts";
+
+// Provenance seeds. workflow_blockers / workflow_open_questions reference
+// workflow_operations and workflow_item_lifecycles, so the snapshot seeds
+// must build that minimal provenance chain first (same shape the foundation
+// schema tests use). Revisions sit far above the fixture's authority revision
+// so the seed never collides with real writer operations.
+const SEED_REVISION_BASE = 910_001;
+
+function fixtureProjectId(): string {
+  const authority = getProjectAuthorityRow();
+  assert.ok(authority, "fixture project_authority row should exist");
+  return authority.projectId;
+}
+
+function seedOperation(operationId: string, revision: number): void {
+  _getAdapter()!.prepare(
+    `INSERT INTO workflow_operations (
+       operation_id, project_id, operation_type, idempotency_key,
+       expected_revision, resulting_revision,
+       expected_authority_epoch, resulting_authority_epoch,
+       actor_type, actor_id, source_transport, request_hash, created_at
+     ) VALUES (?, ?, 'snapshot-test', ?, ?, ?, 0, 0, 'agent', 'test', 'test', ?, '2026-09-05T00:00:00.000Z')`,
+  ).run(
+    operationId,
+    fixtureProjectId(),
+    `key-${operationId}`,
+    revision - 1,
+    revision,
+    `hash-${operationId}`,
+  );
+}
+
+function seedMilestoneLifecycle(
+  lifecycleId: string,
+  operationId: string,
+  revision: number,
+): void {
+  _getAdapter()!.prepare(
+    `INSERT INTO workflow_item_lifecycles (
+       lifecycle_id, project_id, item_kind, milestone_id, lifecycle_status,
+       created_at, updated_at,
+       last_operation_id, last_project_revision, last_authority_epoch
+     ) VALUES (?, ?, 'milestone', 'M001', 'in_progress', '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z', ?, ?, 0)`,
+  ).run(lifecycleId, fixtureProjectId(), operationId, revision);
+}
+
+function seedBlocker(input: {
+  blockerId: string;
+  lifecycleId: string;
+  operationId: string;
+  revision: number;
+  kind?: string;
+  openedAt?: string;
+}): void {
+  _getAdapter()!.prepare(
+    `INSERT INTO workflow_blockers (
+       blocker_id, project_id, lifecycle_id, blocker_kind, resolution_owner,
+       blocker_status, description, requested_action, opened_at,
+       opened_operation_id, opened_project_revision, opened_authority_epoch
+     ) VALUES (?, ?, ?, ?, 'user', 'open', ?, ?, ?, ?, ?, 0)`,
+  ).run(
+    input.blockerId,
+    fixtureProjectId(),
+    input.lifecycleId,
+    input.kind ?? "ambiguous_intent",
+    `${input.blockerId} description`,
+    `${input.blockerId} requested action`,
+    input.openedAt ?? "2026-09-05T00:00:00.000Z",
+    input.operationId,
+    input.revision,
+  );
+}
+
+function seedQuestion(input: {
+  questionId: string;
+  lifecycleId: string;
+  operationId: string;
+  revision: number;
+  text: string;
+  createdAt: string;
+}): void {
+  // The initial-state trigger requires created/last provenance to match and
+  // created_at == updated_at for a question that begins open.
+  _getAdapter()!.prepare(
+    `INSERT INTO workflow_open_questions (
+       question_id, project_id, lifecycle_id, question_text, question_status,
+       state_version, created_at, updated_at,
+       created_operation_id, created_project_revision, created_authority_epoch,
+       last_operation_id, last_project_revision, last_authority_epoch
+     ) VALUES (?, ?, ?, ?, 'open', 0, ?, ?, ?, ?, 0, ?, ?, 0)`,
+  ).run(
+    input.questionId,
+    fixtureProjectId(),
+    input.lifecycleId,
+    input.text,
+    input.createdAt,
+    input.createdAt,
+    input.operationId,
+    input.revision,
+    input.operationId,
+    input.revision,
+  );
+}
+
+function seedVerificationRows(): void {
+  const db = _getAdapter()!;
+  db.prepare(
+    `INSERT INTO assessments (path, milestone_id, status, scope, full_content, created_at)
+     VALUES
+       ('snapshot-assess-pass', 'M001', 'pass', 'slice', '', '2026-09-05T00:00:00.000Z'),
+       ('snapshot-assess-fail', 'M001', 'FAIL', 'slice', '', '2026-09-05T00:00:00.000Z')`,
+  ).run();
+  // Tasks (M001, S01, T01) and (M001, S02, T01) exist in the fixture; the
+  // verification_evidence FK targets that composite key.
+  db.prepare(
+    `INSERT INTO verification_evidence (
+       task_id, slice_id, milestone_id, command, exit_code, verdict, duration_ms, created_at
+     ) VALUES
+       ('T01', 'S01', 'M001', 'npm test', 0, 'passed', 12, '2026-09-05T00:00:00.000Z'),
+       ('T01', 'S02', 'M001', 'npm test', 1, 'failed', 34, '2026-09-05T00:00:00.000Z'),
+       ('T01', 'S02', 'M001', 'npm run check', 1, 'Failed', 56, '2026-09-05T00:00:00.000Z')`,
+  ).run();
+}
+
+/** Seeds blockers/questions with deliberately mixed insert order + revisions. */
+function seedSnapshotOpenItems(): void {
+  transaction(() => {
+    seedOperation("op-snap-a", SEED_REVISION_BASE);
+    seedOperation("op-snap-b", SEED_REVISION_BASE + 1);
+    seedMilestoneLifecycle("life-snap", "op-snap-a", SEED_REVISION_BASE);
+
+    // Blockers: inserted out of order; B-snap-zz carries the lower revision so
+    // ordering must come from (opened_project_revision, blocker_id), not
+    // insertion order or id alone.
+    seedBlocker({
+      blockerId: "B-snap-zz",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-a",
+      revision: SEED_REVISION_BASE,
+      openedAt: "2026-09-05T00:00:03.000Z",
+    });
+    seedBlocker({
+      blockerId: "B-snap-aa",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-b",
+      revision: SEED_REVISION_BASE + 1,
+      openedAt: "2026-09-05T00:00:01.000Z",
+    });
+    // Same revision as B-snap-aa: id is the tiebreaker.
+    seedBlocker({
+      blockerId: "B-snap-ab",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-b",
+      revision: SEED_REVISION_BASE + 1,
+      openedAt: "2026-09-05T00:00:02.000Z",
+    });
+
+    // Questions: inserted out of order; ordering must come from
+    // (created_at, question_id), not insertion order.
+    seedQuestion({
+      questionId: "Q-snap-later",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-a",
+      revision: SEED_REVISION_BASE,
+      text: "Which storage engine should back the queue?",
+      createdAt: "2026-09-05T00:00:09.000Z",
+    });
+    seedQuestion({
+      questionId: "Q-snap-b",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-a",
+      revision: SEED_REVISION_BASE,
+      text: "Same-timestamp question B",
+      createdAt: "2026-09-05T00:00:05.000Z",
+    });
+    seedQuestion({
+      questionId: "Q-snap-a",
+      lifecycleId: "life-snap",
+      operationId: "op-snap-a",
+      revision: SEED_REVISION_BASE,
+      text: "Same-timestamp question A",
+      createdAt: "2026-09-05T00:00:05.000Z",
+    });
+  });
+}
+
+test("readProjectSnapshotFromDb emits exactly the DbProjectSnapshot key set", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+
+  const snapshot = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(snapshot);
+  assert.deepEqual(Object.keys(snapshot).sort(), [
+    "authority",
+    "blockers",
+    "capturedAt",
+    "current",
+    "milestones",
+    "openQuestions",
+    "progress",
+    "verification",
+  ]);
+  assert.deepEqual(Object.keys(snapshot.authority), ["projectId", "schemaVersion", "revision", "authorityEpoch"]);
+  assert.deepEqual(Object.keys(snapshot.current), [
+    "activeMilestone",
+    "activeSlice",
+    "activeTask",
+    "phase",
+    "nextAction",
+  ]);
+  assert.deepEqual(Object.keys(snapshot.progress), ["milestones", "slices", "tasks"]);
+  assert.deepEqual(Object.keys(snapshot.progress.milestones), ["total", "done", "active", "pending", "parked"]);
+  assert.deepEqual(Object.keys(snapshot.progress.slices), ["total", "done", "active", "pending"]);
+  assert.deepEqual(Object.keys(snapshot.progress.tasks), ["total", "done", "pending"]);
+  assert.deepEqual(Object.keys(snapshot.milestones), ["items", "truncated"]);
+  assert.deepEqual(Object.keys(snapshot.verification), ["assessments", "evidence"]);
+  assert.deepEqual(Object.keys(snapshot.verification.assessments), ["total", "pass", "fail"]);
+  assert.deepEqual(Object.keys(snapshot.verification.evidence), ["total", "passed", "failed"]);
+});
+
+test("readProjectSnapshotFromDb assembles authority, current, progress, open items, verification, and milestones", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  seedSnapshotOpenItems();
+  seedVerificationRows();
+
+  const snapshot = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(snapshot);
+  const state = await deriveState(fixture.root);
+
+  const authorityRow = getProjectAuthorityRow();
+  assert.ok(authorityRow);
+  assert.equal(snapshot.authority.projectId, authorityRow.projectId);
+  assert.ok(snapshot.authority.projectId.length > 0, "projectId should be the real authority id");
+  assert.equal(snapshot.authority.revision, authorityRow.revision);
+  assert.equal(snapshot.authority.authorityEpoch, authorityRow.authorityEpoch);
+  assert.equal(snapshot.authority.schemaVersion, getSchemaVersion());
+  assert.equal(typeof snapshot.authority.schemaVersion, "number");
+
+  assert.deepEqual(snapshot.current.activeMilestone, { id: "M001", title: "Authority Fixture" });
+  assert.deepEqual(snapshot.current.activeSlice, { id: "S02", title: "Ready dependent slice" });
+  assert.deepEqual(snapshot.current.activeTask, { id: "T01", title: "Ready task" });
+  // The current section must be the same derivation the canonical state
+  // reader serves, not a snapshot-specific re-implementation.
+  assert.deepEqual(snapshot.current.activeMilestone, state.activeMilestone
+    ? { id: state.activeMilestone.id, title: state.activeMilestone.title }
+    : null);
+  assert.deepEqual(snapshot.current.activeSlice, state.activeSlice
+    ? { id: state.activeSlice.id, title: state.activeSlice.title }
+    : null);
+  assert.deepEqual(snapshot.current.activeTask, state.activeTask
+    ? { id: state.activeTask.id, title: state.activeTask.title }
+    : null);
+  assert.equal(snapshot.current.phase, state.phase);
+  assert.equal(typeof snapshot.current.nextAction, "string");
+  assert.ok(snapshot.current.nextAction.length > 0);
+
+  assert.deepEqual(snapshot.progress.milestones, { total: 1, done: 0, active: 1, pending: 0, parked: 0 });
+  assert.deepEqual(snapshot.progress.slices, { total: 2, done: 1, active: 0, pending: 1 });
+  assert.deepEqual(snapshot.progress.tasks, { total: 2, done: 1, pending: 1 });
+
+  assert.equal(snapshot.blockers.length, 3);
+  assert.deepEqual(
+    snapshot.blockers.map((b) => b.blockerId),
+    ["B-snap-zz", "B-snap-aa", "B-snap-ab"],
+  );
+  assert.deepEqual(snapshot.blockers[0], {
+    blockerId: "B-snap-zz",
+    blockerKind: "ambiguous_intent",
+    resolutionOwner: "user",
+    description: "B-snap-zz description",
+    requestedAction: "B-snap-zz requested action",
+    openedAt: "2026-09-05T00:00:03.000Z",
+    openedProjectRevision: SEED_REVISION_BASE,
+  });
+
+  assert.equal(snapshot.openQuestions.length, 3);
+  assert.deepEqual(
+    snapshot.openQuestions.map((q) => q.questionId),
+    ["Q-snap-a", "Q-snap-b", "Q-snap-later"],
+  );
+  assert.deepEqual(snapshot.openQuestions[2], {
+    questionId: "Q-snap-later",
+    questionText: "Which storage engine should back the queue?",
+    createdAt: "2026-09-05T00:00:09.000Z",
+  });
+
+  assert.deepEqual(snapshot.verification, {
+    assessments: { total: 2, pass: 1, fail: 1 },
+    evidence: { total: 3, passed: 1, failed: 2 },
+  });
+
+  assert.equal(snapshot.milestones.truncated, false);
+  assert.deepEqual(snapshot.milestones.items, [
+    { id: "M001", title: "Authority Fixture", status: "active", sequence: 0 },
+  ]);
+
+  assert.equal(typeof snapshot.capturedAt, "string");
+  assert.ok(!Number.isNaN(Date.parse(snapshot.capturedAt)), "capturedAt should be an ISO timestamp");
+});
+
+test("readProjectSnapshotFromDb is byte-deterministic at a stable revision", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+  seedSnapshotOpenItems();
+
+  const first = await readProjectSnapshotFromDb(fixture.root);
+  const second = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(first);
+  assert.ok(second);
+
+  // capturedAt legitimately moves between reads; everything else must not.
+  const firstPayload = JSON.stringify({ ...first, capturedAt: "<capturedAt>" });
+  const secondPayload = JSON.stringify({ ...second, capturedAt: "<capturedAt>" });
+  assert.equal(firstPayload, secondPayload);
+});
+
+test("readProjectSnapshotFromDb truncates the milestone registry beyond the cap", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+
+  // Fixture has M001; M002..M051 push the registry past the 50-item cap.
+  // Milestones default to sequence 0, so registry order is id-lexicographic
+  // and M051 is the row dropped by truncation.
+  transaction(() => {
+    for (let n = 2; n <= 51; n += 1) {
+      insertMilestone({
+        id: `M${String(n).padStart(3, "0")}`,
+        title: `Extra milestone ${n}`,
+        status: "pending",
+      });
+    }
+  });
+
+  const snapshot = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(snapshot);
+
+  assert.equal(MAX_SNAPSHOT_MILESTONES, 50);
+  assert.equal(snapshot.milestones.truncated, true);
+  assert.equal(snapshot.milestones.items.length, 50);
+  assert.equal(snapshot.milestones.items[0]?.id, "M001");
+  assert.equal(snapshot.milestones.items[49]?.id, "M050");
+  assert.equal(
+    snapshot.milestones.items.some((m) => m.id === "M051"),
+    false,
+    "the milestone past the cap must not appear in the registry",
+  );
+  // Counts stay project-wide even when the registry is truncated.
+  assert.deepEqual(snapshot.progress.milestones, { total: 51, done: 0, active: 1, pending: 50, parked: 0 });
+});
+
+test("readProjectSnapshotFromDb returns null when no database exists", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-snapshot-empty-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // The reader must not ride on a global handle left open by another test's
+  // fixture, and must not create the database as a side effect.
+  closeDatabase();
+
+  const snapshot = await readProjectSnapshotFromDb(root);
+
+  assert.equal(snapshot, null);
+  assert.equal(existsSync(join(root, ".gsd", "gsd.db")), false, "missing DB must not be created");
+});

--- a/src/tests/read-cli-args.test.ts
+++ b/src/tests/read-cli-args.test.ts
@@ -51,6 +51,45 @@ test("runReadCli handles global flags before read", async () => {
 	}
 });
 
+test("runReadCli accepts the snapshot kind and fails closed without a DB", async () => {
+	const stdout = captureWrite(process.stdout);
+	const stderr = captureWrite(process.stderr);
+	try {
+		// The hermes fixture has no gsd.db, so the accepted snapshot kind must
+		// refuse loudly instead of falling back to projections — arg parsing
+		// only, no DB opened, no reader reached.
+		const exitCode = await runReadCli(
+			["node", "gsd", "read", "snapshot", "--json", "--project", fixture],
+			probelessPreflight,
+		);
+
+		assert.equal(exitCode, 1);
+		assert.equal(stdout.output(), "");
+		assert.match(stderr.output(), /snapshot requires a GSD database/);
+	} finally {
+		stdout.restore();
+		stderr.restore();
+	}
+});
+
+test("runReadCli rejects unknown read kinds with usage on stderr", async () => {
+	const stdout = captureWrite(process.stdout);
+	const stderr = captureWrite(process.stderr);
+	try {
+		const exitCode = await runReadCli(
+			["node", "gsd", "read", "snapshott", "--json", "--project", fixture],
+			probelessPreflight,
+		);
+
+		assert.equal(exitCode, 1);
+		assert.equal(stdout.output(), "");
+		assert.match(stderr.output(), /^Usage: gsd read <progress\|roadmap\|memory\|snapshot>/);
+	} finally {
+		stdout.restore();
+		stderr.restore();
+	}
+});
+
 function captureWrite(stream: NodeJS.WriteStream): { output: () => string; restore: () => void } {
 	const chunks: string[] = [];
 	const original = stream.write.bind(stream);

--- a/src/tests/read-cli-snapshot-db.test.ts
+++ b/src/tests/read-cli-snapshot-db.test.ts
@@ -1,0 +1,230 @@
+/**
+ * `gsd read snapshot` DB-only wiring (#2102).
+ *
+ * Unlike progress, the snapshot kind has no projection fallback: a present
+ * and openable project DB must feed the envelope data through the injectable
+ * DB snapshot reader, while a missing DB or a failed read refuses loudly
+ * with exit 1 (fail closed — never a degraded payload). The reader is
+ * exercised through its injectable seam — the same pattern as the
+ * progress/snapshot wiring tests in read-cli-progress-db.test.ts — so these
+ * cases pin the wiring and fail-closed decisions, not the snapshot payload
+ * itself (pinned by tests/project-snapshot.test.ts in the extension).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  runReadCli,
+  type DbSnapshotModuleImporter,
+  type DbSnapshotReader,
+  type ReadCliSchemaPreflight,
+} from "../read-cli.ts";
+import { closeDatabase, openDatabase } from "../resources/extensions/gsd/gsd-db.ts";
+import {
+  openWorkflowDatabaseIsolated,
+  resolveProjectRootDbPath,
+} from "../resources/extensions/gsd/db-workspace.ts";
+import { SCHEMA_VERSION, SchemaTooNewError } from "../resources/extensions/gsd/db/engine.ts";
+
+const realPreflight: ReadCliSchemaPreflight = {
+  resolveProjectRootDbPath,
+  openIsolatedDatabase: (path) => openWorkflowDatabaseIsolated(path),
+  supportedSchemaVersion: SCHEMA_VERSION,
+  createSchemaTooNewError: (currentVersion, supportedVersion) =>
+    new SchemaTooNewError(currentVersion, supportedVersion),
+};
+
+interface CaptureOpts {
+  preflight?: ReadCliSchemaPreflight;
+  snapshotReader?: DbSnapshotReader;
+  moduleImporter?: DbSnapshotModuleImporter;
+}
+
+async function captureReadCli(argv: string[], opts: CaptureOpts = {}) {
+  let stdout = "";
+  let stderr = "";
+  const originalOut = process.stdout.write;
+  const originalErr = process.stderr.write;
+  process.stdout.write = ((chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const exitCode = await runReadCli(
+      argv,
+      opts.preflight ?? realPreflight,
+      undefined,
+      undefined,
+      opts.snapshotReader,
+      opts.moduleImporter,
+    );
+    return { exitCode, stdout, stderr };
+  } finally {
+    process.stdout.write = originalOut;
+    process.stderr.write = originalErr;
+  }
+}
+
+function readSnapshotArgv(base: string): string[] {
+  return ["node", "gsd", "read", "snapshot", "--json", "--project", base];
+}
+
+function makeProject(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-read-cli-snapshot-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "STATE.md"),
+    "# Project State\n\n**Phase:** planning\n",
+  );
+  return base;
+}
+
+function makeSnapshotSentinel(): Record<string, unknown> {
+  return {
+    authority: { projectId: "proj", schemaVersion: 48, revision: 7, authorityEpoch: 0 },
+    current: {
+      activeMilestone: { id: "M001", title: "From DB" },
+      activeSlice: null,
+      activeTask: null,
+      phase: "execute",
+      nextAction: "Keep going",
+    },
+    progress: {
+      milestones: { total: 1, done: 0, active: 1, pending: 0, parked: 0 },
+      slices: { total: 0, done: 0, active: 0, pending: 0 },
+      tasks: { total: 0, done: 0, pending: 0 },
+    },
+    blockers: [],
+    openQuestions: [],
+    verification: {
+      assessments: { total: 0, pass: 0, fail: 0 },
+      evidence: { total: 0, passed: 0, failed: 0 },
+    },
+    milestones: { items: [], truncated: false },
+    capturedAt: "2026-09-05T00:00:00.000Z",
+  };
+}
+
+test("gsd read snapshot serves the DB-backed envelope with the pinned snapshot key set when the DB is present", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const sentinel = makeSnapshotSentinel();
+  let calls = 0;
+  const run = await captureReadCli(readSnapshotArgv(base), {
+    snapshotReader: async (projectDir) => {
+      calls++;
+      assert.equal(projectDir, base);
+      return sentinel;
+    },
+  });
+
+  assert.equal(run.exitCode, 0);
+  const envelope = JSON.parse(run.stdout);
+  assert.equal(envelope.integration_version, 1);
+  assert.equal(envelope.kind, "snapshot");
+  assert.equal(envelope.projectDir, base);
+  assert.deepEqual(Object.keys(envelope.data).sort(), [
+    "authority",
+    "blockers",
+    "capturedAt",
+    "current",
+    "milestones",
+    "openQuestions",
+    "progress",
+    "verification",
+  ]);
+  assert.deepEqual(envelope.data, sentinel);
+  assert.equal(calls, 1);
+});
+
+test("gsd read snapshot uses the project DB from a canonical milestone worktree", async (t) => {
+  const base = makeProject();
+  const worktree = join(base, ".gsd-worktrees", "M001");
+  mkdirSync(join(worktree, ".gsd"), { recursive: true });
+  writeFileSync(join(worktree, ".gsd", "STATE.md"), "# Project State\n\n**Phase:** planning\n");
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readSnapshotArgv(worktree), {
+    snapshotReader: async (projectDir) => {
+      assert.equal(projectDir, worktree);
+      return makeSnapshotSentinel();
+    },
+  });
+
+  assert.equal(run.exitCode, 0);
+  const envelope = JSON.parse(run.stdout);
+  assert.equal(envelope.kind, "snapshot");
+  assert.equal(envelope.data.authority.projectId, "proj");
+});
+
+test("gsd read snapshot refuses loudly when the DB-backed read fails", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readSnapshotArgv(base), {
+    snapshotReader: async () => {
+      throw new Error("boom");
+    },
+  });
+
+  assert.equal(run.exitCode, 1);
+  assert.equal(run.stdout, "");
+  assert.ok(
+    run.stderr.includes("DB-backed snapshot read failed"),
+    `stderr should explain the failure, got: ${run.stderr}`,
+  );
+  assert.ok(run.stderr.includes("boom"), `stderr should carry the cause, got: ${run.stderr}`);
+});
+
+test("gsd read snapshot refuses loudly when no DB exists (fail closed, no fallback)", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  let calls = 0;
+  const run = await captureReadCli(readSnapshotArgv(base), {
+    snapshotReader: async () => {
+      calls++;
+      return makeSnapshotSentinel();
+    },
+  });
+
+  assert.equal(run.exitCode, 1);
+  assert.equal(run.stdout, "");
+  assert.ok(
+    run.stderr.includes("snapshot requires a GSD database"),
+    `stderr should explain the missing DB, got: ${run.stderr}`,
+  );
+  assert.equal(calls, 0, "reader must not be invoked when the DB file is absent");
+});
+
+test("gsd read snapshot explains how to repair a stale extension bundle", async (t) => {
+  const base = makeProject();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  assert.equal(openDatabase(join(base, ".gsd", "gsd.db")), true);
+  closeDatabase();
+
+  const run = await captureReadCli(readSnapshotArgv(base), {
+    moduleImporter: async () => {
+      throw new Error("Cannot find module state/project-snapshot.ts");
+    },
+  });
+
+  assert.equal(run.exitCode, 1);
+  assert.equal(run.stdout, "");
+  assert.match(run.stderr, /synchronize the extension bundle/);
+});


### PR DESCRIPTION
Closes #2102

## Summary

Adds one additive, read-only canonical tool that answers "where is this project and what should happen next" from the DB in a single bounded payload — registered natively, on the packaged MCP server, and as `gsd read snapshot --json`, all atomically per the #2099 implementation boundary.

## Contract

- Input: `projectDir?` only. No contract envelope, no snapshot token, no profiles, no event cursor.
- Output (compact JSON, deterministic ordering): `authority` (projectId, schemaVersion, revision, authorityEpoch), `current` (active milestone/slice/task, phase, next action from `deriveState()`), project-wide `progress` counts, canonical open blockers, open questions, verification summary, bounded milestone registry (`MAX_SNAPSHOT_MILESTONES = 50` with explicit `truncated` flag), ISO `capturedAt`.
- Fail closed on every surface: errors are only `db_unavailable` / `query_error` via the existing canonical-read model. No projection fallback anywhere (ADR-046's display-only exception is scoped to `gsd_progress`).
- Not atomic end-to-end: DB sections share one `readTransaction`; `deriveState()` runs outside it (same tearing contract as `readProgressFromDb`, documented on `capturedAt`).

## What changed

- `packages/contracts/src/workflow.ts` — `gsd_project_snapshot` contract entry (read policy, `workflow.project.snapshot` schema/audit).
- `src/resources/extensions/gsd/db/queries.ts` — five SELECT-only read-seam exports: `getProjectAuthorityRow`, `getOpenBlockers`, `getOpenQuestions`, `getSchemaVersion`, `getVerificationSummary`.
- `src/resources/extensions/gsd/state/project-snapshot.ts` — builder with the revision-stability retry loop (authority token + `PRAGMA data_version`), modeled on `readProgressFromDb`.
- `src/resources/extensions/gsd/bootstrap/db-tools.ts` — native tool via `withCanonicalReadAdapter`.
- `packages/mcp-server/src/workflow-tools.ts` — packaged registration via `runSerializedCanonicalReadOperation` + `importWorkflowRuntimeModule` (multi-project correct); `mapCanonicalReadError` gained `read_project_snapshot`.
- `src/resources/extensions/gsd/mcp-bridge.ts` — bridge re-export pointing at the direct module (mirrors `readProgressFromDb`; avoids a barrel import cycle).
- `src/read-cli.ts` — `snapshot` kind with injectable `dbSnapshotReader`, loud failure on DB errors and missing DB; envelope stays `integration_version: 1`.

## Tests

- `project-snapshot.test.ts` — exact key-set pinning, seeded blockers/questions/verification rows, byte-determinism at a stable revision, 51-milestone truncation, ordering determinism, null on missing DB with no side-effect file.
- `canonical-read-tools.test.ts` — native vs MCP parity (equal payload), `db_unavailable` + no `gsd.db` side effect, `query_error` via `DROP TABLE workflow_blockers`.
- `read-cli-snapshot-db.test.ts` / `read-cli-args.test.ts` — envelope shape, fail-closed paths, arg validation.
- Existing gates derive the new tool automatically: tool-naming, workflow-phase-contract-matrix, contracts tests, MCP surface-count — all green unchanged.

## Verification

`pnpm run verify:pr` green (build:core → typecheck:extensions → test:unit), zero failing suites. Also ran the packaged MCP suites (`mcp-server`, `moonshot-tool-schema`) on dist: 87/87.