### PR TITLE
fix(gsd): stop doubling the colon in provider-error pause messages

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -513,7 +513,7 @@ async function pauseTransientWithBackoff(
     ctx.ui.notify(`Transient provider errors persisted after ${MAX_TRANSIENT_AUTO_RESUMES} auto-resume attempts. Pausing for manual review.`, "warning");
   }
   await pauseAutoForProviderError(ctx.ui, errorDetail, () => pauseAuto(ctx, pi, {
-    message: `Provider error: ${errorDetail}`,
+    message: `Provider error${errorDetail}`,
     category: "provider",
     isTransient: allowAutoResume,
     retryAfterMs,
@@ -931,7 +931,7 @@ export async function handleAgentEnd(
     // state (split-brain, #1973). The transient branch above deliberately does
     // NOT abort — it auto-resumes the same unit in the same session.
     await pauseAutoForProviderError(ctx.ui, errorDetail, () => pauseAuto(ctx, pi, {
-      message: `Provider error: ${errorDetail}`,
+      message: `Provider error${errorDetail}`,
       category: "provider",
       isTransient: false,
     }, { abortActiveTurn: true }), {

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -718,6 +718,60 @@ test("usage-limit agent_end resolves a credential-cooldown cancellation without 
   }
 });
 
+test("transient provider-error pause message has a single colon (#2227)", async (t) => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const timers: Array<{ fn: () => void; delay?: number }> = [];
+  globalThis.setTimeout = ((fn: () => void, delay?: number) => {
+    timers.push({ fn, delay });
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  t.after(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    _resetPendingResolve();
+    resetTransientRetryState();
+    autoSession.reset();
+  });
+
+  resetTransientRetryState();
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+  const resultPromise = new Promise<any>((resolve) => _setCurrentResolve(resolve));
+
+  // No basePath on the session, so tryProviderModelFallback short-circuits
+  // and the exhausted transient error falls through to pauseTransientWithBackoff.
+  await handleAgentEnd({
+    sendMessage: () => {},
+  } as any, {
+    willRetry: false,
+    messages: [{
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "Connection error.",
+    }],
+  } as any, {
+    model: { provider: "openai-codex", id: "gpt-5.5" },
+    modelRegistry: { getAvailable: () => [] },
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWidget: () => {},
+      setWorkingMessage: () => {},
+    },
+  } as any);
+
+  const result = await resultPromise;
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext.category, "provider");
+  assert.equal(result.errorContext.isTransient, true);
+  assert.equal(
+    result.errorContext.message,
+    "Provider error: Connection error.",
+    "pause message must contain exactly one colon-space (#2227)",
+  );
+  assert.equal(timers.length, 1, "transient pause schedules exactly one auto-resume timer");
+});
+
 test("retry-exhausted transient provider errors trigger model fallback (#1364, #2031)", async () => {
   const originalCwd = process.cwd();
   const originalSetTimeout = globalThis.setTimeout;
@@ -1428,4 +1482,64 @@ test("#1973: permanent/unknown provider-error pause aborts the still-live host t
     process.chdir(originalCwd);
     rmSync(base, { recursive: true, force: true });
   }
+});
+
+test("permanent/unknown provider-error pause message has a single colon (#2227)", async (t) => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-unknown-pause-colon-"));
+  let abortCalls = 0;
+  t.after(() => {
+    _resetPendingResolve();
+    autoSession.reset();
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  resetTransientRetryState();
+  autoSession.reset();
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  process.chdir(base);
+
+  autoSession.active = true;
+  autoSession.basePath = base;
+  autoSession.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+  const resultPromise = new Promise<any>((resolve) => _setCurrentResolve(resolve));
+
+  const ctx = {
+    model: { provider: "anthropic", id: "claude-opus-4" },
+    modelRegistry: { getAvailable: () => [] },
+    isIdle: () => false,
+    abort: () => {
+      abortCalls += 1;
+    },
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWidget: () => {},
+      setWorkingMessage: () => {},
+    },
+  } as any;
+  const pi = {
+    setModel: async () => false,
+    sendMessage: () => {},
+  } as any;
+
+  await handleAgentEnd(pi, {
+    messages: [{
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "Anthropic stream ended before message_stop",
+    }],
+  } as any, ctx);
+
+  const result = await resultPromise;
+  assert.equal(abortCalls, 1, "permanent/unknown pause must abort the live host turn");
+  assert.deepEqual(result, {
+    status: "cancelled",
+    errorContext: {
+      message: "Provider error: Anthropic stream ended before message_stop",
+      category: "provider",
+      isTransient: false,
+    },
+  });
 });


### PR DESCRIPTION
## TL;DR

**What:** the two provider-error pause messages that prepended a literal `Provider error: ` before the colon-leading `errorDetail` suffix now use the suffix convention, so banners render `Provider error: <detail>` instead of `Provider error: : <detail>`.
**Why:** `errorDetail` is built with a leading `": "` and every consumer treats it as a suffix — two interpolations didn't, doubling the colon in the transient and permanent/unknown pause banners (#2227, reporter saw `Provider error: : Anthropic stream ended before message_stop`).
**How:** two one-line template corrections plus regression tests on both paths.

Addresses the double-colon note in #2227 (does not close it — the issue's pinned-zone duplication is routed separately to a human).

## What

- `src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts`: `pauseTransientWithBackoff` and the permanent/unknown pause in `handleAgentEnd` now render `` `Provider error${errorDetail}` ``, matching the rate-limit cancel (:912), `Tool schema error${errorDetail}`, the `buildPauseDetail` closures, and `pauseAutoForProviderError`. An empty detail renders `Provider error` with no dangling colon.
- `src/resources/extensions/gsd/tests/provider-errors.test.ts`: two tests driving the real `handleAgentEnd` path, asserting the pause message by exact equality — one through the transient path, one through the permanent/unknown path with the issue's literal message.

## Why

The doubled colon made auto-mode's pause banner look malformed at exactly the moment users are reading an error. Tracing all `errorDetail` consumers showed the suffix contract is universal; only these two interpolations deviated. The issue's literal banner comes from the permanent/unknown site: `Anthropic stream ended before message_stop` classifies as `unknown`, not transient — which is why fixing only the transient path would have missed the reported surface.

## How

Both regression tests failed against the pre-fix code with the doubled form (the permanent-path test reproduces the issue-title banner end-to-end) and pass after. Site-by-site audit of every `errorDetail` consumer confirms single-colon output everywhere, including the empty-detail case. Known pre-existing oddity, unchanged and out of scope: `unit-phase.ts` can pass an already-prefixed `errorContext.message` into `pauseAutoForProviderError`, producing a doubled prefix on that unrelated path — flagged for a possible follow-up.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).