### PR TITLE
fix(hermes): capture the delivery target per run so async notifications arrive

### DIFF
--- a/integrations/hermes/open_gsd_hermes/commands.py
+++ b/integrations/hermes/open_gsd_hermes/commands.py
@@ -297,7 +297,13 @@ class GsdCommandRouter:
 
         # Spawn the supervised subprocess; create_milestone returns a local
         # session id immediately and continues the stream reader in the
-        # background.
+        # background. The delivery target is captured here on the bound
+        # command thread; the reader thread has no session binding.
+        notify_target = (
+            self._notifications.resolve_target()
+            if self._notifications is not None
+            else None
+        )
         try:
             session_id = self._client.create_milestone(
                 project_dir,
@@ -305,6 +311,7 @@ class GsdCommandRouter:
                 context_file=context_file,
                 notifications=self._notifications,
                 on_terminal=_on_milestone_terminal,
+                notify_target=notify_target,
             )
         except ValueError:
             return "Usage: `/gsd new-milestone <spec>` (or `--file <path>`)"

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -53,6 +53,7 @@ class GsdMcpClient:
         self._milestone_pending_blocker_method: str | None = None
         self._milestone_command_block_failure: str | None = None
         self._milestone_notifications: Any = None  # NotificationService | None
+        self._milestone_notify_target: Any = None  # DeliveryTarget | None
         self._milestone_project_dir: str | None = None
         self._milestone_on_terminal: Callable[[str], None] | None = None
         self._milestone_notified_terminal: bool = False
@@ -470,6 +471,7 @@ class GsdMcpClient:
         context_file: str | None = None,
         notifications: Any = None,
         on_terminal: Callable[[str], None] | None = None,
+        notify_target: Any = None,
     ) -> str:
         """Spawn `gsd headless --supervised new-milestone` and return a session id.
 
@@ -477,6 +479,10 @@ class GsdMcpClient:
         stream-json stdout and drives the supplied NotificationService on
         blocker/terminal events. Returns a local session id immediately
         (headless does not emit init_result on stdout).
+
+        notify_target must be captured by the caller on the bound command
+        thread (e.g. NotificationService.resolve_target()): the reader
+        thread has no session binding of its own.
 
         Raises ValueError if neither (or both) of context_text/context_file
         is supplied.
@@ -519,6 +525,7 @@ class GsdMcpClient:
         self._milestone_pending_blocker_method = None
         self._milestone_command_block_failure = None
         self._milestone_notifications = notifications
+        self._milestone_notify_target = notify_target
         self._milestone_project_dir = project_dir
         self._milestone_on_terminal = on_terminal
         self._milestone_notified_terminal = False
@@ -582,7 +589,9 @@ class GsdMcpClient:
             if not self._milestone_notified_terminal:
                 if self._milestone_notifications is not None:
                     self._milestone_notifications.notify_terminal(
-                        "failed", "Planning blocked"
+                        "failed",
+                        "Planning blocked",
+                        target=self._milestone_notify_target,
                     )
                 if self._milestone_on_terminal is not None:
                     self._milestone_on_terminal("failed")
@@ -608,9 +617,13 @@ class GsdMcpClient:
                 summary = self._build_milestone_completion_message(
                     self._milestone_project_dir or ""
                 )
-                self._milestone_notifications.notify_milestone_complete(summary)
+                self._milestone_notifications.notify_milestone_complete(
+                    summary, target=self._milestone_notify_target
+                )
             else:
-                self._milestone_notifications.notify_terminal(status, error)
+                self._milestone_notifications.notify_terminal(
+                    status, error, target=self._milestone_notify_target
+                )
         if self._milestone_on_terminal is not None:
             self._milestone_on_terminal(status)
         self._milestone_notified_terminal = True
@@ -671,7 +684,9 @@ class GsdMcpClient:
             self._milestone_command_block_failure = failure
             if not self._milestone_notified_terminal:
                 if self._milestone_notifications is not None:
-                    self._milestone_notifications.notify_terminal("failed", failure)
+                    self._milestone_notifications.notify_terminal(
+                        "failed", failure, target=self._milestone_notify_target
+                    )
                 if self._milestone_on_terminal is not None:
                     self._milestone_on_terminal("failed")
                 self._milestone_notified_terminal = True
@@ -689,7 +704,8 @@ class GsdMcpClient:
                     status="blocked",
                     pending_blocker=event,
                     session_id=self._milestone_session_id,
-                )
+                ),
+                target=self._milestone_notify_target,
             )
 
     def cancel_milestone(self) -> None:
@@ -763,6 +779,7 @@ class GsdMcpClient:
         self._milestone_pending_blocker_id = None
         self._milestone_pending_blocker_method = None
         self._milestone_command_block_failure = None
+        self._milestone_notify_target = None
 
     def respond_to_milestone_blocker(self, response: str) -> None:
         """Write an extension_ui_response to the milestone subprocess stdin.

