### PR TITLE
fix(gsd): converge journaled exchange replay before replaying identities

### DIFF
--- a/src/resources/extensions/gsd/managed-projection-history.ts
+++ b/src/resources/extensions/gsd/managed-projection-history.ts
@@ -226,6 +226,29 @@ function isTransientProjectionRootLockError(error: unknown): boolean {
   return false;
 }
 
+function projectionErrorMessage(error: unknown): string | null {
+  return error instanceof Error ? error.message : null;
+}
+
+// Deterministic exchange/deletion protocol failures, classified by error
+// class rather than a single error-message substring: a native wording change
+// must not turn a recoverable retention into a permanent journal wedge.
+function isUnexpectedOccupantError(error: unknown): boolean {
+  const message = projectionErrorMessage(error);
+  return message !== null
+    && /unexpected occupant retained in guard|retained unexpected occupants/u.test(message);
+}
+
+function isJournaledExchangeIdentityChangedError(error: unknown): boolean {
+  const message = projectionErrorMessage(error);
+  return message !== null
+    && message.includes("projection identity changed during journaled exchange");
+}
+
+function isDeterministicExchangeIdentityError(error: unknown): boolean {
+  return isUnexpectedOccupantError(error) || isJournaledExchangeIdentityChangedError(error);
+}
+
 function openManagedProjectionRootWithRetry<T>(
   open: () => T,
   wait: (delayMs: number) => void = (delayMs) => {
@@ -268,6 +291,15 @@ export function _withManagedProjectionRootForTest<T>(
   operation: (handle: ProjectionRootIdentityLock) => T,
 ): T {
   return withManagedProjectionRoot("", operation, open);
+}
+
+export function _recoverManagedProjectionMutationsForTest(
+  open: (targetRoot: string) => ProjectionRootIdentityLock,
+  targetRoot: string,
+): void {
+  withManagedProjectionRoot(targetRoot, (handle) => {
+    recoverManagedProjectionMutations(targetRoot, handle);
+  }, open);
 }
 
 function parseManagedProjectionPaths(value: unknown): string[] {
@@ -1120,11 +1152,157 @@ function exchangeMutationPaths(
   persistMutation(handle, mutation);
 }
 
+const ABSENT_PROJECTION_IDENTITY = "-";
+
+function projectedIdentity(handle: ProjectionRootIdentityLock, path: string): string {
+  return handle.pathExists(path) ? handle.pathIdentity(path) : ABSENT_PROJECTION_IDENTITY;
+}
+
+function retainExchangeParticipants(
+  handle: ProjectionRootIdentityLock,
+  mutation: PersistedManagedProjectionMutation,
+): void {
+  const retain = (evidencePath: string | null, kind: "temporary" | "quarantine" | "canonical"): void => {
+    if (evidencePath === null || !handle.pathExists(evidencePath)) return;
+    const scope = handle.pathKind(evidencePath) === "directory" ? "tree" : "file";
+    recordUnboundProjectionEvidence(handle, {
+      evidencePath,
+      evidenceIdentity: handle.pathIdentity(evidencePath),
+      kind,
+      logicalPath: mutation.logicalPath,
+      scope,
+    });
+  };
+  retain(mutation.logicalPath, "canonical");
+  retain(mutation.temporaryPath, "temporary");
+  retain(mutation.replacementPath, "quarantine");
+  retain(mutation.quarantinePath, "quarantine");
+  retain(mutation.exchangeGuardPath, "quarantine");
+}
+
+// Degrades a contradictory journaled exchange to reviewable evidence and
+// retires the journal entry (the semantics the remove path already ships)
+// instead of re-throwing raw and wedging every later projection operation.
+function retireExchangeWithRetainedEvidence(
+  handle: ProjectionRootIdentityLock,
+  mutation: PersistedManagedProjectionMutation,
+): never {
+  retainExchangeParticipants(handle, mutation);
+  handle.removeFile(`${JOURNAL_LOGICAL_ROOT}/${basename(mutation.journalPath)}`);
+  throw new Error("managed projection target identity changed; recovery evidence retained");
+}
+
+function reconcileProjectionExchange(
+  handle: ProjectionRootIdentityLock,
+  mutation: PersistedManagedProjectionMutation,
+): PersistedProjectionExchange | null {
+  const exchange = mutation.exchangeState;
+  if (exchange === null) return null;
+  // The swap landed before the clearing persist ran: only the journal needs
+  // to converge. Retire the entry instead of re-issuing the exchange.
+  if (exchange.rightIdentity !== ABSENT_PROJECTION_IDENTITY
+    && projectedIdentity(handle, exchange.leftPath) === exchange.rightIdentity) {
+    mutation.exchangeState = null;
+    mutation.exchangeGuardIdentity = null;
+    persistMutation(handle, mutation);
+    return null;
+  }
+  // Anything other than a converged or staging-only drift is a contradiction
+  // between the persisted exchange and disk that replay cannot resolve.
+  if (projectedIdentity(handle, exchange.leftPath) !== exchange.leftIdentity
+    || projectedIdentity(handle, exchange.guardPath) !== exchange.guardIdentity) {
+    retireExchangeWithRetainedEvidence(handle, mutation);
+  }
+  if (projectedIdentity(handle, exchange.rightPath) === exchange.rightIdentity) return exchange;
+  return restageProjectionExchangeRight(handle, mutation, exchange);
+}
+
+function restageProjectionExchangeRight(
+  handle: ProjectionRootIdentityLock,
+  mutation: PersistedManagedProjectionMutation,
+  exchange: PersistedProjectionExchange,
+): PersistedProjectionExchange {
+  const role = exchange.rightPath === mutation.temporaryPath
+    ? "temporary"
+    : exchange.rightPath === mutation.replacementPath
+      ? "replacement"
+      : "quarantine";
+  const directory = dirname(exchange.rightPath).replaceAll("\\", "/");
+  const prefix = directory === "." ? "" : `${directory}/`;
+  if (handle.pathExists(exchange.rightPath)) {
+    const scope = handle.pathKind(exchange.rightPath) === "directory" ? "tree" : "file";
+    // The right slot is protocol-owned staging we created. If it still holds
+    // the intended content under a drifted identity (the volume-serial flip
+    // shape), re-bind the journal to the actual identity and replay.
+    const intendedContent = role === "temporary"
+      ? Buffer.from(mutation.content!, mutation.encoding!)
+      : Buffer.alloc(0);
+    if (projectionContentDigest(handle, exchange.rightPath, scope)
+      === `sha256:${createHash("sha256").update(intendedContent).digest("hex")}`) {
+      const actualIdentity = handle.pathIdentity(exchange.rightPath);
+      if (role === "temporary") mutation.temporaryIdentity = actualIdentity;
+      else mutation.placeholderIdentity = actualIdentity;
+      const rebound = { ...exchange, rightIdentity: actualIdentity };
+      mutation.exchangeState = rebound;
+      persistMutation(handle, mutation);
+      return rebound;
+    }
+    recordUnboundProjectionEvidence(handle, {
+      evidencePath: exchange.rightPath,
+      evidenceIdentity: handle.pathIdentity(exchange.rightPath),
+      kind: role === "temporary" ? "temporary" : "quarantine",
+      logicalPath: mutation.logicalPath,
+      scope,
+    });
+  }
+  // The staging slot no longer holds the intended content (or is gone):
+  // re-stage under a fresh random name — reusing the diverged deterministic
+  // name is what makes the wedge restart-proof — and keep any displaced
+  // protocol artifact the rename orphans as reviewable evidence.
+  let rightPath: string;
+  if (role === "temporary") {
+    if (handle.pathExists(mutation.replacementPath!)) {
+      recordUnboundProjectionEvidence(handle, {
+        evidencePath: mutation.replacementPath!,
+        evidenceIdentity: handle.pathIdentity(mutation.replacementPath!),
+        kind: "quarantine",
+        logicalPath: mutation.logicalPath,
+        scope: "file",
+      });
+    }
+    mutation.temporaryPath = `${prefix}.gsd-projection-tmp-${randomUUID()}`;
+    mutation.replacementPath = `${mutation.temporaryPath}.replaced`;
+    mutation.temporaryIdentity = handle.prepareFileTemporary(
+      mutation.temporaryPath,
+      Buffer.from(mutation.content!, mutation.encoding!),
+    );
+    rightPath = mutation.temporaryPath;
+  } else if (role === "replacement") {
+    mutation.replacementPath = `${prefix}.gsd-projection-remove-${randomUUID()}`;
+    mutation.placeholderIdentity = handle.prepareFileTemporary(mutation.replacementPath, Buffer.alloc(0));
+    rightPath = mutation.replacementPath;
+  } else {
+    mutation.quarantinePath = `${prefix}.gsd-projection-remove-${randomUUID()}`;
+    mutation.placeholderIdentity = mutation.operation === "remove-tree"
+      ? handle.prepareDirectoryPlaceholder(mutation.quarantinePath)
+      : handle.prepareFileTemporary(mutation.quarantinePath, Buffer.alloc(0));
+    rightPath = mutation.quarantinePath!;
+  }
+  const restaged: PersistedProjectionExchange = {
+    ...exchange,
+    rightPath,
+    rightIdentity: role === "temporary" ? mutation.temporaryIdentity! : mutation.placeholderIdentity!,
+  };
+  mutation.exchangeState = restaged;
+  persistMutation(handle, mutation);
+  return restaged;
+}
+
 function resumeProjectionExchange(
   handle: ProjectionRootIdentityLock,
   mutation: PersistedManagedProjectionMutation,
 ): void {
-  const exchange = mutation.exchangeState;
+  const exchange = reconcileProjectionExchange(handle, mutation);
   if (exchange === null) return;
   try {
     handle.exchangePaths(
@@ -1150,28 +1328,11 @@ function retainFailedExchangeEvidence(
   error: unknown,
   _directory: boolean,
 ): void {
-  if (!(error instanceof Error) || !error.message.includes("unexpected occupant retained in guard")) return;
-  const exchange = mutation.exchangeState;
-  if (exchange === null || !handle.pathExists(exchange.guardPath)) return;
-  const actual = handle.pathIdentity(exchange.guardPath);
-  if (actual === exchange.guardIdentity || actual === exchange.rightIdentity) return;
-  const retain = (evidencePath: string | null, kind: "temporary" | "quarantine" | "canonical"): void => {
-    if (evidencePath === null || !handle.pathExists(evidencePath)) return;
-    const scope = handle.pathKind(evidencePath) === "directory" ? "tree" : "file";
-    recordUnboundProjectionEvidence(handle, {
-      evidencePath,
-      evidenceIdentity: handle.pathIdentity(evidencePath),
-      kind,
-      logicalPath: mutation.logicalPath,
-      scope,
-    });
-  };
-  retain(mutation.logicalPath, "canonical");
-  retain(mutation.temporaryPath, "temporary");
-  retain(mutation.replacementPath, "quarantine");
-  retain(mutation.quarantinePath, "quarantine");
-  retain(exchange.guardPath, "quarantine");
-  handle.removeFile(`${JOURNAL_LOGICAL_ROOT}/${basename(mutation.journalPath)}`);
+  // Only deterministic identity contradictions convert to retained evidence.
+  // Transient classes (EBUSY / sharing violation / EXDEV) keep the entry and
+  // rethrow so the existing outer retry schedules keep ownership.
+  if (!isDeterministicExchangeIdentityError(error)) return;
+  retireExchangeWithRetainedEvidence(handle, mutation);
 }
 
 function applyWriteMutation(
@@ -1930,9 +2091,7 @@ function applyEvidenceResolution(
       true,
     );
   } catch (error) {
-    if (!(error instanceof Error)
-      || !error.message.includes("retained unexpected occupants")
-      || !handle.pathExists(source)) throw error;
+    if (!isUnexpectedOccupantError(error) || !handle.pathExists(source)) throw error;
     const pending: PersistedUnboundProjectionEvidence = {
       evidenceId: evidenceId(source, "quarantine", evidence.logicalPath, "tree"),
       evidencePath: source,

--- a/src/resources/extensions/gsd/tests/managed-projection-exchange-replay.test.ts
+++ b/src/resources/extensions/gsd/tests/managed-projection-exchange-replay.test.ts
@@ -1,0 +1,270 @@
+// Journaled exchange replay convergence tests.
+// File Purpose: Verifies that resumeProjectionExchange reconciles persisted
+// exchange state against current disk state before replaying it, and that
+// deterministic replay failures degrade to retained evidence instead of
+// wedging the journal (#2193, #2108).
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  acquireProjectionRootIdentityLock,
+  type ProjectionRootIdentityLock,
+} from "@gsd/native/file-identity";
+
+import {
+  _recoverManagedProjectionMutationsForTest,
+  loadManagedProjectionPaths,
+  loadUnboundProjectionEvidence,
+} from "../managed-projection-history.ts";
+import { closeDatabase, openDatabase } from "../gsd-db.ts";
+
+interface ExchangeFixture {
+  base: string;
+  rootPath: string;
+  logicalPath: string;
+  temporaryPath: string;
+  replacementPath: string;
+  guardPath: string;
+  journalPath: string;
+  placeholderIdentity: string;
+  temporaryIdentity: string;
+  replacementIdentity: string;
+  guardIdentity: string;
+}
+
+// Builds the on-disk state of a write mutation interrupted between its two
+// journaled exchanges: the canonical target holds the empty placeholder from
+// the first swap, the displaced canonical content sits in the replacement
+// slot, and the staging temp holds the intended content. The journal claims
+// the second swap (left = target placeholder, right = staging temp) is still
+// in flight.
+function prepareExchangeFixture(prefix: string): ExchangeFixture {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  const rootPath = join(base, ".gsd");
+  mkdirSync(join(rootPath, "notes"), { recursive: true });
+  assert.equal(openDatabase(join(rootPath, "gsd.db")), true);
+  const logicalPath = "notes/result.md";
+  const temporaryPath = "notes/.gsd-projection-tmp-00000000-0000-0000-0000-000000000001";
+  const replacementPath = `${temporaryPath}.replaced`;
+  const guardPath = "notes/.gsd-projection-exchange-00000000-0000-0000-0000-000000000002";
+  const journalPath = join(
+    rootPath,
+    "migration",
+    "projection-mutations",
+    "00000000-0000-0000-0000-000000000003.json",
+  );
+  const stat = lstatSync(rootPath, { bigint: true });
+  const handle = acquireProjectionRootIdentityLock(rootPath, stat.dev.toString(), stat.ino.toString());
+  try {
+    const placeholderIdentity = handle.prepareFileTemporary(logicalPath, Buffer.alloc(0));
+    const scratch = join(rootPath, "notes", ".gsd-projection-tmp-00000000-0000-0000-0000-000000000004");
+    writeFileSync(scratch, "reviewed\n");
+    renameSync(scratch, join(rootPath, replacementPath));
+    const replacementIdentity = handle.pathIdentity(replacementPath);
+    const temporaryIdentity = handle.prepareFileTemporary(temporaryPath, Buffer.from("replacement\n"));
+    const guardIdentity = handle.prepareFileTemporary(guardPath, Buffer.alloc(0));
+    return {
+      base,
+      rootPath,
+      logicalPath,
+      temporaryPath,
+      replacementPath,
+      guardPath,
+      journalPath,
+      placeholderIdentity,
+      temporaryIdentity,
+      replacementIdentity,
+      guardIdentity,
+    };
+  } finally {
+    handle.close();
+  }
+}
+
+function cleanupFixture(base: string): void {
+  closeDatabase();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function writeExchangeJournal(
+  fixture: ExchangeFixture,
+  overrides: {
+    temporaryPath?: string;
+    temporaryIdentity?: string;
+    exchangeState?: Record<string, string>;
+  } = {},
+): void {
+  const temporaryPath = overrides.temporaryPath ?? fixture.temporaryPath;
+  const temporaryIdentity = overrides.temporaryIdentity ?? fixture.temporaryIdentity;
+  mkdirSync(join(fixture.rootPath, "migration", "projection-mutations"), { recursive: true });
+  writeFileSync(fixture.journalPath, `${JSON.stringify({
+    logicalPath: fixture.logicalPath,
+    operation: "write",
+    legacyCleanup: false,
+    content: Buffer.from("replacement\n").toString("base64"),
+    encoding: "base64",
+    temporaryPath,
+    temporaryIdentity,
+    replacementPath: `${fixture.temporaryPath}.replaced`,
+    replacementIdentity: fixture.replacementIdentity,
+    quarantinePath: null,
+    quarantineIdentity: null,
+    placeholderIdentity: fixture.placeholderIdentity,
+    exchangeGuardPath: fixture.guardPath,
+    exchangeGuardIdentity: fixture.guardIdentity,
+    exchangeState: overrides.exchangeState ?? {
+      leftPath: fixture.logicalPath,
+      rightPath: temporaryPath,
+      leftIdentity: fixture.placeholderIdentity,
+      rightIdentity: temporaryIdentity,
+      guardPath: fixture.guardPath,
+      guardIdentity: fixture.guardIdentity,
+    },
+  })}\n`);
+}
+
+// A real identity-lock handle whose exchangePaths fails with the given error,
+// exactly as the native engine reports a deterministic or transient exchange
+// failure. Every other operation is forwarded to the real handle so evidence
+// retention, journal writes, and digests run against real disk state.
+function handleFailingExchangePaths(
+  rootPath: string,
+  fault: Error,
+): ProjectionRootIdentityLock {
+  const stat = lstatSync(rootPath, { bigint: true });
+  const real = acquireProjectionRootIdentityLock(rootPath, stat.dev.toString(), stat.ino.toString());
+  return new Proxy(real, {
+    get(target, property): unknown {
+      if (property === "exchangePaths") return () => { throw fault; };
+      const value = Reflect.get(target, property) as unknown;
+      return typeof value === "function" ? (value as (...args: unknown[]) => unknown).bind(target) : value;
+    },
+  });
+}
+
+test("converged journaled exchange replay retires the entry without re-exchanging", (t) => {
+  const fixture = prepareExchangeFixture("gsd-exchange-replay-converged-");
+  t.after(() => cleanupFixture(fixture.base));
+
+  // The swap already landed on disk; only the clearing persist never ran. A
+  // racer then placed an unexpected occupant on the (normally consumed) guard
+  // path, so a blind replay would fail on the guard identity.
+  const stat = lstatSync(fixture.rootPath, { bigint: true });
+  const handle = acquireProjectionRootIdentityLock(fixture.rootPath, stat.dev.toString(), stat.ino.toString());
+  try {
+    handle.exchangePaths(
+      fixture.logicalPath,
+      fixture.temporaryPath,
+      fixture.placeholderIdentity,
+      fixture.temporaryIdentity,
+      fixture.guardPath,
+      fixture.guardIdentity,
+    );
+  } finally {
+    handle.close();
+  }
+  writeFileSync(join(fixture.rootPath, fixture.guardPath), "racing occupant\n");
+  writeExchangeJournal(fixture);
+
+  assert.ok(loadManagedProjectionPaths(fixture.base).includes(fixture.logicalPath));
+  assert.equal(readFileSync(join(fixture.rootPath, fixture.logicalPath), "utf8"), "replacement\n");
+  assert.equal(existsSync(fixture.journalPath), false);
+  assert.deepEqual(loadUnboundProjectionEvidence(fixture.base), []);
+});
+
+test("journaled exchange replay re-binds drifted staging identity when content matches", (t) => {
+  const fixture = prepareExchangeFixture("gsd-exchange-replay-rebind-");
+  t.after(() => cleanupFixture(fixture.base));
+
+  // Same staging content under a new identity (the volume-serial flip shape).
+  const scratch = join(fixture.rootPath, "notes", ".gsd-projection-tmp-00000000-0000-0000-0000-000000000005");
+  writeFileSync(scratch, "replacement\n");
+  renameSync(scratch, join(fixture.rootPath, fixture.temporaryPath));
+  writeExchangeJournal(fixture);
+
+  assert.ok(loadManagedProjectionPaths(fixture.base).includes(fixture.logicalPath));
+  assert.equal(readFileSync(join(fixture.rootPath, fixture.logicalPath), "utf8"), "replacement\n");
+  assert.equal(existsSync(fixture.journalPath), false);
+  assert.equal(existsSync(join(fixture.rootPath, fixture.temporaryPath)), false);
+  assert.equal(existsSync(join(fixture.rootPath, fixture.replacementPath)), false);
+  assert.deepEqual(loadUnboundProjectionEvidence(fixture.base), []);
+});
+
+test("journaled exchange replay re-stages diverged staging content under a fresh path", (t) => {
+  const fixture = prepareExchangeFixture("gsd-exchange-replay-restage-");
+  t.after(() => cleanupFixture(fixture.base));
+
+  // Staging content diverged: the journal cannot prove what the temp holds.
+  const scratch = join(fixture.rootPath, "notes", ".gsd-projection-tmp-00000000-0000-0000-0000-000000000005");
+  writeFileSync(scratch, "tampered\n");
+  renameSync(scratch, join(fixture.rootPath, fixture.temporaryPath));
+  writeExchangeJournal(fixture);
+
+  assert.ok(loadManagedProjectionPaths(fixture.base).includes(fixture.logicalPath));
+  assert.equal(readFileSync(join(fixture.rootPath, fixture.logicalPath), "utf8"), "replacement\n");
+  assert.equal(existsSync(fixture.journalPath), false);
+  // The diverged staging artifact and the displaced replacement stay on disk
+  // as reviewable evidence instead of being silently discarded.
+  assert.equal(existsSync(join(fixture.rootPath, fixture.temporaryPath)), true);
+  assert.deepEqual(
+    loadUnboundProjectionEvidence(fixture.base).map((entry) => entry.evidencePath).sort(),
+    [fixture.temporaryPath, fixture.replacementPath].sort(),
+  );
+});
+
+test("deterministic journaled exchange failure retains evidence and retires the entry on first failure", (t) => {
+  const fixture = prepareExchangeFixture("gsd-exchange-replay-identity-changed-");
+  t.after(() => cleanupFixture(fixture.base));
+  writeExchangeJournal(fixture);
+
+  const fault = new Error("projection identity changed during journaled exchange");
+  assert.throws(
+    () => _recoverManagedProjectionMutationsForTest(
+      () => handleFailingExchangePaths(fixture.rootPath, fault),
+      fixture.base,
+    ),
+    /managed projection target identity changed; recovery evidence retained/u,
+  );
+  assert.equal(existsSync(fixture.journalPath), false);
+  assert.deepEqual(
+    loadUnboundProjectionEvidence(fixture.base).map((entry) => entry.evidencePath).sort(),
+    [fixture.logicalPath, fixture.temporaryPath, fixture.replacementPath, fixture.guardPath].sort(),
+  );
+});
+
+test("transient journaled exchange failure keeps the entry and propagates for retry", (t) => {
+  const fixture = prepareExchangeFixture("gsd-exchange-replay-transient-");
+  t.after(() => cleanupFixture(fixture.base));
+  writeExchangeJournal(fixture);
+
+  const fault = new Error("projection root operation failed: sharing violation (os error 32)");
+  assert.throws(
+    () => _recoverManagedProjectionMutationsForTest(
+      () => handleFailingExchangePaths(fixture.rootPath, fault),
+      fixture.base,
+    ),
+    (error: unknown) => error === fault,
+  );
+  assert.equal(existsSync(fixture.journalPath), true);
+  const replayed = JSON.parse(readFileSync(fixture.journalPath, "utf8")) as { exchangeState: unknown };
+  assert.notEqual(replayed.exchangeState, null);
+
+  // The retained entry stays owned by the existing retry schedule: the next
+  // recovery pass without the fault converges and retires it.
+  assert.ok(loadManagedProjectionPaths(fixture.base).includes(fixture.logicalPath));
+  assert.equal(readFileSync(join(fixture.rootPath, fixture.logicalPath), "utf8"), "replacement\n");
+  assert.equal(existsSync(fixture.journalPath), false);
+});

--- a/src/resources/extensions/gsd/tests/migrate-safety-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-safety-audit.test.ts
@@ -1333,7 +1333,10 @@ test("exchange racer recovery closes its journal after retaining every participa
       },
     })}\n`);
 
-    assert.throws(() => loadManagedProjectionPaths(base), /unexpected occupant retained in guard/i);
+    assert.throws(
+      () => loadManagedProjectionPaths(base),
+      /managed projection target identity changed; recovery evidence retained/u,
+    );
     assert.equal(existsSync(journal), false);
     assert.equal(existsSync(join(rootPath, temporaryPath)), true);
     assert.equal(existsSync(join(rootPath, replacementPath)), true);


### PR DESCRIPTION
## TL;DR

**What:** Reconciles a journaled projection exchange against current disk state before replaying it, and classifies replay failures by error class instead of error-message substring.
**Why:** An interrupted exchange that persists deterministic protocol state (a drifted staging identity, an unexpected guard occupant) made `resumeProjectionExchange` replay stale identities forever, wedging every projection operation on the store (#2193, the replay-forever core of #2108).
**How:** `resumeProjectionExchange` now reconciles each exchange slot via `handle.pathIdentity` first; deterministic contradictions degrade to retained evidence and retire the journal entry, while transient failures keep the entry and rethrow so existing retry schedules keep ownership.

## What

All changes are in `src/resources/extensions/gsd/managed-projection-history.ts` (plus tests); no native code is touched, so the JS behavior works against engines that predate any native fix (existing N-API surface only).

- **Convergence-reconciliation before blind replay** (`resumeProjectionExchange`): before re-issuing `handle.exchangePaths` with persisted identities, each slot is reconciled against disk:
  - *Already converged* (the swap landed but the clearing persist never ran): clear `exchangeState`/`exchangeGuardIdentity`, persist, retire the entry.
  - *Staging-only drift* (left and guard match their journaled identities; only the protocol-owned staging slot diverged): if the staging content digest matches the mutation's intended staging content, re-bind `rightIdentity` (and the bound mutation identity) to the actual identity, persist, and replay with corrected identities; otherwise record the stale staging as unbound evidence, re-stage under a fresh `randomUUID()` path (same defense as the existing unclaimed-temp path), persist, and proceed.
  - *Anything else*: do not replay — retain all exchange participants as reviewable evidence, remove the journal entry, and throw the existing `managed projection target identity changed; recovery evidence retained` shape (mirroring what `applyRemoveMutation` already ships).
- **Error-class classifier** replaces the message-substring gates: `unexpected occupant retained in guard` and `projection identity changed during journaled exchange` are deterministic classes and convert to retained evidence + journal retirement on the FIRST failure (no replay counter); transient classes (`isTransientProjectionRootLockError`, EXDEV) keep the entry and rethrow. The second substring gate in `applyEvidenceResolution` (`retained unexpected occupants`) now uses the same shared classifier, so all gates live in one place that survives native wording changes.
- Retention uses the existing `recordUnboundProjectionEvidence` machinery unchanged; evidence stays reviewable through the existing `/gsd doctor` flows.

## Why

After a volume-serial flip or a racer occupying an exchange guard, the persisted journal claimed identities that no longer matched disk. Blind replay deterministically failed, the old single-substring gate did not match the identity-changed class, the entry was never retired, and every projection operation (including renders and `/gsd doctor`) re-threw across restarts. The database stays canonical the whole time — projections are regenerable — so fail-retained (reviewable evidence + journal retirement) is safe, and it is the semantics the remove path already ships.

## How

Reconciliation is ordered cheapest-first: converged check (one identity probe), then left/guard exact-match verification, then staging-only drift handling. The staging digest comparison reuses `projectionContentDigest`, and the intended content is derived from the journal itself (write content for the temp slot; empty placeholder for the replacement/quarantine slots). Re-stage renames are validated against `validateMutation`'s journal-binding rules so an interrupted re-stage itself replays cleanly.

Tests (`managed-projection-exchange-replay.test.ts`, written failing-first against the pre-fix code) cover: converged replay retires without re-exchanging; right-only drift re-binds on content match; diverged content re-stages under a fresh path and retains the stale artifacts; a deterministic identity-changed failure retains evidence and retires the entry on first failure; a transient (sharing violation / os error 32) failure keeps the entry, propagates the original error, and converges on the next recovery pass. The existing `exchange racer recovery closes its journal after retaining every participant` test was updated from the old raw-throw assertion to the retained-evidence error shape (behavior intentionally changed by this fix; its journal-closed and four-participant-evidence assertions are unchanged).

## Test evidence

- `node --test src/resources/extensions/gsd/tests/managed-projection-exchange-replay.test.ts` — 5/5 pass (4 of 5 failed before the fix, as intended)
- Adjacent suites: `managed-projection-root-retry`, `projection-root-errors`, `projection-observation`, `atomic-write`, `workflow-tool-executors`, `complete-milestone-projection-stale`, `projection-regression` — all pass (167 tests)
- `migrate-safety-audit.test.ts` — 130 pass / 23 fail before and after (identical failure sets; the 23 require the locally built native test addon with `setMutationBoundaryFaultForTest`, which needs a Rust toolchain — pre-existing in this environment, out of scope for this change)
- `pnpm run verify:fast` — all checks passed

Fixes #2193
Refs #2108

AI-assisted: yes