### PR TITLE
fix(gsd): normalize Markdown-formatted versions in the version check

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -12,20 +12,30 @@ jobs:
     if: ${{ github.event_name == 'issues' && contains(github.event.issue.body, 'GSD version') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+      - uses: actions/checkout@v7
+
       - name: Check GSD version and comment if outdated
         uses: actions/github-script@v9
         with:
           script: |
+            const { isOutdated, isVersionLike, normalizeReportedVersion } = await import(
+              `${process.cwd()}/scripts/lib/version-check-core.mjs`
+            );
+
             const body = context.payload.issue.body || '';
             const issueNumber = context.payload.issue.number;
 
-            const match = body.match(/###\s+GSD version\s*\n+\s*([^\s\n]+)/i);
+            const match = body.match(/###\s+GSD version\s*\n+\s*((?:GSD\s+)?[^\s\n]+)/i);
             if (!match) {
               core.info('Could not find a GSD version value in the issue body - skipping.');
               return;
             }
 
-            const reportedVersion = match[1].trim().replace(/^v/, '');
+            const reportedVersion = normalizeReportedVersion(match[1]);
+            if (!isVersionLike(reportedVersion)) {
+              core.info('Reported value "' + reportedVersion + '" is not a version - skipping.');
+              return;
+            }
             core.info('Reported version: ' + reportedVersion);
 
             const npmResponse = await fetch('https://registry.npmjs.org/@opengsd%2fgsd-pi/latest');
@@ -36,19 +46,6 @@ jobs:
             const npmData = await npmResponse.json();
             const latestVersion = npmData.version;
             core.info('Latest version: ' + latestVersion);
-
-            function parseVersion(v) {
-              const parts = v.replace(/^v/, '').split('.').map(Number);
-              return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
-            }
-
-            function isOutdated(reported, latest) {
-              const r = parseVersion(reported);
-              const l = parseVersion(latest);
-              if (r[0] !== l[0]) return r[0] < l[0];
-              if (r[1] !== l[1]) return r[1] < l[1];
-              return r[2] < l[2];
-            }
 
             if (!isOutdated(reportedVersion, latestVersion)) {
               core.info('Version ' + reportedVersion + ' is current - no comment needed.');

--- a/scripts/__tests__/version-check-workflow.test.mjs
+++ b/scripts/__tests__/version-check-workflow.test.mjs
@@ -107,15 +107,63 @@ test("workflow checks out the repo before running the inline script", () => {
   assert.ok(checkout, "a checkout step must run before the github-script step");
 });
 
-test("workflow uses the shared module instead of inline comparison logic", () => {
-  assert.match(script, /scripts\/lib\/version-check-core\.mjs/);
-  assert.match(script, /normalizeReportedVersion\(/);
-  assert.match(script, /isVersionLike\(/);
-  assert.match(script, /isOutdated\(/);
-  assert.doesNotMatch(script, /function parseVersion/);
+async function executeWorkflow(reportedVersion) {
+  const comments = [];
+  const labels = [];
+  const outputs = [];
+  const context = {
+    payload: { issue: { body: `### GSD version\n\n${reportedVersion}\n`, number: 2189 } },
+    repo: { owner: "open-gsd", repo: "gsd-pi" },
+  };
+  const core = {
+    info() {},
+    warning() {},
+    setFailed(message) { assert.fail(message); },
+    setOutput(name, value) { outputs.push({ name, value }); },
+  };
+  const github = {
+    rest: {
+      issues: {
+        async listComments() { return { data: [] }; },
+        async createComment(payload) { comments.push(payload); },
+        async addLabels(payload) { labels.push(payload); },
+      },
+    },
+  };
+  async function fetchLatest(url) {
+    assert.equal(url, "https://registry.npmjs.org/@opengsd%2fgsd-pi/latest");
+    return { ok: true, async json() { return { version: "1.18.0" }; } };
+  }
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+  const run = new AsyncFunction("context", "core", "github", "fetch", "process", script);
+  await run(context, core, github, fetchLatest, { cwd: () => repoRoot });
+  return { comments, labels, outputs };
+}
+
+test("workflow does not write upgrade prompts for current or invalid versions", async () => {
+  for (const version of ["1.18.0", "`1.18.0`", "GSD v1.18.0", "latest", "GSD", "unknown"]) {
+    assert.deepEqual(
+      await executeWorkflow(version),
+      { comments: [], labels: [], outputs: [] },
+      `input: ${JSON.stringify(version)}`,
+    );
+  }
 });
 
-test("workflow keeps the bot marker and needs-upgrade label", () => {
-  assert.match(script, /gsd-version-check/);
-  assert.match(script, /needs-upgrade/);
+test("workflow posts the upgrade comment and label for older versions", async () => {
+  for (const version of ["1.17.0", "GSD v1.17.0"]) {
+    const { comments, labels } = await executeWorkflow(version);
+    assert.equal(comments.length, 1);
+    const { body, ...destination } = comments[0];
+    assert.deepEqual(destination, { owner: "open-gsd", repo: "gsd-pi", issue_number: 2189 });
+    assert.ok(body.startsWith("<!-- gsd-version-check -->\n"));
+    assert.ok(body.includes("**GSD v1.17.0**"));
+    assert.ok(body.includes("**v1.18.0**"));
+    assert.deepEqual(labels, [{
+      owner: "open-gsd",
+      repo: "gsd-pi",
+      issue_number: 2189,
+      labels: ["needs-upgrade"],
+    }]);
+  }
 });

--- a/scripts/__tests__/version-check-workflow.test.mjs
+++ b/scripts/__tests__/version-check-workflow.test.mjs
@@ -1,0 +1,121 @@
+// Project/App: gsd-pi
+// File Purpose: Tests for the version-check workflow normalization logic and workflow wiring.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import YAML from "yaml";
+
+import {
+  isOutdated,
+  isVersionLike,
+  normalizeReportedVersion,
+} from "../lib/version-check-core.mjs";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+const workflow = YAML.parse(
+  readFileSync(join(repoRoot, ".github/workflows/version-check.yml"), "utf8"),
+);
+const scriptStep = workflow.jobs["check-version"].steps.find((step) =>
+  step.uses?.startsWith("actions/github-script@"),
+);
+const script = scriptStep.with.script;
+
+test("issue #2191 version forms all normalize to the bare version", () => {
+  const cases = [
+    "1.18.0",
+    "v1.18.0",
+    "V1.18.0",
+    "`1.18.0`",
+    "`v1.18.0`",
+    "GSD v1.18.0",
+    "GSD V1.18.0",
+    "gsd v1.18.0",
+    "GSD 1.18.0",
+    "GSDv1.18.0",
+    "  1.18.0  ",
+    "  `1.18.0`  ",
+  ];
+  for (const raw of cases) {
+    assert.equal(normalizeReportedVersion(raw), "1.18.0", `input: ${JSON.stringify(raw)}`);
+  }
+});
+
+test("normalizeReportedVersion preserves a genuinely older version", () => {
+  assert.equal(normalizeReportedVersion("`1.17.0`"), "1.17.0");
+});
+
+test("comparison still flags old versions and accepts current or newer ones", () => {
+  assert.equal(isOutdated("1.17.0", "1.18.0"), true);
+  assert.equal(isOutdated("1.18.0", "1.18.0"), false);
+  assert.equal(isOutdated("1.18.0", "1.18.1"), true);
+  assert.equal(isOutdated("2.0.0", "1.18.0"), false);
+});
+
+test("markdown-formatted current version no longer compares as outdated", () => {
+  // Regression from issue #2191: `1.18.0` parsed as 0.18.0 and was flagged.
+  assert.equal(isOutdated(normalizeReportedVersion("`1.18.0`"), "1.18.0"), false);
+});
+
+test("non-version garbage is not treated as a version", () => {
+  for (const garbage of ["", "latest", "unknown", "not sure", "GSD"]) {
+    assert.equal(isVersionLike(garbage), false, `input: ${JSON.stringify(garbage)}`);
+  }
+  assert.equal(isVersionLike("1.18.0"), true);
+});
+
+test("workflow extraction captures GSD-prefixed and formatted values whole", () => {
+  const literal = script.match(/body\.match\((\/.*\/i)\)/)?.[1];
+  assert.ok(literal, "extraction regex literal must exist in the script");
+  const parsed = literal.match(/^\/(.*)\/([a-z]*)$/s);
+  const extractor = new RegExp(parsed[1], parsed[2]);
+  const cases = [
+    ["1.18.0", "### GSD version\n\n1.18.0\n"],
+    ["`1.18.0`", "### GSD version\n\n`1.18.0`\n"],
+    ["`v1.18.0`", "### GSD version\n\n`v1.18.0`\n"],
+    ["GSD v1.18.0", "### GSD version\n\nGSD v1.18.0\n"],
+    ["GSD 1.18.0", "### GSD version\n\nGSD 1.18.0\n"],
+    ["GSDv1.18.0", "### GSD version\n\nGSDv1.18.0\n"],
+  ];
+  for (const [value, body] of cases) {
+    const captured = body.match(extractor)?.[1];
+    assert.ok(captured, `must capture a value for: ${value}`);
+    assert.equal(
+      normalizeReportedVersion(captured),
+      "1.18.0",
+      `captured ${JSON.stringify(captured)} for: ${value}`,
+    );
+  }
+});
+
+test("workflow extraction keeps a genuinely old GSD-prefixed version flaggable", () => {
+  const literal = script.match(/body\.match\((\/.*\/i)\)/)?.[1];
+  const extractor = new RegExp(literal.match(/^\/(.*)\/([a-z]*)$/s)[1], "i");
+  const captured = "### GSD version\n\nGSD v1.17.0\n".match(extractor)?.[1];
+  assert.equal(normalizeReportedVersion(captured), "1.17.0");
+  assert.equal(isOutdated(normalizeReportedVersion(captured), "1.18.0"), true);
+});
+
+test("workflow checks out the repo before running the inline script", () => {
+  const steps = workflow.jobs["check-version"].steps;
+  const scriptStepIndex = steps.indexOf(scriptStep);
+  assert.ok(scriptStepIndex > 0, "github-script step must exist");
+  const checkout = steps
+    .slice(0, scriptStepIndex)
+    .find((step) => step.uses?.startsWith("actions/checkout@"));
+  assert.ok(checkout, "a checkout step must run before the github-script step");
+});
+
+test("workflow uses the shared module instead of inline comparison logic", () => {
+  assert.match(script, /scripts\/lib\/version-check-core\.mjs/);
+  assert.match(script, /normalizeReportedVersion\(/);
+  assert.match(script, /isVersionLike\(/);
+  assert.match(script, /isOutdated\(/);
+  assert.doesNotMatch(script, /function parseVersion/);
+});
+
+test("workflow keeps the bot marker and needs-upgrade label", () => {
+  assert.match(script, /gsd-version-check/);
+  assert.match(script, /needs-upgrade/);
+});

--- a/scripts/lib/version-check-core.mjs
+++ b/scripts/lib/version-check-core.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Project/App: gsd-pi
+// File Purpose: Shared normalization and comparison for the version-check workflow.
+
+// Turn a raw "GSD version" field value (e.g. "  `GSD v1.18.0`  ") into a bare
+// version string ("1.18.0") so it compares equal to the npm latest release
+// instead of triggering a bogus upgrade comment (issue #2191).
+export function normalizeReportedVersion(raw) {
+  return String(raw ?? "")
+    .trim()
+    .replace(/^`+|`+$/g, "")
+    .trim()
+    .replace(/^gsd\s*v?/i, "")
+    .replace(/^v/i, "")
+    .trim();
+}
+
+// The workflow skips (no comment, no label) when the reported value is not version-like.
+export function isVersionLike(value) {
+  return /^\d/.test(value);
+}
+
+function parseVersion(v) {
+  const parts = v.replace(/^v/, "").split(".").map(Number);
+  return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+}
+
+export function isOutdated(reported, latest) {
+  const r = parseVersion(reported);
+  const l = parseVersion(latest);
+  if (r[0] !== l[0]) return r[0] < l[0];
+  if (r[1] !== l[1]) return r[1] < l[1];
+  return r[2] < l[2];
+}


### PR DESCRIPTION
## TL;DR

**What:** The version-check workflow now normalizes the reported GSD version (whitespace, backticks, `v`/`GSD v` prefixes) before comparing against the latest release, with the logic single-sourced in `scripts/lib/version-check-core.mjs`.
**Why:** A Markdown-code-formatted current version (`` `1.18.0` ``) compared unequal to v1.18.0 and triggered a bogus upgrade comment — issue #2189's own reporter hit this (#2191).
**How:** The workflow imports `normalizeReportedVersion`/`isVersionLike`/`isOutdated` from the new module via the same await-import pattern production workflows use; extraction additionally captures an optional leading `GSD ` prefix; garbage/non-version-like input is skipped instead of producing a bogus comment.

## What

- `scripts/lib/version-check-core.mjs` (new) — `normalizeReportedVersion` (trim → strip wrapping backticks → strip `gsd v`/`v` prefixes case-insensitively), `isVersionLike` (must start with a digit), `isOutdated` (comparison moved verbatim from the workflow).
- `.github/workflows/version-check.yml` — checkout added; the inline script imports the module, uses `normalizeReportedVersion` for comparison and comment text, skips non-version-like garbage, and the extraction regex captures an optional leading `GSD ` so `GSD v1.18.0` is handled whole.
- `scripts/__tests__/version-check-workflow.test.mjs` (new) — the full #2191 matrix (plain/v/backticked/GSD-prefixed forms all normalize to 1.18.0; 1.17.0 still flags; garbage skips), two tests that EXECUTE the workflow's script end-to-end with mocked context/npm/core (current/garbage → no writes; older → the upgrade comment), plus checkout-ordering and bot-marker/label retention checks.

## Why

Backtick-wrapped values parsed as `[0, 18, 0] < [1, 18, 0]`, so a current version triggered the upgrade prompt — issue #2189's own automated comment demonstrates it. Non-version-like garbage previously produced the same bogus comment; it now skips cleanly.

Closes #2191

## How

The normalization logic is single-sourced in the module and the workflow imports it via the production-proven `ai-triage.yml` await-import pattern (a mirror-in-YAML alternative was rejected as duplicated logic). Per review, the two source-string assertion tests were replaced with execution of the actual workflow script under mocked context/npm/core — current/garbage inputs produce no comment writes, older inputs produce the upgrade comment. The extraction regex intentionally captures token-level values only; backticked values with inner spaces still skip (full-line capture rejected — it would swallow trailing junk into the comparison).

> This PR is AI-assisted.

## Testing

After resolving a missing test dependency, focused tests and workflow execution passed, reproduced the baseline bug, and produced comment/label evidence. No screenshot was captured because this workflow has no local rendered UI; generated Markdown and API payloads show its output. Live GitHub execution remains outside this phase.

<details>
<summary>Evidence: Workflow behavior transcript</summary>

```text
BASE: backticked current version produced the bogus comment and needs-upgrade label; no-upgrade assertion failed as expected.
{"reported":"1.18.0","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"v1.18.0","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"V1.18.0","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"`1.18.0`","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"`v1.18.0`","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"GSD v1.18.0","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"GSD V1.18.0","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"gsd v1.18.0","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"GSD 1.18.0","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"GSDv1.18.0","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"  `1.18.0`  ","comments":0,"labels":[],"message":"Version 1.18.0 is current - no comment needed."}
{"reported":"latest","comments":0,"labels":[],"message":"Reported value \"latest\" is not a version - skipping."}
{"reported":"GSD","comments":0,"labels":[],"message":"Reported value \"###\" is not a version - skipping."}
{"reported":"unknown","comments":0,"labels":[],"message":"Reported value \"unknown\" is not a version - skipping."}
{"reported":"`GSD v1.18.0`","comments":0,"labels":[],"message":"Reported value \"\" is not a version - skipping."}
{"reported":"GSD version 1.18.0","comments":0,"labels":[],"message":"Reported value \"ersion\" is not a version - skipping."}
{"reported":"1.17.0","comments":1,"labels":["needs-upgrade"],"message":"Posted upgrade prompt for v1.17.0 -> v1.18.0"}
{"reported":"`1.17.0`","comments":1,"labels":["needs-upgrade"],"message":"Posted upgrade prompt for v1.17.0 -> v1.18.0"}
{"reported":"GSD v1.17.0","comments":1,"labels":["needs-upgrade"],"message":"Posted upgrade prompt for v1.17.0 -> v1.18.0"}
Sensitivity: normalization, garbage guard, comment write, and label write mutations all rejected.
```
</details>
<details>
<summary>Evidence: Captured GitHub comment and label payloads</summary>

```text
{
  "boundary": "Actual inline workflow and real module; npm and GitHub APIs mocked; no external writes.",
  "baseline": {
    "version": "`1.18.0`",
    "comments": [
      {
        "owner": "open-gsd",
        "repo": "gsd-pi",
        "issue_number": 2189,
        "body": "<!-- gsd-version-check -->\n\nThanks for filing this bug report!\n\nIt looks like you are running **GSD v`1.18.0`**, but the latest release is **v1.18.0**.\n\nBefore we investigate further, please upgrade and check whether the issue still occurs:\n\n`` `bash\nnpm install -g @opengsd/gsd-pi@latest\ngsd --version   # should print 1.18.0\n`` `\n\nThen re-run your reproduction steps. If the problem persists on **v1.18.0**, please update the **GSD version** field in this issue and let us know.\n\n> **Why?** Many bugs are fixed in subsequent releases. Confirming on the latest version keeps the team focused on real, current issues.\n\n---\n*This is an automated check. If you are intentionally pinned to an older version, feel free to explain why and we will continue from there.*"
      }
    ],
    "labels": [
      {
        "owner": "open-gsd",
        "repo": "gsd-pi",
        "issue_number": 2189,
        "labels": [
          "needs-upgrade"
        ]
      }
    ],
    "outputs": [],
    "logs": [
      "Reported version: `1.18.0`",
      "Latest version: 1.18.0",
      "Posted upgrade prompt for v`1.18.0` -> v1.18.0"
    ]
  },
  "target": [
    {
      "version": "1.18.0",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "v1.18.0",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "V1.18.0",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "`1.18.0`",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "`v1.18.0`",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "GSD v1.18.0",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "GSD V1.18.0",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "gsd v1.18.0",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "GSD 1.18.0",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "GSDv1.18.0",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "  `1.18.0`  ",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported version: 1.18.0",
        "Latest version: 1.18.0",
        "Version 1.18.0 is current - no comment needed."
      ]
    },
    {
      "version": "latest",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported value \"latest\" is not a version - skipping."
      ]
    },
    {
      "version": "GSD",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported value \"###\" is not a version - skipping."
      ]
    },
    {
      "version": "unknown",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported value \"unknown\" is not a version - skipping."
      ]
    },
    {
      "version": "`GSD v1.18.0`",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported value \"\" is not a version - skipping."
      ]
    },
    {
      "version": "GSD version 1.18.0",
      "comments": [],
      "labels": [],
      "outputs": [],
      "logs": [
        "Reported value \"ersion\" is not a version - skipping."
      ]
    },
    {
      "version": "1.17.0",
      "comments": [
        {
          "owner": "open-gsd",
          "repo": "gsd-pi",
          "issue_number": 2189,
          "body": "<!-- gsd-version-check -->\n\nThanks for filing this bug report!\n\nIt looks like you are running **GSD v1.17.0**, but the latest release is **v1.18.0**.\n\nBefore we investigate further, please upgrade and check whether the issue still occurs:\n\n`` `bash\nnpm install -g @opengsd/gsd-pi@latest\ngsd --version   # should print 1.18.0\n`` `\n\nThen re-run your reproduction steps. If the problem persists on **v1.18.0**, please update the **GSD version** field in this issue and let us know.\n\n> **Why?** Many bugs are fixed in subsequent releases. Confirming on the latest version keeps the team focused on real, current issues.\n\n---\n*This is an automated check. If you are intentionally pinned to an older version, feel free to explain why and we will continue from there.*"
        }
      ],
      "labels": [
        {
          "owner": "open-gsd",
          "repo": "gsd-pi",
          "issue_number": 2189,
          "labels": [
            "needs-upgrade"
          ]
        }
      ],
      "outputs": [],
      "logs": [
        "Reported version: 1.17.0",
        "Latest version: 1.18.0",
        "Posted upgrade prompt for v1.17.0 -> v1.18.0"
      ]
    },
    {
      "version": "`1.17.0`",
      "comments": [
        {
          "owner": "open-gsd",
          "repo": "gsd-pi",
          "issue_number": 2189,
          "body": "<!-- gsd-version-check -->\n\nThanks for filing this bug report!\n\nIt looks like you are running **GSD v1.17.0**, but the latest release is **v1.18.0**.\n\nBefore we investigate further, please upgrade and check whether the issue still occurs:\n\n`` `bash\nnpm install -g @opengsd/gsd-pi@latest\ngsd --version   # should print 1.18.0\n`` `\n\nThen re-run your reproduction steps. If the problem persists on **v1.18.0**, please update the **GSD version** field in this issue and let us know.\n\n> **Why?** Many bugs are fixed in subsequent releases. Confirming on the latest version keeps the team focused on real, current issues.\n\n---\n*This is an automated check. If you are intentionally pinned to an older version, feel free to explain why and we will continue from there.*"
        }
      ],
      "labels": [
        {
          "owner": "open-gsd",
          "repo": "gsd-pi",
          "issue_number": 2189,
          "labels": [
            "needs-upgrade"
          ]
        }
      ],
      "outputs": [],
      "logs": [
        "Reported version: 1.17.0",
        "Latest version: 1.18.0",
        "Posted upgrade prompt for v1.17.0 -> v1.18.0"
      ]
    },
    {
      "version": "GSD v1.17.0",
      "comments": [
        {
          "owner": "open-gsd",
          "repo": "gsd-pi",
          "issue_number": 2189,
          "body": "<!-- gsd-version-check -->\n\nThanks for filing this bug report!\n\nIt looks like you are running **GSD v1.17.0**, but the latest release is **v1.18.0**.\n\nBefore we investigate further, please upgrade and check whether the issue still occurs:\n\n`` `bash\nnpm install -g @opengsd/gsd-pi@latest\ngsd --version   # should print 1.18.0\n`` `\n\nThen re-run your reproduction steps. If the problem persists on **v1.18.0**, please update the **GSD version** field in this issue and let us know.\n\n> **Why?** Many bugs are fixed in subsequent releases. Confirming on the latest version keeps the team focused on real, current issues.\n\n---\n*This is an automated check. If you are intentionally pinned to an older version, feel free to explain why and we will continue from there.*"
        }
      ],
      "labels": [
        {
          "owner": "open-gsd",
          "repo": "gsd-pi",
          "issue_number": 2189,
          "labels": [
            "needs-upgrade"
          ]
        }
      ],
      "outputs": [],
      "logs": [
        "Reported version: 1.17.0",
        "Latest version: 1.18.0",
        "Posted upgrade prompt for v1.17.0 -> v1.18.0"
      ]
    }
  ],
  "sensitivity": [
    {
      "name": "normalization bypassed",
      "detected": true
    },
    {
      "name": "guard bypassed",
      "detected": true
    },
    {
      "name": "comment disabled",
      "detected": true
    },
    {
      "name": "label disabled",
      "detected": true
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Generated older-version upgrade comment</summary>

```text
<!-- gsd-version-check -->

Thanks for filing this bug report!

It looks like you are running **GSD v1.17.0**, but the latest release is **v1.18.0**.

Before we investigate further, please upgrade and check whether the issue still occurs:

`` `bash
npm install -g @opengsd/gsd-pi@latest
gsd --version   # should print 1.18.0
`` `

Then re-run your reproduction steps. If the problem persists on **v1.18.0**, please update the **GSD version** field in this issue and let us know.

> **Why?** Many bugs are fixed in subsequent releases. Confirming on the latest version keeps the team focused on real, current issues.

---
*This is an automated check. If you are intentionally pinned to an older version, feel free to explain why and we will continue from there.*
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ad740c9576082c92d0e22b85dada6f3a64da40ab","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `scripts/__tests__/version-check-workflow.test.mjs:110` - The intent requires “no source-grep of workflow internals beyond the parsed YAML contract,” but lines 111–115 assert JavaScript source strings, including `assert.match(script, /normalizeReportedVersion\(/)`, and lines 119–120 only search for marker/label text. Parsing YAML first does not make these behavioral checks: commented-out calls or disabled comment/label operations would still pass. Replace both tests with execution of the workflow script using mocked context, npm response, and GitHub methods; assert current/garbage inputs produce no writes and older inputs produce the required comment and label.

🔧 Fix: test: execute version-check workflow to verify upgrade behavior
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test scripts/__tests__/version-check-workflow.test.mjs` — initially blocked by missing yaml; passed after temporarily installing locked yaml@2.9.0 locally.</code>
- <code>`node /Users/jeremymcspadden/.no-mistakes/evidence/01M1XSCVWGZRD8SMCM5TZJEAEY/workflow-evidence.mjs` — executed base and target workflow scripts with real module imports and mocked npm/GitHub APIs; checked the input matrix and captured payloads.</code>
- `Reproduced the base regression and confirmed checks reject disabled normalization, garbage guard, comment creation, and labeling.`
- <code>`git status --short` — clean after removing the temporary dependency.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

