### PR TITLE
fix(gsd): dismiss pending elicitation when a unit is abandoned

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -297,6 +297,8 @@ Recovery steering nudges the LLM to finish durable output before timing out. Whe
 
 Interactive prompts that block waiting for human input (such as `ask_user_questions` during discuss-phase/milestone, or secure value entry) are exempt from the idle and hard timeouts: while one is in flight, the watchdogs re-arm instead of firing, so a long human deliberation never cancels the prompt or aborts its turn. A genuinely hung non-interactive unit still hits the hard cap as usual.
 
+If a unit is abandoned, auto mode aborts its active turn, dismisses any pending question dialog, and clears its in-flight tool tracking. Transcript scrolling is restored, and the abandoned prompt no longer exempts later units from the idle or hard timeout.
+
 For operator forensics, timeout recovery updates the unit runtime record with fields such as `phase`, `timeoutAt`, `lastProgressAt`, `lastProgressKind`, `recoveryAttempts`, and `lastRecoveryReason`. Finalize timeouts are recorded with `lastProgressKind` values like `finalize-pre-timeout` or `finalize-post-timeout`; successful finalization records `finalize-success`.
 
 The journal also closes every iteration explicitly. After a unit ends, auto mode emits `post-unit-finalize-start` before closeout and `post-unit-finalize-end` with a `status`, `action`, and optional `reason`. Every loop iteration then emits `iteration-end` with the final status and, when available, the failure class, unit type, unit id, and reason. Use these events to distinguish "agent never returned" from "agent returned but finalize/closeout stopped the loop."

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -67,6 +67,8 @@ import { preserveProjectionChanges } from "../projection-worker.js";
 import { throwIfTransientProjectionLockError } from "../projection-root-errors.js";
 import { buildDispatchKey } from "./dispatch-key.js";
 import { stableClaimSignature } from "./lease-conflict-notice.js";
+import { abortActiveUnitTurn } from "./unit-turn-abort.js";
+import { clearInFlightTools } from "../auto-tool-tracking.js";
 import {
   COMPLETED_NO_ADVANCE_GUARD_ID,
   formatWedgeRefusalNotice,
@@ -1873,6 +1875,15 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   }
 
   private async recordAbandonCloseout(unit: UnitRef, reason: string): Promise<void> {
+    // #2212: the abandoned turn may still be parked in a pending
+    // ask_user_questions elicitation. Aborting the turn trips the tool's
+    // abort signal, so showInterviewRound finishes and the TUI dialog
+    // unmounts; the normal tool_execution_end → markToolEnd path retires
+    // the in-flight entry. clearInFlightTools covers the case where that
+    // end event never arrives, so a leaked interactive entry cannot exempt
+    // later units from the idle watchdog and hard timeout.
+    abortActiveUnitTurn(this.ctx);
+    clearInFlightTools();
     this.status.activeUnit = undefined;
     this.pendingTargetSnapshot = null;
     this.bumpTransition();

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -59,6 +59,12 @@ import {
   getOpenWedge,
 } from "../auto-liveness-backstop.js";
 import { renderRoadmapFromDb } from "../markdown-renderer.js";
+import {
+  clearInFlightTools,
+  getInFlightToolCount,
+  hasInteractiveToolInFlight,
+  markToolStart,
+} from "../auto-tool-tracking.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixture builder
@@ -1114,6 +1120,37 @@ test("abandonActiveUnit clears an abnormal exit so the same unit can advance aga
   assert.equal(second.kind, "advanced");
   if (second.kind !== "advanced") throw new Error("expected re-advance after abandonment");
   assert.deepEqual(second.unit, first.unit);
+  assert.ok(f.journalNames().includes("unit-abandon"));
+});
+
+test("#2212: abandonActiveUnit aborts the turn hosting a pending elicitation and clears in-flight tool entries", async (t) => {
+  const f = makeFixture();
+  t.after(() => f.cleanup());
+  t.after(() => clearInFlightTools());
+
+  // Simulate the abandoned turn: still alive (not idle — a pending
+  // ask_user_questions dialog is mounted) with the interactive tool in flight.
+  const extCtx = f.ctx.ctx as { isIdle: () => boolean; abort: () => void };
+  let abortCalls = 0;
+  extCtx.isIdle = () => false;
+  extCtx.abort = () => {
+    abortCalls += 1;
+  };
+  markToolStart("tc-2212-pending-question", true, "ask_user_questions");
+  assert.equal(hasInteractiveToolInFlight(), true, "precondition: interactive elicitation in flight");
+
+  const first = await f.orchestrator.advance();
+  assert.equal(first.kind, "advanced");
+  if (first.kind !== "advanced") throw new Error("expected first advance");
+
+  await f.orchestrator.abandonActiveUnit(first.unit, "verify-gate wedge");
+
+  // The abort is what dismisses the mounted dialog: the tool's abort signal
+  // makes showInterviewRound finish and unmount (mechanism pinned in
+  // shared/tests/interview-abort-dismiss.test.ts).
+  assert.equal(abortCalls, 1, "unit-abandon must abort the turn hosting the pending elicitation");
+  assert.equal(hasInteractiveToolInFlight(), false, "unit-abandon must clear the interactive in-flight watchdog exemption");
+  assert.equal(getInFlightToolCount(), 0, "unit-abandon must clear stale in-flight tool entries");
   assert.ok(f.journalNames().includes("unit-abandon"));
 });
 

