### PR TITLE
fix(gsd): accept UAT in gsd_summary_save

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -597,16 +597,18 @@ export function registerDbTools(pi: ExtensionAPI): void {
 		name: "gsd_summary_save",
 		label: "Save Summary",
 		description:
-			"Save a summary, research, UI spec, context, or assessment artifact to the GSD database and write it to disk. " +
-			"Computes the file path from milestone/slice/task IDs automatically.",
+			"Save a summary, research, UI spec, context, assessment, or UAT artifact to the GSD database and write it to disk. " +
+			"Computes the file path from milestone/slice/task IDs automatically. " +
+			"UAT artifacts are slice-scoped (milestone_id + slice_id, no task_id) and persist to the slice's UAT record, which re-renders the slice's UAT markdown after the slice completes.",
 		promptSnippet:
-			"Save a GSD artifact (summary/research/UI spec/context/assessment) to DB and disk",
+			"Save a GSD artifact (summary/research/UI spec/context/assessment/UAT) to DB and disk",
 		promptGuidelines: [
-			"Use gsd_summary_save to persist structured artifacts (SUMMARY, RESEARCH, UI-SPEC, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT).",
+			"Use gsd_summary_save to persist structured artifacts (SUMMARY, RESEARCH, UI-SPEC, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT, UAT).",
 			"milestone_id is required for milestone/slice/task artifacts. Omit milestone_id only for root-level PROJECT/PROJECT-DRAFT/REQUIREMENTS/REQUIREMENTS-DRAFT.",
 			"The tool computes the relative path automatically: milestones/M001/M001-SUMMARY.md, milestones/M001/slices/S01/S01-SUMMARY.md, etc.",
 			"Root-level artifact paths are PROJECT.md, PROJECT-DRAFT.md, REQUIREMENTS.md, and REQUIREMENTS-DRAFT.md.",
-			"artifact_type must be one of: SUMMARY, RESEARCH, UI-SPEC, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT.",
+			"artifact_type must be one of: SUMMARY, RESEARCH, UI-SPEC, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT, UAT.",
+			"UAT (despite the tool name) saves the slice's UAT acceptance document: pass milestone_id + slice_id and no task_id; it persists to the slice's UAT record, so corrections to a completed slice's UAT markdown survive projection flushes.",
 			"Use CONTEXT-DRAFT for incremental draft persistence; use CONTEXT for the final milestone context after depth verification.",
 			`Keep each content payload under ${SUMMARY_SAVE_CONTENT_MAX_LENGTH} characters; save large context incrementally with CONTEXT-DRAFT/PROJECT-DRAFT/REQUIREMENTS-DRAFT instead of one oversized call.`,
 		],
@@ -635,6 +637,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 					"PROJECT-DRAFT",
 					"REQUIREMENTS",
 					"REQUIREMENTS-DRAFT",
+					"UAT",
 				],
 				{ description: "Artifact type to save" },
 			),

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -826,6 +826,19 @@ export function setSliceSummaryMd(milestoneId: string, sliceId: string, summaryM
   ).run({ ":mid": milestoneId, ":sid": sliceId, ":summary_md": summaryMd, ":uat_md": uatMd }));
 }
 
+/**
+ * Update only the slice's UAT carrier column (full_uat_md), leaving the summary
+ * carrier untouched. Returns false when no matching slice row exists so callers
+ * can fail loudly instead of persisting a no-op.
+ */
+export function setSliceUatMd(milestoneId: string, sliceId: string, uatMd: string): boolean {
+  if (!getDbOrNull()!) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const updated = transaction(() => getDbOrNull()!.prepare(
+    `UPDATE slices SET full_uat_md = :uat_md WHERE milestone_id = :mid AND id = :sid`,
+  ).run({ ":mid": milestoneId, ":sid": sliceId, ":uat_md": uatMd }));
+  return Number((updated as { changes?: number }).changes ?? 0) === 1;
+}
+
 
 
 

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -11,12 +11,15 @@ import {
   _getAdapter,
   getArtifact,
   getAssessment,
+  getSlice,
   insertAssessment,
   insertGateRow,
   insertMilestone,
+  setSliceSummaryMd,
   upsertRequirement,
   getAllMilestones,
 } from "../gsd-db.ts";
