### PR TITLE
fix(gsd): accept decorated and descriptive verdict strings at the gate

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -1546,7 +1546,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
 						}),
 						exitCode: Type.Number({ description: "Exit code of the command" }),
 						verdict: Type.String({
-							description: "Pass/fail verdict (e.g. '✅ pass', '❌ fail')",
+							description:
+								"Pass/fail verdict (e.g. '✅ pass', '❌ fail', 'pass: all checks green'). Bare 'pass'/'passed'/'fail'/'failed', leading markers, and 'verdict: <details>' descriptions are accepted.",
 						}),
 						durationMs: Type.Number({
 							description: "Duration of the command in milliseconds",

--- a/src/resources/extensions/gsd/tests/task-verification-evidence-exit-code.test.ts
+++ b/src/resources/extensions/gsd/tests/task-verification-evidence-exit-code.test.ts
@@ -18,6 +18,7 @@ import {
   getTaskVerificationEvidence,
 } from "../gsd-db.ts";
 import { hasQualifyingTaskEvidence } from "../verification-gate.ts";
+import type { TaskVerificationEvidence } from "../verification-gate.ts";
 
 const MID = "m1";
 const SID = "s1";
@@ -208,5 +209,67 @@ describe("hasQualifyingTaskEvidence: negated verify idioms", () => {
     });
 
     assert.equal(hasQualifyingTaskEvidence(getTaskVerificationEvidence(MID, SID, TID)), false);
+  });
+});
+
+// ─── Lenient verdict matching at the gate (#2014) ───────────────────────────
+describe("hasQualifyingTaskEvidence: lenient verdict matching (#2014)", () => {
+  const record = (verdict: string, exitCode = 0): TaskVerificationEvidence => ({
+    command: "pnpm test",
+    exitCode,
+    verdict,
+    durationMs: 10,
+  });
+
+  test("bare pass/passed verdicts still qualify (case-insensitive)", () => {
+    assert.equal(hasQualifyingTaskEvidence([record("pass")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("passed")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("PASS")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("Passed")]), true);
+  });
+
+  test("bare fail/failed verdicts still disqualify", () => {
+    assert.equal(hasQualifyingTaskEvidence([record("fail")]), false);
+    assert.equal(hasQualifyingTaskEvidence([record("failed")]), false);
+    assert.equal(hasQualifyingTaskEvidence([record("FAIL")]), false);
+  });
+
+  test("decorated verdicts qualify (#2014)", () => {
+    assert.equal(hasQualifyingTaskEvidence([record("✅ pass")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("✅ Passed")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("❌ fail")]), false);
+    assert.equal(hasQualifyingTaskEvidence([record("❌ failed")]), false);
+  });
+
+  test("descriptive 'verdict: details' forms qualify on the leading token (#2014)", () => {
+    assert.equal(hasQualifyingTaskEvidence([record("pass: all checks green")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("✅ pass: all checks green")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("failed: x")]), false);
+  });
+
+  test("em/en-dash and spaced-hyphen description separators evaluate the leading token (#2014)", () => {
+    assert.equal(hasQualifyingTaskEvidence([record("pass — all checks green")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("pass – all checks green")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("pass - all checks green")]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("failed — suite B")]), false);
+  });
+
+  test("unknown verdict tokens fail closed even with exit 0 (#2014)", () => {
+    assert.equal(hasQualifyingTaskEvidence([record("partial")]), false);
+    assert.equal(hasQualifyingTaskEvidence([record("failure")]), false);
+    assert.equal(hasQualifyingTaskEvidence([record("ok")]), false);
+    assert.equal(hasQualifyingTaskEvidence([record("✅")]), false);
+  });
+
+  test("verdict-less records still fall back to exitCode === 0 (#2213)", () => {
+    assert.equal(hasQualifyingTaskEvidence([record("", 0)]), true);
+    assert.equal(hasQualifyingTaskEvidence([record("", 1)]), false);
+  });
+
+  test("one decorated failing record disqualifies an otherwise passing set", () => {
+    assert.equal(
+      hasQualifyingTaskEvidence([record("✅ pass"), record("❌ fail")]),
+      false,
+    );
   });
 });

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -83,13 +83,36 @@ export interface DiscoverCommandsOptions {
   cwd: string;
 }
 
