### PR TITLE
fix(native): allow deletion while the SQLite identity lock is held on Windows

### DIFF
--- a/native/crates/engine/src/sqlite_file_lock.rs
+++ b/native/crates/engine/src/sqlite_file_lock.rs
@@ -24,7 +24,10 @@ impl SqliteFileIdentityLock {
             options
                 .read(true)
                 .write(create)
-                .share_mode(0x0000_0001 | 0x0000_0002);
+                // FILE_SHARE_DELETE (0x4) keeps deletion possible while the lock is held
+            // (#2158): an open-boundary delete then fails the open cleanly and
+            // identity correlation still rejects any delete+recreate race.
+            .share_mode(0x0000_0001 | 0x0000_0002 | 0x0000_0004);
             if create {
                 options.create(true);
             }


### PR DESCRIPTION
Closes #2158

## Root cause (confirmed with Windows evidence)

The Windows SQLite identity lock opened the file with `FILE_SHARE_READ | FILE_SHARE_WRITE` only. While the lock is held during open correlation, `DeleteFile` is refused — so the open-boundary deletion in `readProjectProgressViaBridge`'s regression test failed with EBUSY, the file was never deleted, and the test failed on its final `existsSync === false` assertion. Nothing ever recreated the file; the earlier #2181 openRaw guard was necessary hardening but not this bug.

Diagnostic branch (see #2182) logged it directly on the Windows runner: `hook DELETE FAILED` on pre-fix runs; with this one-line share-mode change: `hook deleted ... existsSync=false` → `after read: result=null existsSync=false` → suite green.

## Fix

Add `FILE_SHARE_DELETE (0x4)` to the lock's share mode. Deletion at the boundary now succeeds and the open fails cleanly (null, no recreation — the contract the test pins). The lock's anti-replacement purpose is preserved: a delete+recreate race still yields a different file identity, which post-open identity correlation rejects loudly (`GSD_STALE_STATE: Database path changed while its handle opened`).

## Verification

- Windows runner (via #2182's diagnostic branch carrying this change): all 10 package-test suites fail-0, including `readProjectProgressViaBridge`; diag logs confirm delete-succeeds → read-null → no-recreate.
- `native/*` trips the portability classifier, so this PR's own windows-portability job revalidates the change on a clean branch.