+import { renderAllFromDb } from "../markdown-renderer.ts";
 import { getAutoWorker, registerAutoWorker } from "../db/auto-workers.ts";
 import { claimMilestoneLease, getMilestoneLease } from "../db/milestone-leases.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
@@ -380,6 +383,131 @@ test("executeSummarySave persists UI-SPEC artifacts at the computed flat-phase p
     closeDatabase();
     cleanup(base);
   }
+});
+
+function completeSliceRow(milestoneId: string, sliceId: string): void {
+  const db = _getAdapter();
+  if (!db) throw new Error("DB not open");
+  db.prepare(
+    "UPDATE slices SET status = 'complete', completed_at = ? WHERE milestone_id = ? AND id = ?",
+  ).run(new Date().toISOString(), milestoneId, sliceId);
+}
+
+test("executeSummarySave persists UAT artifacts to the slice UAT carrier", async (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+  openTestDb(base);
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  seedSlice("M001", "S01", "in_progress");
+
+  const result = await inProjectDir(base, () => executeSummarySave({
+    milestone_id: "M001",
+    slice_id: "S01",
+    artifact_type: "UAT",
+    content: "# UAT\n\nAcceptance: 5 units verified\n",
+  }, base));
+
+  assert.notEqual(result.isError, true);
+  assert.equal(result.details.operation, "save_summary");
+  assert.equal(result.details.path, "phases/01-m001/01-01-UAT.md");
+  assert.equal(result.details.artifact_type, "UAT");
+
+  // CRITICAL: UAT content lands in the UAT carrier, never the summary carrier.
+  const slice = getSlice("M001", "S01");
+  assert.equal(slice?.full_uat_md, "# UAT\n\nAcceptance: 5 units verified\n");
+  assert.equal(slice?.full_summary_md, "", "UAT saves must not touch full_summary_md");
+
+  const filePath = join(base, ".gsd", "phases", "01-m001", "01-01-UAT.md");
+  assert.ok(existsSync(filePath), "UAT artifact should be written to disk");
+  assert.match(readFileSync(filePath, "utf-8"), /Acceptance: 5 units/);
+  assert.equal(getArtifact("phases/01-m001/01-01-UAT.md")?.artifact_type, "UAT");
+});
+
+test("executeSummarySave UAT correction re-renders a completed slice's UAT projection", async (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+  openTestDb(base);
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  seedSlice("M001", "S01", "in_progress");
+  // Simulate completion output: the carriers hold the pre-correction UAT text.
+  setSliceSummaryMd(
+    "M001",
+    "S01",
+    "# Slice summary",
+    "# UAT\n\nAcceptance: 5 units verified\n\n## Evidence\n- unit A: pass\n- unit B: pass\n",
+  );
+  completeSliceRow("M001", "S01");
+
+  // Initial flush: the DB-owned projection renders the pre-correction text.
+  const firstFlush = await renderAllFromDb(base);
+  assert.deepEqual(firstFlush.errors, []);
+  const uatPath = join(base, ".gsd", "phases", "01-foundation", "01-01-UAT.md");
+  assert.ok(existsSync(uatPath), "completed slice should project its UAT file");
+  assert.match(readFileSync(uatPath, "utf-8"), /Acceptance: 5 units/);
+
+  const result = await inProjectDir(base, () => executeSummarySave({
+    milestone_id: "M001",
+    slice_id: "S01",
+    artifact_type: "UAT",
+    content: "# UAT\n\nAcceptance: 7 units verified (superseded by S02)\n\n## Evidence\n- unit A: pass\n- unit B: pass\n- unit C: pass\n",
+  }, base));
+  assert.notEqual(result.isError, true);
+  assert.equal(result.details.path, "phases/01-foundation/01-01-UAT.md");
+
+  // Post-completion flush: the correction must survive — no silent revert.
+  const secondFlush = await renderAllFromDb(base);
+  assert.deepEqual(secondFlush.errors, []);
+  const rendered = readFileSync(uatPath, "utf-8");
+  assert.match(rendered, /Acceptance: 7 units verified/);
+  assert.doesNotMatch(rendered, /Acceptance: 5 units/);
+
+  const slice = getSlice("M001", "S01");
+  assert.match(slice?.full_uat_md ?? "", /Acceptance: 7 units verified/);
+  assert.equal(slice?.full_summary_md, "# Slice summary", "summary carrier must be untouched");
+});
+
+test("executeSummarySave rejects UAT saves without a usable slice target", async (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+  openTestDb(base);
+  insertMilestone({ id: "M001", title: "Foundation", status: "active" });
+  seedSlice("M001", "S01", "in_progress");
+
+  const noSliceId = await inProjectDir(base, () => executeSummarySave({
+    milestone_id: "M001",
+    artifact_type: "UAT",
+    content: "# UAT\n",
+  }, base));
+  assert.equal(noSliceId.isError, true);
+  assert.equal(noSliceId.details.error, "missing_slice_id");
+
+  const withTaskId = await inProjectDir(base, () => executeSummarySave({
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T01",
+    artifact_type: "UAT",
+    content: "# UAT\n",
+  }, base));
+  assert.equal(withTaskId.isError, true);
+  assert.equal(withTaskId.details.error, "unexpected_task_id");
+
+  const unknownSlice = await inProjectDir(base, () => executeSummarySave({
+    milestone_id: "M001",
+    slice_id: "S09",
+    artifact_type: "UAT",
+    content: "# UAT\n",
+  }, base));
+  assert.equal(unknownSlice.isError, true);
+  assert.equal(unknownSlice.details.error, "slice_not_found");
 });
 
 test("executeSummarySave mirrors milestone artifacts into the active worktree projection", async () => {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -19,6 +19,7 @@ import {
   insertGateRun,
   readTransaction,
   saveGateResult,
+  setSliceUatMd,
   upsertMilestonePlanning,
   upsertQualityGate,
 } from "../gsd-db.js";
@@ -137,6 +138,7 @@ export const SUPPORTED_SUMMARY_ARTIFACT_TYPES = [
   "PROJECT-DRAFT",
   "REQUIREMENTS",
   "REQUIREMENTS-DRAFT",
+  "UAT",
 ] as const;
 
 export function isSupportedSummaryArtifactType(
@@ -491,6 +493,20 @@ export async function executeSummarySave(
       isError: true,
     };
   }
+  if (params.artifact_type === "UAT" && !params.slice_id) {
+    return {
+      content: [{ type: "text", text: `Error: slice_id is required for artifact_type "UAT". UAT saves are slice-scoped and persist to the slice's UAT record (full_uat_md).` }],
+      details: { operation: "save_summary", error: "missing_slice_id" },
+      isError: true,
+    };
+  }
+  if (params.artifact_type === "UAT" && params.task_id) {
+    return {
+      content: [{ type: "text", text: `Error: task_id is not supported for artifact_type "UAT". UAT saves are slice-scoped; omit task_id.` }],
+      details: { operation: "save_summary", error: "unexpected_task_id" },
+      isError: true,
+    };
+  }
   const writeGateSnapshot = loadWriteGateSnapshot(basePath);
   const prefs = loadEffectiveGSDPreferences(basePath)?.preferences;
   const rootArtifactGuard = shouldBlockRootArtifactSaveInSnapshot(
@@ -698,6 +714,19 @@ export async function executeSummarySave(
       relativePath = projection.artifactPath;
       projectedContent = projection.content;
     } else {
+      if (params.artifact_type === "UAT") {
+        // UAT must land in the slice's UAT carrier (full_uat_md), never the
+        // summary carrier: after slice completion the UAT projection re-renders
+        // from this column, so post-completion corrections survive flushes.
+        const updated = setSliceUatMd(params.milestone_id!, params.slice_id!, contentToSave);
+        if (!updated) {
+          return {
+            content: [{ type: "text", text: `Error: no slice "${params.slice_id}" found in milestone "${params.milestone_id}". UAT saves require an existing slice row.` }],
+            details: { operation: "save_summary", error: "slice_not_found" },
+            isError: true,
+          };
+        }
+      }
       await saveArtifactToDb(
         {
           path: relativePath,


### PR DESCRIPTION
## TL;DR

`gsd_summary_save` now accepts `artifact_type: "UAT"`, giving a supported write path into a slice's UAT carrier (`slices.full_uat_md`). A completed slice's UAT projection is DB-owned and re-renders from that column on every flush, so post-completion corrections made through the tool now survive instead of being silently impossible.

Fixes #2215

## Detailed explanation

After a slice completes, `.gsd/phases/<phase>/NN-MM-UAT.md` becomes a DB-owned projection: `renderSliceSummary` re-renders it from `slices.full_uat_md` on every flush, and the drift checker compares it against that same column. Before this change, no tool could write either UAT carrier — `gsd_summary_save` rejected the type outright and `gsd_uat_result_save` records run results, not criterion text — so a factual error in a completed slice's UAT markdown was permanent (hand edits were reverted on the next flush).

This PR implements the maintainer decision on the issue: widen `gsd_summary_save` with a `UAT` artifact type and route UAT writes to the UAT carrier.

- **Tool surface** (`src/resources/extensions/gsd/bootstrap/db-tools.ts`): added `UAT` to the `artifact_type` enum, and updated the tool description, snippet, and prompt guidelines to state that UAT is accepted, that it is slice-scoped (`milestone_id` + `slice_id`, no `task_id`), and that it lands in the slice's UAT record which re-renders the slice's UAT markdown after slice completion (covering the summary-tool-writes-UAT naming wart).
- **Routing** (`src/resources/extensions/gsd/tools/workflow-tool-executors.ts`): added `UAT` to `SUPPORTED_SUMMARY_ARTIFACT_TYPES`. A UAT save writes `slices.full_uat_md` via a new `setSliceUatMd` helper *before* the existing generic persistence (artifacts row + disk write), so UAT content never touches the summary carrier (`full_summary_md`) and both UAT stores move together. Validation fails loudly on missing `slice_id`, a `task_id`, or an unknown slice row. The render-ownership gate in `markdown-renderer.ts` is unchanged: pre-completion saves persist to the DB while the file stays agent-owned; post-completion saves feed the DB-owned render.
- **DB helper** (`src/resources/extensions/gsd/gsd-db.ts`): `setSliceUatMd(milestoneId, sliceId, md)` updates only `full_uat_md` (unlike `setSliceSummaryMd`, which writes both carriers) and returns `false` when no slice row matches, so callers can error instead of persisting a silent no-op.

## Test evidence

New tests in `src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts`:

- `executeSummarySave persists UAT artifacts to the slice UAT carrier` — UAT save writes `full_uat_md`, leaves `full_summary_md` empty, and writes the artifacts row + disk file.
- `executeSummarySave UAT correction re-renders a completed slice's UAT projection` — completed slice flush renders the old text; a post-completion UAT save plus a second `renderAllFromDb` flush renders the corrected text (no revert), with the summary carrier untouched.
- `executeSummarySave rejects UAT saves without a usable slice target` — missing `slice_id`, `task_id` present, and unknown slice each fail loudly.

Commands and results:

```
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types \
  --test --test-name-pattern="executeSummarySave" \
  src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
→ tests 22, pass 22, fail 0   (includes the 3 new tests)

# compiled runner (same file, post test:compile)
node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process \
  --test --test-name-pattern="executeSummarySave" \
  dist-test/src/resources/extensions/gsd/tests/workflow-tool-executors.test.js
→ tests 22, pass 22, fail 0

# adjacent surfaces: gsd-tools, tool-param-optionality, workflow-tool-base-path,
# execute-summary-save-empty-project, prompt-contracts, write-gate,
# tool-surface-readiness, mcp-tool-name, tool-availability-audit,
# db-tools-alias-suppression, tool-search-shim
→ all pass (33 + 159 + 8 tests across the three batches)

pnpm run typecheck:extensions   → clean
pnpm run verify:fast            → ci-fast-gates: all checks passed
```

AI-assisted: yes
