### PR TITLE
fix(gsd): match persisted tool calls structurally, not by activity-file grep

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -253,6 +253,25 @@ function hasRoadmapReassessmentArtifact(basePath: string, milestoneId: string): 
   return false;
 }
 
+/**
+ * Structural tool match inside one activity JSONL entry (#2223). Only real
+ * toolCall parts and toolResult messages count — the unit's own prompt is
+ * persisted as a custom_message entry that names every tool, so text content
+ * must never match.
+ */
+function activityEntryMentionsTool(rawEntry: unknown, toolName: string): boolean {
+  const entry = rawEntry as { type?: unknown; message?: unknown } | null;
+  if (!entry || entry.type !== "message" || !entry.message) return false;
+  const message = entry.message as { role?: unknown; content?: unknown; toolName?: unknown };
+  if (message.role === "assistant" && Array.isArray(message.content)) {
+    for (const part of message.content) {
+      const typed = part as { type?: unknown; name?: unknown } | null;
+      if (typed && typed.type === "toolCall" && typed.name === toolName) return true;
+    }
+  }
+  return message.role === "toolResult" && message.toolName === toolName;
+}
+
 function unitActivityMentionsTool(basePath: string, unitType: string, unitId: string, toolName: string): boolean {
   const safeUnitId = unitId.replace(/\//g, "-");
   const activityDir = join(basePath, ".gsd", "activity");
@@ -263,7 +282,15 @@ function unitActivityMentionsTool(basePath: string, unitType: string, unitId: st
       if (!entry.isFile()) continue;
       if (!entry.name.endsWith(`${unitType}-${safeUnitId}.jsonl`)) continue;
       const content = readFileSync(join(activityDir, entry.name), "utf-8");
-      if (content.includes(toolName)) return true;
+      for (const line of content.split("\n")) {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (activityEntryMentionsTool(parsed, toolName)) return true;
+      }
     }
   } catch {
     return false;

--- a/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts
@@ -2,8 +2,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
 
 import { postUnitPreVerification } from "../auto-post-unit.ts";
 import { AutoSession } from "../auto/session.ts";
@@ -295,4 +297,251 @@ test("artifact retry context stays stable across attempts while notifications sh
   } finally {
     cleanup(base);
   }
+});
+
+// ─── Activity-JSONL detector regression (#2223) ─────────────────────────────
+// unitActivityMentionsTool greps .gsd/activity/<unit>.jsonl as a fallback. The
+// unit's own prompt is persisted in that same file as a plain custom_message
+// entry listing every tool name, so only structural toolCall/toolResult
+// entries may count as a reopen/replan handoff.
+
+function makeActivityRepo(): string {
+  const base = join(tmpdir(), `gsd-handoff-activity-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  return base;
+}
+
+function writeActivityFile(base: string, lines: string[]): void {
+  mkdirSync(join(base, ".gsd", "activity"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "activity", "001-complete-slice-M001-S01.jsonl"), lines.join("\n"));
+}
+
+function cleanupActivityRepo(base: string): void {
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+function unitPromptEntry(): string {
+  return JSON.stringify({
+    type: "custom_message",
+    customType: "gsd-unit-prompt",
+    message:
+      "Complete slice M001/S01. Call gsd_task_complete to finish a task, " +
+      "gsd_task_reopen to reopen a task, or gsd_replan_slice to replan this slice.",
+  });
+}
+
+function activityToolCallEntry(toolName: string): string {
+  return JSON.stringify({
+    type: "message",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "toolCall", name: toolName, id: "call_1", arguments: { taskId: "T01" } },
+        { type: "text", text: "Reopening T01 before handing off." },
+      ],
+    },
+  });
+}
+
+test("activity file whose only gsd_task_reopen mention is the unit prompt is not a handoff", async (t) => {
+  const base = makeActivityRepo();
+  t.after(() => cleanupActivityRepo(base));
+  writeActivityFile(base, [unitPromptEntry()]);
+
+  const s = new AutoSession();
+  s.active = true;
+  s.basePath = base;
+  s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+  const notifications: string[] = [];
+  const result = await postUnitPreVerification(
+    makePostUnitContext(base, s, notifications),
+    { skipSettleDelay: true, skipWorktreeSync: true },
+  );
+
+  assert.equal(result, "continue");
+  assert.equal(s.pendingVerificationRetry, null);
+  assert.ok(
+    notifications.every((message) => !message.includes("handed off via reopen/replan")),
+    `unit prompt alone must not read as handoff, got: ${notifications.join("\n")}`,
+  );
+  assert.ok(
+    notifications.some((message) => message.includes("DB unavailable")),
+    `expected DB-unavailable fallback, got: ${notifications.join("\n")}`,
+  );
+});
+
+test("activity file with a real gsd_task_reopen toolCall entry counts as a handoff", async (t) => {
+  const base = makeActivityRepo();
+  t.after(() => cleanupActivityRepo(base));
+  writeActivityFile(base, [activityToolCallEntry("gsd_task_reopen")]);
+
+  const s = new AutoSession();
+  s.active = true;
+  s.basePath = base;
+  s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+  const notifications: string[] = [];
+  const result = await postUnitPreVerification(
+    makePostUnitContext(base, s, notifications),
+    { skipSettleDelay: true, skipWorktreeSync: true },
+  );
+
+  assert.equal(result, "continue");
+  assert.ok(
+    notifications.some((message) => message.includes("handed off via reopen/replan")),
+    `expected handoff notification, got: ${notifications.join("\n")}`,
+  );
+});
+
+test("activity file with a gsd_replan_slice toolResult entry counts as a replan signal", async (t) => {
+  const base = makeActivityRepo();
+  t.after(() => cleanupActivityRepo(base));
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-REPLAN.md"), "# Replan\n");
+  writeActivityFile(base, [
+    JSON.stringify({
+      type: "message",
+      message: {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "gsd_replan_slice",
+        isError: false,
+        content: "Slice replanned with reopened task T02.",
+      },
+    }),
+  ]);
+
+  const s = new AutoSession();
+  s.active = true;
+  s.basePath = base;
+  s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+  const notifications: string[] = [];
+  const result = await postUnitPreVerification(
+    makePostUnitContext(base, s, notifications),
+    { skipSettleDelay: true, skipWorktreeSync: true },
+  );
+
+  assert.equal(result, "continue");
+  assert.ok(
+    notifications.some((message) => message.includes("valid replan outcome")),
+    `expected handoff notification, got: ${notifications.join("\n")}`,
+  );
+});
+
+test("ordinary message text mentioning the tools is not a handoff or replan", async (t) => {
+  const base = makeActivityRepo();
+  t.after(() => cleanupActivityRepo(base));
+  writeActivityFile(base, [
+    JSON.stringify({
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I considered gsd_task_reopen and gsd_replan_slice but the slice is complete." },
+        ],
+      },
+    }),
+    JSON.stringify({
+      type: "message",
+      message: { role: "user", content: [{ type: "text", text: "do not call gsd_task_reopen" }] },
+    }),
+    JSON.stringify({
+      type: "message",
+      message: {
+        role: "toolResult",
+        toolCallId: "call_9",
+        toolName: "gsd_exec",
+        isError: false,
+        content: "ran: gsd_task_reopen --dry-run (not invoked)",
+      },
+    }),
+  ]);
+
+  const s = new AutoSession();
+  s.active = true;
+  s.basePath = base;
+  s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+  const notifications: string[] = [];
+  const result = await postUnitPreVerification(
+    makePostUnitContext(base, s, notifications),
+    { skipSettleDelay: true, skipWorktreeSync: true },
+  );
+
+  assert.equal(result, "continue");
+  assert.ok(
+    notifications.every((message) => !message.includes("handed off via reopen/replan")),
+    `assistant/user text must not read as handoff, got: ${notifications.join("\n")}`,
+  );
+  assert.ok(
+    notifications.every((message) => !message.includes("valid replan outcome")),
+    `assistant/user text must not read as replan outcome, got: ${notifications.join("\n")}`,
+  );
+  assert.ok(
+    notifications.some((message) => message.includes("DB unavailable")),
+    `expected DB-unavailable fallback, got: ${notifications.join("\n")}`,
+  );
+});
+
+test("malformed activity lines are skipped without breaking tool detection", async (t) => {
+  const base = makeActivityRepo();
+  t.after(() => cleanupActivityRepo(base));
+  writeActivityFile(base, [
+    '{"type": "message", "message": { "role": "assistant", "content": [ truncated',
+    activityToolCallEntry("gsd_task_reopen"),
+  ]);
+
+  const s = new AutoSession();
+  s.active = true;
+  s.basePath = base;
+  s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+  const notifications: string[] = [];
+  const result = await postUnitPreVerification(
+    makePostUnitContext(base, s, notifications),
+    { skipSettleDelay: true, skipWorktreeSync: true },
+  );
+
+  assert.equal(result, "continue");
+  assert.ok(
+    notifications.some((message) => message.includes("handed off via reopen/replan")),
+    `expected handoff notification after skipping corrupt line, got: ${notifications.join("\n")}`,
+  );
+});
+
+test("activity file whose only gsd_replan_slice mention is the unit prompt is not a replan outcome", async (t) => {
+  const base = makeActivityRepo();
+  t.after(() => cleanupActivityRepo(base));
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-REPLAN.md"), "# Replan\n");
+  writeActivityFile(base, [unitPromptEntry()]);
+
+  const s = new AutoSession();
+  s.active = true;
+  s.basePath = base;
+  s.currentUnit = { type: "complete-slice", id: "M001/S01", startedAt: Date.now() };
+
+  const notifications: string[] = [];
+  const result = await postUnitPreVerification(
+    makePostUnitContext(base, s, notifications),
+    { skipSettleDelay: true, skipWorktreeSync: true },
+  );
+
+  assert.equal(result, "continue");
+  assert.ok(
+    notifications.every((message) => !message.includes("valid replan outcome")),
+    `unit prompt alone must not read as replan outcome, got: ${notifications.join("\n")}`,
+  );
+  assert.ok(
+    notifications.every((message) => !message.includes("handed off via reopen/replan")),
+    `unit prompt alone must not read as handoff, got: ${notifications.join("\n")}`,
+  );
+  assert.ok(
+    notifications.some((message) => message.includes("DB unavailable")),
+    `expected DB-unavailable fallback, got: ${notifications.join("\n")}`,
+  );
 });


### PR DESCRIPTION
## TL;DR

**What:** `unitActivityMentionsTool` now parses activity JSONL entries and matches only real `toolCall`/`toolResult` structures instead of grepping raw file text.
**Why:** the unit's own prompt entry lists the full tool surface, so the raw grep made every complete-slice session look like it handed off via `gsd_task_reopen`/`gsd_replan_slice`, skipping closeout retry and escalating into `completed-no-advance` wedges.
**How:** same traversal `session-forensics.ts` uses for these files; signature, file-matching loop, and error behavior unchanged.

Closes #2223

## What

- `src/resources/extensions/gsd/auto-post-unit.ts`: `unitActivityMentionsTool` splits the file into lines, `JSON.parse`s each (corrupt lines skipped), and matches an assistant content part with `type === "toolCall"` + `name === toolName`, or a message with `role === "toolResult"` + `toolName === toolName`. `custom_message` and ordinary text entries never match.
- `src/resources/extensions/gsd/tests/complete-slice-reopen-handoff.test.ts`: regression tests — prompt-only mention is not a handoff/replan (the bug), real toolCall/toolResult entries still count (no false negative), assistant/user text and unrelated tool-result content mentioning the names do not count, corrupt lines are skipped.

## Why

A session whose expected SUMMARY artifact is missing must fall through to closeout retry unless the unit actually invoked a reopen/replan tool. With the raw grep, the detector matched unconditionally, so slice rows never advanced and the `completed-no-advance` liveness guard minted hard wedges (two wedges from one false positive in the reporter's run). The in-memory matchers in the same file already matched structurally; this brings the persisted-activity fallback in line.

## How

The parser's entry shapes were verified against the real writer (`activity-log.ts` serializes `sessionManager.getEntries()` verbatim per line) and the established reader (`session-forensics.ts` `extractTrace`), so persisted tool calls keep matching — no false-negative regression. Blast radius: besides the two complete-slice detectors, the same function also feeds the `gsd_reassess_roadmap` evidence checks in the same file, which had the same prompt-text false-positive class and tighten in the same direction. Known pre-existing edges, unchanged and out of scope: the duplicate raw-grep helper in `auto-verification.ts` (same bug class, different flow — flagged for a follow-up), the fallback not checking `isError` on persisted tool results, and historical activity files for a reused unit ID.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).