### PR TITLE
feat(legacy-import): surface structured errors

### DIFF
--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -30,6 +30,7 @@ import {
   formatLegacyImportForwardRepairChoice,
   parseLegacyImportForwardRepairChoices,
 } from "./legacy-import-forward-repair-choice-token.js";
+import { LegacyImportApplicationError } from "./legacy-import-application-error.js";
 import { LEGACY_IMPORT_RESTORE_ASSESSMENT_CONSENT_SCHEMA_VERSION, type LegacyImportRestoreAssessmentConsent } from "./legacy-import-restore-assessment.js";
 import {
   preserveProjectionChanges,
@@ -668,6 +669,36 @@ export function formatLegacyImportError(err: StructuredLegacyImportError): strin
 }
 
 /**
+ * Recover builds a "Preview" (a sealed proposal of what will change) before
+ * applying anything. That Preview contains a list of diagnoses (things it
+* noticed) and resolutions (how each diagnosis was resolved) with a unresolved
+* counter. This function turns each unresolved into a full list of messages
+* explaining which and where are the unresolved issues.
+ */
+function formatUnresolvedRecoverDiagnoses(prepared: Readonly<PreparedVerifiedRecoverApplication>): string {
+  const preview = prepared.preview.preview;
+  const sourceById = new Map(preview.sources.map((source) => [source.source_id, source]));
+  const unresolvedIds = new Set(
+    preview.resolutions
+      .filter((resolution) => resolution.disposition === "requires-user" || resolution.disposition === "unsupported")
+      .map((resolution) => resolution.diagnosis_id),
+  );
+  const unresolved = preview.diagnoses.filter((diagnosis) => unresolvedIds.has(diagnosis.diagnosis_id));
+  if (unresolved.length === 0) {
+    return "  (no diagnosis detail available — unresolved count is nonzero but no matching diagnosis was found)";
+  }
+  return unresolved
+    .map((diagnosis) => {
+      const source = sourceById.get(diagnosis.source_id);
+      const location = source
+        ? `${source.path}${diagnosis.locator.line === undefined ? "" : `:${diagnosis.locator.line}`}`
+        : diagnosis.source_id;
+      return `  [${diagnosis.code}] ${location}\n    ${diagnosis.message}`;
+    })
+    .join("\n");
+}
+
+/**
  * `gsd recover` — Explicitly import legacy markdown into canonical DB state.
  *
  * Applies one sealed Preview through the verified Import Application boundary,
@@ -713,10 +744,32 @@ export async function handleRecover(
         markdown,
         beforeDb,
       ))) return;
-      application = applyPreparedVerifiedRecoverApplication(
-        prepared,
-        prepared.preview.preview_hash,
-      );
+      try {
+        application = applyPreparedVerifiedRecoverApplication(
+          prepared,
+          prepared.preview.preview_hash,
+        );
+      } catch (applyErr) {
+        if (
+          applyErr instanceof LegacyImportApplicationError
+          && applyErr.code === "LEGACY_IMPORT_APPLICATION_PREVIEW_UNRESOLVED"
+        ) {
+          ctx.ui.notify(
+            [
+              `gsd recover: ${applyErr.context.unresolved_count ?? "some"} item(s) in the Preview need a decision before this can be applied.`,
+              "",
+              formatUnresolvedRecoverDiagnoses(prepared),
+              "",
+              "Fix the source markdown, or re-run with the shown --choice options once available, then retry gsd recover.",
+              "",
+              formatLegacyImportErrorBaseline(applyErr),
+            ].join("\n"),
+            "error",
+          );
+          return;
+        }
+        throw applyErr;
+      }
       appliedPreview = true;
     }
     const { backup } = application;

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -602,7 +602,30 @@ export function formatLegacyImportErrorBaseline(err: StructuredLegacyImportError
  * it only adds a paragraph on top of the same facts every error already
  * gets.
  */
