### PR TITLE
fix(gsd): classify status-only "400 Bad Request" as transient network (no hard pause)

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -96,6 +96,17 @@ const MODEL_ERROR_RE =
 // Genuine auth rejections (401 unauthorized, forbidden, …) still classify as
 // permanent earlier and keep precedence.
 const NO_API_KEY_RE = /no api key (?:available )?(?:for|found)(?: provider)?:?/i;
+// Bare status-line 400 with no diagnostic body — the message is exactly
+// "400 Bad Request" (plus whitespace/newline). Gateways (observed: GitHub
+// Copilot's model router, 2026-09-11) occasionally reject an otherwise-valid
+// request with a status-only 400 and an empty body; the identical request
+// then succeeds on retry. Genuine request-shape rejections carry a JSON error
+// body, so they either match MODEL_ERROR_RE above or keep the conservative
+// `unknown` pause below. Only the status-only form is treated as transient:
+// the bounded same-model retry (MAX_NETWORK_RETRIES) disambiguates — a
+// deterministic 400 re-fails cheaply and still reaches the fallback/pause
+// path, while a gateway hiccup recovers on the first retry.
+const BARE_400_STATUS_RE = /^\s*400\s+Bad Request\s*$/i;
 
 // Provider-side model entitlement rejection: the SDK accepted the model switch,
 // but the provider refused at request time because the current account/plan/tier
@@ -213,6 +224,12 @@ export function classifyError(errorMsg: string, retryAfterMs?: number): ErrorCla
   //    Both are fallback-eligible, not same-model transient.
   if (MODEL_ERROR_RE.test(errorMsg) || NO_API_KEY_RE.test(errorMsg)) {
     return { kind: "model-error" };
+  }
+
+  // 7b. Status-only 400 (no diagnostic body) — transient gateway rejection.
+  //     Bounded same-model retry disambiguates from a deterministic rejection.
+  if (BARE_400_STATUS_RE.test(errorMsg)) {
+    return { kind: "network", retryAfterMs: retryAfterMs ?? 3_000 };
   }
 
   // 8. Unknown

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -96,17 +96,25 @@ const MODEL_ERROR_RE =
 // Genuine auth rejections (401 unauthorized, forbidden, …) still classify as
 // permanent earlier and keep precedence.
 const NO_API_KEY_RE = /no api key (?:available )?(?:for|found)(?: provider)?:?/i;
-// Bare status-line 400 with no diagnostic body — the message is exactly
-// "400 Bad Request" (plus whitespace/newline). Gateways (observed: GitHub
-// Copilot's model router, 2026-09-11) occasionally reject an otherwise-valid
-// request with a status-only 400 and an empty body; the identical request
-// then succeeds on retry. Genuine request-shape rejections carry a JSON error
-// body, so they either match MODEL_ERROR_RE above or keep the conservative
-// `unknown` pause below. Only the status-only form is treated as transient:
-// the bounded same-model retry (MAX_NETWORK_RETRIES) disambiguates — a
-// deterministic 400 re-fails cheaply and still reaches the fallback/pause
-// path, while a gateway hiccup recovers on the first retry.
-const BARE_400_STATUS_RE = /^\s*400\s+Bad Request\s*$/i;
+// Bare status-line 400 with no diagnostic body — the message is effectively
+// "400 Bad Request" (plus whitespace/newline), OPTIONALLY wrapped by the
+// provider adapter's generic "Provider error:" prefix. Gateways (observed:
+// GitHub Copilot's model router, 2026-09-11) occasionally reject an otherwise-
+// valid kimi-k3 request with a status-only 400 and an empty body; the identical
+// request then succeeds on retry. When the turn's errorMessage is empty/useless,
+// the recovery path classifies the assistant content text instead, which arrives
+// as "Provider error: 400 Bad Request\n" — so the prefix (and a stray leading
+// colon, as in the adapter's "Provider error: : …" timeout form) MUST be
+// tolerated or the status-only 400 is misclassified as `unknown` and hard-pauses
+// auto-mode. Genuine request-shape rejections carry a JSON error body, so they
+// either match MODEL_ERROR_RE above or keep the conservative `unknown` pause
+// below (the anchored `$` after "Bad Request" rejects any trailing body). Only
+// the status-only form is treated as transient: the bounded same-model retry
+// (MAX_NETWORK_RETRIES) disambiguates — a deterministic 400 re-fails cheaply and
+// still reaches the fallback/pause path, while a gateway hiccup recovers on the
+// first retry.
+const BARE_400_STATUS_RE =
+  /^\s*(?:provider error\s*:?\s*)?:?\s*400\s+Bad Request\s*$/i;
 
 // Provider-side model entitlement rejection: the SDK accepted the model switch,
 // but the provider refused at request time because the current account/plan/tier

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -1323,6 +1323,25 @@ test("classifyError treats a status-only '400 Bad Request' as transient network"
   }
 });
 
