### PR TITLE
test(gsd): normalize volatile disk-space sample in env-check parity test

### DIFF
--- a/src/resources/extensions/gsd/tests/integration/doctor-environment-async.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-environment-async.test.ts
@@ -34,9 +34,21 @@ function makeProject(t: TestContext, files: Record<string, string>): string {
   return dir;
 }
 
+// The disk_space check samples live free space separately in the sync and
+// async paths, so its message embeds a size ("71.3GB free") that can shift
+// between the two samples (CI run 34550581124: 71.2GB vs 71.3GB). Mask the
+// volatile size before comparing; check id, status and detail stay verbatim.
+function maskVolatileDiskSize(r: EnvironmentCheckResult): EnvironmentCheckResult {
+  if (r.name !== "disk_space") return r;
+  return { ...r, message: r.message.replace(/\d+(\.\d+)?(MB|GB) free/, "<size> free") };
+}
+
 // Stable, order-independent signature of a check-result set for comparison.
 function normalize(results: EnvironmentCheckResult[]): string[] {
-  return results.map((r) => `${r.name}|${r.status}|${r.message}|${r.detail ?? ""}`).sort();
+  return results
+    .map(maskVolatileDiskSize)
+    .map((r) => `${r.name}|${r.status}|${r.message}|${r.detail ?? ""}`)
+    .sort();
 }
 
 test("runEnvironmentChecksAsync returns the same results as runEnvironmentChecks", async (t) => {


### PR DESCRIPTION
## TL;DR

**What:** Normalizes the volatile free-space number in `disk_space` messages before the sync/async environment-check parity comparison.
**Why:** The parity test samples live disk space twice (once per code path), so it fails whenever free space shifts between the two samples.
**How:** Mask the `NN.NGB free` / `NNNMB free` size in `disk_space` messages on both actual and expected inside the shared `normalize` helper; every other field is still asserted verbatim.

## What

Single file changed: `src/resources/extensions/gsd/tests/integration/doctor-environment-async.test.ts`.

- Added `maskVolatileDiskSize()`, applied inside the shared `normalize()` helper so both parity tests (`returns the same results as runEnvironmentChecks` and the bare-directory variant) are covered.
- For `disk_space` rows only, the message's size token (`71.3GB free`, `480MB free`) is replaced with `<size> free` before comparison. Check id, status, message prefix, and detail are still compared verbatim — non-volatile assertions are unchanged.
- No production code touched. No mocking introduced.

## Why

Flaky test observed in CI: run 34550581124 on PR #2269 failed the parity assertion with actual `disk_space|ok|71.2GB free|` vs expected `disk_space|ok|71.3GB free|`, then passed on re-run.

Root cause: `runEnvironmentChecks` (sync) and `runEnvironmentChecksAsync` genuinely re-sample free space via `df -k` at slightly different times, and the ok-path message embeds a `toFixed(1)` GB count. The test's job is to prove the two paths agree on result-set *structure* (same check ids, statuses, message shapes) — not that the machine's free byte count is constant across two samples microseconds apart. There is no injection seam for the `df` call in either path, so masking the volatile field on both sides is the smallest honest normalization. The bare-directory parity test had the same latent flake, hence the fix lives in the shared `normalize` helper.

Refs #2269 (flaky test observed in that PR's CI; no separate tracking issue).

## How

`normalize()` now pipes each result through `maskVolatileDiskSize()` before building its comparison signature:

- `r.name !== "disk_space"` rows pass through untouched.
- `disk_space` messages get `/\d+(\.\d+)?(MB|GB) free/` replaced with `<size> free`, normalizing all three message shapes (`ok`: `NN.NGB free`, `warning`: `Disk space getting low: NN.NGB free`, `error`: `Low disk space: NNNMB free`) while keeping their prefixes asserted.
- Status is deliberately **not** masked: it only flips if a sample crosses the 500MB/2GB thresholds, which is not the observed flake class and would be worth failing on.

## Test evidence

- Targeted run (repo's `test:integration` invocation, single file): 3/3 pass.
- Stability: 5 consecutive runs of the file, all `pass 3 / fail 0`.
- Mask sanity check: `"71.2GB free"` and `"71.3GB free"` both normalize to `"<size> free"` (equal), warning/error prefixes preserved, non-matching messages untouched.
- `pnpm run typecheck:extensions` reports zero errors in the changed file (repo-wide ambient errors exist locally due to an unbuilt/postinstall-incomplete environment; unrelated files only).

AI-assisted: yes