### PR TITLE
fix(gsd): make the headless query preview non-mutating

### DIFF
--- a/src/headless-query.ts
+++ b/src/headless-query.ts
@@ -178,6 +178,9 @@ async function runHeadlessQueryUnsafe(
       midTitle: state.activeMilestone.title,
       state,
       prefs: loaded?.preferences,
+      // Read-only contract: the preview decides like a real turn but must not
+      // persist dispatch effects (#2230 — e.g. gate omission on evaluating-gates).
+      preview: true,
     })
     next = {
       action: dispatch.action,

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -182,6 +182,12 @@ export interface DispatchContext {
   sessionBaseUrl?: string;
   /** Session model auth mode, used for transport preflight checks. */
   sessionAuthMode?: "apiKey" | "oauth" | "externalCli" | "none";
+  /**
+   * Preview mode (read-only `gsd headless ... query`): dispatch decisions are
+   * computed exactly as in a real turn, but no rule may persist a dispatch
+   * side effect (DB writes, file writes, counters, markers).
+   */
+  preview?: boolean;
 }
 
 function resolveExistingExpectedArtifact(
@@ -377,12 +383,20 @@ export async function readUatGateVerdict(
  * Returns false in light mode (or when prefs absent) so the milestone
  * rules behave exactly as before.
  */
-export function getDeepStageGate(prefs: GSDPreferences | undefined, basePath: string): DeepStageGate {
-  return resolveDeepProjectSetupState(prefs, basePath);
+export function getDeepStageGate(
+  prefs: GSDPreferences | undefined,
+  basePath: string,
+  preview = false,
+): DeepStageGate {
+  return resolveDeepProjectSetupState(prefs, basePath, preview);
 }
 
-export function hasPendingDeepStage(prefs: GSDPreferences | undefined, basePath: string): boolean {
-  const gate = getDeepStageGate(prefs, basePath);
+export function hasPendingDeepStage(
+  prefs: GSDPreferences | undefined,
+  basePath: string,
+  preview = false,
+): boolean {
+  const gate = getDeepStageGate(prefs, basePath, preview);
   return gate.status === "pending" || gate.status === "blocked";
 }
 
@@ -835,17 +849,21 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "rewrite-docs (override gate)",
-    match: async ({ mid, midTitle, state, basePath, session }) => {
+    match: async ({ mid, midTitle, state, basePath, session, preview }) => {
       const pendingOverrides = await loadActiveOverrides(basePath);
       if (pendingOverrides.length === 0) return null;
       const count = getRewriteCount(basePath);
       if (count >= MAX_REWRITE_ATTEMPTS) {
-        const { resolveAllOverrides } = await import("./files.js");
-        await resolveAllOverrides(basePath);
-        setRewriteCount(basePath, 0);
+        // Preview: same fall-through decision, no override resolution or
+        // counter reset persisted.
+        if (!preview) {
+          const { resolveAllOverrides } = await import("./files.js");
+          await resolveAllOverrides(basePath);
+          setRewriteCount(basePath, 0);
+        }
         return null;
       }
-      setRewriteCount(basePath, count + 1);
+      if (!preview) setRewriteCount(basePath, count + 1);
       const unitId = state.activeSlice ? `${mid}/${state.activeSlice.id}` : mid;
       return {
         action: "dispatch",
@@ -875,7 +893,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
     // Fire BEFORE the execution-entry phase rules so we redispatch to
     // `discuss-milestone` instead of hitting the plan-v2 gate.
     name: "execution-entry phase (no context) → discuss-milestone",
-    match: async ({ state, mid, midTitle, basePath, session, prefs, structuredQuestionsAvailable }) => {
+    match: async ({ state, mid, midTitle, basePath, session, prefs, structuredQuestionsAvailable, preview }) => {
       if (!EXECUTION_ENTRY_PHASES.has(state.phase)) return null;
       if (!MILESTONE_ID_RE.test(mid)) return null;
       if (isRegistryMilestoneComplete(state, mid)) return null;
@@ -904,7 +922,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // deadlock. Deep planning is still user-driven even inside auto-mode,
       // so it must wait for explicit approval instead of taking this bypass.
       if (shouldBypassMilestoneDepthGateInAuto(prefs)) {
-        hostWriteGateAdapter.markDepthVerified(mid, basePath);
+        if (!preview) hostWriteGateAdapter.markDepthVerified(mid, basePath);
       }
       return {
         action: "dispatch",
@@ -954,6 +972,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       activeTools,
       registeredTools,
       sessionBaseUrl,
+      preview,
     }) => {
       const needsRunUat = await checkNeedsRunUat(
         basePath,
@@ -1012,7 +1031,8 @@ export const DISPATCH_RULES: DispatchRule[] = [
           level: "warning" as const,
         };
       }
-      incrementUatCount(basePath, mid, sliceId);
+      // Preview must not burn a retry attempt; the dispatch decision is shared.
+      if (!preview) incrementUatCount(basePath, mid, sliceId);
       const uatFile = resolveSliceFile(basePath, mid, sliceId, "UAT")!;
       const uatContent = await loadFile(uatFile);
       return {
@@ -1083,18 +1103,18 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "needs-discussion → discuss-milestone",
-    match: async ({ state, mid, midTitle, basePath, prefs, structuredQuestionsAvailable }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, structuredQuestionsAvailable, preview }) => {
       if (state.phase !== "needs-discussion") return null;
       // Deep mode bypass: yield to the project-level deep stage gates
       // (workflow-prefs, discuss-project, discuss-requirements,
       // research-decision, research-project) when any of them still have
       // work pending. Without this guard, the milestone discuss rule wins
       // before the deep rules ever get a chance to fire.
-      if (hasPendingDeepStage(prefs, basePath)) return null;
+      if (hasPendingDeepStage(prefs, basePath, preview)) return null;
       // H6 fix (#4973): keep the non-deep auto-mode bypass, but do not
       // pre-verify deep planning's user-facing milestone approval gate.
       if (shouldBypassMilestoneDepthGateInAuto(prefs)) {
-        hostWriteGateAdapter.markDepthVerified(mid, basePath);
+        if (!preview) hostWriteGateAdapter.markDepthVerified(mid, basePath);
       }
       return {
         action: "dispatch",
@@ -1117,11 +1137,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
     // defaults-writing. Keep it in-process so missing preferences cannot loop
     // on the same no-input unit until the liveness backstop trips.
     name: "deep: pre-planning (no workflow prefs) → workflow-preferences",
-    match: async ({ state, basePath, prefs }) => {
+    match: async ({ state, basePath, prefs, preview }) => {
       if (prefs?.planning_depth !== "deep") return null;
       if (state.phase !== "pre-planning" && state.phase !== "needs-discussion") return null;
       if (isWorkflowPrefsCaptured(basePath)) return null; // already captured — fall through
-      ensureWorkflowPreferencesCaptured(basePath);
+      // Preview: report the same fall-through without writing the defaults.
+      if (!preview) ensureWorkflowPreferencesCaptured(basePath);
       return null;
     },
   },
@@ -1175,10 +1196,10 @@ export const DISPATCH_RULES: DispatchRule[] = [
     // rule reads the marker to decide whether to fan out 4 parallel research subagents.
     // Light mode skips entirely.
     name: "deep: pre-planning (no research decision) → research-decision",
-    match: async ({ state, basePath, prefs, structuredQuestionsAvailable }) => {
+    match: async ({ state, basePath, prefs, structuredQuestionsAvailable, preview }) => {
       if (prefs?.planning_depth !== "deep") return null;
       if (state.phase !== "pre-planning" && state.phase !== "needs-discussion") return null;
-      const gate = resolveDeepProjectSetupState(prefs, basePath);
+      const gate = resolveDeepProjectSetupState(prefs, basePath, preview);
       if (gate.status !== "pending" || gate.stage !== "research-decision") return null;
       return {
         action: "dispatch",
@@ -1196,10 +1217,10 @@ export const DISPATCH_RULES: DispatchRule[] = [
     // out 4 parallel subagents (stack, features, architecture, pitfalls).
     // Skipped entirely when user chose "skip" at the research-decision gate.
     name: "deep: pre-planning (research approved, files missing) → research-project",
-    match: async ({ state, basePath, prefs, structuredQuestionsAvailable, sessionProvider }) => {
+    match: async ({ state, basePath, prefs, structuredQuestionsAvailable, sessionProvider, preview }) => {
       if (prefs?.planning_depth !== "deep") return null;
       if (state.phase !== "pre-planning" && state.phase !== "needs-discussion") return null;
-      const gate = resolveDeepProjectSetupState(prefs, basePath);
+      const gate = resolveDeepProjectSetupState(prefs, basePath, preview);
       if (gate.status === "blocked" && gate.stage === "project-research") {
         return {
           action: "stop" as const,
@@ -1219,18 +1240,22 @@ export const DISPATCH_RULES: DispatchRule[] = [
         level: "info" as const,
       };
       if (existsSync(inflightMarkerPath)) return researchInFlightStop;
-      mkdirSync(runtimeDir, { recursive: true });
-      try {
-        writeFileSync(
-          inflightMarkerPath,
-          JSON.stringify({ started: new Date().toISOString() }) + "\n",
-          { encoding: "utf-8", flag: "wx" },
-        );
-      } catch (err) {
-        if (err && typeof err === "object" && "code" in err && err.code === "EEXIST") {
-          return researchInFlightStop;
+      // Preview: the in-flight marker is a dispatch effect — report the
+      // dispatch without claiming the fan-out.
+      if (!preview) {
+        mkdirSync(runtimeDir, { recursive: true });
+        try {
+          writeFileSync(
+            inflightMarkerPath,
+            JSON.stringify({ started: new Date().toISOString() }) + "\n",
+            { encoding: "utf-8", flag: "wx" },
+          );
+        } catch (err) {
+          if (err && typeof err === "object" && "code" in err && err.code === "EEXIST") {
+            return researchInFlightStop;
+          }
+          throw err;
         }
-        throw err;
       }
       try {
         const prompt = await researchProjectPromptBuilder(basePath, structuredQuestionsAvailable, sessionProvider);
@@ -1242,7 +1267,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
         };
       } catch (err) {
         try {
-          if (existsSync(inflightMarkerPath)) unlinkSync(inflightMarkerPath);
+          // Preview never created the marker — unlinking could delete one a
+          // concurrent dispatch just created (#2230).
+          if (!preview && existsSync(inflightMarkerPath)) unlinkSync(inflightMarkerPath);
         } catch (cleanupErr) {
           logWarning(
             "dispatch",
@@ -1255,7 +1282,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "pre-planning (no context) → discuss-milestone",
-    match: async ({ state, mid, midTitle, basePath, prefs, session, structuredQuestionsAvailable }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, session, structuredQuestionsAvailable, preview }) => {
       if (state.phase !== "pre-planning") return null;
       if (isRegistryMilestoneComplete(state, mid)) return null;
       const contextBasePath = resolveWorktreeProjectRoot(basePath, session?.originalBasePath);
@@ -1268,7 +1295,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // H6 fix (#4973): keep the non-deep auto-mode bypass, but do not
       // pre-verify deep planning's user-facing milestone approval gate.
       if (shouldBypassMilestoneDepthGateInAuto(prefs)) {
-        hostWriteGateAdapter.markDepthVerified(mid, basePath);
+        if (!preview) hostWriteGateAdapter.markDepthVerified(mid, basePath);
       }
       return {
         action: "dispatch",
@@ -1456,7 +1483,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
     // PLAN.md is only a projection, so plan-slice/refine-slice handlers must
     // explicitly clear `is_sketch` when a sketch becomes a full plan.
     name: "refining → refine-slice",
-    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry, sessionProvider }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry, sessionProvider, preview }) => {
       if (state.phase !== "refining") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice.id;
@@ -1467,7 +1494,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (isDbAvailable()) {
         const planFile = resolveSliceFile(basePath, mid, sid, "PLAN");
         if (planFile && existsSync(planFile)) {
-          setSliceSketchFlag(mid, sid, false);
+          // Preview shares the skip decision; only the heal write is
+          // suppressed.
+          if (!preview) setSliceSketchFlag(mid, sid, false);
           return { action: "skip" };
         }
       }
@@ -1548,7 +1577,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "evaluating-gates → gate-evaluate",
-    match: async ({ state, mid, midTitle, basePath, prefs }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, preview }) => {
       if (state.phase !== "evaluating-gates") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice.id;
@@ -1557,7 +1586,10 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // Gate evaluation is opt-in via preferences
       const gateConfig = prefs?.gate_evaluation;
       if (!gateConfig?.enabled) {
-        markPendingGatesOmittedForTurn(mid, sid, "gate-evaluate");
+        // Preview contract: a preview must not persist dispatch effects. The
+        // skip decision is shared; only the omission write is suppressed
+        // (#2230 — a headless query must not flip pending gates).
+        if (!preview) markPendingGatesOmittedForTurn(mid, sid, "gate-evaluate");
         return { action: "skip" };
       }
 
@@ -1631,7 +1663,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → reactive-execute (parallel dispatch)",
-    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry, sessionProvider }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry, sessionProvider, preview }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return null; // fall through
 
@@ -1719,15 +1751,18 @@ export const DISPATCH_RULES: DispatchRule[] = [
         );
 
         // Persist dispatched batch so verification and recovery can check
-        // exactly which tasks were sent.
-        const { saveReactiveState } = await import("./reactive-graph.js");
-        saveReactiveState(basePath, mid, sid, {
-          sliceId: sid,
-          completed: [...completed],
-          dispatched: selected,
-          graphSnapshot: metrics,
-          updatedAt: new Date().toISOString(),
-        });
+        // exactly which tasks were sent. Preview reports the batch without
+        // persisting it.
+        if (!preview) {
+          const { saveReactiveState } = await import("./reactive-graph.js");
+          saveReactiveState(basePath, mid, sid, {
+            sliceId: sid,
+            completed: [...completed],
+            dispatched: selected,
+            graphSnapshot: metrics,
+            updatedAt: new Date().toISOString(),
+          });
+        }
 
         // Encode selected task IDs in unitId for artifact verification.
         // Format: M001/S01/reactive+T02,T03
@@ -1763,7 +1798,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → execute-task (recover missing task plan → plan-slice)",
-    match: async ({ state, mid, midTitle, basePath, session, sessionContextWindow, modelRegistry, sessionProvider }) => {
+    match: async ({ state, mid, midTitle, basePath, session, sessionContextWindow, modelRegistry, sessionProvider, preview }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -1807,29 +1842,48 @@ export const DISPATCH_RULES: DispatchRule[] = [
         // artifacts rather than at a hardcoded canonical path.
         let planRenderError: string | null = null;
         if (!resolveSliceFile(artifactBasePath, mid, sid, "PLAN")) {
-          try {
-            const { renderPlanFromDb } = await import("./markdown-renderer.js");
-            const rendered = await renderPlanFromDb(artifactBasePath, mid, sid);
-            process.stderr.write(
-              `gsd-projection-heal: re-rendered missing slice PLAN for ${unitId} from the DB at ${rendered.planPath}\n`,
-            );
-          } catch (err) {
-            // A Windows sharing violation is transient contention, not a DB
-            // projection gap. Preserve it as a typed throw so Recovery
-            // Classification routes through the loop's existing retry budget.
-            throwIfTransientProjectionLockError(err);
-            // Fail loud below: a DB that genuinely lacks the slice rows is a
-            // real error, and the stop diagnosis reports it verbatim.
-            planRenderError = err instanceof Error ? err.message : String(err);
-            logWarning(
-              "dispatch",
-              `slice PLAN re-render from DB failed for ${unitId}: ${planRenderError}`,
-            );
-          }
-          if (slicePlanHasEmbeddedTasks(artifactBasePath, mid, sid)) {
-            session?.missingTaskPlanRetryCount?.delete(unitId);
-            // PLAN restored — fall through to the normal execute-task rule.
-            return null;
+          if (preview) {
+            // Preview: the re-render is a PLAN projection write. Mirror the
+            // failure-free outcome read-only: renderPlanFromDb writes only
+            // after the slice and its active tasks resolve from the DB, and
+            // its rendered plan always carries a <tasks> block — so a real
+            // turn would restore the PLAN, see embedded tasks, and fall
+            // through to the normal execute-task rule (#2230). Otherwise the
+            // render would throw and reach the same replan decision below.
+            const { getSlice, getSliceTasks } = await import("./gsd-db.js");
+            if (
+              isDbAvailable() &&
+              getSlice(mid, sid) &&
+              getSliceTasks(mid, sid).some((task) => task.status !== "skipped")
+            ) {
+              session?.missingTaskPlanRetryCount?.delete(unitId);
+              return null;
+            }
+          } else {
+            try {
+              const { renderPlanFromDb } = await import("./markdown-renderer.js");
+              const rendered = await renderPlanFromDb(artifactBasePath, mid, sid);
+              process.stderr.write(
+                `gsd-projection-heal: re-rendered missing slice PLAN for ${unitId} from the DB at ${rendered.planPath}\n`,
+              );
+            } catch (err) {
+              // A Windows sharing violation is transient contention, not a DB
+              // projection gap. Preserve it as a typed throw so Recovery
+              // Classification routes through the loop's existing retry budget.
+              throwIfTransientProjectionLockError(err);
+              // Fail loud below: a DB that genuinely lacks the slice rows is a
+              // real error, and the stop diagnosis reports it verbatim.
+              planRenderError = err instanceof Error ? err.message : String(err);
+              logWarning(
+                "dispatch",
+                `slice PLAN re-render from DB failed for ${unitId}: ${planRenderError}`,
+              );
+            }
+            if (slicePlanHasEmbeddedTasks(artifactBasePath, mid, sid)) {
+              session?.missingTaskPlanRetryCount?.delete(unitId);
+              // PLAN restored — fall through to the normal execute-task rule.
+              return null;
+            }
           }
         }
         // #1520: if the slice plan with embedded tasks exists at the original
@@ -1961,7 +2015,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   {
     name: "validating-milestone → validate-milestone",
     match: async (ctx) => {
-      const { state, mid, midTitle, basePath, prefs, session } = ctx;
+      const { state, mid, midTitle, basePath, prefs, session, preview } = ctx;
       if (state.phase !== "validating-milestone") return null;
 
       const adoptedMilestone = isMilestoneLifecycleAdopted(mid);
@@ -1982,8 +2036,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // #6225: validation requires per-slice ASSESSMENT artifacts (MV02), but
       // the default auto path can complete all slices without creating them.
       // Backfill no-change assessments for completed slices that already have
-      // SUMMARY evidence before dispatching validate-milestone.
-      if (!adoptedMilestone) backfillMissingAssessmentsFromSummaries(basePath, mid);
+      // SUMMARY evidence before dispatching validate-milestone. Preview skips
+      // the backfill writes; the dispatch decision below is unaffected.
+      if (!adoptedMilestone && !preview) backfillMissingAssessmentsFromSummaries(basePath, mid);
 
       // #4781 phase 2: trivial-scope milestones skip the dedicated validate
       // unit — complete-milestone's own verification steps (3/4/5 in the
@@ -1995,21 +2050,28 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (prefs?.phases?.skip_milestone_validation || trivialVariant) {
         const skipReason = trivialVariant ? "trivial-scope" : "preference";
         if (adoptedMilestone) {
-          const waiver = recordAdoptedMilestoneValidationWaiver(
-            basePath,
-            mid,
-            skipReason,
-            prefs,
-          );
-          if (!waiver.ok) {
-            return {
-              action: "stop",
-              reason: `Cannot waive milestone validation for ${mid}: ${waiver.error}`,
-              level: "warning",
-            };
+          // Preview: skip the waiver commit but keep the downstream guarded
+          // dispatch decision identical.
+          if (!preview) {
+            const waiver = recordAdoptedMilestoneValidationWaiver(
+              basePath,
+              mid,
+              skipReason,
+              prefs,
+            );
+            if (!waiver.ok) {
+              return {
+                action: "stop",
+                reason: `Cannot waive milestone validation for ${mid}: ${waiver.error}`,
+                level: "warning",
+              };
+            }
           }
           const { evaluateGuardedCompleteMilestoneDispatch } = await import("./milestone-closeout.js");
-          return evaluateGuardedCompleteMilestoneDispatch(ctx);
+          // Preview suppressed the waiver write above; tell the guarded
+          // evaluation to treat the would-be waiver as recorded so the
+          // returned decision equals the real turn's (#2230).
+          return evaluateGuardedCompleteMilestoneDispatch(ctx, { assumeValidationWaived: preview });
         }
         const artifactBasePath = resolveArtifactBasePath(basePath, mid, session);
         const projectRoot = resolveWorktreeProjectRoot(basePath, session?.originalBasePath);
@@ -2045,6 +2107,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
           "",
           `Milestone validation was skipped via ${skipSource}.`,
         ].join("\n");
+        // Preview shares the skip decision; the VALIDATION projection and the
+        // DB-backed pass rows are dispatch effects and are not persisted.
+        if (preview) return { action: "skip" };
         atomicWriteSync(validationPath, content, "utf-8");
         try {
           // DB-backed state derivation keys off assessments, not only the file

--- a/src/resources/extensions/gsd/closeout-consistency-gate.ts
+++ b/src/resources/extensions/gsd/closeout-consistency-gate.ts
@@ -30,6 +30,7 @@ import { invalidateAllCaches } from "./cache.js";
 import {
   isMilestoneLifecycleAdopted,
   readMilestoneCloseoutAuthorization,
+  type MilestoneCloseoutAuthorization,
   type MilestoneCloseoutBlocker,
 } from "./db/milestone-closeout-readiness.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
@@ -43,6 +44,24 @@ import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { atomicWriteSync, removeProjectionFileSync } from "./atomic-write.js";
 
 export const CLOSEOUT_CONSISTENCY_BLOCKED_REASON = "closeout-consistency-blocked";
+
+/**
+ * Authorization blockers a fresh validation waiver supersedes. The real
+ * grant only requires an adopted, open lifecycle — it never inspects the
+ * recorded validation state — so under a preview dry-run these blockers are
+ * exactly the ones the would-be waiver would erase. `validation-receipt-invalid`
+ * is excluded: it implies corrupt or multiple waivers, where the real grant
+ * throws and the dispatch rule stops.
+ */
+const VALIDATION_SHAPED_BLOCKERS: ReadonlySet<MilestoneCloseoutBlocker["kind"]> = new Set([
+  "validation-missing",
+  "validation-not-pass",
+  "validation-stale",
+  "validation-attempt-newer",
+  "validation-source-revision-mismatch",
+  "criterion-unsatisfied",
+  "source-revision-mismatch",
+]);
 
 export type CloseoutConsistencyFailureReason =
   | "db-unavailable"
@@ -70,6 +89,20 @@ export interface CloseoutConsistencyOptions {
   allowOpenMilestone?: boolean;
   artifactBasePath?: string;
   allowPassThroughValidation?: boolean;
+  /**
+   * Preview dry-run (#2230): the dispatch rule records the validation waiver
+   * immediately before this gate in a real turn, and preview suppresses that
+   * write. When set, a missing-waiver block is treated as waived (without
+   * writing) so the preview decision equals the real turn's. Any other
+   * blocker still blocks, matching the real post-waiver evaluation.
+   */
+  assumeValidationWaived?: boolean;
+  /**
+   * Preview dry-run (#2230): evaluate without the gate's own writes — the
+   * pass-through validation recorder and evidence-based gate closure.
+   * Decisions are mirrored read-only so the result equals the real turn's.
+   */
+  readOnly?: boolean;
 }
 
 function blocked(reason: CloseoutConsistencyFailureReason, message: string): CloseoutConsistencyResult {
@@ -253,13 +286,21 @@ export function checkCloseoutConsistencyGate(
     validationRequired &&
     !adoptedMilestone &&
     validation?.status !== "pass" &&
-    options.allowPassThroughValidation &&
-    recordCloseoutPassThroughValidationIfReady(
-      milestoneId,
-      options.artifactBasePath ?? artifactBasePathFromDb(),
-    )
+    options.allowPassThroughValidation
   ) {
-    validation = getLatestAssessmentByScope(milestoneId, "milestone-validation");
+    const artifactBasePath = options.artifactBasePath ?? artifactBasePathFromDb();
+    if (options.readOnly) {
+      // Preview: the pass-through recorder writes a VALIDATION projection and
+      // assessment/gate rows. It only records when no assessment exists and
+      // every closed slice has SUMMARY evidence — mirror those read-only
+      // preconditions and evaluate the rest of the gate as if recorded,
+      // without writing (#2230).
+      if (!validation && artifactBasePath && allSlicesHaveCloseoutSummaryEvidence(milestoneId, artifactBasePath)) {
+        validation = { status: "pass" } as NonNullable<typeof validation>;
+      }
+    } else if (recordCloseoutPassThroughValidationIfReady(milestoneId, artifactBasePath)) {
+      validation = getLatestAssessmentByScope(milestoneId, "milestone-validation");
+    }
   }
   let canonicalAuthorization = null;
   let authorizationDrift: VerificationSourceDriftDiagnosis = {
@@ -298,6 +339,31 @@ export function checkCloseoutConsistencyGate(
       milestoneId,
       sourceRevision: source.sourceRevision,
     });
+    if (
+      options.assumeValidationWaived &&
+      !canonicalAuthorization.authorized &&
+      canonicalAuthorization.blockers.length > 0 &&
+      canonicalAuthorization.blockers.every(
+        (blocker) => VALIDATION_SHAPED_BLOCKERS.has(blocker.kind),
+      )
+    ) {
+      // Preview dry-run: the would-be waiver is treated as recorded. The real
+      // grant is unconditional with respect to validation state (it only
+      // requires an adopted, open lifecycle and supersedes any prior waiver
+      // or validation event), so any all-validation-shaped blocker would be
+      // erased by the fresh waiver. The fabricated receipt carries the
+      // gate's own source revision, so the revision-match outcome equals the
+      // real waiver granted for this tree. `validation-receipt-invalid` is
+      // excluded: it implies corrupt/multiple waivers, where the real grant
+      // throws and the rule stops.
+      canonicalAuthorization = {
+        authorized: true,
+        kind: "waived",
+        eventId: `preview:${milestoneId}`,
+        revision: 0,
+        testedSourceRevision: source.sourceRevision,
+      } satisfies MilestoneCloseoutAuthorization;
+    }
     if (
       !canonicalAuthorization.authorized &&
       canonicalAuthorization.blockers.some(
@@ -355,7 +421,10 @@ export function checkCloseoutConsistencyGate(
     ? inspectQualityGatesFromEvidence(milestoneId, gateClosureOptions)
     : { repaired: [], unresolved: [] };
 
-  if (!adoptedMilestone && gateClosureOptions) {
+  // Closing gates persists what the read-only inspection above already found;
+  // the pending-gate decision below uses plannedGateClosure either way, so
+  // suppressing the write under preview is decision-neutral (#2230).
+  if (!adoptedMilestone && gateClosureOptions && !options.readOnly) {
     closeQualityGatesFromEvidence(milestoneId, gateClosureOptions);
   }
 

--- a/src/resources/extensions/gsd/deep-project-setup-policy.ts
+++ b/src/resources/extensions/gsd/deep-project-setup-policy.ts
@@ -128,6 +128,7 @@ function downstreamSetupArtifactsValid(root: string, basePath: string): boolean 
 export function resolveDeepProjectSetupState(
   prefs: GSDPreferences | undefined,
   basePath: string,
+  preview = false,
 ): DeepProjectSetupState {
   if (prefs?.planning_depth !== "deep") {
     return {
@@ -143,8 +144,12 @@ export function resolveDeepProjectSetupState(
     // the missing `workflow_prefs_captured: true` flag is drift (manual edit,
     // partial write, merge conflict). Restore it instead of forcing the user
     // back through setup — the original Bug #2 false-pending root cause.
+    // The heal is persistence-only: the fall-through re-derives its decision
+    // from the same artifacts `downstreamSetupArtifactsValid` just verified,
+    // so suppressing it under preview keeps the returned decision identical
+    // (#2230).
     if (downstreamSetupArtifactsValid(root, basePath)) {
-      ensureWorkflowPreferencesCaptured(basePath);
+      if (!preview) ensureWorkflowPreferencesCaptured(basePath);
       // Fall through — checks below will pass since downstreamSetupArtifactsValid
       // already verified them.
     } else {
@@ -190,7 +195,9 @@ export function resolveDeepProjectSetupState(
 
   const marker = readDecision(basePath);
   if (!marker.exists) {
-    writeDefaultResearchSkipDecision(basePath, "missing-default-repair");
+    // The deterministic skip default below is decided here either way; the
+    // marker write is persistence-only for future turns (#2230 preview).
+    if (!preview) writeDefaultResearchSkipDecision(basePath, "missing-default-repair");
     return {
       status: "complete",
       stage: null,
@@ -198,7 +205,7 @@ export function resolveDeepProjectSetupState(
     };
   }
   if (!marker.valid) {
-    writeDefaultResearchSkipDecision(basePath, "malformed-default-repair");
+    if (!preview) writeDefaultResearchSkipDecision(basePath, "malformed-default-repair");
     return {
       status: "complete",
       stage: null,
@@ -213,7 +220,7 @@ export function resolveDeepProjectSetupState(
     };
   }
   if (!isExplicitResearchDecision(marker)) {
-    writeDefaultResearchSkipDecision(basePath, "legacy-workflow-research-default", marker.source);
+    if (!preview) writeDefaultResearchSkipDecision(basePath, "legacy-workflow-research-default", marker.source);
     return {
       status: "complete",
       stage: null,

--- a/src/resources/extensions/gsd/milestone-closeout.ts
+++ b/src/resources/extensions/gsd/milestone-closeout.ts
@@ -193,6 +193,7 @@ export async function evaluateCompleteMilestoneDispatch(
 /** Run the complete-milestone guards independently of legacy state derivation. */
 export async function evaluateGuardedCompleteMilestoneDispatch(
   ctx: DispatchContext,
+  opts: { assumeValidationWaived?: boolean } = {},
 ): Promise<DispatchAction> {
   const { mid, midTitle, basePath, prefs } = ctx;
   const adoptedMilestone = isDbAvailable() && isMilestoneLifecycleAdopted(mid);
@@ -204,6 +205,12 @@ export async function evaluateGuardedCompleteMilestoneDispatch(
       const summaryPath = resolveExpectedArtifactPath("complete-milestone", mid, artifactBasePath);
       const summaryMissing = !summaryPath || !existsSync(summaryPath);
       if (summaryMissing) {
+        // Preview must not persist dispatch effects (#2230): report the skip
+        // a successful repair produces without writing the projection.
+        // Failure-path divergence (accepted): when the repair would fail, the
+        // real turn dispatches complete-milestone to retry while preview
+        // still reports skip — a preview cannot write the repair.
+        if (ctx.preview) return { action: "skip" };
         const repair = await repairMissingMilestoneSummaryProjection(basePath, mid);
         if (!repair.ok) {
           logWarning(
@@ -219,8 +226,19 @@ export async function evaluateGuardedCompleteMilestoneDispatch(
     }
   }
 
-  const closeoutGitStop = commitPendingMilestoneCloseoutChanges(basePath, mid);
-  if (closeoutGitStop) return closeoutGitStop;
+  // Preview must never commit from a read-only query (#2230): skip the
+  // closeout preflight commit and continue evaluating the guards.
+  // Failure-path divergence (accepted): when the commit would fail or the
+  // tree has unresolved conflicts, the real turn stops here while preview
+  // continues to the guards below — a preview cannot commit. If the commit
+  // SUCCEEDS it advances HEAD before the consistency gate captures its source
+  // revision, so a dirty tree can make the real turn stop with a revision
+  // mismatch that the preview (evaluated against the uncommitted tree) did
+  // not see.
+  if (!ctx.preview) {
+    const closeoutGitStop = commitPendingMilestoneCloseoutChanges(basePath, mid);
+    if (closeoutGitStop) return closeoutGitStop;
+  }
 
   if (prefs?.uat_dispatch) {
     // DB-authoritative (ADR-017): UAT sign-off gating never parses the
@@ -259,6 +277,11 @@ export async function evaluateGuardedCompleteMilestoneDispatch(
       allowOpenMilestone: true,
       allowPassThroughValidation: !adoptedMilestone,
       artifactBasePath: resolveCanonicalMilestoneRoot(basePath, mid),
+      assumeValidationWaived: opts.assumeValidationWaived,
+      // Preview must not persist the gate's own effects (pass-through
+      // validation recording, evidence-based gate closure) — decisions are
+      // mirrored read-only inside the gate (#2230).
+      readOnly: ctx.preview,
     });
     if (adoptedMilestone && !consistency.ok) {
       return {

--- a/src/resources/extensions/gsd/tests/dispatch-preview-read-only.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-preview-read-only.test.ts
@@ -1,0 +1,547 @@
+// Preview dispatch purity tests (#2230)
+// A preview resolveDispatch (read-only `gsd headless ... query`) must decide
+// exactly like a real dispatch but must not persist any dispatch side effect.
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  upsertSlicePlanning,
+  upsertTaskPlanning,
+  insertGateRow,
+  getGateResults,
+  _getAdapter,
+  executeDomainOperation,
+  readDomainOperationFence,
+} from "../gsd-db.ts";
+import { adoptOrTransitionLifecycle } from "../db/writers/lifecycle-commands.ts";
+import type { DomainOperationContext } from "../db/domain-operation.ts";
+import { resolveDeepProjectSetupState } from "../deep-project-setup-policy.ts";
+import type { GSDPreferences } from "../preferences.ts";
+import { deriveState, invalidateStateCache } from "../state.ts";
+import { renderPlanFromDb } from "../markdown-renderer.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import { DISPATCH_RULES, resolveDispatch } from "../auto-dispatch.ts";
+
+const validProject = readFileSync(
+  new URL("../schemas/__fixtures__/valid-project.md", import.meta.url),
+  "utf-8",
+);
+const validRequirements = readFileSync(
+  new URL("../schemas/__fixtures__/valid-requirements.md", import.meta.url),
+  "utf-8",
+);
+
+function setupTestProject(): { tmpDir: string } {
+  const tmpDir = mkdtempSync(join(tmpdir(), "dispatch-preview-"));
+  const dbPath = join(tmpDir, ".gsd", "gsd.db");
+  mkdirSync(join(tmpDir, ".gsd"), { recursive: true });
+  openDatabase(dbPath);
+
+  insertMilestone({
+    id: "M001",
+    title: "Test Milestone",
+    status: "active",
+  });
+
+  insertSlice({
+    milestoneId: "M001",
+    id: "S01",
+    title: "Test Slice",
+    status: "pending",
+    risk: "medium",
+    depends: [],
+  });
+
+  // Write roadmap file (required for deriveState)
+  const milestoneDir = join(tmpDir, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    [
+      "# M001: Test Milestone",
+      "",
+      "## Vision",
+      "Test milestone vision.",
+      "",
+      "## Success Criteria",
+      "- Test criteria",
+      "",
+      "## Delivery Sequence",
+      "- [ ] **S01: Test Slice** `risk:medium`",
+      "  After this: test demo",
+      "",
+    ].join("\n"),
+  );
+
+  return { tmpDir };
+}
+
+function planSlice(tmpDir: string) {
+  upsertSlicePlanning("M001", "S01", {
+    goal: "Test goal",
+    successCriteria: "Test criteria",
+    proofLevel: "contract",
+    integrationClosure: "",
+    observabilityImpact: "Run tests",
+  });
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Test Task",
+    status: "pending",
+  });
+  upsertTaskPlanning("M001", "S01", "T01", {
+    title: "Test Task",
+    description: "Implement test",
+    estimate: "1h",
+    files: ["src/test.ts"],
+    verify: "npm test",
+    inputs: [],
+    expectedOutput: ["src/test.ts"],
+    observabilityImpact: "",
+    fullPlanMd: "",
+  });
+}
+
+/** Fixture in evaluating-gates with pending Q3/Q4 and gate_evaluation absent. */
+async function setupEvaluatingGates() {
+  const { tmpDir } = setupTestProject();
+  planSlice(tmpDir);
+  await renderPlanFromDb(tmpDir, "M001", "S01");
+
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", scope: "slice" });
+
+  invalidateStateCache();
+  const state = await deriveState(tmpDir);
+  assert.equal(state.phase, "evaluating-gates");
+  return { tmpDir, state };
+}
+
+describe("dispatch preview purity (#2230)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    const setup = await setupEvaluatingGates();
+    tmpDir = setup.tmpDir;
+  });
+
+  afterEach(() => {
+    invalidateAllCaches();
+    invalidateStateCache();
+    closeDatabase();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("preview resolves evaluating-gates to skip without persisting gate omission", async () => {
+    const state = await deriveState(tmpDir);
+
+    const result = await resolveDispatch({
+      basePath: tmpDir,
+      mid: "M001",
+      midTitle: "Test Milestone",
+      state,
+      prefs: undefined, // effective gate_evaluation disabled
+      preview: true,
+    });
+
+    assert.equal(result.action, "skip");
+
+    // The preview must not persist the omission: gates stay pending.
+    const byId = new Map(getGateResults("M001", "S01").map((gate) => [gate.gate_id, gate]));
+    assert.equal(byId.get("Q3")?.status, "pending", "preview must not mutate pending gate Q3");
+    assert.equal(byId.get("Q4")?.status, "pending", "preview must not mutate pending gate Q4");
+  });
+
+  test("real dispatch (no preview flag) still omits pending gates", async () => {
+    const state = await deriveState(tmpDir);
+
+    const result = await resolveDispatch({
+      basePath: tmpDir,
+      mid: "M001",
+      midTitle: "Test Milestone",
+      state,
+      prefs: undefined, // effective gate_evaluation disabled
+    });
+
+    assert.equal(result.action, "skip");
+
+    // Real dispatch behavior is unchanged: gate omission is persisted.
+    const byId = new Map(getGateResults("M001", "S01").map((gate) => [gate.gate_id, gate]));
+    assert.equal(byId.get("Q3")?.verdict, "omitted");
+    assert.equal(byId.get("Q4")?.verdict, "omitted");
+  });
+
+  test("preview with explicit gate_evaluation:{enabled:false} leaves gates pending", async () => {
+    const state = await deriveState(tmpDir);
+
+    const result = await resolveDispatch({
+      basePath: tmpDir,
+      mid: "M001",
+      midTitle: "Test Milestone",
+      state,
+      prefs: { gate_evaluation: { enabled: false } },
+      preview: true,
+    });
+
+    assert.equal(result.action, "skip");
+    const byId = new Map(getGateResults("M001", "S01").map((gate) => [gate.gate_id, gate]));
+    assert.equal(byId.get("Q3")?.status, "pending");
+    assert.equal(byId.get("Q4")?.status, "pending");
+  });
+
+  test("repeated preview queries are idempotent and non-mutating", async () => {
+    const first = await resolveDispatch({
+      basePath: tmpDir,
+      mid: "M001",
+      midTitle: "Test Milestone",
+      state: await deriveState(tmpDir),
+      prefs: undefined,
+      preview: true,
+    });
+    const second = await resolveDispatch({
+      basePath: tmpDir,
+      mid: "M001",
+      midTitle: "Test Milestone",
+      state: await deriveState(tmpDir),
+      prefs: undefined,
+      preview: true,
+    });
+
+    assert.deepEqual(second, first);
+    assert.equal(first.action, "skip");
+    const byId = new Map(getGateResults("M001", "S01").map((gate) => [gate.gate_id, gate]));
+    assert.equal(byId.get("Q3")?.status, "pending");
+    assert.equal(byId.get("Q4")?.status, "pending");
+  });
+});
+
+// ─── Adopted skip-validation closeout: preview decision fidelity ──────────
+
+function db() {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  return adapter;
+}
+
+function rowCount(sql: string): number {
+  return Number(db().prepare(sql).get()?.["count"] ?? 0);
+}
+
+function adoptFixtureAtFence(
+  writes: (context: Readonly<DomainOperationContext>) => void,
+): void {
+  const fence = readDomainOperationFence();
+  executeDomainOperation({
+    operationType: "test.fixture.adopt",
+    idempotencyKey: `fixture/test.fixture.adopt/${fence.revision}`,
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: "test",
+    sourceTransport: "test",
+    payload: { operationType: "test.fixture.adopt" },
+  }, (context) => {
+    writes(context);
+    return {
+      events: [{
+        eventType: "test.fixture.adopt",
+        entityType: "milestone",
+        entityId: "M001",
+        payload: { operationType: "test.fixture.adopt" },
+        destinations: ["test"],
+      }],
+      projections: [{
+        projectionKey: `fixture/test.fixture.adopt/${context.resultingRevision}`,
+        projectionKind: "test",
+        rendererVersion: "1",
+      }],
+    };
+  });
+}
+
+/**
+ * Adopted-lifecycle milestone whose slice work is complete: the exact
+ * validator scenario for the skip-validation closeout path.
+ */
+function makeAdoptedFixture(): string {
+  const basePath = mkdtempSync(join(tmpdir(), "dispatch-preview-adopted-"));
+  const milestoneDir = join(basePath, ".gsd", "milestones", "M001");
+  const sliceDir = join(milestoneDir, "slices", "S01");
+  mkdirSync(sliceDir, { recursive: true });
+  writeFileSync(join(basePath, ".gitignore"), ".gsd/\n");
+  writeFileSync(join(basePath, "source.ts"), "export const source = 'preview';\n");
+  writeFileSync(join(sliceDir, "S01-SUMMARY.md"), "# Summary\n");
+  execFileSync("git", ["init"], { cwd: basePath, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: basePath });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: basePath });
+  execFileSync("git", ["add", ".gitignore", "source.ts"], { cwd: basePath });
+  execFileSync("git", ["commit", "-m", "fixture"], { cwd: basePath, stdio: "ignore" });
+
+  assert.equal(openDatabase(join(basePath, ".gsd", "gsd.db")), true);
+  insertMilestone({ id: "M001", title: "Waived validation", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Done", status: "complete" });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Done", status: "complete" });
+  adoptFixtureAtFence((context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "milestone",
+      milestoneId: "M001",
+      lifecycleStatus: "ready",
+    });
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "slice",
+      milestoneId: "M001",
+      sliceId: "S01",
+      lifecycleStatus: "completed",
+    });
+    adoptOrTransitionLifecycle(context, {
+      itemKind: "task",
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      lifecycleStatus: "completed",
+    });
+  });
+  return basePath;
+}
+
+function validatingMilestoneContext(basePath: string, preview: boolean) {
+  const rule = DISPATCH_RULES.find((candidate) =>
+    candidate.name === "validating-milestone → validate-milestone"
+  );
+  assert.ok(rule, "validating-milestone dispatch rule must exist");
+  return rule.match({
+    basePath,
+    mid: "M001",
+    midTitle: "Waived validation",
+    state: {
+      phase: "validating-milestone",
+      activeMilestone: { id: "M001", title: "Waived validation" },
+      activeSlice: null,
+      activeTask: null,
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      registry: [{ id: "M001", title: "Waived validation", status: "active" }],
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      progress: { milestones: { done: 0, total: 1 } },
+    },
+    prefs: { phases: { skip_milestone_validation: true } },
+    preview,
+  } as any);
+}
+
+describe("dispatch preview decision fidelity (#2230 adopted skip-validation)", () => {
+  const fixtures: string[] = [];
+
+  afterEach(() => {
+    invalidateAllCaches();
+    invalidateStateCache();
+    closeDatabase();
+    for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+    fixtures.length = 0;
+  });
+
+  test("preview decides like the real turn when the waiver write is suppressed", async () => {
+    // Preview: waiver write suppressed — decision must still be the one the
+    // real turn reaches once the waiver is recorded.
+    fixtures.push(makeAdoptedFixture());
+    const previewResult = await validatingMilestoneContext(fixtures[0], true);
+    assert.ok(previewResult, "preview rule.match returned null");
+    const previewWaiverCount = rowCount(`SELECT COUNT(*) AS count FROM workflow_waivers`);
+    const previewValidationWritten = existsSync(
+      join(fixtures[0], ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+    );
+    closeDatabase();
+
+    // Real turn: waiver recorded.
+    fixtures.push(makeAdoptedFixture());
+    const realResult = await validatingMilestoneContext(fixtures[1], false);
+    assert.ok(realResult, "real rule.match returned null");
+    const realWaiverCount = rowCount(`SELECT COUNT(*) AS count FROM workflow_waivers`);
+    const realValidationWritten = existsSync(
+      join(fixtures[1], ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+    );
+
+    assert.equal(realResult.action, "dispatch", "real turn dispatches complete-milestone");
+    if (realResult.action !== "dispatch") throw new Error("expected real dispatch");
+    assert.equal(realResult.unitType, "complete-milestone");
+    assert.equal(realWaiverCount, 1);
+
+    assert.equal(
+      previewResult.action,
+      realResult.action,
+      `preview must return the same decision as the real turn (got ${JSON.stringify(previewResult)})`,
+    );
+    if (previewResult.action !== "dispatch") throw new Error("expected preview dispatch");
+    assert.equal(previewResult.unitType, "complete-milestone");
+    assert.equal(previewResult.unitId, realResult.unitId);
+    // The suppression held: no waiver was persisted by the preview.
+    assert.equal(previewWaiverCount, 0);
+    assert.equal(realValidationWritten, true, "real turn writes the waived VALIDATION projection");
+    assert.equal(previewValidationWritten, false, "preview must not write the waived VALIDATION projection");
+  });
+});
+
+// ─── Missing-task-plan recovery: PLAN projection purity (#2230) ───────────
+
+function markdownFiles(basePath: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".md")) out.push(full.slice(basePath.length + 1));
+    }
+  };
+  const gsdDir = join(basePath, ".gsd");
+  if (existsSync(gsdDir)) walk(gsdDir);
+  return out.sort();
+}
+
+function makeExecutingFixture(): string {
+  const { tmpDir } = setupTestProject();
+  planSlice(tmpDir); // DB slice + task rows, but NO PLAN projection on disk
+  return tmpDir;
+}
+
+function missingTaskPlanRuleMatch(basePath: string, preview: boolean) {
+  const rule = DISPATCH_RULES.find((candidate) =>
+    candidate.name === "executing → execute-task (recover missing task plan → plan-slice)"
+  );
+  assert.ok(rule, "missing-task-plan recovery rule must exist");
+  return rule.match({
+    basePath,
+    mid: "M001",
+    midTitle: "Test Milestone",
+    state: {
+      phase: "executing",
+      activeMilestone: { id: "M001", title: "Test Milestone" },
+      activeSlice: { id: "S01", title: "Test Slice" },
+      activeTask: { id: "T01", title: "Test Task" },
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      registry: [{ id: "M001", title: "Test Milestone", status: "active" }],
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      progress: { milestones: { done: 0, total: 1 } },
+    },
+    preview,
+  } as any);
+}
+
+describe("dispatch preview purity: missing-task-plan PLAN projection (#2230)", () => {
+  const fixtures: string[] = [];
+
+  afterEach(() => {
+    invalidateAllCaches();
+    invalidateStateCache();
+    closeDatabase();
+    for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+    fixtures.length = 0;
+  });
+
+  test("preview re-renders nothing; the real turn heals the PLAN — same fall-through", async () => {
+    fixtures.push(makeExecutingFixture());
+    const previewResult = await missingTaskPlanRuleMatch(fixtures[0], true);
+    const previewMarkdown = markdownFiles(fixtures[0]);
+    closeDatabase();
+
+    fixtures.push(makeExecutingFixture());
+    const realResult = await missingTaskPlanRuleMatch(fixtures[1], false);
+    const realMarkdown = markdownFiles(fixtures[1]);
+
+    // Decision parity: both the real render and the read-only mirror end in
+    // the same fall-through to the normal execute-task rule.
+    assert.equal(previewResult, null, "preview mirrors the render-success fall-through");
+    assert.equal(realResult, null, "real turn falls through after healing the PLAN");
+
+    // The real turn wrote the PLAN projection; the preview wrote nothing.
+    assert.ok(
+      realMarkdown.some((file) => file.endsWith("-PLAN.md")),
+      `real turn should heal the PLAN projection, got: ${realMarkdown.join(", ")}`,
+    );
+    assert.deepEqual(
+      previewMarkdown.filter((file) => file.endsWith("-PLAN.md")),
+      [],
+      "preview must not write the PLAN projection",
+    );
+  });
+});
+
+// ─── Deep project setup: self-heal purity (#2230) ──────────────────────────
+
+const deepPrefs = { planning_depth: "deep" } as GSDPreferences;
+
+function makeDeepFixture(opts: { prefsCaptured: boolean; withMarker: boolean }): string {
+  const base = mkdtempSync(join(tmpdir(), "dispatch-preview-deep-"));
+  mkdirSync(join(base, ".gsd", "runtime"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    `---\nplanning_depth: deep${opts.prefsCaptured ? "\nworkflow_prefs_captured: true" : ""}\n---\n`,
+  );
+  writeFileSync(join(base, ".gsd", "PROJECT.md"), validProject);
+  writeFileSync(join(base, ".gsd", "REQUIREMENTS.md"), validRequirements);
+  if (opts.withMarker) {
+    writeFileSync(
+      join(base, ".gsd", "runtime", "research-decision.json"),
+      JSON.stringify({ decision: "skip", source: "workflow-preferences" }),
+    );
+  }
+  return base;
+}
+
+describe("dispatch preview purity: deep setup self-heal (#2230)", () => {
+  const fixtures: string[] = [];
+
+  afterEach(() => {
+    for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+    fixtures.length = 0;
+  });
+
+  test("preview does not self-heal workflow prefs; decision matches the real turn", () => {
+    fixtures.push(makeDeepFixture({ prefsCaptured: false, withMarker: true }));
+    const previewState = resolveDeepProjectSetupState(deepPrefs, fixtures[0], true);
+    const prefsAfterPreview = readFileSync(join(fixtures[0], ".gsd", "PREFERENCES.md"), "utf-8");
+
+    fixtures.push(makeDeepFixture({ prefsCaptured: false, withMarker: true }));
+    const realState = resolveDeepProjectSetupState(deepPrefs, fixtures[1], false);
+    const prefsAfterReal = readFileSync(join(fixtures[1], ".gsd", "PREFERENCES.md"), "utf-8");
+
+    assert.deepEqual(
+      { status: previewState.status, stage: previewState.stage, reason: previewState.reason },
+      { status: realState.status, stage: realState.stage, reason: realState.reason },
+      "preview decision must equal the real turn's",
+    );
+    assert.match(prefsAfterReal, /workflow_prefs_captured: true/, "real turn heals the prefs flag");
+    assert.doesNotMatch(prefsAfterPreview, /workflow_prefs_captured/, "preview must not heal the prefs flag");
+  });
+
+  test("preview does not write the default research marker; decision matches the real turn", () => {
+    fixtures.push(makeDeepFixture({ prefsCaptured: true, withMarker: false }));
+    const previewState = resolveDeepProjectSetupState(deepPrefs, fixtures[0], true);
+    const markerAfterPreview = existsSync(join(fixtures[0], ".gsd", "runtime", "research-decision.json"));
+
+    fixtures.push(makeDeepFixture({ prefsCaptured: true, withMarker: false }));
+    const realState = resolveDeepProjectSetupState(deepPrefs, fixtures[1], false);
+    const markerAfterReal = existsSync(join(fixtures[1], ".gsd", "runtime", "research-decision.json"));
+
+    assert.deepEqual(
+      { status: previewState.status, stage: previewState.stage, reason: previewState.reason },
+      { status: realState.status, stage: realState.stage, reason: realState.reason },
+      "preview decision must equal the real turn's",
+    );
+    assert.equal(markerAfterReal, true, "real turn writes the default skip marker");
+    assert.equal(markerAfterPreview, false, "preview must not write the default skip marker");
+  });
+});

--- a/src/tests/headless-query-preview.test.ts
+++ b/src/tests/headless-query-preview.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Regression test for #2230: the headless query path must call
+ * resolveDispatch with preview: true so a read-only query computes the
+ * next-action preview without persisting dispatch effects.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { runHeadlessQuery } from "../headless-query.ts";
+
+test("headless query passes preview: true to resolveDispatch (#2230)", async () => {
+  const resolveDispatchArgs: Array<Record<string, unknown>> = [];
+
+  const result = await runHeadlessQuery(
+    "/tmp/project",
+    {
+      openProjectDbIfPresent: async () => {},
+      deriveState: async () => ({
+        phase: "evaluating-gates",
+        nextAction: "evaluate quality gates",
+        activeMilestone: { id: "M001", title: "Test Milestone" },
+      }),
+      resolveDispatch: async (opts: Record<string, unknown>) => {
+        resolveDispatchArgs.push(opts);
+        return { action: "skip" };
+      },
+      readAllSessionStatuses: () => [],
+      loadEffectiveGSDPreferences: () => ({ preferences: {} }),
+    } as any,
+    () => {},
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(resolveDispatchArgs.length, 1);
+  assert.equal(resolveDispatchArgs[0].preview, true);
+  assert.equal(result.data?.next.action, "skip");
+});


### PR DESCRIPTION
## TL;DR

**What:** `resolveDispatch` gains an explicit preview mode (only the headless query passes it) in which dispatch rules return the same decision without persisting anything.
**Why:** the headless query computed its preview through the normal resolver, whose rules persist state while matching — the reported case flipped pending Q3/Q4 gates to complete/omitted when gate evaluation is disabled, and a sweep found nine more match-time writes; a diagnostic query was mutating the workflow it observed, and its snapshot was computed pre-write so it also described stale state (#2230).
**How:** suppress every match-time write under preview, mirroring read-only where the decision depends on the write; regression tests pin purity, decision fidelity, and idempotence.

Closes #2230

## What

- `auto-dispatch.ts`: `preview?: boolean` on the dispatch context. The evaluating-gates rule no longer calls `markPendingGatesOmittedForTurn` when previewing (still returns the skip decision). The sweep's other match-time writes are suppressed the same way: slice-sketch heal, UAT/rewrite counters, depth-verified marks, workflow-prefs capture, research markers (including the error-path unlink), reactive state, assessment backfill, adopted-validation waivers, and the legacy VALIDATION projection path. The missing-task-plan rule mirrors the render's failure-free outcome read-only instead of writing the PLAN projection.
- `milestone-closeout.ts` / `closeout-consistency-gate.ts`: under preview the guarded closeout evaluation runs read-only — the pass-through validation recorder and quality-gate closure are suppressed (decision-neutral: the blocking check reads the same state through the read-only inspection plan), and on the adopted-skip path the gate treats the would-be validation waiver as recorded. The waiver grant is unconditional, so the fabrication fires exactly when the real turn would grant; corrupt-waiver shapes (where the real grant throws) are excluded so the preview never lies.
- `deep-project-setup-policy.ts`: the four self-heal writes are skipped under preview (their returned decisions derive from already-verified disk state, so they are decision-pure); plumbing threads the flag through the three dispatch call sites.
- `headless-query.ts`: passes `preview: true`.
- Tests: preview purity for gate rows (absent and explicit `enabled: false` prefs), PLAN projection, prefs/marker self-heals; waiver-path decision fidelity (preview and real both dispatch complete-milestone, waiver row written only by real); repeated queries idempotent; headless wiring asserts the flag is forwarded.

## Why

A polling/status client could alter pending quality gates without requesting execution — a lifecycle-observation contract violation, exactly as reported. The issue also asked to inspect other resolver rules for preview-time effects; the sweep found them, and this PR answers that ask rather than patching the single reported branch.

## How

Decision fidelity is enforced, not assumed: where a suppressed write feeds a later decision, preview mirrors the write's outcome read-only (waiver fabrication, pass-through validation preconditions, PLAN-render fall-through); where the decision derives only from already-persisted state, the write is simply skipped. Known, documented divergences are all failure-path-only and structurally unavoidable for a read-only observation: a preview cannot commit the closeout preflight (real turn stops on commit failure/conflict — or on a post-commit revision mismatch when the tree was dirty), cannot perform the SUMMARY repair (real turn retries by dispatching), and cannot reproduce a waiver-grant rejection (corrupt-waiver shapes). Non-supervised intentionally: the UAT browser-daemon warm-up still runs during preview because its failure decides stop-vs-dispatch — a process side effect, not persisted state. Production dispatch behavior is untouched: every suppression is gated on the flag that only the headless query passes.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).