### PR TITLE
fix(gsd): stop launch cleanup from deleting user-owned skill directories

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -795,16 +795,59 @@ function cleanupBundledSkillsFromEcosystemDir(): void {
 
   for (const entry of readdirSync(bundledSkillsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue
+    const bundledSkillDir = join(bundledSkillsDir, entry.name)
     const targetPath = join(ecosystemDir, entry.name)
     if (!existsSync(targetPath)) continue
 
     try {
       if (lstatSync(targetPath).isSymbolicLink()) continue
+      // Only reclaim byte-exact bundled copies; anything else in the shared
+      // ecosystem dir is user-owned and must never be deleted (#2286).
+      if (!isExactDirectoryCopy(targetPath, bundledSkillDir)) {
+        console.error(`[gsd] WARN: Left user-owned skill in place: ${targetPath} (only exact unmodified bundled skill copies are reclaimed from ${ecosystemDir})`)
+        continue
+      }
       makeTreeWritable(targetPath)
       rmSync(targetPath, { recursive: true, force: true })
     } catch {
       // Non-fatal: never let cleanup of the shared ecosystem dir block startup.
     }
+  }
+}
+
+/**
+ * True only when candidateDir has the same relative file set as referenceDir
+ * with byte-identical file contents. Entry types are checked with lstat
+ * semantics (Dirents), so symlinks on either side are never followed and
+ * non-regular entries (FIFOs, sockets, devices) are rejected before any read —
+ * reading a FIFO would block forever. Any read error or type mismatch counts
+ * as NOT an exact copy: deletion is never allowed on uncertainty.
+ */
+function isExactDirectoryCopy(candidateDir: string, referenceDir: string): boolean {
+  try {
+    const candidateEntries = readdirSync(candidateDir, { withFileTypes: true })
+    const referenceEntries = readdirSync(referenceDir, { withFileTypes: true })
+    if (candidateEntries.length !== referenceEntries.length) return false
+
+    const referenceEntriesByName = new Map(referenceEntries.map((entry) => [entry.name, entry]))
+    for (const candidateEntry of candidateEntries) {
+      const referenceEntry = referenceEntriesByName.get(candidateEntry.name)
+      if (!referenceEntry) return false
+      if (candidateEntry.isSymbolicLink() || referenceEntry.isSymbolicLink()) return false
+      if (candidateEntry.isDirectory() !== referenceEntry.isDirectory()) return false
+
+      const candidatePath = join(candidateDir, candidateEntry.name)
+      const referencePath = join(referenceDir, referenceEntry.name)
+      if (candidateEntry.isDirectory()) {
+        if (!isExactDirectoryCopy(candidatePath, referencePath)) return false
+        continue
+      }
+      if (!candidateEntry.isFile() || !referenceEntry.isFile()) return false
+      if (!readFileSync(candidatePath).equals(readFileSync(referencePath))) return false
+    }
+    return true
+  } catch {
+    return false
   }
 }
 

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, parse } from "node:path";
 import { tmpdir } from "node:os";
