### PR TITLE
fix(gsd): stop husk-task gates from wedging milestone closeout

### DIFF
--- a/src/resources/extensions/gsd/closeout-consistency-gate.ts
+++ b/src/resources/extensions/gsd/closeout-consistency-gate.ts
@@ -123,6 +123,17 @@ function isFileBackedDbPath(path: string | null): boolean {
   return Boolean(path && path !== ":memory:");
 }
 
+/**
+ * Task statuses that mean the task will never run, so its task-scoped gate
+ * rows can never be evaluated: "skipped" (the canonical status replan-slice
+ * projects onto removed "husk" tasks) and the raw legacy alias "cancelled".
+ * Deferred is intentionally absent: a deferred task is not a closed status and
+ * exits via the task-open check before gates are consulted.
+ */
+function isNeverWillRunTaskStatus(status: string | undefined): boolean {
+  return status === "skipped" || status === "cancelled";
+}
+
 function artifactBasePathFromDb(): string | undefined {
   const dbPath = getWorkflowDatabasePath();
   if (!isFileBackedDbPath(dbPath)) return undefined;
@@ -368,7 +379,9 @@ export function checkCloseoutConsistencyGate(
       );
     }
 
+    const taskStatusById = new Map<string, string>();
     for (const task of getSliceTasks(milestoneId, slice.id)) {
+      taskStatusById.set(task.id, task.status);
       if (!isClosedStatus(task.status)) {
         return blocked(
           "task-open",
@@ -377,8 +390,15 @@ export function checkCloseoutConsistencyGate(
       }
     }
 
+    // #2239: replan-slice deliberately retains removed ("husk") task rows, but
+    // their task-scoped gate rows stay pending forever. A gate whose owning
+    // task was skipped/cancelled away is unreachable — no session will ever
+    // evaluate it — so it must not block closeout. Scope is what makes a gate
+    // task-owned (a slice-scoped row may still carry a task_id), and gates of
+    // live tasks keep blocking.
     const pendingGate = getPendingGates(milestoneId, slice.id).find((gate) =>
-      !plannedGateClosure.repaired.some((repair) =>
+      !(gate.scope === "task" && isNeverWillRunTaskStatus(taskStatusById.get(gate.task_id)))
+      && !plannedGateClosure.repaired.some((repair) =>
         repair.gateId === gate.gate_id
         && repair.sliceId === gate.slice_id
         && (repair.taskId ?? "") === gate.task_id

--- a/src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-closeout-consistency-gate.test.ts
@@ -126,6 +126,128 @@ test("closeout consistency treats deferred slices as inactive", () => {
   }
 });
 
+test("closeout consistency ignores pending gates of replanned-away (husk) tasks (#2239)", (t) => {
+  t.after(() => closeDatabase());
+  assert.equal(openDatabase(":memory:"), true);
+  insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+  // Real task: evaluated gate rows are complete.
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", title: "Real", status: "complete" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q5", scope: "task", taskId: "T01", status: "complete" });
+  // Husk tasks retained by replan-slice for history/FK state; their
+  // task-scoped gate rows stay pending forever because no session will
+  // ever evaluate them.
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T02", title: "Husk skipped", status: "skipped" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q6", scope: "task", taskId: "T02" });
+  // Legacy/imported rows can carry the raw "cancelled" alias.
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T03", title: "Husk cancelled", status: "cancelled" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q7", scope: "task", taskId: "T03" });
+  insertAssessment({
+    path: "milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+
+  // In-memory DB resolves no artifact base path, so the husk gates have no
+  // evidence and are not evidence-repairable — matching the reported wedge.
+  assert.deepEqual(checkCloseoutConsistencyGate("M001"), { ok: true });
+});
+
+test("closeout consistency still blocks on a slice-scoped gate row that carries a task_id (#2239)", (t) => {
+  t.after(() => closeDatabase());
+  assert.equal(openDatabase(":memory:"), true);
+  insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", title: "Real", status: "complete" });
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T02", title: "Husk skipped", status: "skipped" });
+  // Scope is what makes a gate task-owned, not a non-empty task_id: the
+  // schema permits slice-scoped rows that carry a task_id, and such a row
+  // must block even when the referenced task was replanned away.
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q8", scope: "slice", taskId: "T02" });
+  insertAssessment({
+    path: "milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+
+  const result = checkCloseoutConsistencyGate("M001");
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.reason, "quality-gate-pending");
+});
+
+test("closeout consistency still blocks on a pending gate owned by a completed task", (t) => {
+  t.after(() => closeDatabase());
+  assert.equal(openDatabase(":memory:"), true);
+  insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", title: "Real", status: "complete" });
+  // Evaluated-gate row lost: the task ran, but its gate row is still pending.
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q5", scope: "task", taskId: "T01" });
+  insertAssessment({
+    path: "milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+
+  const result = checkCloseoutConsistencyGate("M001");
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.reason, "quality-gate-pending");
+});
+
+test("closeout consistency still blocks on a pending slice-scoped gate", (t) => {
+  t.after(() => closeDatabase());
+  assert.equal(openDatabase(":memory:"), true);
+  insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", title: "Real", status: "complete" });
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T02", title: "Husk skipped", status: "skipped" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q8", scope: "slice" });
+  insertAssessment({
+    path: "milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+
+  const result = checkCloseoutConsistencyGate("M001");
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.reason, "quality-gate-pending");
+});
+
+test("closeout consistency blocks a deferred task at task-open before gates are consulted", (t) => {
+  t.after(() => closeDatabase());
+  assert.equal(openDatabase(":memory:"), true);
+  insertMilestone({ id: "M001", title: "Milestone One", status: "complete" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete" });
+  // Precedence document: "deferred" is not a closed status, so the task-open
+  // check fires before any gate row is examined — the pending-gate exclusion
+  // never gets a chance to run for a deferred task owner.
+  insertTask({ milestoneId: "M001", sliceId: "S01", id: "T01", title: "Deferred", status: "deferred" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q5", scope: "task", taskId: "T01" });
+  insertAssessment({
+    path: "milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "verdict: pass",
+  });
+
+  const result = checkCloseoutConsistencyGate("M001");
+
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.reason, "task-open");
+});
+
 test("closeout consistency persists evidence-backed gate closures before checking pending gates", (t) => {
   const artifactBasePath = realpathSync(mkdtempSync(join(tmpdir(), "closeout-gate-order-")));
   t.after(() => {


### PR DESCRIPTION
## TL;DR

**What:** the closeout consistency gate no longer blocks on pending task-scoped quality gates whose owning task was cancelled or skipped away by a replan.
**Why:** replans retain husk task rows deliberately, their gate rows stay `pending` forever, no session will ever evaluate them, and the gate blocked on any pending row of a closed slice — wedging milestone closeout permanently even after passing validation (#2239, Bug A).
**How:** the check excludes task-scoped pending gates whose owner task is in a never-will-run state, matched by gate scope (not task_id presence); everything else blocks exactly as before.

Addresses Bug A of #2239 (does not close it — Bug B, the adopted-path closure-persistence question, is routed to maintainers in the triage comment).

## What

- `closeout-consistency-gate.ts`: in the per-slice loop, a task-status map is built from the `getSliceTasks` iteration already present; the pending-gate predicate additionally skips rows with `scope === "task"` whose owning task is `skipped` or `cancelled` (`isNeverWillRunTaskStatus`). Slice-scoped gates are matched by `scope`, so a slice-scoped row carrying a task_id still blocks. Orphan rows (owner not found) fail closed. `getPendingGates` and the replan write path are untouched.
- `merge-closeout-consistency-gate.test.ts`: five new tests — the reporter's wedge reproduced failing-first (husk Q6/Q7 pending with validation passing), controls pinning that a pending gate of a *completed* task and a pending slice-scoped gate still block, the slice-scoped-with-task_id case, and a deferred-task precedence test (task-open fires before gates; deferred is intentionally not in the exclusion).

## Why

A gate whose owning task never ran is unreachable by construction, so it can never transition out of pending — a documented outcome of the normal replan path, not just of the #2217 recovery bug. The reporter's wedge (`quality gate Q5 is still pending for S03`, recurring, unresumable) is exactly this shape.

## How

The invariant is "all *reachable* gates evaluated", not "all rows evaluated": a gate of a live or completed task can and must be evaluated, so it still blocks; a gate of a removed task cannot. Scope is checked explicitly because slice-scoped rows may carry a task_id (codex-found case, regression-tested failing-first). Blast radius: the exclusion is confined to `checkCloseoutConsistencyGate`'s pending-gate predicate — its two production callers are closeout/merge gates the wedge blocks; `getPendingGates`' other consumers are untouched; composition with the open preview-purity PR (#2238) is merge-clean and decision-parity-safe. Known pre-existing behavior, unchanged and documented: a deferred task still wedges closeout at the earlier task-open check.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).