### PR TITLE
fix(gsd): exempt bounded execution tools from the 5-minute stall watchdog

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -52,6 +52,7 @@ planning_depth: deep
 | Project | `.gsd/PREFERENCES.md` | Current project only |
 
 **Merge behavior:**
+
 - **Scalar fields** (`skill_discovery`, `budget_ceiling`): project wins if defined
 - **Array fields** (`always_use_skills`, etc.): concatenated (global first, then project)
 - **Object fields** (`models`, `git`, `auto_supervisor`): shallow-merged, project overrides per-key
@@ -424,6 +425,7 @@ models:
 Define custom models and providers in `~/.gsd/agent/models.json`. This lets you add models not included in the default registry — useful for self-hosted endpoints (Ollama, vLLM, LM Studio), fine-tuned models, proxies, or new provider releases.
 
 GSD resolves models.json with fallback logic:
+
 1. `~/.gsd/agent/models.json` — primary (GSD)
 2. `~/.pi/agent/models.json` — fallback (Pi)
 3. If neither exists, creates `~/.gsd/agent/models.json`
@@ -608,9 +610,15 @@ auto_supervisor:
   stalled_tool_timeout_minutes: 5  # recover a tool that hangs mid-call (default: 5)
 ```
 
-Long-running coordination tools (`subagent`, and its `Task` alias) are exempt from
-`stalled_tool_timeout_minutes`: a subagent running parallel reviewers can legitimately
-outlast this budget. A genuinely hung subagent is still bounded by `hard_timeout_minutes`.
+Long-running coordination tools (`subagent` and its `Task` alias) and bounded execution
+tools (`gsd_exec`, `gsd_uat_exec`, `async_bash`, `await_job`, and `bg_shell`) are exempt
+from `stalled_tool_timeout_minutes`, including their MCP-prefixed names. These calls
+can legitimately outlast the stalled-tool budget. Execution tools retain their own
+limits: `gsd_exec` and `gsd_uat_exec` use the 600-second exec sandbox clamp;
+`async_bash` returns a job ID immediately; `await_job` has its own wait timeout;
+and `bg_shell` has bounded per-action timeouts. All exempt tools remain subject to
+`hard_timeout_minutes` and do not re-arm that timeout. Other non-interactive tools
+remain subject to the stalled-tool budget.
 
 ### `min_request_interval_ms`
 
@@ -875,6 +883,7 @@ git:
 ```
 
 The script receives two environment variables:
+
 - `SOURCE_DIR` — the original project root
 - `WORKTREE_DIR` — the newly created worktree path
 
@@ -902,10 +911,12 @@ git:
 ```
 
 **Requirements:**
+
 - `auto_push: true` — the milestone branch must be pushed before a PR can be created
 - [`gh` CLI](https://cli.github.com/) installed and authenticated (`gh auth login`)
 
 **How it works:**
+
 1. Milestone completes → GSD squash-merges the worktree to the main branch
 2. Pushes the main branch to remote (if `auto_push: true`)
 3. Pushes the milestone branch to remote
@@ -933,11 +944,13 @@ github:
 | `project` | string | (none) | GitHub Project ID for project board integration |
 
 **Requirements:**
+
 - `gh` CLI installed and authenticated (`gh auth login`)
 - Sync mapping is persisted in `.gsd/github-sync.json`
 - Rate-limit aware — skips sync when GitHub API rate limit is low
 
 **Commands:**
+
 - `/github-sync bootstrap` — initial setup and sync
 - `/github-sync status` — show sync mapping counts
 
@@ -969,6 +982,7 @@ workspace:
 | `repositories.<id>.commit_policy` | string | (none) | Optional per-repo auto-mode turn commit policy: `auto` or `skip`. |
 
 **Path-scope behavior:**
+
 - During planning (`plan-slice`/`replan-slice`), file paths are validated against the selected `targetRepositories`.
 - `gsd_plan_slice.targetRepositories` sets the slice-wide default repository IDs.
 - `gsd_plan_task.targetRepositories` records or overrides the repository IDs for an individual task.

--- a/docs/zh-CN/user-docs/configuration.md
+++ b/docs/zh-CN/user-docs/configuration.md
@@ -52,6 +52,7 @@ token_profile: balanced
 - **对象字段**（`models`、`git`、`auto_supervisor`）：浅合并，项目级按 key 覆盖
 
 <a id="global-api-keys-gsd-config"></a>
+
 ## 全局 API Keys（`/gsd config`）
 
 工具 API keys 会全局保存在 `~/.gsd/agent/auth.json` 中，并自动应用到所有项目。只需用 `/gsd config` 配置一次，无需在每个项目里维护 `.env`。
@@ -331,8 +332,7 @@ auto_supervisor:
   stalled_tool_timeout_minutes: 5  # 恢复在调用中卡死的 tool（默认：5）
 ```
 
