### PR TITLE
fix(gsd): parse flags out of the /gsd park milestone id

### DIFF
--- a/src/resources/extensions/gsd/commands/handlers/workflow.ts
+++ b/src/resources/extensions/gsd/commands/handlers/workflow.ts
@@ -91,6 +91,21 @@ function parseDiscussArgs(args: string): { target: string | null; error: string 
 export const _parseDiscussArgsForTest = parseDiscussArgs;
 
 /**
+ * Parse optional `/gsd park` args.
+ *
+ * Documented form is `/gsd park [id] [reason]`. `--flag` tokens are extracted
+ * so they cannot be swallowed into the milestone id; the first positional
+ * token is the id and the remaining positionals form the reason (#2257).
+ */
+function parseParkArgs(args: string): { id: string | null; reason: string } {
+  const positionals = args.split(/\s+/).filter((t) => t && !t.startsWith("--"));
+  const id = positionals[0] ?? null;
+  const reason = positionals.slice(1).join(" ").replace(/^["']|["']$/g, "");
+  return { id, reason };
+}
+export const _parseParkArgsForTest = parseParkArgs;
+
+/**
  * Refuses interactive commands that mutate durable .gsd/ planning state while
  * auto-mode holds the worktree. Returns true if the command was blocked and
  * the caller should return immediately; false if it is safe to proceed.
@@ -634,7 +649,8 @@ export async function handleWorkflowCommand(trimmed: string, ctx: ExtensionComma
     if (requireNotAutoActive("/gsd park", ctx)) return true;
     const basePath = projectRoot();
     const arg = trimmed.replace(/^park\s*/, "").trim();
-    let targetId = arg;
+    const { id: parsedId, reason: parsedReason } = parseParkArgs(arg);
+    let targetId = parsedId ?? "";
     if (!targetId) {
       const state = await deriveState(basePath);
       if (!state.activeMilestone) {
@@ -647,8 +663,7 @@ export async function handleWorkflowCommand(trimmed: string, ctx: ExtensionComma
       ctx.ui.notify(`${targetId} is already parked. Use /gsd unpark ${targetId} to reactivate.`, "info");
       return true;
     }
-    const reasonParts = arg.replace(targetId, "").trim().replace(/^["']|["']$/g, "");
-    const reason = reasonParts || "Parked via /gsd park";
+    const reason = parsedReason || "Parked via /gsd park";
     let success: boolean;
     try {
       success = parkMilestone(basePath, targetId, reason);

--- a/src/resources/extensions/gsd/tests/park-command-flag-parsing-2257.test.ts
+++ b/src/resources/extensions/gsd/tests/park-command-flag-parsing-2257.test.ts
@@ -1,0 +1,139 @@
+// Regression test for #2257 — /gsd park swallowed flags into the milestone id.
+//
+// The handler used `let targetId = arg`, so `/gsd park M001 --flag reason`
+// looked up the milestone id "M001 --flag reason" and failed silently. Args
+// are now parsed: `--flag` tokens are extracted, the first positional is the
+// id, and the remaining positionals form the reason.
+
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { _parseParkArgsForTest, handleWorkflowCommand } from "../commands/handlers/workflow.ts";
+import { withCommandCwd } from "../commands/context.ts";
+import { getParkedReason, isParked } from "../milestone-actions.ts";
+import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
+import { invalidateStateCache } from "../state.ts";
+import { clearPathCache } from "../paths.ts";
+
+describe("park command arg parsing (#2257)", () => {
+  test("resolves the id and passes the reason through past a flag", () => {
+    assert.deepEqual(_parseParkArgsForTest("M001 --flag reason"), { id: "M001", reason: "reason" });
+  });
+
+  test("extracts value-style flags and strips wrapping quotes from the reason", () => {
+    assert.deepEqual(
+      _parseParkArgsForTest('M001 --rationale "Remaining gaps"'),
+      { id: "M001", reason: "Remaining gaps" },
+    );
+  });
+
+  test("keeps plain reason text after the id", () => {
+    assert.deepEqual(
+      _parseParkArgsForTest("M001 waiting on vendor"),
+      { id: "M001", reason: "waiting on vendor" },
+    );
+  });
+
+  test("id-only input yields an empty reason", () => {
+    assert.deepEqual(_parseParkArgsForTest("M001"), { id: "M001", reason: "" });
+  });
+
+  test("empty input resolves to the no-id path", () => {
+    assert.deepEqual(_parseParkArgsForTest(""), { id: null, reason: "" });
+  });
+
+  test("flag-only input does not become the id", () => {
+    assert.deepEqual(_parseParkArgsForTest("--flag"), { id: null, reason: "" });
+  });
+
+  test("a positional after a flag is still the id per the documented form", () => {
+    assert.deepEqual(_parseParkArgsForTest("--flag deferred"), { id: "deferred", reason: "" });
+  });
+});
+
+describe("park dispatch via handleWorkflowCommand (#2257)", () => {
+  const cleanupFns: Array<() => void> = [];
+
+  afterEach(() => {
+    while (cleanupFns.length) cleanupFns.pop()!();
+  });
+
+  function makeFixture(): string {
+    const base = mkdtempSync(join(tmpdir(), "gsd-park-command-"));
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+    // resolveMilestonePath ignores metadata-only milestone dirs; a content file
+    // marks the legacy-layout directory as a real milestone.
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# M001\n", "utf8");
+    execFileSync("git", ["init", "-b", "main"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: base, stdio: "ignore" });
+    writeFileSync(join(base, "README.md"), "# Test\n", "utf8");
+    execFileSync("git", ["add", "README.md"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "test: initialize fixture"], { cwd: base, stdio: "ignore" });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Test milestone", status: "active" });
+    clearPathCache();
+    invalidateStateCache();
+    cleanupFns.push(() => {
+      closeDatabase();
+      clearPathCache();
+      invalidateStateCache();
+      rmSync(base, { recursive: true, force: true });
+    });
+    return base;
+  }
+
+  function makeCtx() {
+    const notifications: Array<{ message: string; level?: string }> = [];
+    return {
+      notifications,
+      ui: {
+        notify(message: string, level?: string) {
+          notifications.push({ message, level });
+        },
+      },
+    };
+  }
+
+  test("park <id> --flag reason resolves <id> and stores the reason", async () => {
+    const base = makeFixture();
+    const ctx = makeCtx();
+    const handled = await withCommandCwd(
+      base,
+      () => handleWorkflowCommand("park M001 --flag waiting on vendor", ctx as any, {} as any),
+    );
+
+    assert.equal(handled, true);
+    assert.ok(isParked(base, "M001"), "M001 is parked");
+    assert.equal(getParkedReason(base, "M001"), "waiting on vendor");
+    assert.ok(
+      ctx.notifications.some((n) => n.message === "Parked M001. Run /gsd unpark M001 to reactivate."),
+      "expected success notification for M001",
+    );
+    assert.ok(
+      !ctx.notifications.some((n) => /Could not park/.test(n.message)),
+      "expected no could-not-park failure",
+    );
+  });
+
+  test("park with no id parks the active milestone with the default reason", async () => {
+    const base = makeFixture();
+    const ctx = makeCtx();
+    const handled = await withCommandCwd(
+      base,
+      () => handleWorkflowCommand("park --flag", ctx as any, {} as any),
+    );
+
+    assert.equal(handled, true);
+    assert.ok(isParked(base, "M001"), "active milestone M001 is parked");
+    assert.equal(getParkedReason(base, "M001"), "Parked via /gsd park");
+    assert.ok(
+      !ctx.notifications.some((n) => /Could not park/.test(n.message)),
+      "expected no could-not-park failure",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

`/gsd park` treated its entire argument string as the milestone id, so any `--flag` (and the reason) was swallowed into the id and the lookup failed silently (`Could not park M006 --rationale "..."`). Args are now parsed: `--flag` tokens are extracted, the first positional is the milestone id, and the remaining positionals form the reason.

## Details

The handler did `let targetId = arg` (whole string as the id), while the help text in `core.ts` advertises `/gsd park [id] ... [reason]`. Any trailing input — including flags — ended up inside the id, so `parkMilestone()` could never find the milestone (#2126 repro: `/gsd park M006 --rationale "..."` produced a milestone title containing the literal flag text).

This adds a small `parseParkArgs()` helper next to the existing `parseDiscussArgs()` in `workflow.ts`, following the same local-parser + `_parseXArgsForTest` export pattern:

- tokens starting with `--` are extracted (park declares no flags of its own; they must not land in the id or the reason)
- first positional token = milestone id; `null` when absent, so the existing no-id path (park the active milestone via `deriveState`) keeps working unchanged
- remaining positionals = reason text, preserving the existing default (`Parked via /gsd park`) and leading/trailing quote stripping

Behavior change worth noting: `/gsd park --flag` (flag only, no positional) now resolves the id per the documented form instead of parking a milestone literally named `--flag`. A bare positional after a flag is still the id — `/gsd park [id] [reason]` cannot disambiguate that, and it matches the old positional contract.

Fixes #2257

## Tests

New `src/resources/extensions/gsd/tests/park-command-flag-parsing-2257.test.ts`, following the `discuss-command-targeting-5471.test.ts` parser pattern and the `discard-command.test.ts` end-to-end pattern:

- parser: `<id> --flag reason` resolves `<id>` and passes `reason` through (issue acceptance case); value-style flags with quoted reasons; plain reason text; id-only; empty input (no-id path); flag-only input does not become the id
- end-to-end via `handleWorkflowCommand`: `park M001 --flag waiting on vendor` parks M001 with the reason stored in PARKED.md and no `Could not park` failure; `park --flag` parks the active milestone with the default reason

```
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \
  src/resources/extensions/gsd/tests/park-command-flag-parsing-2257.test.ts \
  src/resources/extensions/gsd/tests/park-milestone.test.ts \
  src/resources/extensions/gsd/tests/park-db-sync.test.ts \
  src/resources/extensions/gsd/tests/discuss-command-targeting-5471.test.ts \
  src/resources/extensions/gsd/tests/discard-command.test.ts
→ tests 35, pass 35, fail 0
```

`pnpm run verify:fast` — all checks passed. No existing tests asserted the old swallow behavior.

AI-assisted: yes