### PR TITLE
fix(gsd): judge evidence cross-ref claims by the newest matching run

### DIFF
--- a/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
+++ b/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
@@ -185,25 +185,19 @@ function findMatches(
   );
   if (substring.length > 0) return substring;
 
-  // Token match: split on whitespace and check significant overlap
+  // Token match: split on whitespace and check significant overlap. The score
+  // only identifies WHICH command the claim refers to; it must not filter
+  // WHICH outcome is authoritative — a passing re-run can score lower than the
+  // superseded failures it replaces, and the newest matching run decides the
+  // verdict (#2205).
   const claimedTokens = normalized.split(/\s+/).filter(t => t.length > 2);
   if (claimedTokens.length === 0) return [];
 
-  const scoredMatches: Array<{ call: BashEvidence; score: number }> = [];
-
-  for (const call of bashCalls) {
+  return bashCalls.filter((call) => {
     const callTokens = new Set(call.command.split(/\s+/));
     const matchCount = claimedTokens.filter(t => callTokens.has(t)).length;
-    const score = matchCount / claimedTokens.length;
-    if (score >= 0.5) {
-      scoredMatches.push({ call, score });
-    }
-  }
-
-  const bestScore = Math.max(0, ...scoredMatches.map((match) => match.score));
-  return scoredMatches
-    .filter((match) => match.score === bestScore)
-    .map((match) => match.call);
+    return matchCount / claimedTokens.length >= 0.5;
+  });
 }
 
 function latestMatch(matches: readonly BashEvidence[]): BashEvidence {

--- a/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
+++ b/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
@@ -100,6 +100,86 @@ test("newer script-wrapped pass is not shadowed by a stale exact failing run", (
   assert.deepEqual(mismatches, []);
 });
 
+test("token-matched verification is judged by its newest run, not the highest-scoring one", () => {
+  // Issue #2205: three runs share verification vocabulary. The newest run (the
+  // genuine pass) scores lowest on token overlap (0.5 vs 1.0 / 0.75), so the
+  // bestScore filter kept only the superseded failures and the harness flagged
+  // a passing task. Token overlap identifies WHICH command; the newest run of
+  // that command is the authoritative outcome.
+  const claim = "node test persistence verify";
+  const mismatches = crossReferenceEvidence(
+    [{ command: claim, exitCode: 0, verdict: "passed after retry" }],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command: "fake persistence verify node test idempotency",
+        exitCode: 1,
+        outputSnippet: "Error: invariant violated",
+        timestamp: 1,
+      },
+      {
+        kind: "bash",
+        toolCallId: "call-2",
+        command: "runtime persistence node test fake proof",
+        exitCode: 1,
+        outputSnippet: "Error: module not found",
+        timestamp: 2,
+      },
+      {
+        kind: "bash",
+        toolCallId: "call-3",
+        command: "verify node fake idempotency proof",
+        exitCode: 0,
+        outputSnippet: "ALL_OK",
+        timestamp: 3,
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.deepEqual(mismatches, []);
+});
+
+test("a newest token-matched failure still flags after earlier passing runs", () => {
+  // Complement of #2205: newest-run authority must not hide a failure. When
+  // the newest token-matched run failed, the claimed pass is still falsified
+  // even though older runs passed.
+  const claim = "node test persistence verify";
+  const mismatches = crossReferenceEvidence(
+    [{ command: claim, exitCode: 0, verdict: "passed" }],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command: "fake persistence verify node test idempotency",
+        exitCode: 0,
+        outputSnippet: "ALL_OK",
+        timestamp: 1,
+      },
+      {
+        kind: "bash",
+        toolCallId: "call-2",
+        command: "runtime persistence node test fake proof",
+        exitCode: 0,
+        outputSnippet: "ALL_OK",
+        timestamp: 2,
+      },
+      {
+        kind: "bash",
+        toolCallId: "call-3",
+        command: "verify node fake idempotency proof",
+        exitCode: 1,
+        outputSnippet: "Error: invariant violated",
+        timestamp: 3,
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.equal(mismatches.length, 1);
+  assert.equal(mismatches[0].severity, "error");
+  assert.match(mismatches[0].reason, /Claimed exitCode=0/);
+});
+
 test("later containing script does not override an exact successful run", () => {
   const command = "npm test";
   const mismatches = crossReferenceEvidence(
@@ -313,4 +393,37 @@ test("claimed command absent from bash calls reports a warning mismatch with nul
   const missing = mismatches.filter((m) => m.severity === "warning" && m.actual === null);
   assert.equal(missing.length, 1);
   assert.equal(missing[0].actual, null);
+});
+
+test("accepted tradeoff: a newer overlapping command passing masks an older same-vocabulary failure (#2205 review)", () => {
+  // Codex review case, pinned as an ACCEPTED tradeoff of newest-run authority
+  // in the fuzzy token tier: an older failure of the claimed command is masked
+  // when a newer, only partially-overlapping command passes. The alternative
+  // (bestScore outcome filtering) was the #2205 wedge itself — it let a
+  // superseded failed run out-vote a newer pass. If this masking ever matters
+  // in practice, the fix is a command-family grouping, not score filtering.
+  const claim = "node --test tests/auth.test.js";
+  const mismatches = crossReferenceEvidence(
+    [{ command: claim, exitCode: 0, verdict: "passed" }],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command: "node --test --test-reporter=spec tests/auth.test.js",
+        exitCode: 1,
+        outputSnippet: "tests/auth.test.js failing",
+        timestamp: 1,
+      },
+      {
+        kind: "bash",
+        toolCallId: "call-2",
+        command: "node --test tests/unrelated.test.js",
+        exitCode: 0,
+        outputSnippet: "unrelated pass",
+        timestamp: 2,
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.deepEqual(mismatches, []);
 });


### PR DESCRIPTION
## TL;DR

**What:** The evidence cross-ref's token-overlap fallback no longer filters candidates to the bestScore-tied subset — `latestMatch` now judges the claim against the newest run among all token-matched candidates.
**Why:** When a verification command failed for tooling reasons, was fixed, and re-run to success, the newer passing run could score LOWER on token overlap — so the bestScore filter kept only the superseded failed runs and the harness flagged "Claimed exitCode=0 but actual exitCode=1" on a genuinely passing task (#2205).
**How:** Keep the >= 0.5 threshold for command identification; let the existing `latestMatch` decide the authoritative outcome from the full candidate set. Exact and substring match paths unchanged.

## What

- `src/resources/extensions/gsd/safety/evidence-cross-ref.ts` — the token-overlap fallback in `findMatches` returns all >= 0.5 candidates instead of the bestScore-tied subset (−10/+6 lines).
- `src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts` — 2 regression tests: (1) three same-vocabulary runs with token scores 1.0/0.75/0.5, exits 1/1/0, claimed exitCode=0 → judged clean (the newest pass scores lowest, so bestScore filtering would have flagged it); (2) newest token-matched failure after earlier passes still flags. Plus a pinned accepted-tradeoff test: a newer partially-overlapping command passing masks an older same-vocabulary failure — documented as inherent to newest-run authority in the fuzzy tier.

## Why

Token overlap identifies *which command* a claim refers to; it must not decide *which outcome* is authoritative. The reported forensic (three `node` runtime-proof runs, exits 1/1/0, newest = the pass) showed the bestScore filter selecting a superseded failure and routing recovery on correct work.

Closes #2205

## How

An isolated validator drove probes confirming all five semantic properties (later-pass-never-flagged, newest-failure-still-flags, older-never-re-run-still-flags, exact/substring tiers unchanged, threshold retained) and revert-sensitivity (both new tests fail with the fix stashed). 16/16 in evidence-cross-ref, 64/64 across adjacent evidence/safety suites, 82/82 with the false-positive suite, typecheck clean apart from 2 pre-existing unrelated errors. Known accepted boundary (pinned by test): in the fuzzy tier, a newer partially-overlapping command passing masks an older same-vocabulary failure — exact-command failures remain protected by the exact-match early return.

> This PR is AI-assisted.

## Testing

After fixing missing dependencies, focused tests and command-to-persisted-evidence checks passed. Base substitution reproduced the regression failures. Runtime transcripts and verdicts were retained; temporary files were cleaned up.

<details>
<summary>Evidence: Executed fail/fail/pass commands and harness verdicts</summary>

```text
$ node -e "throw Error('invariant violated')" persistence verify test
exitCode=1
[eval]:1
throw Error('invariant violated')
^

Error: invariant violated
    at [eval]:1:7
    at runScriptInThisContext (node:internal/vm:219:10)
    at node:internal/process/execution:483:12
    at [eval]-wrapper:6:24
    at runScriptInContext (node:internal/process/execution:481:60)
    at evalFunction (node:internal/process/execution:315:30)
    at evalTypeScript (node:internal/process/execution:327:3)
    at node:internal/main/eval_string:71:3

Node.js v26.0.0

$ node -e "require('missing-runtime-proof-module')" persistence test
exitCode=1
node:internal/modules/cjs/loader:1478
  throw err;
  ^

Error: Cannot find module 'missing-runtime-proof-module'
Require stack:
- /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1ZYBCJGRJAZD6K2Q579NP16/[eval]
    at Module._resolveFilename (node:internal/modules/cjs/loader:1475:15)
    at wrapResolveFilename (node:internal/modules/cjs/loader:1048:27)
    at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1072:10)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1093:12)
    at Module._load (node:internal/modules/cjs/loader:1261:25)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.require (node:internal/modules/cjs/loader:1575:12)
    at require (node:internal/modules/helpers:191:16)
    at [eval]:1:1
    at runScriptInThisContext (node:internal/vm:219:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1ZYBCJGRJAZD6K2Q579NP16/[eval]'
  ]
}

Node.js v26.0.0

$ node -e "console.log('ALL_OK')" verify
exitCode=0
ALL_OK

Persisted fail/fail/pass: newest lower-overlap pass accepted: []
Newest lower-overlap failure flags older passes: [{"severity":"error","claimed":{"command":"node test persistence verify","exitCode":0,"verdict":"passed after retry"},"actual":{"kind":"bash","toolCallId":"runtime-2","command":"node -e \"console.log('ALL_OK')\" verify","exitCode":1,"outputSnippet":"ALL_OK\n\nCommand exited with code 0","timestamp":1788852353594},"reason":"Claimed exitCode=0 but actual exitCode=1"}]
Older failure with no retry still flags: [{"severity":"error","claimed":{"command":"node test persistence verify","exitCode":0,"verdict":"passed after retry"},"actual":{"kind":"bash","toolCallId":"runtime-0","command":"node -e \"throw Error('invariant violated')\" persistence verify test","exitCode":1,"outputSnippet":"[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1","timestamp":1788852353506},"reason":"Claimed exitCode=0 but actual exitCode=1"}]
Exact failure protected from newer fuzzy pass: [{"severity":"error","claimed":{"command":"node test persistence verify","exitCode":0,"verdict":"passed after retry"},"actual":{"kind":"bash","toolCallId":"runtime-0","command":"node test persistence verify","exitCode":1,"outputSnippet":"[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1","timestamp":1788852353506},"reason":"Claimed exitCode=0 but actual exitCode=1"}]
Same timestamp: later recorded pass wins: []
Below-threshold pass cannot mask failure: [{"severity":"error","claimed":{"command":"node test persistence verify","exitCode":0,"verdict":"passed after retry"},"actual":{"kind":"bash","toolCallId":"runtime-0","command":"node -e \"throw Error('invariant violated')\" persistence verify test","exitCode":1,"outputSnippet":"[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1","timestamp":1788852353506},"reason":"Claimed exitCode=0 but actual exitCode=1"}]
Accepted fuzzy masking tradeoff: []
```
</details>
<details>
<summary>Evidence: Recorded evidence and semantic verdicts</summary>

```text
[
  {
    "scenario": "Persisted fail/fail/pass: newest lower-overlap pass accepted",
    "recorded": [
      {
        "kind": "bash",
        "toolCallId": "runtime-0",
        "command": "node -e \"throw Error('invariant violated')\" persistence verify test",
        "exitCode": 1,
        "outputSnippet": "[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1",
        "timestamp": 1788852353506
      },
      {
        "kind": "bash",
        "toolCallId": "runtime-1",
        "command": "node -e \"require('missing-runtime-proof-module')\" persistence test",
        "exitCode": 1,
        "outputSnippet": "node:internal/modules/cjs/loader:1478\n  throw err;\n  ^\n\nError: Cannot find module 'missing-runtime-proof-module'\nRequire stack:\n- /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1ZYBCJGRJAZD6K2Q579NP16/[eval]\n    at Module._resolveFilename (node:internal/modules/cjs/loader:1475:15)\n    at wrapResolveFilename (node:internal/modules/cjs/loader:1048:27)\n    at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1072:10)\n    at resolveForCJSWithHooks (node:internal/module",
        "timestamp": 1788852353552
      },
      {
        "kind": "bash",
        "toolCallId": "runtime-2",
        "command": "node -e \"console.log('ALL_OK')\" verify",
        "exitCode": 0,
        "outputSnippet": "ALL_OK\n\nCommand exited with code 0",
        "timestamp": 1788852353594
      }
    ],
    "mismatches": []
  },
  {
    "scenario": "Newest lower-overlap failure flags older passes",
    "recorded": [
      {
        "kind": "bash",
        "toolCallId": "runtime-0",
        "command": "node -e \"throw Error('invariant violated')\" persistence verify test",
        "exitCode": 0,
        "outputSnippet": "[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1",
        "timestamp": 1788852353506
      },
      {
        "kind": "bash",
        "toolCallId": "runtime-1",
        "command": "node -e \"require('missing-runtime-proof-module')\" persistence test",
        "exitCode": 0,
        "outputSnippet": "node:internal/modules/cjs/loader:1478\n  throw err;\n  ^\n\nError: Cannot find module 'missing-runtime-proof-module'\nRequire stack:\n- /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1ZYBCJGRJAZD6K2Q579NP16/[eval]\n    at Module._resolveFilename (node:internal/modules/cjs/loader:1475:15)\n    at wrapResolveFilename (node:internal/modules/cjs/loader:1048:27)\n    at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1072:10)\n    at resolveForCJSWithHooks (node:internal/module",
        "timestamp": 1788852353552
      },
      {
        "kind": "bash",
        "toolCallId": "runtime-2",
        "command": "node -e \"console.log('ALL_OK')\" verify",
        "exitCode": 1,
        "outputSnippet": "ALL_OK\n\nCommand exited with code 0",
        "timestamp": 1788852353594
      }
    ],
    "mismatches": [
      {
        "severity": "error",
        "claimed": {
          "command": "node test persistence verify",
          "exitCode": 0,
          "verdict": "passed after retry"
        },
        "actual": {
          "kind": "bash",
          "toolCallId": "runtime-2",
          "command": "node -e \"console.log('ALL_OK')\" verify",
          "exitCode": 1,
          "outputSnippet": "ALL_OK\n\nCommand exited with code 0",
          "timestamp": 1788852353594
        },
        "reason": "Claimed exitCode=0 but actual exitCode=1"
      }
    ]
  },
  {
    "scenario": "Older failure with no retry still flags",
    "recorded": [
      {
        "kind": "bash",
        "toolCallId": "runtime-0",
        "command": "node -e \"throw Error('invariant violated')\" persistence verify test",
        "exitCode": 1,
        "outputSnippet": "[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1",
        "timestamp": 1788852353506
      }
    ],
    "mismatches": [
      {
        "severity": "error",
        "claimed": {
          "command": "node test persistence verify",
          "exitCode": 0,
          "verdict": "passed after retry"
        },
        "actual": {
          "kind": "bash",
          "toolCallId": "runtime-0",
          "command": "node -e \"throw Error('invariant violated')\" persistence verify test",
          "exitCode": 1,
          "outputSnippet": "[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1",
          "timestamp": 1788852353506
        },
        "reason": "Claimed exitCode=0 but actual exitCode=1"
      }
    ]
  },
  {
    "scenario": "Exact failure protected from newer fuzzy pass",
    "recorded": [
      {
        "kind": "bash",
        "toolCallId": "runtime-0",
        "command": "node test persistence verify",
        "exitCode": 1,
        "outputSnippet": "[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1",
        "timestamp": 1788852353506
      },
      {
        "kind": "bash",
        "toolCallId": "runtime-2",
        "command": "node -e \"console.log('ALL_OK')\" verify",
        "exitCode": 0,
        "outputSnippet": "ALL_OK\n\nCommand exited with code 0",
        "timestamp": 1788852353594
      }
    ],
    "mismatches": [
      {
        "severity": "error",
        "claimed": {
          "command": "node test persistence verify",
          "exitCode": 0,
          "verdict": "passed after retry"
        },
        "actual": {
          "kind": "bash",
          "toolCallId": "runtime-0",
          "command": "node test persistence verify",
          "exitCode": 1,
          "outputSnippet": "[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1",
          "timestamp": 1788852353506
        },
        "reason": "Claimed exitCode=0 but actual exitCode=1"
      }
    ]
  },
  {
    "scenario": "Same timestamp: later recorded pass wins",
    "recorded": [
      {
        "kind": "bash",
        "toolCallId": "runtime-0",
        "command": "node -e \"throw Error('invariant violated')\" persistence verify test",
        "exitCode": 1,
        "outputSnippet": "[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1",
        "timestamp": 1
      },
      {
        "kind": "bash",
        "toolCallId": "runtime-1",
        "command": "node -e \"require('missing-runtime-proof-module')\" persistence test",
        "exitCode": 1,
        "outputSnippet": "node:internal/modules/cjs/loader:1478\n  throw err;\n  ^\n\nError: Cannot find module 'missing-runtime-proof-module'\nRequire stack:\n- /Users/jeremymcspadden/.no-mistakes/worktrees/c2f4d848183f/01M1ZYBCJGRJAZD6K2Q579NP16/[eval]\n    at Module._resolveFilename (node:internal/modules/cjs/loader:1475:15)\n    at wrapResolveFilename (node:internal/modules/cjs/loader:1048:27)\n    at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1072:10)\n    at resolveForCJSWithHooks (node:internal/module",
        "timestamp": 1
      },
      {
        "kind": "bash",
        "toolCallId": "runtime-2",
        "command": "node -e \"console.log('ALL_OK')\" verify",
        "exitCode": 0,
        "outputSnippet": "ALL_OK\n\nCommand exited with code 0",
        "timestamp": 1
      }
    ],
    "mismatches": []
  },
  {
    "scenario": "Below-threshold pass cannot mask failure",
    "recorded": [
      {
        "kind": "bash",
        "toolCallId": "runtime-0",
        "command": "node -e \"throw Error('invariant violated')\" persistence verify test",
        "exitCode": 1,
        "outputSnippet": "[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1",
        "timestamp": 1788852353506
      },
      {
        "kind": "bash",
        "toolCallId": "runtime-2",
        "command": "node -e \"console.log(123)\" unrelated",
        "exitCode": 0,
        "outputSnippet": "ALL_OK\n\nCommand exited with code 0",
        "timestamp": 1788852353594
      }
    ],
    "mismatches": [
      {
        "severity": "error",
        "claimed": {
          "command": "node test persistence verify",
          "exitCode": 0,
          "verdict": "passed after retry"
        },
        "actual": {
          "kind": "bash",
          "toolCallId": "runtime-0",
          "command": "node -e \"throw Error('invariant violated')\" persistence verify test",
          "exitCode": 1,
          "outputSnippet": "[eval]:1\nthrow Error('invariant violated')\n^\n\nError: invariant violated\n    at [eval]:1:7\n    at runScriptInThisContext (node:internal/vm:219:10)\n    at node:internal/process/execution:483:12\n    at [eval]-wrapper:6:24\n    at runScriptInContext (node:internal/process/execution:481:60)\n    at evalFunction (node:internal/process/execution:315:30)\n    at evalTypeScript (node:internal/process/execution:327:3)\n    at node:internal/main/eval_string:71:3\n\nNode.js v26.0.0\n\nCommand exited with code 1",
          "timestamp": 1788852353506
        },
        "reason": "Claimed exitCode=0 but actual exitCode=1"
      }
    ]
  },
  {
    "scenario": "Accepted fuzzy masking tradeoff",
    "mismatches": []
  }
]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"eb3f0d65b845256f44411f1643afb7d3a6a4b484","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Initial focused test command failed to start because typescript and minimatch were missing; resolved with `pnpm install --frozen-lockfile --ignore-scripts --store-dir .test-pnpm-store`.</code>
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts src/resources/extensions/gsd/tests/evidence-xref-gsd-exec.test.ts src/resources/extensions/gsd/tests/safety-harness-false-positives.test.ts` — passed.</code>
- <code>`node --experimental-strip-types /Users/jeremymcspadden/.no-mistakes/evidence/01M1ZYBCJGRJAZD6K2Q579NP16/runtime-proof.mjs` — executed fail/fail/pass commands, recorded results, saved/reloaded evidence, and asserted newest-run, exact-failure, unretried-failure, timestamp-tie, threshold, and accepted masking behavior.</code>
- <code>`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --import /Users/jeremymcspadden/.no-mistakes/evidence/01M1ZYBCJGRJAZD6K2Q579NP16/base-hook.mjs --experimental-strip-types --test --test-name-pattern=&#39;token-matched|accepted tradeoff&#39; src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts` — all three regressions failed as expected against the base implementation.</code>
- <code>Removed temporary dependencies and cache; `git status --short` was empty.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

