### PR TITLE
feat(mcp): GSD-side smoke probe and per-host checklist for canonical read tools

### DIFF
--- a/docs/agents/mcp-host-smoke.md
+++ b/docs/agents/mcp-host-smoke.md
@@ -1,0 +1,87 @@
+# MCP-host smoke: gsd_progress and gsd_project_snapshot
+
+Records MCP-host smoke evidence for the two canonical read tools (issue #2173, umbrella #2099), keeping host-configuration differences separate from GSD contract defects.
+
+## Run the GSD-side probe first
+
+The probe proves the server side before any host is involved. From a repo root with `pnpm install` done:
+
+```sh
+pnpm run build:core
+node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types scripts/mcp-host-smoke.mjs
+```
+
+`build:core` is required (not just `build:mcp-server`): the workflow-tool bridge warm-up loads the GSD runtime from the checkout's root `dist/`, and a fresh checkout has none.
+
+- Exits 0 with a PASS per check when the packaged server advertises and serves both tools with the exact response keysets.
+- Pass `--project <absolute dir>` to probe a real project instead of the seeded fixture.
+- If any check fails, stop: that is a GSD contract defect, not a host issue. File it with the probe output before touching host configuration.
+
+## Per-host checklist
+
+For each host below: use the config snippet against a local build (`pnpm run build:core`), then record results in the template at the bottom. Replace `<repo>` with the absolute path to your gsd-pi checkout.
+
+### VS Code Copilot
+
+- Config: `.vscode/mcp.json` in the workspace:
+
+```json
+{
+  "servers": {
+    "gsd": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["<repo>/packages/mcp-server/dist/cli.js"]
+    }
+  }
+}
+```
+
+- Start: reload window, open Copilot Chat → tools/tools-picker, confirm `gsd` tools appear after approval.
+- Invoke: ask Copilot "show GSD project progress", then "show the full project snapshot"; confirm the tool calls run and answers reflect DB state (active milestone/slice/task, blockers, next action).
+
+### Cursor
+
+- Config: `~/.cursor/mcp.json` with the same `mcpServers.gsd` shape (`command: "node"`, `args: ["<repo>/packages/mcp-server/dist/cli.js"]`).
+- Start: Cursor Settings → MCP → confirm `gsd` listed and tools discovered.
+- Invoke: in agent mode, request project progress, then the project snapshot; confirm both tool invocations succeed.
+
+### Claude Code
+
+- Config: `claude mcp add gsd -- node <repo>/packages/mcp-server/dist/cli.js`
+- Start: `/mcp` — confirm the `gsd` server connects and lists tools.
+- Invoke: "use the gsd_progress tool" and "use gsd_project_snapshot"; confirm structured results render.
+
+### Codex
+
+- Config: `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.gsd]
+command = "node"
+args = ["<repo>/packages/mcp-server/dist/cli.js"]
+```
+
+- Start: new Codex session; confirm the server connects (no startup warnings).
+- Invoke: request project progress, then the project snapshot; confirm both calls succeed.
+
+## Classification rules
+
+- Probe green + host failure → host configuration. Fix belongs in host docs or the host's config; record the difference here.
+- Probe failure → GSD contract defect. File an issue with the probe output; do not work around it in host config.
+- A host that cannot run stdio servers in your configuration → record that explicitly; never silently omit the host.
+
+## Results template
+
+Attach per host to issue #2173:
+
+```text
+Host: <name> <version>
+Config mode: <snippet used, verbatim>
+Probe result at time of run: <pass/fail + date>
+- Discovery: gsd_progress <yes/no>, gsd_project_snapshot <yes/no>
+- Invocation gsd_progress: <pass/fail + observed phase/active refs>
+- Invocation gsd_project_snapshot: <pass/fail + revision + milestone count>
+- Deviations from expected observations: <none / details>
+Classification: <host-config | GSD-defect | n/a — all passed>
+```

--- a/scripts/mcp-host-smoke.mjs
+++ b/scripts/mcp-host-smoke.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// Project/App: gsd-pi
+// File Purpose: Automated GSD-side probe for MCP-host smoke evidence (issue #2173).
+// Boots the packaged MCP server over stdio, verifies gsd_progress and
+// gsd_project_snapshot discovery + invocation against a seeded fixture, and
+// prints a per-check PASS/FAIL table. Proves the server side is contract-correct
+// before any host (VS Code Copilot, Cursor, Claude Code, Codex) is involved.
+//
+// Run from the repo root:
+//   node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types scripts/mcp-host-smoke.mjs
+// Optional: --project <absolute dir> to probe a real project instead of the fixture.
+
+import { existsSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import process from "node:process";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const cliJs = resolve(repoRoot, "packages/mcp-server/dist/cli.js");
+
+if (!existsSync(cliJs)) {
+	console.error("Packaged MCP server not built. Run: pnpm run build:core");
+	process.exit(1);
+}
+
+// gsd_progress serves DbProgressResult (bridge path) — 10 keys; optional
+// hierarchy extensions from #2143 are additive and not asserted here.
+const PROGRESS_KEYS = [
+	"activeMilestone", "activeSlice", "activeTask", "phase",
+	"milestones", "slices", "tasks", "requirements",
+	"blockers", "nextAction",
+].sort();
+
+const SNAPSHOT_KEYS = [
+	"authority", "current", "progress", "blockers", "openQuestions",
+	"verification", "milestones", "capturedAt",
+].sort();
+
+const results = [];
+function record(name, ok, detail) {
+	results.push({ name, ok, detail });
+	console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? ` — ${detail}` : ""}`);
+}
+
+function keysetOf(value) {
+	return value && typeof value === "object" ? Object.keys(value).sort() : null;
+}
+
+function sameMembers(a, b) {
+	return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// Resolve a seeded fixture in-process (same loader runs this file).
+const { createWorkflowAuthorityFixture } = await import(
+	"../src/resources/extensions/gsd/tests/workflow-authority-fixture.ts"
+);
+
+const argProject = process.argv.includes("--project")
+	? process.argv[process.argv.indexOf("--project") + 1]
+	: null;
+
+const fixture = argProject
+	? null
+	: await createWorkflowAuthorityFixture();
+const projectDir = argProject
+	? realpathSync(argProject)
+	: fixture.root;
+
+const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+const { StdioClientTransport } = await import("@modelcontextprotocol/sdk/client/stdio.js");
+
+const client = new Client({ name: "gsd-mcp-host-smoke", version: "0.0.0" });
+const transport = new StdioClientTransport({
+	command: process.execPath,
+	args: [cliJs],
+	cwd: projectDir,
+	env: {
+		PATH: process.env.PATH,
+		HOME: process.env.HOME,
+		TMPDIR: realpathSync(tmpdir()),
+		GSD_NON_INTERACTIVE: "1",
+	},
+	stderr: "pipe",
+});
+
+try {
+	await client.connect(transport);
+
+	// --- Discovery -----------------------------------------------------------
+	const listed = await client.listTools();
+	const names = listed.tools.map((t) => t.name);
+	record("tools/list: gsd_progress advertised", names.includes("gsd_progress"));
+	record("tools/list: gsd_project_snapshot advertised", names.includes("gsd_project_snapshot"));
+
+	// --- gsd_progress invocation ----------------------------------------------
+	const progress = await client.callTool({ name: "gsd_progress", arguments: { projectDir } });
+	const progressPayload = JSON.parse(progress.content[0].text);
+	record(
+		"gsd_progress: exact keyset",
+		!progress.isError && sameMembers(keysetOf(progressPayload), PROGRESS_KEYS),
+		`keys=${keysetOf(progressPayload)?.join(",")}`,
+	);
+	record(
+		"gsd_progress: payload is DB-authoritative (phase present, no projection fallback)",
+		typeof progressPayload.phase === "string" && progressPayload.phase.length > 0,
+		`phase=${progressPayload.phase}`,
+	);
+
+	// --- gsd_project_snapshot invocation ---------------------------------------
+	const snapshot = await client.callTool({ name: "gsd_project_snapshot", arguments: { projectDir } });
+	const snapshotPayload = JSON.parse(snapshot.content[0].text);
+	const structured = snapshot.structuredContent;
+	record(
+		"gsd_project_snapshot: exact keyset",
+		!snapshot.isError && sameMembers(keysetOf(snapshotPayload), SNAPSHOT_KEYS),
+		`keys=${keysetOf(snapshotPayload)?.join(",")}`,
+	);
+	record(
+		"gsd_project_snapshot: structuredContent mirrors details",
+		structured?.operation === "read_project_snapshot"
+			&& structured?.snapshot
+			&& sameMembers(keysetOf(structured.snapshot), SNAPSHOT_KEYS),
+		`operation=${structured?.operation}`,
+	);
+	record(
+		"gsd_project_snapshot: authority revision is numeric",
+		Number.isSafeInteger(snapshotPayload.authority?.revision),
+		`revision=${snapshotPayload.authority?.revision}`,
+	);
+	record(
+		"gsd_project_snapshot: milestone registry bounded with truncated flag",
+		Array.isArray(snapshotPayload.milestones?.items)
+			&& snapshotPayload.milestones.items.length <= 50
+			&& typeof snapshotPayload.milestones.truncated === "boolean",
+		`items=${snapshotPayload.milestones?.items?.length}, truncated=${snapshotPayload.milestones?.truncated}`,
+	);
+} catch (err) {
+	record("probe completed without transport/protocol error", false, err.message);
+} finally {
+	await client.close().catch(() => {});
+	fixture?.cleanup();
+}
+
+const failed = results.filter((r) => !r.ok).length;
+console.log(`\n${results.length - failed}/${results.length} checks passed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
Implements the harness layer of #2173 (the issue stays open until at least one per-host run is recorded).

## Summary

Implements layer 1 of #2173: an automated GSD-side probe that proves the packaged MCP server is contract-correct for `gsd_progress` and `gsd_project_snapshot` before any host is involved, plus the per-host manual checklist (layer 2) for VS Code Copilot, Cursor, Claude Code, and Codex.

## What's included

- `scripts/mcp-host-smoke.mjs` — boots `packages/mcp-server/dist/cli.js` over stdio via the MCP SDK, runs discovery + invocation for both tools against a seeded `createWorkflowAuthorityFixture()` project (or `--project <dir>` for a real one), and validates: both tools advertised; `gsd_progress` exact 10-key set with DB-authoritative phase; `gsd_project_snapshot` exact 8-key set, `structuredContent` mirroring `details`, numeric authority revision, bounded milestone registry with `truncated` flag. Fails loud with a per-check PASS/FAIL table and non-zero exit.
- `docs/agents/mcp-host-smoke.md` — run instructions, per-host config snippets (VS Code `mcp.json`, Cursor `~/.cursor/mcp.json`, Claude Code `claude mcp add`, Codex `config.toml`), invocation steps, host-config-vs-GSD-defect classification rules, and the results template to attach to #2173.

## Verification

Probe run against a full `pnpm run build:core` checkout: **8/8 checks PASS, exit 0**. One setup gotcha captured in the doc: the workflow-tool bridge warm-up loads the GSD runtime from the checkout's root `dist/`, so `build:core` (not just `build:mcp-server`) is the prerequisite — a fresh checkout with only the package built fails at startup with the fail-closed bridge error.

## Notes

- Read-only end to end: the probe mutates nothing outside its temp fixture.
- Per-host runs are maintainer/contributor-executed per the checklist; at least one recorded run remains open on #2173 before that issue closes.