### PR TITLE
fix(gsd): make plan-slice re-dispatch idempotent over existing pending rows

### DIFF
--- a/src/resources/extensions/gsd/db/writers/slice-lifecycle.ts
+++ b/src/resources/extensions/gsd/db/writers/slice-lifecycle.ts
@@ -167,6 +167,166 @@ export function grantSliceCancellationWaiver(
   return { waiverId, waiverStatus: "active" };
 }
 
+export interface PlanReconciliationAuthorization {
+  taskId: string;
+  requirementId: string;
+  waiverId: string;
+}
+
+const PLAN_RECONCILIATION_OPERATION = "workflow.slice.plan";
+const PLAN_RECONCILIATION_AUTHORIZATION_OPERATION = "workflow.slice.plan.authorization";
+
+/**
+ * Mint the cancellation authorization the slice-completion invariant demands
+ * for a task that a plan-slice re-dispatch omits (#2217). Runs inside the
+ * `workflow.slice.plan` Domain Operation and stamps the Waiver with that
+ * operation's provenance; the matching waived Requirement Disposition is
+ * recorded by `recordPlanReconciliationDisposition` in the fenced
+ * authorization operation that follows, because the schema requires a Waiver
+ * to predate its waived Disposition by at least one project revision.
+ */
+export function grantPlanReconciliationWaiver(
+  context: Readonly<DomainOperationContext>,
+  input: SliceIdentity & { taskId: string },
+): PlanReconciliationAuthorization {
+  if (requireActiveDomainOperationContext(context) !== PLAN_RECONCILIATION_OPERATION) {
+    throw new Error("Plan reconciliation Waiver requires a workflow.slice.plan Domain Operation");
+  }
+  const slice = {
+    milestoneId: requireText(input.milestoneId, "milestoneId"),
+    sliceId: requireText(input.sliceId, "sliceId"),
+  };
+  const taskId = requireText(input.taskId, "taskId");
+  const lifecycle = getDb().prepare(`
+    SELECT lifecycle_id
+    FROM workflow_item_lifecycles
+    WHERE project_id = :project_id
+      AND item_kind = 'task'
+      AND milestone_id = :milestone_id
+      AND slice_id = :slice_id
+      AND task_id = :task_id
+  `).get({
+    ":project_id": context.projectId,
+    ":milestone_id": slice.milestoneId,
+    ":slice_id": slice.sliceId,
+    ":task_id": taskId,
+  }) as Record<string, unknown> | undefined;
+  if (!lifecycle) {
+    throw new Error(
+      `Plan reconciliation requires the cancelled Task lifecycle for ${slice.milestoneId}/${slice.sliceId}/${taskId}`,
+    );
+  }
+  const lifecycleId = String(lifecycle["lifecycle_id"]);
+  const requirementId = `plan-omission:${slice.milestoneId}/${slice.sliceId}/${taskId}`;
+  const requirement = getDb().prepare(`
+    SELECT id FROM requirements WHERE id = :id
+  `).get({ ":id": requirementId }) as Record<string, unknown> | undefined;
+  if (!requirement) {
+    getDb().prepare(`
+      INSERT INTO requirements (id, class, status, description, source)
+      VALUES (:id, 'cancellation', 'waived', :description, 'plan-slice')
+    `).run({
+      ":id": requirementId,
+      ":description": `Omission of task ${taskId} from slice ${slice.milestoneId}/${slice.sliceId} authorized by plan-slice reconciliation`,
+    });
+  }
+  const scope = `task:${slice.milestoneId}/${slice.sliceId}/${taskId}`;
+  const existing = getDb().prepare(`
+    SELECT waiver_id
+    FROM workflow_waivers
+    WHERE lifecycle_id = :lifecycle_id
+      AND requirement_id = :requirement_id
+      AND waiver_status = 'active'
+      AND scope = :scope
+  `).all({
+    ":lifecycle_id": lifecycleId,
+    ":requirement_id": requirementId,
+    ":scope": scope,
+  }) as Array<Record<string, unknown>>;
+  if (existing.length > 1) {
+    throw new Error("Plan reconciliation found multiple active cancellation Waivers for one task");
+  }
+  if (existing.length === 1) {
+    return { taskId, requirementId, waiverId: String(existing[0]!["waiver_id"]) };
+  }
+  const waiverId = randomUUID();
+  getDb().prepare(`
+    INSERT INTO workflow_waivers (
+      waiver_id, project_id, lifecycle_id, requirement_id, blocker_id,
+      waiver_status, scope, rationale, granted_by_actor_type,
+      granted_by_actor_id, granted_at, expires_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES (
+      :waiver_id, :project_id, :lifecycle_id, :requirement_id, NULL,
+      'active', :scope, :rationale, 'policy',
+      NULL, :granted_at, NULL,
+      :operation_id, :project_revision, :authority_epoch
+    )
+  `).run({
+    ":waiver_id": waiverId,
+    ":project_id": context.projectId,
+    ":lifecycle_id": lifecycleId,
+    ":requirement_id": requirementId,
+    ":scope": scope,
+    ":rationale": `Plan-slice reconciliation omitted task ${taskId} from slice ${slice.milestoneId}/${slice.sliceId}; the omission is authorized for slice completion`,
+    ":granted_at": new Date().toISOString(),
+    ":operation_id": context.operationId,
+    ":project_revision": context.resultingRevision,
+    ":authority_epoch": context.resultingAuthorityEpoch,
+  });
+  return { taskId, requirementId, waiverId };
+}
+
+/**
+ * Record the waived Requirement Disposition that binds a reconciliation
+ * Waiver into a current authorized cancellation for slice completion. The
+ * schema's waiver-authority trigger requires the Waiver's project revision to
+ * strictly precede the Disposition's, so this runs in its own fenced
+ * `workflow.slice.plan.authorization` Domain Operation after the plan
+ * operation commits.
+ */
+export function recordPlanReconciliationDisposition(
+  context: Readonly<DomainOperationContext>,
+  input: PlanReconciliationAuthorization,
+): void {
+  if (requireActiveDomainOperationContext(context) !== PLAN_RECONCILIATION_AUTHORIZATION_OPERATION) {
+    throw new Error("Plan reconciliation Disposition requires a workflow.slice.plan.authorization Domain Operation");
+  }
+  const requirementId = requireText(input.requirementId, "requirementId");
+  const waiverId = requireText(input.waiverId, "waiverId");
+  const head = getDb().prepare(`
+    SELECT disposition_id
+    FROM workflow_requirement_dispositions
+    WHERE requirement_id = :requirement_id
+      AND NOT EXISTS (
+        SELECT 1 FROM workflow_requirement_dispositions successor
+        WHERE successor.supersedes_disposition_id = workflow_requirement_dispositions.disposition_id
+      )
+  `).get({ ":requirement_id": requirementId }) as Record<string, unknown> | undefined;
+  getDb().prepare(`
+    INSERT INTO workflow_requirement_dispositions (
+      disposition_id, project_id, requirement_id, disposition, waiver_id,
+      supersedes_disposition_id, rationale, created_at,
+      operation_id, project_revision, authority_epoch
+    ) VALUES (
+      :disposition_id, :project_id, :requirement_id, 'waived', :waiver_id,
+      :supersedes_id, :rationale, :created_at,
+      :operation_id, :project_revision, :authority_epoch
+    )
+  `).run({
+    ":disposition_id": randomUUID(),
+    ":project_id": context.projectId,
+    ":requirement_id": requirementId,
+    ":waiver_id": waiverId,
+    ":supersedes_id": head ? String(head["disposition_id"]) : null,
+    ":rationale": "Waived by plan-slice reconciliation for the omitted task",
+    ":created_at": new Date().toISOString(),
+    ":operation_id": context.operationId,
+    ":project_revision": context.resultingRevision,
+    ":authority_epoch": context.resultingAuthorityEpoch,
+  });
+}
+
 function revokeSliceCancellationWaivers(
   context: Readonly<DomainOperationContext>,
   lifecycleId: string,

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -22,11 +22,15 @@ import {
   projectCanonicalStatusToLegacy,
   readDomainOperationFence,
 } from '../gsd-db.ts';
+import { appendKernelCheckpoint } from '../db/writers/lifecycle-commands.ts';
 import { handlePlanSlice as handlePlanSliceWithInvocation } from '../tools/plan-slice.ts';
 import { handlePlanTask as handlePlanTaskWithInvocation } from '../tools/plan-task.ts';
 import { internalPlanningInvocation } from '../planning-invocation.ts';
 import { parseProjectionPlan as parsePlan } from '../schemas/parsers.ts';
 import { deriveState, invalidateStateCache } from '../state.ts';
+import { claimTaskAttempt, settleTaskAttempt } from '../task-execution-domain-operation.ts';
+import { recordTaskTechnicalVerdict } from '../task-verification-domain-operation.ts';
+import { completeSlice } from '../slice-lifecycle-domain-operation.ts';
 
 function handlePlanSlice(
   params: Parameters<typeof handlePlanSliceWithInvocation>[0],
@@ -1116,6 +1120,31 @@ test('handlePlanSlice durably cancels omitted pending tasks when replanning a sm
       FROM workflow_item_lifecycles
       WHERE item_kind = 'task' AND milestone_id = 'M001' AND slice_id = 'S02' AND task_id = 'T05'
     `).get(), { lifecycle_status: 'cancelled', state_version: 1 });
+    // Reconciled invariant (#2217): the re-dispatch runs over an all-pending
+    // set, so each omission it cancels carries its own cancellation Waiver
+    // with a current waived Disposition — slice completion needs no manual
+    // waiver for these rows.
+    for (const omittedTaskId of ['T04', 'T05']) {
+      const omittedLifecycle = adapter.prepare(`
+        SELECT lifecycle_id FROM workflow_item_lifecycles
+        WHERE item_kind = 'task' AND milestone_id = 'M001' AND slice_id = 'S02' AND task_id = ?
+      `).get(omittedTaskId) as { lifecycle_id: string } | undefined;
+      assert.ok(omittedLifecycle, `omitted ${omittedTaskId} must keep its lifecycle row`);
+      const waiver = adapter.prepare(`
+        SELECT waiver_id, requirement_id FROM workflow_waivers
+        WHERE lifecycle_id = ? AND waiver_status = 'active'
+      `).get(omittedLifecycle.lifecycle_id) as { waiver_id: string; requirement_id: string } | undefined;
+      assert.ok(waiver, `omitted ${omittedTaskId} must carry an active cancellation Waiver`);
+      const disposition = adapter.prepare(`
+        SELECT disposition FROM workflow_requirement_dispositions
+        WHERE waiver_id = ? AND requirement_id = ?
+          AND NOT EXISTS (
+            SELECT 1 FROM workflow_requirement_dispositions successor
+            WHERE successor.supersedes_disposition_id = workflow_requirement_dispositions.disposition_id
+          )
+      `).get(waiver.waiver_id, waiver.requirement_id) as { disposition: string } | undefined;
+      assert.equal(disposition?.disposition, 'waived', `omitted ${omittedTaskId} must carry a current waived Disposition`);
+    }
     assert.doesNotMatch(readFileSync(slicePlanPath, 'utf-8'), /T04/, 'omitted T04 should be removed from plan');
 
     const beforeReopenAttempt = {
@@ -1320,6 +1349,315 @@ test('handlePlanSlice resolves relative task IO paths against worktree roots', a
     }, worktree);
 
     assert.ok(!('error' in result), `expected success, got: ${(result as { error?: string }).error}`);
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ── Interrupted plan-slice replay reconciliation (#2217) ─────────────────────
+//
+// When crash recovery re-fires plan-slice, the second planning run may emit
+// bare task ids (T01..) while the interrupted first run persisted
+// slice-prefixed rows (S02-T01..). Before #2217 the re-dispatch inserted a
+// duplicate bare-id set and durably cancelled the prefixed originals without
+// any cancellation Waiver, permanently blocking slice completion.
+
+function replayChainInvocation(step: string, taskId?: string): {
+  idempotencyKey: string;
+  sourceTransport: 'pi-tool';
+  actorType: string;
+  actorId: string;
+} {
+  return {
+    idempotencyKey: `test/replay-chain/${taskId ?? 'slice'}/${step}`,
+    sourceTransport: 'pi-tool',
+    actorType: 'agent',
+    actorId: 'plan-slice-replay-test',
+  };
+}
+
+function sliceCompletionCloseout() {
+  return {
+    sliceTitle: 'Planning slice',
+    oneLiner: 'Completed after an interrupted plan-slice replay.',
+    narrative: 'The replayed dispatch reconciled task rows without duplication.',
+    verification: 'Focused completion-chain tests pass.',
+    uatContent: '',
+    operationalReadiness: '',
+    deviations: 'None.',
+    knownLimitations: 'None.',
+    followUps: 'None.',
+    provides: [],
+    requires: [],
+    affects: [],
+    keyFiles: [],
+    keyDecisions: [],
+    patternsEstablished: [],
+    observabilitySurfaces: [],
+    drillDownPaths: [],
+    requirementsAdvanced: [],
+    requirementsValidated: [],
+    requirementsSurfaced: [],
+    requirementsInvalidated: [],
+    filesModified: [],
+  };
+}
+
+function seedExecutionFixtures(): void {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  adapter.prepare(`
+    INSERT INTO workers (
+      worker_id, host, pid, started_at, version, last_heartbeat_at, status,
+      project_root_realpath
+    ) VALUES (
+      'worker-1', 'test-host', 1, '2026-09-10T00:00:00.000Z', 'test',
+      '2026-09-10T00:00:00.000Z', 'active', '/tmp/project'
+    )
+  `).run();
+  adapter.prepare(`
+    INSERT INTO milestone_leases (
+      milestone_id, worker_id, fencing_token, acquired_at, expires_at, status
+    ) VALUES (
+      'M001', 'worker-1', 7, '2026-09-10T00:00:00.000Z',
+      '2099-09-10T00:00:00.000Z', 'held'
+    )
+  `).run();
+}
+
+function insertClaimedDispatch(taskId: string): number {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  adapter.prepare(`
+    INSERT INTO unit_dispatches (
+      trace_id, turn_id, worker_id, milestone_lease_token,
+      milestone_id, slice_id, task_id, unit_type, unit_id,
+      status, attempt_n, started_at
+    ) VALUES (
+      :trace_id, :turn_id, 'worker-1', 7,
+      'M001', 'S02', :task_id, 'execute-task', :unit_id,
+      'claimed', 1, '2026-09-10T00:00:00.000Z'
+    )
+  `).run({
+    ':trace_id': `trace/${taskId}`,
+    ':turn_id': `turn/${taskId}`,
+    ':task_id': taskId,
+    ':unit_id': `M001/S02/${taskId}`,
+  });
+  return Number(adapter.prepare('SELECT MAX(id) AS id FROM unit_dispatches').get()?.id);
+}
+
+/**
+ * Drive one task through the durable completion chain (claim, settle,
+ * technical verdict, completion publish) so slice completion can accept it.
+ */
+function runTaskToCompleted(taskId: string): void {
+  const attemptId = claimTaskAttempt({
+    invocation: replayChainInvocation('claim', taskId),
+    task: { milestoneId: 'M001', sliceId: 'S02', taskId },
+    workerId: 'worker-1',
+    milestoneLeaseToken: 7,
+    coordinationDispatchId: insertClaimedDispatch(taskId),
+  }).attemptId;
+  settleTaskAttempt({
+    invocation: replayChainInvocation('settle', taskId),
+    attemptId,
+    outcome: 'succeeded',
+    failureClass: 'none',
+    summary: 'Task implementation succeeded.',
+    output: { artifact: 'replay-chain-history' },
+  });
+  recordTaskTechnicalVerdict({
+    invocation: replayChainInvocation('verify', taskId),
+    attemptId,
+    testedSourceRevision: 'git:replay-chain-source-revision',
+    verdict: 'pass',
+    rationale: 'Focused verification passed.',
+    evidence: {
+      evidenceClass: 'command',
+      commandOrTool: 'node --test plan-slice.test.ts',
+      workingDirectory: '/tmp/project',
+      startedAt: '2026-09-10T00:01:00.000Z',
+      endedAt: '2026-09-10T00:01:01.000Z',
+      exitCode: 0,
+      observation: 'passed',
+      durableOutputRef: `db://fixture/${taskId}/verification`,
+      environment: { runner: 'node-test', fixture: 'plan-slice-replay' },
+    },
+  });
+
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  const lifecycleId = String(adapter.prepare(
+    'SELECT lifecycle_id FROM workflow_execution_attempts WHERE attempt_id = ?',
+  ).get(attemptId)?.lifecycle_id);
+  let previousCheckpointId = String(adapter.prepare(`
+    SELECT kernel_checkpoint_id FROM workflow_kernel_checkpoints
+    WHERE attempt_id = ? AND next_stage = 'verify'
+      AND NOT EXISTS (
+        SELECT 1 FROM workflow_kernel_checkpoints successor
+        WHERE successor.previous_kernel_checkpoint_id =
+          workflow_kernel_checkpoints.kernel_checkpoint_id
+      )
+  `).get(attemptId)?.kernel_checkpoint_id);
+  const fence = readDomainOperationFence();
+  executeDomainOperation({
+    operationType: 'task.completion.publish',
+    idempotencyKey: `test/replay-chain/${taskId}/publish`,
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: 'test',
+    sourceTransport: 'test',
+    payload: { taskId, attemptId },
+  }, (context) => {
+    adoptOrTransitionLifecycle(context, {
+      itemKind: 'task',
+      milestoneId: 'M001',
+      sliceId: 'S02',
+      taskId,
+      lifecycleStatus: 'completed',
+    });
+    for (const nextStage of ['route', 'closeout', 'settled'] as const) {
+      previousCheckpointId = appendKernelCheckpoint(context, {
+        lifecycleId,
+        attemptId,
+        nextStage,
+        previousKernelCheckpointId: previousCheckpointId,
+      }).kernelCheckpointId;
+    }
+    adapter.prepare(`
+      UPDATE tasks SET status = 'complete', completed_at = '2026-09-10T00:02:00.000Z'
+      WHERE milestone_id = 'M001' AND slice_id = 'S02' AND id = ?
+    `).run(taskId);
+    return {
+      events: [{
+        eventType: 'task.completion.published',
+        entityType: 'task',
+        entityId: `M001/S02/${taskId}`,
+        payload: { attemptId },
+        destinations: ['test'],
+      }],
+      projections: [{
+        projectionKey: `test/publish/${taskId.toLowerCase()}`,
+        projectionKind: 'test',
+        rendererVersion: '1',
+      }],
+    };
+  });
+}
+
+test('handlePlanSlice interrupted replay reuses existing prefixed rows instead of duplicating them (#2217)', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    const first = await handlePlanSlice({
+      ...validParams(),
+      tasks: [
+        { ...validParams().tasks[0], taskId: 'S02-T01' },
+        { ...validParams().tasks[1], taskId: 'S02-T02' },
+      ],
+    }, base);
+    assert.ok(!('error' in first), `unexpected error: ${'error' in first ? first.error : ''}`);
+
+    // Recovery re-dispatch: the planner emits bare ids this time.
+    const second = await handlePlanSlice({
+      ...validParams(),
+      tasks: [
+        { ...validParams().tasks[0], taskId: 'T01', title: 'Rewritten slice handler' },
+        { ...validParams().tasks[1], taskId: 'T02' },
+      ],
+    }, base);
+    assert.ok(!('error' in second), `unexpected error: ${'error' in second ? second.error : ''}`);
+
+    assert.deepEqual(getSliceTasks('M001', 'S02').map((task) => [task.id, task.status]), [
+      ['S02-T01', 'pending'],
+      ['S02-T02', 'pending'],
+    ], 'the replay must reuse the prefixed rows instead of inserting bare-id duplicates');
+    assert.equal(getTask('M001', 'S02', 'T01') ?? null, null, 'bare-id duplicate rows must not be created');
+    assert.equal(getTask('M001', 'S02', 'S02-T01')?.title, 'Rewritten slice handler');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handlePlanSlice interrupted replay completes the slice without manual waivers (#2217)', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    const first = await handlePlanSlice({
+      ...validParams(),
+      tasks: [
+        { ...validParams().tasks[0], taskId: 'S02-T01' },
+        { ...validParams().tasks[1], taskId: 'S02-T02' },
+      ],
+    }, base);
+    assert.ok(!('error' in first), `unexpected error: ${'error' in first ? first.error : ''}`);
+
+    const second = await handlePlanSlice({
+      ...validParams(),
+      tasks: [
+        { ...validParams().tasks[0], taskId: 'T01' },
+        { ...validParams().tasks[1], taskId: 'T02' },
+      ],
+    }, base);
+    assert.ok(!('error' in second), `unexpected error: ${'error' in second ? second.error : ''}`);
+
+    assert.equal(getSliceTasks('M001', 'S02').length, 2, 'replay must not duplicate task rows');
+
+    seedExecutionFixtures();
+    for (const taskId of ['S02-T01', 'S02-T02']) {
+      runTaskToCompleted(taskId);
+    }
+    const receipt = completeSlice({
+      invocation: replayChainInvocation('complete-slice'),
+      slice: { milestoneId: 'M001', sliceId: 'S02' },
+      closeout: sliceCompletionCloseout(),
+    });
+    assert.equal(receipt.status, 'committed');
+    assert.deepEqual(receipt.cancelledTaskIds, [], 'no task should be cancelled by the reconciled replay');
+    assert.equal(getSlice('M001', 'S02')?.status, 'complete');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handlePlanSlice reconciled omission mints its cancellation authorization in-operation (#2217)', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    const first = await handlePlanSlice(validParams(), base);
+    assert.ok(!('error' in first), `unexpected error: ${'error' in first ? first.error : ''}`);
+
+    // Replay shrinks the task set: T02 is omitted and cancelled as today, but
+    // the reconciliation writer must mint the Waiver + waived Disposition the
+    // completion-side invariant demands.
+    const second = await handlePlanSlice({
+      ...validParams(),
+      tasks: [validParams().tasks[0]],
+    }, base);
+    assert.ok(!('error' in second), `unexpected error: ${'error' in second ? second.error : ''}`);
+
+    assert.deepEqual(getSliceTasks('M001', 'S02').map((task) => [task.id, task.status]), [
+      ['T01', 'pending'],
+      ['T02', 'skipped'],
+    ]);
+
+    seedExecutionFixtures();
+    runTaskToCompleted('T01');
+    const receipt = completeSlice({
+      invocation: replayChainInvocation('complete-slice-omission'),
+      slice: { milestoneId: 'M001', sliceId: 'S02' },
+      closeout: sliceCompletionCloseout(),
+    });
+    assert.equal(receipt.status, 'committed', 'completion must succeed without a manual waiver');
+    assert.deepEqual(receipt.cancelledTaskIds, ['T02']);
+    assert.equal(getSlice('M001', 'S02')?.status, 'complete');
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -37,6 +37,13 @@ import {
   PlanningGuardError,
   planningOperationPayload,
 } from "../planning-domain-operation.js";
+import { executeDomainOperation, type DomainOperationResult } from "../db/domain-operation.js";
+import { readDomainOperationFence } from "../db/writers/lifecycle-commands.js";
+import {
+  grantPlanReconciliationWaiver,
+  recordPlanReconciliationDisposition,
+  type PlanReconciliationAuthorization,
+} from "../db/writers/slice-lifecycle.js";
 import {
   type PlanningInvocation,
 } from "../planning-invocation.js";
@@ -325,6 +332,64 @@ function validateTaskPathsBeforePersist(
     .join("\n");
 }
 
+/**
+ * Record the waived Requirement Dispositions for the cancellation Waivers the
+ * plan operation minted for reconciled omissions (#2217). The schema's
+ * waiver-authority trigger requires a Waiver to precede its waived
+ * Disposition by at least one project revision, so this runs as its own
+ * fenced Domain Operation keyed to the plan operation's receipt — a replayed
+ * plan operation reuses the same key and therefore stays idempotent.
+ */
+function authorizeReconciliationOmissions(input: {
+  invocation: PlanningInvocation;
+  planReceipt: DomainOperationResult;
+  milestoneId: string;
+  sliceId: string;
+  authorizations: PlanReconciliationAuthorization[];
+}): void {
+  const idempotencyKey = `plan-authorization:${input.planReceipt.operationId}`;
+  const fence = readDomainOperationFence(idempotencyKey);
+  const authorizationsPayload = input.authorizations.map((authorization) => ({
+    taskId: authorization.taskId,
+    requirementId: authorization.requirementId,
+    waiverId: authorization.waiverId,
+  }));
+  executeDomainOperation({
+    operationType: "workflow.slice.plan.authorization",
+    idempotencyKey,
+    expectedRevision: fence.revision,
+    expectedAuthorityEpoch: fence.authorityEpoch,
+    actorType: input.invocation.actorType,
+    ...(input.invocation.actorId ? { actorId: input.invocation.actorId } : {}),
+    sourceTransport: input.invocation.sourceTransport,
+    ...(input.invocation.traceId ? { traceId: input.invocation.traceId } : {}),
+    ...(input.invocation.turnId ? { turnId: input.invocation.turnId } : {}),
+    payload: planningOperationPayload({
+      milestoneId: input.milestoneId,
+      sliceId: input.sliceId,
+      authorizations: authorizationsPayload,
+    }),
+  }, (context) => {
+    for (const authorization of input.authorizations) {
+      recordPlanReconciliationDisposition(context, authorization);
+    }
+    return {
+      events: [{
+        eventType: "workflow.slice.plan.authorized",
+        entityType: "slice",
+        entityId: `${input.milestoneId}/${input.sliceId}`,
+        payload: { authorizations: authorizationsPayload },
+        destinations: ["projection"],
+      }],
+      projections: [{
+        projectionKey: `planning/${input.milestoneId}/${input.sliceId}`.toLowerCase(),
+        projectionKind: "markdown",
+        rendererVersion: "v1",
+      }],
+    };
+  });
+}
+
 export async function handlePlanSlice(
   rawParams: PlanSliceParams,
   basePath: string,
@@ -393,6 +458,10 @@ export async function handlePlanSlice(
   }
 
   let operationStatus: "committed" | "replayed";
+  // Cancellation authorizations minted for reconciled omissions (#2217).
+  // Empty on a replayed plan operation (the mutation does not re-run), which
+  // also skips the follow-up authorization operation.
+  const reconciliationAuthorizations: PlanReconciliationAuthorization[] = [];
   try {
     const receipt = executePlanningDomainOperation({
       operationType: "workflow.slice.plan",
@@ -478,11 +547,43 @@ export async function handlePlanSlice(
 
         const newTaskIds = new Set(taskPayload.map((task) => task.taskId));
         const existingTasks = getSliceTasks(params.milestoneId, params.sliceId);
+        // #2217 scope guard: only a re-dispatch over a slice whose task rows
+        // are ALL still pending reconciles in place. First-run planning (no
+        // existing rows) and replans that touch non-pending rows keep the
+        // exact-id behavior below untouched.
+        const reconcileInPlace = hasTaskPayload &&
+          existingTasks.length > 0 &&
+          existingTasks.every((task) => task.status === "pending");
+        const existingTaskIds = new Set(existingTasks.map((task) => task.id));
+        // An interrupted plan-slice run may have persisted slice-prefixed ids
+        // (S02-T01..) while the re-dispatched planning run emits bare ids
+        // (T01..). In the all-pending replay case those resolve to the same
+        // work, so the incoming id is matched to the existing row and the row
+        // is reused (keeping its id and disposition) instead of duplicated.
+        const rowIdByIncomingTaskId = new Map<string, string | null>(taskPayload.map((task): [string, string | null] => {
+          if (existingTaskIds.has(task.taskId)) return [task.taskId, task.taskId];
+          const prefixedId = `${params.sliceId}-${task.taskId}`;
+          return [task.taskId, reconcileInPlace && existingTaskIds.has(prefixedId) ? prefixedId : null];
+        }));
+        const collidingIncomingTask = taskPayload.find((task) => {
+          if (rowIdByIncomingTaskId.get(task.taskId) === null) return false;
+          return taskPayload.some((other) =>
+            other.taskId !== task.taskId &&
+            rowIdByIncomingTaskId.get(other.taskId) === rowIdByIncomingTaskId.get(task.taskId));
+        });
+        if (collidingIncomingTask) {
+          throw new PlanningGuardError(
+            `tasks ${collidingIncomingTask.taskId} and its slice-prefixed alias both resolve to the same existing row — use one id per task`,
+          );
+        }
+        const matchedRowIds = new Set(
+          [...rowIdByIncomingTaskId.values()].filter((rowId): rowId is string => rowId !== null),
+        );
         if (hasTaskPayload) {
           for (const task of existingTasks) {
             const legacyLifecycleStatus = normalizeLegacyLifecycleStatus(task.status);
             const observedLifecycleStatus = legacyLifecycleStatus ?? "ready";
-            const omitted = !newTaskIds.has(task.id);
+            const omitted = !matchedRowIds.has(task.id);
             const lifecycle = adoptLifecycleIfMissing(context, {
               itemKind: "task",
               milestoneId: params.milestoneId,
@@ -494,7 +595,7 @@ export async function handlePlanSlice(
               ...(omitted ? { adoptedFromStatus: observedLifecycleStatus } : {}),
             });
             if (
-              newTaskIds.has(task.id) &&
+              matchedRowIds.has(task.id) &&
               (lifecycle.lifecycleStatus === "completed" || lifecycle.lifecycleStatus === "cancelled")
             ) {
               throw new PlanningGuardError(
@@ -513,7 +614,7 @@ export async function handlePlanSlice(
           throw new PlanningGuardError(`cannot re-plan cancelled task ${cancelledIncomingTask.id} — use gsd_task_reopen first`);
         }
         const omittedTasks = hasTaskPayload
-          ? existingTasks.filter((task) => !newTaskIds.has(task.id))
+          ? existingTasks.filter((task) => !matchedRowIds.has(task.id))
           : [];
         const completedOmission = omittedTasks.find((task) => isClosedStatus(task.status) && task.status !== "skipped");
         if (completedOmission) {
@@ -554,11 +655,21 @@ export async function handlePlanSlice(
               taskId: task.id,
               status: "skipped",
             });
+            // #2217: a reconciled omission must carry the cancellation
+            // authorization the completion-side invariant demands, so slice
+            // completion is not permanently blocked without a manual waiver.
+            if (reconcileInPlace) {
+              reconciliationAuthorizations.push(grantPlanReconciliationWaiver(context, {
+                milestoneId: params.milestoneId,
+                sliceId: params.sliceId,
+                taskId: task.id,
+              }));
+            }
           }
 
-          const existingTaskById = new Map(existingTasks.map((task) => [task.id, task]));
           for (const task of taskPayload) {
-            if (!existingTaskById.has(task.taskId)) {
+            const rowId = rowIdByIncomingTaskId.get(task.taskId) ?? null;
+            if (!rowId) {
               insertTask({
                 id: task.taskId,
                 sliceId: params.sliceId,
@@ -567,7 +678,8 @@ export async function handlePlanSlice(
                 status: "pending",
               });
             }
-            upsertTaskPlanning(params.milestoneId, params.sliceId, task.taskId, {
+            const persistedTaskId = rowId ?? task.taskId;
+            upsertTaskPlanning(params.milestoneId, params.sliceId, persistedTaskId, {
               title: task.title,
               description: task.description,
               estimate: task.estimate,
@@ -584,18 +696,18 @@ export async function handlePlanSlice(
               itemKind: "task",
               milestoneId: params.milestoneId,
               sliceId: params.sliceId,
-              taskId: task.taskId,
+              taskId: persistedTaskId,
               lifecycleStatus: "ready",
             });
             if (lifecycle.lifecycleStatus === "cancelled") {
-              throw new PlanningGuardError(`cannot re-plan cancelled task ${task.taskId} — use gsd_task_reopen first`);
+              throw new PlanningGuardError(`cannot re-plan cancelled task ${persistedTaskId} — use gsd_task_reopen first`);
             }
             if (lifecycle.lifecycleStatus === "pending") {
               adoptOrTransitionLifecycle(context, {
                 itemKind: "task",
                 milestoneId: params.milestoneId,
                 sliceId: params.sliceId,
-                taskId: task.taskId,
+                taskId: persistedTaskId,
                 lifecycleStatus: "ready",
               });
             }
@@ -616,14 +728,24 @@ export async function handlePlanSlice(
           insertGateRow({ milestoneId: params.milestoneId, sliceId: params.sliceId, gateId: gid, scope: "slice" });
         }
         for (const task of taskPayload) {
+          const persistedTaskId = rowIdByIncomingTaskId.get(task.taskId) ?? task.taskId;
           for (const gid of resolveTaskGates(gateEvaluation)) {
-            insertGateRow({ milestoneId: params.milestoneId, sliceId: params.sliceId, gateId: gid, scope: "task", taskId: task.taskId });
+            insertGateRow({ milestoneId: params.milestoneId, sliceId: params.sliceId, gateId: gid, scope: "task", taskId: persistedTaskId });
           }
         }
         ensurePendingSliceQ8(context, params);
       },
     });
     operationStatus = receipt.status;
+    if (receipt.status === "committed" && reconciliationAuthorizations.length > 0) {
+      authorizeReconciliationOmissions({
+        invocation,
+        planReceipt: receipt,
+        milestoneId: params.milestoneId,
+        sliceId: params.sliceId,
+        authorizations: reconciliationAuthorizations,
+      });
+    }
   } catch (err) {
     if (err instanceof PlanningGuardError) return { error: err.message };
     return { error: `db write failed: ${(err as Error).message}` };


### PR DESCRIPTION
## TL;DR

**What:** Plan-slice re-dispatch now reconciles in place over existing all-pending task rows instead of duplicating them and cancelling the originals without authorization.
**Why:** Interrupted plan-slice recovery re-fired the dispatch; the second run's bare task ids (T01..) didn't collide with the first run's slice-prefixed rows (S02-T01..), so both sets coexisted and the canonical-cancelled duplicates permanently blocked slice completion.
**How:** Match incoming ids to existing prefixed rows when every existing row is still pending, reuse those rows (id and disposition preserved), and mint the cancellation authorization the completion invariant demands for genuine omissions.

Fixes #2217

## What

- `src/resources/extensions/gsd/tools/plan-slice.ts` — inside the `workflow.slice.plan` Domain Operation, when the re-dispatch runs over a slice whose task rows are **all still pending** (the interrupted-replay case), each incoming task id is matched to an existing row either exactly or by the `${sliceId}-` prefixed form. Matched rows are reused: their prefixed ids and dispositions are preserved, planning content is refreshed on them, and per-task gates attach to the persisted row id. Only genuinely new tasks get new rows. Tasks omitted from the new set are cancelled as before, but each omission now mints a cancellation Waiver inside the operation. Scope guard: first-run planning (no existing rows) and replans over any non-pending row keep the previous exact-id behavior untouched.
- `src/resources/extensions/gsd/db/writers/slice-lifecycle.ts` — two new context-bound writers, `grantPlanReconciliationWaiver` (gated to `workflow.slice.plan`) and `recordPlanReconciliationDisposition` (gated to a new fenced `workflow.slice.plan.authorization` operation). They mint a task-lifecycle Waiver plus a current waived Requirement Disposition — exactly what `completeSliceHierarchy` already demands (`hasCurrentCancellationAuthorization`). The completion-side refusal and `grantSliceCancellationWaiver`'s `slice.cancel` gate are unchanged.
- `src/resources/extensions/gsd/tests/plan-slice.test.ts` — new interrupted-replay suite and updated cancel-on-omit assertions (see Tests).

## Why

The planning dispatch rule re-fires plan-slice after crash recovery with no idempotency check against pre-existing rows. The duplicate rows were then durably cancelled (legacy `skipped`, canonical `cancelled`) by the plan path, which structurally could not mint the Waiver disposition the completion-side invariant requires — leaving the slice permanently uncompletable without a manual waiver. Per the maintainer decision on the issue (option b), the reconciliation happens in the same operation, existing rows keep their prefixed ids and dispositions, and the writer mints the authorization it needs rather than weakening the completion-side invariant.

## How (authorization fencing detail)

The schema's waiver-authority trigger (`trg_workflow_requirement_disposition_waiver_authority`) requires a Waiver's project revision to **strictly precede** its waived Disposition's, so both rows cannot be written under one operation's revision. The Waiver is therefore stamped with the plan operation's provenance, and the Disposition is recorded in an immediately following `workflow.slice.plan.authorization` Domain Operation whose idempotency key is derived from the plan operation's receipt (`plan-authorization:<operationId>`), keeping the whole sequence replay-safe and inside the existing domain-operation/waiver fencing (FK provenance, immutability triggers, disposition head rule).

Each reconciled omission also gets a durable requirement row (`plan-omission:<milestone>/<slice>/<task>`, class `cancellation`, source `plan-slice`) so the Waiver/Disposition FK chain resolves; it is visibly marked as plan-path authorization metadata.

## Tests

All pre-existing failing behavior was captured test-first (each new test fails on `main` before the fix):

- `handlePlanSlice interrupted replay reuses existing prefixed rows instead of duplicating them (#2217)` — replays a plan with bare ids over prefixed rows; asserts the prefixed rows keep ids/pending status, planning content is refreshed, and no bare-id duplicates exist.
- `handlePlanSlice interrupted replay completes the slice without manual waivers (#2217)` — full chain: interrupt, replay, drive both reused tasks through claim/settle/verdict/publish, then slice completion commits with zero cancelled tasks.
- `handlePlanSlice reconciled omission mints its cancellation authorization in-operation (#2217)` — replay shrinks the task set; the omitted task is cancelled with an active Waiver + current waived Disposition and slice completion commits **without a manual waiver**.
- The existing cancel-on-omit test (`durably cancels omitted pending tasks when replanning a smaller task set`) now also asserts the reconciled invariant: omitted rows carry an active cancellation Waiver with a current waived Disposition.

Test commands and results (targeted only; no full-suite runs):

```
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types \
  --test src/resources/extensions/gsd/tests/plan-slice.test.ts \
         src/resources/extensions/gsd/tests/slice-completion-domain-operation.test.ts \
         src/resources/extensions/gsd/tests/slice-lifecycle-domain-operations.test.ts
→ 57 tests, 57 pass, 0 fail
```

Also green (adjacent seams): `replan-slice-domain-replay`, `planning-domain-operations` (the one unrelated failure, "two processes racing the same invocation fence", reproduces on clean `main` in this sandbox — child-process loader issue), `reassess-roadmap-domain-operation`, `workflow-tool-executors`, `silent-catch-diagnostics`, `complete-slice`, `skip-slice-cascades-tasks`, `reopen-slice` — 145 pass / 0 fail excluding that pre-existing case. `pnpm run verify:fast` passes.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Regression tests for the changed invariant

AI-assisted: yes