### PR TITLE
docs(ci): propose sharded pre-review verification

### DIFF
--- a/.github/workflows/pre-review-verification-sharded.yml
+++ b/.github/workflows/pre-review-verification-sharded.yml
@@ -52,6 +52,7 @@ jobs:
           SHARD_COUNT: ${{ inputs.shard_count }}
         run: |
           set -euo pipefail
+          # shellcheck disable=SC2153 # GitHub Actions injects SOURCE_REPO from step env.
           if [[ ! "$SOURCE_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
             echo "::error::source_repo must be owner/repo, got: $SOURCE_REPO"
             exit 1
@@ -93,6 +94,7 @@ jobs:
           SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           set -euo pipefail
+          # shellcheck disable=SC2153 # GitHub Actions injects SOURCE_REPO from step env.
           repo_url="https://github.com/${SOURCE_REPO}.git"
           target_ref="refs/heads/${SOURCE_REF}"
           git init "$GITHUB_WORKSPACE"
@@ -296,6 +298,7 @@ jobs:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
         run: |
           set -euo pipefail
+          # shellcheck disable=SC2153 # GitHub Actions injects SOURCE_REPO from step env.
           repo_url="https://github.com/${SOURCE_REPO}.git"
           git init "$GITHUB_WORKSPACE"
           cd "$GITHUB_WORKSPACE"
@@ -401,6 +404,7 @@ jobs:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
         run: |
           set -euo pipefail
+          # shellcheck disable=SC2153 # GitHub Actions injects SOURCE_REPO from step env.
           git init "$GITHUB_WORKSPACE"
           cd "$GITHUB_WORKSPACE"
           git remote add origin "https://github.com/${SOURCE_REPO}.git"

--- a/.github/workflows/pre-review-verification-sharded.yml
+++ b/.github/workflows/pre-review-verification-sharded.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   build:
     name: build once
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     defaults:
       run:
@@ -279,7 +279,7 @@ jobs:
   test-shard:
     name: test-shard (${{ matrix.shard }}/${{ inputs.shard_count }})
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -388,7 +388,7 @@ jobs:
   lifecycle-gate:
     name: lifecycle shadow gate once
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     defaults:
       run:
@@ -446,7 +446,7 @@ jobs:
     name: aggregate shard results
     needs: [build, test-shard, lifecycle-gate]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     defaults:
       run:

--- a/.github/workflows/pre-review-verification-sharded.yml
+++ b/.github/workflows/pre-review-verification-sharded.yml
@@ -1,0 +1,551 @@
+# Optional sharded pre-review verification. This workflow is manually dispatched
+# and intentionally does not replace ci.yml or any merge-protection signal.
+name: Pre-review verification (sharded)
+
+run-name: "Pre-review sharded verify: ${{ inputs.source_repo }}:${{ inputs.source_ref }} @ ${{ inputs.expected_sha }}"
+
+"on":
+  workflow_dispatch:
+    inputs:
+      source_repo:
+        description: "Public repository to verify, for example pimmink/gsd-pi"
+        required: true
+        type: string
+      source_ref:
+        description: "Branch in source_repo to verify"
+        required: true
+        type: string
+      expected_sha:
+        description: "Full 40-character commit SHA that source_ref must resolve to"
+        required: true
+        type: string
+      shard_count:
+        description: "Number of parallel test:unit:compiled shards"
+        required: false
+        type: string
+        default: "4"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pre-review-sharded-${{ inputs.source_repo }}-${{ inputs.source_ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build once
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      shard_matrix: ${{ steps.matrix.outputs.shard_matrix }}
+      manifest_total: ${{ steps.expand.outputs.total }}
+    steps:
+      - name: Validate inputs and remote ref before checkout
+        env:
+          SOURCE_REPO: ${{ inputs.source_repo }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          SHARD_COUNT: ${{ inputs.shard_count }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$SOURCE_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "::error::source_repo must be owner/repo, got: $SOURCE_REPO"
+            exit 1
+          fi
+          if [[ -z "$SOURCE_REF" || "$SOURCE_REF" == -* || "$SOURCE_REF" == refs/* ]]; then
+            echo "::error::source_ref must be a plain branch name"
+            exit 1
+          fi
+          if ! git check-ref-format --branch "$SOURCE_REF" >/dev/null; then
+            echo "::error::source_ref is not a valid Git branch name"
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::expected_sha must be exactly 40 lowercase hexadecimal characters"
+            exit 1
+          fi
+          if [[ ! "$SHARD_COUNT" =~ ^[0-9]+$ || "$SHARD_COUNT" -lt 1 || "$SHARD_COUNT" -gt 16 ]]; then
+            echo "::error::shard_count must be an integer between 1 and 16"
+            exit 1
+          fi
+
+          target_ref="refs/heads/${SOURCE_REF}"
+          repo_url="https://github.com/${SOURCE_REPO}.git"
+          remote_matches="$(git ls-remote "$repo_url" "$target_ref")"
+          match_count="$(printf '%s\n' "$remote_matches" | grep -c .)" || match_count=0
+          if [[ "$match_count" -ne 1 ]]; then
+            echo "::error::Expected exactly one match for ${target_ref} on ${repo_url}, found ${match_count}."
+            exit 1
+          fi
+          remote_sha="$(printf '%s\n' "$remote_matches" | cut -f1)"
+          if [[ "$remote_sha" != "$EXPECTED_SHA" ]]; then
+            echo "::error::${target_ref} on ${repo_url} points at ${remote_sha}, not ${EXPECTED_SHA}."
+            exit 1
+          fi
+
+      - name: Checkout exact source commit without credentials
+        env:
+          SOURCE_REPO: ${{ inputs.source_repo }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+          repo_url="https://github.com/${SOURCE_REPO}.git"
+          target_ref="refs/heads/${SOURCE_REF}"
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "$repo_url"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git -c protocol.version=2 fetch --no-tags --prune --depth=1 origin \
+            "+${target_ref}:refs/checkout-ref"
+          git checkout --force --detach refs/checkout-ref
+
+      - name: Assert checked-out SHA
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          head_sha="$(git rev-parse HEAD)"
+          if [[ "$head_sha" != "$EXPECTED_SHA" ]]; then
+            echo "::error::HEAD is ${head_sha}, expected ${EXPECTED_SHA}."
+            exit 1
+          fi
+
+      - name: Write initial summary
+        run: |
+          {
+            echo "### Sharded pre-review verification"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| source repo | ${{ inputs.source_repo }} |"
+            echo "| source ref | ${{ inputs.source_ref }} |"
+            echo "| expected sha | ${{ inputs.expected_sha }} |"
+            echo "| shard count | ${{ inputs.shard_count }} |"
+            echo "| authority | advisory pre-review signal; upstream ci.yml remains merge authority |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Compute shard matrix
+        id: matrix
+        env:
+          SHARD_COUNT: ${{ inputs.shard_count }}
+        run: |
+          set -euo pipefail
+          matrix="$(node -e "console.log(JSON.stringify(Array.from({length: Number(process.env.SHARD_COUNT)}, (_, i) => i + 1)))")"
+          echo "shard_matrix=${matrix}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+        with:
+          version: 10.12.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+          GSD_SKIP_RTK_INSTALL: "1"
+          GSD_SKIP_DEP_REPAIR: "1"
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          shared-key: pre-review-sharded-native-linux-x64-gnu
+          workspaces: native -> target
+
+      - name: Build native addon from source
+        env:
+          RUSTFLAGS: "-C target-cpu=x86-64"
+        run: pnpm run build:native:test
+
+      - name: Build core and compile tests
+        env:
+          RUSTFLAGS: "-C target-cpu=x86-64"
+        run: |
+          set -euo pipefail
+          pnpm run build:core
+          pnpm run typecheck:extensions
+          pnpm run test:compile
+
+      - name: Mirror native addon into dist-test
+        run: |
+          set -euo pipefail
+          mkdir -p dist-test/native/addon
+          shopt -s nullglob
+          addons=(native/addon/*.node)
+          if [[ ${#addons[@]} -eq 0 ]]; then
+            echo "::error::No compiled .node addon found under native/addon/."
+            exit 1
+          fi
+          cp "${addons[@]}" dist-test/native/addon/
+
+      - name: Derive canonical compiled-test manifest
+        id: expand
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require("fs");
+          const path = require("path");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const script = pkg.scripts?.["test:unit:compiled"];
+          if (!script) {
+            console.error("::error::package.json has no test:unit:compiled script.");
+            process.exit(1);
+          }
+          const globs = [...script.matchAll(/"(dist-test\/[^"]+)"/g)].map((match) => match[1]);
+          if (globs.length === 0) {
+            console.error("::error::Could not extract dist-test globs from test:unit:compiled.");
+            process.exit(1);
+          }
+          const files = new Set();
+          for (const pattern of globs) {
+            const dir = path.dirname(pattern);
+            const base = path.basename(pattern);
+            const regex = new RegExp("^" + base.split("*").map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&")).join(".*") + "$");
+            if (!fs.existsSync(dir)) {
+              console.error(`::error::Manifest directory does not exist: ${dir}`);
+              process.exit(1);
+            }
+            for (const entry of fs.readdirSync(dir)) {
+              if (regex.test(entry)) files.add(path.join(dir, entry));
+            }
+          }
+          const sorted = [...files].sort();
+          if (sorted.length === 0) {
+            console.error("::error::Compiled-test manifest is empty.");
+            process.exit(1);
+          }
+          fs.writeFileSync("test-manifest.txt", sorted.join("\n") + "\n");
+          console.log(`Canonical manifest: ${sorted.length} compiled test files.`);
+          NODE
+          total="$(wc -l < test-manifest.txt | tr -d ' ')"
+          echo "total=${total}" >> "$GITHUB_OUTPUT"
+          sha256sum test-manifest.txt > test-manifest.sha256
+
+      - name: Partition canonical manifest
+        env:
+          SHARD_COUNT: ${{ inputs.shard_count }}
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require("fs");
+          const shardCount = Number(process.env.SHARD_COUNT);
+          const files = fs.readFileSync("test-manifest.txt", "utf8").trim().split("\n").filter(Boolean);
+          const base = Math.floor(files.length / shardCount);
+          const extra = files.length % shardCount;
+          let cursor = 0;
+          for (let index = 0; index < shardCount; index++) {
+            const size = base + (index < extra ? 1 : 0);
+            const chunk = files.slice(cursor, cursor + size);
+            cursor += size;
+            fs.writeFileSync(`test-manifest-shard-${index + 1}.txt`, chunk.length ? chunk.join("\n") + "\n" : "");
+            console.log(`shard ${index + 1}/${shardCount}: ${chunk.length} files`);
+          }
+          if (cursor !== files.length) process.exit(1);
+          NODE
+
+      - name: Package build output for shard jobs
+        run: tar czf build-output.tar.gz dist dist-test packages/*/dist
+
+      - name: Upload build output
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: pre-review-sharded-build-output
+          path: build-output.tar.gz
+          retention-days: 1
+
+      - name: Upload test manifest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: pre-review-sharded-test-manifest
+          path: |
+            test-manifest.txt
+            test-manifest.sha256
+            test-manifest-shard-*.txt
+          retention-days: 3
+
+  test-shard:
+    name: test-shard (${{ matrix.shard }}/${{ inputs.shard_count }})
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJson(needs.build.outputs.shard_matrix) }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout exact source commit without credentials
+        env:
+          SOURCE_REPO: ${{ inputs.source_repo }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          repo_url="https://github.com/${SOURCE_REPO}.git"
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "$repo_url"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git -c protocol.version=2 fetch --no-tags --prune --depth=1 origin \
+            "+refs/heads/${SOURCE_REF}:refs/checkout-ref"
+          git checkout --force --detach refs/checkout-ref
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+        with:
+          version: 10.12.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+          GSD_SKIP_RTK_INSTALL: "1"
+          GSD_SKIP_DEP_REPAIR: "1"
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build output
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: pre-review-sharded-build-output
+
+      - name: Extract build output
+        run: tar xzf build-output.tar.gz
+
+      - name: Download test manifest
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: pre-review-sharded-test-manifest
+
+      - name: Verify manifest checksum
+        run: sha256sum -c test-manifest.sha256
+
+      - name: Run this shard partition
+        env:
+          GSD_NATIVE_PREFER_LOCAL: "1"
+        run: |
+          set -o pipefail
+          shard_file="test-manifest-shard-${{ matrix.shard }}.txt"
+          if [[ ! -s "$shard_file" ]]; then
+            echo "shard=${{ matrix.shard }} passed=0 failed=0 skipped=0" | tee "shard-${{ matrix.shard }}-summary.txt"
+            exit 0
+          fi
+          mapfile -t shard_files < "$shard_file"
+          node --import ./scripts/dist-test-resolve.mjs \
+            --experimental-test-isolation=process \
+            --test-reporter=./scripts/test-reporter-compact.mjs \
+            --test "${shard_files[@]}" \
+            2>&1 | tee "shard-${{ matrix.shard }}.log"
+          summary_line="$(grep -E '^(✔|✖) [0-9]+ passed, [0-9]+ failed, [0-9]+ skipped$' "shard-${{ matrix.shard }}.log" | tail -1)"
+          if [[ -z "$summary_line" ]]; then
+            echo "::error::Could not find compact-reporter summary for shard ${{ matrix.shard }}."
+            exit 1
+          fi
+          passed="$(echo "$summary_line" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+')"
+          failed="$(echo "$summary_line" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+')"
+          skipped="$(echo "$summary_line" | grep -oE '[0-9]+ skipped' | grep -oE '[0-9]+')"
+          echo "shard=${{ matrix.shard }} passed=${passed} failed=${failed} skipped=${skipped}" | tee "shard-${{ matrix.shard }}-summary.txt"
+
+      - name: Upload shard summary
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: shard-${{ matrix.shard }}-summary
+          path: shard-${{ matrix.shard }}-summary.txt
+          if-no-files-found: warn
+          retention-days: 3
+
+      - name: Upload shard diagnostic log on failure
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: shard-${{ matrix.shard }}-diagnostics
+          path: shard-${{ matrix.shard }}.log
+          if-no-files-found: ignore
+          retention-days: 3
+
+  lifecycle-gate:
+    name: lifecycle shadow gate once
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout exact source commit without credentials
+        env:
+          SOURCE_REPO: ${{ inputs.source_repo }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://github.com/${SOURCE_REPO}.git"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git -c protocol.version=2 fetch --no-tags --prune --depth=1 origin \
+            "+refs/heads/${SOURCE_REF}:refs/checkout-ref"
+          git checkout --force --detach refs/checkout-ref
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+        with:
+          version: 10.12.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+          GSD_SKIP_RTK_INSTALL: "1"
+          GSD_SKIP_DEP_REPAIR: "1"
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build output
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: pre-review-sharded-build-output
+
+      - name: Extract build output
+        run: tar xzf build-output.tar.gz
+
+      - name: Run lifecycle shadow gate
+        env:
+          GSD_NATIVE_PREFER_LOCAL: "1"
+        run: pnpm run gate:lifecycle-shadow-no-cutover 2>&1 | tee lifecycle-shadow-gate.log
+
+  aggregate:
+    name: aggregate shard results
+    needs: [build, test-shard, lifecycle-gate]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Fail if any shard job failed
+        if: needs.test-shard.result != 'success'
+        run: |
+          echo "::error::One or more test-shard jobs did not succeed: ${{ needs.test-shard.result }}"
+          exit 1
+
+      - name: Fail if lifecycle gate failed
+        if: needs.lifecycle-gate.result != 'success'
+        run: |
+          echo "::error::lifecycle-gate did not succeed: ${{ needs.lifecycle-gate.result }}"
+          exit 1
+
+      - name: Download test manifest
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: pre-review-sharded-test-manifest
+
+      - name: Download shard summaries
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          pattern: shard-*-summary
+          path: summaries
+          merge-multiple: true
+
+      - name: Prove manifest coverage
+        env:
+          SHARD_COUNT: ${{ inputs.shard_count }}
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require("fs");
+          const shardCount = Number(process.env.SHARD_COUNT);
+          const canonical = fs.readFileSync("test-manifest.txt", "utf8").trim().split("\n").filter(Boolean);
+          const reassembled = [];
+          for (let index = 1; index <= shardCount; index++) {
+            const file = `test-manifest-shard-${index}.txt`;
+            if (!fs.existsSync(file)) {
+              console.error(`::error::Missing shard manifest: ${file}`);
+              process.exit(1);
+            }
+            reassembled.push(...fs.readFileSync(file, "utf8").trim().split("\n").filter(Boolean));
+          }
+          if (reassembled.length !== new Set(reassembled).size) {
+            console.error("::error::Duplicate file assignment across shards.");
+            process.exit(1);
+          }
+          const left = [...canonical].sort();
+          const right = [...reassembled].sort();
+          if (left.length !== right.length || left.some((value, index) => value !== right[index])) {
+            console.error("::error::Shard partitions do not exactly reassemble the canonical manifest.");
+            process.exit(1);
+          }
+          console.log(`Manifest coverage proven: ${left.length} files assigned exactly once.`);
+          NODE
+
+      - name: Sum shard results
+        env:
+          SHARD_COUNT: ${{ inputs.shard_count }}
+        run: |
+          set -euo pipefail
+          total_passed=0
+          total_failed=0
+          total_skipped=0
+          shard_files=(summaries/shard-*-summary.txt)
+          if [[ ${#shard_files[@]} -ne ${SHARD_COUNT} ]]; then
+            echo "::error::Expected ${SHARD_COUNT} shard summaries, found ${#shard_files[@]}."
+            exit 1
+          fi
+          for file in "${shard_files[@]}"; do
+            cat "$file"
+            passed="$(grep -oE 'passed=[0-9]+' "$file" | cut -d= -f2)"
+            failed="$(grep -oE 'failed=[0-9]+' "$file" | cut -d= -f2)"
+            skipped="$(grep -oE 'skipped=[0-9]+' "$file" | cut -d= -f2)"
+            total_passed=$((total_passed + passed))
+            total_failed=$((total_failed + failed))
+            total_skipped=$((total_skipped + skipped))
+          done
+          echo "Aggregate: ${total_passed} passed, ${total_failed} failed, ${total_skipped} skipped"
+          if [[ "$total_failed" -ne 0 ]]; then
+            echo "::error::Aggregate reports ${total_failed} test failure(s)."
+            exit 1
+          fi
+
+      - name: Write final summary
+        if: always()
+        run: |
+          {
+            echo "### Sharded pre-review verification aggregate"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| source repo | ${{ inputs.source_repo }} |"
+            echo "| source ref | ${{ inputs.source_ref }} |"
+            echo "| expected sha | ${{ inputs.expected_sha }} |"
+            echo "| shard count | ${{ inputs.shard_count }} |"
+            echo "| authority | advisory pre-review signal only |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/dev/sharded-pre-review-verification.md
+++ b/docs/dev/sharded-pre-review-verification.md
@@ -43,6 +43,28 @@ as-is without maintainer direction:
    `dispatch` and `status`; richer `watch`, `resume`, `logs`, and `triage` commands can be added
    if maintainers want the full contributor-side ergonomics upstream.
 
+## Existing Contributor Harness
+
+The omitted operational pieces are already implemented in the separate public
+[`pimmink/gsd-pi-ci`](https://github.com/pimmink/gsd-pi-ci/tree/chore/remote-verify-triage)
+repository. They are linked rather than copied here so this draft stays focused on whether the
+core upstream workflow shape is wanted.
+
+| Component | Purpose |
+| --- | --- |
+| [`remote-pr-verification-sharded.yml`](https://github.com/pimmink/gsd-pi-ci/blob/chore/remote-verify-triage/.github/workflows/remote-pr-verification-sharded.yml) | Primary clean-runner tier: derives a manifest from the checked-out commit, runs deterministic shards, verifies coverage, and can collect advisory timing evidence. |
+| [`remote-pr-verification.yml`](https://github.com/pimmink/gsd-pi-ci/blob/chore/remote-verify-triage/.github/workflows/remote-pr-verification.yml) | Independent stable, unsharded fallback when the sharded harness itself needs a cross-check. |
+| [`remote-full-gate.yml`](https://github.com/pimmink/gsd-pi-ci/blob/chore/remote-verify-triage/.github/workflows/remote-full-gate.yml) | Separate clean-runner reproduction for full-gate experimentation; it is not asserted to be upstream merge parity. |
+| [`remote-verify.sh`](https://github.com/pimmink/gsd-pi-ci/blob/chore/remote-verify-triage/scripts/remote-verify.sh) | Safe dispatch helper plus `status`, compact `watch`/`resume`, browser `open`, totals-focused `logs`, and advisory first-failure `triage`. |
+| [`validate-timing-evidence.mjs`](https://github.com/pimmink/gsd-pi-ci/blob/chore/remote-verify-triage/scripts/validate-timing-evidence.mjs) | Validates optional timing artifacts against SHA, manifest, workflow, lockfile, runner, and schema provenance before publication. |
+| [`remote-verification-guide.md`](https://github.com/pimmink/gsd-pi-ci/blob/chore/remote-verify-triage/docs/remote-verification-guide.md) | Operational contract: tier selection, exact-SHA rules, native staging, `pipefail`, logging, timing, fallback, and authority boundaries. |
+| [`phase-2-deferral.md`](https://github.com/pimmink/gsd-pi-ci/blob/chore/remote-verify-triage/docs/phase-2-deferral.md) | Evidence and explicit deferrals for merge-parity scope, including Windows, Node 22, and Docker e2e. |
+
+Operationally, a contributor dispatches the sharded tier with a full SHA, follows it with
+`watch` or `resume`, uses `logs` for final totals, and uses `triage` only for a bounded first
+diagnostic step after a failed job. The stable workflow is the independent fallback if the
+sharded harness is under suspicion. The upstream PR's own CI remains merge authority throughout.
+
 ## Proposed shape
 
 ```mermaid

--- a/docs/dev/sharded-pre-review-verification.md
+++ b/docs/dev/sharded-pre-review-verification.md
@@ -1,8 +1,8 @@
 # Sharded pre-review verification proposal
 
 This document is a draft review artifact for issue #2176. It describes a contributor-developed
-workflow for producing faster, reproducible pre-review validation evidence. It is not a proposal
-to replace the upstream merge gate.
+workflow for producing faster, reproducible pre-review validation evidence and links the concrete
+review implementation in this draft PR. It is not a proposal to replace the upstream merge gate.
 
 ## Summary
 
@@ -29,6 +29,17 @@ more transparent:
 - run on a clean remote runner instead of a busy local machine;
 - produce a single run URL and aggregate totals that can be linked from a PR;
 - keep the real upstream CI gate unchanged.
+
+## Files In This Draft PR
+
+The draft PR includes the implementation shape for review, not because it should be merged exactly
+as-is without maintainer direction:
+
+- `.github/workflows/pre-review-verification-sharded.yml` — optional manual workflow that validates
+   a branch/SHA pair, builds once, compiles tests once, partitions a canonical compiled-test manifest,
+   runs deterministic shards, runs the lifecycle gate once, and aggregates totals fail-closed.
+- `scripts/pre-review-verify.sh` — contributor helper for dispatching the workflow only after
+   `git ls-remote` proves `source_ref` resolves to `expected_sha`.
 
 ## Proposed shape
 

--- a/docs/dev/sharded-pre-review-verification.md
+++ b/docs/dev/sharded-pre-review-verification.md
@@ -1,0 +1,116 @@
+# Sharded pre-review verification proposal
+
+This document is a draft review artifact for issue #2176. It describes a contributor-developed
+workflow for producing faster, reproducible pre-review validation evidence. It is not a proposal
+to replace the upstream merge gate.
+
+## Summary
+
+The proposed workflow is an optional, manually dispatched pre-review verification tier for broad
+changes. A contributor pushes a branch, supplies the exact expected SHA, and dispatches a clean
+remote runner workflow that builds once, compiles tests once, partitions the compiled unit-test
+manifest into deterministic shards, and aggregates the result fail-closed.
+
+Upstream `ci.yml` remains the only merge authority. This workflow is intended to improve the
+feedback loop before asking maintainers to review a broad change.
+
+## Why this exists
+
+While preparing multiple upstream fixes, local broad verification was often the slowest and least
+reliable part of the contributor loop. A laptop can produce noisy failures under CPU or thermal
+contention, but waiting for full PR CI means finding broad validation problems later, after the PR
+is already in front of maintainers.
+
+The contributor-side workflow developed for this fork tries to make that middle step faster and
+more transparent:
+
+- verify one exact pushed commit;
+- fail before checkout when branch and SHA do not match;
+- run on a clean remote runner instead of a busy local machine;
+- produce a single run URL and aggregate totals that can be linked from a PR;
+- keep the real upstream CI gate unchanged.
+
+## Proposed shape
+
+```mermaid
+flowchart TD
+  A[Contributor pushes branch] --> B[Dispatch pre-review verify]
+  B --> C[Check source_ref == expected_sha]
+  C -->|mismatch| X[Fail before checkout]
+  C -->|match| D[Build once]
+  D --> E[Compile tests once]
+  E --> F[Create canonical manifest]
+  F --> G[Shard manifest]
+  G --> H1[Shard 1]
+  G --> H2[Shard 2]
+  G --> H3[Shard 3]
+  G --> H4[Shard 4]
+  H1 --> I[Aggregate totals]
+  H2 --> I
+  H3 --> I
+  H4 --> I
+  I --> J[Contributor links evidence]
+  J --> K[Upstream CI remains merge authority]
+```
+
+Core properties:
+
+- `workflow_dispatch` only at first;
+- inputs: `source_ref`, full 40-character `expected_sha`, optional `shard_count`;
+- no token checkout for public source reads;
+- exact-SHA verification before and after checkout;
+- one build/compile step produces the test artifacts;
+- the checked-out commit's own test script determines the canonical test manifest;
+- shards run precomputed, non-overlapping manifest partitions;
+- aggregate job verifies coverage and fails on any failed test;
+- stable unsharded fallback remains available.
+
+## Cost and timing evidence
+
+The evidence supports a faster contributor feedback loop, not a blanket cost or sustainability
+claim.
+
+| Measurement | Result |
+| --- | --- |
+| Stable unsharded reference | about 19m11s wall-clock |
+| Sharded proof run | about 12m04s wall-clock |
+| Wall-clock reduction | about 37% |
+| Unsharded summed runner time | about 19.2 runner-minutes |
+| Sharded summed runner time | about 27.1 runner-minutes |
+| Public fork GitHub billing API | `billable.UBUNTU.total_ms: 0` for measured runs |
+
+On paid per-minute runner billing, the measured sharded proof is faster but not inherently cheaper
+in raw compute minutes. Using GitHub's published baseline Linux rate of $0.006/min, the calibrated
+comparison would be roughly $0.16 sharded versus $0.12 unsharded. At GitHub's Linux 4-core larger
+runner rate of $0.012/min, it would be roughly $0.32 versus $0.23.
+
+Upstream currently uses Blacksmith 4-vCPU Linux runners. Blacksmith publicly advertises lower
+per-minute Ubuntu pricing and faster hardware, but the real maintainer cost depends on the
+project's runner plan, OSS terms, concurrency constraints, and whether faster feedback is worth
+parallel runner capacity.
+
+## Guardrails
+
+This should not be represented as merge parity.
+
+Out of scope unless maintainers explicitly ask for it:
+
+- replacing upstream `ci.yml`;
+- reproducing every PR/merge gate;
+- Windows portability parity;
+- Node 22 smoke parity;
+- conditional Docker e2e parity;
+- claiming carbon or sustainability wins without energy evidence.
+
+The first reviewable version should stay conservative: optional, manual, documented, and easy to
+discard if maintainers prefer contributor-side tooling only.
+
+## Review questions
+
+1. Would a contributor-facing, manually dispatched pre-review verification tier be useful upstream?
+2. Should this stay in contributor forks instead of the main repository?
+3. If upstream wants it, should it run on the same runner provider as `ci.yml` or on standard
+   GitHub-hosted Linux runners?
+4. Is the extra summed runner time acceptable for a faster review loop?
+5. Which parts, if any, should be promoted first: exact-SHA dispatch, manifest sharding, aggregate
+   evidence, or only the documentation pattern?

--- a/docs/dev/sharded-pre-review-verification.md
+++ b/docs/dev/sharded-pre-review-verification.md
@@ -39,7 +39,9 @@ as-is without maintainer direction:
    a branch/SHA pair, builds once, compiles tests once, partitions a canonical compiled-test manifest,
    runs deterministic shards, runs the lifecycle gate once, and aggregates totals fail-closed.
 - `scripts/pre-review-verify.sh` — contributor helper for dispatching the workflow only after
-   `git ls-remote` proves `source_ref` resolves to `expected_sha`.
+   `git ls-remote` proves `source_ref` resolves to `expected_sha`. The first draft includes
+   `dispatch` and `status`; richer `watch`, `resume`, `logs`, and `triage` commands can be added
+   if maintainers want the full contributor-side ergonomics upstream.
 
 ## Proposed shape
 
@@ -116,6 +118,22 @@ Out of scope unless maintainers explicitly ask for it:
 The first reviewable version should stay conservative: optional, manual, documented, and easy to
 discard if maintainers prefer contributor-side tooling only.
 
+## What This Draft Deliberately Leaves Out
+
+The contributor-side harness has more operational affordances than this first upstream draft.
+Those pieces are useful locally, but they would make the initial PR much harder to review:
+
+- `watch` / `resume` output that only reports job-status changes;
+- `logs` parsing that extracts final pass/fail/skip totals from job logs instead of trusting the
+   green checkmark alone;
+- first-failure `triage` classification;
+- optional per-file timing collection and provenance validation;
+- a stable unsharded fallback workflow;
+- any merge-parity reproduction of Windows, Node 22 smoke, or Docker e2e jobs.
+
+The review question for maintainers is whether the core shape is useful. If yes, the helper and
+workflow can be extended incrementally; if no, those pieces should remain contributor-side tooling.
+
 ## Review questions
 
 1. Would a contributor-facing, manually dispatched pre-review verification tier be useful upstream?
@@ -125,3 +143,5 @@ discard if maintainers prefer contributor-side tooling only.
 4. Is the extra summed runner time acceptable for a faster review loop?
 5. Which parts, if any, should be promoted first: exact-SHA dispatch, manifest sharding, aggregate
    evidence, or only the documentation pattern?
+6. Should the richer helper ergonomics (`watch`, `resume`, `logs`, `triage`) and timing evidence
+   stay contributor-side or be added later after the core workflow shape is accepted?

--- a/scripts/pre-review-verify.sh
+++ b/scripts/pre-review-verify.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Dispatch helper for .github/workflows/pre-review-verification-sharded.yml.
+
+set -euo pipefail
+
+HARNESS_REPO="open-gsd/gsd-pi"
+SOURCE_REPO="pimmink/gsd-pi"
+SOURCE_REF=""
+EXPECTED_SHA=""
+SHARD_COUNT="4"
+WORKFLOW_REF="main"
+WORKFLOW_FILE="pre-review-verification-sharded.yml"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pre-review-verify.sh dispatch --source-ref <branch> --expected-sha <40-char-sha> [options]
+  scripts/pre-review-verify.sh status <run-id> [--repo owner/repo]
+
+Options for dispatch:
+  --source-repo owner/repo   Source repository containing the branch (default: pimmink/gsd-pi)
+  --repo owner/repo          Repository containing the workflow (default: open-gsd/gsd-pi)
+  --workflow-ref ref         Ref containing the workflow file (default: main)
+  --shard-count n           Number of shards (default: 4)
+
+The helper verifies source_ref resolves to expected_sha before dispatching.
+EOF
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+parse_dispatch_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --source-repo) SOURCE_REPO="$2"; shift 2 ;;
+      --source-ref) SOURCE_REF="$2"; shift 2 ;;
+      --expected-sha) EXPECTED_SHA="$2"; shift 2 ;;
+      --repo) HARNESS_REPO="$2"; shift 2 ;;
+      --workflow-ref) WORKFLOW_REF="$2"; shift 2 ;;
+      --shard-count) SHARD_COUNT="$2"; shift 2 ;;
+      *) die "unknown dispatch argument: $1" ;;
+    esac
+  done
+  [[ "$SOURCE_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || die "--source-repo must be owner/repo"
+  [[ -n "$SOURCE_REF" ]] || die "--source-ref is required"
+  [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] || die "--expected-sha must be a full 40-character lowercase SHA"
+  [[ "$SHARD_COUNT" =~ ^[0-9]+$ ]] || die "--shard-count must be an integer"
+}
+
+dispatch() {
+  parse_dispatch_args "$@"
+  local remote_line remote_sha before_id run_id run_url
+  remote_line="$(git ls-remote "https://github.com/${SOURCE_REPO}.git" "refs/heads/${SOURCE_REF}")" || die "git ls-remote failed"
+  [[ -n "$remote_line" ]] || die "refs/heads/${SOURCE_REF} does not exist on ${SOURCE_REPO}"
+  remote_sha="$(printf '%s\n' "$remote_line" | cut -f1)"
+  [[ "$remote_sha" == "$EXPECTED_SHA" ]] || die "${SOURCE_REPO}:${SOURCE_REF} is ${remote_sha}, not ${EXPECTED_SHA}"
+
+  before_id="$(gh run list --repo "$HARNESS_REPO" --workflow "$WORKFLOW_FILE" --limit 1 --json databaseId --jq '.[0].databaseId // "none"' 2>/dev/null || echo none)"
+  gh workflow run "$WORKFLOW_FILE" --repo "$HARNESS_REPO" --ref "$WORKFLOW_REF" \
+    -f "source_repo=${SOURCE_REPO}" \
+    -f "source_ref=${SOURCE_REF}" \
+    -f "expected_sha=${EXPECTED_SHA}" \
+    -f "shard_count=${SHARD_COUNT}"
+
+  for _ in {1..20}; do
+    sleep 3
+    run_id="$(gh run list --repo "$HARNESS_REPO" --workflow "$WORKFLOW_FILE" --limit 1 --json databaseId --jq '.[0].databaseId // "none"' 2>/dev/null || echo none)"
+    if [[ "$run_id" != "none" && "$run_id" != "$before_id" ]]; then
+      run_url="$(gh run view "$run_id" --repo "$HARNESS_REPO" --json url --jq '.url')"
+      echo "run-id: ${run_id}"
+      echo "run-url: ${run_url}"
+      echo "source: ${SOURCE_REPO}:${SOURCE_REF} @ ${EXPECTED_SHA}"
+      return 0
+    fi
+  done
+  die "could not determine newly-dispatched run id"
+}
+
+status() {
+  local run_id="${1:-}"
+  shift || true
+  [[ -n "$run_id" ]] || die "run id is required"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) HARNESS_REPO="$2"; shift 2 ;;
+      *) die "unknown status argument: $1" ;;
+    esac
+  done
+  gh run view "$run_id" --repo "$HARNESS_REPO"
+}
+
+main() {
+  require_cmd git
+  require_cmd gh
+  local command="${1:-}"
+  shift || true
+  case "$command" in
+    dispatch) dispatch "$@" ;;
+    status) status "$@" ;;
+    -h|--help|"") usage ;;
+    *) die "unknown command: $command" ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Linked issue

Refs #2176

## Summary

This PR implements the maintainer-approved core of the optional sharded pre-review verification proposal:

- manually dispatched exact-SHA verification;
- one clean-runner build and compiled-test manifest;
- deterministic, non-overlapping unit-test shards;
- fail-closed manifest coverage and aggregate totals;
- shared Node/pnpm setup through a pinned composite action;
- explicit advisory-only status: upstream `ci.yml` remains merge authority.

The PR does not replace merge CI or add standing workflow triggers.

## Scope decision applied

The maintainer decision on #2176 keeps the dispatch-only sharded unit-test tier and exact-SHA pinning upstream. The lifecycle shadow gate is left out of this workflow to avoid duplicating the repository's normal `verify:pr` contract; `gate:lifecycle-shadow-no-cutover` remains part of that normal validation path. `watch`, `resume`, `logs`, `triage`, Windows/Node 22/Docker parity, and stable fallback tooling remain in the separate contributor harness.

## Security and authority boundaries

The workflow accepts a public `source_repo` input, validates `source_ref` against the full expected SHA before checkout, checks the resulting `HEAD` again after checkout, requests only `contents: read`, and uses no repository secrets. It is manual dispatch only and runs the requested public commit on upstream runners.

The aggregate is advisory pre-review evidence. Existing upstream CI remains the only merge authority.

## Implementation

- `.github/workflows/pre-review-verification-sharded.yml`
  - validates inputs and branch/SHA identity;
  - builds once and derives the manifest from the checked-out commit's own `test:unit:compiled` script;
  - partitions the manifest deterministically;
  - runs shards in parallel and proves exact manifest coverage;
  - aggregates pass/fail/skip totals fail-closed.
- `.github/actions/pre-review-node-setup/action.yml`
  - centralizes pinned pnpm, Node.js, cache, and frozen-install setup for build and shard jobs.
- `scripts/pre-review-verify.sh`
  - provides safe `dispatch` and `status` commands with pre-dispatch `git ls-remote` verification.
- `docs/dev/sharded-pre-review-verification.md`
  - documents the workflow, tradeoffs, scope, security boundary, and contributor-side deferrals.

## Validation

- `actionlint -config-file .config/actionlint.yaml .github/workflows/pre-review-verification-sharded.yml`
- `bash -n scripts/pre-review-verify.sh`
- `scripts/pre-review-verify.sh --help`
- `node --test scripts/__tests__/github-workflows-runner-contract.test.mjs` - 6/6 passed
- `git diff --check`
- explicit scope checks confirm no lifecycle gate or duplicate setup blocks remain in the upstream workflow.

## Change type

- [x] `ci` / tooling
- [ ] Source behavior
- [ ] Merge-gate replacement

## AI disclosure

This PR includes AI-assisted review and implementation editing. The contributor remains responsible for the design, code, validation, and maintainer-facing scope.