--- a/src/resources/extensions/shared/tests/interview-abort-dismiss.test.ts
+++ b/src/resources/extensions/shared/tests/interview-abort-dismiss.test.ts
@@ -1,0 +1,73 @@
+// gsd-pi — Regression test for #2212 defect B (dismissal mechanism)
+//
+// When an auto-mode unit is abandoned while an ask_user_questions round is
+// still pending, the hosting turn must be aborted. The dismissal path is the
+// tool's abort signal: showInterviewRound registers an abort listener that
+// finishes the round (done()), which unmounts the TUI dialog and restores
+// transcript key bindings. This pins that mechanism: an abort while the round
+// is pending resolves the dialog exactly once with an interrupted result.
+//
+// The wiring under test (unit-abandon → ctx.abort) is covered in
+// gsd/tests/auto-orchestrator.test.ts.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { showInterviewRound, type Question, type RoundResult } from "../interview-ui.js";
+
+const ENTER = "\r";
+
+describe("interview-ui abort dismissal (#2212)", () => {
+	it("dismisses a pending round exactly once when the abort signal fires", async () => {
+		const controller = new AbortController();
+		const doneCalls: RoundResult[] = [];
+		let widget: { handleInput(input: string): void } | undefined;
+
+		const questions: Question[] = [
+			{
+				id: "route",
+				header: "Route",
+				question: "Which route?",
+				options: [
+					{ label: "Web App", description: "A web app" },
+					{ label: "CLI Tool", description: "A CLI tool" },
+				],
+			},
+		];
+
+		const resultPromise = showInterviewRound(questions, { signal: controller.signal }, {
+			ui: {
+				custom: (factory: any) => new Promise<RoundResult>((resolve) => {
+					const mockTui = { requestRender: () => {} };
+					const mockTheme = {
+						fg: (_c: string, t: string) => t,
+						bold: (t: string) => t,
+						dim: (t: string) => t,
+						italic: (t: string) => t,
+						strikethrough: (t: string) => t,
+						accent: (t: string) => t,
+						success: (t: string) => t,
+						warning: (t: string) => t,
+						error: (t: string) => t,
+						info: (t: string) => t,
+						muted: (t: string) => t,
+						dimmed: (t: string) => t,
+					};
+					widget = factory(mockTui, mockTheme, {}, (result: RoundResult) => {
+						doneCalls.push(result);
+						resolve(result);
+					});
+				}),
+			},
+		} as any);
+
+		assert.ok(widget, "widget should be created synchronously");
+		// Dialog is mounted and pending (no answer submitted yet).
+		widget.handleInput(ENTER);
+
+		controller.abort();
+
+		const result = await resultPromise;
+		assert.equal(doneCalls.length, 1, "abort while pending must finish the round exactly once (dialog unmounts)");
+		assert.deepEqual(result, { endInterview: false, answers: {}, interrupted: true });
+	});
+});


