### PR TITLE
release: v1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,70 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-09-09
+
+### Added
+- **vscode**: add Copilot project read tools
+- **gsd**: expose progress read metadata
+- **mcp**: GSD-side smoke probe and per-host checklist for canonical read tools (#2174)
+- **vscode**: show DB-authoritative project progress in sidebar (#2136) (#2143)
+- **gsd**: add gsd_project_snapshot canonical DB read tool (#2170)
+
+### Fixed
+- **gsd**: stop husk-task gates from wedging milestone closeout
+- **gsd**: rebuild markdown projections at the invocation root
+- **gsd**: make the headless query preview non-mutating
+- **gsd**: stop doubling the colon in provider-error pause messages (#2229)
+- **gsd**: match persisted tool calls structurally, not by activity-file grep (#2226)
+- **gsd**: classify the lease-fencing abort as structural so the loop stops retrying (#2225)
+- **gsd**: ack the resume-wedge before the session switch so refusals render (#2224)
+- **gsd**: preserve the planned task title on legacy completions (#2220)
+- **gsd**: dismiss pending elicitation when a unit is abandoned (#2214)
+- **gsd**: enforce the blocking-rework gate on canonical task completion
+- **gsd**: honor passing task evidence over command-not-found verify pauses (#2211)
+- **gsd**: judge evidence cross-ref claims by the newest matching run (#2206)
+- **gsd**: exempt bounded execution tools from the 5-minute stall watchdog (#2204)
+- **gsd**: stop the bash write-guard from blocking read-only state access (#2201)
+- **gsd**: pause with the finalize cause instead of wedging on identical finalize retries (#2199)
+- **gsd**: enforce blocking post-unit hooks in step mode and persist gate state (#2197)
+- **gsd**: validate run-hook IDs by unit type (#2196)
+- **gsd**: normalize Markdown-formatted versions in the version check (#2192)
+- **gsd**: claim successor attempt after an authorized recovery resume (#2190)
+- **mcp**: block GSD_WORKFLOW_BRIDGE_TEST_DISABLE from secure_env_collect
+- **mcp**: address PR #2187 review findings
+- **vscode**: address PR #2179 review findings
+- **legacy-import**: handle same milestone IDs with different unique id
+- **vscode**: harden Copilot project read tools
+- **vscode**: constrain Copilot project reads
+- **gsd**: add GPT-6 Astra Copilot support
+- **gsd**: recover milestone completion status from summaries
+- **gsd**: honor auto_push at closeout when git.isolation is none (#2156)
+- **native**: allow deletion while the SQLite identity lock is held on Windows (#2183)
+- **gsd**: detect same-version resource drift via live fingerprint (#2163)
+- **gsd**: fix streaming render starvation and CTRL+O flash (#2124)
+- **gsd**: prevent UAT schema errors from poisoning retries (#2017)
+- **pi-agent-core**: preserve isError from resolved tool results (#2016)
+- **legacy-import**: handle contradictory task field in summary guard (#2152)
+- **gsd**: refuse no-create opens of a deleted DB path before any handle exists (#2181)
+- **gsd**: register out-of-band CONTEXT.md as a DB artifact at handoff (#2169)
+- **gsd**: pause with blocker escalation at the verify gate instead of wedging (#2168)
+- **gsd**: stop infinite redispatch when a retry-bound unit's dispatch fails (#2167)
+- **gsd**: pause with cause on schema-rejected completions in the durable path (#2166)
+- **gsd**: route execute-task git-commit retries through verification-retry (#2164)
+- **hermes**: link gsd-mcp-server and emit version bounds in generated config (#2151)
+- **vscode**: preserve opened sidebar sections across webview refresh (#2155)
+- **pi-agent-core**: continue and surface max_tokens truncation instead of ending silently (#2161)
+- **gsd**: stop classifying database snapshot wording as browser-required (#2162)
+- **scripts**: suggest a valid Codex review command in pr-risk-check (#2160)
+- **gsd**: drop unfixable compat-marker keys instead of quarantining the marker (#2147)
+- **gsd**: stop doctor env_git_remote false 'unreachable' on healthy repos (#2146)
+- **gsd**: keep blank lines truly empty in pushIndented PLAN.md output (#2145)
+- **gsd**: isolate project snapshot DB handle (#2172)
+- **gsd**: close Codex review findings on gsd_project_snapshot (#2175)
+
+### Changed
+- **gsd**: delete dead planner-handoff module (#2149)
+
 ## [1.18.0] - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ See [CHANGELOG.md](./CHANGELOG.md) for release-by-release fixes and [Legacy Rele
 ## Latest Release Highlights
 
 <!-- release-highlights:start -->
-Latest release: **v1.18.0**
+Latest release: **v1.19.0**
 
-- **gsd:** Refresh models and pricing in session (#2095).
-- **models:** Refresh generated model catalog (#2120).
-- **gsd:** Remove dead Copilot catalog classification (#2094).
-- **issue:** Bug: finalize/retry lease race + gsd_task_recovery_resume missing 'remediate' handler strands completed tasks (#2113).
-- **gsd:** Make Copilot suggestions fail closed (#2093).
-- **gsd:** Preserve GitHub Copilot catalog unknowns (#2092).
-- **gsd:** Browser daemon warm-up burns its full timeout on an inherited stdio pipe (#2104).
-- **auto:** Register liveness identity on rejected unit-run claim (#2097) (#2098).
+- **vscode:** Add Copilot project read tools.
+- **gsd:** Expose progress read metadata.
+- **mcp:** GSD-side smoke probe and per-host checklist for canonical read tools (#2174).
+- **vscode:** Show DB-authoritative project progress in sidebar (#2136) (#2143).
+- **gsd:** Add gsd_project_snapshot canonical DB read tool (#2170).
+- **gsd:** Delete dead planner-handoff module (#2149).
+- **gsd:** Stop husk-task gates from wedging milestone closeout.
+- **gsd:** Rebuild markdown projections at the invocation root.
 
 <!-- release-highlights:end -->
 

--- a/extensions/google-search/package.json
+++ b/extensions/google-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-extensions/google-search",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Web search via Google with AI-synthesized answers and source citations",
   "type": "module",
   "keywords": [

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -215,7 +215,7 @@ class GsdMcpClient:
                 "params": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.18.0"},
+                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.19.0"},
                 },
             }
         )

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-gsd-hermes"
-version = "1.18.0"
+version = "1.19.0"
 description = "Hermes Agent plugin — GSD structured delivery engine integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-ast"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ast-grep-core",
  "globset",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-engine"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "arboard",
  "dashmap",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-grep"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "grep-matcher",
  "grep-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "1.18.0"
+version = "1.19.0"
 edition = "2021"
 license = "MIT"
 authors = ["GSD Contributors"]

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-arm64",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-x64",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-arm64-gnu",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-x64-gnu",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-win32-x64-msvc",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
   "repository": {
@@ -210,11 +210,11 @@
   },
   "optionalDependencies": {
     "@mariozechner/clipboard": "0.3.6",
-    "@opengsd/engine-darwin-arm64": "1.18.0",
-    "@opengsd/engine-darwin-x64": "1.18.0",
-    "@opengsd/engine-linux-arm64-gnu": "1.18.0",
-    "@opengsd/engine-linux-x64-gnu": "1.18.0",
-    "@opengsd/engine-win32-x64-msvc": "1.18.0",
+    "@opengsd/engine-darwin-arm64": "1.19.0",
+    "@opengsd/engine-darwin-x64": "1.19.0",
+    "@opengsd/engine-linux-arm64-gnu": "1.19.0",
+    "@opengsd/engine-linux-x64-gnu": "1.19.0",
+    "@opengsd/engine-win32-x64-msvc": "1.19.0",
     "fsevents": "~2.3.3",
     "koffi": "^2.9.0",
     "node-pty": "^1.1.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/contracts",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Shared public contracts for GSD workspace boundaries",
   "license": "MIT",
   "gsd": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/daemon",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "GSD daemon — background process for project monitoring and Discord integration",
   "license": "MIT",
   "repository": {

--- a/packages/gsd-agent-core/package.json
+++ b/packages/gsd-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-core",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "GSD session orchestration layer on top of @gsd/pi-coding-agent",
   "type": "module",
   "gsd": {

--- a/packages/gsd-agent-modes/package.json
+++ b/packages/gsd-agent-modes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-modes",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "GSD run modes and CLI layer",
   "type": "module",
   "gsd": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/mcp-server",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "MCP server exposing GSD orchestration tools for compatible clients",
   "license": "MIT",
   "gsd": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/native",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Native Rust bindings for GSD — high-performance native modules via N-API",
   "type": "commonjs",
   "gsd": {

--- a/packages/pi-agent-core/package.json
+++ b/packages/pi-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-agent-core",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "General-purpose agent with transport abstraction, state management, and attachment support",
   "type": "module",
   "gsd": {

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-ai",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Unified LLM API with automatic model discovery and provider configuration",
   "type": "module",
   "gsd": {

--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-coding-agent",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Coding agent CLI (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-tui",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Terminal UI library (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/rpc-client/package.json
+++ b/packages/rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/rpc-client",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Standalone RPC client SDK for GSD — zero internal dependencies",
   "license": "MIT",
   "gsd": {

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glittercowboy/gsd",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "piConfig": {
     "name": "gsd",
     "configDir": ".gsd"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,20 +169,20 @@ importers:
         specifier: 0.3.6
         version: 0.3.6
       '@opengsd/engine-darwin-arm64':
-        specifier: 1.18.0
-        version: 1.18.0
+        specifier: 1.19.0
+        version: 1.19.0
       '@opengsd/engine-darwin-x64':
-        specifier: 1.18.0
-        version: 1.18.0
+        specifier: 1.19.0
+        version: 1.19.0
       '@opengsd/engine-linux-arm64-gnu':
-        specifier: 1.18.0
-        version: 1.18.0
+        specifier: 1.19.0
+        version: 1.19.0
       '@opengsd/engine-linux-x64-gnu':
-        specifier: 1.18.0
-        version: 1.18.0
+        specifier: 1.19.0
+        version: 1.19.0
       '@opengsd/engine-win32-x64-msvc':
-        specifier: 1.18.0
-        version: 1.18.0
+        specifier: 1.19.0
+        version: 1.19.0
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -2007,28 +2007,28 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@opengsd/engine-darwin-arm64@1.18.0':
-    resolution: {integrity: sha512-wXiCNiXq7g5ZnKblgXO2k1nm15VjMA/jM3P8iLWxGGrotsT68Wj8k05HFY5yWAdMYgP76iIIOCLRvONTjkT6EQ==}
+  '@opengsd/engine-darwin-arm64@1.19.0':
+    resolution: {integrity: sha512-vsJJqqyTTrERP11AP0Xhi+87Td0n6Ps9Ew2dk/HYyLq2W06Mh35+agc8edEjsxh+V3uthGWu3WC8T7MEWRxOrQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@opengsd/engine-darwin-x64@1.18.0':
-    resolution: {integrity: sha512-ArRl2hLqiak/WFtSJNyf4WK215RxSBLvz/T3kBU/Wv7nC4nP81/V3SWnbYi6tDxWHpE+Uhjbdz7S1UkpHlzHMQ==}
+  '@opengsd/engine-darwin-x64@1.19.0':
+    resolution: {integrity: sha512-/nLNYQC6TnxduKZQJn4/rLLJqV7tMoSNHgR635kQFHv/EC2TYpAqNT7R/kvE2gp5ObeBgaR7R2Nh+tSuN88Lzw==}
     cpu: [x64]
     os: [darwin]
 
-  '@opengsd/engine-linux-arm64-gnu@1.18.0':
-    resolution: {integrity: sha512-sWZhUBRw6sFxHWsN3oqjpe/diql5ezoChCkvtPLG/wZzIu/E992GpZvUfiXlvg8s6TaGNuKR5wyPfflO/u+Ofw==}
+  '@opengsd/engine-linux-arm64-gnu@1.19.0':
+    resolution: {integrity: sha512-lsZKyI3ZMf/k+nuRoA2TNPSu/ElR5A4hgqH2dAsOoZuOYAsPBxPzhwJvLTdzn5Ti21R5Ls9rUophQvHFpylFTw==}
     cpu: [arm64]
     os: [linux]
 
-  '@opengsd/engine-linux-x64-gnu@1.18.0':
-    resolution: {integrity: sha512-sTwzn8wB68pheLodaA9mJQWj1SkIdS1YiQ7eBA7+RrOWcdb3CgW1dIXi6ZaakH5tj+olmLblYrydpDth1ew/ng==}
+  '@opengsd/engine-linux-x64-gnu@1.19.0':
+    resolution: {integrity: sha512-L69Mc/9Q+k9dqvyR9zwvBTzir5zROFRdfWg3najnGSHx/ITShFa4k8x8rJfdR4P7fqFvrjaWuDvItFC3112x3g==}
     cpu: [x64]
     os: [linux]
 
-  '@opengsd/engine-win32-x64-msvc@1.18.0':
-    resolution: {integrity: sha512-jMxcOoquSiZzbAZnkoAjpibLHepdyq8+wpdYizSyPEEDsHU+8kMPGUucekZjMNM5BhPrq31hroTa1oQhmYT2rA==}
+  '@opengsd/engine-win32-x64-msvc@1.19.0':
+    resolution: {integrity: sha512-AC6de8k3AOhzpPvBlsSXhv/vPpKmQ/bUcbceC7TMcvSPn3v3445eBMvLZ+G1IWzK3sJo4jNMBHk9G60u1tgCMA==}
     cpu: [x64]
     os: [win32]
 
@@ -7724,19 +7724,19 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@opengsd/engine-darwin-arm64@1.18.0':
+  '@opengsd/engine-darwin-arm64@1.19.0':
     optional: true
 
-  '@opengsd/engine-darwin-x64@1.18.0':
+  '@opengsd/engine-darwin-x64@1.19.0':
     optional: true
 
-  '@opengsd/engine-linux-arm64-gnu@1.18.0':
+  '@opengsd/engine-linux-arm64-gnu@1.19.0':
     optional: true
 
-  '@opengsd/engine-linux-x64-gnu@1.18.0':
+  '@opengsd/engine-linux-x64-gnu@1.19.0':
     optional: true
 
-  '@opengsd/engine-win32-x64-msvc@1.18.0':
+  '@opengsd/engine-win32-x64-msvc@1.19.0':
     optional: true
 
   '@opengsd/gsd-browser@0.2.2': {}


### PR DESCRIPTION
Version bump for v1.19.0. Direct push to main was rejected by branch rules, so the release commit lands through the merge queue. npm, the `v1.19.0` tag and the GitHub release are already published.