### PR TITLE
fix(gsd): surface the recovery action id on blocker receipts

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -1429,13 +1429,13 @@ export function registerDbTools(pi: ExtensionAPI): void {
 		description:
 			"Record a Task execution result and verification input in SQLite. Canonical Tasks advance to host verification or recovery and publish completion only after a current passing Technical Verdict; legacy Tasks complete directly and refresh readable projections.",
 		promptSnippet:
-			"Record a GSD Task result and advance verification or recovery",
+			"Record a GSD Task result and advance verification or recovery; a blocker receipt includes recoveryActionId for gsd_task_recovery_resume when a recovery action is recorded",
 		promptGuidelines: [
 			"Use gsd_task_complete (or gsd_complete_task) when a task is finished and needs to be recorded.",
 			"Include verification whenever possible. If verification is omitted, the executor derives it from verificationEvidence when possible.",
 			"verificationEvidence is an array of objects with command, exitCode, verdict, durationMs.",
 			"The tool validates required fields and returns an error message if verification cannot be derived.",
-			"Canonical success returns attemptId, resultId, nextStage, and summaryPath while completion awaits host verification; a blocker routes to recovery.",
+			"Canonical success returns attemptId, resultId, nextStage, and summaryPath while completion awaits host verification; a blocker routes to recovery and returns recoveryActionId for gsd_task_recovery_resume when a recovery action is recorded.",
 			"Legacy success returns summaryPath and may report stale projection repair or a duplicate non-mutating retry; matching parameters alone do not make a replay.",
 		],
 		parameters: Type.Object({

--- a/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
+++ b/src/resources/extensions/gsd/task-completion-compatibility-adapter.ts
@@ -27,7 +27,10 @@ import {
   settleTaskAttempt,
   type StagedTaskCompletionMutation,
 } from "./task-execution-domain-operation.js";
-import { readTaskRecoveryRoute } from "./task-recovery-domain-operation.js";
+import {
+  readTaskRecoveryRoute,
+  type TaskRecoveryRouteSnapshot,
+} from "./task-recovery-domain-operation.js";
 import { readTaskTechnicalVerdict } from "./task-verification-domain-operation.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import {
@@ -150,6 +153,23 @@ export interface TaskCompletionAuthorityOptions {
 }
 
 /**
+ * Name the recorded recovery action and its sanctioned next move so a caller
+ * never has to guess the recoveryActionId (#2267). Shared by the
+ * running-attempt gate rejections and the canonical blocker receipt.
+ */
+export function recoveryRouteLever(route: TaskRecoveryRouteSnapshot): string {
+  if (route.resumeAuthorized) {
+    return ` Recovery action ${route.recoveryActionId} (${route.action}) already authorizes its successor — ` +
+      "rerun `/gsd auto` to continue from the repair checkpoint.";
+  }
+  if (route.resumeEligibility?.eligible) {
+    return ` Recovery action ${route.recoveryActionId} (${route.action}) is eligible for resume — ` +
+      `call gsd_task_recovery_resume with recoveryActionId "${route.recoveryActionId}".`;
+  }
+  return ` Recovery action ${route.recoveryActionId} (${route.action}) is recorded for this Attempt.`;
+}
+
+/**
  * Describe the latest Attempt's settled state and any recorded recovery
  * action so a session rejected by the running-attempt gate learns the
  * sanctioned exit instead of a bare rejection (#1973). Best-effort: an empty
@@ -164,15 +184,7 @@ function latestAttemptRecoveryContext(task: TaskCompletionIdentity): string {
         attempt.resultFailureClass ? ` failureClass=${attempt.resultFailureClass}` : ""}`
       : " still marked running";
     const route = readTaskRecoveryRoute(attempt.attemptId);
-    const lever = route
-      ? route.resumeAuthorized
-        ? ` Recovery action ${route.recoveryActionId} (${route.action}) already authorizes its successor — ` +
-          "rerun `/gsd auto` to continue from the repair checkpoint."
-        : route.resumeEligibility?.eligible
-          ? ` Recovery action ${route.recoveryActionId} (${route.action}) is eligible for resume — ` +
-          `call gsd_task_recovery_resume with recoveryActionId "${route.recoveryActionId}".`
-          : ` Recovery action ${route.recoveryActionId} (${route.action}) is recorded for this Attempt.`
-      : "";
+    const lever = route ? recoveryRouteLever(route) : "";
     return ` Latest Attempt ${attempt.attemptId} is${settled}.${lever}`;
   } catch {
     return "";

--- a/src/resources/extensions/gsd/tests/task-complete-blocker-recovery-route-2267.test.ts
+++ b/src/resources/extensions/gsd/tests/task-complete-blocker-recovery-route-2267.test.ts
@@ -1,0 +1,227 @@
+// Project/App: gsd-pi
+// File Purpose: Canonical blocker completion receipts name the recorded recovery action (#2267).
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, test } from "node:test";
+
+process.env.GSD_WORKFLOW_EXECUTORS_MODULE = fileURLToPath(
+  new URL("../tools/workflow-tool-executors.ts", import.meta.url),
+);
+
+import {
+  _getAdapter,
+  closeDatabase,
+  openDatabase,
+} from "../gsd-db.ts";
+import {
+  claimTaskAttempt,
+} from "../task-execution-domain-operation.ts";
+import {
+  readTaskRecoveryRoute,
+  recordFailureAndSelectRecovery,
+} from "../task-recovery-domain-operation.ts";
+import { executeTaskComplete } from "../tools/workflow-tool-executors.ts";
+import type { ExecutionInvocation } from "../execution-invocation.ts";
+
+const tempDirs = new Set<string>();
+
+function db() {
+  const adapter = _getAdapter();
+  assert.ok(adapter);
+  return adapter;
+}
+
+function row(sql: string): Record<string, unknown> {
+  return db().prepare(sql).get() ?? {};
+}
+
+function invocation(key: string): ExecutionInvocation {
+  return {
+    idempotencyKey: key,
+    sourceTransport: "pi-tool",
+    actorType: "agent",
+    traceId: key,
+  };
+}
+
+function completionParams(): Record<string, unknown> {
+  return {
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T01",
+    oneLiner: "Staged the executor result",
+    narrative: "The executor result is ready for independent host verification.",
+    verification: "Executor reports the focused test passed.",
+    deviations: "None.",
+    knownIssues: "None.",
+    keyFiles: ["src/task.ts"],
+    keyDecisions: ["Host verification owns completion."],
+    blockerDiscovered: false,
+    verificationEvidence: [{
+      command: "npm test",
+      exitCode: 0,
+      verdict: "pass",
+      durationMs: 10,
+    }],
+  };
+}
+
+function createBase(): string {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-blocker-route-2267-"));
+  tempDirs.add(basePath);
+  const phaseDir = join(basePath, ".gsd", "phases", "01-test");
+  mkdirSync(phaseDir, { recursive: true });
+  writeFileSync(join(phaseDir, "01-01-PLAN.md"), [
+    "# S01: Completion identity",
+    "",
+    "## Tasks",
+    "",
+    "- [ ] **T01: Stage result** `est:10m`",
+    "  - Do: Stage executor output",
+    "  - Verify: npm test",
+    "",
+  ].join("\n"));
+  assert.equal(openDatabase(join(basePath, ".gsd", "gsd.db")), true);
+  db().exec(`
+    INSERT INTO milestones (id, title, status, created_at)
+    VALUES ('M001', 'Completion identity', 'active', '2026-07-12T00:00:00.000Z');
+    INSERT INTO slices (milestone_id, id, title, status, created_at)
+    VALUES ('M001', 'S01', 'Completion seam', 'active', '2026-07-12T00:00:00.000Z');
+    INSERT INTO tasks (milestone_id, slice_id, id, title, status, verify, sequence)
+    VALUES ('M001', 'S01', 'T01', 'Stage result', 'in_progress', 'npm test', 1);
+  `);
+  return basePath;
+}
+
+function claimCanonicalAttempt(basePath: string): string {
+  db().exec(`
+    INSERT INTO workers (
+      worker_id, host, pid, started_at, version, last_heartbeat_at, status,
+      project_root_realpath
+    ) VALUES (
+      'worker-1', 'test-host', 1, '2026-07-12T00:00:00.000Z', 'test',
+      '2026-07-12T00:00:00.000Z', 'active', '${basePath.replaceAll("'", "''")}'
+    );
+    INSERT INTO milestone_leases (
+      milestone_id, worker_id, fencing_token, acquired_at, expires_at, status
+    ) VALUES (
+      'M001', 'worker-1', 7, '2026-07-12T00:00:00.000Z',
+      '2099-07-12T00:00:00.000Z', 'held'
+    );
+    INSERT INTO unit_dispatches (
+      trace_id, turn_id, worker_id, milestone_lease_token,
+      milestone_id, slice_id, task_id, unit_type, unit_id,
+      status, attempt_n, started_at
+    ) VALUES (
+      'trace-claim', 'turn-claim', 'worker-1', 7,
+      'M001', 'S01', 'T01', 'execute-task', 'M001/S01/T01',
+      'claimed', 1, '2026-07-12T00:00:00.000Z'
+    );
+  `);
+  const claim = claimTaskAttempt({
+    invocation: invocation("fixture/claim"),
+    task: { milestoneId: "M001", sliceId: "S01", taskId: "T01" },
+    workerId: "worker-1",
+    milestoneLeaseToken: 7,
+    coordinationDispatchId: Number(row("SELECT id FROM unit_dispatches").id),
+  });
+  return claim.attemptId;
+}
+
+afterEach(() => {
+  closeDatabase();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+test("a canonical blocker receipt names the recorded recovery action and the resume call", async () => {
+  const basePath = createBase();
+  const attemptId = claimCanonicalAttempt(basePath);
+  const blockerInvocation = invocation("pi:gsd_task_complete:blocker-call");
+  const first = await executeTaskComplete({
+    ...completionParams(),
+    blockerDiscovered: true,
+  } as never, basePath, blockerInvocation);
+  assert.equal((first.details as Record<string, unknown>).nextStage, "route");
+
+  // The supervisor routes the settled blocker failure with the same durable
+  // operation production uses (attempt.route); the surviving worker's retry
+  // then replays the completion receipt with the action now on record.
+  const routed = recordFailureAndSelectRecovery({
+    invocation: invocation("fixture/route-blocker"),
+    attemptId,
+    resultId: String((first.details as Record<string, unknown>).resultId),
+    owner: "agent",
+    classification: { failureKind: "fatal" },
+    summary: "A blocker was discovered.",
+    evidence: { source: "executor" },
+    rationale: "Route the recorded blocker.",
+  });
+  assert.ok(routed.recoveryActionId);
+
+  const replay = await executeTaskComplete({
+    ...completionParams(),
+    blockerDiscovered: true,
+  } as never, basePath, blockerInvocation);
+
+  const details = replay.details as Record<string, unknown>;
+  assert.equal(typeof details.recoveryActionId, "string");
+  assert.ok((details.recoveryActionId as string).length > 0);
+  assert.equal(details.recoveryActionId, routed.recoveryActionId);
+  assert.equal(details.action, routed.action);
+  assert.equal(details.resumeEligible, true);
+  assert.equal(readTaskRecoveryRoute(attemptId)?.recoveryActionId, details.recoveryActionId);
+  const text = String(replay.content[0]?.text);
+  assert.ok(
+    text.includes(`Recovery action ${routed.recoveryActionId} (${routed.action}) is eligible for resume`),
+    `notification must name the recovery action: ${text}`,
+  );
+  assert.ok(
+    text.includes(`call gsd_task_recovery_resume with recoveryActionId "${routed.recoveryActionId}"`),
+    `notification must name the sanctioned resume call: ${text}`,
+  );
+});
+
+test("a canonical blocker receipt with no recorded recovery action keeps the plain routing notice", async () => {
+  const basePath = createBase();
+  claimCanonicalAttempt(basePath);
+
+  const result = await executeTaskComplete({
+    ...completionParams(),
+    blockerDiscovered: true,
+  } as never, basePath, invocation("pi:gsd_task_complete:blocker-call"));
+
+  assert.equal(result.isError, undefined);
+  const details = result.details as Record<string, unknown>;
+  assert.equal(details.nextStage, "route");
+  assert.equal("recoveryActionId" in details, false);
+  assert.equal(
+    String(result.content[0]?.text),
+    "Recorded blocker for task T01; awaiting recovery routing.",
+  );
+});
+
+test("a canonical non-blocker completion stays on the verification notice without recovery fields", async () => {
+  const basePath = createBase();
+  claimCanonicalAttempt(basePath);
+
+  const result = await executeTaskComplete(
+    completionParams() as never,
+    basePath,
+    invocation("pi:gsd_task_complete:verify-call"),
+  );
+
+  assert.equal(result.isError, undefined);
+  const details = result.details as Record<string, unknown>;
+  assert.equal(details.nextStage, "verify");
+  assert.equal("recoveryActionId" in details, false);
+  assert.equal("action" in details, false);
+  assert.equal(
+    String(result.content[0]?.text),
+    "Staged task T01; awaiting host verification before completion.",
+  );
+});

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -55,12 +55,17 @@ import {
   unresolvedReworkError,
 } from "./complete-task.js";
 import {
+  recoveryRouteLever,
   resolveTaskCompletionAuthority,
   stageTaskCompletion,
 } from "../task-completion-compatibility-adapter.js";
 import type { ExecutionInvocation } from "../execution-invocation.js";
 import type { DomainJsonValue } from "../db/domain-operation.js";
-import { resumeTaskRecovery } from "../task-recovery-domain-operation.js";
+import {
+  readTaskRecoveryRoute,
+  resumeTaskRecovery,
+  type TaskRecoveryRouteSnapshot,
+} from "../task-recovery-domain-operation.js";
 import { applyTaskSettle, planTaskSettle } from "../task-settle.js";
 import type { CompleteSliceParams, EscalationOption } from "../types.js";
 import { handleCompleteSlice } from "./complete-slice.js";
@@ -1045,12 +1050,27 @@ export async function executeTaskComplete(
           verificationEvidence,
         },
       });
+      // A routed blocker must leave the worker with the recoveryActionId that
+      // gsd_task_recovery_resume requires instead of forcing it to guess ids
+      // or read the database (#2267). Best-effort: a fresh blocker report
+      // precedes recovery routing, so no action exists yet and the plain
+      // routing notice stands.
+      let recoveryRoute: TaskRecoveryRouteSnapshot | null = null;
+      if (staged.nextStage === "route") {
+        try {
+          recoveryRoute = readTaskRecoveryRoute(staged.attemptId);
+        } catch {
+          recoveryRoute = null;
+        }
+      }
       return {
         content: [{
           type: "text",
           text: staged.nextStage === "verify"
             ? `Staged task ${params.taskId}; awaiting host verification before completion.`
-            : `Recorded blocker for task ${params.taskId}; awaiting recovery routing.`,
+            : `Recorded blocker for task ${params.taskId}; awaiting recovery routing.${
+              recoveryRoute ? recoveryRouteLever(recoveryRoute) : ""
+            }`,
         }],
         details: {
           operation: "complete_task",
@@ -1061,6 +1081,13 @@ export async function executeTaskComplete(
           resultId: staged.resultId,
           summaryPath: staged.summaryPath,
           nextStage: staged.nextStage,
+          ...(recoveryRoute ? {
+            recoveryActionId: recoveryRoute.recoveryActionId,
+            action: recoveryRoute.action,
+            ...(recoveryRoute.resumeEligibility
+              ? { resumeEligible: recoveryRoute.resumeEligibility.eligible }
+              : {}),
+          } : {}),
         },
       };
     }


### PR DESCRIPTION
## TL;DR

**What:** a canonical blocker receipt (`gsd_task_complete` with `blockerDiscovered`) now surfaces `recoveryActionId`, `action`, and `resumeEligible` in its result details when a recovery action is recorded, and the routing notification names the id and the sanctioned `gsd_task_recovery_resume` call.
**Why:** the manual blocker route omitted the identifier the public recovery-resume contract requires, while the #1593/#1597 abort route surfaced it — leaving workers to guess IDs or read the database (#2267).
**How:** best-effort `readTaskRecoveryRoute(attemptId)` on the `nextStage: "route"` receipt, with the routing wording extracted verbatim from `latestAttemptRecoveryContext` into a shared helper; the tool description now names the field.

Addresses #2267 (does not close it — the issue's full repair → authorize → successor → completion e2e test and the failed-resume error-message rework remain open).

## What

- `workflow-tool-executors.ts`: on a blocker receipt, best-effort route lookup (try/catch → absent, never throws); `details` gains `recoveryActionId`/`action`/`resumeEligible`; the notification appends the eligibility lever. Non-blocker (`nextStage: "verify"`) results are byte-identical.
- `task-completion-compatibility-adapter.ts`: `latestAttemptRecoveryContext`'s three-case wording extracted into exported `recoveryRouteLever(route)` (single source of truth; adapter output unchanged, 44 adapter tests green).
- `db-tools.ts`: the tool's `promptSnippet`/`promptGuidelines` now name `recoveryActionId` — qualified with "when a recovery action is recorded", since a fresh blocker intentionally mints none (#2148).
- New suite: replay-after-routing receipt names the recorded action and resume call (failing-first), fresh no-route blocker keeps the plain notice, verify-stage unchanged.

## Why

The recovery action is recorded during blocker settlement, and `readTaskRecoveryRoute(attemptId)` resolves it — the data existed at receipt time but wasn't surfaced, so the documented resume API was unusable without database access. Root-cause finding worth noting: a *fresh* blocker mints no recovery action at all (auto-mode deliberately pauses rather than routing fresh blockers, #2148); the id exists in the replayed-after-routing state (#1973 surviving-worker retry), which is exactly where this fix surfaces it.

## How

Wording parity is proven byte-for-byte against the pre-extraction implementation (the adapter suite asserts the #1973 messages). Blast radius: `latestAttemptRecoveryContext` keeps its two gate-rejection call sites unchanged; `recoveryRouteLever` gains one new caller; verify-stage and non-blocker results are pinned by exact-string assertions; the tool layer passes `details` through unvalidated. Open remainder on #2267, unchanged by this patch: the full blocker → repair → authorize → successor → completion e2e chain, and reworking the failed-resume error to name a supported next action.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).