-长时协调工具（`subagent` 及其 `Task` 别名）不受 `stalled_tool_timeout_minutes` 约束——并行
-reviewer 的 subagent 合法运行可能远超该预算。真正卡死的 subagent 仍由 `hard_timeout_minutes` 兜底。
+`stalled_tool_timeout_minutes` 的工具豁免范围及超时限制，参见[英文配置指南](../../user-docs/configuration.md#auto_supervisor)。
 
 ### `budget_ceiling`
 
@@ -391,6 +391,7 @@ verification_max_retries: 2       # 最大重试次数（默认：2）
 如果 shell 找不到可执行文件，GSD 会将该检查归类为 `failureClass: command-not-found`。这包括退出码 127、`command not found` 输出，以及 Windows 的 `is not recognized as an internal or external command` 错误。该检查会在 verification evidence 中记为 `inconclusive`，不会消耗 `verification_max_retries`，并会暂停自动模式，等待你安装缺失的可执行文件或修正命令后再恢复。
 
 <a id="url-blocking-fetch_page"></a>
+
 ### URL Blocking（`fetch_page`）
 
 `fetch_page` 工具默认会阻止访问私有网络和内部网络地址，以防 SSRF（server-side request forgery）。这能防止 agent 被诱导去访问内部服务、云 metadata endpoint 或本地文件。
@@ -513,6 +514,7 @@ ln -sf "$SOURCE_DIR/assets" "$WORKTREE_DIR/assets"
 路径既可以是绝对路径，也可以相对项目根目录。脚本有 30 秒超时限制。失败不会中断流程，GSD 会记录告警后继续。
 
 <a id="gitauto_pr"></a>
+
 #### `git.auto_pr`
 
 在 milestone 完成时自动创建 pull request。适用于 Gitflow 或分支工作流团队，在合并到目标分支前通过 PR 做审查。

--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -220,9 +220,12 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
           });
           return;
         }
