### PR TITLE
fix(legacy-import): preserve milestone state

### DIFF
--- a/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
+++ b/src/resources/extensions/gsd/legacy-import-preview-gsd-hierarchy.ts
@@ -733,7 +733,36 @@ function interpretFlatArtifact(
     const summaryId = frontmatterField(file, "id")?.value;
     const summarySlice = frontmatterField(file, "slice")?.value;
     const summaryTask = frontmatterField(file, "task")?.value;
-    if (summaryId !== undefined && summaryTask === undefined && /^(?:S\d+|M\d+)/u.test(summaryId)) {
+    if (summaryId !== undefined && summaryTask === undefined && /^M\d+/u.test(summaryId)) {
+      const claim = claimsByDirectory.get(directorySegment(file.entry.logical_path, "flat"));
+      const canonicalId = canonicalMilestoneId(summaryId);
+      const status = frontmatterField(file, "status");
+      if (claim !== undefined && canonicalId === claim.canonicalId && status !== undefined) {
+        addCandidate(
+          candidates,
+          file,
+          { kind: "milestone", key: claim.canonicalId, field: "status" },
+          status.value,
+          "flat-matching-milestone-summary-attestation",
+          { start: status.line.start, end: status.line.end },
+        );
+      }
+      else if (claim !== undefined && canonicalId !== undefined && canonicalId !== claim.canonicalId && status !== undefined) {
+        addDiagnosis(
+          diagnoses,
+          file,
+          "milestone-summary-id-ambiguous",
+          `Milestone summary id "${summaryId}" does not exactly match the containing phase's ROADMAP claim "${claim.canonicalId}" and cannot be attested automatically.`,
+          { start: status.line.start, end: status.line.end },
+        );
+      }
+      preserveHeading(file, candidates, "flat-non-task-summary-preserved", {
+        reason: "non-task-summary",
+        id: summaryId,
+      });
+      return;
+    }
+    if (summaryId !== undefined && summaryTask === undefined && /^S\d+/u.test(summaryId)) {
       preserveHeading(file, candidates, "flat-non-task-summary-preserved", {
         reason: "non-task-summary",
         id: summaryId,

--- a/src/resources/extensions/gsd/milestone-ids.ts
+++ b/src/resources/extensions/gsd/milestone-ids.ts
@@ -8,7 +8,7 @@
 import { randomInt } from "node:crypto";
 import { join } from "node:path";
 import { logWarning } from "./workflow-logger.js";
-import { readdirSync, existsSync } from "node:fs";
+import { readdirSync, existsSync, readFileSync } from "node:fs";
 import { milestonesDir, gsdProjectionRoot } from "./paths.js";
 import { LAYOUT_SEGMENTS } from "./layout-policy.js";
 import { loadQueueOrder, sortByQueueOrder } from "./queue-order.js";
@@ -165,9 +165,14 @@ function scanMilestoneIdsFromDir(basePath: string, dir: string): string[] {
       const flatMatch = d.name.match(/^(\d+)-(.+)$/);
       if (flatMatch) {
         const phaseNum = parseInt(flatMatch[1]!, 10);
-        const fromSlug = normalizeDiscussMilestoneId(flatMatch[2]!);
+        const rest = flatMatch[2]!;
+        const fromSlug = normalizeDiscussMilestoneId(rest);
         if (MILESTONE_ID_RE.test(fromSlug)) {
           return fromSlug;
+        }
+        const headingId = milestoneIdFromPhaseDirHeading(join(dir, d.name), phaseNum);
+        if (headingId) {
+          return headingId;
         }
         const numericId = String(phaseNum);
         if (legacyNumericIds.has(numericId)) {
@@ -178,6 +183,49 @@ function scanMilestoneIdsFromDir(basePath: string, dir: string): string[] {
       return null;
     })
     .filter((id): id is string => id !== null);
+}
+
+/**
+ * Read the canonical suffixed milestone ID from a flat-phase directory's own
+ * ROADMAP/SUMMARY markdown heading (`# M00N-suffix: Title`), when present.
+ * This support handling same milestone IDs with different unique ids.
+ * Returns null when no phase file carries a matching heading — callers fall
+ * back to the bare M00N form in that case.
+ */
+function milestoneIdFromPhaseDirHeading(phaseDirPath: string, phaseNum: number): string | null {
+  const expectedNum = String(phaseNum).padStart(3, "0");
+  const headingRe = new RegExp(`^#\\s+(M${expectedNum}(?:-[a-z0-9]{6})?)\\b`, "m");
+  let entries: string[];
+  try {
+    entries = readdirSync(phaseDirPath);
+  } catch (err) {
+    // A missing/unreadable phase dir here is expected during traversal races
+    // (directory removed between listing and stat) and is not this helper's
+    // failure to report — the caller already handles a null return by
+    // falling back to the bare M00N form. Only a genuinely existing-but-
+    // unreadable directory is surprising enough to warn about.
+    if (existsSync(phaseDirPath)) {
+      logWarning("engine", `milestoneIdFromPhaseDirHeading: ${phaseDirPath} exists but readdirSync failed — ${getErrorMessage(err)}`);
+    }
+    return null;
+  }
+  const candidates = entries
+    .filter((name) => /-(ROADMAP|SUMMARY)\.md$/.test(name))
+    .sort((a, b) => (a.endsWith("ROADMAP.md") === b.endsWith("ROADMAP.md") ? 0 : a.endsWith("ROADMAP.md") ? -1 : 1));
+  for (const name of candidates) {
+    const candidatePath = join(phaseDirPath, name);
+    try {
+      const content = readFileSync(candidatePath, "utf-8");
+      const match = content.match(headingRe);
+      if (match) return match[1]!;
+    } catch (err) {
+      // Unreadable candidate file: try the next one, but still surface a
+      // warning — a heading-bearing file that cannot be read silently
+      // degrades this milestone to the ambiguous bare-M00N fallback.
+      logWarning("engine", `milestoneIdFromPhaseDirHeading: ${candidatePath} exists but readFileSync failed — ${getErrorMessage(err)}`);
+    }
+  }
+  return null;
 }
 
 function idsWithLegacyNumericDirs(basePath: string): Set<string> {

--- a/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
+++ b/src/resources/extensions/gsd/tests/legacy-import-preview-gsd.test.ts
@@ -836,6 +836,65 @@ describe("legacy .gsd captured-byte interpretation", () => {
     );
   });
 
+  test("set milestone completion status from a matching milestone summary", (t) => {
+    const interpretation = interpretLegacyGsdCapture(captureFiles(t, {
+      "phases/09-team/09-ROADMAP.md": [
+        "# M009-rfuh2h: Team milestone",
+        "",
+        "- [x] **S01: First slice** `risk:low` `depends:[]`",
+        "",
+      ].join("\n"),
+      "phases/09-team/09-SUMMARY.md": [
+        "---",
+        "id: M009-rfuh2h",
+        "status: complete",
+        "---",
+        "",
+        "# M009: Must attest milestone completion",
+        "",
+      ].join("\n"),
+    }));
+
+    assert.deepEqual(interpretation.diagnoses, []);
+    assert.deepEqual(
+      interpretation.candidates
+        .filter((candidate) => candidate.target.kind === "milestone" && candidate.target.field === "status")
+        .map((candidate) => [candidate.target.key, candidate.normalized]),
+      [["M009-rfuh2h", "complete"]],
+    );
+  });
+
+  test("flags a mistmatch numeric milestone id when using unique id flag", (t) => {
+    const interpretation = interpretLegacyGsdCapture(captureFiles(t, {
+      "phases/09-team/09-ROADMAP.md": [
+        "# M009-rfuh2h: Team milestone",
+        "",
+        "- [x] **S01: First slice** `risk:low` `depends:[]`",
+        "",
+      ].join("\n"),
+      "phases/09-team/09-SUMMARY.md": [
+        "---",
+        "id: M009",
+        "status: complete",
+        "---",
+        "",
+        "# M009: Must not silently attest from an ambiguous bare id",
+        "",
+      ].join("\n"),
+    }));
+
+    assert.deepEqual(
+      interpretation.diagnoses.map((diagnosis) => diagnosis.code),
+      ["milestone-summary-id-ambiguous"],
+    );
+    assert.deepEqual(
+      interpretation.candidates.filter(
+        (candidate) => candidate.target.kind === "milestone" && candidate.target.field === "status",
+      ),
+      [],
+    );
+  });
+
   test("emits action-matrix decision candidates and complete anchors for present collections", (t) => {
     const base = temporaryDirectory(t);
     const physicalRoot = join(base, ".gsd");

--- a/src/resources/extensions/gsd/tests/milestone-id-resolution.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-id-resolution.test.ts
@@ -22,6 +22,38 @@ test("flat-phase NN-slug directories resolve to canonical M-form IDs (#1773)", (
   }
 });
 
+test("unique ids sharing the same milestone id resolve to distinct milestones", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-milestone-id-resolution-"));
+  try {
+    const phases = join(base, ".gsd", "phases");
+    const dirA = join(phases, "05-gv3j8m-milestone-A");
+    const dirB = join(phases, "05-hxpveq-milestone-B");
+    mkdirSync(dirA, { recursive: true });
+    mkdirSync(dirB, { recursive: true });
+    writeFileSync(join(dirA, "05-ROADMAP.md"), "# M005-gv3j8m: Milestone A\n");
+    writeFileSync(join(dirB, "05-ROADMAP.md"), "# M005-hxpveq: Milestone B\n");
+
+    const ids = findMilestoneIds(base);
+    assert.ok(ids.includes("M005-gv3j8m"), "first suffixed milestone keeps its own suffix");
+    assert.ok(ids.includes("M005-hxpveq"), "second suffixed milestone is not collapsed into the first");
+    assert.equal(ids.length, 2, "both milestones are discovered as distinct entries");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("a name with 6-char suffix does not get misread as a unique id", () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-milestone-id-resolution-"));
+  try {
+    const phases = join(base, ".gsd", "phases");
+    mkdirSync(join(phases, "16-queued-milestone"), { recursive: true });
+
+    assert.deepEqual(findMilestoneIds(base), ["M016"]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("legacy M-form and bare numeric directory names keep their exact behavior", () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-milestone-id-resolution-"));
   try {


### PR DESCRIPTION
## Linked issue

<!--
PRs without a linked issue will be closed.
Open or find an issue first: https://github.com/open-gsd/gsd-pi/issues
-->

Closes #<!-- issue number — required -->

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

Not a first time contributor, based on the CONTRIBUTING.md doc I can skip the issue creation.

This is a continuation of PR #2152.

---

## TL;DR

**What:** <!-- One sentence — what does this change? --> correctly import the state of milestones to the DB. Additionally when using unique ids flag two milestones that share the same id, but different unique id are treated as the same milestone.
**Why:** <!-- One sentence — why is it needed? --> import was wrongly setting the default DB state for all milestone with status: active. Milestones with _same_ id, but _different unique ids_ are treated correctly as _different_ milestones.
**How:** <!-- One sentence — what's the approach? --> check the SUMMARY files to see the status of the milestones and tasks. Milestones ids are extended to be verified from ROADMAP/SUMMARY to handle unique ids.

## What

<!-- Detailed description of the change. What files, modules, or systems are affected? -->

The legacy import was not reading correctly the status of the milestone. leaving every recovered milestone at its DB default (active) regardless of what the summary or its VALIDATION.md says.

The milestones with different unique ids affects the import process since it merges the different milestones as one. Then auto mode removes files automatically detecting a gap between the DB and the file state.

## Why

<!-- The motivation. What problem does this solve? -->
When running a recover to import files to the DB. The current legacy import flow can't read the state from the SUMMARY.md and leaves all the milestones and tasks as active.
This makes it impossible to use auto mode for example. It will try to work on the first milestone for that project.

Using unique ids for milestones is expected that this can happen `M001-abc123` and `M001-qwe789`. These should be treated as different milestones and not merged together.

## How

<!-- The approach. How does the implementation work? Key decisions and alternatives considered? -->

Read the SUMMARY.md files and extract the state from each file to set that value in the DB.
I run recover on my milestones state and I saw the state changing from all active to completed after implementing the change on gsd directly and running that version on my local.

When milestones are having the same name, but different unique ids. The right milestone `MXXX-uniqueID` is retrieved from ROADMAP.md first and if it's missing from SUMMARY.md files. This is done this way instead of assuming the next 6 chars are unique ids to avoid the case of a string that is part of the milestone name that coincidentally has 6 chars.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->