+// Regression (2026-09-11): when the turn's errorMessage is empty/useless the
+// recovery path classifies the assistant content text, which arrives with the
+// provider adapter's "Provider error:" prefix baked in ("Provider error: 400 Bad
+// Request\n"). The anchored bare-400 regex must tolerate that wrapper (and the
+// adapter's "Provider error: : …" stray-colon form) or the status-only 400 falls
+// through to `unknown` and hard-pauses auto-mode — the exact wedge W-a8123253.
+test("classifyError treats a provider-prefixed status-only '400 Bad Request' as transient network", () => {
+  for (const message of [
+    "Provider error: 400 Bad Request",
+    "Provider error: 400 Bad Request\n",
+    "Provider error: : 400 Bad Request",
+    ": 400 Bad Request",
+  ]) {
+    const result = classifyError(message);
+    assert.ok(isTransient(result), `${JSON.stringify(message)} must be transient`);
+    assert.equal(result.kind, "network");
+  }
+});
+
 test("classifyError keeps 400 with diagnostic body on the non-transient path", () => {
   // Known request-shape rejection phrasing stays model-error (fallback-eligible).
   const withInvalidParams = classifyError('400 {"error":{"message":"invalid params: max_tokens"}}');

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -1309,6 +1309,35 @@ test("classifyError: 'partial response received' alone is transient network", ()
   assert.equal(result.kind, "network");
 });
 
+// ── Bare status-only 400 (no diagnostic body) ────────────────────────────────
+// Observed 2026-09-11: GitHub Copilot's model router rejected an otherwise-valid
+// kimi-k3 request with a status-only "400 Bad Request" and empty body; the same
+// session succeeded on retry. The status-only form must be transient (bounded
+// same-model retry), not the `unknown` hard-pause.
+
+test("classifyError treats a status-only '400 Bad Request' as transient network", () => {
+  for (const message of ["400 Bad Request", "400 Bad Request\n", "  400  Bad Request  "]) {
+    const result = classifyError(message);
+    assert.ok(isTransient(result), `${JSON.stringify(message)} must be transient`);
+    assert.equal(result.kind, "network");
+  }
+});
+
+test("classifyError keeps 400 with diagnostic body on the non-transient path", () => {
+  // Known request-shape rejection phrasing stays model-error (fallback-eligible).
+  const withInvalidParams = classifyError('400 {"error":{"message":"invalid params: max_tokens"}}');
+  assert.equal(withInvalidParams.kind, "model-error");
+  // An unrecognized 400 body keeps the conservative unknown pause.
+  const unknown400 = classifyError('400 {"error":{"message":"some unrecognized rejection"}}');
+  assert.equal(unknown400.kind, "unknown");
+  assert.ok(!isTransient(unknown400), "400 with body must not be auto-retried");
+});
+
+test("classifyError keeps bare 401/403 status lines permanent", () => {
+  assert.equal(classifyError("401 Unauthorized").kind, "permanent");
+  assert.equal(classifyError("403 Forbidden").kind, "permanent");
+});
+
 // ── Context overflow / context window exceeded (#4528) ───────────────────────
 
 test("classifyError: MiniMax context window error is transient server", () => {


### PR DESCRIPTION
Fixes #2275.

## Problem

`classifyError` had no branch for a **status-only `400 Bad Request`** (empty diagnostic body). It fell through to `{ kind: "unknown" }` -> non-transient -> indefinite provider-pause. Since the identical request usually succeeds on retry, the unit-break recurs and trips the liveness backstop. Observed from GitHub Copilot's model router on `kimi-k3`.

When a turn's `errorMessage` is empty/useless, the recovery path classifies the assistant **content text**, which the provider adapter wraps as `"Provider error: 400 Bad Request\n"` — so the classifier must tolerate that prefix too.

## Change

Add `BARE_400_STATUS_RE`, checked **after** `MODEL_ERROR_RE`, classifying a status-only 400 (optionally `Provider error:`-prefixed) as transient `network` so the bounded same-model retry (`MAX_NETWORK_RETRIES`) disambiguates a gateway hiccup from a deterministic rejection:

```ts
const BARE_400_STATUS_RE =
  /^\s*(?:provider error\s*:?\s*)?:?\s*400\s+Bad Request\s*$/i;
```

The anchored `$` after `Bad Request` keeps any body-bearing 400 (`400 {"error":{...}}`, `400 invalid argument`) on the `model-error`/`unknown` path. `401`/`403` stay `permanent`; `500` stays `server`.

## Commits

- `classify status-only '400 Bad Request' as transient network error`
- `tolerate "Provider error:" prefix on status-only 400`

## Tests

`src/resources/extensions/gsd/tests/provider-errors.test.ts` — full suite green (98/98), including new cases for the bare and `Provider error:`-prefixed status-only 400, plus negative cases asserting body-bearing 400s and 401/403/500 are unchanged.

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
  --experimental-strip-types --test \
  src/resources/extensions/gsd/tests/provider-errors.test.ts
```