@@ -352,6 +353,237 @@ test("initResources syncs bundled skills to the GSD agent dir by default", async
     existsSync(join(tmp, ".agents", "skills", "lint", "SKILL.md")),
     false,
     "initResources should not write bundled skills to ~/.agents/skills by default",
+  );
+});
+
+// The bundled agent-browser skill has nested directories, so an exact copy of
+// it exercises the recursive comparison in the ecosystem-dir cleanup (#2286).
+function bundledAgentBrowserSkillDir(): string {
+  return join(bundledSkillsDir(), "agent-browser");
+}
+
+test("initResources leaves a user-modified same-named skill in ~/.agents/skills untouched", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-ecosystem-user-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const ecosystemSkillDir = join(tmp, ".agents", "skills", "agent-browser");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  t.after(() => {
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  cpSync(bundledAgentBrowserSkillDir(), ecosystemSkillDir, { recursive: true });
+  const userContent = "---\nname: agent-browser\ndescription: my local tweaks\n---\n";
+  writeFileSync(join(ecosystemSkillDir, "SKILL.md"), userContent);
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    existsSync(ecosystemSkillDir),
+    true,
+    "a user-modified same-named skill must not be deleted from ~/.agents/skills",
+  );
+  assert.equal(
+    readFileSync(join(ecosystemSkillDir, "SKILL.md"), "utf-8"),
+    userContent,
+    "the user's modified SKILL.md must survive initResources",
+  );
+  assert.equal(
+    existsSync(join(ecosystemSkillDir, "references", "commands.md")),
+    true,
+    "the user's nested skill files must survive initResources",
+  );
+});
+
+test("initResources reclaims an exact bundled skill copy from ~/.agents/skills", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-ecosystem-exact-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const ecosystemSkillDir = join(tmp, ".agents", "skills", "agent-browser");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  t.after(() => {
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  cpSync(bundledAgentBrowserSkillDir(), ecosystemSkillDir, { recursive: true });
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    existsSync(ecosystemSkillDir),
+    false,
+    "an exact unmodified bundled skill copy should be reclaimed from ~/.agents/skills",
+  );
+});
+
+test("initResources leaves a symlinked ecosystem skill entry untouched", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-ecosystem-symlink-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const symlinkTargetDir = join(tmp, "my-own-skills", "agent-browser");
+  const ecosystemSkillDir = join(tmp, ".agents", "skills", "agent-browser");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  t.after(() => {
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  cpSync(bundledAgentBrowserSkillDir(), symlinkTargetDir, { recursive: true });
+  mkdirSync(join(tmp, ".agents", "skills"), { recursive: true });
+  symlinkSync(symlinkTargetDir, ecosystemSkillDir);
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    existsSync(ecosystemSkillDir),
+    true,
+    "a symlinked ecosystem skill entry must not be removed",
+  );
+  assert.equal(
+    lstatSync(ecosystemSkillDir).isSymbolicLink(),
+    true,
+    "the symlink itself must survive initResources",
+  );
+  assert.equal(
+    existsSync(join(symlinkTargetDir, "SKILL.md")),
+    true,
+    "the symlink target directory must survive initResources",
+  );
+});
+
+test("initResources emits a diagnostic when skipping a user-modified ecosystem skill", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-ecosystem-warn-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const ecosystemSkillDir = join(tmp, ".agents", "skills", "lint");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  const consoleErrors = t.mock.method(console, "error", () => {});
+
+  t.after(() => {
+    consoleErrors.mock.restore();
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  cpSync(join(bundledSkillsDir(), "lint"), ecosystemSkillDir, { recursive: true });
+  writeFileSync(join(ecosystemSkillDir, "SKILL.md"), "user modified\n");
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    existsSync(ecosystemSkillDir),
+    true,
+    "the user-modified skill must survive initResources",
+  );
+  assert.ok(
+    consoleErrors.mock.calls.some((call) =>
+      call.arguments.some((arg) => {
+        const message = String(arg);
+        return message.includes("WARN") && message.includes(ecosystemSkillDir);
+      }),
+    ),
+    `initResources should emit a WARN diagnostic naming ${ecosystemSkillDir}`,
+  );
+});
+
+test("initResources leaves an ecosystem skill with a nested symlink entry untouched", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-ecosystem-nested-link-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const ecosystemSkillDir = join(tmp, ".agents", "skills", "agent-browser");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  const consoleErrors = t.mock.method(console, "error", () => {});
+
+  t.after(() => {
+    consoleErrors.mock.restore();
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  cpSync(bundledAgentBrowserSkillDir(), ecosystemSkillDir, { recursive: true });
+  // Same relative file set, and the link target is byte-identical to the
+  // bundled file — only the entry itself being a symlink makes it user-owned.
+  const linkedName = join("references", "commands.md");
+  rmSync(join(ecosystemSkillDir, linkedName));
+  symlinkSync(
+    join(bundledAgentBrowserSkillDir(), linkedName),
+    join(ecosystemSkillDir, linkedName),
+  );
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    existsSync(ecosystemSkillDir),
+    true,
+    "a skill tree containing a nested symlink must not be deleted from ~/.agents/skills",
+  );
+  assert.equal(
+    lstatSync(join(ecosystemSkillDir, linkedName)).isSymbolicLink(),
+    true,
+    "the nested symlink itself must survive initResources",
+  );
+  assert.ok(
+    consoleErrors.mock.calls.some((call) =>
+      call.arguments.some((arg) => String(arg).includes(ecosystemSkillDir)),
+    ),
+    `initResources should emit a WARN diagnostic naming ${ecosystemSkillDir}`,
+  );
+});
+
+test("initResources leaves an ecosystem skill containing a FIFO untouched without hanging", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("mkfifo is not available on Windows");
+    return;
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-ecosystem-fifo-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const ecosystemSkillDir = join(tmp, ".agents", "skills", "agent-browser");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  const consoleErrors = t.mock.method(console, "error", () => {});
+
+  t.after(() => {
+    consoleErrors.mock.restore();
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  cpSync(bundledAgentBrowserSkillDir(), ecosystemSkillDir, { recursive: true });
+  // Same relative file set as the bundle, but the entry is a FIFO — reading it
+  // would block forever, so the compare must reject it before any read.
+  const fifoRelPath = join("references", "commands.md");
+  const fifoPath = join(ecosystemSkillDir, fifoRelPath);
+  rmSync(fifoPath);
+  const mkfifo = spawnSync("mkfifo", [fifoPath]);
+  assert.equal(mkfifo.status, 0, `mkfifo failed: ${mkfifo.stderr?.toString()}`);
+  assert.equal(statSync(fifoPath).isFIFO(), true, "test setup should create a FIFO");
+
+  const { initResources } = await import("../resource-loader.ts");
+  initResources(fakeAgentDir);
+
+  assert.equal(
+    existsSync(ecosystemSkillDir),
+    true,
+    "a skill tree containing a FIFO must not be deleted from ~/.agents/skills",
+  );
+  assert.equal(
+    statSync(fifoPath).isFIFO(),
+    true,
+    "the FIFO itself must survive initResources",
+  );
+  assert.ok(
+    consoleErrors.mock.calls.some((call) =>
+      call.arguments.some((arg) => String(arg).includes(ecosystemSkillDir)),
+    ),
+    `initResources should emit a WARN diagnostic naming ${ecosystemSkillDir}`,
   );
 });
 
@@ -830,7 +1062,7 @@ test("initResources removes exact bundled skill orphans from the ecosystem dir",
   );
 });
 
