### PR TITLE
fix(gsd): pause recovery-exhausted validate-milestone instead of clobbering VALIDATION.md

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -43,6 +43,7 @@ import {
   resolveMilestoneFile,
   clearPathCache,
   resolveGsdRootFile,
+  normalizeRealPath,
 } from "./paths.js";
 import {
   existsSync,
@@ -480,15 +481,17 @@ export function writeBlockerPlaceholder(
   const artifactBase = resolveArtifactVerificationBase(unitId, base);
   const canonicalArtifactPath = resolveExpectedArtifactPath(unitType, unitId, artifactBase);
   if (!canonicalArtifactPath) return null;
-  const blockerArtifactPath = unitType === "execute-task"
+  const blockerArtifactPath = unitType === "execute-task" || unitType === "complete-milestone"
     ? canonicalArtifactPath.replace(/-SUMMARY\.md$/u, "-RECOVERY-BLOCKER.md")
     : unitType === "plan-slice"
       ? canonicalArtifactPath.replace(/-PLAN\.md$/u, "-RECOVERY-BLOCKER.md")
-      : canonicalArtifactPath;
-  // DB-backed Task and slice-plan blockers must never occupy their canonical
-  // completion projections.
+      : unitType === "validate-milestone"
+        ? canonicalArtifactPath.replace(/-VALIDATION\.md$/u, "-RECOVERY-BLOCKER.md")
+        : canonicalArtifactPath;
+  // DB-backed Task, slice-plan, milestone-validation, and milestone-summary
+  // blockers must never occupy their canonical projections.
   if (
-    (unitType === "execute-task" || unitType === "plan-slice") &&
+    (unitType === "execute-task" || unitType === "plan-slice" || unitType === "validate-milestone" || unitType === "complete-milestone") &&
     blockerArtifactPath === canonicalArtifactPath
   ) return null;
   const dir = dirname(blockerArtifactPath);
@@ -499,8 +502,9 @@ export function writeBlockerPlaceholder(
       ? "This diagnostic records a fail-closed planning gate; it is not a roadmap or completed milestone work."
       : unitType === "plan-slice"
         ? "This diagnostic does not complete slice planning; auto-mode must remain paused until a valid plan is persisted."
-
-      : "This placeholder was written by auto-mode so the pipeline can advance.";
+        : unitType === "validate-milestone" || unitType === "complete-milestone"
+          ? "This diagnostic is not a canonical result; no validation verdict or milestone completion was recorded."
+          : "This placeholder was written by auto-mode so the pipeline can advance.";
   const content = [
     `# BLOCKER — auto-mode recovery failed`,
     ``,
@@ -553,9 +557,17 @@ export function writeBlockerPlaceholder(
     }
   }
 
-  return unitType === "plan-slice"
-    ? relative(base, blockerArtifactPath)
-    : diagnoseExpectedArtifact(unitType, unitId, base);
+  // Sidecar diagnostics report the file actually written; placeholders that
+  // occupy their canonical path keep the expected-artifact description.
+  if (blockerArtifactPath === canonicalArtifactPath) {
+    return diagnoseExpectedArtifact(unitType, unitId, base);
+  }
+  const writtenRel = relative(base, blockerArtifactPath);
+  // Milestone resolvers realpath-anchor their results, so when base sits
+  // behind a symlink (e.g. /tmp) re-anchor the relative path to the real base.
+  return writtenRel.startsWith("..")
+    ? relative(normalizeRealPath(base), blockerArtifactPath)
+    : writtenRel;
 }
 
 // ─── Merge State Reconciliation ───────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -293,7 +293,7 @@ export async function recoverTimedOutUnit(
   // #4175/#1995: Never replace canonical lifecycle projections with blocker
   // placeholders. They cannot update the required DB state, so finalization
   // rejects them and retries unchanged input indefinitely. Pause fail-closed.
-  if (unitType === "complete-milestone" || unitType === "plan-slice") {
+  if (unitType === "complete-milestone" || unitType === "plan-slice" || unitType === "validate-milestone") {
     writeUnitRuntimeRecord(basePath, unitType, unitId, currentUnitStartedAt, {
       phase: "paused",
       recoveryAttempts: recoveryAttempts + 1,
@@ -301,7 +301,9 @@ export async function recoverTimedOutUnit(
     });
     const message = unitType === "complete-milestone"
       ? `Milestone ${unitId} ${reason}-recovery exhausted ${maxRecoveryAttempts} attempt(s) — worktree branch preserved. Re-run /gsd auto once blockers are resolved.`
-      : `Slice plan ${unitId} ${reason}-recovery exhausted ${maxRecoveryAttempts} attempt(s) — canonical PLAN preserved. Re-run /gsd auto once blockers are resolved.`;
+      : unitType === "validate-milestone"
+        ? `Milestone validation ${unitId} ${reason}-recovery exhausted ${maxRecoveryAttempts} attempt(s) — no canonical validation result was persisted; canonical VALIDATION preserved. Re-run /gsd auto once blockers are resolved.`
+        : `Slice plan ${unitId} ${reason}-recovery exhausted ${maxRecoveryAttempts} attempt(s) — canonical PLAN preserved. Re-run /gsd auto once blockers are resolved.`;
     ctx.ui.notify(
       message,
       "error",

--- a/src/resources/extensions/gsd/tests/validate-milestone-recovery-fail-closed-2251.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-recovery-fail-closed-2251.test.ts
@@ -1,0 +1,248 @@
+// Project/App: gsd-pi
+// File Purpose: Regression coverage for #2251 — exhausted validate-milestone
+// recovery must pause fail-closed instead of writing a blocker placeholder
+// into the canonical VALIDATION.md projection, and recovery messaging must
+// never claim a canonical validation result was persisted when none was.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  resolveExpectedArtifactPath,
+  writeBlockerPlaceholder,
+} from "../auto-recovery.ts";
+import { normalizeRealPath } from "../paths.ts";
+import { recoverTimedOutUnit, type RecoveryContext } from "../auto-timeout-recovery.ts";
+import { readUnitRuntimeRecord, writeUnitRuntimeRecord } from "../unit-runtime.ts";
+import {
+  closeDatabase,
+  getMilestone,
+  insertMilestone,
+  isDbAvailable,
+  openDatabase,
+} from "../gsd-db.ts";
+
+function createBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-validate-fail-closed-2251-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  return base;
+}
+
+function cleanupBase(base: string): void {
+  if (isDbAvailable()) closeDatabase();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function recoveryContext(base: string, startedAt: number): RecoveryContext {
+  return {
+    basePath: base,
+    verbose: false,
+    currentUnitStartedAt: startedAt,
+    unitRecoveryCount: new Map(),
+  };
+}
+
+/** Open a DB with an active M001 that has NO canonical validation verdict, and seed exhausted recovery attempts. */
+function seedExhaustedRecovery(base: string): number {
+  const startedAt = Date.now();
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+  writeUnitRuntimeRecord(base, "validate-milestone", "M001", startedAt, {
+    recoveryAttempts: 2,
+  });
+  return startedAt;
+}
+
+test("#2251: exhausted validate-milestone recovery pauses fail-closed instead of clobbering the canonical VALIDATION projection", async (t) => {
+  const base = createBase();
+  t.after(() => cleanupBase(base));
+  const startedAt = seedExhaustedRecovery(base);
+  const validationPath = resolveExpectedArtifactPath("validate-milestone", "M001", base)!;
+  const blockerPath = validationPath.replace(/-VALIDATION\.md$/u, "-RECOVERY-BLOCKER.md");
+  const notifications: string[] = [];
+  const messages: unknown[] = [];
+
+  const result = await recoverTimedOutUnit(
+    { ui: { notify: (message: string) => notifications.push(message) } } as any,
+    { sendMessage: (message: unknown) => messages.push(message) } as any,
+    "validate-milestone",
+    "M001",
+    "idle",
+    recoveryContext(base, startedAt),
+  );
+
+  assert.equal(result, "paused", "exhausted validation recovery must stop fail-closed");
+  assert.equal(
+    readUnitRuntimeRecord(base, "validate-milestone", "M001")?.phase,
+    "paused",
+    "the runtime record must show the unit paused, not skipped",
+  );
+  assert.equal(
+    existsSync(validationPath),
+    false,
+    "the canonical VALIDATION projection must never be created by recovery",
+  );
+  assert.equal(existsSync(blockerPath), false, "the timeout pause must not fabricate an artifact");
+  assert.equal(
+    getMilestone("M001")?.status,
+    "active",
+    "recovery must leave milestone authority unchanged",
+  );
+  assert.equal(messages.length, 0, "exhaustion must not schedule another model turn");
+  assert.equal(notifications.filter((message) => message.includes("recovery exhausted")).length, 1);
+  assert.equal(notifications.some((message) => message.includes("Advancing pipeline")), false);
+});
+
+test("#2251: writeBlockerPlaceholder for validate-milestone never occupies the canonical VALIDATION path", (t) => {
+  const base = createBase();
+  t.after(() => cleanupBase(base));
+  const validationPath = resolveExpectedArtifactPath("validate-milestone", "M001", base)!;
+  const blockerPath = validationPath.replace(/-VALIDATION\.md$/u, "-RECOVERY-BLOCKER.md");
+  const persisted = "# M001 validation\n\nverdict: needs-attention\n";
+  writeFileSync(validationPath, persisted, "utf-8");
+
+  const result = writeBlockerPlaceholder(
+    "validate-milestone",
+    "M001",
+    base,
+    "deterministic policy rejection",
+  );
+
+  assert.equal(
+    result,
+    join(".gsd", "milestones", "M001", "M001-RECOVERY-BLOCKER.md"),
+    "must return the actually-written sibling path",
+  );
+  assert.doesNotMatch(
+    result ?? "",
+    /gsd_validate_milestone/u,
+    "the returned location must not be expected-artifact prose",
+  );
+  assert.equal(
+    readFileSync(validationPath, "utf-8"),
+    persisted,
+    "the canonical VALIDATION projection must remain untouched",
+  );
+  assert.match(readFileSync(blockerPath, "utf-8"), /deterministic policy rejection/u);
+});
+
+test("#2251: writeBlockerPlaceholder for complete-milestone never occupies the canonical SUMMARY projection", (t) => {
+  const base = createBase();
+  t.after(() => cleanupBase(base));
+  const summaryPath = resolveExpectedArtifactPath("complete-milestone", "M001", base)!;
+  const blockerPath = summaryPath.replace(/-SUMMARY\.md$/u, "-RECOVERY-BLOCKER.md");
+  const persisted = "# M001 summary (partial)\n";
+  writeFileSync(summaryPath, persisted, "utf-8");
+
+  const result = writeBlockerPlaceholder("complete-milestone", "M001", base, "retries exhausted");
+
+  assert.equal(
+    result,
+    join(".gsd", "milestones", "M001", "M001-RECOVERY-BLOCKER.md"),
+    "must return the actually-written sibling path",
+  );
+  assert.equal(
+    readFileSync(summaryPath, "utf-8"),
+    persisted,
+    "the canonical SUMMARY projection must remain untouched",
+  );
+  assert.match(readFileSync(blockerPath, "utf-8"), /retries exhausted/u);
+});
+
+test("#2251: writeBlockerPlaceholder returns null when the canonical path does not match the sidecar rename suffix", (t) => {
+  const base = createBase();
+  t.after(() => cleanupBase(base));
+  // paths.ts resolveFile's legacy fallback resolves a bare `VALIDATION.md`
+  // (no `<MID>-`/phase prefix), which does not match the `-VALIDATION.md$`
+  // sidecar rename. The bail-out must force the pause fallback (null) and
+  // leave that canonical projection untouched.
+  const legacyValidationPath = join(base, ".gsd", "milestones", "M001", "VALIDATION.md");
+  const persisted = "# M001 validation (legacy layout)\n\nverdict: pass\n";
+  writeFileSync(legacyValidationPath, persisted, "utf-8");
+  assert.equal(
+    resolveExpectedArtifactPath("validate-milestone", "M001", base),
+    normalizeRealPath(legacyValidationPath),
+    "fixture must resolve the legacy-named file as the canonical artifact",
+  );
+
+  const result = writeBlockerPlaceholder("validate-milestone", "M001", base, "retries exhausted");
+
+  assert.equal(result, null, "a non-renameable canonical path must bail out to the pause fallback");
+  assert.equal(
+    readFileSync(legacyValidationPath, "utf-8"),
+    persisted,
+    "the canonical VALIDATION projection must remain untouched",
+  );
+});
+
+test("#2251: writeBlockerPlaceholder returns a sidecar path that resolves through a symlinked base", (t) => {
+  const base = createBase();
+  const linkParent = mkdtempSync(join(tmpdir(), "gsd-validate-fail-closed-2251-link-"));
+  const linkedBase = join(linkParent, "linked-base");
+  symlinkSync(base, linkedBase, "dir");
+  t.after(() => {
+    cleanupBase(base);
+    rmSync(linkParent, { recursive: true, force: true });
+  });
+  const validationPath = resolveExpectedArtifactPath("validate-milestone", "M001", base)!;
+  const persisted = "# M001 validation\n";
+  writeFileSync(validationPath, persisted, "utf-8");
+
+  const result = writeBlockerPlaceholder("validate-milestone", "M001", linkedBase, "retries exhausted");
+
+  assert.equal(
+    result,
+    join(".gsd", "milestones", "M001", "M001-RECOVERY-BLOCKER.md"),
+    "the returned path must be clean relative to the real base, not a ..-escapes artifact",
+  );
+  assert.doesNotMatch(result ?? "", /\.\./u, "the returned path must not escape via symlink segments");
+  const sidecar = join(normalizeRealPath(linkedBase), result ?? "");
+  assert.equal(existsSync(sidecar), true, "the returned path must resolve to the written sidecar");
+  assert.match(readFileSync(sidecar, "utf-8"), /retries exhausted/u);
+  assert.equal(
+    readFileSync(validationPath, "utf-8"),
+    persisted,
+    "the canonical VALIDATION projection must remain untouched",
+  );
+});
+
+test("#2251: exhausted validate-milestone recovery never reports a canonical result as persisted", async (t) => {
+  const base = createBase();
+  t.after(() => cleanupBase(base));
+  const startedAt = seedExhaustedRecovery(base);
+  const notifications: string[] = [];
+  const messages: unknown[] = [];
+
+  const result = await recoverTimedOutUnit(
+    { ui: { notify: (message: string) => notifications.push(message) } } as any,
+    { sendMessage: (message: unknown) => messages.push(message) } as any,
+    "validate-milestone",
+    "M001",
+    "hard",
+    recoveryContext(base, startedAt),
+  );
+  assert.equal(messages.length, 0, "exhaustion must not schedule another model turn");
+
+  assert.equal(result, "paused", "exhausted hard-timeout validation recovery must stop fail-closed");
+  assert.equal(
+    readUnitRuntimeRecord(base, "validate-milestone", "M001")?.phase,
+    "paused",
+    "the runtime record must show the unit paused, not skipped",
+  );
+  assert.ok(notifications.length > 0, "recovery must notify the operator");
+  for (const message of notifications) {
+    assert.doesNotMatch(
+      message,
+      /persisted via gsd_validate_milestone/u,
+      "recovery must not claim a canonical validation result was persisted",
+    );
+    assert.equal(
+      message.includes("Advancing pipeline"),
+      false,
+      "recovery must not report that the pipeline advanced",
+    );
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** recovery-exhausted `validate-milestone` units now pause fail-closed instead of writing a BLOCKER placeholder onto the canonical `VALIDATION.md` projection, and the placeholder writer can never occupy a canonical DB-projection path for the milestone unit types.
**Why:** deterministic validation failures (e.g. #2025's trigger abort) exhausted recovery, the skip path clobbered `VALIDATION.md` while notifying that a canonical result was "persisted via gsd_validate_milestone" (nothing was), and DB-only finalization retried unchanged until the ADR-047 liveness backstop wedged auto-mode (#2251).
**How:** add `validate-milestone` to the existing fail-closed pause set; extend `writeBlockerPlaceholder`'s sibling-rename bail-out to the milestone unit types; return the actually-written path instead of expectation prose.

Closes #2251

## What

- `auto-timeout-recovery.ts`: `validate-milestone` joins `complete-milestone`/`plan-slice` in the fail-closed pause list — recovery exhaustion now pauses with an explicit "no canonical validation result was persisted; canonical VALIDATION preserved" message instead of placeholder-and-advance.
- `auto-recovery.ts`: `writeBlockerPlaceholder` extends the existing `-RECOVERY-BLOCKER.md` sibling rename + identical-path → `null` bail-out (previously execute-task/plan-slice only) to `validate-milestone` (`-VALIDATION.md`) and `complete-milestone` (`-SUMMARY.md`); returns the real written sidecar path (re-anchored through `normalizeRealPath` for symlinked bases) rather than `diagnoseExpectedArtifact` prose for those types.
- New suite (6 tests): exhausted recovery pauses with the canonical projection byte-identical and no pipeline advance; both milestone helpers never touch canonical paths and return real sidecar paths; a non-suffix-matching canonical path forces the null → pause fallback; a symlinked base returns a clean resolved path; notifications never claim persistence.

## Why

`VALIDATION.md` is a DB-rendered projection — the engine's own recovery steering forbids writing it manually, yet the placeholder path did exactly that and then announced success in the same breath. With the projection clobbered, DB-only finalization could never observe a verdict and the unit spun to a hard wedge.

## How

The wedge's third leg — the no-verdict finalize retry — is already bounded on current main by the post-#2199 non-advancing-recurrence ledger (pauses with cause at the second identical occurrence), so no second bound was added; this PR removes the placeholder-clobber leg that fed it. Blast radius: execute-task/plan-slice placeholder behavior and prose are unchanged (215 adjacent tests green); the other expected-artifact types are file-backed agent-authored artifacts where placeholder treatment is pre-existing. Known pre-existing edges, unchanged and out of scope: `refine-slice` and `complete-slice` placeholders occupy file-backed PLAN/SUMMARY artifacts (agent-authored, not DB-rendered), and the deterministic-policy-error path can still write a sibling and advance — it can no longer touch the canonical path.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).