### PR TITLE
feat(gsd): preserve effective model and routing provenance on assistant messages

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
@@ -5,9 +5,10 @@ import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import stripAnsi from "strip-ansi";
 import type { AssistantMessage } from "@gsd/pi-ai";
+import { visibleWidth } from "@gsd/pi-tui";
 
-import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
-import { AssistantMessageComponent } from "../assistant-message.js";
+import { initTheme, getMarkdownTheme } from "@gsd/pi-coding-agent/theme/theme.js";
+import { AssistantMessageComponent, formatAssistantModelMeta } from "../assistant-message.js";
 import { formatTimestamp } from "../timestamp.js";
 import { renderPlainSpeakerMessage } from "../transcript-design.js";
 
@@ -69,5 +70,152 @@ describe("AssistantMessageComponent plain surface", () => {
 		const d = new Date(0);
 		const expectedDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 		assert.match(plain, new RegExp(expectedDate));
+	});
+});
+
+describe("assistant header model provenance (ADR-049)", () => {
+	function makeAssistant(overrides: Record<string, unknown> = {}): AssistantMessage {
+		return {
+			role: "assistant",
+			provider: "test",
+			model: "gpt-5.6-luna",
+			timestamp: 0,
+			content: [{ type: "text", text: "ok" }],
+			...overrides,
+		} as unknown as AssistantMessage;
+	}
+
+	function renderPlain(message: AssistantMessage, width = 80): string[] {
+		return new AssistantMessageComponent(message, true).render(width).map((line) => stripAnsi(line));
+	}
+
+	function headerLines(lines: string[]): string[] {
+		return lines.filter((line) => line.includes("╭─ GSD"));
+	}
+
+	test("direct/legacy message renders the requested model only", () => {
+		const lines = renderPlain(makeAssistant());
+		assert.equal(headerLines(lines).length, 1);
+		const header = headerLines(lines)[0];
+		assert.match(header, /╭─ GSD · gpt-5\.6-luna · /);
+		assert.doesNotMatch(header, /←/);
+		assert.doesNotMatch(header, /dynamic/);
+		assert.equal(header.split("gpt-5.6-luna").length - 1, 1);
+	});
+
+	test("differing responseModel shows effective model first with the requested model retained", () => {
+		const meta = formatAssistantModelMeta(
+			makeAssistant({ model: "openrouter/auto", responseModel: "anthropic/claude-opus-4.7" }),
+		);
+		assert.equal(meta, "anthropic/claude-opus-4.7 ← openrouter/auto");
+		const header = headerLines(
+			renderPlain(makeAssistant({ model: "openrouter/auto", responseModel: "anthropic/claude-opus-4.7" })),
+		)[0];
+		assert.match(header, /anthropic\/claude-opus-4\.7 ← openrouter\/auto/);
+	});
+
+	test("equal, empty, and missing responseModel render one model with no dangling separator", () => {
+		for (const responseModel of ["gpt-5.6-luna", "", "   ", undefined]) {
+			const lines = renderPlain(makeAssistant({ responseModel }));
+			const header = headerLines(lines)[0];
+			assert.doesNotMatch(header, /←/, `responseModel=${String(responseModel)}`);
+			assert.match(header, /gpt-5\.6-luna · /, `responseModel=${String(responseModel)}`);
+		}
+	});
+
+	test("gsd-dynamic light, standard, and heavy tiers are all rendered", () => {
+		for (const tier of ["light", "standard", "heavy"] as const) {
+			const lines = renderPlain(
+				makeAssistant({ modelRouting: { source: "gsd-dynamic", tier, modelDowngraded: false } }),
+			);
+			const header = headerLines(lines)[0];
+			assert.match(header, new RegExp(`\\(dynamic/${tier}\\)`), `tier=${tier}`);
+		}
+	});
+
+	test("tier is shown regardless of modelDowngraded", () => {
+		for (const modelDowngraded of [false, true]) {
+			const lines = renderPlain(
+				makeAssistant({ modelRouting: { source: "gsd-dynamic", tier: "light", modelDowngraded } }),
+			);
+			assert.match(headerLines(lines)[0], /\(dynamic\/light\)/, `modelDowngraded=${String(modelDowngraded)}`);
+		}
+	});
+
+	test("provider-side and GSD routing render together and stay distinct", () => {
+		const lines = renderPlain(
+			makeAssistant({
+				model: "openrouter/auto",
+				responseModel: "anthropic/claude-opus-4.7",
+				modelRouting: { source: "gsd-dynamic", tier: "heavy", modelDowngraded: true },
+			}),
+		);
+		const header = headerLines(lines)[0];
+		assert.match(header, /anthropic\/claude-opus-4\.7 ← openrouter\/auto \(dynamic\/heavy\)/);
+	});
+
+	test("provenance appears exactly once and only on the metadata-bearing segment", () => {
+		const message = makeAssistant({
+			model: "openrouter/auto",
+			responseModel: "anthropic/claude-opus-4.7",
+			modelRouting: { source: "gsd-dynamic", tier: "standard", modelDowngraded: false },
+			content: [
+				{ type: "thinking", thinking: "thinking text" },
+				{ type: "text", text: "visible answer" },
+			],
+		}) as AssistantMessage;
+
+		const ranged = new AssistantMessageComponent(message, false, getMarkdownTheme(), "date-time-iso", {
+			startIndex: 0,
+			endIndex: 0,
+		});
+		const thinkingPlain = ranged.render(80).map((line) => stripAnsi(line)).join("\n");
+		assert.doesNotMatch(thinkingPlain, /dynamic\/standard/);
+		// Non-final segments show the requested model alone while streaming.
+		assert.match(thinkingPlain, /╭─ GSD · openrouter\/auto\s*\n/);
+		assert.doesNotMatch(thinkingPlain, /anthropic\/claude-opus-4\.7/);
+
+		ranged.setShowMetadata(true);
+		const finalPlain = ranged.render(80).map((line) => stripAnsi(line)).join("\n");
+		assert.equal(finalPlain.split("dynamic/standard").length - 1, 1);
+	});
+
+	test("error and aborted messages keep their body behavior and still show provenance", () => {
+		const errorMessage = makeAssistant({
+			stopReason: "error",
+			errorMessage: "provider exploded",
+			modelRouting: { source: "gsd-dynamic", tier: "light", modelDowngraded: false },
+		});
+		const errorLines = renderPlain(errorMessage);
+		assert.match(errorLines.join("\n"), /Error: provider exploded/);
+		assert.match(headerLines(errorLines)[0], /\(dynamic\/light\)/);
+
+		const abortLines = renderPlain(makeAssistant({ stopReason: "aborted" }));
+		assert.match(abortLines.join("\n"), /Operation aborted/);
+		assert.match(headerLines(abortLines)[0], /gpt-5\.6-luna · /);
+	});
+
+	test("narrow widths drop the requested alias and timestamp before the dynamic tier; wide widths keep everything", () => {
+		const message = makeAssistant({
+			model: "openrouter/auto",
+			responseModel: "anthropic/claude-opus-4.7",
+			modelRouting: { source: "gsd-dynamic", tier: "heavy", modelDowngraded: false },
+		});
+
+		for (const width of [30, 60, 120, 200]) {
+			const lines = renderPlain(message, width);
+			assert.equal(headerLines(lines).length, 1, `width=${width}`);
+			for (const line of lines) {
+				assert.ok(visibleWidth(line) <= width, `width=${width} line too wide: ${line}`);
+			}
+		}
+
+		const narrow = headerLines(renderPlain(message, 60))[0];
+		assert.match(narrow, /\(dynamic\/heavy\)/, "tier must survive a constrained width");
+		assert.doesNotMatch(narrow, /openrouter\/auto/, "requested alias drops before the tier");
+
+		const wide = headerLines(renderPlain(message, 200))[0];
+		assert.match(wide, /anthropic\/claude-opus-4\.7 ← openrouter\/auto \(dynamic\/heavy\)/);
+		assert.ok(wide.includes(formatTimestamp(0, "date-time-iso")));
 	});
 });

