### PR TITLE
fix(gsd): isolate project snapshot DB handle

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2946,7 +2946,7 @@ export function registerWorkflowTools(
 
   server.tool(
     "gsd_project_snapshot",
-    "Read the full project snapshot from the GSD database (DB-authoritative, never projections). Returns requirements, decisions, milestones, and authority revision in one payload.",
+    "Read the project snapshot from the GSD database (DB-authoritative, never projections). Returns authority, current focus, progress, blockers, open questions, verification, and bounded milestones in one payload.",
     {
       projectDir: z
         .string()

--- a/src/resources/extensions/gsd/state/derive/db-open.ts
+++ b/src/resources/extensions/gsd/state/derive/db-open.ts
@@ -2,8 +2,8 @@
 // File Purpose: Workflow DB open helpers for state derivation.
 
 import type { GSDState } from '../../types.js';
-import { getAllMilestones, isDbAvailable, isSchemaTooNewError, setMilestoneQueueOrder } from '../../gsd-db.js';
-import { openExistingWorkflowDatabase, type WorkflowDatabaseOpenResult } from '../../db-workspace.js';
+import { getAllMilestones, getDbPath, isDbAvailable, isSchemaTooNewError, setMilestoneQueueOrder } from '../../gsd-db.js';
+import { openExistingWorkflowDatabase, resolveProjectRootDbPath, type WorkflowDatabaseOpenResult } from '../../db-workspace.js';
 import { loadQueueOrder, sortByQueueOrder } from '../../queue-order.js';
 
 export function syncQueueOrderProjectionToDb(basePath: string): void {
@@ -18,7 +18,8 @@ export function syncQueueOrderProjectionToDb(basePath: string): void {
 }
 
 export function ensureExistingWorkflowDbOpen(basePath: string): boolean {
-  if (isDbAvailable()) {
+  const requestedDbPath = resolveProjectRootDbPath(basePath);
+  if (isDbAvailable() && getDbPath() === requestedDbPath) {
     syncQueueOrderProjectionToDb(basePath);
     return true;
   }

--- a/src/resources/extensions/gsd/tests/project-snapshot.test.ts
+++ b/src/resources/extensions/gsd/tests/project-snapshot.test.ts
@@ -391,3 +391,22 @@ test("readProjectSnapshotFromDb returns null when no database exists", async (t)
   assert.equal(snapshot, null);
   assert.equal(existsSync(join(root, ".gsd", "gsd.db")), false, "missing DB must not be created");
 });
+
+test("readProjectSnapshotFromDb reopens the requested project instead of reusing another global DB", async (t) => {
+  const first = await createWorkflowAuthorityFixture();
+  const second = await createWorkflowAuthorityFixture();
+  t.after(() => {
+    first.cleanup();
+    second.cleanup();
+  });
+
+  first.reopen();
+  const firstAuthority = getProjectAuthorityRow();
+  assert.ok(firstAuthority);
+
+  const secondSnapshot = await readProjectSnapshotFromDb(second.root);
+  assert.ok(secondSnapshot);
+
+  assert.notEqual(secondSnapshot.authority.projectId, firstAuthority.projectId);
+  assert.equal(secondSnapshot.current.activeMilestone?.title, "Authority Fixture");
+});


### PR DESCRIPTION
## Linked issue

Refs #2102
Stacked on #2170

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Fixes one same-process project-isolation bug in the new `gsd_project_snapshot` DB read path and aligns the packaged MCP description with the actual payload.  
**Why:** Without this, `gsd_project_snapshot` can return project A's authority snapshot when called for project B after project A opened the process-global DB handle.  
**How:** Reuse the open workflow DB only when `getDbPath()` matches the requested project DB path; otherwise reopen the requested existing DB, with a regression test covering project A -> project B reads.

## What

This is a narrow follow-up patch for #2170, not a competing implementation of #2102.

Changed files:

- `src/resources/extensions/gsd/state/derive/db-open.ts`
  - Compares the active global DB path with `resolveProjectRootDbPath(basePath)` before taking the `isDbAvailable()` early return.
  - Reopens the requested existing project DB when the current handle points at another project.
- `src/resources/extensions/gsd/tests/project-snapshot.test.ts`
  - Adds a regression test that opens fixture/project A, then reads a snapshot for fixture/project B in the same process.
  - Asserts project B does not receive project A's authority `projectId`.
- `packages/mcp-server/src/workflow-tools.ts`
  - Updates the public `gsd_project_snapshot` description to match the real response contract: authority/current/progress/blockers/open questions/verification/milestones, not requirements/decisions.

## Why

#2170 correctly implements the #2102 shape as a DB-authoritative snapshot surface across native tools, packaged MCP, and `gsd read snapshot --json`. The only issue I found is in the local DB-opening helper used by the snapshot path.

Current behavior in the PR branch:

```mermaid
flowchart TD
    A[Read project A] --> B[Global workflow DB handle opens for A]
    B --> C[Read project B in same process]
    C --> D{isDbAvailable?}
    D -->|yes| E[Return early]
    E --> F[Snapshot query still uses A handle]
    F --> G[Project B request receives project A authority]
```

Fixed behavior:

```mermaid
flowchart TD
    A[Read project A] --> B[Global workflow DB handle opens for A]
    B --> C[Read project B in same process]
    C --> D{current DB path equals requested DB path?}
    D -->|yes| E[Reuse handle]
    D -->|no| F[Open requested existing project DB]
    F --> G[Snapshot query uses B handle]
```

This matters because `gsd_project_snapshot` is explicitly canonical and DB-authoritative. A stale cross-project snapshot is more dangerous than a loud missing-DB error because the payload looks valid.

## How

The fix keeps the existing #2170 design intact:

- DB-only snapshot behavior remains unchanged.
- Projection fallback remains out of scope.
- Canonical-read error semantics remain unchanged.
- The change only tightens when the process-global DB handle may be reused.

Implementation detail:

```ts
const requestedDbPath = resolveProjectRootDbPath(basePath);
if (isDbAvailable() && getDbPath() === requestedDbPath) {
  syncQueueOrderProjectionToDb(basePath);
  return true;
}
```

If the current handle belongs to a different project, the helper falls through to `openExistingWorkflowDatabase(basePath)`.

## Related work

- Closes path for #2102 through #2170: `gsd_project_snapshot` canonical DB read tool.
- Related but separate: #2143 / W033, which is the VS Code/sidebar consumer-side progress work and should not be folded into this snapshot contract.
- This PR intentionally does not import unrelated local mixed-patch work such as `gsd read progress` projection fallback changes, broader MCP packaging parity, CI/native-addon coverage changes, generated model catalog churn, or workflow lifecycle fixes.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Validated locally on `review/2170-project-snapshot`:

- `pnpm run build:mcp-server`
- `pnpm exec tsx --test src/resources/extensions/gsd/tests/project-snapshot.test.ts src/resources/extensions/gsd/tests/canonical-read-tools.test.ts src/tests/read-cli-snapshot-db.test.ts src/tests/read-cli-args.test.ts` — 24/24 passed
- `pnpm exec tsc --noEmit --project tsconfig.extensions.json` — passed
- `git diff --check` — passed

Earlier focused validation while preparing the patch:

- `project-snapshot.test.ts` — 6/6 passed
- `canonical-read-tools.test.ts` — 10/10 passed
- `read-cli-snapshot-db.test.ts` + `read-cli-args.test.ts` — 8/8 passed

## AI disclosure

- [x] This PR includes AI-assisted code

AI assistance was used to compare #2170 with related local W033/#2143 work, identify the project-isolation failure mode, write the focused regression, apply the minimal fix, and draft this PR body. The patch was validated with the commands above.