### PR TITLE
fix(gsd): isolate project snapshot DB handle

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2946,7 +2946,7 @@ export function registerWorkflowTools(
 
   server.tool(
     "gsd_project_snapshot",
-    "Read the full project snapshot from the GSD database (DB-authoritative, never projections). Returns requirements, decisions, milestones, and authority revision in one payload.",
+    "Read the project snapshot from the GSD database (DB-authoritative, never projections). Returns authority, current focus, progress, blockers, open questions, verification, and bounded milestones in one payload.",
     {
       projectDir: z
         .string()
@@ -2964,7 +2964,7 @@ export function registerWorkflowTools(
             await importWorkflowRuntimeModule<any>(
               "../../../src/resources/extensions/gsd/state/project-snapshot.js",
             )
-          ).readProjectSnapshotFromDb(projectDir);
+          ).readProjectSnapshotFromDb(projectDir, { preserveGlobalDbHandle: true });
           if (!snapshot) {
             throw new Error("Database adapter not available (db_unavailable)");
           }

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -3359,7 +3359,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
 			const snapshot = await withCanonicalReadAdapter(
 				basePath,
-				async () => readProjectSnapshotFromDb(basePath),
+				async () => readProjectSnapshotFromDb(basePath, { preserveGlobalDbHandle: true }),
 			);
 			if (!snapshot) {
 				// The adapter preflight succeeded but the reader could not open

--- a/src/resources/extensions/gsd/state/derive/db-open.ts
+++ b/src/resources/extensions/gsd/state/derive/db-open.ts
@@ -3,7 +3,7 @@
 
 import type { GSDState } from '../../types.js';
 import { getAllMilestones, isDbAvailable, isSchemaTooNewError, setMilestoneQueueOrder } from '../../gsd-db.js';
-import { openExistingWorkflowDatabase, type WorkflowDatabaseOpenResult } from '../../db-workspace.js';
+import { getWorkflowDatabasePath as getDbPath, openExistingWorkflowDatabase, resolveProjectRootDbPath, type WorkflowDatabaseOpenResult } from '../../db-workspace.js';
 import { loadQueueOrder, sortByQueueOrder } from '../../queue-order.js';
 
 export function syncQueueOrderProjectionToDb(basePath: string): void {
@@ -22,7 +22,9 @@ export function ensureExistingWorkflowDbOpen(
   options: { throwOnOpenFailure?: boolean; syncQueueOrder?: boolean } = {},
 ): boolean {
   const syncQueueOrder = options.syncQueueOrder !== false;
-  if (isDbAvailable()) {
+  const requestedDbPath = resolveProjectRootDbPath(basePath);
+  const currentDbPath = getDbPath();
+  if (isDbAvailable() && (currentDbPath === requestedDbPath || currentDbPath === ":memory:")) {
     if (syncQueueOrder) syncQueueOrderProjectionToDb(basePath);
     return true;
   }

--- a/src/resources/extensions/gsd/state/derive/db-open.ts
+++ b/src/resources/extensions/gsd/state/derive/db-open.ts
@@ -5,6 +5,8 @@ import type { GSDState } from '../../types.js';
 import { getAllMilestones, isDbAvailable, isSchemaTooNewError, setMilestoneQueueOrder } from '../../gsd-db.js';
 import { getWorkflowDatabasePath as getDbPath, openExistingWorkflowDatabase, resolveProjectRootDbPath, type WorkflowDatabaseOpenResult } from '../../db-workspace.js';
 import { loadQueueOrder, sortByQueueOrder } from '../../queue-order.js';
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 export function syncQueueOrderProjectionToDb(basePath: string): void {
   const queueOrder = loadQueueOrder(basePath);
@@ -17,14 +19,31 @@ export function syncQueueOrderProjectionToDb(basePath: string): void {
   setMilestoneQueueOrder(desiredIds);
 }
 
+/**
+ * Compare DB paths by canonical form: resolveProjectRootDbPath canonicalizes
+ * (realpath) while the open handle keeps the spelling it was opened with — on
+ * macOS a /var vs /private/var mismatch must reuse the same DB, not reopen it.
+ * A missing requested path falls back to its raw form so it can never match.
+ */
+function isSameOpenDatabase(currentDbPath: string | null, requestedDbPath: string): boolean {
+  if (!currentDbPath) return false;
+  if (currentDbPath === ":memory:" || currentDbPath === requestedDbPath) return true;
+  const canonical = (p: string): string => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return resolve(p);
+    }
+  };
+  return canonical(currentDbPath) === canonical(requestedDbPath);
+}
+
 export function ensureExistingWorkflowDbOpen(
   basePath: string,
   options: { throwOnOpenFailure?: boolean; syncQueueOrder?: boolean } = {},
 ): boolean {
   const syncQueueOrder = options.syncQueueOrder !== false;
-  const requestedDbPath = resolveProjectRootDbPath(basePath);
-  const currentDbPath = getDbPath();
-  if (isDbAvailable() && (currentDbPath === requestedDbPath || currentDbPath === ":memory:")) {
+  if (isDbAvailable() && isSameOpenDatabase(getDbPath(), resolveProjectRootDbPath(basePath))) {
     if (syncQueueOrder) syncQueueOrderProjectionToDb(basePath);
     return true;
   }

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -442,7 +442,10 @@ export async function deriveStateFromDb(
   _artifactReadRoot: string = basePath,
   options: { syncQueueOrder?: boolean } = {},
 ): Promise<GSDState> {
-  if (!ensureExistingWorkflowDbOpen(basePath, options)) {
+  // Use the canonical read root (matches the caller's DB-open call in
+  // derive/index.ts) — a worktree basePath can resolve to a different (or
+  // nonexistent) DB path than the canonical project root.
+  if (!ensureExistingWorkflowDbOpen(_artifactReadRoot, options)) {
     return buildDbUnavailableState();
   }
 

--- a/src/resources/extensions/gsd/state/derive/index.ts
+++ b/src/resources/extensions/gsd/state/derive/index.ts
@@ -45,7 +45,12 @@ export async function deriveState(
   const stopTimer = debugTime("derive-state-impl");
   let result: GSDState;
 
-  ensureExistingWorkflowDbOpen(basePath, { syncQueueOrder: opts?.syncQueueOrder });
+  // Resolve/open through the canonical read root, matching deriveStateFromDb
+  // below — otherwise a worktree basePath with projectRootForReads can open
+  // the wrong (or no) DB while deriveStateFromDb still reads the correct one.
+  ensureExistingWorkflowDbOpen(opts?.projectRootForReads ?? basePath, {
+    syncQueueOrder: opts?.syncQueueOrder,
+  });
 
   if (isDbAvailable()) {
     const stopDbTimer = debugTime("derive-state-db");

--- a/src/resources/extensions/gsd/state/progress-from-db.ts
+++ b/src/resources/extensions/gsd/state/progress-from-db.ts
@@ -148,8 +148,11 @@ async function readProgressFromDbInternal(
   // Read-only surface: never mutate. The queue-order projection sync stays a
   // runtime derive/dispatch repair (see docs/user-docs/auto-mode.md); read
   // paths report the DB-authoritative order as-is even when the file is newer.
-  ensureExistingWorkflowDbOpen(basePath, { throwOnOpenFailure, syncQueueOrder: false });
-  if (!isDbAvailable()) return null;
+  const openedRequestedDb = ensureExistingWorkflowDbOpen(basePath, {
+    throwOnOpenFailure,
+    syncQueueOrder: false,
+  });
+  if (!openedRequestedDb || !isDbAvailable()) return null;
 
   invalidateStateCache();
   for (let attempt = 1; ; attempt++) {

--- a/src/resources/extensions/gsd/state/project-snapshot.ts
+++ b/src/resources/extensions/gsd/state/project-snapshot.ts
@@ -24,6 +24,11 @@ import {
   type OpenQuestionRow,
   type VerificationSummaryCounts,
 } from "../gsd-db.js";
+import {
+  closeWorkflowDatabase as closeDatabase,
+  getWorkflowDatabasePath as getDbPath,
+  openWorkflowDatabasePath as openDatabase,
+} from "../db-workspace.js";
 import type { GSDState } from "../types.js";
 
 const MAX_REVISION_ATTEMPTS = 3;
@@ -68,6 +73,10 @@ export interface DbProjectSnapshot {
   verification: VerificationSummaryCounts;
   milestones: { items: DbProjectSnapshotMilestone[]; truncated: boolean };
   capturedAt: string;
+}
+
+export interface ReadProjectSnapshotOptions {
+  preserveGlobalDbHandle?: boolean;
 }
 
 interface SnapshotStabilityToken {
@@ -182,24 +191,38 @@ function buildCurrent(state: GSDState): DbProjectSnapshotCurrent {
  * derive/dispatch repair, so the snapshot reports DB-authoritative order
  * as-is even when QUEUE-ORDER.json is newer.
  */
-export async function readProjectSnapshotFromDb(basePath: string): Promise<DbProjectSnapshot | null> {
-  ensureExistingWorkflowDbOpen(basePath, { syncQueueOrder: false });
-  if (!isDbAvailable()) return null;
+export async function readProjectSnapshotFromDb(
+  basePath: string,
+  opts: ReadProjectSnapshotOptions = {},
+): Promise<DbProjectSnapshot | null> {
+  const previousDbPath = opts.preserveGlobalDbHandle ? getDbPath() : null;
+  try {
+    const openedRequestedDb = ensureExistingWorkflowDbOpen(basePath, { syncQueueOrder: false });
+    if (!openedRequestedDb || !isDbAvailable()) return null;
 
-  invalidateStateCache();
-  for (let attempt = 1; ; attempt++) {
-    const before = readStabilityToken();
-    const dbRead = readSnapshotDb();
-    const state = await deriveState(basePath, { syncQueueOrder: false });
-    const after = readStabilityToken();
-
-    if (stabilityTokensMatch(before, after) || attempt === MAX_REVISION_ATTEMPTS) {
-      return {
-        ...dbRead,
-        current: buildCurrent(state),
-        capturedAt: new Date().toISOString(),
-      };
-    }
     invalidateStateCache();
+    for (let attempt = 1; ; attempt++) {
+      const before = readStabilityToken();
+      const dbRead = readSnapshotDb();
+      const state = await deriveState(basePath, { syncQueueOrder: false });
+      const after = readStabilityToken();
+
+      if (stabilityTokensMatch(before, after) || attempt === MAX_REVISION_ATTEMPTS) {
+        return {
+          ...dbRead,
+          current: buildCurrent(state),
+          capturedAt: new Date().toISOString(),
+        };
+      }
+      invalidateStateCache();
+    }
+  } finally {
+    if (opts.preserveGlobalDbHandle && getDbPath() !== previousDbPath) {
+      if (previousDbPath) {
+        openDatabase(previousDbPath);
+      } else {
+        closeDatabase();
+      }
+    }
   }
 }

--- a/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
@@ -17,7 +17,7 @@ import {
   getDb,
   openDatabase,
 } from "../mcp-bridge.ts";
-import { insertRequirement, insertMilestone, insertSlice, insertTask, getDbPath } from "../gsd-db.ts";
+import { insertRequirement, insertMilestone, insertSlice, insertTask, getDbPath, getProjectAuthorityRow } from "../gsd-db.ts";
 import { resolveProjectRootDbPath } from "../db-workspace.ts";
 import { invalidateAllCaches } from "../cache.ts";
 
@@ -393,6 +393,80 @@ test("canonical read parity: gsd_project_snapshot returns the same payload for n
     assert.equal(typeof nativeSnapshot!.authority, "object");
     assert.ok(String((nativeSnapshot!.authority as { projectId?: unknown }).projectId ?? "").length > 0);
     assert.deepEqual((nativeSnapshot!.milestones as { items?: unknown[] }).items?.length, 1);
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read parity: gsd_project_snapshot reads project B without switching the global DB handle", async () => {
+  const baseA = makeProjectBase("gsd-canonical-snapshot-global-a");
+  const baseB = makeProjectBase("gsd-canonical-snapshot-global-b");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+
+    openDatabase(resolveProjectRootDbPath(baseA));
+    const authorityA = getProjectAuthorityRow();
+    assert.ok(authorityA, "project A authority should exist");
+
+    openDatabase(resolveProjectRootDbPath(baseB));
+    insertMilestone({ id: "M001", title: "Project B milestone", status: "active" });
+    const authorityB = getProjectAuthorityRow();
+    assert.ok(authorityB, "project B authority should exist");
+    assert.notEqual(authorityB.projectId, authorityA.projectId);
+
+    openDatabase(resolveProjectRootDbPath(baseA));
+    const before = getDbPath();
+    assert.ok(before, "global DB should be open on project A");
+
+    const nativeSnapshotResult = await nativeTool(native, "gsd_project_snapshot").execute(
+      "call-8b",
+      {},
+      undefined,
+      undefined,
+      { cwd: baseB },
+    );
+    const nativeSnapshot = (nativeSnapshotResult as {
+      details?: { snapshot?: { authority?: { projectId?: string } } };
+    }).details?.snapshot;
+    assert.equal(nativeSnapshot?.authority?.projectId, authorityB.projectId);
+    assert.equal(getDbPath(), before, "native snapshot read must keep global DB path unchanged");
+
+    const mcpSnapshotResult = await mcpTool(mcp, "gsd_project_snapshot").handler({ projectDir: baseB });
+    const mcpSnapshot = (mcpSnapshotResult as {
+      structuredContent?: { snapshot?: { authority?: { projectId?: string } } };
+    }).structuredContent?.snapshot;
+    assert.equal(mcpSnapshot?.authority?.projectId, authorityB.projectId);
+    assert.equal(getDbPath(), before, "MCP snapshot read must keep global DB path unchanged");
+  } finally {
+    cleanup([baseA, baseB]);
+  }
+});
+
+test("canonical read parity: gsd_project_snapshot leaves no global DB open when none was open before", async () => {
+  const base = makeProjectBase("gsd-canonical-snapshot-no-global");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+
+    openDatabase(resolveProjectRootDbPath(base));
+    insertMilestone({ id: "M001", title: "Snapshot milestone", status: "active" });
+    closeDatabase();
+    assert.equal(getDbPath(), null, "fixture should start with no global DB handle");
+
+    const nativeSnapshotResult = await nativeTool(native, "gsd_project_snapshot").execute(
+      "call-8c",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    assert.equal(readError(nativeSnapshotResult), undefined);
+    assert.equal(getDbPath(), null, "native snapshot read must not leave a global DB handle open");
+
+    const mcpSnapshotResult = await mcpTool(mcp, "gsd_project_snapshot").handler({ projectDir: base });
+    assert.equal(readError(mcpSnapshotResult), undefined);
+    assert.equal(getDbPath(), null, "MCP snapshot read must not leave a global DB handle open");
   } finally {
     cleanup([base]);
   }

--- a/src/resources/extensions/gsd/tests/progress-from-db.test.ts
+++ b/src/resources/extensions/gsd/tests/progress-from-db.test.ts
@@ -5,7 +5,9 @@
 
 import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
-import { writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
@@ -201,6 +203,21 @@ test("readProgressFromDb reflects DB state, never stale projection files", async
   assert.equal(result.activeMilestone?.id, "M001");
   assert.notEqual(result.activeMilestone?.title, "Stale Projection");
   assert.notEqual(result.nextAction, "Stale action from projection");
+});
+
+test("readProgressFromDb returns null for a missing requested DB instead of reusing an open global DB", async (t) => {
+  const existing = await createWorkflowAuthorityFixture();
+  const missingRoot = join(tmpdir(), `gsd-progress-missing-${randomUUID()}`);
+  mkdirSync(join(missingRoot, ".gsd"), { recursive: true });
+  t.after(() => {
+    existing.cleanup();
+    rmSync(missingRoot, { recursive: true, force: true });
+  });
+
+  existing.reopen();
+  const result = await readProgressFromDb(missingRoot);
+
+  assert.equal(result, null);
 });
 
 test("readProgressFromDb retries when the authority revision moves", async (t) => {

--- a/src/resources/extensions/gsd/tests/project-snapshot.test.ts
+++ b/src/resources/extensions/gsd/tests/project-snapshot.test.ts
@@ -7,9 +7,10 @@
 
 import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 
 import {
   _getAdapter,
@@ -505,4 +506,41 @@ test("readProjectSnapshotFromDb returns the last attempt during sustained revisi
     3,
     "sustained movement must stop at MAX_REVISION_ATTEMPTS and return the last attempt",
   );
+});
+
+test("readProjectSnapshotFromDb reopens the requested project instead of reusing another global DB", async (t) => {
+  const first = await createWorkflowAuthorityFixture();
+  const second = await createWorkflowAuthorityFixture();
+  t.after(() => {
+    first.cleanup();
+    second.cleanup();
+  });
+
+  first.reopen();
+  const firstAuthority = getProjectAuthorityRow();
+  assert.ok(firstAuthority);
+
+  const secondSnapshot = await readProjectSnapshotFromDb(second.root);
+  assert.ok(secondSnapshot);
+
+  assert.notEqual(secondSnapshot.authority.projectId, firstAuthority.projectId);
+  assert.equal(secondSnapshot.current.activeMilestone?.title, "Authority Fixture");
+});
+
+test("readProjectSnapshotFromDb returns null for a missing requested DB instead of reusing an open global DB", async (t) => {
+  const existing = await createWorkflowAuthorityFixture();
+  const missingRoot = join(tmpdir(), `gsd-project-snapshot-missing-${randomUUID()}`);
+  mkdirSync(join(missingRoot, ".gsd"), { recursive: true });
+  t.after(() => {
+    existing.cleanup();
+    rmSync(missingRoot, { recursive: true, force: true });
+  });
+
+  existing.reopen();
+  const existingAuthority = getProjectAuthorityRow();
+  assert.ok(existingAuthority);
+
+  const missingSnapshot = await readProjectSnapshotFromDb(missingRoot);
+
+  assert.equal(missingSnapshot, null);
 });


### PR DESCRIPTION
## Linked issue

Refs #2102  
Follow-up to #2170  
Supersedes the closed, unmerged stacked PR #2171

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Re-submits and extends the #2171 snapshot project-isolation fix directly against `main`, now that #2170 has merged.  
**Why:** #2171 was closed after #2170 merged, but closing the stacked PR did not merge this fix; current `main` still allowed same-process reads to reuse or leave behind the wrong process-global workflow DB handle.  
**How:** Treat the requested project DB open result as authoritative, restore prior global DB state for canonical snapshot surfaces, and add regressions for existing-project, missing-DB, native, packaged MCP, CLI, and progress-reader paths.

## Why this PR exists after #2171 was closed

#2171 was originally opened as a stacked patch onto #2170 because the bug was found while reviewing the new `gsd_project_snapshot` implementation. That was the right shape while #2170 was still open.

After #2170 merged, #2171 was closed unmerged. That is an easy mistake to make: visually, it can look like the stacked branch became obsolete once its base branch landed. But technically the commit in #2171 was never part of #2170. A stacked PR is not automatically absorbed when its base PR merges.

The result is that `main` now contains the new snapshot feature from #2170, but not the project-isolation fix from #2171.

```mermaid
flowchart TD
    A[#2170 snapshot feature branch] --> B[#2170 merged into main]
    C[#2171 stacked fix branch] --> A
    B --> D[main has gsd_project_snapshot]
    C -. closed unmerged .-> E[fix commit not merged]
    D --> F[current main still has DB-handle reuse bug]
```

What should happen is this:

```mermaid
flowchart TD
    A[#2170 already merged] --> B[main has snapshot implementation]
    C[#2171 fix commit] --> D[this PR against main]
    D --> E[main also gets project-isolation regression + fix]
```

So this PR is intentionally small: it preserves the useful #2171 fix without reopening the broader #2102 design discussion.

## What changed

This PR fixes same-process project-isolation for DB-backed progress/snapshot readers and updates one public MCP description.

Changed files:

- `src/resources/extensions/gsd/state/derive/db-open.ts`
  - Reuses an already-open global workflow DB only when `getDbPath()` matches `resolveProjectRootDbPath(basePath)`.
- `src/resources/extensions/gsd/state/project-snapshot.ts`
  - Treats `ensureExistingWorkflowDbOpen(basePath)` returning `false` as authoritative, so a missing requested DB cannot fall through to a previous project's open handle.
  - Adds `{ preserveGlobalDbHandle: true }` for canonical native/MCP surfaces that must read through snapshot logic without permanently changing process-global DB state.
  - Restores the previous global DB path after the read, or closes the DB if no global handle existed before.
- `src/resources/extensions/gsd/state/progress-from-db.ts`
  - Applies the same requested-open check to progress reads. This closes the related edge case where `gsd read progress` could combine an unavailable requested project with counts from a previously open project DB.
- `src/resources/extensions/gsd/bootstrap/db-tools.ts`
  - Native `gsd_project_snapshot` calls the preserve mode and treats a null snapshot as `db_unavailable` rather than returning successful `null` data.
- `packages/mcp-server/src/workflow-tools.ts`
  - Packaged MCP `gsd_project_snapshot` calls the preserve mode.
  - Aligns the public tool description with the actual response contract: authority/current/progress/blockers/open questions/verification/milestones, not requirements/decisions.
- Tests add coverage for:
  - project A -> project B snapshot reads returning B;
  - missing requested DB while another global DB is open returning `null`/`db_unavailable`;
  - native and packaged MCP snapshot reads preserving an existing global DB path;
  - native and packaged MCP snapshot reads leaving no global DB open when none was open before;
  - progress reads returning `null` rather than reusing a previous project's DB.

## Why

#2170 correctly added `gsd_project_snapshot` as a DB-authoritative read surface across native tools, packaged MCP, and `gsd read snapshot --json`. Because the snapshot is explicitly canonical, serving data from the wrong project is worse than failing loudly: the payload looks valid and authoritative.

Current `main` can follow this path:

```mermaid
sequenceDiagram
    participant Consumer
    participant Runtime
    participant DB as Process-global DB handle

    Consumer->>Runtime: readProjectSnapshotFromDb(projectA)
    Runtime->>DB: open projectA/gsd.db
    DB-->>Runtime: handle available for project A

    Consumer->>Runtime: readProjectSnapshotFromDb(projectB)
    Runtime->>Runtime: ensureExistingWorkflowDbOpen(projectB)
    Runtime->>Runtime: isDbAvailable() === true
    Runtime-->>Consumer: snapshot built from project A handle
```

Copilot also pointed out the related missing-DB edge case: if project A is globally open and project B has no DB, a caller that ignores `ensureExistingWorkflowDbOpen()`'s `false` return can still see `isDbAvailable() === true` for project A. This revision makes both snapshot and progress readers trust the requested-open boolean.

## How

The fix keeps the #2170 contract intact:

- No projection fallback is added to snapshot.
- The DB-only/fail-closed snapshot behavior remains unchanged.
- Canonical-read error semantics remain unchanged.
- The change tightens when a global DB handle may be reused and when it must be restored.

Implementation detail:

```ts
const requestedDbPath = resolveProjectRootDbPath(basePath);
if (isDbAvailable() && getDbPath() === requestedDbPath) {
  syncQueueOrderProjectionToDb(basePath);
  return true;
}
```

Snapshot/progress readers then treat the boolean result as authoritative:

```ts
const openedRequestedDb = ensureExistingWorkflowDbOpen(basePath);
if (!openedRequestedDb || !isDbAvailable()) return null;
```

Canonical native/MCP snapshot surfaces opt into handle preservation:

```ts
readProjectSnapshotFromDb(projectDir, { preserveGlobalDbHandle: true })
```

```mermaid
flowchart LR
    A[Requested project path] --> B[resolveProjectRootDbPath]
    C[Current global DB path] --> D{same path?}
    B --> D
    D -->|yes| E[reuse open handle]
    D -->|no| F[open requested DB]
    E --> G[build snapshot]
    F --> G
    G --> H{preserve prior handle?}
    H -->|yes| I[restore previous path or close]
    H -->|no| J[leave direct reader behavior unchanged]
```

## Review follow-up

This PR was updated after review:

- Copilot PR review recommended pinning the missing-requested-DB case while another global DB handle is open. Added direct snapshot coverage and changed snapshot/progress readers to fail closed from the requested-open result.
- A local critical subagent review recommended preserving global DB handle state for native and packaged MCP snapshot reads. Added native/MCP coverage for preserving an existing handle and for leaving no handle open when none existed before.
- `codex review` on this CLI version does not support `--adversarial`; I ran it with an explicit adversarial review prompt instead. It surfaced the progress-reader missing-DB edge and native-null snapshot edge; both are addressed here. It also raised broader concurrency/logger-state concerns around process-global DB ownership. Those are larger than this small PR and remain out of scope; this patch does not redesign the DB singleton or logger base-path ownership model.

## Related work

- #2102: original `gsd_project_snapshot` issue.
- #2170: merged implementation of the snapshot feature.
- #2171: previous stacked PR containing the initial fix, closed unmerged after #2170 landed.
- #2143: related but separate VS Code/sidebar progress consumer work; this PR does not change that surface.
- #2105: existing DB-authoritative progress foundation used as the pattern for canonical reads.

This PR deliberately does not implement new #2102 scope, does not change VS Code progress UI behavior, and does not import unrelated local mixed-patch work.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described below
- [ ] No tests needed — explained above

Validated locally on fresh `upstream/main` branch `fix/project-snapshot-db-handle`:

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:pi`
- `pnpm run build:rpc-client`
- `pnpm run build:mcp-server`
- `pnpm exec tsx --test src/resources/extensions/gsd/tests/project-snapshot.test.ts src/resources/extensions/gsd/tests/canonical-read-tools.test.ts src/tests/read-cli-snapshot-db.test.ts src/tests/read-cli-args.test.ts` — 24/24 passed before review follow-up
- `pnpm run build:mcp-server`
- `pnpm exec tsx --test src/resources/extensions/gsd/tests/project-snapshot.test.ts src/resources/extensions/gsd/tests/canonical-read-tools.test.ts src/resources/extensions/gsd/tests/progress-from-db.test.ts src/tests/read-cli-snapshot-db.test.ts src/tests/read-cli-progress-db.test.ts src/tests/read-cli-schema-too-new.test.ts src/tests/read-cli-args.test.ts` — 48/48 passed after Copilot/Codex follow-up
- `pnpm exec tsc --noEmit --project tsconfig.extensions.json` — passed
- `git diff --check` — passed

## AI disclosure

- [x] This PR includes AI-assisted code

AI assistance was used to compare #2170/#2171 against current `main`, confirm that #2171 closed without merging this fix, preserve the small patch, run Copilot/subagent/Codex reviews, and validate the final result. The submitted diff was reviewed and tested with the commands above.