--- a/integrations/hermes/open_gsd_hermes/notifications.py
+++ b/integrations/hermes/open_gsd_hermes/notifications.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable
 
 from open_gsd_hermes.config import GsdConfig
 from open_gsd_hermes.types import DeliveryTarget, PluginContext, SessionStatus
+
+logger = logging.getLogger(__name__)
 
 
 class NotificationService:
@@ -23,6 +26,15 @@ class NotificationService:
         self._get_target = get_target
         self._dispatch = dispatch or ctx.dispatch_tool
 
+    def resolve_target(self) -> DeliveryTarget | None:
+        """Snapshot the live delivery target (call on a bound thread).
+
+        Async senders (supervisor/milestone threads) run without a bound
+        session key, so their target must be captured at thread spawn on
+        the bound command thread and passed to send().
+        """
+        return self._get_target()
+
     def _should_send(self, kind: str) -> bool:
         level = self._config.notification_level
         if level == "verbose":
@@ -32,11 +44,25 @@ class NotificationService:
         # normal
         return kind in ("blocker", "transition", "failure", "complete")
 
-    def send(self, text: str, *, kind: str = "transition") -> bool:
+    def send(
+        self,
+        text: str,
+        *,
+        kind: str = "transition",
+        target: DeliveryTarget | None = None,
+    ) -> bool:
         if not self._should_send(kind):
             return False
-        target = self._get_target()
+        # An explicit target (captured at thread spawn) wins; the live
+        # resolution serves command-path callers and must not fall back to
+        # env when a bound gateway target was captured.
         if target is None:
