### PR TITLE
fix(tui): stop pinned zone mirroring text still visible in the transcript

### DIFF
--- a/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts
@@ -814,6 +814,33 @@ export class ToolExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
+	/**
+	 * Rows the transcript actually displays for this tool — used by the pinned
+	 * zone's offscreen measurement. render() returns the full body render
+	 * regardless of collapse state, which overstates the post-text height and
+	 * mirrors text that is still visible (duplicate "Working · Latest Output"
+	 * content).
+	 *
+	 * Assumption: both collapsed forms render exactly one row. render()'s two
+	 * non-expanded early returns delegate to renderCompactToolStrip() and
+	 * renderCommandCard(), and each of those returns a single-element array
+	 * (see transcript-design.ts). If either ever grows a header/detail split,
+	 * update this method to match.
+	 */
+	getDisplayedLineCount(width: number): number {
+		if (this.hideComponent) return 0;
+		// Bash collapsed (non-error): renderCommandCard() → one row.
+		if (this.normalizedToolName === "bash" && !this.showExpandedBody() && !this.result?.isError) {
+			return 1;
+		}
+		const hasImages = this.result?.content?.some((block) => block.type === "image") ?? false;
+		// Other tools collapsed (non-error, no images): renderCompactToolStrip() → one row.
+		if (!this.showExpandedBody() && !this.result?.isError && !hasImages) {
+			return 1;
+		}
+		return this.render(width).length;
+	}
+
 	override render(width: number): string[] {
 		if (this.hideComponent) {
 			return [];

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-pinned-zone.test.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-pinned-zone.test.ts
@@ -1,0 +1,142 @@
+// gsd-pi — pinned-zone viewport measurement vs displayed (rolled-up) tool height.
+//
+// Regression: rowsRenderedAfterContentIndex() counted kind:"tool" segments via
+// component.render(width).length — the FULL body render (read tool shows up to
+// 10 collapsed lines, bash cards show 5 preview lines) rather than the rows the
+// transcript actually displays after replaceCompactToolRowsWithPhaseSummary()
+// folds finished tools into single-row phase summaries. The overcount crossed
+// the offscreen threshold while the pinnable text was still on-screen, so the
+// pinned zone mirrored a sentence the transcript still showed — the same line
+// rendered twice, 3 rows apart (issue: screenshot evidence "Working · Latest
+// Output" duplicating the last assistant sentence).
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	findLatestPinnableCandidates,
+	rowsRenderedAfterContentIndex,
+	tearDownPinnedZone,
+	updatePinnedMessageZone,
+} from "./chat-pinned-zone.js";
+import { createStreamingRenderState } from "../streaming-render-state.js";
+import { Container, TUI } from "@gsd/pi-tui";
+import { initTheme } from "@gsd/pi-coding-agent/theme/theme.js";
+
+initTheme();
+
+function makeTerminal(rows: number, columns: number) {
+	return {
+		isTTY: true,
+		columns,
+		rows,
+		kittyProtocolActive: false,
+		start() {},
+		stop() {},
+		drainInput: async () => {},
+		write() {},
+		moveBy() {},
+		hideCursor() {},
+		showCursor() {},
+		clearLine() {},
+		clearFromCursor() {},
+		clearScreen() {},
+		setTitle() {},
+	} as any;
+}
+
+/**
+ * Fake tool segment: render() returns a tall frame (like an expanded read/exec
+ * result), but the transcript actually displays it rolled up to one summary
+ * row (replaceCompactToolRowsWithPhaseSummary).
+ */
+class TallButRolledUpTool {
+	constructor(private displayLines: number, private fullLines: number) {}
+	render(width: number): string[] {
+		return Array.from({ length: this.fullLines }, () => "x".repeat(width));
+	}
+	getDisplayedLineCount(width: number): number {
+		return this.displayLines;
+	}
+}
+
+function makeHost(termRows = 33, termCols = 110) {
+	const ui = new TUI(makeTerminal(termRows, termCols));
+	return {
+		streamingRenderState: createStreamingRenderState(),
+		pinnedMessageContainer: new Container(),
+		statusContainer: new Container(),
+		loadingAnimation: undefined,
+		getMarkdownThemeWithSettings: () => undefined,
+		ui: Object.assign(ui, { requestRender: () => {} }),
+	} as any;
+}
+
+test("rowsRenderedAfterContentIndex counts tool-summary segments at their displayed height", () => {
+	const rs = createStreamingRenderState();
+	// One rolled-up tool run after the pinnable text: displayed as a 1-row
+	// phase summary, but its raw render() is 30 rows tall.
+	rs.renderedSegments = [
+		{ kind: "tool-summary", component: { render: () => ["summary"] } as any, phases: [] },
+	];
+	let rows = rowsRenderedAfterContentIndex(0, 110, rs);
+	// tool-summary is not counted via seg.kind === "tool" —PATCH NOTE: pre-fix
+	// behavior counts nothing for tool-summary segments; the second segment
+	// below exercises the tool branch.
+	rs.renderedSegments = [
+		{ kind: "tool", contentIndex: 7, component: new TallButRolledUpTool(1, 30) as any },
+	];
+	rows = rowsRenderedAfterContentIndex(0, 110, rs);
+	assert.equal(rows, 1, "tool with getDisplayedLineCount must count displayed rows, not render() rows");
+});
+
+test("updatePinnedMessageZone does not mirror text still visible in the transcript", () => {
+	const host = makeHost();
+	const rs = host.streamingRenderState;
+	const sentence = "现在编写这个测试文件。mypy 仅检查 src，因此测试只需要 ruff。";
+	const contentBlocks = [
+		{ type: "text", text: sentence },
+		{ type: "toolCall", id: "t1", name: "gsd_exec", arguments: {} },
+	];
+	// Tool finished and rolled up: transcript shows exactly 1 row after the text.
+	rs.renderedSegments = [
+		{ kind: "tool", contentIndex: 1, component: new TallButRolledUpTool(1, 30) as any },
+	];
+
+	const { toreDownPinnedZone } = updatePinnedMessageZone(host, rs, contentBlocks);
+
+	// offscreenThreshold = max(1, 33 - 13 - 8) = 12; after-rows = 1 < 12,
+	// so no candidate qualifies and no pinned zone may be created.
+	assert.equal(toreDownPinnedZone, false);
+	assert.equal(rs.pinnedBorder, undefined, "pinned zone must not mirror text that is still on-screen");
+});
+
+test("updatePinnedMessageZone still mirrors when following rows genuinely push text off-screen", () => {
+	const host = makeHost();
+	const rs = host.streamingRenderState;
+	const sentence = "现在编写这个测试文件。mypy 仅检查 src，因此测试只需要 ruff。";
+	const contentBlocks = [
+		{ type: "text", text: sentence },
+		{ type: "toolCall", id: "t1", name: "gsd_exec", arguments: {} },
+	];
+	rs.renderedSegments = [
+		{ kind: "tool", contentIndex: 1, component: new TallButRolledUpTool(14, 14) as any },
+	];
+
+	updatePinnedMessageZone(host, rs, contentBlocks);
+
+	assert.ok(rs.pinnedBorder, "pinned zone must still engage when rows truly exceed the threshold");
+	assert.equal(rs.lastPinnedText, sentence);
+
+	tearDownPinnedZone(host);
+});
+
+test("findLatestPinnableCandidates skips text after the last tool call", () => {
+	const candidates = findLatestPinnableCandidates([
+		{ type: "text", text: "earlier" },
+		{ type: "toolCall", id: "t1", name: "bash", arguments: {} },
+		{ type: "text", text: "still streaming" },
+	]);
+	assert.equal(candidates.length, 1);
+	assert.equal(candidates[0].text, "earlier");
+});

--- a/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-pinned-zone.ts
+++ b/packages/gsd-agent-modes/src/modes/interactive/controllers/chat-pinned-zone.ts
@@ -42,6 +42,25 @@ export function findLatestPinnableText(contentBlocks: Array<any>): string {
 // Performance: uses getLineCount() for Markdown components to avoid full
 // markdown lexer passes on every streaming delta. The cached line count
 // is only recomputed when the width changes (rare during streaming).
+//
+// Tool segments are measured at the height the transcript actually
+// displays, not the full render(): after replaceCompactToolRowsWithPhaseSummary()
+// folds finished tools into single-row phase summaries, render() still returns
+// the expanded body (read shows up to 10 collapsed lines, bash cards 5 preview
+// lines). Counting the raw render height overstates the rows below the
+// pinnable text, crosses the offscreen threshold early, and mirrors a
+// sentence that is still on-screen — the duplicate shown at "Working ·
+// Latest Output".
+function displayedLineCount(component: unknown, width: number, fallback: () => string[]): number {
+	try {
+		const hook = (component as { getDisplayedLineCount?: (width: number) => number }).getDisplayedLineCount;
+		if (typeof hook === "function") return hook.call(component, width);
+	} catch {
+		// Fall through to render-based measurement below.
+	}
+	return fallback().length;
+}
+
 export function rowsRenderedAfterContentIndex(
 	contentIndex: number,
 	width: number,
@@ -54,6 +73,10 @@ export function rowsRenderedAfterContentIndex(
 				// Use cached line count — avoids full render + lexer pass
 				rows += (seg.component as any).getLineCount?.(width) ?? seg.component.render(width).length;
 			} else if (seg.kind === "tool" && seg.contentIndex > contentIndex) {
+				rows += displayedLineCount(seg.component, width, () => seg.component.render(width));
+			} else if (seg.kind === "tool-summary") {
+				// Rolled-up phase summaries: render() matches their displayed height
+				// (1-2 rows per phase), so plain render() is the displayed count.
 				rows += seg.component.render(width).length;
 			}
 		} catch {


### PR DESCRIPTION
> **Replacement for #2228** — that PR's head branch was accidentally deleted and recreated during the rebase, which auto-closed it and GitHub refuses to reopen it (`state cannot be changed. The ... branch was force-pushed or recreated.`). Same change, rebased on current main with the #2229 overlap removed, plus the review-notice comment fix from #2228's feedback.

## Linked issue

Closes #2227

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Measure the pinned zone's offscreen rows at the height the transcript actually displays (and count rolled-up tool summaries), instead of the raw `render()` height.
**Why:** The overcount makes the `Working · Latest Output` pinned zone mirror an assistant sentence that is still on-screen — the same line renders twice, 3 rows apart (#2227).
**How:** New `ToolExecutionComponent.getDisplayedLineCount()` (collapsed bash command cards and compact tool strips display exactly one row; expanded bodies keep their full height), a `displayedLineCount()` helper in `chat-pinned-zone.ts`, and a `tool-summary` counting branch.

## What

- `packages/gsd-agent-modes/src/modes/interactive/controllers/chat-pinned-zone.ts`
  - `rowsRenderedAfterContentIndex()` now measures `kind:"tool"` segments via `getDisplayedLineCount()` when available (falling back to `render().length` for components without the hook) and counts `kind:"tool-summary"` segments (previously skipped entirely), so the offscreen decision reflects the transcript's real displayed height after `replaceCompactToolRowsWithPhaseSummary()` folds finished tools into one-row phase summaries.
- `packages/gsd-agent-modes/src/modes/interactive/components/tool-execution.ts`
  - New `getDisplayedLineCount(width)`: `0` when hidden, `1` for collapsed bash command cards and compact tool strips, otherwise `render(width).length` (expanded / errored / image-bearing bodies really do occupy those rows).
- Tests
  - `packages/gsd-agent-modes/src/modes/interactive/controllers/chat-pinned-zone.test.ts` (new): tool with `getDisplayedLineCount` counts displayed rows; `updatePinnedMessageZone` must not mirror text that is still visible; must still mirror when following rows genuinely exceed the threshold; candidate selection skips text after the last tool call.

## Why

Screenshot forensics on a live 110×33 auto-mode session (issue #2227) shows the same assistant sentence rendered twice, 3 rows apart (pixel diff mean 3.1/255 between the copies), under a paused `Provider error: Anthropic stream ended before message_stop` run. `rowsRenderedAfterContentIndex()` counted each finished tool at its full `render()` height (~10+ rows for a tool folded into a 1-row phase summary), crossing `offscreenThreshold` (12 for a 33-row terminal) while the sentence was still on-screen, so the pinned zone mirrored it — contradicting the tear-down contract ("tear down the pinned zone so we don't duplicate on-screen text").

## How

The displayed-height hook is intentionally conservative: only `ToolExecutionComponent` gains `getDisplayedLineCount()`, and `rowsRenderedAfterContentIndex()` uses it when present, falling back to the old `render().length` measurement for any other component (including future ones). This keeps the change surgical — no changes to rendering itself, only to the vertical-occupancy estimate that drives the mirror decision. `tool-summary` segments render at their displayed height already (1–2 rows per phase), so they are counted via `render()`.

The "collapsed = one row" assumption (review nit on #2228) is verified and documented: `render()`'s two non-expanded branches delegate to `renderCompactToolStrip()` and `renderCommandCard()`, both of which return single-element arrays (transcript-design.ts:560, :624). The JSDoc states this and flags updating the method if either renderer ever grows a header/detail split; each early return carries a one-line pointer to its renderer.

Alternatives considered: measuring the live `chatContainer` layout directly (rejected — TUI containers are not height-addressable at measurement time without a full render pass, which the existing comment explicitly avoids for streaming performance); tearing down the pinned zone on every rollup flush (rejected — breaks mirroring for genuinely-scrolled text).

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `pi-tui` — Terminal UI (gsd-agent-modes interactive TUI)
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above

Verified locally on top of current main (rebased after #2229 per #2228 review):
- New pinned-zone regression tests: on the pre-fix tree, "does not mirror text still visible" failed with `pinnedBorder` present (the bug); post-fix all 4 pass.
- Full interactive-mode suites (`src/modes/interactive/*.test.ts`, controllers, dynamic-border, tool-card runtime): 110/110 pass.
- `provider-errors.test.ts` (now carrying #2229's double-colon tests): 94/94 pass on this branch.

## AI disclosure

- [x] This PR includes AI-assisted code <!-- Claude Code (Anthropic) — bug triage from user-supplied screenshots (pixel-level forensics), root-cause analysis, fix, and regression tests; rebase/scope-reduction and assumption-verification per review feedback from #2228. Tests verified red-on-old/green-on-new as described in the test plan. -->