### PR TITLE
feat(gsd): show current dispatched model in the AUTO status strip

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/gsd-status-widget.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/gsd-status-widget.test.ts
@@ -122,4 +122,49 @@ describe("GsdStatusWidget", () => {
 		const head = lines[0] ?? "";
 		assert.ok(head.trimEnd().endsWith("S01"), "slice/task progress should sit on the far right of the header line");
 	});
+
+	test("renders the dispatched model ahead of timing in the head line", () => {
+		const widget = new GsdStatusWidget(() => ({
+			override: "auto",
+			activeToolCount: 1,
+			cwd: "/tmp/project",
+			manuallyExpanded: false,
+			gsdProgress: {
+				phase: "Executing T03 renderer polish",
+				modeTag: "AUTO",
+				elapsed: "14m",
+				eta: "~6m left",
+				model: "openai/gpt-5.3-codex",
+				widgetMode: "small",
+			},
+		}));
+		const lines = widget.render(120).map((line) => stripAnsi(line));
+		const plain = lines.join("\n");
+		assert.match(plain, /openai\/gpt-5\.3-codex/);
+		const head = lines[0] ?? "";
+		const modelIdx = head.indexOf("openai/gpt-5.3-codex");
+		const elapsedIdx = head.indexOf("14m");
+		assert.ok(modelIdx !== -1 && elapsedIdx !== -1 && modelIdx < elapsedIdx, "model segment should precede timing segments");
+		assert.match(head, /openai\/gpt-5\.3-codex · 14m · ~6m left/);
+	});
+
+	test("head line has no model segment artifacts when none is dispatched", () => {
+		const widget = new GsdStatusWidget(() => ({
+			override: "auto",
+			activeToolCount: 1,
+			cwd: "/tmp/project",
+			manuallyExpanded: false,
+			gsdProgress: {
+				phase: "Executing T03 renderer polish",
+				modeTag: "AUTO",
+				elapsed: "14m",
+				eta: "~6m left",
+				widgetMode: "small",
+			},
+		}));
+		const plain = widget.render(120).map((line) => stripAnsi(line)).join("\n");
+		assert.match(plain, /14m · ~6m left/);
+		assert.doesNotMatch(plain, /·\s*·/, "no empty separator artifacts from a missing model");
+		assert.doesNotMatch(plain, /·\s*14m/, "head-right should not start with an empty model segment");
+	});
 });

