### PR TITLE
fix(gsd): stop emitting trailing whitespace in summary frontmatter

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-projections.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-projections.test.ts
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict';
 import { existsSync, mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { regenerateIfMissing, renderPlanContent, renderPlanProjection, renderStateProjection, renderSummaryProjection } from '../workflow-projections.ts';
+import { regenerateIfMissing, renderPlanContent, renderPlanProjection, renderStateProjection, renderSummaryContent, renderSummaryProjection } from '../workflow-projections.ts';
 import type { SliceRow, TaskRow } from '../gsd-db.ts';
 import { closeDatabase, getArtifactsByPathPrefix, insertMilestone, insertSlice, insertTask, openDatabase } from '../gsd-db.ts';
 import { clearPathCache, _clearGsdRootCache, normalizeRealPath, resolveMilestoneFile, resolveTaskFile } from '../paths.ts';
@@ -184,6 +184,32 @@ test('workflow-projections: multiple tasks rendered in order', () => {
   const idxT1 = content.indexOf('**T01:');
   const idxT2 = content.indexOf('**T02:');
   assert.ok(idxT1 < idxT2, 'T01 should appear before T02');
+});
+
+// ─── renderSummaryContent: frontmatter whitespace (#2253) ────────────────
+
+// #2253: empty duration/completed_at must emit bare `duration:` / `completed_at:`
+// lines (valid YAML null, whitespace-clean). The old `key: ${value || ""}`
+// template left a trailing space that tripped `git diff --check` and gsd
+// doctor's whitespace guard on every pre-completion T##-SUMMARY.md.
+test('renderSummaryContent: empty duration and completed_at emit bare frontmatter keys with no trailing space', () => {
+  const task = makeTask({ duration: '', completed_at: null });
+  const content = renderSummaryContent(task, 'S01', 'M001');
+  const lines = content.split('\n');
+  assert.ok(lines.includes('duration:'),
+    `expected bare "duration:" line, got: ${JSON.stringify(lines.find(l => l.startsWith('duration')))}`);
+  assert.ok(lines.includes('completed_at:'),
+    `expected bare "completed_at:" line, got: ${JSON.stringify(lines.find(l => l.startsWith('completed_at')))}`);
+  assert.ok(!content.includes('duration: \n'), 'no trailing space after bare duration:');
+  assert.ok(!content.includes('completed_at: \n'), 'no trailing space after bare completed_at:');
+});
+
+test('renderSummaryContent: populated duration and completed_at render values unchanged', () => {
+  const task = makeTask({ duration: '5m 30s', completed_at: '2026-01-15T10:30:00.000Z' });
+  const content = renderSummaryContent(task, 'S01', 'M001');
+  const lines = content.split('\n');
+  assert.ok(lines.includes('duration: 5m 30s'), `expected "duration: 5m 30s", got: ${JSON.stringify(lines.find(l => l.startsWith('duration')))}`);
+  assert.ok(lines.includes('completed_at: 2026-01-15T10:30:00.000Z'), `expected timestamp, got: ${JSON.stringify(lines.find(l => l.startsWith('completed_at')))}`);
 });
 
 test('workflow-projections: renderPlanProjection preserves an unowned obsolete plan', () => {

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -273,9 +273,9 @@ key_files:
 ${keyFilesYaml}
 key_decisions:
 ${keyDecisionsYaml}
-duration: ${taskRow.duration || ""}
+duration:${taskRow.duration ? ` ${taskRow.duration}` : ""}
 verification_result: ${verificationResult}
-completed_at: ${taskRow.completed_at || ""}
+completed_at:${taskRow.completed_at ? ` ${taskRow.completed_at}` : ""}
 blocker_discovered: ${taskRow.blocker_discovered ? "true" : "false"}
 ---
 


### PR DESCRIPTION
## TL;DR

**What:** `renderSummaryContent` emits bare `duration:` / `completed_at:` when the values are absent instead of `duration: ` / `completed_at: ` with a trailing space.
**Why:** the trailing space trips `git diff --check` on every pre-completion T##-SUMMARY.md, and `gsd doctor`'s snapshot guard then reports `conflict_markers_in_tracked_files`, blocking auto-mode (#2253).
**How:** conditional interpolation — absent values render as whitespace-clean YAML null; populated values render byte-identically to before.

Closes #2253

## What

- `workflow-projections.ts`: the two frontmatter lines use conditional interpolation (`duration:${value ? ` ${value}` : ""}`); `duration` is string-typed and `completed_at` is `string | null`, so truthiness covers all empty shapes.
- `workflow-projections.test.ts`: two tests — empty values emit bare keys with no trailing space (failing-first), populated values render unchanged.

## Why

This is the same trailing-whitespace class already fixed for PLAN.md (`pushIndented`, #2145) and ROADMAP.md (#1510); the summary renderer was the remaining site. Any task summary written before its first completion carries the defect, so the doctor guard blocked auto-mode for ordinary in-progress tasks.

## How

End-to-end verified against the exact gates `gsd doctor` runs: the fixed renderer's output passes `git diff --check` and `git diff --cached --check`; the old output fails both with `trailing whitespace`. Parser safety verified across both consumers — the JS frontmatter parser (`\s*:\s*(.*)$` + trim) and the native Rust parser both treat bare and spaced empty keys identically — so no downstream behavior changes. All other frontmatter keys in this function are non-empty by construction; the empty-`one_liner` markdown case has no line-end whitespace and is unaffected.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).