### PR TITLE
fix(gsd): refuse no-create opens of a deleted DB path before any handle exists

### DIFF
--- a/src/resources/extensions/gsd/db-provider.ts
+++ b/src/resources/extensions/gsd/db-provider.ts
@@ -1,7 +1,7 @@
 // Project/App: gsd-pi
 // File Purpose: SQLite provider loading and lifecycle helpers for the GSD database facade.
 
-import { closeSync, openSync } from "node:fs";
+import { closeSync, existsSync, openSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 export type DbProviderName = "node:sqlite";
@@ -158,7 +158,17 @@ export class SqliteProviderLoader {
     if (path === ":memory:") return new DatabaseSync(path);
 
     const createIfMissing = options.createIfMissing !== false;
-    if (createIfMissing) closeSync(openSync(path, "a"));
+    if (createIfMissing) {
+      closeSync(openSync(path, "a"));
+    } else if (!existsSync(path)) {
+      // DatabaseSync passes SQLITE_OPEN_CREATE, so a no-create open of a path
+      // deleted at the open boundary would recreate an empty DB on Windows
+      // (#2158). Refuse explicitly before any handle exists.
+      throw Object.assign(
+        new Error(`unable to open database file: ${path}`),
+        { code: "SQLITE_CANTOPEN", errcode: 14 },
+      );
+    }
     const readOnlyGuard = new DatabaseSync(path, { readOnly: true });
     try {
       let writablePath: string | URL = path;

--- a/src/resources/extensions/gsd/tests/db-provider.test.ts
+++ b/src/resources/extensions/gsd/tests/db-provider.test.ts
@@ -276,6 +276,25 @@ describe("db-provider", () => {
     assert.equal(guard.closed, true);
   });
 
+  test("openRaw without createIfMissing refuses a deleted path without recreating it (#2158)", () => {
+    const directory = mkdtempSync(join(tmpdir(), "gsd-provider-no-recreate-"));
+    try {
+      const deps = createDeps();
+      const loader = createSqliteProviderLoader(deps);
+      const missing = join(directory, "gsd.db");
+      FakeNodeDatabase.instances.length = 0;
+
+      assert.throws(
+        () => loader.openRaw(missing, { createIfMissing: false }),
+        (err: NodeJS.ErrnoException) => err.code === "SQLITE_CANTOPEN",
+      );
+      assert.equal(existsSync(missing), false, "a no-create open must not recreate the DB file");
+      assert.equal(FakeNodeDatabase.instances.length, 0, "no database handle may be created for a missing path");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("reports provider unavailability with the supported Node version", () => {
     const deps = createDeps({
       tryRequireNodeSqlite(): unknown {


### PR DESCRIPTION
Closes #2158

## Summary

`openRaw({ createIfMissing: false })` opened `new DatabaseSync(path, { readOnly: true })` directly on the target path. node's `DatabaseSync` passes `SQLITE_OPEN_CREATE`, so when the DB file was deleted at the open boundary (the exact race the bridge test simulates via `_setDatabaseOpenBeforeRawForTest`), Windows recreated an empty `gsd.db` and the read's `db_unavailable`/null contract was violated — the failure that has been blocking `windows-portability` on every heavy-gate PR (#2156, #2163, #2144, #2135).

## Fix

Explicit `existsSync` refusal with `SQLITE_CANTOPEN` before any handle is constructed when `createIfMissing` is false. No handle, no file, deterministic on every platform — the POSIX path already failed at the `DatabaseSync` open; this makes the refusal explicit instead of incidental.

## Verification

- Provider suite 11/11 including the new regression (throws `SQLITE_CANTOPEN`, no file created, no `FakeNodeDatabase` handle constructed).
- Bridge suite (`workflow-tools.test.ts`, includes the failing-at-boundary test) 77/77; progress/snapshot/parity/derive suites 66/66.
- Windows confirmation lands via this PR's own `windows-portability` run (src diff should trigger the heavy gate).