### PR TITLE
fix(gsd): classify the lease-fencing abort as structural so the loop stops retrying

### DIFF
--- a/src/resources/extensions/gsd/auto/infra-errors.ts
+++ b/src/resources/extensions/gsd/auto/infra-errors.ts
@@ -33,7 +33,8 @@ export const INFRA_ERROR_CODES: ReadonlySet<string> = new Set([
 /**
  * Detect whether an error is an unrecoverable infrastructure failure.
  * Checks the `code` property (Node system errors) and falls back to
- * scanning the message string for known error code tokens.
+ * scanning the message string for known error code tokens, plus
+ * structural SQLite aborts that retrying can never resolve.
  *
  * Returns the matched code string, or null if the error is not an
  * infrastructure failure.
@@ -50,6 +51,13 @@ export function isInfrastructureError(err: unknown): string | null {
   // SQLite WAL corruption is not transient — retrying burns LLM budget
   // for guaranteed failures (#2823).
   if (msg.includes("database disk image is malformed")) return "SQLITE_CORRUPT";
+  // Lease-fencing RAISE(ABORT) is deterministic: the turn no longer holds the
+  // milestone lease, and retrying the identical iteration can never re-acquire
+  // the same fencing token. Retrying only burns LLM budget (the loop's
+  // stale-lease forceReclaim recovery on resume is the sanctioned re-entry).
+  // One substring covers both trigger messages (with and without the
+  // "or current replacement lease" tail).
+  if (msg.includes("requires the current held lease")) return "LEASE_FENCING_LOST";
   return null;
 }
 

--- a/src/resources/extensions/gsd/tests/infra-error.test.ts
+++ b/src/resources/extensions/gsd/tests/infra-error.test.ts
@@ -112,6 +112,47 @@ test("returns null for non-infra code property", () => {
   assert.equal(isInfrastructureError(err), null);
 });
 
+// ── isInfrastructureError: structural SQLite aborts ──────────────────────────
+
+test("classifies lease-fencing RAISE(ABORT) as LEASE_FENCING_LOST (long trigger)", () => {
+  const err = new Error(
+    "workflow attempt requires the current held lease or current replacement lease",
+  );
+  assert.equal(isInfrastructureError(err), "LEASE_FENCING_LOST");
+});
+
+test("classifies lease-fencing RAISE(ABORT) as LEASE_FENCING_LOST (short trigger)", () => {
+  const err = new Error("workflow attempt requires the current held lease");
+  assert.equal(isInfrastructureError(err), "LEASE_FENCING_LOST");
+});
+
+test("lease-fencing classification survives sqlite trigger wrapping", () => {
+  // node:sqlite surfaces RAISE(ABORT) text verbatim, but a driver-level
+  // constraint prefix must not break the classification — a non-null code is
+  // what the auto-loop keys on to hard-stop instead of retrying.
+  const err = new Error(
+    "UNIQUE constraint failed: RAISE(ABORT, workflow attempt requires the current held lease or current replacement lease)",
+  );
+  assert.notEqual(isInfrastructureError(err), null);
+  assert.equal(isInfrastructureError(err), "LEASE_FENCING_LOST");
+});
+
+test("does not over-match messages that merely mention leases", () => {
+  assert.equal(isInfrastructureError(new Error("milestone lease acquired")), null);
+});
+
+test("SQLITE_CORRUPT special-case still fires (regression guard)", () => {
+  assert.equal(isInfrastructureError(new Error("database disk image is malformed")), "SQLITE_CORRUPT");
+});
+
+test("ENOSPC code detection still fires (regression guard)", () => {
+  assert.equal(isInfrastructureError(Object.assign(new Error("write ENOSPC"), { code: "ENOSPC" })), "ENOSPC");
+});
+
+test("generic error still returns null (regression guard)", () => {
+  assert.equal(isInfrastructureError(new Error("something broke")), null);
+});
+
 // ── isInfrastructureError: edge cases ────────────────────────────────────────
 
 test("message fallback still fires even if code property is non-infra", () => {


### PR DESCRIPTION
## TL;DR

**What:** `isInfrastructureError` now classifies the workflow-attempt lease-fencing `RAISE(ABORT)` as structural (`LEASE_FENCING_LOST`).
**Why:** the abort is deterministic, but the loop treated it as a retryable iteration error and re-dispatched the same unit unboundedly (7× observed, $7–15 cost spikes) because `consecutiveErrors` resets across pause/resume.
**How:** one message-based check mirroring the existing `SQLITE_CORRUPT` special-case; the loop's existing infra path then hard-stops with a crash note.

Closes #2222

## What

- `src/resources/extensions/gsd/auto/infra-errors.ts`: after the `SQLITE_CORRUPT` case, a message containing `requires the current held lease` returns `LEASE_FENCING_LOST`. The substring covers all three trigger raise sites (`db-attempt-recovery-schema.ts:157`, `db-lifecycle-foundation-schema.ts:193/231`).
- `src/resources/extensions/gsd/tests/infra-error.test.ts`: regression tests for both trigger message variants, wrapped-message safety, and over-match guards (a message that merely mentions leases stays `null`; `SQLITE_CORRUPT`/`ENOSPC`/generic behavior unchanged).

## Why

A turn that lost its milestone lease can never re-acquire the same fencing token by retrying the identical iteration — exactly the guaranteed-failure class the function already special-cases for WAL corruption. Falling through to the retry path burned LLM budget without ever advancing the unit; the pause→resume cycle resets the loop-local strike counter, so the ceiling never applied. With this classification, the loop takes its existing infrastructure-error path (notify + crash note + stop); the sanctioned re-entry (`/gsd auto`) recovers through the stale-lease forceReclaim path, which is the correct way to obtain a fresh fencing token.

## How

Blast radius checked across all four non-test callers of `isInfrastructureError`: the auto-loop catch block is the intended beneficiary; the native-git-bridge and git-service call sites gate on `TRANSIENT_GIT_RETRY_CODES` or are unreachable with this message, and behave identically to before (same precedent as the existing `SQLITE_CORRUPT` return). Verified with a live node:sqlite repro that `RAISE(ABORT)` text surfaces verbatim (the repo driver is node:sqlite, not better-sqlite3). Scope note: the `consecutiveErrors` reset amplifier named in the issue is a separate concern (loop-state persistence) and intentionally untouched.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).