### PR TITLE
fix(gsd): claim successor attempt after an authorized recovery resume

### DIFF
--- a/src/resources/extensions/gsd/auto/task-execution-cutover.ts
+++ b/src/resources/extensions/gsd/auto/task-execution-cutover.ts
@@ -497,12 +497,16 @@ export async function runWithTaskExecutionAttempt(
       // task reopen is history and must not advertise a dead resume (#1948).
       // A consumed resume is likewise historical even though its one-shot
       // authorization now reads false; eligibility distinguishes that state
-      // from a current abort that still needs operator repair (#2112).
+      // from a current abort that still needs operator repair (#2112). The
+      // already-resumed handling is evaluated independently of the
+      // resumeAuthorized flag: a freshly authorized resume carries the same
+      // marker while the kernel still parks at route, so its re-entry must
+      // fall through to the successor claim instead of re-routing the
+      // already-routed Result (#2188).
       if (
         predecessor.nextStage === "route" &&
         terminalRecovery?.recoveryOwner === "agent" &&
-        terminalRecovery.action === "abort" &&
-        !terminalRecovery.resumeAuthorized
+        terminalRecovery.action === "abort"
       ) {
         if (terminalRecovery.resumeEligibility?.failedGuard === "already-resumed") {
           // A consumed authorization proves that a successor claim committed
@@ -514,9 +518,10 @@ export async function runWithTaskExecutionAttempt(
             return runWithTaskExecutionAttempt(input, run, deps);
           }
         }
-        return taskRecoveryAbortResult(terminalRecovery.recoveryActionId);
-      }
-      if (predecessor.nextStage === "route") {
+        if (!terminalRecovery.resumeAuthorized) {
+          return taskRecoveryAbortResult(terminalRecovery.recoveryActionId);
+        }
+      } else if (predecessor.nextStage === "route") {
         if (predecessor.outcome === "succeeded") {
           const recovery = terminalRecovery;
           if (!recovery) {

--- a/src/resources/extensions/gsd/auto/task-execution-cutover.ts
+++ b/src/resources/extensions/gsd/auto/task-execution-cutover.ts
@@ -509,10 +509,9 @@ export async function runWithTaskExecutionAttempt(
         terminalRecovery.action === "abort"
       ) {
         if (terminalRecovery.resumeEligibility?.failedGuard === "already-resumed") {
-          // A consumed authorization proves that a successor claim committed
-          // after the predecessor snapshot was read. Refresh and evaluate that
-          // newer lineage head instead of returning the dead abort lever from
-          // the stale finalize/retry race (#2112).
+          // The resume event may still await a claim or already be consumed.
+          // Refresh in case a successor committed after the predecessor read,
+          // avoiding the stale finalize/retry abort lever (#2112).
           const refreshed = deps.readLatestTaskAttempt(task);
           if (refreshed && refreshed.attemptId !== predecessor.attemptId) {
             return runWithTaskExecutionAttempt(input, run, deps);

--- a/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts
@@ -31,6 +31,7 @@ import {
   readTaskRecoveryResumeEligibility,
   readTaskRecoveryRoute,
   recordFailureAndSelectRecovery,
+  resumeTaskRecovery,
 } from "../task-recovery-domain-operation.js";
 import { reopenTask } from "../task-lifecycle-domain-operation.js";
 import {
@@ -1256,6 +1257,90 @@ test("an explicitly resumed durable abort claims one later Attempt", async () =>
   assert.equal(runs, 1);
   assert.equal(domain.claims.length, 1);
   assert.equal(domain.claims[0].retryOfAttemptId, "attempt-1");
+});
+
+test("an authorized resume re-entry claims the successor instead of re-routing the routed Result (#2188)", async () => {
+  const { runWithTaskExecutionAttempt } = await subject();
+  const firstDispatchId = seedCanonicalTask();
+  const task = { milestoneId: "M001", sliceId: "S01", taskId: "T01" };
+  const first = claimTaskAttempt({
+    invocation: { idempotencyKey: "resume/claim/1", sourceTransport: "internal", actorType: "agent" },
+    task,
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+    coordinationDispatchId: firstDispatchId,
+  });
+  const settled = settleTaskAttempt({
+    invocation: { idempotencyKey: "resume/settle/1", sourceTransport: "internal", actorType: "agent" },
+    attemptId: first.attemptId,
+    outcome: "failed",
+    failureClass: "fatal",
+    summary: "fatal execution failure",
+    output: {},
+  });
+  const abort = recordFailureAndSelectRecovery({
+    invocation: { idempotencyKey: "resume/route/1", sourceTransport: "internal", actorType: "agent" },
+    attemptId: first.attemptId,
+    resultId: settled.resultId,
+    owner: "agent",
+    classification: { failureKind: "fatal" },
+    summary: "fatal execution failure",
+    evidence: { source: "test" },
+    rationale: "abort",
+  });
+  assert.equal(abort.action, "abort");
+  resumeTaskRecovery({
+    invocation: { idempotencyKey: "resume/resume/1", sourceTransport: "internal", actorType: "user", actorId: "user-1" },
+    recoveryActionId: abort.recoveryActionId,
+    repairSummary: "The fatal condition was repaired.",
+    evidence: { verification: "operator confirmed the repair" },
+  });
+
+  // Exact cutover-visible state right after the authorized resume: the kernel
+  // still parks at route, so resumeAuthorized reads true while the eligibility
+  // diagnosis reports the already-resumed marker. The #2113 refresh handling
+  // must be reachable in this state, not gated behind !resumeAuthorized.
+  const route = readTaskRecoveryRoute(first.attemptId);
+  assert.equal(route?.recoveryOwner, "agent");
+  assert.equal(route?.action, "abort");
+  assert.equal(route?.resumeAuthorized, true);
+  assert.equal(route?.resumeEligibility?.failedGuard, "already-resumed");
+
+  const base = canonicalDeps();
+  let routes = 0;
+  const deps: CutoverDeps = {
+    ...base,
+    routeTaskFailure(routeInput) {
+      routes += 1;
+      return base.routeTaskFailure(routeInput);
+    },
+  };
+  let ran = false;
+  const result = await runWithTaskExecutionAttempt(input({
+    dispatchId: insertClaimedDispatch(2),
+  }), async () => {
+    ran = true;
+    const claimed = readLatestTaskAttempt(task);
+    if (!claimed || claimed.attemptId === first.attemptId) {
+      throw new Error("the authorized resume must claim a fresh successor Attempt before execution");
+    }
+    settleTaskAttempt({
+      invocation: { idempotencyKey: "resume/settle/2", sourceTransport: "internal", actorType: "agent" },
+      attemptId: claimed.attemptId,
+      outcome: "succeeded",
+      failureClass: "none",
+      summary: "recovered execution finished",
+      output: {},
+    });
+    return { action: "next", data: {} };
+  }, deps);
+
+  assert.equal(result.action, "next");
+  assert.equal(ran, true);
+  assert.equal(routes, 0, "the already-routed Result must not be routed again");
+  const latest = readLatestTaskAttempt(task);
+  assert.equal(latest?.attemptNumber, 2);
+  assert.equal(latest?.retryOfAttemptId, first.attemptId);
 });
 
 test("execute-task exceptions settle, route, and return the durable recovery action", async () => {


### PR DESCRIPTION
## TL;DR

**What:** The task-execution cutover now honors an authorized recovery resume: the #2113 already-resumed refresh branch is reachable, and re-entry after `gsd_task_recovery_resume` claims the successor Attempt instead of re-routing the already-routed Result.
**Why:** The refresh branch was nested inside `!terminalRecovery.resumeAuthorized`, but an authorized resume sets that flag true — dead exactly when needed, stranding tasks in an abort → resume → abort loop on v1.18.0 (#2188).
**How:** The outer abort guard drops the `!resumeAuthorized` conjunct; the abort return moves inside `if (!resumeAuthorized)`; the routing block becomes `else if` so an authorized resume falls through to the existing `retryOfAttemptId` → `claimTaskAttempt` successor claim.

## What

- `src/resources/extensions/gsd/auto/task-execution-cutover.ts` — guard restructure only (no new state, no changed write path): unresumed live aborts and other-guard aborts (#2112/#1948) keep identical fail-closed behavior; consumed-resume refresh (#2113) unchanged; an authorized resume now falls through to the successor claim with `retryOfAttemptId` set.
- `src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts` — integration regression: authorized resume → re-entry claims a fresh Attempt 2 (`retryOfAttemptId = attempt-1`), zero re-routes, result `next`; failed pre-fix with the exact loop symptom (`Task Result already has a recovery observation` at `requireRoutableResult`).

## Why

`resumeTaskRecovery()` writes only the `task.recovery.resumed` event + correction checkpoint — `resumeAuthorized` becomes true (per `isTaskRecoveryResumeAuthorized`) while the kernel stays at `route`, making the nested branch's guard false. The authorization is strictly one-shot: the successor claim satisfies the resume's NOT EXISTS guard, so each operator resume yields exactly one claim, and no new loop is possible. No evidence bypass: the flag derives solely from the durable resume event written through `requireResumableRecoveryScope` + `requireRepairEvidence`.

Closes #2188

## How

Verified by full state enumeration across every reachable guard configuration (unresumed abort, other-guard abort, consumed-resume refresh, refresh race, fresh authorized resume, verify-stage authorized — all before/after outcomes identical except the targeted state 5), 244 tests green across the cutover/recovery/loop/verification battery, revert-sensitivity proven (the new test fails with the fix stashed, carrying the loop symptom), and typecheck clean apart from 2 pre-existing unrelated errors. Codex second review found nothing real. Known non-blocking edge: an agent abort with `resumeAuthorized = true` but a non-`already-resumed` guard now claims (unreachable via normal flow).

> This PR is AI-assisted.

## Testing

After dependency setup, focused tests passed and SQLite-backed recovery operations demonstrated successor claim, successful settlement, and one-shot authorization. The old guard reproduced the reported error. Captured state evidence uses a controlled executor callback, not an interactive CLI session; temporary dependencies were removed.

<details>
<summary>Evidence: Recovery state: successor succeeded, authorization consumed, later re-entry reused successor</summary>

```text
{
  "interface": "Real recovery domain operations and auto-mode cutover with SQLite; executor callback supplies successful task result",
  "afterRepair": {
    "recoveryActionId": "a34a53ee-7fd3-4b7a-ba87-1919d4f9d109",
    "action": "abort",
    "recoveryOwner": "agent",
    "failureKind": "fatal",
    "blocker": null,
    "resumeAuthorized": true,
    "resumeEligibility": {
      "recoveryActionId": "a34a53ee-7fd3-4b7a-ba87-1919d4f9d109",
      "attemptId": "ae9a278f-3332-4fb8-b71d-b0bf5a3b99ea",
      "resultId": "55ecec65-cc9e-4e11-87f2-5a06a573c6f9",
      "eligible": false,
      "failedGuard": "already-resumed",
      "detail": "Recovery Action was already resumed"
    }
  },
  "afterAutoReentry": {
    "result": {
      "action": "next",
      "data": {}
    },
    "routes": 0,
    "latest": {
      "attemptId": "dcfafee5-f32d-48b6-a10e-429a86c80b82",
      "resultId": "52aafcd4-9b76-49ff-bb5e-ee5c25ef3303",
      "resultFailureClass": "none",
      "resultSummary": "recovered execution finished",
      "attemptNumber": 2,
      "retryOfAttemptId": "ae9a278f-3332-4fb8-b71d-b0bf5a3b99ea",
      "state": "settled",
      "outcome": "succeeded",
      "nextStage": "verify",
      "coordinationDispatchId": 2,
      "workerId": "worker-1",
      "milestoneLeaseToken": 7
    }
  },
  "consumedAuthorization": {
    "recoveryActionId": "a34a53ee-7fd3-4b7a-ba87-1919d4f9d109",
    "action": "abort",
    "recoveryOwner": "agent",
    "failureKind": "fatal",
    "blocker": null,
    "resumeAuthorized": false,
    "resumeEligibility": {
      "recoveryActionId": "a34a53ee-7fd3-4b7a-ba87-1919d4f9d109",
      "attemptId": "ae9a278f-3332-4fb8-b71d-b0bf5a3b99ea",
      "resultId": "55ecec65-cc9e-4e11-87f2-5a06a573c6f9",
      "eligible": false,
      "failedGuard": "already-resumed",
      "detail": "Recovery Action was already resumed"
    }
  },
  "subsequentAutoReentry": {
    "result": {
      "action": "next",
      "data": {}
    },
    "latest": {
      "attemptId": "dcfafee5-f32d-48b6-a10e-429a86c80b82",
      "resultId": "52aafcd4-9b76-49ff-bb5e-ee5c25ef3303",
      "resultFailureClass": "none",
      "resultSummary": "recovered execution finished",
      "attemptNumber": 2,
      "retryOfAttemptId": "ae9a278f-3332-4fb8-b71d-b0bf5a3b99ea",
      "state": "settled",
      "outcome": "succeeded",
      "nextStage": "verify",
      "coordinationDispatchId": 2,
      "workerId": "worker-1",
      "milestoneLeaseToken": 7
    }
  }
}
```
</details>
<details>
<summary>Evidence: Pre-fix regression reproduction</summary>

`Old guard reproduced: Task Result already has a recovery observation`

```text
✖ an authorized resume re-entry claims the successor instead of re-routing the routed Result (#2188) (156.194084ms)
ℹ tests 1
ℹ suites 0
ℹ pass 0
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1561.806375

✖ failing tests:

test at src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts:1262:1
✖ an authorized resume re-entry claims the successor instead of re-routing the routed Result (#2188) (156.194084ms)
  Error: Task Result already has a recovery observation
      at requireRoutableResult (file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/task-recovery-domain-operation.ts:536:11)
      at file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/task-recovery-domain-operation.ts:974:5
      at file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/db/domain-operation.ts:1065:22
      at DbTransactionRunner.runTransaction (file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/db-transaction.ts:57:22)
      at DbTransactionRunner.immediateTransaction (file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/db-transaction.ts:33:17)
      at immediateTransaction (file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/db/engine.ts:2758:29)
      at runDomainOperationTransaction (file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/db/domain-operation.ts:959:12)
      at executeDomainOperationCore (file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/db/domain-operation.ts:982:18)
      at executeDomainOperation (file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/db/domain-operation.ts:1233:10)
      at recordFailureAndSelectRecovery (file:///Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1XGC8M25EC70ZHD453BJJK3/src/resources/extensions/gsd/task-recovery-domain-operation.ts:957:21)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4816e5c4aab4e34329a609503aade37f432b2e0c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install --frozen-lockfile --ignore-scripts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-task-execution-cutover.test.ts src/resources/extensions/gsd/tests/task-recovery-domain-operation.test.ts src/resources/extensions/gsd/tests/task-recovery-convergence.test.ts`
- <code>Ran `--test-name-pattern=&#39;#2188&#39;` with the evidence hook `/Users/jeremymcspadden/.no-mistakes/evidence/01M1XGC8M25EC70ZHD453BJJK3/recovery-evidence.mjs`; asserted successful settlement, consumed authorization, and subsequent re-entry without another execution.</code>
- <code>Repeated the focused regression with `RECOVERY_BASELINE=1`, loading the base commit&#39;s guard through the evidence hook; reproduced the exact reported failure.</code>
- <code>Removed installed dependency directories and confirmed `git status --short` was empty.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ `package.json` - Cannot complete `pnpm run typecheck:extensions`: this worktree lacks node_modules, so tsc is unavailable. Restore dependencies and rerun the check.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

