### PR TITLE
fix(gsd): actionable error when test resolver hits an unbuilt workspace dist

### DIFF
--- a/src/resources/extensions/gsd/tests/dist-redirect.mjs
+++ b/src/resources/extensions/gsd/tests/dist-redirect.mjs
@@ -1,10 +1,135 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { dirname, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 
 const ROOT = new URL("../../../../../", import.meta.url);
+
+// Fresh worktrees often run focused tests before workspace packages are built.
+// Node then surfaces a bare ERR_MODULE_NOT_FOUND for the missing dist output.
+// These helpers attribute that failure to the workspace package and name the
+// exact build command that fixes it.
+
+function isWorkspacePackageLink(pkgDir) {
+  // Workspace links point at packages/<name>; registry installs live under
+  // some node_modules directory. Only the former get the build hint.
+  try {
+    return !realpathSync(pkgDir).split(sep).includes('node_modules');
+  } catch {
+    return false;
+  }
+}
+
+function exportsFileTarget(exportsMap, subpath) {
+  if (exportsMap == null || Array.isArray(exportsMap)) return null;
+  let entry;
+  let capture = null;
+  if (typeof exportsMap === 'string') {
+    if (subpath !== '') return null;
+    entry = exportsMap;
+  } else {
+    const key = subpath === '' ? '.' : `./${subpath}`;
+    if (Object.hasOwn(exportsMap, key)) {
+      entry = exportsMap[key];
+    } else {
+      // Single-star pattern fallback (e.g. "./*": "./dist/*.js").
+      for (const [pattern, value] of Object.entries(exportsMap)) {
+        const star = pattern.indexOf('*');
+        if (!pattern.startsWith('./') || star === -1) continue;
+        const prefix = pattern.slice(2, star);
+        const suffix = pattern.slice(star + 1);
+        if (
+          subpath.startsWith(prefix) &&
+          subpath.endsWith(suffix) &&
+          subpath.length >= prefix.length + suffix.length
+        ) {
+          entry = value;
+          capture = subpath.slice(prefix.length, subpath.length - suffix.length);
+          break;
+        }
+      }
+      if (entry === undefined) return null;
+    }
+  }
+
+  // Pick the ESM-relevant condition; "types"-only entries resolve to nothing.
+  const toFileTarget = (node) => {
+    if (typeof node === 'string') return capture === null ? node : node.replaceAll('*', capture);
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const found = toFileTarget(item);
+        if (found) return found;
+      }
+      return null;
+    }
+    if (node && typeof node === 'object') {
+      for (const condition of ['import', 'node', 'default']) {
+        if (condition in node) {
+          const found = toFileTarget(node[condition]);
+          if (found) return found;
+        }
+      }
+    }
+    return null;
+  };
+
+  const target = toFileTarget(entry);
+  return target !== null && target.startsWith('./') ? target.slice(2) : null;
+}
+
+function missingWorkspaceDistError(specifier, context) {
+  if (
+    specifier.startsWith('.') || specifier.startsWith('/') ||
+    specifier.startsWith('#') || specifier.startsWith('node:') ||
+    specifier.startsWith('file:')
+  ) {
+    return null;
+  }
+  if (!context?.parentURL?.startsWith('file:')) return null;
+  const segments = specifier.split('/');
+  const nameLength = segments[0].startsWith('@') ? 2 : 1;
+  if (segments.length < nameLength) return null;
+  const packageName = segments.slice(0, nameLength).join('/');
+  const subpath = segments.slice(nameLength).join('/');
+
+  // Find the nearest node_modules link for the package, mirroring Node's
+  // resolution walk (covers nested links like packages/*/node_modules/@opengsd/*).
+  const manifestRel = join('node_modules', ...packageName.split('/'), 'package.json');
+  let dir = dirname(fileURLToPath(context.parentURL));
+  let visited = null;
+  let pkgDir = null;
+  let manifest = null;
+  while (dir !== visited) {
+    visited = dir;
+    const manifestPath = join(dir, manifestRel);
+    if (!existsSync(manifestPath)) {
+      dir = dirname(dir);
+      continue;
+    }
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    } catch {
+      return null;
+    }
+    pkgDir = join(dir, 'node_modules', ...packageName.split('/'));
+    break;
+  }
+  if (!manifest) return null;
+
+  const target = exportsFileTarget(manifest.exports, subpath);
+  if (!target) return null;
+  if (!target.startsWith('dist/') && !target.includes('/dist/')) return null;
+  if (isWorkspacePackageLink(pkgDir) && !existsSync(join(pkgDir, target))) {
+    const name = typeof manifest.name === 'string' ? manifest.name : packageName;
+    return new Error(
+      `Workspace package "${name}" dist not found (missing ${target}). ` +
+      `Build it first: pnpm --filter ${name} build`,
+    );
+  }
+  return null;
+}
 
 export function resolve(specifier, context, nextResolve) {
   if (specifier.startsWith('node:')) {
@@ -110,7 +235,14 @@ export function resolve(specifier, context, nextResolve) {
     }
   }
 
-  return nextResolve(specifier, context);
+  // Happy path: delegate untouched. Only when resolution fails do we check
+  // whether a workspace package's dist output is missing, so the developer
+  // sees the build command instead of a bare ERR_MODULE_NOT_FOUND.
+  try {
+    return nextResolve(specifier, context);
+  } catch (error) {
+    throw missingWorkspaceDistError(specifier, context) ?? error;
+  }
 }
 
 export function load(url, context, nextLoad) {

--- a/src/resources/extensions/gsd/tests/dist-redirect.test.mjs
+++ b/src/resources/extensions/gsd/tests/dist-redirect.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { resolve } from './dist-redirect.mjs';
+
+// Mirrors how workspace packages are linked in a real checkout: the package
+// lives outside node_modules and is symlinked into node_modules/<scope>/<name>,
+// so the resolver's node_modules walk finds the fixture like a workspace link.
+function fixturePackage(root, name, manifest, { withDist = false } = {}) {
+  const pkgDir = join(root, 'packages', name.replace('@opengsd/', ''));
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify(manifest));
+  if (withDist) {
+    mkdirSync(join(pkgDir, 'dist'), { recursive: true });
+    writeFileSync(join(pkgDir, 'dist', 'index.js'), 'export {};\n');
+  }
+  const linkDir = join(root, 'node_modules', ...name.split('/'));
+  mkdirSync(join(linkDir, '..'), { recursive: true });
+  symlinkSync(pkgDir, linkDir, 'dir');
+  const parent = join(root, 'parent.mjs');
+  writeFileSync(parent, 'export {};\n');
+  return { parentURL: pathToFileURL(parent).href };
+}
+
+// Stands in for Node's default resolver, which throws the bare
+// ERR_MODULE_NOT_FOUND seen in fresh worktrees with unbuilt packages.
+const throwingNext = (specifier, context) => {
+  const error = new Error(`Cannot find module '${specifier}' imported from ${context.parentURL}`);
+  error.code = 'ERR_MODULE_NOT_FOUND';
+  throw error;
+};
+
+test('resolve fails loud with the build command when a workspace dist entry is missing', () => {
+  const root = mkdtempSync(join(tmpdir(), 'gsd-dist-redirect-'));
+  try {
+    const context = fixturePackage(root, '@opengsd/fake-unbuilt-pkg', {
+      name: '@opengsd/fake-unbuilt-pkg',
+      exports: {
+        '.': { import: './dist/index.js' },
+        './readers/graph': { import: './dist/readers/graph.js' },
+      },
+    });
+
+    assert.throws(
+      () => resolve('@opengsd/fake-unbuilt-pkg/readers/graph', context, throwingNext),
+      /Workspace package "@opengsd\/fake-unbuilt-pkg" dist not found \(missing dist\/readers\/graph\.js\)\. Build it first: pnpm --filter @opengsd\/fake-unbuilt-pkg build/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolve delegates untouched when the workspace dist entry exists', () => {
+  const root = mkdtempSync(join(tmpdir(), 'gsd-dist-redirect-'));
+  try {
+    const context = fixturePackage(root, '@opengsd/fake-built-pkg', {
+      name: '@opengsd/fake-built-pkg',
+      exports: { '.': { import: './dist/index.js' } },
+    }, { withDist: true });
+
+    const sentinel = { url: 'file:///sentinel', format: 'module', shortCircuit: true };
+    const next = () => sentinel;
+    assert.equal(resolve('@opengsd/fake-built-pkg', context, next), sentinel);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolve rethrows the original error for packages without a workspace link', () => {
+  const root = mkdtempSync(join(tmpdir(), 'gsd-dist-redirect-'));
+  try {
+    const parent = join(root, 'parent.mjs');
+    writeFileSync(parent, 'export {};\n');
+    const context = { parentURL: pathToFileURL(parent).href };
+
+    assert.throws(
+      () => resolve('@opengsd/never-linked-pkg', context, throwingNext),
+      (error) => error.code === 'ERR_MODULE_NOT_FOUND' &&
+        error.message.includes("Cannot find module '@opengsd/never-linked-pkg'"),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

When a focused source test resolves a workspace package whose `dist` output has not been built, the test resolver now fails loud with the exact build command that fixes it instead of a bare `ERR_MODULE_NOT_FOUND`.

## Explanation

In a fresh worktree, running a focused test dies with a cryptic module-resolution error before any assertion runs:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/@opengsd/mcp-server/dist/readers/graph.js'
imported from .../src/read-cli.ts
```

The resolver in `src/resources/extensions/gsd/tests/dist-redirect.mjs` (used by `resolve-ts.mjs`) delegates unrecognized workspace-package bare imports to Node's default resolution, which resolves through the pnpm workspace link and the package's `exports` map to missing `dist` output.

This change keeps the happy path untouched (resolution still delegates to `nextResolve` unchanged) and only intercepts resolution failures. On failure, the resolver:

- finds the nearest `node_modules/<pkg>/package.json` link (mirroring Node's walk, including nested links like `packages/*/node_modules/@opengsd/*`),
- derives the package name and the missing file from that manifest's `exports` map (nothing hardcoded),
- confirms the link points at a workspace package (not a registry install) and that the exports target is a `dist` path that does not exist,

and then throws:

```
Workspace package "@opengsd/mcp-server" dist not found (missing dist/readers/graph.js). Build it first: pnpm --filter @opengsd/mcp-server build
```

Anything it cannot attribute (non-workspace package, non-`dist` target, unparseable manifest, exports target present) rethrows the original error unchanged.

This is remedy (a) from the issue; the CI clean-checkout smoke test is a separate follow-up.

Fixes #2189

## Tests

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/dist-redirect.test.mjs` — 3/3 pass (new: missing dist fires the actionable error; built dist delegates untouched; unattributable packages rethrow the original error).
- Repro at HEAD in a fresh worktree, before: `ERR_MODULE_NOT_FOUND ... dist/readers/graph.js`; after: `Workspace package "@opengsd/mcp-server" dist not found (missing dist/readers/graph.js). Build it first: pnpm --filter @opengsd/mcp-server build`.
- After building the owning chain (`pnpm --filter @opengsd/contracts build`, `@opengsd/rpc-client`, `@opengsd/mcp-server`), the previously failing focused test passes: `--test src/tests/read-cli-progress-db.test.ts` → 8/8, and `--test src/resources/extensions/gsd/tests/progress-from-db.test.ts src/resources/extensions/gsd/tests/dist-redirect.test.mjs` → 12/12.

AI-assisted: yes