### PR TITLE
fix(gsd): quoted shell arguments no longer feed the verify prose heuristic

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -1116,6 +1116,61 @@ test("validateVerificationCommand allows grep patterns with quoted pipes", () =>
   assert.equal(validateVerificationCommand("grep -c '^## SectionA\\|^### Sub1\\|^### Sub2' notes.md").ok, true);
 });
 
+test("isLikelyCommand: quoted segments are shell data, not prose (issue #2290)", () => {
+  // The reporter's verify: the quoted grep pattern contains prose marker
+  // words ("from", "the"), but quoted text is shell data — it must not flip
+  // a runnable command to prose.
+  assert.equal(
+    isLikelyCommand("bash scripts/hello-seat.sh && test -x scripts/hello-seat.sh && grep -q 'hello from the localnodes seat' scripts/hello-seat.sh"),
+    true,
+  );
+  // Minimal case: the quoted segment is the only content beside the prefix.
+  assert.equal(isLikelyCommand("grep -q 'hello from the localnodes seat' scripts/hello-seat.sh"), true);
+  assert.equal(isLikelyCommand('grep -q "the pattern contains that" file.txt'), true);
+});
+
+test("isLikelyCommand: unquoted prose after a command word is still rejected (issue #2290 control)", () => {
+  assert.equal(isLikelyCommand("bash scripts/x.sh and then verify the outcome manually"), false);
+});
+
+test("isLikelyCommand: escaped quote inside double quotes stays shell data (issue #2290)", () => {
+  // `\"` does not close the double-quoted segment, so "and the rest" stays
+  // quoted data instead of leaking into the prose heuristic.
+  assert.equal(isLikelyCommand('grep -q "say \\"from\\" and the rest" file.txt'), true);
+});
+
+test("isLikelyCommand: unterminated quote is left intact for prose detection (issue #2290)", () => {
+  // A quote that never closes leaves the quoting state unresolved, so nothing
+  // is stripped and the prose heuristic still sees the remainder — this
+  // protects #1671-style prose that contains an apostrophe (dell'esempio).
+  assert.equal(validateVerificationCommand("grep 'hello from the that").ok, false);
+  // A clean remainder still validates as a command; if the quote is genuinely
+  // malformed the shell fails loudly at execution (unexpected EOF). The
+  // shell-syntax rule does not flag unterminated quotes.
+  assert.equal(isLikelyCommand("grep 'needle in haystack file.txt"), true);
+});
+
+test("isLikelyCommand: backtick segments are not stripped (issue #2290)", () => {
+  // Backticks are command substitution, not quoted data — their content still
+  // feeds the prose heuristic. Backtick commands are already rejected earlier
+  // by the shell-syntax rule in validateVerificationCommand.
+  assert.equal(isLikelyCommand("echo `from the that` file"), false);
+});
+
+test("isLikelyCommand: token-count guard uses the full command, not the stripped stream (issue #2290)", () => {
+  // Stripping leaves "contains" as the only marker word and drops the stream
+  // below four tokens — the minimum must be measured on the original stream
+  // so unquoted prose is still rejected.
+  assert.equal(isLikelyCommand('./report.txt contains "hello world"'), false);
+});
+
+test("isLikelyCommand: escaped quotes outside quoted segments stay in the token stream (issue #2290)", () => {
+  // `\'` is an escaped literal quote, not a quote delimiter — the pair must
+  // not vanish from the stripped stream, or the inner word ("the") would be
+  // misread as an unquoted prose marker.
+  assert.equal(isLikelyCommand("grep -q \\'the\\' file.txt"), true);
+});
+
 test("validateVerificationCommand allows exit-code echo diagnostic suffix", () => {
   assert.equal(validateVerificationCommand('python3 tools/check-status.py; echo "exit:$?"').ok, true);
   assert.equal(validateVerificationCommand("python3 tools/check-status.py; echo 'exit:$?'").ok, true);

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -643,14 +643,68 @@ const PROSE_MARKER_WORDS = new Set([
 ]);
 
 /**
+ * Remove quoted segments from a command string. Quoted text is shell data,
+ * not prose (#2290). Single quotes contain no escapes; `\"` and `\\` escape
+ * inside double quotes. Escaped pairs outside quotes (e.g. `\'`) are literals
+ * and are kept verbatim. Backticks are command substitution, not quoted data,
+ * and are left intact. If a quote never closes, the string is returned
+ * unchanged: the remainder is ambiguous shell input, so the prose heuristic
+ * keeps seeing it (protects #1671-style prose containing apostrophes).
+ */
+function stripQuotedSegments(cmd: string): string {
+  let out = "";
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+
+  for (let i = 0; i < cmd.length; i += 1) {
+    const ch = cmd[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && !inSingle) {
+      if (inDouble) {
+        // Inside double quotes the pair is quoted data — drop it, and make
+        // sure an escaped quote cannot close the segment.
+        escaped = true;
+        continue;
+      }
+      // Outside quotes the pair is a literal: keep both characters so the
+      // token stream keeps its shape (e.g. \' is data, not a quote delimiter).
+      out += ch;
+      if (i + 1 < cmd.length) {
+        out += cmd[i + 1];
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (ch === "\"" && !inSingle) {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (!inSingle && !inDouble) out += ch;
+  }
+
+  if (inSingle || inDouble || escaped) return cmd;
+  return out;
+}
+
+/**
  * Does a known-command-prefixed string read as prose rather than a command?
  * True when there are English function words after the command word —
  * e.g. "git log shows the scaffold commit authored by ...".
  * Flags after the command word do not suppress this check (#1671).
+ * The token-count minimum runs on the full token stream; `proseTokens` (with
+ * quoted segments stripped, #2290) is only used for marker-word matching.
  */
-function readsAsProseAfterCommandWord(tokens: string[]): boolean {
+function readsAsProseAfterCommandWord(tokens: string[], proseTokens: string[]): boolean {
   if (tokens.length < 4) return false;
-  return tokens
+  return proseTokens
     .slice(1)
     .some(t => PROSE_MARKER_WORDS.has(t.toLowerCase().replace(/[.,;:!?]+$/, "")));
 }
@@ -684,16 +738,24 @@ export function isLikelyCommand(cmd: string): boolean {
   const effectiveTokens = firstToken === "!" ? tokens.slice(1) : tokens;
   if (firstToken === "!" && effectiveTokens.length === 0) return false;
 
+  // Quoted segments are shell data, not prose (#2290): words inside quotes
+  // (e.g. a `grep 'hello from the seat'` pattern) must not reach the prose
+  // heuristic. Only the prose-word evaluation sees the stripped stream —
+  // prefix, path, and flag detection still run on the full command.
+  const stripped = stripQuotedSegments(trimmed).trim();
+  const strippedTokens = stripped ? stripped.split(/\s+/) : [];
+  const proseTokens = firstToken === "!" ? strippedTokens.slice(1) : strippedTokens;
+
   // Known command prefix → command, unless the rest reads as English prose
   if (KNOWN_COMMAND_PREFIXES.has(effectiveFirstToken)) {
-    return !readsAsProseAfterCommandWord(effectiveTokens);
+    return !readsAsProseAfterCommandWord(effectiveTokens, proseTokens);
   }
 
   // Path-like first token → command, unless the rest reads as English prose.
   // "./out/report.txt exists and contains the summary" is a description of a
   // file, not an invocation of it.
   if (effectiveFirstToken.startsWith("/") || effectiveFirstToken.startsWith("./") || effectiveFirstToken.startsWith("../")) {
-    return !readsAsProseAfterCommandWord(effectiveTokens);
+    return !readsAsProseAfterCommandWord(effectiveTokens, proseTokens);
   }
 
   // Has flag-like tokens → command
@@ -716,7 +778,7 @@ export function isLikelyCommand(cmd: string): boolean {
   // — `greet/hello.txt exists and contains "hello"` ran the .txt file as a
   // program and failed with exit 126 "Permission denied", failing the gate for
   // a task that had in fact succeeded. English function words are the tell.
-  return !readsAsProseAfterCommandWord(effectiveTokens);
+  return !readsAsProseAfterCommandWord(effectiveTokens, proseTokens);
 }
 
 /**


### PR DESCRIPTION
## TL;DR

**What:** the verify pre-exec prose heuristic now evaluates a quote-stripped token stream, so quoted shell arguments can't trigger the prose rejection.
**Why:** `grep -q 'hello from the localnodes seat' scripts/hello-seat.sh` was rejected as "does not look like a runnable command" because "from"/"the" inside the quoted pattern matched PROSE_MARKER_WORDS — and the planner repair loop, never told the rule, repeated until auto-mode paused (#2290).
**How:** `stripQuotedSegments` (escape-aware, conservative on unterminated quotes) feeds only the marker-word check; token counting, prefix matching, path/flag detection, and the shell-syntax rule still see the full command.

Addresses the gate-correctness defect of #2290 (does not close it — the planner-repair-prompt and pause-classification asks are tracked as follow-ups in the triage comment).

## What

- `verification-gate.ts`: new `stripQuotedSegments` helper; all three `readsAsProseAfterCommandWord` call sites evaluate the stripped token stream, while the four-token minimum guard runs on the FULL token stream (so `./report.txt contains "hello world"` still rejects on its unquoted marker), and known-command-prefix/path/flag matching is unchanged. Unterminated quotes leave the original string intact — a stray apostrophe splitting prose (the #1671 fixture `dell'esempio`) is still rejected; a genuinely malformed command fails loudly at shell execution as before.
- `verification-gate.test.ts`: seven new tests — the reporter's exact repro (failing-first), escaped quotes inside and outside quoted segments, unquoted-prose and mixed-data controls, backtick pinning, and the unterminated-quote precedence.

## Why

A quoted argument is shell data, not prose; feeding it to a prose heuristic made any grep/test whose pattern contained an English function word unverifiable, and the failure loop burned the planner's retries on a rule it couldn't see.

## How

The conservative unterminated-quote fallback is load-bearing: mutation-testing it breaks the #1671 prose fixture, proving the fallback (not the strip) carries that case. Adversarial sweep confirmed no over-correction — unquoted marker-word tails still reject, quoted segments can't launder a prose tail, and the #1994 English-only limitation is untouched (orthogonal redesign). Known semantics shift, same class as the pre-existing `echo done` no-op-verify: a verify whose prose is entirely inside a quoted `echo` argument now executes instead of being prose-rejected — execution remains the final arbiter. Blast radius: the helper is private to the prose check; 288 tests across 12 verification suites green.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).