--- a/packages/gsd-agent-modes/src/modes/interactive/components/assistant-message.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/assistant-message.ts
@@ -1,13 +1,54 @@
 // Project/App: gsd-pi
 // File Purpose: Assistant message rail renderer for interactive terminal sessions.
 import type { AssistantMessage } from "@gsd/pi-ai";
-import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@gsd/pi-tui";
+import { Container, Markdown, type MarkdownTheme, Spacer, Text, visibleWidth } from "@gsd/pi-tui";
 import { getMarkdownTheme, theme } from "@gsd/pi-coding-agent/theme/theme.js";
 import { type TimestampFormat } from "./timestamp.js";
 import { formatTimestamp } from "./timestamp.js";
 import { RenderCache } from "./render-cache.js";
-import { renderPlainSpeakerMessage } from "./transcript-design.js";
+import { CHAT_CORNER_TOP_LEFT, renderPlainSpeakerMessage } from "./transcript-design.js";
 import { asServerToolUse, asWebSearchResult, isToolContentBlock } from "../gsd-content-blocks.js";
+
+const ASSISTANT_HEADER_LABEL = "GSD";
+// Visible prefix of the speaker header line, ahead of the model meta.
+const ASSISTANT_HEADER_PREFIX = `${CHAT_CORNER_TOP_LEFT}${ASSISTANT_HEADER_LABEL} · `;
+
+/**
+ * Model + routing provenance for the assistant header, derived only from the
+ * stored message (ADR-049). Shows the provider-reported effective model first
+ * (`effective ← requested`) when `responseModel` is non-empty and differs,
+ * plus the GSD dynamic-routing tier snapshot when present.
+ */
+export function formatAssistantModelMeta(message: AssistantMessage): string {
+	const requested = typeof message.model === "string" ? message.model.trim() : "";
+	const reported = typeof message.responseModel === "string" ? message.responseModel.trim() : "";
+	const parts: string[] = [];
+	if (requested.length > 0 && reported.length > 0 && reported !== requested) {
+		parts.push(`${reported} ← ${requested}`);
+	} else if (reported.length > 0) {
+		parts.push(reported);
+	} else if (requested.length > 0) {
+		parts.push(requested);
+	}
+	if (message.modelRouting?.source === "gsd-dynamic") {
+		parts.push(`(dynamic/${message.modelRouting.tier})`);
+	}
+	return parts.join(" ");
+}
+
+/** The same meta without the lower-priority requested-alias clause. */
+function formatAssistantModelMetaCompact(message: AssistantMessage): string {
+	const meta = formatAssistantModelMeta(message);
+	const aliasIdx = meta.indexOf(" ← ");
+	if (aliasIdx === -1) return meta;
+	const tail = meta.slice(aliasIdx);
+	const tierIdx = tail.indexOf(" (dynamic/");
+	return tierIdx === -1 ? meta.slice(0, aliasIdx) : meta.slice(0, aliasIdx) + tail.slice(tierIdx);
+}
+
+function headerMetaFits(meta: string, frameWidth: number): boolean {
+	return visibleWidth(ASSISTANT_HEADER_PREFIX) + visibleWidth(meta) <= frameWidth;
+}
 
 export interface ContentRange {
 	startIndex: number;
@@ -290,17 +331,41 @@ export class AssistantMessageComponent extends Container {
 		const frameWidth = Math.max(20, width);
 		const lines = super.render(frameWidth);
 		if (lines.length === 0) return [];
-		const metaParts = [];
-		if (this.lastMessage?.model) metaParts.push(this.lastMessage.model);
-		if (this.showMetadata && this.lastMessage?.timestamp != null) {
-			metaParts.push(formatTimestamp(this.lastMessage.timestamp, this.timestampFormat));
-		}
 		const rendered = renderPlainSpeakerMessage(lines, frameWidth, {
-			label: "GSD",
-			meta: metaParts.length > 0 ? metaParts.join(" · ") : undefined,
+			label: ASSISTANT_HEADER_LABEL,
+			meta: this.renderHeaderMeta(frameWidth),
 			tone: "assistant",
 		});
 		return this.renderCache.set(`${width}:${this.renderVersion}`, rendered);
+	}
+
+	/**
+	 * Header metadata, derived only from the stored message. Provenance
+	 * (effective model, dynamic tier) is metadata: it rides the same
+	 * metadata-bearing final segment as the timestamp, while streaming or
+	 * non-final segments show the requested model alone. At constrained widths
+	 * the effective model and dynamic tier are preserved ahead of
+	 * lower-priority requested-alias and timestamp details (ADR-049); whatever
+	 * remains overflows into the existing hard truncation.
+	 */
+	private renderHeaderMeta(frameWidth: number): string | undefined {
+		if (!this.lastMessage?.model) return undefined;
+		const provenanceMeta = this.showMetadata ? formatAssistantModelMeta(this.lastMessage) : "";
+		const baseMeta = this.showMetadata ? provenanceMeta : this.lastMessage.model;
+		const timestamp =
+			this.showMetadata && this.lastMessage?.timestamp != null
+				? formatTimestamp(this.lastMessage.timestamp, this.timestampFormat)
+				: undefined;
+		const compactMeta = this.showMetadata ? formatAssistantModelMetaCompact(this.lastMessage) : baseMeta;
+		const candidates = [
+			baseMeta && timestamp ? `${baseMeta} · ${timestamp}` : "",
+			baseMeta,
+			compactMeta,
+		];
+		for (const candidate of candidates) {
+			if (candidate && headerMetaFits(candidate, frameWidth)) return candidate;
+		}
+		return baseMeta || undefined;
 	}
 
 	private clearRenderCache(): void {

--- a/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/interactive-chat-render.test.ts
@@ -3,9 +3,13 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentMessage } from "@gsd/pi-agent-core";
 import type { AssistantMessage } from "@gsd/pi-ai";
 import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
+import { findMostRecentSession, loadEntriesFromFile, SessionManager } from "@gsd/pi-coding-agent/core/session-manager.js";
 import { Container } from "@gsd/pi-tui";
 import stripAnsi from "strip-ansi";
 
@@ -167,5 +171,103 @@ describe("interactive chat replay: aborted turns preserve completed tool results
 			/Operation aborted/,
 			"a tool with no result on an aborted turn should render as interrupted",
 		);
+	});
+});
+
+describe("model attribution survives session persistence and replay (ADR-049)", () => {
+	function routedAssistant(index: number, overrides: Record<string, unknown>): AgentMessage {
+		return {
+			id: `a-routed-${index}`,
+			role: "assistant",
+			provider: "openrouter",
+			model: "openrouter/auto",
+			timestamp: index,
+			stopReason: "stop",
+			content: [{ type: "text", text: `Routed answer ${index}` }],
+			...overrides,
+		} as unknown as AgentMessage;
+	}
+
+	function usage(): Record<string, unknown> {
+		return {
+			input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+	}
+
+	test("each reopened message keeps its own original attribution across a later model change", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "model-routing-replay-"));
+		try {
+			const session = SessionManager.create(process.cwd(), tempDir);
+			session.appendMessage(
+				routedAssistant(1, {
+					responseModel: "anthropic/claude-opus-4.7",
+					modelRouting: { source: "gsd-dynamic", tier: "heavy", modelDowngraded: true },
+				}) as AssistantMessage,
+			);
+			session.appendModelChange("openrouter", "gpt-5.6-luna");
+			session.appendMessage(
+				routedAssistant(2, {
+					model: "gpt-5.6-luna",
+					modelRouting: { source: "gsd-dynamic", tier: "light", modelDowngraded: false },
+				}) as AssistantMessage,
+			);
+
+			const sessionFile = findMostRecentSession(tempDir);
+			assert.ok(sessionFile, "session file must exist on disk");
+
+			// No schema-version bump: the additive field rides the v3 format.
+			const entries = loadEntriesFromFile(sessionFile);
+			const header = entries.find((e) => e.type === "session") as { version?: number };
+			assert.equal(header.version, 3);
+			const stored = entries.filter((e) => e.type === "message").map((e) => (e as { message: AssistantMessage }).message);
+			assert.deepEqual(stored[0].modelRouting, { source: "gsd-dynamic", tier: "heavy", modelDowngraded: true });
+			assert.deepEqual(stored[1].modelRouting, { source: "gsd-dynamic", tier: "light", modelDowngraded: false });
+
+			const reopened = SessionManager.open(sessionFile);
+			const host = createHost();
+			renderSessionContext(host, reopened.buildSessionContext());
+			const rendered = stripAnsi(host.chatContainer.render(120).join("\n"));
+
+			assert.match(rendered, /anthropic\/claude-opus-4\.7 ← openrouter\/auto \(dynamic\/heavy\)/);
+			assert.match(rendered, /gpt-5\.6-luna \(dynamic\/light\)/);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("legacy v3 JSONL messages without modelRouting render unchanged", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "model-routing-legacy-"));
+		try {
+			const sessionFile = join(tempDir, "legacy.jsonl");
+			const legacyMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "legacy answer" }],
+				api: "openai-completions",
+				provider: "openrouter",
+				model: "openrouter/auto",
+				usage: usage(),
+				stopReason: "stop",
+				timestamp: 1,
+			};
+			writeFileSync(
+				sessionFile,
+				'{"type":"session","version":3,"id":"legacy","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}\n' +
+					`${JSON.stringify({ type: "message", id: "1", parentId: null, timestamp: "2026-01-01T00:00:01.000Z", message: legacyMessage })}\n`,
+			);
+			assert.equal(readFileSync(sessionFile, "utf8").includes("modelRouting"), false);
+
+			const entries = loadEntriesFromFile(sessionFile);
+			const messages = entries.filter((e) => e.type === "message").map((e) => (e as { message: AgentMessage }).message);
+			const host = createHost();
+			renderSessionContext(host, { messages } as any);
+			const rendered = stripAnsi(host.chatContainer.render(120).join("\n"));
+
+			assert.match(rendered, /╭─ GSD · openrouter\/auto · /);
+			assert.doesNotMatch(rendered, /←/);
+			assert.doesNotMatch(rendered, /dynamic/);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -320,6 +320,25 @@ export interface UserMessage {
 	timestamp: number; // Unix timestamp in milliseconds
 }
 
