### PR TITLE
fix(gsd): surface park DB-sync failures and make failed parks retryable

### DIFF
--- a/src/resources/extensions/gsd/commands/handlers/workflow.ts
+++ b/src/resources/extensions/gsd/commands/handlers/workflow.ts
@@ -649,7 +649,14 @@ export async function handleWorkflowCommand(trimmed: string, ctx: ExtensionComma
     }
     const reasonParts = arg.replace(targetId, "").trim().replace(/^["']|["']$/g, "");
     const reason = reasonParts || "Parked via /gsd park";
-    const success = parkMilestone(basePath, targetId, reason);
+    let success: boolean;
+    try {
+      success = parkMilestone(basePath, targetId, reason);
+    } catch (err) {
+      // #2255: the park did not take (e.g. DB sync failed) — surface it as an error.
+      ctx.ui.notify(`Could not park ${targetId}: ${(err as Error).message}`, "error");
+      return true;
+    }
     ctx.ui.notify(
       success ? `Parked ${targetId}. Run /gsd unpark ${targetId} to reactivate.` : `Could not park ${targetId} — milestone not found.`,
       success ? "info" : "warning",

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1879,7 +1879,14 @@ async function handleMilestoneActions(
       : reason === "needs_rethink" ? "Needs rethinking — approach needs reconsideration"
       : "Parked by user";
 
-    const success = parkMilestone(basePath, milestoneId, reasonText);
+    let success: boolean;
+    try {
+      success = parkMilestone(basePath, milestoneId, reasonText);
+    } catch (err) {
+      // #2255: the park did not take (e.g. DB sync failed) — surface it as an error.
+      ctx.ui.notify(`Could not park ${milestoneId}: ${(err as Error).message}`, "error");
+      return true;
+    }
     if (success) {
       ctx.ui.notify(`Parked ${milestoneId}. Run /gsd unpark ${milestoneId} to reactivate.`, "info");
     } else {
@@ -2461,7 +2468,14 @@ export async function showSmartEntry(
       const { fireStatusViaCommand } = await import("./commands.js");
       await fireStatusViaCommand(ctx);
     } else if (choice === "park") {
-      const success = parkMilestone(basePath, milestoneId, "Validation attention deferred by user");
+      let success: boolean;
+      try {
+        success = parkMilestone(basePath, milestoneId, "Validation attention deferred by user");
+      } catch (err) {
+        // #2255: the park did not take (e.g. DB sync failed) — surface it as an error.
+        ctx.ui.notify(`Could not park ${milestoneId}: ${(err as Error).message}`, "error");
+        return;
+      }
       ctx.ui.notify(
         success ? `Parked ${milestoneId}. Run /gsd unpark ${milestoneId} to reactivate.` : `Could not park ${milestoneId} — milestone not found.`,
         success ? "info" : "warning",

--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -52,9 +52,13 @@ function assertNotAutoActive(action: string): void {
 // ─── Park ──────────────────────────────────────────────────────────────────
 
 /**
- * Park a milestone — creates a PARKED.md marker file with reason and timestamp.
- * Parked milestones are skipped during active-milestone discovery but stay on disk.
+ * Park a milestone — records status='parked' in the DB, then creates a
+ * PARKED.md marker file with reason and timestamp. Parked milestones are
+ * skipped during active-milestone discovery but stay on disk.
  * Returns true if successfully parked, false if milestone not found, already parked, or complete.
+ * Throws if the DB sync fails (#2255): no marker file is written in that case,
+ * so the caller never reports success for a park that did not take, and a
+ * later retry starts clean instead of short-circuiting as already parked (#2256).
  */
 export function parkMilestone(basePath: string, milestoneId: string, reason: string): boolean {
   assertNotAutoActive("park milestone");
@@ -86,15 +90,21 @@ export function parkMilestone(basePath: string, milestoneId: string, reason: str
     "",
   ].join("\n");
 
-  atomicWriteSync(parkedPath, content, "utf-8");
-  // Sync DB status so deriveStateFromDb also skips this milestone (#2694)
+  // DB write FIRST (#2256): if the sync fails, no marker file is written, so
+  // the park can be retried instead of being stuck as file-parked/DB-active.
+  // The failure propagates (#2255) — callers must not report success.
   if (dbAvailable) {
     try {
       updateMilestoneStatus(milestoneId, "parked");
     } catch (err) {
-      logWarning("engine", `parkMilestone DB sync failed for ${milestoneId}: ${(err as Error).message}`);
+      throw new Error(`parkMilestone DB sync failed for ${milestoneId}: ${(err as Error).message}`);
     }
   }
+  // If the marker write fails after the DB sync, the row is parked with no
+  // marker on disk. That state is recoverable in both directions: a retry
+  // re-runs the idempotent DB write and rewrites the marker, and
+  // unparkMilestone repairs DB-parked-without-marker (#3707).
+  atomicWriteSync(parkedPath, content, "utf-8");
   invalidateAllCaches();
   return true;
 }

--- a/src/resources/extensions/gsd/tests/park-db-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/park-db-sync.test.ts
@@ -17,6 +17,7 @@ import {
   closeDatabase,
   insertMilestone,
   getMilestone,
+  _getAdapter,
 } from "../gsd-db.ts";
 
 function createBase(): string {
@@ -154,4 +155,62 @@ test("park/unpark are safe when DB is not available (#2694 guard)", () => {
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
+});
+
+test("parkMilestone throws when DB sync fails and does not claim success (#2255)", (t) => {
+  const base = createBase();
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(":memory:");
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  // Make every UPDATE on milestones fail (SELECTs keep working, so the
+  // pre-park closed-status guard still runs).
+  _getAdapter()!.exec(
+    "CREATE TRIGGER fail_milestone_update BEFORE UPDATE ON milestones BEGIN SELECT RAISE(ABORT, 'simulated park DB failure'); END;",
+  );
+
+  assert.throws(
+    () => parkMilestone(base, "M001", "test"),
+    /parkMilestone DB sync failed for M001/,
+    "DB sync failure must propagate, not return true",
+  );
+  assert.equal(
+    existsSync(join(base, ".gsd", "milestones", "M001", "M001-PARKED.md")),
+    false,
+    "PARKED.md must not be written when the DB sync fails",
+  );
+  assert.equal(getMilestone("M001")!.status, "active", "DB status must stay unchanged");
+});
+
+test("park completes on retry after a DB sync failure (#2256)", (t) => {
+  const base = createBase();
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(":memory:");
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  _getAdapter()!.exec(
+    "CREATE TRIGGER fail_milestone_update BEFORE UPDATE ON milestones BEGIN SELECT RAISE(ABORT, 'simulated park DB failure'); END;",
+  );
+  assert.throws(() => parkMilestone(base, "M001", "test"));
+  assert.equal(
+    existsSync(join(base, ".gsd", "milestones", "M001", "M001-PARKED.md")),
+    false,
+    "failed attempt must not leave the marker behind (retry would short-circuit)",
+  );
+
+  // DB recovers — the retry must complete the park instead of failing.
+  _getAdapter()!.exec("DROP TRIGGER fail_milestone_update;");
+  const parked = parkMilestone(base, "M001", "test");
+  assert.ok(parked, "retried parkMilestone succeeds");
+  assert.equal(getMilestone("M001")!.status, "parked", "DB update completes on retry");
+  assert.ok(
+    existsSync(join(base, ".gsd", "milestones", "M001", "M001-PARKED.md")),
+    "PARKED.md written on retry",
+  );
 });


### PR DESCRIPTION
## TL;DR

**What:** `parkMilestone` now writes the DB status before the marker file, throws when the DB sync fails, and callers surface that error instead of reporting success.
**Why:** A failed DB sync was logged and swallowed (`return true`), so operators were told a milestone was parked when the DB was never updated, and the already-written marker file made every retry short-circuit as "already parked".
**How:** Reorder the DB write ahead of the marker write, propagate the failure as a thrown error, and catch it at the `/gsd park` handler and guided-flow call sites to notify with "error" severity.

## What

- `src/resources/extensions/gsd/milestone-actions.ts` — `parkMilestone` now performs the DB status write **before** writing `PARKED.md`. If the DB sync fails, the error propagates (`parkMilestone DB sync failed for <id>: ...`) and no marker file is written, so the park is retryable (#2256) and callers can no longer mistake failure for success (#2255). If the marker write fails after the DB sync, the row is parked with no marker — a state already handled by retry (the DB write is idempotent and the marker is rewritten) and by `unparkMilestone`'s existing repair for DB-parked-without-marker (#3707). The normal success path is unchanged apart from write order.
- `src/resources/extensions/gsd/commands/handlers/workflow.ts` — the `/gsd park` handler catches the new error and notifies with "error" severity instead of showing a success message.
- `src/resources/extensions/gsd/guided-flow.ts` — both interactive park call sites catch the error and notify with "error" severity.
- `src/resources/extensions/gsd/auto-post-unit.ts` needed no change: its abandon-detect park call is already wrapped in a try/catch that logs and notifies.
- `src/resources/extensions/gsd/tests/park-db-sync.test.ts` — two regression tests that simulate the DB failure with a `RAISE(ABORT)` trigger on `milestones` updates.

## Why

Fixes #2255 — `parkMilestone` caught the DB-sync error, logged a warning, invalidated caches, and returned `true`; every caller reported "Parked <id>" while the DB was never updated.

Fixes #2256 — the `existsSync(parkedPath)` short-circuit ran before the DB write, so a park that moved the file but failed the DB write could never be retried: every retry returned "already parked". Writing the DB first means a failed attempt leaves no marker behind, so a retry runs the normal path and completes.

## How

Alternatives considered: flipping to file-last with DB rollback on marker failure was rejected because reverting to the previous status (e.g. `planned`) is not a guaranteed-allowed transition through the status-transition chokepoint; leaving the idempotent DB row and retrying is simpler and composes with the existing unpark repair. Detecting the file-parked/DB-not-parked desync on entry was rejected because it would also require changing the handler's `isParked()` pre-check to make retries reachable, touching more of the caller chain for a state the reorder makes unreachable from `parkMilestone` itself.

## Test evidence

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/park-db-sync.test.ts src/resources/extensions/gsd/tests/park-milestone.test.ts` — 17/17 pass, including the two new tests:
  - "parkMilestone throws when DB sync fails and does not claim success (#2255)" — asserts the throw, that no `PARKED.md` is written, and the DB status is unchanged.
  - "park completes on retry after a DB sync failure (#2256)" — asserts the retry succeeds, the DB status becomes `parked`, and the marker is written.
- Both new tests fail against the unfixed code (verified by stashing the source changes) and pass with the fix.
- `pnpm run verify:fast` — all checks passed.
- `pnpm run test:compile` — passes.

AI-assisted: yes