-        // Subagent coordinators can legitimately run for many minutes while
-        // bounded child work completes. Leave genuinely hung coordination to
-        // the unit-level hard timeout instead of aborting on wall-clock age.
+        // Subagent coordinators and bounded execution tools (gsd_exec,
+        // gsd_uat_exec, async_bash, await_job, bg_shell) can legitimately run
+        // for many minutes while their work completes — each is bounded by the
+        // exec sandbox clamp or its own job/timeout contract. Leave genuinely
+        // hung work to the unit-level hard timeout instead of aborting on
+        // wall-clock age.
         const oldestStart = getOldestStallDetectableToolStart();
         if (oldestStart === undefined) {
           writeUnitRuntimeRecord(s.basePath, unitType, unitId, s.currentUnit.startedAt, {

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -21,10 +21,22 @@ const inFlightTools = new Map<string, InFlightTool>();
 const INTERACTIVE_TOOLS = new Set(["ask_user_questions", "secure_env_collect"]);
 
 /**
- * Coordination tools that can legitimately run until their child work finishes.
- * The idle watchdog must leave these to the unit-level hard timeout.
+ * Coordination and bounded execution tools that can legitimately run until
+ * their child work or own timeout finishes. Execution bounds per tool:
+ * gsd_exec/gsd_uat_exec — exec sandbox clamp (600s); async_bash — returns a
+ * job ID immediately; await_job — resolves at its own wait timeout;
+ * bg_shell — action-based with bounded per-action timeouts. The idle watchdog
+ * must leave these to the unit-level hard timeout.
  */
-const LONG_RUNNING_COORDINATION_TOOLS = new Set(["subagent", "Task"]);
+const LONG_RUNNING_BOUNDED_TOOLS = new Set([
+  "subagent",
+  "Task",
+  "gsd_exec",
+  "gsd_uat_exec",
+  "async_bash",
+  "await_job",
+  "bg_shell",
+]);
 
 /**
  * Mode-agnostic refcount of in-flight interactive elicitations that are an
@@ -122,12 +134,13 @@ export function hasInteractiveToolInFlight(): boolean {
 
 /**
  * Returns the oldest start time among tools eligible for idle stall detection.
- * Long-running coordination tools are excluded, but remain hard-timeout bound.
+ * Long-running bounded tools (coordination, execution) are excluded, but remain
+ * hard-timeout bound.
  */
 export function getOldestStallDetectableToolStart(): number | undefined {
   let oldest = Infinity;
   for (const { startedAt, toolName } of inFlightTools.values()) {
-    if (!LONG_RUNNING_COORDINATION_TOOLS.has(toolName) && startedAt < oldest) oldest = startedAt;
+    if (!LONG_RUNNING_BOUNDED_TOOLS.has(toolName) && startedAt < oldest) oldest = startedAt;
   }
   return oldest === Infinity ? undefined : oldest;
 }

--- a/src/resources/extensions/gsd/tests/coordination-tool-idle-exemption.test.ts
+++ b/src/resources/extensions/gsd/tests/coordination-tool-idle-exemption.test.ts
@@ -139,6 +139,50 @@ test("a stale ordinary tool is still detected alongside a subagent", (t) => {
   assert.equal(h.notifications.some((message) => message.startsWith("Stalled tool detected:")), true);
 });
 
+test("a bounded execution tool remains in flight after the stalled-tool budget (#2203)", (t) => {
+  const h = startHarness(t);
+  markToolStart("call-1", true, "gsd_exec");
+
+  mock.timers.tick(75_000);
+
+  assert.equal(getInFlightToolCount(), 1);
+  assert.equal(readUnitRuntimeRecord(h.base, "validate-milestone", "M002")?.lastProgressKind, "coordination-tool-in-flight");
+  assert.equal(h.notifications.some((message) => message.startsWith("Stalled tool detected:")), false);
+});
+
+test("a UAT execution tool remains in flight after the stalled-tool budget (#2203)", (t) => {
+  const h = startHarness(t);
+  markToolStart("call-1", true, "gsd_uat_exec");
+
+  mock.timers.tick(75_000);
+
+  assert.equal(getInFlightToolCount(), 1);
+  assert.equal(readUnitRuntimeRecord(h.base, "validate-milestone", "M002")?.lastProgressKind, "coordination-tool-in-flight");
+  assert.equal(h.notifications.some((message) => message.startsWith("Stalled tool detected:")), false);
+});
+
+test("bounded execution tools are excluded from stall aging (#2203)", (t) => {
+  t.after(() => clearInFlightTools());
+  markToolStart("call-1", true, "gsd_exec");
+  markToolStart("call-2", true, "gsd_uat_exec");
+  markToolStart("call-3", true, "async_bash");
+  markToolStart("call-4", true, "await_job");
+  markToolStart("call-5", true, "bg_shell");
+  markToolStart("call-6", true, "mcp__gsd__gsd_exec");
+  assert.equal(getOldestStallDetectableToolStart(), undefined);
+});
+
+test("a stale non-exempt tool is still detected alongside a bounded execution tool (#2203)", (t) => {
+  const h = startHarness(t);
+  markToolStart("call-1", true, "read_file");
+  markToolStart("call-2", true, "gsd_exec");
+
+  mock.timers.tick(75_000);
+
+  assert.equal(getInFlightToolCount(), 0);
+  assert.equal(h.notifications.some((message) => message.startsWith("Stalled tool detected:")), true);
+});
+
 test("subagent does not re-arm the unit hard timeout", (t) => {
   const h = startHarness(t);
   markToolStart("call-1", true, "subagent");
@@ -147,4 +191,17 @@ test("subagent does not re-arm the unit hard timeout", (t) => {
 
   assert.equal(h.s.unitTimeoutHandle, null);
   assert.equal(readUnitRuntimeRecord(h.base, "validate-milestone", "M002")?.phase, "timeout");
+});
+
+test("bounded execution tools do not re-arm the unit hard timeout (#2203)", (t) => {
+  for (const toolName of ["gsd_exec", "gsd_uat_exec", "async_bash", "await_job", "bg_shell"]) {
+    const h = startHarness(t);
+    markToolStart("call-1", true, toolName);
+
+    mock.timers.tick(120_000);
+
+    assert.equal(h.s.unitTimeoutHandle, null, toolName);
+    assert.equal(readUnitRuntimeRecord(h.base, "validate-milestone", "M002")?.phase, "timeout", toolName);
+    cleanup(h);
+  }
 });


### PR DESCRIPTION
## TL;DR

**What:** The idle stuck-tool watchdog's exemption set (renamed `LONG_RUNNING_BOUNDED_TOOLS`) now covers the bounded execution tools `gsd_exec`, `gsd_uat_exec`, `async_bash`, `await_job`, and `bg_shell` alongside `subagent`/`Task`.
**Why:** The exemption set covered only `subagent`/`Task` (#2052), so a ~6.7-minute Playwright verification via `gsd_exec` was stall-killed mid-call at the 5-minute budget — 13 consecutive dispatches on one task, while the engine itself sanctions execution tools with a 600-second clamp (#2203).
**How:** Add the five execution tools to the exemption set; they remain bounded by the exec sandbox clamp or their own job/timeout contracts and by the unit hard timeout, which is now pinned by a dedicated test for every exempt tool.

## What

- `src/resources/extensions/gsd/auto-tool-tracking.ts` — set renamed and extended; per-tool bound comment corrected (gsd_exec/gsd_uat_exec: exec sandbox clamp; async_bash: immediate job registration; await_job: own wait timeout; bg_shell: bounded per-action timeouts); `getOldestStallDetectableToolStart` logic otherwise unchanged.
- `src/resources/extensions/gsd/auto-timers.ts` — watchdog-branch comment widened to the accurate tool list and bounds; no logic change.
- `src/resources/extensions/gsd/tests/coordination-tool-idle-exemption.test.ts` — 4 new tests: watchdog non-firing for `gsd_exec` and `gsd_uat_exec` past the budget (registry intact, progress refreshed), membership for all five names + an MCP-prefixed variant, `read_file` preservation control, and a hard-timeout non-re-arm contract test for every exempt tool.

## Why

`LONG_RUNNING_COORDINATION_TOOLS` was the #2052/#2053 fix for coordination tools; execution tools doing legitimate long verification (Playwright suites, UAT runs) hit the 5-minute idle watchdog mid-call — 11 of 13 dispatches on the reporter's task were stall-killed. Bounded execution tools' correct bound is the sandbox clamp, not the idle watchdog; the idle watchdog remains the guard for genuinely unbounded tools.

Closes #2203

## How

Mirrors the merged #2052 pattern. Tool names verified at their registration sites; MCP-prefixed variants normalize via `stripMcpToolPrefix` (tested). Per-tool bound claims verified in source (async_bash registers a job and returns immediately; await_job resolves at `DEFAULT_TIMEOUT_SECONDS = 120` unless overridden; bg_shell actions carry bounded timeouts). An isolated validator confirmed watchdog semantics unchanged for non-exempt tools (budget, 15s tick, interactive exemption, closeout/recovery flow all untouched), per-tool bound claims accurate in source, and revert-sensitivity (the exemption tests fail with the set change stashed). Codex second review found nothing real in production; its suggestion to pin the hard-timeout contract for the new exemptions is implemented as the dedicated test. Accepted tradeoff (documented): a genuinely hung exempt tool is bounded only by its own timeout/job contract and the unit hard timeout.

> This PR is AI-assisted.

## Testing

Focused suites passed after dependency setup. Baseline substitution reproduced the bug. Runtime evidence confirms successful execution beyond the default watchdog budget using simulated time and a real subprocess; an evidence-harness assertion was corrected before passing. No live model session or UI was exercised. Temporary dependencies were removed.

<details>
<summary>Evidence: Real execution response and persisted watchdog state at 402 simulated seconds</summary>

```text
{
  "clock": "402 seconds simulated; real subprocess",
  "runtime": {
    "version": 1,
    "unitType": "validate-milestone",
    "unitId": "M002",
    "startedAt": 0,
    "updatedAt": 402000,
    "phase": "dispatched",
    "wrapupWarningSent": false,
    "continueHereFired": false,
    "timeoutAt": null,
    "lastProgressAt": 402000,
    "progressCount": 0,
    "lastProgressKind": "coordination-tool-in-flight",
    "recoveryAttempts": 0
  },
  "notifications": [],
  "result": {
    "content": [
      {
        "type": "text",
        "text": "gsd_exec[c641305a-579c-43b5-9e4f-c15d96fe5966] runtime=node exit=0 duration=402000ms\n  stdout: 22B → /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-coordination-watchdog-base-AwY5xV/.gsd/exec/c641305a-579c-43b5-9e4f-c15d96fe5966.stdout\n  stderr: 0B → /var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-coordination-watchdog-base-AwY5xV/.gsd/exec/c641305a-579c-43b5-9e4f-c15d96fe5966.stderr\n--- digest ---\nverification complete"
      }
    ],
    "details": {
      "operation": "gsd_exec",
      "id": "c641305a-579c-43b5-9e4f-c15d96fe5966",
      "runtime": "node",
      "exit_code": 0,
      "signal": null,
      "timed_out": false,
      "aborted": false,
      "force_resolved": false,
      "duration_ms": 402000,
      "stdout_bytes": 22,
      "stderr_bytes": 0,
      "stdout_truncated": false,
      "stderr_truncated": false,
      "stdout_path": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-coordination-watchdog-base-AwY5xV/.gsd/exec/c641305a-579c-43b5-9e4f-c15d96fe5966.stdout",
      "stderr_path": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-coordination-watchdog-base-AwY5xV/.gsd/exec/c641305a-579c-43b5-9e4f-c15d96fe5966.stderr",
      "meta_path": "/var/folders/ts/yrrr1_453qz_str8lsryw04m0000gn/T/gsd-coordination-watchdog-base-AwY5xV/.gsd/exec/c641305a-579c-43b5-9e4f-c15d96fe5966.meta.json"
    },
    "isError": false
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b2f6698a246be07d218861497a09882a915ade8c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install --frozen-lockfile --ignore-scripts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/coordination-tool-idle-exemption.test.ts src/resources/extensions/gsd/tests/in-flight-tool-tracking.test.ts src/resources/extensions/gsd/tests/interactive-tool-idle-exemption.test.ts src/resources/extensions/gsd/tests/exec-sandbox.test.ts`
- `Ran coordination-tool-idle-exemption.test.ts with baseline-loader.mjs loading base-commit tracking code: reproduced the three expected regression failures.`
- `Ran evidence/watchdog-runtime.test.ts through the repository TypeScript loader: real gsd_exec subprocess completed after advancing the watchdog clock to 402 seconds, with no stall notification or recovery attempt.`
- <code>Removed installed test dependencies and confirmed `git status --short` was clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 3 warnings</summary>

- ⚠️ `docs/user-docs/configuration.md:726` - Existing MD024 violations remain at lines 726 and 957 for duplicate workspace headings. Renaming or consolidating these sections is outside this change.
- ⚠️ `docs/zh-CN/user-docs/configuration.md:54` - Existing MD033 violations remain at lines 54, 393, and 516. Explicit HTML anchors were preserved to avoid breaking links.
- ⚠️ `tsconfig.extensions.json` - Extension typechecking could not run: node_modules is absent and tsc is unavailable.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