+/** GSD pre-request dynamic-routing provenance recorded per assistant message (ADR-049). */
+export type ModelRoutingSource = "gsd-dynamic";
+
+/** Complexity tier of a GSD dynamic-routing decision. */
+export type ModelRoutingTier = "light" | "standard" | "heavy";
+
+/**
+ * GSD dynamic-routing snapshot in effect when an assistant message started
+ * (ADR-049). Values are copied at capture time; provider-side routing is
+ * represented by `responseModel` and is never duplicated here.
+ */
+export interface ModelRouting {
+	source: ModelRoutingSource;
+	/** Unit classification in effect when the assistant message started. */
+	tier: ModelRoutingTier;
+	/** True when dynamic routing selected a cheaper model than the configured primary. */
+	modelDowngraded: boolean;
+}
+
 export interface AssistantMessage {
 	role: "assistant";
 	content: (TextContent | ThinkingContent | ToolCall | ServerToolUse | WebSearchResult)[];
@@ -327,6 +346,7 @@ export interface AssistantMessage {
 	provider: Provider;
 	model: string;
 	responseModel?: string; // Concrete `chunk.model` when different from the requested `model` (e.g. OpenRouter `auto` -> `anthropic/...`)
+	modelRouting?: ModelRouting; // GSD dynamic-routing provenance in effect when this response started (ADR-049).
 	responseId?: string; // Provider-specific response/message identifier when the upstream API exposes one
 	diagnostics?: AssistantMessageDiagnostic[]; // Redacted provider/runtime diagnostics for failures and recoveries.
 	usage: Usage;

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -20,6 +20,7 @@ import { getIsolationMode, resolveEffectiveUnitIsolationMode } from "../preferen
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
 import {
+  autoSession,
   clearAutoCompletionStopInProgress,
   clearToolInvocationError,
   getAutoRuntimeSnapshot,
@@ -89,6 +90,7 @@ import { resolveWorkflowToolBasePath } from "./dynamic-tools.js";
 import { getRequiredWorkflowToolsForUnit } from "../unit-tool-contracts.js";
 import { flushAllManifests } from "../workflow-manifest.js";
 import { clearUnitHarnessAbort, recordUnitHarnessAbort, type UnitHarnessAbortRecord } from "../unit-runtime.js";
+import { captureAssistantRoutingStart, clearPendingModelRouting, consumeAssistantRoutingEnd } from "../model-attribution.js";
 import { clearNativeMilestoneStatusSourceRevisions } from "./query-tools.js";
 
 let approvalQuestionAbortInFlight = false;
@@ -1180,6 +1182,7 @@ export function registerHooks(
     resetWriteGateState(basePath);
     resetToolCallLoopGuard();
     clearNativeMilestoneStatusSourceRevisions();
+    clearPendingModelRouting();
     await applyToolCallLoopGuardConfig(basePath);
     approvalQuestionAbortInFlight = false;
     clearDeferredApprovalGate();
@@ -1275,6 +1278,7 @@ export function registerHooks(
     resetWriteGateState(basePath);
     resetToolCallLoopGuard();
     clearNativeMilestoneStatusSourceRevisions();
+    clearPendingModelRouting();
     await applyToolCallLoopGuardConfig(basePath);
     clearDeferredApprovalGate();
     clearDeferredDestructiveConfirmationPause();
@@ -1397,6 +1401,7 @@ export function registerHooks(
     recordRetryableTurnAbort(event);
     resetToolCallLoopGuard();
     resetPendingGatePauseGuard();
+    clearPendingModelRouting();
     await resetAskUserQuestionsTurnCache();
     const { handleAgentEnd } = await import("./agent-end-recovery.js");
     const agentEndBasePath = contextBasePath(ctx);
@@ -1434,12 +1439,23 @@ export function registerHooks(
     }
   });
 
+  // ADR-049 (#2208): snapshot the auto unit's routing at assistant message
+  // start so a unit transition mid-stream cannot relabel the in-flight
+  // response, then attach it on the matching message_end.
+  pi.on("message_start", async (event) => {
+    captureAssistantRoutingStart(event.message, autoSession.currentUnitRouting, isAutoActive());
+  });
+
   pi.on("message_end", async (event) => {
     const { suppressTerminalDeletedWorktreeMessageEnd } = await import("./agent-end-recovery.js");
     suppressTerminalDeletedWorktreeMessageEnd(event);
     if (isAutoActive()) {
       const { sanitizePrematureCloseoutMessageEnd } = await import("../auto-closeout-messaging.js");
       sanitizePrematureCloseoutMessageEnd(event);
+    }
+    const attributed = consumeAssistantRoutingEnd(event.message);
+    if (attributed) {
+      return { message: attributed };
     }
   });
 
@@ -1601,6 +1617,7 @@ export function registerHooks(
   });
 
   pi.on("session_shutdown", async (_event, ctx: ExtensionContext) => {
+    clearPendingModelRouting();
     const { isParallelActive, shutdownParallel } = await import("../parallel-orchestrator.js");
     if (isParallelActive()) {
       try {

--- a/src/resources/extensions/gsd/model-attribution.ts
+++ b/src/resources/extensions/gsd/model-attribution.ts
@@ -1,0 +1,70 @@
+// Project/App: gsd-pi
+// File Purpose: Per-message GSD dynamic-routing attribution (ADR-049, #2208).
+
+import type { ModelRouting } from "@gsd/pi-ai";
+
+/**
+ * Shape shared with `AutoSession.currentUnitRouting`
+ * (`{ tier: string; modelDowngraded: boolean }`). Read once at assistant
+ * message_start and copied as values, so a unit transition while the message
+ * is still streaming cannot relabel it.
+ */
+export interface UnitRoutingSnapshot {
+  tier: string;
+  modelDowngraded: boolean;
+}
+
+const VALID_TIERS: readonly string[] = ["light", "standard", "heavy"];
+
+// Agent assistant lifecycles are serialized, so a single pending snapshot is
+// sufficient. A WeakMap keyed by message identity is not safe: the streaming
+// message_start object and the finalized message_end object are not guaranteed
+// to be the same object.
+let pendingRouting: UnitRoutingSnapshot | null = null;
+
+/**
+ * Capture the routing snapshot in effect when an assistant message starts.
+ * Non-assistant messages never touch pending state; an assistant message that
+ * starts without dynamic-routing state clears any stale snapshot.
+ */
+export function captureAssistantRoutingStart(
+  message: { role?: unknown } | null | undefined,
+  currentRouting: UnitRoutingSnapshot | null | undefined,
+  autoActive: boolean,
+): void {
+  if (!message || message.role !== "assistant") return;
+  if (!autoActive || !currentRouting || !VALID_TIERS.includes(currentRouting.tier)) {
+    pendingRouting = null;
+    return;
+  }
+  pendingRouting = {
+    tier: currentRouting.tier,
+    modelDowngraded: currentRouting.modelDowngraded === true,
+  };
+}
+
+/**
+ * Consume the pending snapshot for an assistant message_end. Returns a
+ * same-role replacement carrying `modelRouting`, or undefined when the
+ * message must not be decorated. Pending state is always cleared after
+ * consumption so it cannot leak to another turn.
+ */
+export function consumeAssistantRoutingEnd<T extends { role?: unknown }>(
+  message: T | null | undefined,
+): (T & { modelRouting: ModelRouting }) | undefined {
+  if (!message || message.role !== "assistant") return undefined;
+  const snapshot = pendingRouting;
+  pendingRouting = null;
+  if (!snapshot) return undefined;
+  const modelRouting: ModelRouting = {
+    source: "gsd-dynamic",
+    tier: snapshot.tier as ModelRouting["tier"],
+    modelDowngraded: snapshot.modelDowngraded,
+  };
+  return { ...message, modelRouting };
+}
+
+/** Drop any pending snapshot (session switch/reset/end boundaries). */
+export function clearPendingModelRouting(): void {
+  pendingRouting = null;
+}

--- a/src/resources/extensions/gsd/tests/model-attribution.test.ts
+++ b/src/resources/extensions/gsd/tests/model-attribution.test.ts
@@ -1,0 +1,100 @@
+// Project/App: gsd-pi
+// File Purpose: Tests for per-message GSD dynamic-routing attribution (ADR-049, #2208).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  captureAssistantRoutingStart,
+  clearPendingModelRouting,
+  consumeAssistantRoutingEnd,
+} from "../model-attribution.ts";
+
+function assistant(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { role: "assistant", model: "gpt-5.6-luna", ...overrides };
+}
+
+test("a message that starts under light routing keeps the light snapshot even after the unit escalates", () => {
+  clearPendingModelRouting();
+  const mutableRouting = { tier: "light", modelDowngraded: false };
+  captureAssistantRoutingStart(assistant(), mutableRouting, true);
+  // Unit transition while the message is still streaming.
+  mutableRouting.tier = "heavy";
+  mutableRouting.modelDowngraded = true;
+
+  const end = assistant({ stopReason: "stop" });
+  const attributed = consumeAssistantRoutingEnd(end);
+  assert.deepEqual(attributed?.modelRouting, { source: "gsd-dynamic", tier: "light", modelDowngraded: false });
+});
+
+test("the next assistant start consumes the updated unit routing", () => {
+  clearPendingModelRouting();
+  captureAssistantRoutingStart(assistant(), { tier: "heavy", modelDowngraded: true }, true);
+  const attributed = consumeAssistantRoutingEnd(assistant());
+  assert.deepEqual(attributed?.modelRouting, { source: "gsd-dynamic", tier: "heavy", modelDowngraded: true });
+});
+
+test("a non-auto assistant message receives no field", () => {
+  clearPendingModelRouting();
+  captureAssistantRoutingStart(assistant(), { tier: "light", modelDowngraded: false }, false);
+  assert.equal(consumeAssistantRoutingEnd(assistant()), undefined);
+
+  captureAssistantRoutingStart(assistant(), null, true);
+  assert.equal(consumeAssistantRoutingEnd(assistant()), undefined);
+});
+
+test("user and toolResult messages are never decorated and never consume pending state", () => {
+  clearPendingModelRouting();
+  captureAssistantRoutingStart(assistant(), { tier: "standard", modelDowngraded: false }, true);
+
+  const userStart = { role: "user", content: "hi" };
+  captureAssistantRoutingStart(userStart, { tier: "standard", modelDowngraded: false }, true);
+  assert.equal(consumeAssistantRoutingEnd(userStart), undefined);
+
+  const toolResultStart = { role: "toolResult", content: [] };
+  assert.equal(consumeAssistantRoutingEnd(toolResultStart), undefined);
+
+  const attributed = consumeAssistantRoutingEnd(assistant());
+  assert.deepEqual(attributed?.modelRouting, { source: "gsd-dynamic", tier: "standard", modelDowngraded: false });
+});
+
+test("a missing message_end followed by a boundary clear cannot leak attribution to another turn", () => {
+  clearPendingModelRouting();
+  captureAssistantRoutingStart(assistant(), { tier: "light", modelDowngraded: false }, true);
+  clearPendingModelRouting();
+  assert.equal(consumeAssistantRoutingEnd(assistant()), undefined);
+});
+
+test("consumption clears pending state: a second message_end is not decorated", () => {
+  clearPendingModelRouting();
+  captureAssistantRoutingStart(assistant(), { tier: "light", modelDowngraded: false }, true);
+  assert.ok(consumeAssistantRoutingEnd(assistant()));
+  assert.equal(consumeAssistantRoutingEnd(assistant()), undefined);
+});
+
+test("a routing snapshot with an unknown tier is not attached", () => {
+  clearPendingModelRouting();
+  captureAssistantRoutingStart(assistant(), { tier: "ultra", modelDowngraded: false }, true);
+  assert.equal(consumeAssistantRoutingEnd(assistant()), undefined);
+});
+
+test("the replacement keeps the assistant role and all original fields", () => {
+  clearPendingModelRouting();
+  captureAssistantRoutingStart(assistant(), { tier: "light", modelDowngraded: false }, true);
+  const end = assistant({
+    provider: "openrouter",
+    model: "openrouter/auto",
+    responseModel: "anthropic/claude-opus-4.7",
+    stopReason: "stop",
+    usage: { totalTokens: 5 },
+  });
+  const attributed = consumeAssistantRoutingEnd(end);
+  assert.equal(attributed?.role, "assistant");
+  assert.equal(attributed?.provider, "openrouter");
+  assert.equal(attributed?.model, "openrouter/auto");
+  assert.equal(attributed?.responseModel, "anthropic/claude-opus-4.7");
+  assert.equal(attributed?.stopReason, "stop");
+  assert.deepEqual(attributed?.usage, { totalTokens: 5 });
+  // The original message object is not mutated into the replacement.
+  assert.equal("modelRouting" in end, false);
+});


### PR DESCRIPTION
## TL;DR

**What:** Every assistant header becomes a durable per-turn record of the model and routing that produced it, rendered from the stored message.
**Why:** Dynamic-routing tier lived only in mutable auto-session state and provider-reported `responseModel` was never shown, so history could not explain past responses (#2208).
**How:** Add an optional `modelRouting` snapshot to `AssistantMessage`, capture it at `message_start` and attach it at `message_end` in the GSD bootstrap, and render it in the assistant header.

## What

- `packages/pi-ai/src/types.ts` — additive optional `AssistantMessage.modelRouting` (`{ source: "gsd-dynamic"; tier: "light" | "standard" | "heavy"; modelDowngraded: boolean }`) with exported `ModelRouting` / `ModelRoutingSource` / `ModelRoutingTier` types, per ADR-049. No existing field changed.
- `src/resources/extensions/gsd/model-attribution.ts` (new) — pure capture/consume helpers: snapshot `AutoSession.currentUnitRouting` at assistant `message_start` (copied as values, so a mid-stream unit transition cannot relabel the response), attach on the matching `message_end`, clear after consumption and on session switch/reset/end boundaries. Non-assistant and non-auto messages are never decorated.
- `src/resources/extensions/gsd/bootstrap/register-hooks.ts` — registers the `message_start` snapshot hook, consumes the snapshot in the existing `message_end` handler (after the unchanged deleted-worktree suppression and premature-closeout sanitation), and clears pending state at `session_start`, `session_switch`, `agent_end`, and `session_shutdown`.
- `packages/gsd-agent-modes/src/modes/interactive/components/assistant-message.ts` — header meta derived only from the stored message: effective model first (`responseModel ?? model`), requested model retained as `effective ← requested` when they differ, `(dynamic/<tier>)` appended when `modelRouting` is present. At constrained widths the timestamp, then the requested-alias clause, drop before the effective model and tier. Provenance rides the same metadata-bearing final segment as the timestamp, so split thinking/text/tool responses show it exactly once and streaming shows the requested model alone. Messages without the field render exactly as before.

## Why

GSD dynamic routing selects a model and tier per auto unit, but that decision lived only in `AutoSession.currentUnitRouting` and was overwritten at each unit start — reload, branch review, and model-quality comparison were ambiguous. Separately, providers like OpenRouter `auto` report a concrete upstream model in `responseModel`, which the header ignored. A historical turn must never be relabeled from whatever routing state is active now.

Fixes #2208
Refs #2078
Refs ADR-049 (docs/dev/ADR-049-model-attribution-field.md)

## How

Per the ADR: the snapshot is captured at `message_start` because reading the mutable field only at end (or render time) can attribute a unit transition that happened mid-stream to the wrong response; a single pending snapshot with explicit boundary cleanup is sufficient because agent assistant lifecycles are serialized; `model`/`responseModel` remain the only model identities (the routing object never duplicates them); the field is optional so old sessions, direct responses, and non-auto messages stay valid with no schema migration or backfill. Header rendering consults only the stored message — never the current model, registry, preferences, or auto-session state — so live finalization and persisted replay produce identical header metadata.

**Public API/CLI/config/file structure:** yes — this adds an optional field and new exported types to the shared `AssistantMessage` contract in `@gsd/pi-ai`. It is additive and backward-compatible; no provider behavior, CLI, config, or session-format change.

## Tests

- `pnpm --filter @gsd/pi-ai test` — 358 passed (includes the `openai-completions-response-model.test.ts` provider semantic guard).
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/model-attribution.test.ts` — 8 passed: capture-at-start beats a mid-stream unit transition, next-start consumes updated routing, non-auto/user/toolResult never decorated, missing-end + boundary clears cannot leak, double-end consumes once, unknown tier rejected, replacement preserves role and fields.
- `... --test src/modes/interactive/components/__tests__/assistant-message-design.test.ts` — 12 passed: legacy/direct header unchanged, differing/equal/empty/missing `responseModel`, all three tiers, downgraded true/false, provider+GSD routing together, provenance once on the final segment, error/aborted bodies, and narrow/wide width safety (`visibleWidth(line) <= width`, tier preserved ahead of alias and timestamp).
- `... --test src/modes/interactive/interactive-chat-render.test.ts` — 6 passed: two routed messages appended across a model change survive persist → reopen → `renderSessionContext()` with their own attribution, no session-version bump (v3 retained), and a legacy v3 JSONL message without `modelRouting` renders unchanged.
- `... --test src/resources/extensions/gsd/tests/auto-closeout-messaging.test.ts src/resources/extensions/gsd/tests/provider-errors.test.ts` — 99 passed (existing `message_end` sanitation intact).
- `pnpm run typecheck:extensions`, `pnpm run build:pi-ai`, `@gsd/agent-modes` build — clean. `pnpm run verify:fast` — all checks passed.

AI-assisted: yes