### PR TITLE
docs(gsd): document that headless recover --preview applies on re-run

### DIFF
--- a/mintlify-docs/guides/commands.mdx
+++ b/mintlify-docs/guides/commands.mdx
@@ -183,7 +183,7 @@ gsd headless              # run auto mode
 gsd headless next         # run a single unit
 gsd quick --output-format json "fix typo"  # structured quick-task result
 gsd headless query        # instant JSON snapshot (~50ms, no LLM)
-gsd headless recover      # print the sealed recovery Preview for approval
+gsd headless recover      # print the sealed recovery Preview; re-run with --preview=<sha256:...> to apply it
 gsd headless --timeout 600000 auto   # with timeout
 gsd auto --thinking medium           # auto shorthand with thinking override
 gsd headless new-milestone --context brief.md --auto
@@ -203,7 +203,7 @@ gsd headless new-milestone --context brief.md --auto
 
 ### `gsd headless recover`
 
-See the [authoritative commands reference](../../docs/user-docs/commands.md#gsd-headless-recover) for the sealed Preview approval flow, evidence-bound recovery flags, and exit behavior.
+The first run prints the sealed Preview and exits without mutating state. Re-running with the recorded `--preview=<sha256:...>` hash selects and applies that recorded recovery. See the [authoritative commands reference](../../docs/user-docs/commands.md#gsd-headless-recover) for the sealed Preview approval flow, evidence-bound recovery flags, and exit behavior.
 
 ### `gsd headless query`
 


### PR DESCRIPTION
## TL;DR

**What:** Corrects the Mintlify docs for `gsd headless recover` to state that re-running with the recorded `--preview=<sha256:...>` hash selects and applies the recorded recovery.
**Why:** The docs read as if the command only prints a preview and never mutates state, while the implementation applies the recovery once the exact hash is supplied.
**How:** Two minimal wording changes in `mintlify-docs/guides/commands.mdx`; no code changes.

## What

`gsd headless recover` (`src/headless-recover.ts`) is hash-gated, not hash-safe: the first run prepares the Import Application, prints the sealed Preview hash, and exits without mutating state. Re-running with the exact `--preview=<sha256:...>` hash it printed matches `prepared.preview.preview_hash` and authorizes `applyPreparedVerifiedRecoverApplication` — the recorded recovery is selected and APPLIED. Only a non-matching (or missing) hash leaves state untouched.

The authoritative reference (`docs/user-docs/commands.md#gsd-headless-recover`) and `docs/user-docs/troubleshooting.md` already state this two-run, applies-on-approval flow correctly. The Mintlify site was the only doc surface with the wrong implication: its inline comment presented the command as print-only, and its section deferred to the reference without stating the re-run semantics. A grep across `README.md`, `docs/`, `gitbook/`, `mintlify-docs/`, and `CONTEXT.md` found no other place documenting `gsd headless recover` (gitbook, README, and CONTEXT.md do not cover it).

## Why

Fixes #2258. An operator who believes preview never mutates state could be surprised when the approved re-run rewrites the database; the docs must state the actual semantics.

## How

Before/after wording per doc site touched (only one site needed changes):

**`mintlify-docs/guides/commands.mdx` — headless code block comment (line 186)**

- Before: `gsd headless recover      # print the sealed recovery Preview for approval`
- After: `gsd headless recover      # print the sealed recovery Preview; re-run with --preview=<sha256:...> to apply it`

**`mintlify-docs/guides/commands.mdx` — `### gsd headless recover` section (line 206)**

- Before: `See the [authoritative commands reference](../../docs/user-docs/commands.md#gsd-headless-recover) for the sealed Preview approval flow, evidence-bound recovery flags, and exit behavior.`
- After: `The first run prints the sealed Preview and exits without mutating state. Re-running with the recorded --preview=<sha256:...> hash selects and applies that recorded recovery. See the [authoritative commands reference](../../docs/user-docs/commands.md#gsd-headless-recover) for the sealed Preview approval flow, evidence-bound recovery flags, and exit behavior.`

**Sites verified accurate, left unchanged:**

- `docs/user-docs/commands.md` — already states "The first call prints the sealed Import Preview and exits without applying the import... rerun with the exact `--preview=<preview-hash>` value it prints. That approved run performs the Import Application and assessment."
- `docs/user-docs/troubleshooting.md` — already states the `--preview=<sha256>` follow-up "applies that unchanged preview" and that `gsd headless recover` "has the same semantics".

`git diff --stat` confirms no code files changed: 1 file, 2 insertions, 2 deletions (docs only). `pnpm run verify:fast` passes.

AI-assisted: yes