+/** Description separators after which a verdict token carries only details (#2014). */
+const VERDICT_SEPARATORS = [":", "—", " – ", " - "];
+const PASSING_VERDICT_RE = /^(pass|passed)$/;
+
+/**
+ * Lenient verdict matching (#2014): the tool schema documents decorated and
+ * descriptive verdicts (e.g. '✅ pass', 'pass: all checks green'). Strip
+ * leading non-alphanumeric markers, then evaluate only the token before the
+ * first description separator, case-insensitively. pass/passed → true;
+ * fail/failed and any unknown token → false (fail-closed).
+ */
+function verdictQualifies(verdict: string): boolean {
+  const stripped = verdict.trim().replace(/^[^a-zA-Z0-9]+/, "");
+  let cut = stripped.length;
+  for (const separator of VERDICT_SEPARATORS) {
+    const index = stripped.indexOf(separator);
+    if (index !== -1 && index < cut) cut = index;
+  }
+  return PASSING_VERDICT_RE.test(stripped.slice(0, cut).trim().toLowerCase());
+}
+
 /**
  * Task-specific evidence qualifies when at least one record exists and every
  * record reports a passing outcome (#1591). The executor's staged verdict is
  * authoritative: negated verify idioms (`! grep -q`, `grep -v`,
  * `git diff --exit-code`) succeed on a non-zero exit, so a "pass" verdict
  * qualifies even with a non-zero exitCode. `exitCode === 0` is the fallback
- * for records staged without a verdict (#2213).
+ * for records staged without a verdict (#2213). Verdict matching is lenient
+ * (#2014): leading markers (`✅ pass`) and `pass: <details>` descriptions are
+ * accepted; unknown tokens fail closed.
  */
 export function hasQualifyingTaskEvidence(
   evidence: TaskVerificationEvidence[] | undefined,
@@ -97,7 +120,7 @@ export function hasQualifyingTaskEvidence(
   if (!evidence || evidence.length === 0) return false;
   return evidence.every((record) => {
     const verdict = (record.verdict ?? "").trim();
-    if (verdict) return /^(pass|passed)$/i.test(verdict);
+    if (verdict) return verdictQualifies(verdict);
     return record.exitCode === 0;
   });
 }


### PR DESCRIPTION
## TL;DR

**What:** The verification gate now accepts decorated and descriptive verdict strings (e.g. `✅ pass`, `pass: all checks green`) instead of only bare `pass`/`passed`.
**Why:** The tool schema documents decorated verdicts, but the gate rejected them, so valid task evidence fell through to global preference commands (#2014).
**How:** Read-side normalization before matching (strip leading markers, evaluate the token before a description separator); storage stays raw.

## What

- `src/resources/extensions/gsd/verification-gate.ts` — `hasQualifyingTaskEvidence` now normalizes each staged verdict through a new `verdictQualifies` helper before matching:
  - trim; strip leading non-alphanumeric markers (`✅`, `❌`, emoji, punctuation);
  - if a description separator (`:`, `—`, ` – `, ` - `) is present, evaluate only the token before the first one;
  - case-insensitive: `pass`/`passed` → qualify; `fail`/`failed` → not; any unknown token → not (fail-closed).
  - The verdict-less `exitCode === 0` fallback from #2213 is unchanged.
- `src/resources/extensions/gsd/bootstrap/db-tools.ts` — the `verificationEvidence.verdict` schema description now states the accepted forms.
- Writers, readers, and accumulation scoping are untouched: storage stays raw by design (accumulation scoping is #2259).

## Why

The schema documents verdicts like `'✅ pass'`, and some flows stage exactly that, but the gate only accepted `/^(pass|passed)$/i`. Documented decorated/descriptive forms failed qualification and the task fell through to global preference commands instead of honoring its own evidence.

Fixes #2014

## How

Leniency lives only on the read side: `verdictQualifies` normalizes, then matches the leading token against `^(pass|passed)$`. Explicit `fail`/`failed` and unknown tokens fail closed, so a garbage verdict can never widen the gate. The change is confined to the gate predicate and its schema description.

## Tests

`src/resources/extensions/gsd/tests/task-verification-evidence-exit-code.test.ts` — new `hasQualifyingTaskEvidence: lenient verdict matching (#2014)` suite (test-first: the decorated/descriptive cases fail on the old regex and pass after the fix):

- bare `pass`/`passed` (case-insensitive) still qualify; bare `fail`/`failed` still disqualify
- `✅ pass`, `✅ Passed`, `❌ fail`, `❌ failed`
- `pass: all checks green`, `✅ pass: all checks green`, `failed: x`
- `—`/`–`/` - ` separators evaluate the leading token
- unknown tokens (`partial`, `failure`, `ok`, marker-only `✅`) fail closed even with exit 0
- verdict-less records still fall back to `exitCode === 0` (#2213)
- one decorated failing record disqualifies the set

Evidence:

- Pre-fix: 3 new tests fail on `origin/main` code (reproduces #2014); post-fix 16/16 pass.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/task-verification-evidence-exit-code.test.ts` → 16 pass, 0 fail
- Adjacent suites (`verification-gate.test.ts`, `verification-scope-misresolution-1628-1630.test.ts`, `verification-retry-policy.test.ts`, `python-resolver.test.ts`) → 182 pass, 0 fail
- Compiled runner (`pnpm run test:compile` + compiled file) → 16 pass, 0 fail
- `pnpm run build:core && pnpm run typecheck:extensions` → clean

AI-assisted: yes