--- a/packages/gsd-agent-modes/src/modes/interactive/components/gsd-status-widget.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/gsd-status-widget.ts
@@ -88,19 +88,19 @@ function buildTaskProgressSegments(progress: GsdProgressState): string[] {
 function renderProgressHeadRight(progress: GsdProgressState): string {
 	const sep = theme.fg("dim", " · ");
 	const progressSegments = buildTaskProgressSegments(progress);
-	const timingParts = [progress.elapsed, progress.eta].filter(
+	const dimParts = [progress.model, progress.elapsed, progress.eta].filter(
 		(part): part is string => Boolean(part),
 	);
 
 	if (progressSegments.length > 0) {
 		const rightParts = [
-			...timingParts.map((part) => theme.fg("dim", part)),
+			...dimParts.map((part) => theme.fg("dim", part)),
 			...progressSegments,
 		];
 		return rightParts.join(sep);
 	}
-	if (timingParts.length > 0) {
-		return theme.fg("dim", timingParts.join(" · "));
+	if (dimParts.length > 0) {
+		return theme.fg("dim", dimParts.join(" · "));
 	}
 	return "";
 }

--- a/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts
@@ -163,6 +163,8 @@ export interface GsdProgressState {
 	unitLabel?: string;
 	elapsed?: string;
 	eta?: string;
+	/** Fully-qualified dispatched model ID (provider/id) auto-mode is currently running, if any. */
+	model?: string;
 	healthSummary?: string;
 	path?: string;
 	widgetMode?: GsdProgressWidgetMode;

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -715,7 +715,6 @@ export function updateProgressWidget(
   unitId: string,
   state: GSDState,
   accessors: WidgetStateAccessors,
-  tierBadge?: string,
 ): void {
   if (!ctx.hasUI) return;
 
@@ -1091,6 +1090,7 @@ function buildGsdProgressPayload(
     unitLabel,
     elapsed,
     eta: etaShort,
+    model: accessors.getCurrentDispatchedModelId() ?? undefined,
     healthSummary,
     path: accessors.getBasePath(),
     widgetMode: mode,

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -3222,18 +3222,7 @@ function updateProgressWidget(
   unitId: string,
   state: GSDState,
 ): void {
-  const badge = s.currentUnitRouting?.tier
-    ? ({ light: "L", standard: "S", heavy: "H" }[s.currentUnitRouting.tier] ??
-      undefined)
-    : undefined;
-  _updateProgressWidget(
-    ctx,
-    unitType,
-    unitId,
-    state,
-    widgetStateAccessors,
-    badge,
-  );
+  _updateProgressWidget(ctx, unitType, unitId, state, widgetStateAccessors);
 }
 
 /** State accessors for the widget — closures over module globals. */

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -734,7 +734,7 @@ test("updateProgressWidget full mode keeps footer-owned signals out of auto deck
   assert.match(rendered, /GSD AUTO/);
   assert.match(rendered, /T01: Add repeat column via idempotent ALTER TABLE/);
   assert.match(rendered, /tools/);
-  assert.doesNotMatch(rendered, /claude-sonnet-4-6/, "footer owns provider/model display");
+  assert.match(rendered, /claude-sonnet-4-6/, "strip shows the dispatched model (#2207)");
   assert.doesNotMatch(rendered, /0\.2%|ctx|1\.0M/, "footer owns raw context meter display");
   assert.doesNotMatch(rendered, /\$/, "footer owns session cost display");
 });
@@ -806,6 +806,61 @@ test("updateProgressWidget small mode renders the dense horizontal grid", (t) =>
 
   for (const width of [40, 80, 120]) {
     assertLinesFit(renderProgressStripLines(progress!, width, { cwd: dir }), width);
+  }
+});
+
+test("updateProgressWidget carries the dispatched model into the strip", (t) => {
+  const dir = makeTempDir("dispatched-model");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  const mocks: ReturnType<typeof createProgressStripUiMock>[] = [];
+
+  t.after(() => {
+    for (const mock of mocks) mock.disposeProgress();
+    _resetWidgetModeForTests();
+    clearSliceProgressCache();
+    cleanup(dir);
+  });
+
+  function capture(modelId: string | null) {
+    const mock = createProgressStripUiMock();
+    mocks.push(mock);
+    updateProgressWidget(
+      {
+        hasUI: true,
+        ui: mock.ui,
+      } as any,
+      "execute-task",
+      "M004/S01/T01",
+      {
+        phase: "executing",
+        activeSlice: { id: "S01", title: "Filter chip bar" },
+        activeTask: { id: "T01", title: "Add category filter" },
+      } as any,
+      {
+        getAutoStartTime: () => Date.now() - 12_000,
+        isStepMode: () => false,
+        getCmdCtx: () => null,
+        getBasePath: () => dir,
+        isVerbose: () => false,
+        isSessionSwitching: () => false,
+        getCurrentDispatchedModelId: () => modelId,
+      },
+    );
+    const progress = mock.getProgressState();
+    assert.ok(progress, "progress strip state should be published");
+    return progress;
+  }
+
+  const withModel = capture("openai/gpt-5.3-codex");
+  assert.equal(withModel.model, "openai/gpt-5.3-codex");
+
+  const withoutModel = capture(null);
+  assert.equal(withoutModel.model, undefined);
+
+  const rendered = renderProgressStrip(withModel, 120, { cwd: dir });
+  assert.match(rendered, /openai\/gpt-5\.3-codex/, "strip should show the dispatched model");
+  for (const width of [40, 80, 120]) {
+    assertLinesFit(renderProgressStripLines(withModel, width, { cwd: dir }), width);
   }
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Shows the current auto-dispatched model id in the live GSD AUTO status strip.
**Why:** The dispatched model was tracked internally (`getCurrentDispatchedModelId()`) but never surfaced to the user, so you couldn't see which model auto-mode is running (#2207).
**How:** Add an optional `model` field to `GsdProgressState`, populate it from the existing widget accessors in `buildGsdProgressPayload`, and render it as the first dim segment on the strip head line.

## What

- `packages/pi-coding-agent/src/core/extensions/extension-upstream-types.ts` — `GsdProgressState` gains an optional `model?: string` (fully-qualified dispatched model id, `provider/id`).
- `src/resources/extensions/gsd/auto-dashboard.ts` — `buildGsdProgressPayload` now includes `model: accessors.getCurrentDispatchedModelId() ?? undefined`.
- `packages/gsd-agent-modes/src/modes/interactive/components/gsd-status-widget.ts` — `renderProgressHeadRight` renders the model as the first dim segment of the head line, ahead of elapsed/eta, using the existing `·` separator style: `claude-code/claude-sonnet-4-6 · 18s · 3m left · slices 1/5 · tasks 2/7`. When absent the segment is filtered out and the strip is byte-identical to today.

## Why

The accessor `getCurrentDispatchedModelId()` exists and is wired into `WidgetStateAccessors`, but only tests consumed it — the live strip never showed which model the auto-loop dispatched. Refs #2078.

Fixes #2207

## How

- The model id is kept whole (e.g. `openai/gpt-5.3-codex`). It sits at the start of the head-right segments, so on very narrow terminals the existing line truncation degrades the rightmost segments first — same mechanism that already governs `unitLabel` today; no new width caps were invented.
- **Dead `tierBadge` parameter removed:** `updateProgressWidget` accepted a `tierBadge?` argument but never used it, and the `auto.ts` wrapper computed an L/S/H routing-tier badge that was silently dropped. The tier letter is routing metadata, not the dispatched model, so per the minimal-slice decision it is removed rather than forwarded: the parameter is gone from `updateProgressWidget` and the dead badge computation is gone from the `auto.ts` wrapper. No behavior change (nothing ever consumed it).
- No changes to the dashboard beyond this slice.

## Tests

- `auto-dashboard.test.ts`:
  - New: `updateProgressWidget carries the dispatched model into the strip` — payload carries the model when the accessor returns one, omits it when null, strip renders the id, and lines fit at 40/80/120 columns.
  - Updated: `updateProgressWidget full mode keeps footer-owned signals out of auto deck` — the old assertion `doesNotMatch(/claude-sonnet-4-6/)` encoded the pre-#2207 decision that the strip never shows a model; it now asserts the dispatched model appears, while the footer-owned context-meter and cost exclusions are unchanged.
- `gsd-status-widget.test.ts`:
  - New: model renders ahead of timing in the head line.
  - New: no model → no segment artifacts (no empty separators), head line unchanged.

Test evidence (local, targeted only):

- `node --test dist-test/src/resources/extensions/gsd/tests/auto-dashboard.test.js` — 48 pass, 0 fail
- `node --test dist-test/packages/gsd-agent-modes/.../gsd-status-widget.test.js dist-test/src/tests/gsd-status-widget.test.js dist-test/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.js` — 20 pass, 0 fail
- `pnpm run typecheck:extensions` — clean
- `pnpm run verify:fast` — all checks passed
- `pnpm run verify:merge:needed -- --base origin/main` — reports the full merge gate is not required for this diff

AI-assisted: yes