### PR TITLE
fix(gsd): close Codex review findings on gsd_project_snapshot

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -3361,6 +3361,11 @@ export function registerDbTools(pi: ExtensionAPI): void {
 				basePath,
 				async () => readProjectSnapshotFromDb(basePath),
 			);
+			if (!snapshot) {
+				// The adapter preflight succeeded but the reader could not open
+				// through its own path — fail closed like MCP and the CLI.
+				throw new Error("GSD database is not available (db_unavailable)");
+			}
 
 			return {
 				content: [
@@ -3375,13 +3380,15 @@ export function registerDbTools(pi: ExtensionAPI): void {
 					snapshot,
 				} as any,
 			};
-		} catch (err) {
-			const msg = err instanceof Error ? err.message : String(err);
-			if (msg.includes("db_unavailable")) {
-				logError("tool", `gsd_project_snapshot failed: ${msg}`, {
-					tool: "gsd_project_snapshot",
-					error: String(err),
-				});
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				// Mirror mapCanonicalReadError: "not available" (e.g. missing
+				// authority row) classifies as db_unavailable, not query_error.
+				if (msg.includes("db_unavailable") || msg.includes("not available")) {
+					logError("tool", `gsd_project_snapshot failed: ${msg}`, {
+						tool: "gsd_project_snapshot",
+						error: String(err),
+					});
 				return {
 					content: [
 						{

--- a/src/resources/extensions/gsd/state/derive/db-open.ts
+++ b/src/resources/extensions/gsd/state/derive/db-open.ts
@@ -19,10 +19,11 @@ export function syncQueueOrderProjectionToDb(basePath: string): void {
 
 export function ensureExistingWorkflowDbOpen(
   basePath: string,
-  options: { throwOnOpenFailure?: boolean } = {},
+  options: { throwOnOpenFailure?: boolean; syncQueueOrder?: boolean } = {},
 ): boolean {
+  const syncQueueOrder = options.syncQueueOrder !== false;
   if (isDbAvailable()) {
-    syncQueueOrderProjectionToDb(basePath);
+    if (syncQueueOrder) syncQueueOrderProjectionToDb(basePath);
     return true;
   }
   let result: WorkflowDatabaseOpenResult;
@@ -44,7 +45,7 @@ export function ensureExistingWorkflowDbOpen(
   if (!result.ok && options.throwOnOpenFailure && result.reason !== "missing-database" && result.reason !== "missing-gsd-dir") {
     throw result.error ?? new Error(`Unable to open the GSD database: ${result.reason}`);
   }
-  if (result.ok) syncQueueOrderProjectionToDb(basePath);
+  if (result.ok && syncQueueOrder) syncQueueOrderProjectionToDb(basePath);
   return result.ok;
 }
 

--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -440,8 +440,9 @@ function checkReplanTrigger(basePath: string, milestoneId: string, sliceId: stri
 export async function deriveStateFromDb(
   basePath: string,
   _artifactReadRoot: string = basePath,
+  options: { syncQueueOrder?: boolean } = {},
 ): Promise<GSDState> {
-  if (!ensureExistingWorkflowDbOpen(basePath)) {
+  if (!ensureExistingWorkflowDbOpen(basePath, options)) {
     return buildDbUnavailableState();
   }
 

--- a/src/resources/extensions/gsd/state/derive/index.ts
+++ b/src/resources/extensions/gsd/state/derive/index.ts
@@ -23,6 +23,8 @@ import { deriveStateFromDb } from './from-db.js';
 
 export interface DeriveStateOptions {
   projectRootForReads?: string;
+  /** Read-only surfaces set this so deriving never mutates DB sequence from QUEUE-ORDER.json. */
+  syncQueueOrder?: boolean;
 }
 
 export {
@@ -43,11 +45,13 @@ export async function deriveState(
   const stopTimer = debugTime("derive-state-impl");
   let result: GSDState;
 
-  ensureExistingWorkflowDbOpen(basePath);
+  ensureExistingWorkflowDbOpen(basePath, { syncQueueOrder: opts?.syncQueueOrder });
 
   if (isDbAvailable()) {
     const stopDbTimer = debugTime("derive-state-db");
-    result = await deriveStateFromDb(basePath, opts?.projectRootForReads ?? basePath);
+    result = await deriveStateFromDb(basePath, opts?.projectRootForReads ?? basePath, {
+      syncQueueOrder: opts?.syncQueueOrder,
+    });
     stopDbTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
     incrementDbDeriveCount();
   } else {

--- a/src/resources/extensions/gsd/state/progress-from-db.ts
+++ b/src/resources/extensions/gsd/state/progress-from-db.ts
@@ -145,13 +145,16 @@ async function readProgressFromDbInternal(
   includeHierarchyDetails: boolean,
   throwOnOpenFailure: boolean,
 ): Promise<DbProgressResult | DbProjectProgressResult | null> {
-  ensureExistingWorkflowDbOpen(basePath, { throwOnOpenFailure });
+  // Read-only surface: never mutate. The queue-order projection sync stays a
+  // runtime derive/dispatch repair (see docs/user-docs/auto-mode.md); read
+  // paths report the DB-authoritative order as-is even when the file is newer.
+  ensureExistingWorkflowDbOpen(basePath, { throwOnOpenFailure, syncQueueOrder: false });
   if (!isDbAvailable()) return null;
 
   invalidateStateCache();
   for (let attempt = 1; ; attempt++) {
     const before = readProgressStabilityToken();
-    const state = await deriveState(basePath);
+    const state = await deriveState(basePath, { syncQueueOrder: false });
     const progress = buildProgressResult(state, readProgressHierarchy());
     const details = includeHierarchyDetails ? getProgressHierarchyDetails() : undefined;
     const result: DbProgressResult | DbProjectProgressResult = details
@@ -177,8 +180,10 @@ async function readProgressFromDbInternal(
  * come from the read seam, since `deriveState` may be execution-scoped while
  * `ProgressResult` buckets are project-wide.
  *
- * Note: the derive open path runs pending migrations and syncs the
- * milestone queue-order projection (same behavior as `gsd headless status`).
+ * Note: the derive open path runs pending migrations when required, but this
+ * read suppresses the milestone queue-order projection sync — reads never
+ * mutate; the runtime derive path owns that repair (same as `gsd headless
+ * status`).
  * Results are bound to stable authority and data-version tokens; under
  * sustained concurrent commits or same-process interleaved writes, a snapshot
  * may still straddle revisions.

--- a/src/resources/extensions/gsd/state/project-snapshot.ts
+++ b/src/resources/extensions/gsd/state/project-snapshot.ts
@@ -178,16 +178,19 @@ function buildCurrent(state: GSDState): DbProjectSnapshotCurrent {
  * snapshot was assembled and the current section may tear relative to the
  * transactional sections under concurrent commits — the stability-retry loop
  * bounds but does not eliminate that (same contract as readProgressFromDb).
+ * Reads never mutate: the queue-order projection sync stays a runtime
+ * derive/dispatch repair, so the snapshot reports DB-authoritative order
+ * as-is even when QUEUE-ORDER.json is newer.
  */
 export async function readProjectSnapshotFromDb(basePath: string): Promise<DbProjectSnapshot | null> {
-  ensureExistingWorkflowDbOpen(basePath);
+  ensureExistingWorkflowDbOpen(basePath, { syncQueueOrder: false });
   if (!isDbAvailable()) return null;
 
   invalidateStateCache();
   for (let attempt = 1; ; attempt++) {
     const before = readStabilityToken();
     const dbRead = readSnapshotDb();
-    const state = await deriveState(basePath);
+    const state = await deriveState(basePath, { syncQueueOrder: false });
     const after = readStabilityToken();
 
     if (stabilityTokensMatch(before, after) || attempt === MAX_REVISION_ATTEMPTS) {

--- a/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/canonical-read-tools.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -455,6 +455,36 @@ test("canonical read parity: dropped workflow_blockers table returns query_error
     );
     assert.ok(isolated, "isolated open should still work after handled snapshot query_error");
     isolated?.close();
+  } finally {
+    cleanup([base]);
+  }
+});
+
+test("canonical read parity: missing project_authority row classifies as db_unavailable for native and MCP snapshot reads", async () => {
+  const base = makeProjectBase("gsd-canonical-snapshot-no-authority");
+  try {
+    const native = makeNativeTools();
+    const mcp = makeMcpTools();
+
+    openDatabase(resolveProjectRootDbPath(base));
+    getDb().prepare("DELETE FROM project_authority").run();
+    closeDatabase();
+    invalidateAllCaches();
+
+    const nativeSnapshotResult = await nativeTool(native, "gsd_project_snapshot").execute(
+      "call-11",
+      {},
+      undefined,
+      undefined,
+      { cwd: base },
+    );
+    const nativeDetails = (nativeSnapshotResult as { details?: { error?: string } }).details;
+    assert.equal(nativeDetails?.error, "db_unavailable",
+      "native must classify the missing authority row like mapCanonicalReadError");
+
+    const mcpSnapshotResult = await mcpTool(mcp, "gsd_project_snapshot").handler({ projectDir: base });
+    const mcpDetails = (mcpSnapshotResult as { structuredContent?: { error?: string } }).structuredContent;
+    assert.equal(mcpDetails?.error, "db_unavailable");
   } finally {
     cleanup([base]);
   }

--- a/src/resources/extensions/gsd/tests/project-snapshot.test.ts
+++ b/src/resources/extensions/gsd/tests/project-snapshot.test.ts
@@ -5,21 +5,24 @@
 // determinism at a stable revision, milestone registry truncation, open-item
 // ordering, and the missing-DB null contract.
 
-import { test } from "node:test";
+import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
   _getAdapter,
   closeDatabase,
+  getAllMilestones,
   getProjectAuthorityRow,
   getSchemaVersion,
   insertMilestone,
+  setMilestoneQueueOrder,
   transaction,
 } from "../gsd-db.ts";
-import { deriveState } from "../state.ts";
+import { deriveState, getDeriveTelemetry, invalidateStateCache, resetDeriveTelemetry } from "../state.ts";
+import { readProgressFromDb } from "../state/progress-from-db.ts";
 import {
   MAX_SNAPSHOT_MILESTONES,
   readProjectSnapshotFromDb,
@@ -390,4 +393,116 @@ test("readProjectSnapshotFromDb returns null when no database exists", async (t)
 
   assert.equal(snapshot, null);
   assert.equal(existsSync(join(root, ".gsd", "gsd.db")), false, "missing DB must not be created");
+});
+
+test("snapshot and progress reads never mutate milestone sequence from QUEUE-ORDER.json (runtime derive still repairs)", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+
+  transaction(() => {
+    insertMilestone({ id: "M002", title: "Second", status: "pending" });
+    insertMilestone({ id: "M003", title: "Third", status: "pending" });
+  });
+  // DB-authoritative order differs from the projection file on purpose.
+  setMilestoneQueueOrder(["M002", "M001", "M003"]);
+  writeFileSync(
+    join(fixture.root, ".gsd", "QUEUE-ORDER.json"),
+    JSON.stringify({ order: ["M001", "M002", "M003"] }),
+  );
+
+  const snapshot = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(snapshot);
+  assert.deepEqual(
+    getAllMilestones().map((m) => m.id),
+    ["M002", "M001", "M003"],
+    "snapshot read must not mirror QUEUE-ORDER.json into DB sequence",
+  );
+  assert.deepEqual(
+    snapshot.milestones.items.map((m) => m.id),
+    ["M002", "M001", "M003"],
+    "registry must report DB-authoritative order, not the projection file",
+  );
+
+  const progress = await readProgressFromDb(fixture.root);
+  assert.ok(progress);
+  assert.deepEqual(
+    getAllMilestones().map((m) => m.id),
+    ["M002", "M001", "M003"],
+    "progress read must not mirror QUEUE-ORDER.json into DB sequence",
+  );
+
+  // The runtime derive path (sync enabled) still repairs sequence from the
+  // file. deriveState is cache-first, so invalidate like a fresh runtime
+  // derive (the read above populated the cache).
+  invalidateStateCache();
+  await deriveState(fixture.root);
+  assert.deepEqual(
+    getAllMilestones().map((m) => m.id),
+    ["M001", "M002", "M003"],
+    "runtime derive must keep the queue-order projection repair",
+  );
+});
+
+/** Same mechanism as progress-from-db.test.ts: bump the authority revision when
+ *  the hierarchy-counts query runs, through the shared adapter. */
+function changeAuthorityDuringCounts(
+  t: TestContext,
+  limit: number,
+): () => number {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  const originalPrepare = adapter.prepare.bind(adapter);
+  let changes = 0;
+
+  adapter.prepare = (sql: string) => {
+    const statement = originalPrepare(sql);
+    if (!sql.includes("AS completed") || !sql.includes("FROM milestones")) return statement;
+    return {
+      ...statement,
+      get(...params: unknown[]) {
+        if (changes < limit) {
+          changes++;
+          originalPrepare("UPDATE milestones SET title = ? WHERE id = 'M001'")
+            .run(`Authority revision ${changes}`);
+          originalPrepare("UPDATE project_authority SET revision = revision + 1 WHERE singleton = 1")
+            .run();
+        }
+        return statement.get(...params);
+      },
+    } as typeof statement;
+  };
+  t.after(() => {
+    adapter.prepare = originalPrepare;
+  });
+  return () => changes;
+}
+
+test("readProjectSnapshotFromDb retries when the authority revision moves during the counts read", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+
+  resetDeriveTelemetry();
+  const changes = changeAuthorityDuringCounts(t, 1);
+
+  const snapshot = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(snapshot);
+  assert.equal(changes(), 1, "the revision bump should have fired exactly once");
+  assert.equal(getDeriveTelemetry().dbDeriveCount, 2, "a moved stability token must trigger a second derive");
+  assert.ok(snapshot.authority.revision >= 1, "the returned snapshot reflects the moved revision");
+});
+
+test("readProjectSnapshotFromDb returns the last attempt during sustained revision movement", async (t) => {
+  const fixture = await createWorkflowAuthorityFixture();
+  t.after(() => fixture.cleanup());
+
+  resetDeriveTelemetry();
+  changeAuthorityDuringCounts(t, 3);
+
+  const snapshot = await readProjectSnapshotFromDb(fixture.root);
+  assert.ok(snapshot);
+  assert.equal(
+    getDeriveTelemetry().dbDeriveCount,
+    3,
+    "sustained movement must stop at MAX_REVISION_ATTEMPTS and return the last attempt",
+  );
 });


### PR DESCRIPTION
Refs #2102
Follow-up to #2170 (Codex review of the merged snapshot implementation)

## Findings addressed

**P1 — Reads can write (finding 1).** `ensureExistingWorkflowDbOpen` unconditionally ran `syncQueueOrderProjectionToDb`, mirroring `.gsd/QUEUE-ORDER.json` into `milestones.sequence` via `UPDATE` — so snapshot/progress reads could mutate the DB and let a projection file override canonical order. The sync is an intentional *runtime* repair (docs pin it to state derivation/dispatch, prompts author the file), so it stays — but reads now suppress it: `ensureExistingWorkflowDbOpen` and `deriveState`/`deriveStateFromDb` gained a `syncQueueOrder` option (default on), and both readers pass `false` through every layer, including the derive they invoke internally. New regression pins both directions: reads leave DB sequence untouched even with a divergent file; a runtime derive still repairs it.

**P1 — Native could return successful `null` (finding 2).** If the reader returned `null` after the isolated preflight succeeded, native serialized `"null"` as success while MCP and CLI failed closed. Native now throws `db_unavailable` on a null reader result, matching the other surfaces.

**P2 — Divergent error classification (finding 3).** `mapCanonicalReadError` classifies `"not available"` messages as `db_unavailable`; the native catch only matched `"db_unavailable"`, so a DB missing its `project_authority` row classified differently per surface. Native now mirrors the canonical mapping. Parity test pins missing-authority → `db_unavailable` on both surfaces.

**P2 — Untested retry/teardown (finding 4).** The determinism test couldn't fail if the retry loop were deleted. Added the progress-suite's deterministic revision-bump mechanism: a moved stability token forces a second derive; sustained movement stops at `MAX_REVISION_ATTEMPTS` and returns the last attempt.

## Verification

- Affected suites green: `project-snapshot` (8 tests incl. 3 new), `canonical-read-tools` (13 incl. 1 new), `progress-from-db`, `derive-state-helpers` (runtime queue-order repair tests unchanged and passing) — 48/48.
- `verify:pr` build + typecheck pass; `test:unit` hits 23 pre-existing failures in `migrate-safety-audit` (native-addon API `set_mutation_boundary_fault_for_test` missing from this fresh worktree's cargo-built addon). Verified NOT ours by stash A/B: identical 23 failures on clean `origin/main` in the same worktree, and the Rust source/binary mismatch is environmental. CI on a clean runner arbitrates.

## Notes

- Finding 2's exact race (reader-null after successful preflight) is not deterministically reproducible in-process — the open layer tolerates read-only files and exclusive locks — so that branch is covered by code and the parity suite's `db_unavailable` paths, not a dedicated race test.
- Overlaps #2172's `db-open.ts`/`project-snapshot.ts` edits (same seam, different bugs: theirs is the wrong-project handle). Merge order will need a small rebase on the later one.