### PR DESCRIPTION
## TL;DR

**What:** The unit-abandon closeout now aborts the dying unit turn and clears the in-flight tool registry, dismissing a pending `ask_user_questions` elicitation instead of leaving it mounted.
**Why:** On the unit-abandon / sanctioned-wedge exit, a pending elicitation from the abandoned turn was never dismissed — the zombie dialog locked TUI scrolling (question mode binds PgUp/PgDn to the options list), a stale spinner kept rendering, and the leaked in-flight entry permanently exempted the session from both watchdogs (#2212, defect B).
**How:** `recordAbandonCloseout` — the single funnel for `settle("failed"/"canceled")` → `unit-abandon` — now calls `abortActiveUnitTurn(ctx)` (the interview dialog's abort listener finishes it with `interrupted: true`, unmounting and restoring key bindings) and `clearInFlightTools()` before the status clear.

## What

- `src/resources/extensions/gsd/auto/orchestrator.ts` — two lines in `recordAbandonCloseout` plus imports. No dismissal machinery was created: `ask_user_questions` already threads its tool-call AbortSignal into `showInterviewRound`, whose abort listener finishes the dialog; the defect was purely that the abandon seam never invoked the abort.
- `src/resources/extensions/gsd/tests/auto-orchestrator.test.ts` — regression: fixture ctx non-idle with an abort spy, seeded in-flight `ask_user_questions` entry → `abandonActiveUnit` aborts once, leaves `hasInteractiveToolInFlight()` false, leaves `getInFlightToolCount()` 0, journals `unit-abandon`.
- `src/resources/extensions/shared/tests/interview-abort-dismiss.test.ts` (new) — mechanism pin: `showInterviewRound` mounted via the mocked `ui.custom` harness, aborted while pending → `done` fires exactly once with `{ endInterview: false, answers: {}, interrupted: true }` (dialog unmount + key-binding restore).

## Why

The abort path already existed and is exactly abandon's semantics — identical to a user interrupt; the fix mirrors `pauseAuto`'s own guarded abort. Idempotent: no pending elicitation or an already-exited turn are no-ops. Note for reviewers: issue #2212's Defect A (the #2148 wedge itself) is already fixed by merged #2168 and lands in the next release after v1.18.0; only Defect B is addressed here.

Closes #2212

## How

An isolated validator traced the full host-side chain (`ctx.abort` → `agent.abort` → `activeRun.abortController.abort()` → tool signal → interview abort listener → `finish({interrupted: true})` → `done()` unmount, exactly-once via the completed flag) and confirmed: the abort's blast radius is the streaming unit turn only (identical to a user interrupt); the registry-wide clear at this teardown seam is the established pattern (auto.ts session-stop/exit-teardown, auto-timers hung-tool verdict) with every entry at this seam belonging to the dying turn; idempotency confirmed for double-abandon and elicitation-free turns; the post-abort closeRun/exit flow does not need the turn alive (the abort-then-closeRun ordering already exists at the retry and crash closeouts). 101/101 across the 9-suite battery; typecheck clean apart from 2 pre-existing unrelated errors.

> This PR is AI-assisted.

## Testing

Installed locked dependencies, passed focused tests and combined behavior checks, reproduced the pre-fix failure, and confirmed restored tests pass. Captured component HTML and runtime state; full TUI interaction was not verified. Temporary worktree artifacts were removed.

<details>
<summary>Evidence: Interview component render and cleanup state; UI host mocked</summary>

```text
<!doctype html><meta charset="utf-8"><title>Abandon interview evidence</title><style>body{background:#17191d;color:#eee;padding:24px;font:15px monospace}pre{white-space:pre-wrap}</style><h1>Before abandonment</h1><p>Actual interview component render, plain test theme. Host mounting is mocked.</p><pre>╭─ Route ──────────────────────────────────────────────────────────────────────────────────────────╮
│  Which route?                                                                                    │
│                                                                                                  │
│   › 1. Web App                                                                                   │
│      A web app                                                                                   │
│     2. CLI Tool                                                                                  │
│      A CLI tool                                                                                  │
│     None of the above                                                                            │
│      Select to type your own answer.                                                             │
│                                                                                                  │
├──────────────────────────────────────────────────────────────────────────────────────────────────┤
│  tab to add notes  |  enter to next  |  esc to exit                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</pre><h1>After abandonment</h1><pre>{
  "mounted": false,
  "abortCalls": 1,
  "doneCalls": 1,
  "result": {
    "endInterview": false,
    "answers": {},
    "interrupted": true
  },
  "interactive": false,
  "count": 0
}</pre>
```
</details>
<details>
<summary>Evidence: Observed interruption, registry cleanup, and abandon journal</summary>

```text
{
  "before": {
    "mounted": true,
    "interactive": true,
    "count": 1
  },
  "after": {
    "mounted": false,
    "abortCalls": 1,
    "doneCalls": 1,
    "result": {
      "endInterview": false,
      "answers": {},
      "interrupted": true
    },
    "interactive": false,
    "count": 0,
    "journal": [
      {
        "ts": "2026-09-08T11:36:42.824Z",
        "flowId": "auto-orchestrator-1788867401731",
        "seq": 1,
        "eventType": "orchestrator-dispatch-match",
        "data": {
          "source": "auto-orchestrator",
          "name": "advance",
          "reason": "fixture-dispatch",
          "unitType": "execute-task",
          "unitId": "M001/S01/T01"
        }
      },
      {
        "ts": "2026-09-08T11:36:42.828Z",
        "flowId": "auto-orchestrator-1788867401731",
        "seq": 2,
        "eventType": "orchestrator-iteration-end",
        "data": {
          "source": "auto-orchestrator",
          "name": "unit-abandon",
          "reason": "verify-gate wedge",
          "unitType": "execute-task",
          "unitId": "M001/S01/T01"
        }
      }
    ]
  }
}
```
</details>
<details>
<summary>Evidence: Evidence harness retained for reproduction</summary>

```text
// Project/App: gsd-pi
// File Purpose: Auto Orchestration module contract and ADR-015 invariant sequence tests.
//
// Phase 2 of #442 collapsed the nine adapter seams into AutoOrchestrator. These
// tests therefore drive the REAL collapsed orchestrator against real temp
// SQLite + git fixtures (fixture builder modelled on
// state-reconciliation-drift.test.ts) and inject dispatch decisions through the
// real unified rule registry (setRegistry) rather than mock adapters. Decision
// logic is asserted on observable advance() outcomes and journal events instead
// of an internal calls[] array. Dispatch-decision parity (formerly the
// createWiredDispatchAdapter tests) is asserted against the exported pure
// decideOrchestratorDispatch helper.

import test from "node:test";
import assert from "node:assert/strict";
import { execFileSync } from "node:child_process";
import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";
import { join } from "node:path";

import {
  _setPreserveProjectionChangesFnForTests,
  classifyAutoAdvanceFailure,
  createAutoOrchestrator,
  decideOrchestratorDispatch,
  resolveLiveOrchestratorBasePath,
} from "../auto/orchestrator.js";
import type { OrchestratorContext } from "../auto/orchestrator.js";
import type { AutoOrchestrationModule, AutoSessionContext } from "../auto/contracts.js";
import type { GSDState } from "../types.js";
import { resolveDispatch, type DispatchContext } from "../auto-dispatch.js";
import { RuleRegistry, setRegistry, resetRegistry } from "../rule-registry.js";
import type { UnifiedRule } from "../rule-types.js";
import { supportsStructuredQuestions } from "../workflow-mcp.js";
import {
  closeDatabase,
  insertArtifact,
  insertAssessment,
  insertGateRow,
  insertMilestone,
  insertSlice,
  insertTask,
  openDatabase,
} from "../gsd-db.js";
import { AutoSession } from "../auto/session.js";
import { markWorkerCrashed, registerAutoWorker } from "../db/auto-workers.js";
import { claimMilestoneLease, forceReleaseLeasesForWorker, getMilestoneLease, releaseMilestoneLease } from "../db/milestone-leases.js";
import { recordDispatchClaim } from "../db/unit-dispatches.js";
import { claimTaskAttempt, settleTaskAttempt } from "../task-execution-domain-operation.js";
import { recordFailureAndSelectRecovery, resumeTaskRecovery } from "../task-recovery-domain-operation.js";
import { internalExecutionInvocation } from "../execution-invocation.js";
import { normalizeRealPath, resolveMilestoneFile } from "../paths.js";
import { acquireSessionLock, releaseSessionLock } from "../session-lock.js";
import { queryJournal } from "../journal.js";
import { invalidateAllCaches } from "../cache.js";
import { invalidateStateCache } from "../state.js";
import {
  COMPLETED_NO_ADVANCE_GUARD_ID,
  getOpenWedge,
} from "../auto-liveness-backstop.js";
import { renderRoadmapFromDb } from "../markdown-renderer.js";
import {
  clearInFlightTools,
  getInFlightToolCount,
  hasInteractiveToolInFlight,
  markToolStart,
} from "../auto-tool-tracking.js";

// ─────────────────────────────────────────────────────────────────────────────
// Fixture builder
//
// Builds a real, isolated project: a git repo (so the pre-dispatch health gate
// and merge-state reconciliation have something real to probe), a SQLite DB
// seeded with one active milestone/slice/task, and the matching ROADMAP/PLAN
// markdown projection. A real session lock is acquired so the orchestrator's
// ensureLockOwnership passes. A fresh AutoSession is wired to the base path. A
// dispatch rule is installed in the real unified registry so resolveDispatch
// yields a deterministic decision — this is the only "injection", and it is the
// same public seam (setRegistry) the dispatch engine already exposes.
// ─────────────────────────────────────────────────────────────────────────────

type DispatchRuleResult =
  | { action: "dispatch"; unitType: string; unitId: string; prompt: string; pauseAfterDispatch?: boolean }
  | { action: "stop"; reason: string; level: "info" | "warning" | "error" }
  | { action: "skip"; matchedRule?: string };

interface FixtureOptions {
  /** When provided, the rule returns this result. Defaults to dispatching M001/S01/T01. */
  dispatch?: () => DispatchRuleResult | Promise<DispatchRuleResult>;
  /** Rule name (becomes the dispatch `reason`/`matchedRule`). */
  ruleName?: string;
  /** Skip seeding a ready task (used for the "no remaining units" / complete scenarios). */
  noTask?: boolean;
  /** Mark the seeded milestone complete (drives the completion → stopped path). */
  complete?: boolean;
}

interface Fixture {
  base: string;
  session: AutoSession;
  ctx: OrchestratorContext;
  orchestrator: AutoOrchestrationModule;
  /** Names emitted to the journal by the orchestrator (data.name), in order. */
  journalNames(): string[];
  cleanup(): void;
}

const DEFAULT_DISPATCH: DispatchRuleResult = {
  action: "dispatch",
  unitType: "execute-task",
  unitId: "M001/S01/T01",
  prompt: "fixture-prompt",
};

function gitInit(base: string): void {
  execFileSync("git", ["init", "--initial-branch=main"], { cwd: base, stdio: "ignore" });
  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: base, stdio: "ignore" });
  execFileSync("git", ["config", "user.name", "Test"], { cwd: base, stdio: "ignore" });
  writeFileSync(join(base, ".gitkeep"), "");
  execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
  execFileSync("git", ["commit", "-m", "initial"], { cwd: base, stdio: "ignore" });
}

function makeFixture(opts: FixtureOptions = {}): Fixture {
  const base = mkdtempSync(join(tmpdir(), "gsd-orchestrator-"));
  gitInit(base);

  const milestoneDir = join(base, ".gsd", "milestones", "M001");
  const sliceDir = join(milestoneDir, "slices", "S01");
  mkdirSync(join(sliceDir, "tasks"), { recursive: true });

  invalidateAllCaches();
  invalidateStateCache();
  openDatabase(join(base, ".gsd", "gsd.db"));
  insertMilestone({ id: "M001", title: "Milestone", status: opts.complete ? "complete" : "active" });
  if (opts.complete) {
    insertSlice({
      id: "S01",
      milestoneId: "M001",
      title: "Slice",
      status: "complete",
      risk: "low",
      depends: [],
      demo: "",
      sequence: 1,
    });
  } else if (!opts.noTask) {
    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active", risk: "low", depends: [], demo: "", sequence: 1 });
    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Task", status: "active" });
  }

  writeFileSync(
    join(milestoneDir, "M001-ROADMAP.md"),
    [
      "# M001: Milestone",
      "",
      "**Vision:** Fixture milestone",
      "",
      "## Slices",
      "",
      "- [ ] **S01: Slice** `risk:low` `depends:[]`",
      "",
    ].join("\n"),
  );
  if (!opts.noTask && !opts.complete) {
    writeFileSync(
      join(sliceDir, "S01-PLAN.md"),
      [
        "# S01: Slice",
        "",
        "**Goal:** Fixture goal",
        "**Demo:** Fixture demo",
        "",
        "## Must-Haves",
        "",
        "- Everything works",
        "",
        "## Tasks",
        "",
        "- [ ] **T01: Task** `est:1h`",
        "",
      ].join("\n"),
    );
  }

  acquireSessionLock(base);

  const session = new AutoSession();
  session.basePath = base;
  session.originalBasePath = base;
  session.currentMilestoneId = "M001";
  session.resourceVersionOnStart = null;
  session.workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });

  const ctx: OrchestratorContext = {
    ctx: { model: {}, modelRegistry: { getAll: () => [], getAvailable: () => [] }, ui: { notify() {} } } as never,
    pi: { getActiveTools: () => [] } as never,
    dispatchBasePath: base,
    runtimeBasePath: base,
    session,
  };

  const ruleName = opts.ruleName ?? "fixture-dispatch";
  const decide = opts.dispatch ?? (() => DEFAULT_DISPATCH);
  const rule: UnifiedRule = {
    name: ruleName,
    when: "dispatch",
    evaluation: "first-match",
    where: async () => decide(),
    then: (r: unknown) => r,
  };
  setRegistry(new RuleRegistry([rule]));

  const orchestrator = createAutoOrchestrator(ctx);

  return {
    base,
    session,
    ctx,
    orchestrator,
    journalNames() {
      return queryJournal(base)
        .map((e) => (e.data as Record<string, unknown> | undefined)?.name)
        .filter((n): n is string => typeof n === "string");
    },
    cleanup() {
      resetRegistry();
      try { releaseSessionLock(base); } catch { /* */ }
      try { closeDatabase(); } catch { /* */ }
      try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
    },
  };
}


import { showInterviewRound } from "../../shared/interview-ui.js";

test("abandon dismisses rendered pending interview through the abort signal", async (t) => {
  const f = makeFixture();
  t.after(() => f.cleanup());
  t.after(() => clearInFlightTools());
  const controller = new AbortController();
  let abortCalls = 0;
  let doneCalls = 0;
  let widget: any;
  let mounted = false;
  const extCtx = f.ctx.ctx as any;
  extCtx.isIdle = () => controller.signal.aborted;
  extCtx.abort = () => { abortCalls++; controller.abort(); };
  const first = await f.orchestrator.advance();
  assert.equal(first.kind, "advanced");
  if (first.kind !== "advanced") throw new Error("expected advance");
  const pending = showInterviewRound([
    { id: "route", header: "Route", question: "Which route?", options: [
      { label: "Web App", description: "A web app" },
      { label: "CLI Tool", description: "A CLI tool" },
    ] },
  ], { signal: controller.signal }, { ui: { custom: (factory: any) => new Promise(resolve => {
    const theme = { fg: (_c: string, text: string) => text, bold: (text: string) => text };
    widget = factory({ requestRender() {} }, theme, {}, (result: any) => {
      doneCalls++; mounted = false; resolve(result);
    });
    mounted = true;
  }) } } as any);
  markToolStart("pending-question", true, "ask_user_questions");
  const before = { mounted, interactive: hasInteractiveToolInFlight(), count: getInFlightToolCount() };
  const rendered = widget.render(100).join("\n");
  await f.orchestrator.abandonActiveUnit(first.unit, "verify-gate wedge");
  assert.equal(abortCalls, 1);
  assert.equal(mounted, false);
  const result = await pending;
  assert.deepEqual(result, { endInterview: false, answers: {}, interrupted: true });
  controller.abort();
  widget.handleInput("\r");
  assert.equal(doneCalls, 1);
  assert.equal(getInFlightToolCount(), 0);
  assert.equal(hasInteractiveToolInFlight(), false);
  assert.ok(f.journalNames().includes("unit-abandon"));
  const after = { mounted, abortCalls, doneCalls, result, interactive: hasInteractiveToolInFlight(), count: getInFlightToolCount(), journal: queryJournal(f.base) };
  const evidence = process.env.ELICITATION_EVIDENCE;
  if (evidence) {
    writeFileSync(join(evidence, "abandon-behavior.json"), JSON.stringify({ before, after }, null, 2));
    const escape = (text: string) => text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
    writeFileSync(join(evidence, "interview-render.html"), `<!doctype html><meta charset="utf-8"><title>Abandon interview evidence</title><style>body{background:#17191d;color:#eee;padding:24px;font:15px monospace}pre{white-space:pre-wrap}</style><h1>Before abandonment</h1><p>Actual interview component render, plain test theme. Host mounting is mocked.</p><pre>${escape(rendered)}</pre><h1>After abandonment</h1><pre>${escape(JSON.stringify({ mounted, abortCalls, doneCalls, result, interactive: after.interactive, count: after.count }, null, 2))}</pre>`);
  }
});
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (3m39s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e247c6ae1faa67d6de2f692c455e4d8da8ce68ad","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Full TUI recovery remains unproven: the harness mocks UI mounting and turn cancellation, so it cannot establish actual PgUp/PgDn restoration or spinner removal. The in-app browser was unavailable for visual inspection. Decide whether this partial evidence is sufficient or require a running-TUI reproduction.
- <code>`pnpm install --frozen-lockfile --ignore-scripts` restored missing dependencies.</code>
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-orchestrator.test.ts src/resources/extensions/shared/tests/interview-abort-dismiss.test.ts src/resources/extensions/gsd/tests/unit-turn-abort.test.ts src/resources/extensions/gsd/tests/interactive-tool-idle-exemption.test.ts`
- <code>Ran temporary `abandon-evidence.test.ts`: connected real orchestration and interview components through an AbortController; asserted interruption, exactly-once completion, cleared registry, and persisted abandon journal; captured HTML and JSON.</code>
- <code>RED / sabotage: temporarily restored base orchestrator and ran `--test-name-pattern=&#39;#2212|abandon dismisses rendered&#39;` against orchestrator and evidence tests. Both failed with abort calls `0 !== 1`.</code>
- <code>GREEN: restored target orchestrator and reran those selectors plus `interview-abort-dismiss.test.ts`; all passed.</code>
- `Attempted in-app browser inspection of locally served HTML; browser unavailable.`
- <code>Removed temporary harness and installed dependency directories; `git status --short` and `git diff --exit-code` confirmed clean source.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ `tsconfig.extensions.json` - TypeScript checking failed because workspace build outputs are missing, including @gsd/pi-coding-agent declarations. The outer executor must provide those outputs and rerun pnpm run typecheck:extensions; this phase cannot establish a clean result.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

