### PR TITLE
fix(gsd): enforce blocking post-unit hooks in step mode and persist gate state

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -1022,7 +1022,9 @@ See [Remote Questions](./remote-questions.md) for setup instructions and Telegra
 
 ### `post_unit_hooks`
 
-Custom hooks that fire after specific unit types complete:
+Custom hooks that fire after specific unit types complete. See the
+[preferences reference](../../src/resources/extensions/gsd/docs/preferences-reference.md#field-guide)
+for blocking gates, step-mode behavior, and pause/resume recovery.
 
 ```yaml
 post_unit_hooks:

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -65,6 +65,7 @@ import {
   consumeHookFailure,
   peekRetryTrigger,
   consumeGateBlock,
+  isGateBlockPending,
   persistHookState,
   resolveHookArtifactPath,
 } from "./post-unit-hooks.js";
@@ -536,6 +537,48 @@ function resolveTaskArtifactPath(
   const taskDir = resolveTasksDir(basePath, mid, sid) ?? slicePath;
   const file = resolveFile(taskDir, tid, suffix);
   return file ? join(taskDir, file) : null;
+}
+
+export async function handlePendingHookOutcome(
+  { s, ctx, pi, pauseAuto }: Pick<PostUnitContext, "s" | "ctx" | "pi" | "pauseAuto">,
+): Promise<"stopped" | null> {
+  const trigger = peekRetryTrigger();
+  if (!trigger && !isGateBlockPending()) return null;
+  persistHookState(s.basePath);
+  if (trigger) {
+    ctx.ui.notify(
+      `Hook requested retry of ${trigger.unitType} ${trigger.unitId} — resetting trigger unit state.`,
+      "info",
+    );
+    try {
+      const disposition = await prepareHookRetry(trigger, s.canonicalProjectRoot);
+      if (disposition === "retry") {
+        if (!s.orchestration) throw new Error("Hook retry requires an active orchestration session");
+        await s.orchestration.retryActiveUnit({
+          unitType: trigger.unitType,
+          unitId: trigger.unitId,
+        });
+      }
+      acknowledgeRetryTrigger(s.basePath);
+    } catch (e) {
+      debugLog("postUnitPostVerification", { phase: "retry-state-reset", error: String(e) });
+      throw e;
+    }
+  }
+
+  const gateBlock = consumeGateBlock();
+  if (gateBlock) {
+    const verdict = gateBlock.verdict ? ` verdict=${gateBlock.verdict};` : "";
+    const artifact = gateBlock.artifact ? ` artifact=${gateBlock.artifact};` : "";
+    const message =
+      `Post-unit gate "${gateBlock.hookName}" blocked ${gateBlock.triggerUnitType} ${gateBlock.triggerUnitId} ` +
+      (s.currentUnit ? `(detected on completion of ${s.currentUnit.type} ${s.currentUnit.id}):` : "(detected on resume):") +
+      `${verdict}${artifact} ${gateBlock.reason}. Run /gsd status to inspect, then /gsd auto after recovery.`;
+    ctx.ui.notify(message, "warning");
+    await pauseAuto(ctx, pi);
+    return "stopped";
+  }
+  return null;
 }
 
 type PendingHookRetry = NonNullable<ReturnType<typeof peekRetryTrigger>>;
@@ -2815,45 +2858,7 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
       return "stopped";
     }
 
-    // Check if a hook requested a retry of the trigger unit
-    const trigger = peekRetryTrigger();
-    if (trigger) {
-      ctx.ui.notify(
-        `Hook requested retry of ${trigger.unitType} ${trigger.unitId} — resetting trigger unit state.`,
-        "info",
-      );
-      try {
-        const disposition = await prepareHookRetry(trigger, s.canonicalProjectRoot);
-        if (disposition === "retry") {
-          if (!s.orchestration) throw new Error("Hook retry requires an active orchestration session");
-          await s.orchestration.retryActiveUnit({
-            unitType: trigger.unitType,
-            unitId: trigger.unitId,
-          });
-        }
-        acknowledgeRetryTrigger(s.basePath);
-      } catch (e) {
-        debugLog("postUnitPostVerification", { phase: "retry-state-reset", error: String(e) });
-        throw e;
-      }
-      // Fall through to normal dispatch — deriveState will re-derive the unit.
-    }
-
-    const gateBlock = consumeGateBlock();
-    if (gateBlock) {
-      // The block reached disk in the persistHookState above (it was still
-      // pending), so a resumed session re-arms the gate instead of selecting
-      // past it (#2194).
-      const verdict = gateBlock.verdict ? ` verdict=${gateBlock.verdict};` : "";
-      const artifact = gateBlock.artifact ? ` artifact=${gateBlock.artifact};` : "";
-      const message =
-        `Post-unit gate "${gateBlock.hookName}" blocked ${gateBlock.triggerUnitType} ${gateBlock.triggerUnitId} ` +
-        `(detected on completion of ${s.currentUnit.type} ${s.currentUnit.id}):` +
-        `${verdict}${artifact} ${gateBlock.reason}. Run /gsd status to inspect, then /gsd auto after recovery.`;
-      ctx.ui.notify(message, "warning");
-      await pauseAuto(ctx, pi);
-      return "stopped";
-    }
+    if (await handlePendingHookOutcome(pctx)) return "stopped";
   }
 
   // ── Fast-path stop detection (#3487) ──

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -2783,8 +2783,15 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
   }
 
   // ── Post-unit hooks ──
-  if (s.currentUnit && !s.stepMode) {
-    const hookUnit = checkPostUnitHooks(s.currentUnit.type, s.currentUnit.id, s.basePath);
+  // A `criticality: blocking` hook is a gate, not a side effect: it must
+  // complete — or pause for manual recovery — before the next unit is
+  // selected, in auto mode and step mode alike (#2194). Step mode skips
+  // non-blocking hooks, so it dispatches with a blocking-only filter.
+  if (s.currentUnit) {
+    // Persist while a synchronously-set gate block is still pending so the
+    // pause is durable: resume restores the block and re-arms the blocked
+    // hook instead of selecting past the failed gate (#2194).
+    const hookUnit = checkPostUnitHooks(s.currentUnit.type, s.currentUnit.id, s.basePath, { blockingOnly: s.stepMode });
     persistHookState(s.basePath);
     if (hookUnit) {
       if (s.currentUnit) {
@@ -2834,7 +2841,9 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
     const gateBlock = consumeGateBlock();
     if (gateBlock) {
-      persistHookState(s.basePath);
+      // The block reached disk in the persistHookState above (it was still
+      // pending), so a resumed session re-arms the gate instead of selecting
+      // past it (#2194).
       const verdict = gateBlock.verdict ? ` verdict=${gateBlock.verdict};` : "";
       const artifact = gateBlock.artifact ? ` artifact=${gateBlock.artifact};` : "";
       const message =

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -73,7 +73,7 @@ import { worktreePath as getWorktreeDir, isInsideWorktreesDir } from "./worktree
 import { emitWorktreeOrphaned } from "./worktree-telemetry.js";
 import { initMetrics } from "./metrics.js";
 import { initRoutingHistory } from "./routing-history.js";
-import { restoreHookState, resetHookState, reconcileRestoredHookDispatch } from "./post-unit-hooks.js";
+import { restoreHookState, resetHookState, reconcileRestoredHookDispatch, reconcileRestoredGateBlock } from "./post-unit-hooks.js";
 import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactive.js";
 import { snapshotSkills } from "./skill-discovery.js";
 import {
@@ -1723,6 +1723,9 @@ export async function bootstrapAutoSession(
     // persisted); re-enqueue it so the hook runs instead of blocking the next
     // unrelated unit's close-out (#1246).
     reconcileRestoredHookDispatch(base, s.sidecarQueue);
+    // A restored gate block has no dispatch either; re-enqueue the blocked
+    // hook so a failed blocking gate cannot be bypassed by resuming (#2194).
+    reconcileRestoredGateBlock(base, s.sidecarQueue);
     resetProactiveHealing();
     // Notify user on health level transitions (green→yellow→red and back)
     setLevelChangeCallback((_from, to, summary) => {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -128,6 +128,7 @@ import {
   persistHookState,
   restoreHookState,
   reconcileRestoredHookDispatch,
+  reconcileRestoredGateBlock,
   clearPersistedHookState,
 } from "./post-unit-hooks.js";
 import { runGSDDoctor, rebuildState } from "./doctor.js";
@@ -3033,6 +3034,9 @@ export async function startAuto(
     // persisted); re-enqueue it so the hook runs instead of blocking the next
     // unrelated unit's close-out (#1246).
     reconcileRestoredHookDispatch(s.basePath, s.sidecarQueue);
+    // A restored gate block has no dispatch either; re-enqueue the blocked
+    // hook so a failed blocking gate cannot be bypassed by resuming (#2194).
+    reconcileRestoredGateBlock(s.basePath, s.sidecarQueue);
     // Re-sync managed resources on resume so long-lived auto sessions pick up
     // bundled extension updates before resume-time verification/state logic runs.
     // GSD_PKG_ROOT is set by loader.ts and points to the gsd-pi package root.

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -29,6 +29,7 @@ import {
 import { _clearCurrentResolve } from "./resolve.js";
 import { runGuards } from "./phases.js";
 import { runFinalize } from "./finalize.js";
+import { handlePendingHookOutcome } from "../auto-post-unit.js";
 import {
   resetSessionTimeoutState,
   restoreTaskHostVerificationContext,
@@ -775,6 +776,11 @@ export async function autoLoop(
       // ── Blanket try/catch: one bad iteration must not kill the session
       const prefs = deps.loadEffectiveGSDPreferences()?.preferences;
       const uokFlags = resolveUokFlags(prefs);
+
+      if (await handlePendingHookOutcome({ s, ctx, pi, pauseAuto: deps.pauseAuto })) {
+        finishTurn("stopped", "manual-attention", "gate-blocked", "gate-blocked");
+        break;
+      }
 
       // ── Check sidecar queue before deriveState ──
       // NOTE: Sidecar dequeue MUST run before validateWorkflowSessionLock so a

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -351,8 +351,8 @@ In `"parent"` mode, slice/task `targetRepositories` default to the declared chil
   - `prompt`: string — prompt sent to the LLM. Supports `{milestoneId}`, `{sliceId}`, `{taskId}` substitutions.
   - `max_cycles`: number — max times this hook fires per trigger (default: 1, max: 10).
   - `model`: optional model override. Accepts a bare model ID **or** the same `{ model, provider?, fallbacks? }` object form as `models.<phase>`. With `fallbacks[]`, a transient trip of the primary provider falls back to the next entry instead of hard-failing the hook — which, for a `blocking` hook with `on_block: { action: pause }`, would otherwise pause the whole run.
-  - `artifact`: string — expected output file name (relative to task/slice dir). Hook is skipped if file already exists (idempotent).
-  - `criticality`: `"advisory"` or `"blocking"` — advisory preserves current best-effort behavior; blocking requires clean hook completion plus a valid outcome verdict before auto-mode advances. Default: `"advisory"`.
+  - `artifact`: string — expected output file name (relative to task/slice dir). Advisory hooks skip an existing artifact; blocking hooks assess its outcome before continuing.
+  - `criticality`: `"advisory"` or `"blocking"` — advisory preserves best-effort behavior in auto mode and is skipped in step mode (`/gsd next`). Blocking hooks require clean completion plus a valid outcome verdict before either mode advances. Default: `"advisory"`.
   - `retry_on`: string — if this file is produced instead of the artifact, re-run the trigger unit then re-run hooks.
   - `on_block`: object — optional routing for blocking findings:
     - `action`: `"retry-unit"`, `"retry-task"`, `"queue-task"`, `"queue-slice"`, or `"pause"`.
@@ -363,6 +363,11 @@ In `"parent"` mode, slice/task `targetRepositories` default to the declared chil
   Blocking hook artifacts must begin with YAML frontmatter containing either `verdict` or `outcome.verdict`.
   Supported verdicts are `pass`, `advisory`, `needs-rework`, `needs-remediation`, and `needs-attention`.
   `pass` and `advisory` continue; `needs-rework` retries the trigger unit when routed with `retry-unit`/`retry-task`; `needs-remediation` and `needs-attention` pause with recovery guidance.
+  Pending gate blocks survive pause/resume, including queued sibling gates and
+  the trigger's completion identity for retry routing. Resume reconciles these
+  gates before selecting the next unit: a resolved gate releases its siblings;
+  a sibling that still needs attention holds selection. Doctor's stale hook-state
+  cleanup preserves pending gate blocks.
   Hook artifacts are compatibility inputs to hook routing, not lifecycle
   authority. Any resulting Task or Slice retry, cancellation, completion, or
   reopen still commits through the canonical database operation; editing a hook

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -290,9 +290,14 @@ export async function checkRuntimeHealth(
       const state = JSON.parse(raw);
       const hasCycleCounts = state.cycleCounts && typeof state.cycleCounts === "object"
         && Object.keys(state.cycleCounts).length > 0;
+      // A persisted gate block re-arms a failed blocking gate on resume;
+      // clearing it would let unreviewed work execute, so it is never stale (#2194).
+      const hasPendingGateBlock = state.gateBlockPending
+        && typeof state.gateBlockPending === "object"
+        && typeof state.gateBlockPending.hookName === "string";
 
       // Only flag if there are actual cycle counts AND no auto-mode is running
-      if (hasCycleCounts) {
+      if (hasCycleCounts && !hasPendingGateBlock) {
         const lock = readCrashLock(basePath);
         const autoRunning = lock ? isLockProcessAlive(lock) : false;
 

--- a/src/resources/extensions/gsd/post-unit-hooks.ts
+++ b/src/resources/extensions/gsd/post-unit-hooks.ts
@@ -27,8 +27,9 @@ export function checkPostUnitHooks(
   completedUnitType: string,
   completedUnitId: string,
   basePath: string,
+  opts?: { blockingOnly?: boolean },
 ): HookDispatchResult | null {
-  return getOrCreateRegistry().evaluatePostUnit(completedUnitType, completedUnitId, basePath);
+  return getOrCreateRegistry().evaluatePostUnit(completedUnitType, completedUnitId, basePath, opts);
 }
 
 export function getActiveHook(): HookExecutionState | null {
@@ -88,6 +89,25 @@ export function restoreHookState(basePath: string): void {
   getOrCreateRegistry().restoreState(basePath);
 }
 
+/** Shared tail of the resume reconciles: enqueue a hook dispatch unless an
+ *  equivalent item is already queued. */
+function enqueueHookDispatch(
+  dispatch: HookDispatchResult,
+  sidecarQueue: SidecarItem[],
+): void {
+  const alreadyQueued = sidecarQueue.some(
+    item => item.kind === "hook" && item.unitType === dispatch.unitType,
+  );
+  if (alreadyQueued) return;
+  sidecarQueue.push({
+    kind: "hook",
+    unitType: dispatch.unitType,
+    unitId: dispatch.unitId,
+    prompt: dispatch.prompt,
+    model: dispatch.model,
+  });
+}
+
 /**
  * Reconcile a restored `activeHook` against the session's sidecar queue.
  *
@@ -106,17 +126,26 @@ export function reconcileRestoredHookDispatch(
 ): void {
   const dispatch = getOrCreateRegistry().getPendingHookDispatch(basePath);
   if (!dispatch) return;
-  const alreadyQueued = sidecarQueue.some(
-    item => item.kind === "hook" && item.unitType === dispatch.unitType,
-  );
-  if (alreadyQueued) return;
-  sidecarQueue.push({
-    kind: "hook",
-    unitType: dispatch.unitType,
-    unitId: dispatch.unitId,
-    prompt: dispatch.prompt,
-    model: dispatch.model,
-  });
+  enqueueHookDispatch(dispatch, sidecarQueue);
+}
+
+/**
+ * Reconcile a restored gate block against the session's sidecar queue (#2194).
+ *
+ * A blocking gate that paused auto-mode clears `activeHook` and persists its
+ * block. Without this, resume finds no hook dispatch and the next
+ * `/gsd next`/`/gsd auto` can select an execute-task unit without the hook
+ * passing. Re-enqueue the blocked hook so it re-runs before any unit is
+ * selected; the registry re-arms it as in-flight so its completion is
+ * re-assessed against the gate artifact.
+ */
+export function reconcileRestoredGateBlock(
+  basePath: string,
+  sidecarQueue: SidecarItem[],
+): void {
+  const dispatch = getOrCreateRegistry().reconcileRestoredGateBlock(basePath);
+  if (!dispatch) return;
+  enqueueHookDispatch(dispatch, sidecarQueue);
 }
 
 export function clearPersistedHookState(basePath: string): void {

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -231,6 +231,15 @@ function captureTaskCompletionIdentity(trigger: HookTriggerRef): Pick<
   );
 }
 
+type HookQueueEntry = {
+  config: PostUnitHookConfig;
+  triggerUnitType: string;
+  triggerUnitId: string;
+  forceRun?: boolean;
+  completionOperationId?: string;
+  legacyCompletedAt?: string;
+};
+
 interface GateOutcome {
   verdict?: PostUnitHookOutcomeVerdict | "failed";
   artifact?: string;
@@ -277,6 +286,8 @@ export class RuleRegistry {
   retryTrigger: RetryTrigger | null = null;
   hookFailure: HookFailureState | null = null;
   gateBlockPending: PostUnitGateBlock | null = null;
+  /** Hooks queued behind the blocked gate, held for re-queue on resume (#2194). */
+  gateBlockQueue: HookQueueEntry[] = [];
 
   constructor(dispatchRules: UnifiedRule[]) {
     this.dispatchRules = dispatchRules;
@@ -358,6 +369,7 @@ export class RuleRegistry {
     completedUnitType: string,
     completedUnitId: string,
     basePath: string,
+    opts?: { blockingOnly?: boolean },
   ): HookDispatchResult | null {
     // If we just completed a hook unit, handle its result
     if (this.activeHook) {
@@ -381,7 +393,13 @@ export class RuleRegistry {
     const hooks = resolvePostUnitHooks(basePath).filter(h =>
       h.after.includes(completedUnitType),
     );
-    if (hooks.length === 0) return null;
+    // `blockingOnly` (step mode) skips advisory hooks: only `criticality:
+    // blocking` gates dispatch there, so a gate can never be bypassed by
+    // running the workflow one step at a time (#2194).
+    const queueHooks = opts?.blockingOnly
+      ? hooks.filter(h => isBlockingHook(h))
+      : hooks;
+    if (queueHooks.length === 0) return null;
 
     const completionIdentity = captureTaskCompletionIdentity({
       triggerUnitType: completedUnitType,
@@ -390,7 +408,7 @@ export class RuleRegistry {
     if (!completionIdentity) return null;
 
     // Build hook queue for this trigger
-    this.hookQueue = hooks.map(config => ({
+    this.hookQueue = queueHooks.map(config => ({
       config,
       triggerUnitType: completedUnitType,
       triggerUnitId: completedUnitId,
@@ -451,7 +469,12 @@ export class RuleRegistry {
         const maxCycles = hookMaxCycles(config);
         const currentCycle = this.cycleCounts.get(cycleKey) ?? 0;
         if (currentCycle >= maxCycles) {
-          this._setGateBlock(config, { triggerUnitType, triggerUnitId }, {
+          this._setGateBlock(config, {
+            triggerUnitType,
+            triggerUnitId,
+            completionOperationId,
+            legacyCompletedAt,
+          }, {
             action: "pause",
             reason: `gate cycle budget exhausted before ${config.name} produced a passing outcome`,
             cycle: currentCycle,
@@ -572,6 +595,44 @@ export class RuleRegistry {
     );
     if (!config) return null;
     return this._buildHookDispatch(config, this.activeHook.triggerUnitId);
+  }
+
+  /**
+   * Re-arm a persisted gate block after resume (#2194).
+   *
+   * A gate block clears `activeHook` before the pause, so a resumed session
+   * would otherwise find no hook state and select the next unit without a
+   * passing verdict. Re-arm restores the blocked gate to its in-flight shape:
+   * the block is consumed, `activeHook` is set (with the captured trigger
+   * completion identity, so needs-rework can reopen the task) so the re-run's
+   * completion is assessed against the gate artifact, and the dispatch is
+   * returned for the caller to enqueue. If the artifact already carries a
+   * passing verdict the block is dropped without rerunning the hook. Hooks
+   * queued behind the blocked gate are re-queued either way so they still
+   * run once the gate resolves.
+   */
+  reconcileRestoredGateBlock(basePath: string): HookDispatchResult | null {
+    const block = this.gateBlockPending;
+    if (!block) return null;
+    this.gateBlockPending = null;
+    this.hookQueue = this.gateBlockQueue;
+    this.gateBlockQueue = [];
+    const config = resolvePostUnitHooks(basePath).find(h => h.name === block.hookName);
+    if (!config) return this._dequeueNextHook(basePath);
+    const outcome = this._readGateOutcome(config, block, basePath);
+    if (outcome.verdict === "pass" || outcome.verdict === "advisory") {
+      return this._dequeueNextHook(basePath);
+    }
+    this.activeHook = {
+      hookName: config.name,
+      triggerUnitType: block.triggerUnitType,
+      triggerUnitId: block.triggerUnitId,
+      cycle: this.cycleCounts.get(hookCycleKey(config, block)) ?? 1,
+      pendingRetry: false,
+      ...(block.completionOperationId ? { completionOperationId: block.completionOperationId } : {}),
+      ...(block.legacyCompletedAt ? { legacyCompletedAt: block.legacyCompletedAt } : {}),
+    };
+    return this._buildHookDispatch(config, block.triggerUnitId);
   }
 
   private _assessHookCompletion(
@@ -936,6 +997,8 @@ export class RuleRegistry {
       hookName: config.name,
       triggerUnitType: trigger.triggerUnitType,
       triggerUnitId: trigger.triggerUnitId,
+      ...(trigger.completionOperationId ? { completionOperationId: trigger.completionOperationId } : {}),
+      ...(trigger.legacyCompletedAt ? { legacyCompletedAt: trigger.legacyCompletedAt } : {}),
       artifact: opts.outcome?.artifact ?? config.artifact,
       artifactPath: opts.outcome?.artifactPath,
       verdict: opts.outcome?.verdict,
@@ -945,6 +1008,10 @@ export class RuleRegistry {
       maxCycles: opts.maxCycles ?? hookMaxCycles(config),
       retryArtifact: opts.retryArtifact,
     };
+    // Capture the hooks still queued behind the blocked gate so resume can
+    // re-queue them; otherwise later gates are silently skipped once the
+    // blocked gate resolves (#2194).
+    this.gateBlockQueue = [...this.hookQueue];
   }
 
   // ── Pre-dispatch hook evaluation (sync, all-matching with compose) ──
@@ -1097,6 +1164,7 @@ export class RuleRegistry {
     this.retryTrigger = null;
     this.hookFailure = null;
     this.gateBlockPending = null;
+    this.gateBlockQueue = [];
   }
 
   // ── Persistence ─────────────────────────────────────────────────────
@@ -1131,6 +1199,15 @@ export class RuleRegistry {
       })),
       retryPending: this.retryPending,
       retryTrigger: this.retryTrigger ? { ...this.retryTrigger } : null,
+      gateBlockPending: this.gateBlockPending ? { ...this.gateBlockPending } : null,
+      gateBlockQueue: this.gateBlockQueue.map(entry => ({
+        hookName: entry.config.name,
+        triggerUnitType: entry.triggerUnitType,
+        triggerUnitId: entry.triggerUnitId,
+        forceRun: entry.forceRun,
+        completionOperationId: entry.completionOperationId,
+        legacyCompletedAt: entry.legacyCompletedAt,
+      })),
       savedAt: new Date().toISOString(),
     };
     const dir = join(basePath, ".gsd");
@@ -1167,23 +1244,7 @@ export class RuleRegistry {
       this.activeHook = state.activeHook && typeof state.activeHook === "object"
         ? { ...state.activeHook }
         : null;
-      this.hookQueue = [];
-      if (Array.isArray(state.hookQueue)) {
-        const hooks = resolvePostUnitHooks(basePath);
-        for (const entry of state.hookQueue) {
-          const config = hooks.find(h => h.name === entry.hookName);
-          if (config) {
-            this.hookQueue.push({
-              config,
-              triggerUnitType: entry.triggerUnitType,
-              triggerUnitId: entry.triggerUnitId,
-              forceRun: entry.forceRun,
-              completionOperationId: entry.completionOperationId,
-              legacyCompletedAt: entry.legacyCompletedAt,
-            });
-          }
-        }
-      }
+      this.hookQueue = this._restoreQueueEntries(basePath, state.hookQueue);
       const retryTrigger = state.retryTrigger;
       if (
         state.retryPending === true &&
@@ -1197,9 +1258,47 @@ export class RuleRegistry {
         this.retryPending = false;
         this.retryTrigger = null;
       }
+      const gateBlock = state.gateBlockPending;
+      if (
+        gateBlock &&
+        typeof gateBlock === "object" &&
+        typeof gateBlock.hookName === "string" &&
+        typeof gateBlock.triggerUnitType === "string" &&
+        typeof gateBlock.triggerUnitId === "string"
+      ) {
+        this.gateBlockPending = { ...gateBlock };
+      } else {
+        this.gateBlockPending = null;
+      }
+      this.gateBlockQueue = this._restoreQueueEntries(basePath, state.gateBlockQueue);
     } catch (e) {
       logWarning("registry", `failed to restore hook state: ${(e as Error).message}`);
     }
+  }
+
+  /** Rehydrate persisted queue entries against current hook configuration;
+   *  entries whose hook no longer exists are dropped. */
+  private _restoreQueueEntries(
+    basePath: string,
+    entries: PersistedHookState["hookQueue"] | PersistedHookState["gateBlockQueue"],
+  ): HookQueueEntry[] {
+    const restored: HookQueueEntry[] = [];
+    if (!Array.isArray(entries)) return restored;
+    const hooks = resolvePostUnitHooks(basePath);
+    for (const entry of entries) {
+      const config = hooks.find(h => h.name === entry.hookName);
+      if (config) {
+        restored.push({
+          config,
+          triggerUnitType: entry.triggerUnitType,
+          triggerUnitId: entry.triggerUnitId,
+          forceRun: entry.forceRun,
+          completionOperationId: entry.completionOperationId,
+          legacyCompletedAt: entry.legacyCompletedAt,
+        });
+      }
+    }
+    return restored;
   }
 
   /** Clear persisted hook state file from disk. */
@@ -1216,6 +1315,8 @@ export class RuleRegistry {
             hookQueue: [],
             retryPending: false,
             retryTrigger: null,
+            gateBlockPending: null,
+            gateBlockQueue: [],
             savedAt: new Date().toISOString(),
           }, null, 2),
           "utf-8",

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -451,7 +451,7 @@ export class RuleRegistry {
             );
           }
           if (!isBlockingHook(config)) continue;
-          const decision = this._handleExistingBlockingArtifact(config, { triggerUnitType, triggerUnitId }, basePath);
+          const decision = this._handleExistingBlockingArtifact(config, entry, basePath);
           if (decision === "skip") continue;
           return decision;
         }

--- a/src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts
@@ -193,3 +193,46 @@ test("doctor surfaces unresolved projection evidence with recovery instructions"
   assert.match(issue.message, /--action=restore/u);
   assert.equal(issue.fixable, false);
 });
+
+test("doctor fix preserves a pending gate block in hook-state.json (#2194)", async (t) => {
+  const dir = createGitProject();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  const hookStatePath = join(dir, ".gsd", "hook-state.json");
+  const writeHookState = (gateBlockPending: unknown): void => {
+    writeFileSync(hookStatePath, JSON.stringify({
+      cycleCounts: { "slice-plan-review/plan-slice/M001/S01": 1 },
+      redispatchedGateKeys: [],
+      activeHook: null,
+      hookQueue: [],
+      retryPending: false,
+      retryTrigger: null,
+      gateBlockPending,
+      savedAt: new Date().toISOString(),
+    }), "utf-8");
+  };
+  writeHookState({
+    hookName: "slice-plan-review",
+    triggerUnitType: "plan-slice",
+    triggerUnitId: "M001/S01",
+    artifact: "SLICE-REVIEW.md",
+    action: "pause",
+    reason: "gate cycle budget exhausted before slice-plan-review produced a passing outcome",
+    cycle: 1,
+    maxCycles: 1,
+  });
+
+  // A pending block re-arms a failed gate on resume; the stale-state fix
+  // must not erase it.
+  await runGSDDoctor(dir, { fix: true });
+  const preserved = JSON.parse(readFileSync(hookStatePath, "utf-8"));
+  assert.equal(preserved.gateBlockPending?.hookName, "slice-plan-review");
+  assert.equal(preserved.gateBlockPending?.triggerUnitId, "M001/S01");
+
+  // Without a pending block the same residual state is still stale and cleared.
+  writeHookState(null);
+  await runGSDDoctor(dir, { fix: true });
+  const cleared = JSON.parse(readFileSync(hookStatePath, "utf-8"));
+  assert.deepEqual(cleared.cycleCounts, {});
+});

--- a/src/resources/extensions/gsd/tests/post-unit-hooks-step-mode.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-hooks-step-mode.test.ts
@@ -1,0 +1,644 @@
+// GSD Extension — Post-unit hooks under /gsd next step mode (#2194).
+//
+// `/gsd next` runs the auto workflow with stepMode=true, and the post-unit
+// hook path used to be guarded by `!s.stepMode`. A `criticality: blocking`
+// hook after plan-slice was therefore bypassed, letting an unreviewed plan
+// reach task execution. These tests pin the step-mode contract:
+//   - a blocking hook dispatches before any execute-task unit can be selected
+//   - a passing hook artifact lets selection proceed (wizard surfaces)
+//   - a failed/exhausted blocking hook pauses instead of exposing execution
+//   - non-blocking hooks keep their step-mode behavior (skipped)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mock } from "node:test";
+
+import { postUnitPostVerification, type PostUnitContext } from "../auto-post-unit.ts";
+import { AutoSession } from "../auto/session.ts";
+import {
+  checkPostUnitHooks,
+  consumeGateBlock,
+  getActiveHook,
+  persistHookState,
+  reconcileRestoredGateBlock,
+  reconcileRestoredHookDispatch,
+  resetHookState,
+  resolveHookArtifactPath,
+  restoreHookState,
+} from "../post-unit-hooks.ts";
+import { _clearGsdRootCache } from "../paths.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  closeDatabase,
+  getTask,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../gsd-db.ts";
+import { executeDomainOperation } from "../db/domain-operation.ts";
+import {
+  adoptOrTransitionLifecycle,
+  completeLegacyTaskForVerifiedAttempt,
+  readDomainOperationFence,
+} from "../db/writers/lifecycle-commands.ts";
+
+function writePreferences(basePath: string, hookYaml: string): void {
+  const content = `---
+post_unit_hooks:
+${hookYaml}
+---
+`;
+  writeFileSync(join(basePath, ".gsd", "PREFERENCES.md"), content, "utf-8");
+  invalidateAllCaches();
+}
+
+const BLOCKING_PLAN_SLICE_HOOK = `  - name: slice-plan-review
+    after:
+      - plan-slice
+    criticality: blocking
+    artifact: SLICE-REVIEW.md
+    max_cycles: 2
+    enabled: true
+    prompt: Review the slice plan and write a frontmatter verdict.
+`;
+
+const BLOCKING_PLAN_SLICE_HOOK_ONE_CYCLE = `  - name: slice-plan-review
+    after:
+      - plan-slice
+    criticality: blocking
+    artifact: SLICE-REVIEW.md
+    max_cycles: 1
+    enabled: true
+    prompt: Review the slice plan and write a frontmatter verdict.
+`;
+
+const ADVISORY_PLAN_SLICE_HOOK = `  - name: slice-plan-review
+    after:
+      - plan-slice
+    artifact: SLICE-REVIEW.md
+    enabled: true
+    prompt: Review the slice plan and write a frontmatter verdict.
+`;
+
+const MIXED_PLAN_SLICE_HOOKS = `  - name: plan-hint
+    after:
+      - plan-slice
+    artifact: PLAN-HINT.md
+    enabled: true
+    prompt: Leave a documentation hint.
+  - name: slice-plan-review
+    after:
+      - plan-slice
+    criticality: blocking
+    artifact: SLICE-REVIEW.md
+    max_cycles: 2
+    enabled: true
+    prompt: Review the slice plan and write a frontmatter verdict.
+`;
+
+const TWO_BLOCKING_PLAN_SLICE_HOOKS = `  - name: gate-a
+    after:
+      - plan-slice
+    criticality: blocking
+    artifact: GATE-A.md
+    max_cycles: 1
+    enabled: true
+    prompt: Gate A.
+  - name: gate-b
+    after:
+      - plan-slice
+    criticality: blocking
+    artifact: GATE-B.md
+    max_cycles: 1
+    enabled: true
+    prompt: Gate B.
+`;
+
+const EXECUTE_TASK_BLOCKING_HOOK = `  - name: review-gate
+    after:
+      - execute-task
+    criticality: blocking
+    artifact: REVIEW.md
+    max_cycles: 2
+    enabled: true
+    prompt: Review the task.
+`;
+
+interface StepModeHarness {
+  base: string;
+  session: AutoSession;
+  pctx: PostUnitContext;
+  pauseAuto: ReturnType<typeof mock.fn>;
+}
+
+function createPctx(basePath: string, session: AutoSession): { pctx: PostUnitContext; pauseAuto: ReturnType<typeof mock.fn> } {
+  const pauseAuto = mock.fn(async () => {});
+  return {
+    pauseAuto,
+    pctx: {
+      s: session,
+      ctx: {
+        ui: { notify: () => {}, setStatus: () => {}, setWidget: () => {}, setFooter: () => {} },
+        model: { id: "test-model" },
+      } as any,
+      pi: { sendMessage: async () => {}, setModel: async () => true } as any,
+      buildSnapshotOpts: () => ({}),
+      lockBase: () => basePath,
+      stopAuto: async () => {},
+      pauseAuto,
+      updateProgressWidget: () => {},
+    },
+  };
+}
+
+function createStepModeHarness(basePath: string, unitType: string, unitId: string): StepModeHarness {
+  const session = new AutoSession();
+  session.basePath = basePath;
+  session.active = true;
+  session.stepMode = true;
+  session.currentUnit = { type: unitType, id: unitId, startedAt: Date.now() };
+  const { pctx, pauseAuto } = createPctx(basePath, session);
+  return { base: basePath, session, pctx, pauseAuto };
+}
+
+function setupFixture(prefix: string, hookYaml: string): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  writePreferences(base, hookYaml);
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active" });
+  return base;
+}
+
+test("step mode dispatches a blocking plan-slice hook before any execute-task unit can be selected", async () => {
+  const originalCwd = process.cwd();
+  let base = "";
+  try {
+    base = setupFixture("gsd-step-blocking-hook-", BLOCKING_PLAN_SLICE_HOOK);
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+
+    const { pctx, session } = createStepModeHarness(base, "plan-slice", "M001/S01");
+
+    const result = await postUnitPostVerification(pctx);
+
+    assert.equal(result, "continue", "loop continues to run the dispatched hook unit");
+    const queued = session.sidecarQueue;
+    assert.equal(queued.length, 1, "exactly the hook sidecar is enqueued");
+    assert.equal(queued[0].kind, "hook");
+    assert.equal(queued[0].unitType, "hook/slice-plan-review");
+    assert.equal(queued[0].unitId, "M001/S01");
+    assert.ok(getActiveHook(), "registry tracks the in-flight blocking hook");
+    assert.equal(consumeGateBlock(), null, "no gate block while the hook is in flight");
+  } finally {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("after the blocking hook records a passing verdict, step-mode selection proceeds", async () => {
+  const originalCwd = process.cwd();
+  let base = "";
+  try {
+    base = setupFixture("gsd-step-blocking-pass-", BLOCKING_PLAN_SLICE_HOOK);
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+
+    const { pctx, session } = createStepModeHarness(base, "plan-slice", "M001/S01");
+    assert.equal(await postUnitPostVerification(pctx), "continue");
+    session.clearCurrentUnit();
+    session.sidecarQueue.length = 0; // the loop drains the enqueued hook dispatch
+
+    // The hook unit completes and writes a passing gate artifact.
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01", "SLICE-REVIEW.md"),
+      "---\nverdict: pass\n---\n\nPlan reviewed. No blocking findings.\n",
+      "utf-8",
+    );
+    session.currentUnit = { type: "hook/slice-plan-review", id: "M001/S01", startedAt: Date.now() };
+
+    const result = await postUnitPostVerification(pctx);
+
+    assert.equal(result, "step-wizard", "wizard surfaces so the next unit can be selected");
+    assert.equal(session.sidecarQueue.length, 0, "passing gate is not re-dispatched");
+    assert.equal(getActiveHook(), null, "gate is cleared after a passing verdict");
+    assert.equal(consumeGateBlock(), null, "passing gate does not block");
+  } finally {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("blocking hook failure under step mode pauses instead of exposing task execution", async () => {
+  const originalCwd = process.cwd();
+  let base = "";
+  try {
+    base = setupFixture("gsd-step-blocking-fail-", BLOCKING_PLAN_SLICE_HOOK_ONE_CYCLE);
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+
+    const { pctx, session, pauseAuto } = createStepModeHarness(base, "plan-slice", "M001/S01");
+    assert.equal(await postUnitPostVerification(pctx), "continue");
+    session.clearCurrentUnit();
+    session.sidecarQueue.length = 0; // the loop drains the enqueued hook dispatch
+
+    // The hook unit completes but its artifact carries no frontmatter verdict;
+    // with max_cycles exhausted the gate must block the advance.
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01", "SLICE-REVIEW.md"),
+      "review notes without a verdict",
+      "utf-8",
+    );
+    session.currentUnit = { type: "hook/slice-plan-review", id: "M001/S01", startedAt: Date.now() };
+
+    const result = await postUnitPostVerification(pctx);
+
+    assert.equal(result, "stopped", "gate failure pauses instead of returning a step action");
+    assert.equal(pauseAuto.mock.callCount(), 1, "auto-mode is paused for manual recovery");
+    assert.equal(session.sidecarQueue.length, 0, "no further unit is dispatched");
+  } finally {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("non-blocking hooks keep their step-mode behavior and stay skipped", async () => {
+  const originalCwd = process.cwd();
+  let base = "";
+  try {
+    base = setupFixture("gsd-step-advisory-hook-", ADVISORY_PLAN_SLICE_HOOK);
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+
+    const { pctx, session } = createStepModeHarness(base, "plan-slice", "M001/S01");
+
+    const result = await postUnitPostVerification(pctx);
+
+    assert.equal(result, "step-wizard", "step completes and the wizard surfaces as today");
+    assert.equal(session.sidecarQueue.length, 0, "advisory hook is not dispatched in step mode");
+    assert.equal(getActiveHook(), null, "no hook state is created");
+  } finally {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("failed gate block persists and resume re-dispatches the blocked hook before selection", async () => {
+  const originalCwd = process.cwd();
+  let base = "";
+  try {
+    base = setupFixture("gsd-step-gate-resume-", BLOCKING_PLAN_SLICE_HOOK_ONE_CYCLE);
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+
+    // plan-slice completes; the hook dispatches.
+    const first = createStepModeHarness(base, "plan-slice", "M001/S01");
+    assert.equal(await postUnitPostVerification(first.pctx), "continue");
+    first.session.clearCurrentUnit();
+    first.session.sidecarQueue.length = 0; // loop drains and runs the hook
+
+    // The hook completes without a verdict: the gate blocks and pauses.
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01", "SLICE-REVIEW.md"),
+      "review notes without a verdict",
+      "utf-8",
+    );
+    first.session.currentUnit = { type: "hook/slice-plan-review", id: "M001/S01", startedAt: Date.now() };
+    assert.equal(await postUnitPostVerification(first.pctx), "stopped");
+
+    // Resume (auto.ts order: restore, then reconcile dispatches + gate blocks).
+    resetHookState();
+    restoreHookState(base);
+    const resumed = new AutoSession();
+    resumed.basePath = base;
+    resumed.active = true;
+    resumed.stepMode = true;
+    reconcileRestoredHookDispatch(base, resumed.sidecarQueue);
+    reconcileRestoredGateBlock(base, resumed.sidecarQueue);
+
+    assert.equal(resumed.sidecarQueue.length, 1, "the blocked hook is re-dispatched on resume");
+    assert.equal(resumed.sidecarQueue[0].kind, "hook");
+    assert.equal(resumed.sidecarQueue[0].unitType, "hook/slice-plan-review");
+    assert.ok(getActiveHook(), "the gate is re-armed in flight so its completion is re-assessed");
+    assert.equal(consumeGateBlock(), null, "the block is superseded by the re-dispatch");
+    resumed.sidecarQueue.length = 0; // loop drains and runs the re-dispatched hook
+
+    // The re-run records a passing verdict: selection may finally proceed.
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01", "SLICE-REVIEW.md"),
+      "---\nverdict: pass\n---\n\nPlan reviewed. No blocking findings.\n",
+      "utf-8",
+    );
+    resumed.currentUnit = { type: "hook/slice-plan-review", id: "M001/S01", startedAt: Date.now() };
+    const { pctx } = createPctx(base, resumed);
+    assert.equal(await postUnitPostVerification(pctx), "step-wizard");
+    assert.equal(resumed.sidecarQueue.length, 0, "passing gate is not re-dispatched");
+    assert.equal(getActiveHook(), null, "gate clears after the re-run passes");
+  } finally {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("resume with an already-passing gate artifact holds no dispatch and clears the block", async () => {
+  const originalCwd = process.cwd();
+  let base = "";
+  try {
+    base = setupFixture("gsd-step-gate-resolved-", BLOCKING_PLAN_SLICE_HOOK_ONE_CYCLE);
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+
+    const first = createStepModeHarness(base, "plan-slice", "M001/S01");
+    assert.equal(await postUnitPostVerification(first.pctx), "continue");
+    first.session.clearCurrentUnit();
+    first.session.sidecarQueue.length = 0;
+
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01", "SLICE-REVIEW.md"),
+      "review notes without a verdict",
+      "utf-8",
+    );
+    first.session.currentUnit = { type: "hook/slice-plan-review", id: "M001/S01", startedAt: Date.now() };
+    assert.equal(await postUnitPostVerification(first.pctx), "stopped");
+
+    // The review is completed manually while paused; resume must not rerun
+    // an already valid hook and must not hold selection.
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01", "SLICE-REVIEW.md"),
+      "---\nverdict: pass\n---\n\nPlan reviewed manually during the pause.\n",
+      "utf-8",
+    );
+    resetHookState();
+    restoreHookState(base);
+    const resumed = new AutoSession();
+    resumed.basePath = base;
+    resumed.active = true;
+    resumed.stepMode = true;
+    reconcileRestoredHookDispatch(base, resumed.sidecarQueue);
+    reconcileRestoredGateBlock(base, resumed.sidecarQueue);
+
+    assert.equal(resumed.sidecarQueue.length, 0, "passing artifact clears the block without a rerun");
+    assert.equal(getActiveHook(), null);
+    assert.equal(consumeGateBlock(), null);
+  } finally {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("step mode runs only the blocking hook from a mixed advisory+blocking queue", async () => {
+  const originalCwd = process.cwd();
+  let base = "";
+  try {
+    base = setupFixture("gsd-step-mixed-hooks-", MIXED_PLAN_SLICE_HOOKS);
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+
+    const { pctx, session } = createStepModeHarness(base, "plan-slice", "M001/S01");
+    const result = await postUnitPostVerification(pctx);
+
+    assert.equal(result, "continue");
+    assert.equal(session.sidecarQueue.length, 1, "only the blocking hook dispatches in step mode");
+    assert.equal(session.sidecarQueue[0].unitType, "hook/slice-plan-review");
+    session.clearCurrentUnit();
+    session.sidecarQueue.length = 0;
+
+    // The blocking gate passes; the advisory hook must stay skipped.
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01", "SLICE-REVIEW.md"),
+      "---\nverdict: pass\n---\n\nPlan reviewed. No blocking findings.\n",
+      "utf-8",
+    );
+    session.currentUnit = { type: "hook/slice-plan-review", id: "M001/S01", startedAt: Date.now() };
+    assert.equal(await postUnitPostVerification(pctx), "step-wizard");
+    assert.equal(session.sidecarQueue.length, 0, "advisory hook remains skipped after the gate passes");
+    assert.equal(getActiveHook(), null);
+  } finally {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+function seedCompletedTaskLifecycle(idempotencyKey: string): void {
+  const fence = readDomainOperationFence();
+  executeDomainOperation({
+    operationType: `test.task.completed.${idempotencyKey}`,
+    idempotencyKey,
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: "test",
+    sourceTransport: "test",
+    payload: {},
+  }, (context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      lifecycleStatus: "completed",
+    });
+    completeLegacyTaskForVerifiedAttempt(context, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+    });
+    return {
+      events: [{
+        eventType: `test.task.completed.${idempotencyKey}`,
+        entityType: "task",
+        entityId: "M001/S01/T01",
+        payload: {},
+        destinations: ["test"],
+      }],
+      projections: [{
+        projectionKey: `test/task/${idempotencyKey}`,
+        projectionKind: "test",
+        rendererVersion: "1",
+      }],
+    };
+  });
+}
+
+test("resume after gate A blocks still runs queued gate B once A passes", async () => {
+  const originalCwd = process.cwd();
+  let base = "";
+  try {
+    base = setupFixture("gsd-step-two-gates-", TWO_BLOCKING_PLAN_SLICE_HOOKS);
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+
+    // plan-slice completes; gate-a (first in queue) dispatches.
+    const first = createStepModeHarness(base, "plan-slice", "M001/S01");
+    assert.equal(await postUnitPostVerification(first.pctx), "continue");
+    assert.equal(first.session.sidecarQueue[0].unitType, "hook/gate-a");
+    first.session.clearCurrentUnit();
+    first.session.sidecarQueue.length = 0;
+
+    // gate-a completes without a verdict; its cycle budget is exhausted, so
+    // the gate blocks with gate-b still queued behind it.
+    first.session.currentUnit = { type: "hook/gate-a", id: "M001/S01", startedAt: Date.now() };
+    assert.equal(await postUnitPostVerification(first.pctx), "stopped");
+
+    // Resume: gate-a is re-armed, and gate-b must be restored with it.
+    resetHookState();
+    restoreHookState(base);
+    const resumed = new AutoSession();
+    resumed.basePath = base;
+    resumed.active = true;
+    resumed.stepMode = true;
+    reconcileRestoredHookDispatch(base, resumed.sidecarQueue);
+    reconcileRestoredGateBlock(base, resumed.sidecarQueue);
+    assert.equal(resumed.sidecarQueue.length, 1);
+    assert.equal(resumed.sidecarQueue[0].unitType, "hook/gate-a");
+    resumed.sidecarQueue.length = 0;
+
+    // gate-a's re-run passes; gate-b must dispatch next — not be skipped.
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01", "GATE-A.md"),
+      "---\nverdict: pass\n---\n\nGate A passed.\n",
+      "utf-8",
+    );
+    resumed.currentUnit = { type: "hook/gate-a", id: "M001/S01", startedAt: Date.now() };
+    const { pctx } = createPctx(base, resumed);
+    assert.equal(await postUnitPostVerification(pctx), "continue");
+    assert.equal(resumed.sidecarQueue.length, 1, "gate-b runs after gate-a passes");
+    assert.equal(resumed.sidecarQueue[0].unitType, "hook/gate-b");
+    resumed.sidecarQueue.length = 0;
+
+    // gate-b passes; selection may finally proceed.
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01", "GATE-B.md"),
+      "---\nverdict: pass\n---\n\nGate B passed.\n",
+      "utf-8",
+    );
+    resumed.currentUnit = { type: "hook/gate-b", id: "M001/S01", startedAt: Date.now() };
+    assert.equal(await postUnitPostVerification(pctx), "step-wizard");
+    assert.equal(resumed.sidecarQueue.length, 0);
+    assert.equal(getActiveHook(), null);
+  } finally {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("resume re-arms an execute-task gate with completion identity and schedules rework", async () => {
+  const originalCwd = process.cwd();
+  let base = "";
+  try {
+    base = setupFixture("gsd-step-gate-rework-", EXECUTE_TASK_BLOCKING_HOOK);
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+    insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task", status: "complete" });
+    seedCompletedTaskLifecycle("gsd-step-gate-rework-op");
+
+    // execute-task completed: the gate dispatches carrying the canonical
+    // completion operation, then pauses the task on needs-attention.
+    const dispatch = checkPostUnitHooks("execute-task", "M001/S01/T01", base);
+    assert.ok(dispatch, "gate dispatches for the completed task");
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01/T01", "REVIEW.md"),
+      "---\nverdict: needs-attention\n---\n\nNeeds human attention.\n",
+      "utf-8",
+    );
+    assert.equal(checkPostUnitHooks("hook/review-gate", "M001/S01/T01", base), null);
+    persistHookState(base);
+
+    // Resume: the re-armed gate keeps the completion identity.
+    resetHookState();
+    restoreHookState(base);
+    const resumed = new AutoSession();
+    resumed.basePath = base;
+    resumed.active = true;
+    resumed.stepMode = true;
+    reconcileRestoredGateBlock(base, resumed.sidecarQueue);
+    assert.equal(resumed.sidecarQueue.length, 1);
+    assert.equal(resumed.sidecarQueue[0].unitType, "hook/review-gate");
+    const rearmed = getActiveHook();
+    assert.ok(rearmed, "gate is re-armed in flight");
+    assert.ok(rearmed.completionOperationId, "re-armed hook keeps the completion operation id");
+    resumed.sidecarQueue.length = 0;
+
+    // The re-run requests rework: the trigger task is reopened for retry
+    // instead of throwing on the missing completion identity.
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01/T01", "REVIEW.md"),
+      "---\nverdict: needs-rework\n---\n\nRework requested.\n",
+      "utf-8",
+    );
+    resumed.currentUnit = { type: "hook/review-gate", id: "M001/S01/T01", startedAt: Date.now() };
+    const retryActiveUnit = mock.fn(async (_unit: { unitType: string; unitId: string }) => {});
+    resumed.orchestration = {
+      start: async () => ({ kind: "started" }),
+      advance: async () => ({ kind: "stopped", reason: "unused" }),
+      settle: async () => {},
+      completeActiveUnit: async () => {},
+      retryActiveUnit,
+      abandonActiveUnit: async () => {},
+      resume: async () => ({ kind: "resumed" }),
+      stop: async (reason: string) => ({ kind: "stopped", reason }),
+      getStatus: () => ({ phase: "running", transitionCount: 0 }),
+    } as any;
+    const { pctx } = createPctx(base, resumed);
+    assert.equal(await postUnitPostVerification(pctx), "step-wizard");
+    assert.equal(retryActiveUnit.mock.callCount(), 1);
+    assert.deepEqual(retryActiveUnit.mock.calls[0]?.arguments[0], {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+    });
+    assert.equal(getTask("M001", "S01", "T01")?.status, "pending", "rework reopens the task");
+  } finally {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    if (base) rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/post-unit-hooks-step-mode.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-hooks-step-mode.test.ts
@@ -16,7 +16,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { mock } from "node:test";
 
-import { postUnitPostVerification, type PostUnitContext } from "../auto-post-unit.ts";
+import { handlePendingHookOutcome, postUnitPostVerification, type PostUnitContext } from "../auto-post-unit.ts";
 import { AutoSession } from "../auto/session.ts";
 import {
   checkPostUnitHooks,
@@ -642,3 +642,121 @@ test("resume re-arms an execute-task gate with completion identity and schedules
     if (base) rmSync(base, { recursive: true, force: true });
   }
 });
+
+test("resume holds selection when a resolved gate has a blocked sibling", async (t) => {
+  const originalCwd = process.cwd();
+  const base = setupFixture("gsd-step-blocked-sibling-", TWO_BLOCKING_PLAN_SLICE_HOOKS);
+  t.after(() => {
+    closeDatabase();
+    process.chdir(originalCwd);
+    resetHookState();
+    invalidateAllCaches();
+    _clearGsdRootCache();
+    rmSync(base, { recursive: true, force: true });
+  });
+  process.chdir(base);
+  _clearGsdRootCache();
+  resetHookState();
+  assert.ok(checkPostUnitHooks("plan-slice", "M001/S01", base));
+  for (const artifact of ["GATE-A.md", "GATE-B.md"]) {
+    writeFileSync(resolveHookArtifactPath(base, "M001/S01", artifact), "---\nverdict: needs-attention\n---\n");
+  }
+  assert.equal(checkPostUnitHooks("hook/gate-a", "M001/S01", base), null);
+  persistHookState(base);
+  writeFileSync(resolveHookArtifactPath(base, "M001/S01", "GATE-A.md"), "---\nverdict: pass\n---\n");
+  resetHookState();
+  restoreHookState(base);
+  const resumed = new AutoSession();
+  resumed.basePath = base;
+  resumed.active = true;
+  resumed.stepMode = true;
+  reconcileRestoredGateBlock(base, resumed.sidecarQueue);
+  const { pctx, pauseAuto } = createPctx(base, resumed);
+  assert.equal(resumed.currentUnit, null);
+  assert.equal(await handlePendingHookOutcome(pctx), "stopped");
+  assert.equal(pauseAuto.mock.callCount(), 1);
+  resetHookState();
+  restoreHookState(base);
+  reconcileRestoredGateBlock(base, resumed.sidecarQueue);
+  assert.equal(resumed.sidecarQueue[0]?.unitType, "hook/gate-b");
+});
+
+for (const queuedSibling of [false, true]) {
+  test(`resume preserves existing-artifact completion identity (sibling=${queuedSibling})`, async (t) => {
+    const originalCwd = process.cwd();
+    let base = "";
+    t.after(() => {
+      closeDatabase();
+      process.chdir(originalCwd);
+      resetHookState();
+      invalidateAllCaches();
+      _clearGsdRootCache();
+      if (base) rmSync(base, { recursive: true, force: true });
+    });
+    base = setupFixture("gsd-step-gate-rework-", (queuedSibling
+      ? EXECUTE_TASK_BLOCKING_HOOK.replaceAll("review-gate", "first-gate").replaceAll("REVIEW.md", "FIRST.md") + EXECUTE_TASK_BLOCKING_HOOK
+      : EXECUTE_TASK_BLOCKING_HOOK));
+    process.chdir(base);
+    _clearGsdRootCache();
+    resetHookState();
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+    insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task", status: "complete" });
+    seedCompletedTaskLifecycle("gsd-step-gate-rework-op");
+
+    writeFileSync(resolveHookArtifactPath(base, "M001/S01/T01", "REVIEW.md"), "---\nverdict: needs-attention\n---\n");
+    if (queuedSibling) {
+      assert.ok(checkPostUnitHooks("execute-task", "M001/S01/T01", base));
+      writeFileSync(resolveHookArtifactPath(base, "M001/S01/T01", "FIRST.md"), "---\nverdict: needs-attention\n---\n");
+      assert.equal(checkPostUnitHooks("hook/first-gate", "M001/S01/T01", base), null);
+      persistHookState(base);
+      writeFileSync(resolveHookArtifactPath(base, "M001/S01/T01", "FIRST.md"), "---\nverdict: pass\n---\n");
+      resetHookState();
+      restoreHookState(base);
+      reconcileRestoredGateBlock(base, []);
+    } else {
+      assert.equal(checkPostUnitHooks("execute-task", "M001/S01/T01", base), null);
+    }
+    persistHookState(base);
+
+    resetHookState();
+    restoreHookState(base);
+    const resumed = new AutoSession();
+    resumed.basePath = base;
+    resumed.active = true;
+    resumed.stepMode = true;
+    reconcileRestoredGateBlock(base, resumed.sidecarQueue);
+    assert.equal(resumed.sidecarQueue.length, 1);
+    assert.equal(resumed.sidecarQueue[0].unitType, "hook/review-gate");
+    const rearmed = getActiveHook();
+    assert.ok(rearmed, "gate is re-armed in flight");
+    assert.ok(rearmed.completionOperationId, "re-armed hook keeps the completion operation id");
+    resumed.sidecarQueue.length = 0;
+
+    writeFileSync(
+      resolveHookArtifactPath(base, "M001/S01/T01", "REVIEW.md"),
+      "---\nverdict: needs-rework\n---\n\nRework requested.\n",
+      "utf-8",
+    );
+    resumed.currentUnit = { type: "hook/review-gate", id: "M001/S01/T01", startedAt: Date.now() };
+    const retryActiveUnit = mock.fn(async (_unit: { unitType: string; unitId: string }) => {});
+    resumed.orchestration = {
+      start: async () => ({ kind: "started" }),
+      advance: async () => ({ kind: "stopped", reason: "unused" }),
+      settle: async () => {},
+      completeActiveUnit: async () => {},
+      retryActiveUnit,
+      abandonActiveUnit: async () => {},
+      resume: async () => ({ kind: "resumed" }),
+      stop: async (reason: string) => ({ kind: "stopped", reason }),
+      getStatus: () => ({ phase: "running", transitionCount: 0 }),
+    } as any;
+    const { pctx } = createPctx(base, resumed);
+    assert.equal(await postUnitPostVerification(pctx), "step-wizard");
+    assert.equal(retryActiveUnit.mock.callCount(), 1);
+    assert.deepEqual(retryActiveUnit.mock.calls[0]?.arguments[0], {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+    });
+    assert.equal(getTask("M001", "S01", "T01")?.status, "pending", "rework reopens the task");
+  });
+}

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -368,6 +368,10 @@ export interface PostUnitGateBlock {
   triggerUnitType: string;
   /** The unit ID that triggered the gate. */
   triggerUnitId: string;
+  /** Canonical operation that completed an execute-task trigger. */
+  completionOperationId?: string;
+  /** Legacy completion timestamp when no canonical lifecycle row exists. */
+  legacyCompletedAt?: string;
   /** Gate artifact name, when configured. */
   artifact?: string;
   /** Absolute path to the gate artifact, when known. */
@@ -546,6 +550,23 @@ export interface PersistedHookState {
     completionOperationId?: string;
     legacyCompletedAt?: string;
   } | null;
+  /**
+   * Blocked gate retained until resume re-arms the hook, so a failed blocking
+   * gate cannot be bypassed by pausing and resuming (#2194).
+   */
+  gateBlockPending?: PostUnitGateBlock | null;
+  /**
+   * Hooks queued behind the blocked gate, re-queued on resume so later gates
+   * are not skipped once the blocked gate resolves (#2194).
+   */
+  gateBlockQueue?: Array<{
+    hookName: string;
+    triggerUnitType: string;
+    triggerUnitId: string;
+    forceRun?: boolean;
+    completionOperationId?: string;
+    legacyCompletedAt?: string;
+  }>;
   /** Timestamp of last state save. */
   savedAt: string;
 }


### PR DESCRIPTION
## TL;DR

**What:** `/gsd next` (step mode) now dispatches `criticality: blocking` post-unit hooks like `/gsd auto` does, and blocking-gate state persists across pause, resume, and `doctor --fix`.
**Why:** The hook dispatch path was guarded by `!s.stepMode`, so a blocking plan-review hook was bypassed and an unreviewed plan could reach task execution — `blocking` silently meant "blocking only in `/gsd auto`" (#2194).
**How:** The step-mode guard passes `blockingOnly: s.stepMode` through to the hook queue (filtering to blocking hooks); gate blocks now persist with their remaining sibling queue and completion identity, and reconcile on resume re-dispatches or holds selection until the gate resolves.

## What

- `src/resources/extensions/gsd/auto-post-unit.ts` — the step-mode guard is removed; `blockingOnly` threads through `post-unit-hooks.ts` into `rule-registry.ts`'s `evaluatePostUnit` (queue filtered to blocking hooks in step mode). Auto mode is byte-identical (`blockingOnly: false` → unfiltered queue).
- `src/resources/extensions/gsd/rule-registry.ts` + `types.ts` — `PersistedHookState` gains `gateBlockPending` (with `completionOperationId`/`legacyCompletedAt`) and `gateBlockQueue` (remaining siblings); `reconcileRestoredGateBlock` re-arms the gate with the original completion identity (needs-attention → needs-rework schedules rework without throwing) and dispatches queued siblings after the first gate passes; `_dequeueNextHook` holds selection while a restored gate needs attention and forwards identity at the existing-artifact boundary.
- `src/resources/extensions/gsd/doctor-runtime-checks.ts` — the stale-state check preserves a pending gate block from `--fix` erasure.
- Tests: new step-mode suite (10 tests: blocking dispatch holds execute-task selection, gate pass advances, failure pauses, mixed advisory+blocking queues, failed-gate pause → resume → re-dispatch, already-passing artifact holds without rerun, needs-rework after resume with identity) + doctor preservation case + multi-gate resume arc.

## Why

Step mode shares the auto workflow's unit pipeline, so a `criticality: blocking` hook must gate it identically — otherwise the meaning of `blocking` depends on which command the user picked. The persistence gaps (gate block and queued siblings lost on pause; doctor erasing a pending block; completion identity lost on re-arm) each allowed an unreviewed plan to reach execution after a resume, defeating the hook.

Closes #2194

## How

Verified end to end: in step mode a blocking plan-review hook dispatches before any execute-task selection, its failure pauses with the gate held, a passing artifact advances, and a pending gate survives pause/resume via the persisted state (pinned by tests, each fix verified by neutralizing it and watching its test fail). 383/384 across the 21-suite battery (the 1 failure is pre-existing on the base: `doctor surfaces unresolved projection evidence` fails identically with changes stashed); typecheck clean apart from 2 pre-existing unrelated errors. Codex review drove two hardening rounds; its accepted-boundary notes: multi-gate restore and identity forwarding are now handled at the shared resume boundary, and the `hookFailure` path (agent-run failure after retries) retains its not-persisted shape as a documented follow-up in the same lifecycle class.

> This PR is AI-assisted.

## Testing

Initial runs were blocked by missing dependencies; after local setup, focused hook, retry, and doctor tests passed. Captured lifecycle output and confirmed regression sensitivity. No screenshot was captured because no interactive terminal session was exercised; actual /gsd next resume-loop validation remains missing.

<details>
<summary>Evidence: Lifecycle transcript: user notices, sibling dispatch, and persisted rework state</summary>

```text
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE:     ^[[34m╭─^[[0m ^[[32m^[[1m✓ GSD Step Complete^[[0m
       ^[[2mCompleted:^[[0m ^[[36mhook: slice-plan-review M001/S01^[[0m
    ^[[34m╰────────────────────────────────────────^[[0m
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE: Post-unit gate "slice-plan-review" blocked plan-slice M001/S01 (detected on completion of hook/slice-plan-review M001/S01): artifact=SLICE-REVIEW.md; gate artifact SLICE-REVIEW.md is missing frontmatter verdict; gate cycle budget exhausted. Run /gsd status to inspect, then /gsd auto after recovery.
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE:     ^[[34m╭─^[[0m ^[[32m^[[1m✓ GSD Step Complete^[[0m
       ^[[2mCompleted:^[[0m ^[[36mplanning M001/S01^[[0m
    ^[[34m╰────────────────────────────────────────^[[0m
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE: Post-unit gate "slice-plan-review" blocked plan-slice M001/S01 (detected on completion of hook/slice-plan-review M001/S01): artifact=SLICE-REVIEW.md; gate artifact SLICE-REVIEW.md is missing frontmatter verdict; gate cycle budget exhausted. Run /gsd status to inspect, then /gsd auto after recovery.
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE:     ^[[34m╭─^[[0m ^[[32m^[[1m✓ GSD Step Complete^[[0m
       ^[[2mCompleted:^[[0m ^[[36mhook: slice-plan-review M001/S01^[[0m
    ^[[34m╰────────────────────────────────────────^[[0m
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE: Post-unit gate "slice-plan-review" blocked plan-slice M001/S01 (detected on completion of hook/slice-plan-review M001/S01): artifact=SLICE-REVIEW.md; gate artifact SLICE-REVIEW.md is missing frontmatter verdict; gate cycle budget exhausted. Run /gsd status to inspect, then /gsd auto after recovery.
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE:     ^[[34m╭─^[[0m ^[[32m^[[1m✓ GSD Step Complete^[[0m
       ^[[2mCompleted:^[[0m ^[[36mhook: slice-plan-review M001/S01^[[0m
    ^[[34m╰────────────────────────────────────────^[[0m
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE: Post-unit gate "gate-a" blocked plan-slice M001/S01 (detected on completion of hook/gate-a M001/S01): artifact=GATE-A.md; missing required gate artifact GATE-A.md; gate cycle budget exhausted. Run /gsd status to inspect, then /gsd auto after recovery.
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE:     ^[[34m╭─^[[0m ^[[32m^[[1m✓ GSD Step Complete^[[0m
       ^[[2mCompleted:^[[0m ^[[36mhook: gate-b M001/S01^[[0m
    ^[[34m╰────────────────────────────────────────^[[0m
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE: Hook requested retry of execute-task M001/S01/T01 — resetting trigger unit state.
USER NOTICE:     ^[[34m╭─^[[0m ^[[32m^[[1m✓ GSD Step Complete^[[0m
       ^[[2mCompleted:^[[0m ^[[36mhook: review-gate M001/S01/T01^[[0m
    ^[[34m╰────────────────────────────────────────^[[0m
PERSISTED TASK: {"milestone_id":"M001","slice_id":"S01","id":"T01","title":"Task","status":"pending","one_liner":"","narrative":"","verification_result":"","duration":"","completed_at":null,"blocker_discovered":false,"deviations":"","known_issues":"","key_files":[],"key_decisions":[],"full_summary_md":"","description":"","estimate":"","files":[],"verify":"","inputs":[],"expected_output":[],"required_workflow_tools":[],"observability_impact":"","full_plan_md":"","sequence":0,"blocker_source":"","escalation_pending":0,"escalation_awaiting_review":0,"escalation_artifact_path":null,"escalation_override_applied_at":null,"target_repositories":[]}
USER NOTICE: Post-unit gate "gate-b" blocked plan-slice M001/S01 (detected on resume): verdict=needs-attention; artifact=GATE-B.md; gate reported needs-attention. Run /gsd status to inspect, then /gsd auto after recovery.
RESUMED DISPATCH: [{"kind":"hook","unitType":"hook/gate-b","unitId":"M001/S01","prompt":"Gate B.\n\n**Browser tool safety:** Do NOT use `browser_wait_for` with `condition: \"network_idle\"` — it hangs indefinitely when dev servers keep persistent connections (Vite HMR, WebSocket). Use `selector_visible`, `text_visible`, or `delay` instead."}]
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE: Hook requested retry of execute-task M001/S01/T01 — resetting trigger unit state.
USER NOTICE:     ^[[34m╭─^[[0m ^[[32m^[[1m✓ GSD Step Complete^[[0m
       ^[[2mCompleted:^[[0m ^[[36mhook: review-gate M001/S01/T01^[[0m
    ^[[34m╰────────────────────────────────────────^[[0m
PERSISTED TASK: {"milestone_id":"M001","slice_id":"S01","id":"T01","title":"Task","status":"pending","one_liner":"","narrative":"","verification_result":"","duration":"","completed_at":null,"blocker_discovered":false,"deviations":"","known_issues":"","key_files":[],"key_decisions":[],"full_summary_md":"","description":"","estimate":"","files":[],"verify":"","inputs":[],"expected_output":[],"required_workflow_tools":[],"observability_impact":"","full_plan_md":"","sequence":0,"blocker_source":"","escalation_pending":0,"escalation_awaiting_review":0,"escalation_artifact_path":null,"escalation_override_applied_at":null,"target_repositories":[]}
fatal: not a git repository (or any of the parent directories): .git
USER NOTICE: Hook requested retry of execute-task M001/S01/T01 — resetting trigger unit state.
USER NOTICE:     ^[[34m╭─^[[0m ^[[32m^[[1m✓ GSD Step Complete^[[0m
       ^[[2mCompleted:^[[0m ^[[36mhook: review-gate M001/S01/T01^[[0m
    ^[[34m╰────────────────────────────────────────^[[0m
PERSISTED TASK: {"milestone_id":"M001","slice_id":"S01","id":"T01","title":"Task","status":"pending","one_liner":"","narrative":"","verification_result":"","duration":"","completed_at":null,"blocker_discovered":false,"deviations":"","known_issues":"","key_files":[],"key_decisions":[],"full_summary_md":"","description":"","estimate":"","files":[],"verify":"","inputs":[],"expected_output":[],"required_workflow_tools":[],"observability_impact":"","full_plan_md":"","sequence":0,"blocker_source":"","escalation_pending":0,"escalation_awaiting_review":0,"escalation_artifact_path":null,"escalation_override_applied_at":null,"target_repositories":[]}
✔ step mode dispatches a blocking plan-slice hook before any execute-task unit can be selected (78.811208ms)
✔ after the blocking hook records a passing verdict, step-mode selection proceeds (78.841959ms)
✔ blocking hook failure under step mode pauses instead of exposing task execution (73.621125ms)
✔ non-blocking hooks keep their step-mode behavior and stay skipped (62.963708ms)
✔ failed gate block persists and resume re-dispatches the blocked hook before selection (85.954458ms)
✔ resume with an already-passing gate artifact holds no dispatch and clears the block (72.185375ms)
✔ step mode runs only the blocking hook from a mixed advisory+blocking queue (76.045459ms)
✔ resume after gate A blocks still runs queued gate B once A passes (144.729583ms)
✔ resume re-arms an execute-task gate with completion identity and schedules rework (266.608041ms)
✔ resume holds selection when a resolved gate has a blocked sibling (54.894167ms)
✔ resume preserves existing-artifact completion identity (sibling=false) (229.585417ms)
✔ resume preserves existing-artifact completion identity (sibling=true) (253.850834ms)
ℹ tests 12
ℹ suites 0
ℹ pass 12
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 2880.380625
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m52s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1484fa4ac5d5698e8dce4ed140fd407794ef6487","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `src/resources/extensions/gsd/rule-registry.ts:624` - The requirement that resume dispatch sibling gates before task execution remains unmet. If gate A pauses, A&#39;s artifact is manually changed to pass, and sibling B already has a needs-attention artifact, the changed `return this._dequeueNextHook(basePath)` sets B&#39;s pending block but returns null. Resume queues nothing, allowing task selection before B passes. Handle pending blocks and retries at the shared resume boundary before normal selection.
- 🚨 `src/resources/extensions/gsd/rule-registry.ts:632` - The required &#39;needs-attention → needs-rework schedules rework without throwing&#39; behavior remains incomplete. For an execute-task with an existing needs-attention artifact, _dequeueNextHook passes only trigger type and ID to _handleExistingBlockingArtifact, dropping the captured completion identity. The new conditional restoration here cannot recover it; a needs-rework verdict after resume throws. Forward the captured identity at the existing-artifact boundary, including for queued siblings.

🔧 Fix: fix(gsd): handle restored gate blocks and preserve retry identity
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `src/resources/extensions/gsd/tests/post-unit-hooks-step-mode.test.ts` - End-to-end evidence remains incomplete. The passing lifecycle tests mock pause/orchestration and call resume helpers directly; they do not demonstrate /gsd next through startAuto/bootstrapAutoSession and autoLoop. The transcript proves helper behavior, but actual resume-before-selection wiring still needs executable validation.
- <code>Initial targeted test attempts failed on missing proper-lockfile/typescript; resolved with `pnpm install --frozen-lockfile --ignore-scripts --store-dir .test-pnpm-store`.</code>
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/post-unit-hooks-step-mode.test.ts src/resources/extensions/gsd/tests/post-unit-hooks.test.ts src/resources/extensions/gsd/tests/rule-registry.test.ts src/resources/extensions/gsd/tests/post-unit-retry-on-orchestrator-bridge.test.ts` — 87 passed.</code>
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern=&#39;doctor fix preserves a pending gate block&#39; src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts` — passed.</code>
- <code>Executed evidence-directory `lifecycle-evidence.test.ts` with the repository TypeScript loader, capturing actual notifications, resumed sibling dispatch, and task database records.</code>
- <code>Executed the blocking-dispatch regression with evidence-directory `disable-step-hooks.mjs` loaded through `--import`; it failed as expected with step-wizard instead of continue. Sabotage applied only in memory.</code>
- <code>Removed installed test dependencies and local package store; `git status --short` was clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 2 warnings</summary>

- ⚠️ `docs/user-docs/configuration.md:55` - Markdown lint reports 10 pre-existing issues, confirmed unchanged from HEAD: eight MD032 spacing issues and two MD024 duplicate headings. Left untouched under the no-drive-by-formatting policy.
- ⚠️ `package.json:128` - Extension typecheck could not run: node_modules is absent and tsc is unavailable. Dependencies must be restored before this check can complete.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