+            target = self._get_target()
+        if target is None:
+            logger.warning(
+                "GSD notification dropped (no delivery target): %s",
+                text,
+            )
             return False
         payload = {
             "platform": target.platform,
@@ -50,7 +76,9 @@ class NotificationService:
         except Exception:
             return False
 
-    def notify_blocker(self, status: SessionStatus) -> None:
+    def notify_blocker(
+        self, status: SessionStatus, target: DeliveryTarget | None = None
+    ) -> None:
         blocker = status.pending_blocker or {}
         q = (
             blocker.get("question")
@@ -59,22 +87,35 @@ class NotificationService:
             or blocker.get("message")
             or "Action required"
         )
-        self.send(f"🚧 GSD blocker: {q}\nReply with `/gsd reply <your answer>`", kind="blocker")
+        self.send(
+            f"🚧 GSD blocker: {q}\nReply with `/gsd reply <your answer>`",
+            kind="blocker",
+            target=target,
+        )
 
-    def notify_transition(self, message: str) -> None:
-        self.send(f"📋 GSD: {message}", kind="transition")
+    def notify_transition(
+        self, message: str, target: DeliveryTarget | None = None
+    ) -> None:
+        self.send(f"📋 GSD: {message}", kind="transition", target=target)
 
-    def notify_milestone_complete(self, message: str) -> None:
-        self.send(message, kind="complete")
+    def notify_milestone_complete(
+        self, message: str, target: DeliveryTarget | None = None
+    ) -> None:
+        self.send(message, kind="complete", target=target)
 
-    def notify_terminal(self, status: str, error: str | None = None) -> None:
+    def notify_terminal(
+        self,
+        status: str,
+        error: str | None = None,
+        target: DeliveryTarget | None = None,
+    ) -> None:
         normalized_status = status.lower()
         if normalized_status in ("complete", "completed", "done"):
-            self.send("✅ GSD auto mode finished.", kind="complete")
+            self.send("✅ GSD auto mode finished.", kind="complete", target=target)
         elif normalized_status == "cancelled":
-            self.send("⏹ GSD session cancelled.", kind="complete")
+            self.send("⏹ GSD session cancelled.", kind="complete", target=target)
         else:
             msg = f"❌ GSD session {status}"
             if error:
                 msg += f": {error}"
-            self.send(msg, kind="failure")
+            self.send(msg, kind="failure", target=target)

--- a/integrations/hermes/open_gsd_hermes/supervisor.py
+++ b/integrations/hermes/open_gsd_hermes/supervisor.py
@@ -12,7 +12,7 @@ from open_gsd_hermes.config import GsdConfig
 from open_gsd_hermes.formatting import format_ref
 from open_gsd_hermes.gsd_client import GsdMcpClient
 from open_gsd_hermes.notifications import NotificationService
-from open_gsd_hermes.types import ProgressSnapshot, SessionStatus
+from open_gsd_hermes.types import DeliveryTarget, ProgressSnapshot, SessionStatus
 
 
 class SupervisorState(str, Enum):
@@ -62,10 +62,14 @@ class SupervisorFsm:
         self._set_context = set_context
         self._thread: threading.Thread | None = None
         self._stop = threading.Event()
+        # Captured in start() on the bound command thread; the loop thread
+        # has no session binding, so its sends must use this snapshot.
+        self._target: DeliveryTarget | None = None
 
     def start(self) -> None:
         if self._thread and self._thread.is_alive():
             return
+        self._target = self._notifications.resolve_target()
         self._stop = threading.Event()
         self._thread = threading.Thread(
             target=self._loop,
@@ -144,9 +148,13 @@ class SupervisorFsm:
             stop_event.set()
         self._set_context(ctx)
         if blocker_notification:
-            self._notifications.notify_blocker(blocker_notification)
+            self._notifications.notify_blocker(
+                blocker_notification, target=self._target
+            )
         if terminal_notification:
-            self._notifications.notify_terminal(*terminal_notification)
+            self._notifications.notify_terminal(
+                *terminal_notification, target=self._target
+            )
 
     def _map_status(self, raw: str) -> SupervisorState:
         mapping = {
@@ -176,5 +184,7 @@ class SupervisorFsm:
             if old != new and new:
                 parts.append(f"{label} → {format_ref(new, include_title=False)}")
         if parts:
-            self._notifications.notify_transition(", ".join(parts))
+            self._notifications.notify_transition(
+                ", ".join(parts), target=self._target
+            )
             self._client.invalidate_cache(ctx.project_dir)

--- a/integrations/hermes/tests/test_milestone_client.py
+++ b/integrations/hermes/tests/test_milestone_client.py
@@ -18,7 +18,7 @@ import pytest
 
 from open_gsd_hermes.config import GsdConfig
 from open_gsd_hermes.gsd_client import GsdMcpClient
-from open_gsd_hermes.types import ProgressSnapshot
+from open_gsd_hermes.types import DeliveryTarget, ProgressSnapshot
 
 
 def _config() -> GsdConfig:
@@ -227,13 +227,38 @@ def test_stream_loop_notifies_terminal_on_process_exit() -> None:
                     client._milestone_stream_loop(fake_proc)
 
     notifications.notify_milestone_complete.assert_called_once_with(
-        "✅ Milestone M001 ready — 2 slices, 5 tasks. Run `/gsd auto` to start."
+        "✅ Milestone M001 ready — 2 slices, 5 tasks. Run `/gsd auto` to start.",
+        target=None,
     )
     notifications.notify_terminal.assert_not_called()
     assert client.milestone_active() is False
     assert client.milestone_session_id() is None
     assert client.milestone_pending_blocker_id() is None
     assert client._milestone_pending_blocker_method is None
+
+
+def test_milestone_reader_forwards_target_captured_at_spawn() -> None:
+    """The reader passes the command-thread target snapshot to its notifies.
+
+    The reader thread has no session binding, so create_milestone's caller
+    captures the delivery target on the bound command thread and the
+    snapshot is forwarded verbatim (issue #2288).
+    """
+    client = GsdMcpClient(_config())
+    notifications = MagicMock()
+    target = DeliveryTarget("slack", "channel", "C_A")
+    fake_proc = _FakeProc()
+    fake_proc.poll.return_value = 0
+    fake_proc.stdout.readline.side_effect = [b""]
+
+    with patch.object(client, "_milestone_proc", fake_proc):
+        with patch.object(client, "_milestone_project_dir", "/proj"):
+            with patch.object(client, "_milestone_notifications", notifications):
+                with patch.object(client, "_milestone_notify_target", target):
+                    client._milestone_stream_loop(fake_proc)
+
+    call = notifications.notify_milestone_complete.call_args
+    assert call.kwargs["target"] is target
 
 
 def test_stream_loop_failure_reports_drained_stderr() -> None:
@@ -251,7 +276,7 @@ def test_stream_loop_failure_reports_drained_stderr() -> None:
             client._milestone_stream_loop(fake_proc)
 
     notifications.notify_terminal.assert_called_once_with(
-        "failed", "fatal diagnostics"
+        "failed", "fatal diagnostics", target=None
     )
 
 
@@ -269,7 +294,9 @@ def test_stream_loop_releases_blocked_exit_with_pending_blocker() -> None:
             with patch.object(client, "_milestone_notifications", notifications):
                 client._milestone_stream_loop(fake_proc)
 
-    notifications.notify_terminal.assert_called_once_with("failed", "Planning blocked")
+    notifications.notify_terminal.assert_called_once_with(
+        "failed", "Planning blocked", target=None
+    )
     assert client.milestone_active() is False
     assert client.milestone_session_id() is None
 
@@ -287,7 +314,9 @@ def test_stream_loop_releases_noninteractive_blocked_exit() -> None:
         with patch.object(client, "_milestone_notifications", notifications):
             client._milestone_stream_loop(fake_proc)
 
-    notifications.notify_terminal.assert_called_once_with("failed", "Planning blocked")
+    notifications.notify_terminal.assert_called_once_with(
+        "failed", "Planning blocked", target=None
+    )
     assert client.milestone_active() is False
     assert client.milestone_session_id() is None
 
@@ -309,7 +338,7 @@ def test_stream_loop_retains_running_proc_on_stream_loss() -> None:
                 client._milestone_stream_loop(fake_proc)
 
                 notifications.notify_terminal.assert_called_once_with(
-                    "failed", "stream lost — run /gsd cancel"
+                    "failed", "stream lost — run /gsd cancel", target=None
                 )
                 on_terminal.assert_called_once_with("failed")
                 assert client.milestone_active() is True
@@ -351,6 +380,7 @@ def test_stream_loop_handles_blocking_command_block() -> None:
     notifications.notify_terminal.assert_called_with(
         "failed",
         "/gsd auto cannot run because the active milestone is blocked by validation.",
+        target=None,
     )
     notifications.notify_milestone_complete.assert_not_called()
     assert client.milestone_active() is False

--- a/integrations/hermes/tests/test_notifications_async_target.py
+++ b/integrations/hermes/tests/test_notifications_async_target.py
@@ -1,0 +1,246 @@
+"""Regression tests for issue #2288: async notifications silently dropped.
+
+Async senders (supervisor FSM poll loop, milestone stream reader) run on
+plain threads where no session key is bound, so live target resolution
+returns None there. The delivery target must be captured on the bound
+command thread at thread spawn and passed explicitly to send(); live
+resolution (command-path callers) still wins when no target is passed.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from open_gsd_hermes.config import GsdConfig
+from open_gsd_hermes.notifications import NotificationService
+from open_gsd_hermes.session_key import (
+    bind_session_key,
+    reset_session_key,
+    resolve_session_key,
+)
+from open_gsd_hermes.supervisor import SupervisorContext, SupervisorFsm, SupervisorState
+from open_gsd_hermes.types import (
+    DeliveryTarget,
+    ProgressSnapshot,
+    SessionStatus,
+)
+
+
+def _live_get_target() -> DeliveryTarget | None:
+    """Mirror register()'s get_target closure: live session key → target."""
+    key = resolve_session_key()
+    if not key:
+        return None
+    return DeliveryTarget.from_session_key(key)
+
+
+def _make_service(
+    get_target: Callable[[], DeliveryTarget | None],
+) -> tuple[NotificationService, list[dict[str, Any]]]:
+    dispatched: list[dict[str, Any]] = []
+
+    def dispatch(_name: str, args: dict[str, Any]) -> None:
+        dispatched.append(args)
+
+    service = NotificationService(
+        MagicMock(),
+        GsdConfig(),
+        get_target,
+        dispatch=dispatch,
+    )
+    return service, dispatched
+
+
+def _run_on_thread(fn: Callable[[], Any]) -> Any:
+    """Run fn on a fresh thread and re-raise its exception on the caller."""
+    box: dict[str, Any] = {}
+
+    def worker() -> None:
+        try:
+            box["result"] = fn()
+        except Exception as e:
+            box["error"] = e
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join()
+    if "error" in box:
+        raise box["error"]
+    return box.get("result")
+
+
+def _capture_on_bound_thread(service: NotificationService, key: str) -> DeliveryTarget:
+    """Resolve the target as a spawn site does on the bound command thread."""
+    token = bind_session_key(key)
+    try:
+        target = service.resolve_target()
+    finally:
+        reset_session_key(token)
+    assert target is not None
+    return target
+
+
+class _FakeSupervisorClient:
+    def __init__(self, status: SessionStatus) -> None:
+        self._status = status
+
+    def status(self, _session_id: str) -> SessionStatus:
+        return self._status
+
+    def progress(self, _project_dir: str) -> ProgressSnapshot:
+        return ProgressSnapshot(phase="execute")
+
+    def invalidate_cache(self, _project_dir: str | None = None) -> None:
+        pass
+
+
+def test_send_with_target_captured_on_bound_thread_delivers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Core #2288: a worker send with the spawn-captured target delivers."""
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    service, dispatched = _make_service(_live_get_target)
+
+    captured = _capture_on_bound_thread(service, "agent:main:slack:channel:C1")
+
+    delivered = _run_on_thread(
+        lambda: service.send("done", kind="complete", target=captured)
+    )
+    assert delivered is True
+    assert dispatched == [
+        {
+            "platform": "slack",
+            "chat_type": "channel",
+            "chat_id": "C1",
+            "text": "done",
+        }
+    ]
+
+
+def test_worker_keeps_starting_chat_after_another_chat_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chat B's later command must not redirect chat A's worker sends.
+
+    Both chats share one service (as in register()); only each run's own
+    spawn-time capture may be used, so per-run passing — never a shared
+    stash updated by every command — keeps A's worker on A. A worker with
+    no capture of its own must not inherit B's target either.
+    """
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    service, dispatched = _make_service(_live_get_target)
+
+    target_a = _capture_on_bound_thread(service, "agent:main:slack:channel:C_A")
+    _capture_on_bound_thread(service, "agent:main:slack:channel:C_B")
+
+    delivered = _run_on_thread(
+        lambda: service.send("done", kind="complete", target=target_a)
+    )
+    assert delivered is True
+    assert dispatched[0]["chat_id"] == "C_A"
+
+    # No shared fallback: an uncaptured worker send must not deliver to B.
+    leaked = _run_on_thread(lambda: service.send("done", kind="complete"))
+    assert leaked is False
+    assert len(dispatched) == 1
+
+
+def test_worker_uses_captured_target_not_env_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The env fallback must not override the command-thread capture.
+
+    An unbound worker under an env value would still resolve "live" — the
+    explicit capture must win instead.
+    """
+    monkeypatch.setenv("HERMES_SESSION_KEY", "agent:main:cli:direct:env")
+    service, dispatched = _make_service(_live_get_target)
+
+    captured = _capture_on_bound_thread(service, "agent:main:slack:channel:C_gw")
+    assert captured.chat_id == "C_gw"
+
+    delivered = _run_on_thread(
+        lambda: service.send("done", kind="complete", target=captured)
+    )
+    assert delivered is True
+    assert dispatched[0]["chat_id"] == "C_gw"
+
+
+def test_send_without_any_target_returns_false_and_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    service, dispatched = _make_service(_live_get_target)
+
+    with caplog.at_level("WARNING", logger="open_gsd_hermes.notifications"):
+        delivered = service.send("lost", kind="complete")
+
+    assert delivered is False
+    assert dispatched == []
+    assert any("target" in record.message.lower() for record in caplog.records)
+
+
+def test_send_without_explicit_target_still_resolves_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Command-path callers keep live resolution (unchanged semantics)."""
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    service, dispatched = _make_service(_live_get_target)
+
+    token = bind_session_key("agent:main:slack:channel:C_live")
+    try:
+        delivered = service.send("hi", kind="complete")
+    finally:
+        reset_session_key(token)
+
+    assert delivered is True
+    assert dispatched[0]["chat_id"] == "C_live"
+
+
+def test_supervisor_delivers_to_target_captured_at_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SupervisorFsm.start() captures the target; its loop delivers to it.
+
+    Whether the loop's own first tick or a later unbound tick fires the
+    blocker notification, exactly one delivery happens and it goes to the
+    chat captured on the bound starting thread.
+    """
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    service, dispatched = _make_service(_live_get_target)
+    client = _FakeSupervisorClient(
+        SessionStatus(
+            status="blocked",
+            pending_blocker={"id": "b1", "question": "Approve?"},
+        )
+    )
+    ctx = SupervisorContext(
+        session_id="s1",
+        project_dir="/proj",
+        state=SupervisorState.RUNNING,
+    )
+    fsm = SupervisorFsm(
+        GsdConfig(),
+        client,  # type: ignore[arg-type]
+        service,
+        lambda: ctx,
+        lambda c: None,
+    )
+
+    token = bind_session_key("agent:main:slack:channel:C_A")
+    try:
+        fsm.start()
+    finally:
+        reset_session_key(token)
+    fsm.stop()
+
+    _run_on_thread(fsm._tick)
+
+    assert len(dispatched) == 1
+    assert dispatched[0]["chat_id"] == "C_A"
+    assert dispatched[0]["platform"] == "slack"

--- a/integrations/hermes/tests/test_supervisor_fsm.py
+++ b/integrations/hermes/tests/test_supervisor_fsm.py
@@ -527,7 +527,7 @@ def test_supervisor_notifies_new_blocker_while_already_blocked() -> None:
     fsm._tick()
 
     assert ctx.pending_blocker_id == "b2"
-    notifications.notify_blocker.assert_called_once_with(client._status)
+    notifications.notify_blocker.assert_called_once_with(client._status, target=None)
 
 
 def test_supervisor_terminal_status_notifies_even_when_progress_fails() -> None:
@@ -555,7 +555,7 @@ def test_supervisor_terminal_status_notifies_even_when_progress_fails() -> None:
     assert ctx.state == SupervisorState.COMPLETE
     assert ctx.notified_terminal
     assert stored == [ctx]
-    notifications.notify_terminal.assert_called_once_with("complete", None)
+    notifications.notify_terminal.assert_called_once_with("complete", None, target=None)
 
 
 def test_supervisor_terminal_notification_failure_still_stops() -> None:


### PR DESCRIPTION
## TL;DR

**What:** hermes delivery targets are captured per run on the bound command thread and passed explicitly to async senders, which now log a warning instead of silently dropping when no target exists.
**Why:** async notifications (milestone completion, terminal, supervisor stall/blocker/transition) all resolved the target at send time from the session key, but their threads run unbound — `get_target()` returned None and every send silently returned False, leaving users with an acknowledgement and no terminal event (#2288).
**How:** `send()` gains an explicit `target` parameter (explicit → live → warn); `SupervisorFsm.start()` and the `/gsd new-milestone` command capture the target on the bound thread and hand it to their workers.

Addresses #2288.

## What

- `notifications.py`: `send(text, *, kind, target=None)` — resolution order is explicit target → live `get_target()` (command-path callers unchanged) → `logger.warning` + False; all `notify_*` helpers pass the target through. The package gains its first module logger.
- `supervisor.py`: `SupervisorFsm.start()` captures `resolve_target()` into `self._target` (each `start()` recaptures — no cross-run state) and every `_loop` notify passes it.
- `gsd_client.py` + `commands.py`: `/gsd new-milestone` resolves `notify_target` on the bound thread and passes it into `create_milestone(...)`, stored per-run (`_milestone_notify_target`), forwarded at all reader notify sites, cleared in `_clear_milestone_state`.
- Tests: 7 new/updated — unbound-thread delivery via the spawn capture (failing-first), a two-chat discriminator (A's worker still delivers to A after B runs a command — empirically shown to fail against any shared-stash design), env-fallback cannot override a captured gateway target, warn-and-False when no target exists, command-path live resolution unchanged, supervisor capture, reader forwarding.

## Why

`threading.Thread` starts with a fresh contextvars context, so send-time resolution was structurally unable to see the session on worker threads. Resolving once on the bound command thread and passing the snapshot down is the minimal contract that keeps per-run isolation: each run owns the target it was started with.

## How

Codex review of the first iteration caught two real defects in an earlier shared-stash design — an unrelated chat's command could redirect an active run's notifications, and an env fallback could override a captured gateway target — so the design moved to per-run capture with zero shared state (the two-chat test was proven to fail against the stash design before the redesign). Blast radius: command-path sends keep live-first semantics; a forgotten capture degrades to a warned drop, never a wrong-chat send; `pyproject.toml` untouched. Verified with the full hermes pytest suite (105 passed, 1 skipped) in a clean checkout — note the main checkout's own GSD state makes `test_read_cli_contract` fail there regardless of this diff (environmental, passes in a clean tree).

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).