-function explainKnownLegacyImportError(_err: StructuredLegacyImportError): string | null {
+function explainKnownLegacyImportError(err: StructuredLegacyImportError): string | null {
+  if (err.code === "LEGACY_IMPORT_CLASSIFICATION_LIFECYCLE_AUTHORITY_INVALID") {
+    const targetKey = typeof err.context?.target_key === "string" ? err.context.target_key : undefined;
+    if (!targetKey) return null;
+    const parts = targetKey.split("/");
+    const [milestoneId, sliceId, taskId] = parts;
+    const scopeLine = taskId !== undefined
+      ? `${milestoneId}/${sliceId}, task ${taskId}`
+      : sliceId !== undefined
+        ? `${milestoneId}, slice ${sliceId}`
+        : targetKey;
+    return [
+      `A markdown artifact references ${scopeLine}, but no PLAN establishes it as a real slice/task.`,
+      "",
+      taskId !== undefined
+        ? `  Look for a ${sliceId}-T${taskId.replace(/^T/, "")}-SUMMARY.md (or similar) with no matching entry in the slice's own\n`
+          + `  NN-${sliceId.replace(/^S/, "").padStart(2, "0")}-PLAN.md — the PLAN file may be missing, or the task id inside it\n`
+          + `  doesn't match the SUMMARY's parent/task ids.`
+        : `  Look for a ROADMAP entry for ${scopeLine} with no matching PLAN file on disk, or a PLAN whose\n`
+          + `  milestone/slice id doesn't match what the ROADMAP declares.`,
+      "",
+      "Fix the source markdown (restore or correct the missing PLAN) and retry gsd recover.",
+    ].join("\n");
+  }
   return null;
 }
 

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -30,7 +30,6 @@ import {
   formatLegacyImportForwardRepairChoice,
   parseLegacyImportForwardRepairChoices,
 } from "./legacy-import-forward-repair-choice-token.js";
-import { LegacyImportBaseSnapshotError } from "./legacy-import-preview-base.js";
 import { LEGACY_IMPORT_RESTORE_ASSESSMENT_CONSENT_SCHEMA_VERSION, type LegacyImportRestoreAssessmentConsent } from "./legacy-import-restore-assessment.js";
 import {
   preserveProjectionChanges,
@@ -546,6 +545,80 @@ async function confirmRecover(
 }
 
 /**
+ * Structural shape shared by every LegacyImport*Error class in this
+ * subsystem (LegacyImportApplicationError, LegacyImportBackupError,
+ * LegacyImportBaseSnapshotError, LegacyImportClassificationError,
+ * LegacyImportPreviewError, LegacyImportDatabaseTargetError,
+ * LegacyImportPreviewDatabaseTargetError, LegacyImportSourceError,
+ * LegacyImportRecoveryActionError, and others), even though none of them
+ * share a common base class. Duck-typed on the fields that matter for a
+ * readable message rather than exact class identity, so every current and
+ * future error class gets the same baseline handling without another
+ * instanceof branch.
+ */
+export interface StructuredLegacyImportError {
+  name: string;
+  message: string;
+  code?: unknown;
+  stage?: unknown;
+  context?: Readonly<Record<string, unknown>>;
+  evidence?: Readonly<Record<string, unknown>>;
+}
+
+export function isStructuredLegacyImportError(err: unknown): err is StructuredLegacyImportError {
+  return (
+    err instanceof Error
+    && err.name.startsWith("LegacyImport")
+    && ("code" in err || "context" in err || "evidence" in err)
+  );
+}
+
+/**
+ * Baseline formatting every structured legacy-import error with: class name,
+ * stage, code, and the error's own context/evidence as readable key:value
+ * lines. The goal is to surface what the error itself already carries
+ * (structured, safe-to-show data), not internal file/line detail.
+ */
+export function formatLegacyImportErrorBaseline(err: StructuredLegacyImportError): string {
+  const details = err.evidence ?? err.context;
+  const lines = [
+    `[${err.name}]${typeof err.stage === "string" ? ` stage=${err.stage}` : ""}${typeof err.code === "string" ? ` code=${err.code}` : ""}`,
+  ];
+  if (details && Object.keys(details).length > 0) {
+    lines.push("Context:");
+    for (const [key, value] of Object.entries(details)) {
+      lines.push(`  ${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Optional plain-language explanation for legacy-import error codes worth
+ * translating into concrete, actionable prose ("look for this file",
+ * "here's the likely cause"). Returns null for every code without a known
+ * translation, in which case only the baseline above is shown; adding a
+ * translation for a new code never takes anything away from the baseline,
+ * it only adds a paragraph on top of the same facts every error already
+ * gets.
+ */
+function explainKnownLegacyImportError(_err: StructuredLegacyImportError): string | null {
+  return null;
+}
+
+/**
+ * Format a caught legacy-import error for the user: the baseline (always),
+ * with a plain-language explanation prepended when one exists for the code.
+ * Every LegacyImport*Error goes through this same path — there is no
+ * separate, lesser-quality branch for codes without a known explanation.
+ */
+export function formatLegacyImportError(err: StructuredLegacyImportError): string {
+  const baseline = formatLegacyImportErrorBaseline(err);
+  const explanation = explainKnownLegacyImportError(err);
+  return explanation ? `${explanation}\n\n${baseline}` : baseline;
+}
+
+/**
  * `gsd recover` — Explicitly import legacy markdown into canonical DB state.
  *
  * Applies one sealed Preview through the verified Import Application boundary,
@@ -693,13 +766,15 @@ export async function handleRecover(
     );
     ctx.ui.notify(lines.join("\n"), "success");
   } catch (err) {
+    if (isStructuredLegacyImportError(err)) {
+      const formatted = formatLegacyImportError(err);
+      logWarning("command", `recover failed: ${formatted.replace(/\n/g, " ")}`);
+      ctx.ui.notify(`gsd recover failed: ${err.message}\n\n${formatted}`, "error");
+      return;
+    }
     const message = err instanceof Error ? err.message : String(err);
-    const details = err instanceof LegacyImportBaseSnapshotError
-      ? ` [${err.code}] context=${JSON.stringify(err.context)}`
-      : "";
-    const msg = `${message}${details}`;
-    logWarning("command", `recover failed: ${msg}`);
-    ctx.ui.notify(`gsd recover failed: ${msg}`, "error");
+    logWarning("command", `recover failed: ${message}`);
+    ctx.ui.notify(`gsd recover failed: ${message}`, "error");
   }
 }
 

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -626,6 +626,32 @@ function explainKnownLegacyImportError(err: StructuredLegacyImportError): string
       "Fix the source markdown (restore or correct the missing PLAN) and retry gsd recover.",
     ].join("\n");
   }
+  if (err.code === "LEGACY_IMPORT_BACKUP_FOREIGN_KEY_FAILED") {
+    const violations = Array.isArray(err.context?.violations)
+      ? err.context.violations as ReadonlyArray<Record<string, unknown>>
+      : null;
+    if (!violations) return null;
+    const totalCount = typeof err.context?.violation_count === "number" ? err.context.violation_count : violations.length;
+    const byTable = new Map<string, number>();
+    for (const v of violations) {
+      const table = String(v.table ?? "?");
+      byTable.set(table, (byTable.get(table) ?? 0) + 1);
+    }
+    return [
+      `The database has ${totalCount} row(s) whose foreign keys point at missing parent rows — recover refuses to`,
+      "build a backup from a database that already fails referential integrity.",
+      "",
+      "By table:",
+      ...[...byTable.entries()].map(([table, count]) => `  ${table}: ${count} row(s)`),
+      "",
+      "Sample violations (table, rowid, missing parent table):",
+      ...violations.slice(0, 10).map((v) => `  ${v.table} rowid=${v.rowid} -> missing ${v.parent}`),
+      "",
+      "This usually means old rows still reference a milestone/slice/task id that no longer exists",
+      "(for example, a leftover row from before a unique-milestone-id rename). Find and either delete",
+      "or repoint those rows to the current id, then retry gsd recover.",
+    ].join("\n");
+  }
   return null;
 }
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -131,6 +131,46 @@ export {
 } from "./pending-auto-start.js";
 export { checkAutoStartAfterDiscuss } from "./discussion-handoff.js";
 
+/**
+ * Cap on how many quarantined file paths are listed by name in the self-heal
+ * notification before collapsing the rest into a "…and N more" summary line
+ * -- purely a display limit (e.g. a mass-rebuild quarantining 90 files
+ * shouldn't dump 90 lines into one notification), not a meaningful count.
+ */
+const MAX_QUARANTINED_PATHS_SHOWN = 5;
+
+/**
+ * Format the self-heal auto-rebuild success notification, including a note
+ * about any quarantined pre-rebuild bytes. rebuildMarkdownProjectionsFromDb
+ * already preserves externally-edited content into .gsd/quarantine/projections/
+ * before overwriting it with the DB's rendered version, but the auto-rebuild
+ * notification previously never mentioned this — a user could lose track of
+ * richer hand-authored content that got silently replaced with a sparser
+ * DB-derived render, with no visible pointer to where the original bytes went.
+ */
+export function formatMarkdownSelfHealNotification(rebuild: {
+  rendered: number;
+  errors: readonly string[];
+  quarantined: number;
+  quarantinedPaths: readonly string[];
+}): { message: string; level: "info" | "warning" } {
+  const quarantineNote = rebuild.quarantined > 0
+    ? `\n${rebuild.quarantined} file(s) had content that differed from the last DB-rendered version — `
+      + `the pre-rebuild bytes were preserved, not discarded, under:\n`
+      + rebuild.quarantinedPaths.slice(0, MAX_QUARANTINED_PATHS_SHOWN).map((p) => `  ${p}`).join("\n")
+      + (rebuild.quarantinedPaths.length > MAX_QUARANTINED_PATHS_SHOWN
+        ? `\n  …and ${rebuild.quarantinedPaths.length - MAX_QUARANTINED_PATHS_SHOWN} more`
+        : "")
+      + "\nReview those files before assuming the rebuilt markdown is complete — "
+      + "the DB row may be sparser than what was quarantined."
+    : "";
+  const message = `Self-heal: rebuilt markdown projections from the authoritative DB `
+    + `(${rebuild.rendered} rendered${rebuild.errors.length > 0 ? `, ${rebuild.errors.length} error(s)` : ""}).`
+    + quarantineNote;
+  const level = rebuild.errors.length > 0 || rebuild.quarantined > 0 ? "warning" : "info";
+  return { message, level };
+}
+
 export function shouldSkipGitBootstrapAfterInit(result: { gitEnabled?: boolean }): boolean {
   return result.gitEnabled === false;
 }
@@ -2074,11 +2114,8 @@ export async function showSmartEntry(
               const after = await checkMarkdownHierarchyAgainstDb(basePath);
               if (after.action === "none") {
                 clearMarkdownAutoRebuildBackoff();
-                ctx.ui.notify(
-                  `Self-heal: rebuilt markdown projections from the authoritative DB ` +
-                    `(${rebuild.rendered} rendered${rebuild.errors.length > 0 ? `, ${rebuild.errors.length} error(s)` : ""}).`,
-                  rebuild.errors.length > 0 ? "warning" : "info",
-                );
+                const { message, level } = formatMarkdownSelfHealNotification(rebuild);
+                ctx.ui.notify(message, level);
               } else {
                 if (after.recoveryCommand === "/gsd rebuild markdown") {
                   recordMarkdownAutoRebuildFailure(after);

--- a/src/resources/extensions/gsd/legacy-import-backup.ts
+++ b/src/resources/extensions/gsd/legacy-import-backup.ts
@@ -2198,10 +2198,24 @@ function runIndependentVerification(
       requireOnlyMainDatabase(db, connection.openedPath ?? expectedPath);
       requireExactlyOk(db, "quick_check");
       requireExactlyOk(db, "integrity_check");
-      if (db.prepare("PRAGMA foreign_key_check").all().length !== 0) {
+      const foreignKeyViolations = db.prepare("PRAGMA foreign_key_check").all();
+      if (foreignKeyViolations.length !== 0) {
         verificationFail(
           "LEGACY_IMPORT_BACKUP_FOREIGN_KEY_FAILED",
           "legacy import backup contains foreign-key violations",
+          {
+            violation_count: foreignKeyViolations.length,
+            // PRAGMA foreign_key_check rows: { table, rowid, parent, fkid }.
+            // Cap what we attach so a badly-drifted DB doesn't produce an
+            // unbounded error payload; the count above still reports the
+            // true total.
+            violations: foreignKeyViolations.slice(0, 50).map((row) => ({
+                table: String((row as Record<string, unknown>).table ?? ""),
+                rowid: Number((row as Record<string, unknown>).rowid ?? 0),
+                parent: String((row as Record<string, unknown>).parent ?? ""),
+                fkid: Number((row as Record<string, unknown>).fkid ?? 0),
+              })),
+          },
         );
       }
       requireSchemaAnchors(db);

--- a/src/resources/extensions/gsd/tests/commands-maintenance-structured-legacy-error.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-maintenance-structured-legacy-error.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../commands-maintenance.ts";
 import { LegacyImportPreviewError } from "../legacy-import-preview.ts";
 import { LegacyImportSourceError } from "../legacy-import-preview-source.ts";
+import { LegacyImportClassificationError } from "../legacy-import-preview-classifier.ts";
 
 describe("isStructuredLegacyImportError", () => {
   test("recognizes any LegacyImport*Error carrying code/context/evidence", () => {
@@ -104,5 +105,18 @@ describe("formatLegacyImportError", () => {
     );
     const message = formatLegacyImportError(err);
     assert.equal(message, formatLegacyImportErrorBaseline(err));
+  });
+
+  test("a missing-PLAN lifecycle error prepends its explanation above the same baseline every other error gets", () => {
+    const err = new LegacyImportClassificationError(
+      "LEGACY_IMPORT_CLASSIFICATION_LIFECYCLE_AUTHORITY_INVALID",
+      "legacy import canonical lifecycle has no hierarchy row",
+      { target_key: "M009-rfuh2h/S02/T01" },
+    );
+    const message = formatLegacyImportError(err);
+    const baseline = formatLegacyImportErrorBaseline(err);
+    assert.match(message, /no PLAN establishes it as a real slice\/task/);
+    assert.match(message, /M009-rfuh2h\/S02, task T01/);
+    assert.ok(message.endsWith(baseline), "baseline must be appended verbatim, not replaced");
   });
 });

--- a/src/resources/extensions/gsd/tests/commands-maintenance-structured-legacy-error.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-maintenance-structured-legacy-error.test.ts
@@ -1,0 +1,108 @@
+// Project/App: gsd-pi
+// File Purpose: Every LegacyImport*Error class gets the same baseline
+// formatting (class name, stage, code, context/evidence) with no exceptions
+// -- no error class falls through to a bare, context-free message anymore.
+// Later commits add plain-language explanations for specific codes on top
+// of this same baseline; this file covers the baseline itself.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isStructuredLegacyImportError,
+  formatLegacyImportErrorBaseline,
+  formatLegacyImportError,
+  type StructuredLegacyImportError,
+} from "../commands-maintenance.ts";
+import { LegacyImportPreviewError } from "../legacy-import-preview.ts";
+import { LegacyImportSourceError } from "../legacy-import-preview-source.ts";
+
+describe("isStructuredLegacyImportError", () => {
+  test("recognizes any LegacyImport*Error carrying code/context/evidence", () => {
+    const previewErr = new LegacyImportPreviewError(
+      "create",
+      "LEGACY_IMPORT_PREVIEW_BASE_CHANGED",
+      "base changed during creation",
+      true,
+      { expected_revision: 1, observed_revision: 2 },
+    );
+    assert.ok(isStructuredLegacyImportError(previewErr));
+  });
+
+  test("rejects plain Error and non-LegacyImport errors", () => {
+    assert.equal(isStructuredLegacyImportError(new Error("plain")), false);
+    assert.equal(isStructuredLegacyImportError(new TypeError("oops")), false);
+    assert.equal(isStructuredLegacyImportError("a string"), false);
+    assert.equal(isStructuredLegacyImportError(null), false);
+  });
+});
+
+describe("formatLegacyImportErrorBaseline", () => {
+  test("reports class name, stage, code, and every context entry readably", () => {
+    const err = new LegacyImportPreviewError(
+      "create",
+      "LEGACY_IMPORT_PREVIEW_BASE_CHANGED",
+      "base changed during creation",
+      true,
+      { expected_revision: 1, observed_revision: 2 },
+    );
+    const message = formatLegacyImportErrorBaseline(err);
+    assert.match(message, /\[LegacyImportPreviewError\]/);
+    assert.match(message, /stage=create/);
+    assert.match(message, /code=LEGACY_IMPORT_PREVIEW_BASE_CHANGED/);
+    assert.match(message, /expected_revision: 1/);
+    assert.match(message, /observed_revision: 2/);
+  });
+
+  test("falls back to evidence when context is absent (live-restore style errors)", () => {
+    const errLike: StructuredLegacyImportError = {
+      name: "LegacyImportLiveRestoreError",
+      message: "restore failed",
+      code: "LEGACY_IMPORT_LIVE_RESTORE_VERIFY_FAILED",
+      stage: "verify",
+      evidence: { attempt: 2, path: "/tmp/x" },
+    };
+    const message = formatLegacyImportErrorBaseline(errLike);
+    assert.match(message, /\[LegacyImportLiveRestoreError\]/);
+    assert.match(message, /attempt: 2/);
+    assert.match(message, /path: \/tmp\/x/);
+  });
+
+  test("omits the Context section entirely when there is nothing to report", () => {
+    const errLike: StructuredLegacyImportError = {
+      name: "LegacyImportSourceError",
+      message: "source unreadable",
+      code: "LEGACY_IMPORT_SOURCE_UNREADABLE",
+    };
+    const message = formatLegacyImportErrorBaseline(errLike);
+    assert.doesNotMatch(message, /Context:/);
+  });
+
+  test("real LegacyImportSourceError instances are recognized and formatted", () => {
+    const err = new LegacyImportSourceError(
+      "capture",
+      "LEGACY_IMPORT_SOURCE_UNREADABLE",
+      "legacy import source directory cannot be read",
+      false,
+      { root_id: "project-phases", logical_path: ".gsd/phases" },
+    );
+    assert.ok(isStructuredLegacyImportError(err));
+    const message = formatLegacyImportErrorBaseline(err);
+    assert.match(message, /\[LegacyImportSourceError\]/);
+    assert.match(message, /root_id: project-phases/);
+  });
+});
+
+describe("formatLegacyImportError", () => {
+  test("with no known explanation yet implemented, shows only the baseline", () => {
+    const err = new LegacyImportPreviewError(
+      "create",
+      "LEGACY_IMPORT_PREVIEW_BASE_CHANGED",
+      "base changed during creation",
+      true,
+      { expected_revision: 1 },
+    );
+    const message = formatLegacyImportError(err);
+    assert.equal(message, formatLegacyImportErrorBaseline(err));
+  });
+});

--- a/src/resources/extensions/gsd/tests/commands-maintenance-structured-legacy-error.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-maintenance-structured-legacy-error.test.ts
@@ -17,6 +17,7 @@ import {
 import { LegacyImportPreviewError } from "../legacy-import-preview.ts";
 import { LegacyImportSourceError } from "../legacy-import-preview-source.ts";
 import { LegacyImportClassificationError } from "../legacy-import-preview-classifier.ts";
+import { LegacyImportBackupError } from "../legacy-import-backup.ts";
 
 describe("isStructuredLegacyImportError", () => {
   test("recognizes any LegacyImport*Error carrying code/context/evidence", () => {
@@ -117,6 +118,22 @@ describe("formatLegacyImportError", () => {
     const baseline = formatLegacyImportErrorBaseline(err);
     assert.match(message, /no PLAN establishes it as a real slice\/task/);
     assert.match(message, /M009-rfuh2h\/S02, task T01/);
+    assert.ok(message.endsWith(baseline), "baseline must be appended verbatim, not replaced");
+  });
+
+  test("a foreign-key violation error prepends its explanation above the same baseline every other error gets", () => {
+    const violations = [{ table: "quality_gates", rowid: 7, parent: "milestones", fkid: 0 }];
+    const err = new LegacyImportBackupError(
+      "LEGACY_IMPORT_BACKUP_FOREIGN_KEY_FAILED",
+      "legacy import backup contains foreign-key violations",
+      { violation_count: 1, violations },
+      "verification",
+      false,
+    );
+    const message = formatLegacyImportError(err);
+    const baseline = formatLegacyImportErrorBaseline(err);
+    assert.match(message, /row\(s\) whose foreign keys point at missing parent rows/);
+    assert.match(message, /quality_gates: 1 row\(s\)/);
     assert.ok(message.endsWith(baseline), "baseline must be appended verbatim, not replaced");
   });
 });

--- a/src/resources/extensions/gsd/tests/gsd-recover.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-recover.test.ts
@@ -771,7 +771,7 @@ describe('gsd-recover', async () => {
       assert.equal(notes.at(-1)?.kind, 'error');
       const message = notes.at(-1)?.message ?? '';
       assert.match(message, /LEGACY_IMPORT_BASE_ROW_DUPLICATE/);
-      assert.match(message, /"row_set":"decision_memories"/);
+      assert.match(message, /row_set: decision_memories/);
       assert.match(message, /source_decision_id/);
       assert.match(message, /D001/);
     } finally {

--- a/src/resources/extensions/gsd/tests/gsd-recover.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-recover.test.ts
@@ -1204,4 +1204,62 @@ describe('gsd-recover', async () => {
       cleanup(base);
     }
   });
+
+  test('handleRecover explains a missing PLAN behind an orphaned task SUMMARY', async () => {
+    const base = createFixtureBase();
+    try {
+      writeFile(base, 'phases/09-team/09-ROADMAP.md', [
+        '# M009-rfuh2h: Team milestone',
+        '',
+        '- [ ] **S01: Recover generated artifacts** `risk:low` `depends:[]`',
+        '- [x] **S02: Orphaned slice with no PLAN** `risk:low` `depends:[]`',
+        '',
+      ].join('\n'));
+      writeFile(base, 'phases/09-team/09-01-PLAN.md', [
+        '# S01: Recover generated artifacts',
+        '',
+        '**Milestone:** M009-rfuh2h',
+        '**Slice:** S01',
+        '',
+        '<tasks>',
+        '- [ ] **T01**: Recover generated task',
+        '</tasks>',
+        '',
+      ].join('\n'));
+      writeFile(base, 'phases/09-team/S01-T01-SUMMARY.md', [
+        '---',
+        'id: T01',
+        'parent: S01',
+        'milestone: M009-rfuh2h',
+        '---',
+        '',
+        '# T01: Recover generated task',
+        '',
+      ].join('\n'));
+      // S02 has no 09-02-PLAN.md at all -- only its task SUMMARY survived.
+      writeFile(base, 'phases/09-team/S02-T01-SUMMARY.md', [
+        '---',
+        'id: T01',
+        'parent: S02',
+        'milestone: M009-rfuh2h',
+        '---',
+        '',
+        '# T01: Orphaned task',
+        '',
+      ].join('\n'));
+      openDatabase(join(base, '.gsd', 'gsd.db'));
+
+      const { ctx, notes } = makeCtx();
+      await handleRecover(ctx, base);
+
+      assert.equal(notes.at(-1)?.kind, 'error');
+      const message = notes.at(-1)?.message ?? '';
+      assert.match(message, /M009-rfuh2h/);
+      assert.match(message, /S02/);
+      assert.match(message, /no PLAN establishes it as a real slice\/task/);
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
 });

--- a/src/resources/extensions/gsd/tests/gsd-recover.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-recover.test.ts
@@ -1198,7 +1198,7 @@ describe('gsd-recover', async () => {
       assert.deepEqual(canonicalRecoverSnapshot(), before);
       assert.deepEqual(recoverSourceSnapshot(base), sourceBefore);
       assert.equal(notes.at(-1)?.kind, 'error');
-      assert.match(notes.at(-1)?.message ?? '', /unresolved|requires.*user/i);
+      assert.match(notes.at(-1)?.message ?? '', /item\(s\) in the Preview need a decision/i);
     } finally {
       closeDatabase();
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/guided-flow-markdown-self-heal-notification.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow-markdown-self-heal-notification.test.ts
@@ -1,0 +1,70 @@
+// Project/App: gsd-pi
+// File Purpose: formatMarkdownSelfHealNotification must surface quarantined
+// pre-rebuild bytes, not just a bare "rebuilt N" message. Regression: the
+// auto-rebuild self-heal path previously never mentioned that
+// rebuildMarkdownProjectionsFromDb had already quarantined externally-edited
+// (often richer, hand-authored) content before overwriting it with the DB's
+// sparser rendered version -- a user could lose track of the original bytes
+// with no visible pointer to where they went.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { formatMarkdownSelfHealNotification } from "../guided-flow.ts";
+
+describe("formatMarkdownSelfHealNotification", () => {
+  test("plain rebuild with nothing quarantined reports info with no quarantine note", () => {
+    const { message, level } = formatMarkdownSelfHealNotification({
+      rendered: 12,
+      errors: [],
+      quarantined: 0,
+      quarantinedPaths: [],
+    });
+    assert.equal(level, "info");
+    assert.match(message, /Self-heal: rebuilt markdown projections from the authoritative DB \(12 rendered\)\./);
+    assert.doesNotMatch(message, /quarantine/i);
+  });
+
+  test("quarantined files escalate to warning and list their preserved paths", () => {
+    const { message, level } = formatMarkdownSelfHealNotification({
+      rendered: 90,
+      errors: [],
+      quarantined: 90,
+      quarantinedPaths: [
+        ".gsd/quarantine/projections/x/gsd/phases/01/01-01-PLAN.md",
+        ".gsd/quarantine/projections/x/gsd/phases/02/02-01-PLAN.md",
+      ],
+    });
+    assert.equal(level, "warning");
+    assert.match(message, /90 file\(s\) had content that differed/);
+    assert.match(message, /the pre-rebuild bytes were preserved, not discarded/);
+    assert.match(message, /01-01-PLAN\.md/);
+    assert.match(message, /02-01-PLAN\.md/);
+    assert.match(message, /DB row may be sparser than what was quarantined/);
+  });
+
+  test("quarantined path list is capped and reports an overflow count", () => {
+    const paths = Array.from({ length: 8 }, (_, i) => `.gsd/quarantine/projections/x/file-${i}.md`);
+    const { message } = formatMarkdownSelfHealNotification({
+      rendered: 8,
+      errors: [],
+      quarantined: 8,
+      quarantinedPaths: paths,
+    });
+    assert.match(message, /file-0\.md/);
+    assert.match(message, /file-4\.md/);
+    assert.doesNotMatch(message, /file-5\.md/);
+    assert.match(message, /…and 3 more/);
+  });
+
+  test("render errors also escalate to warning even with nothing quarantined", () => {
+    const { message, level } = formatMarkdownSelfHealNotification({
+      rendered: 5,
+      errors: ["boom"],
+      quarantined: 0,
+      quarantinedPaths: [],
+    });
+    assert.equal(level, "warning");
+    assert.match(message, /5 rendered, 1 error\(s\)/);
+  });
+});

--- a/src/resources/extensions/gsd/tests/legacy-import-backup-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/legacy-import-backup-verification.test.ts
@@ -697,3 +697,26 @@ test("legacy import backup verification rejects non-exact input before independe
   assert.equal(opens, 0);
   assert.ok(lstatSync(fixture.stagingDirectory).isDirectory(), "contract rejection does not claim ownership");
 });
+
+test("legacy import backup verification attaches the actual foreign-key violation rows to the error context", (t) => {
+  const { testVerify } = verificationApi();
+  const fixture = snapshotFixture(t);
+  const violationRows = [
+    { table: "workflow_item_lifecycles", rowid: 49, parent: "milestones", fkid: 3 },
+    { table: "workflow_item_lifecycles", rowid: 50, parent: "slices", fkid: 2 },
+    { table: "quality_gates", rowid: 7, parent: "milestones", fkid: 0 },
+  ];
+  const err = expectVerificationError(
+    () => testVerify(fixture.input, {
+      openReadOnly: (path) => interceptedConnection(path, {
+        rows: (sql, rows) => sql.toLowerCase().includes("pragma foreign_key_check")
+          ? violationRows.map((row) => ({ ...row }))
+          : rows,
+      }),
+    }),
+    "verification",
+    "LEGACY_IMPORT_BACKUP_FOREIGN_KEY_FAILED",
+  );
+  assert.equal(err.context.violation_count, 3);
+  assert.deepEqual(err.context.violations, violationRows);
+});


### PR DESCRIPTION
## Linked issue

<!--
PRs without a linked issue will be closed.
Open or find an issue first: https://github.com/open-gsd/gsd-pi/issues
-->

I have tested this as you can see in the linked issued where I posted some screenshots.

Closes #2242 

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** <!-- One sentence — what does this change? --> Improve errors for import-legacy failures.
**Why:** <!-- One sentence — why is it needed? --> The errors are not helpful for a user to resolve them without asking an AI agent.
**How:** <!-- One sentence — what's the approach? --> the code already knows where are the errors. This fix adds that knowledge next to the error title.

## What

<!-- Detailed description of the change. What files, modules, or systems are affected? -->
Errors triggered during recover process are handled by a structured error formatter. The change are focusing on `legacy-import`.

## Why

<!-- The motivation. What problem does this solve? -->
The existing error message that you get while running gsd recover are impossible to understand what was the issue. You need to ask an AI agent to understand it, which most of the times is looping into many directions trying to figured out the actual problem.
Fixing it manually most of the times is way simpler (and not token spent).

## How

<!-- The approach. How does the implementation work? Key decisions and alternatives considered? -->
A new interface is created that handles the structured error format. For every error some additional information is added. Every type of error already knows why and where this was caused. This was hidden to the user with a error message.
The fix is exposing that context to the user so they can take action and decide on how to solve.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->