-test("initResources removes non-symlink ecosystem skill name collisions", async (t) => {
+test("initResources preserves user-owned non-symlink ecosystem skill name collisions", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-skills-ambiguous-"));
   const fakeAgentDir = join(tmp, ".gsd", "agent");
   const ecosystemLintDir = join(tmp, ".agents", "skills", "lint");
@@ -852,8 +1084,13 @@ test("initResources removes non-symlink ecosystem skill name collisions", async 
 
   assert.equal(
     existsSync(ecosystemLintFile),
-    false,
-    "non-symlink ecosystem skill collisions should be removed",
+    true,
+    "user-owned ecosystem skill collisions that are not exact bundled copies must be preserved",
+  );
+  assert.equal(
+    readFileSync(ecosystemLintFile, "utf-8").includes("# Custom lint"),
+    true,
+    "the user-owned collision's content must be untouched",
   );
 });
 


### PR DESCRIPTION
## TL;DR

**What:** launch cleanup now reclaims an entry in `~/.agents/skills/` only when it is a byte-exact copy of the bundled skill; anything else is left in place with a WARN diagnostic naming the path.
**Why:** the cleanup `rmSync`-deleted any same-named non-symlink directory on every launch — including user-authored and user-modified skills — directly contradicting its own contract that only exact bundled copies are reclaimed (#2286; reproduced three directories destroyed per run).
**How:** a recursive exact-copy compare guards the deletion; the walk never follows symlinks and never reads non-regular files.

Closes #2286

## What

- `src/resource-loader.ts`: the non-symlink branch of `cleanupBundledSkillsFromEcosystemDir` verifies `isExactDirectoryCopy(target, bundled)` before `rmSync`; non-exact entries emit `[gsd] WARN: Left user-owned skill in place: <path>`. The compare walks both trees with lstat-semantics `Dirent` predicates — symlinks on either side are rejected, directories recurse, and only regular files are byte-compared (a crafted FIFO can no longer hang startup; special entries are rejected before any read). Read errors compare as not-exact: deletion never happens on uncertainty. Exact copies are still reclaimed, so stale duplicates from pre-managed installs are cleaned exactly as before.
- `src/tests/resource-loader.test.ts`: five new/rewritten tests — user-modified copy survives (failing-first; the old test asserted the deletion and was deliberately rewritten per the issue), exact copy still reclaimed, nested symlink survives, a FIFO in the tree neither hangs nor is deleted (POSIX-only), and the WARN names the path.

## Why

Silent `rm -rf` of a user directory on launch is the worst failure mode a cleanup can have; the code's own comment promised the opposite behavior. Byte-exactness is the ownership proof the comment implies: an exact copy is redundant with the bundled tree, anything else is user-owned.

## How

Adversarial validation covered nested directories, extra/missing files, single-byte changes, unreadable files, nested symlinks, and a real FIFO — every non-exact shape survives with the diagnostic, exact shapes are reclaimed, and no read happens on a non-regular entry (the FIFO's pre-fix hang was reproduced and is structurally eliminated). Root-level symlinks keep their existing silent skip. The pre-existing test asserting deletion of non-symlink collisions was rewritten to assert survival — that reversal is the issue's requested behavior change. Blast radius: the compare is private to this one cleanup path; every other `rmSync` in the file operates strictly under the managed `~/.gsd/agent/` tree.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).