### PR TITLE
fix(gsd): surface the subjective-UAT answer binding in prepare text output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 
 ## [Unreleased]
 
+### Fixed
+- **gsd**: surface the subjective-UAT answer binding in gsd_prepare_milestone_subjective_uat text output
+
 ## [1.19.0] - 2026-09-09
 
 ### Added

--- a/src/resources/extensions/gsd/tests/milestone-subjective-uat-domain-operation.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-subjective-uat-domain-operation.test.ts
@@ -2,7 +2,7 @@
 // File Purpose: Canonical subjective-UAT question, answer, provenance, replay, and rollback contracts.
 
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
@@ -19,6 +19,10 @@ import {
   answerMilestoneSubjectiveUat,
   prepareMilestoneSubjectiveUat,
 } from "../milestone-subjective-uat-domain-operation.ts";
+import {
+  executePrepareMilestoneSubjectiveUat,
+  formatPreparedSubjectiveUatText,
+} from "../tools/workflow-tool-executors.ts";
 import {
   _getAdapter,
   closeDatabase,
@@ -58,8 +62,9 @@ function userInvocation(idempotencyKey: string) {
 }
 
 function setup(): void {
-  basePath = mkdtempSync(join(tmpdir(), "gsd-milestone-subjective-uat-"));
-  assert.equal(openDatabase(join(basePath, "gsd.db")), true);
+  basePath = realpathSync(mkdtempSync(join(tmpdir(), "gsd-milestone-subjective-uat-")));
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+  assert.equal(openDatabase(join(basePath, ".gsd", "gsd.db")), true);
   insertMilestone({ id: "M001", title: "Subjective UAT", status: "active" });
   const fence = readDomainOperationFence();
   executeDomainOperation({
@@ -552,4 +557,65 @@ test("subjective UAT replay rejects shape-valid option binding corruption", () =
     () => prepareMilestoneSubjectiveUat(input),
     /subjective UAT receipt.*options.*invalid|corrupt/i,
   );
+});
+
+test("prepare executor surfaces the answer binding in its text output", async () => {
+  setup();
+  const { invocation, ...params } = prepareInput("subjective/prepare/executor-text");
+  const result = await executePrepareMilestoneSubjectiveUat(
+    params,
+    basePath!,
+    invocation as never,
+  );
+
+  assert.equal(result.isError, undefined, result.content[0]!.text);
+  const details = result.details as {
+    criterionId: string;
+    questionId: string;
+    interactionId: string;
+    acceptedOptionId: string;
+    rejectedOptionId: string;
+    testedSourceRevision: string;
+  };
+  const text = result.content[0]!.text;
+
+  // Every value the answer tool binds on must be readable from the text channel:
+  // the model never sees `details`, only `content[].text`.
+  assert.match(text, /Prepared subjective UAT for M001: Does the guided flow feel natural and clear\?/);
+  assert.ok(text.includes(`criterionId=${details.criterionId}`));
+  assert.ok(text.includes(`questionId=${details.questionId}`));
+  assert.ok(text.includes(`interactionId=${details.interactionId}`));
+  assert.ok(text.includes(`testedSourceRevision=${details.testedSourceRevision}`));
+  assert.ok(text.includes(`optionId=${details.acceptedOptionId} label="Accept (Recommended)" (accepted, recommended)`));
+  assert.ok(text.includes(`optionId=${details.rejectedOptionId} label="Reject" (rejected)`));
+
+  // And those values round-trip through the answer tool unchanged.
+  const answered = answerMilestoneSubjectiveUat({
+    invocation: userInvocation("subjective/answer/executor-text"),
+    criterionId: details.criterionId,
+    questionId: details.questionId,
+    interactionId: details.interactionId,
+    selectedOptionId: details.acceptedOptionId,
+    verbatimResponse: "Accept (Recommended)",
+    rationale: "Copied from the prepare text output.",
+    testedSourceRevision: details.testedSourceRevision,
+  });
+  assert.equal(answered.disposition, "accepted");
+});
+
+test("formatPreparedSubjectiveUatText lists withdrawn questions when present", () => {
+  const text = formatPreparedSubjectiveUatText({
+    milestoneId: "M009",
+    criterionId: "crit",
+    questionId: "q2",
+    interactionId: "i2",
+    testedSourceRevision: "sha256:abc",
+    withdrawnQuestionIds: ["q1"],
+    options: [
+      { optionId: "a", disposition: "accepted", label: "Accept (Recommended)", description: "", recommended: true },
+      { optionId: "r", disposition: "rejected", label: "Reject", description: "", recommended: false },
+    ],
+  }, "Prompt?");
+  assert.ok(text.endsWith("Withdrawn prior open questions: q1"));
+  assert.ok(text.includes("optionId=a label=\"Accept (Recommended)\" (accepted, recommended)"));
 });

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -1883,6 +1883,52 @@ export async function executeValidateMilestone(
   }
 }
 
+/**
+ * Render the prepared subjective-UAT binding into the text channel.
+ *
+ * The structured `details` payload already carries the binding, but the model
+ * only sees `content[].text`. Without the IDs in the text the model cannot
+ * satisfy gsd_answer_milestone_subjective_uat's exact-binding check and the
+ * milestone validation gate becomes unreachable.
+ */
+export function formatPreparedSubjectiveUatText(
+  result: PreparedSubjectiveUatBinding,
+  focusedPrompt: string,
+): string {
+  const optionLines = result.options
+    .map((option) =>
+      `  - optionId=${option.optionId} label="${option.label}" ` +
+      `(${option.disposition}${option.recommended ? ", recommended" : ""})`)
+    .join("\n");
+  const lines = [
+    `Prepared subjective UAT for ${result.milestoneId}: ${focusedPrompt}`,
+    "",
+    "Binding for gsd_answer_milestone_subjective_uat (pass these values exactly):",
+    `  criterionId=${result.criterionId}`,
+    `  questionId=${result.questionId}`,
+    `  interactionId=${result.interactionId}`,
+    `  testedSourceRevision=${result.testedSourceRevision}`,
+    "  options:",
+    optionLines,
+    "  selectedOptionId must be one of the optionIds above; verbatimResponse must equal that option's label.",
+  ];
+  if (result.withdrawnQuestionIds.length > 0) {
+    lines.push(`Withdrawn prior open questions: ${result.withdrawnQuestionIds.join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+type PreparedSubjectiveUatBinding = Pick<
+  Awaited<ReturnType<typeof prepareMilestoneSubjectiveUat>>,
+  | "milestoneId"
+  | "criterionId"
+  | "questionId"
+  | "interactionId"
+  | "testedSourceRevision"
+  | "withdrawnQuestionIds"
+  | "options"
+>;
+
 export async function executePrepareMilestoneSubjectiveUat(
   params: PrepareMilestoneSubjectiveUatExecutorParams,
   basePath: string,
@@ -1900,7 +1946,7 @@ export async function executePrepareMilestoneSubjectiveUat(
     return {
       content: [{
         type: "text",
-        text: `Prepared subjective UAT for ${result.milestoneId}: ${params.focusedPrompt}`,
+        text: formatPreparedSubjectiveUatText(result, params.focusedPrompt),
       }],
       details: {
         operation: "prepare_milestone_subjective_uat",


### PR DESCRIPTION
## Linked issue

Closes #2296

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** `gsd_prepare_milestone_subjective_uat` now prints the answer binding (criterion/question/interaction ids, both option ids + labels, tested source revision) in its text output.
**Why:** The model only sees `content[].text`; the binding lived solely in `details`, so `gsd_answer_milestone_subjective_uat` could never be called correctly and milestones with a UAT class could not be validated or completed.
**How:** Small `formatPreparedSubjectiveUatText` helper in the executor; executor-level test asserts the text carries every bound value and that those values round-trip through `answerMilestoneSubjectiveUat`.

## What

- `src/resources/extensions/gsd/tools/workflow-tool-executors.ts`
  - New exported `formatPreparedSubjectiveUatText(result, focusedPrompt)`.
  - `executePrepareMilestoneSubjectiveUat` uses it for `content[0].text`. `details` is unchanged.
- `src/resources/extensions/gsd/tests/milestone-subjective-uat-domain-operation.test.ts`
  - Fixture now opens the DB at `<base>/.gsd/gsd.db` (what `ensureDbOpen(basePath)` expects) so the executor can be exercised directly.
  - New test: executor text contains `criterionId`, `questionId`, `interactionId`, `testedSourceRevision`, and both `optionId=… label="…"` lines matching `details`; then answers using exactly those values and asserts `disposition === "accepted"`.
  - New test: withdrawn question ids are appended when present.
- `CHANGELOG.md`: Unreleased / Fixed entry.

## Why

`preparedBinding()` in `db/writers/milestone-subjective-uat.ts` does an exact join on `criterionId + questionId + interactionId` against the `milestone.subjective-uat.prepared` event, then requires `selectedOptionId ∈ {acceptedOptionId, rejectedOptionId}` and `verbatimResponse === option.label`. Those are all freshly generated UUIDs / server-defined labels. If the model cannot read them, the answer step is impossible by construction, and:

- `validateMilestone` rejects `verdict: pass` while a required `subjective_uat` criterion lacks an accepted human acceptance;
- `gsd_complete_milestone` rejects without a current validation;
- re-preparing withdraws the open question and rotates the IDs, so retrying makes it worse;
- probing with new `criterionKey`s creates more required criteria.

Reproduced on two independent projects (M004 in one repo, M001 in another); both had to be unblocked by hand-recovering the `details` payload from `.gsd/activity/*.jsonl`.

## How

The prepare receipt already contains everything needed; this only changes what is rendered to text. Output shape:

```
Prepared subjective UAT for M001: <focusedPrompt>

Binding for gsd_answer_milestone_subjective_uat (pass these values exactly):
  criterionId=<uuid>
  questionId=<uuid>
  interactionId=<uuid>
  testedSourceRevision=<rev>
  options:
  - optionId=<uuid> label="Accept (Recommended)" (accepted, recommended)
  - optionId=<uuid> label="Reject" (rejected)
  selectedOptionId must be one of the optionIds above; verbatimResponse must equal that option's label.
Withdrawn prior open questions: <ids>   # only when non-empty
```

Alternatives considered:
- Relaxing `preparedBinding()` to accept the criterion id alone — rejected; the strict binding is a deliberate provenance guarantee (see `subjective UAT rejects agent identity and mismatched bindings without residue`).
- Adding a separate "list open subjective UAT bindings" read tool — heavier, and the prepare call is the natural place since the model must act on its result immediately.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes (`details` payload unchanged; text output is additive)

## Test plan

- [x] New/updated tests included — `milestone-subjective-uat-domain-operation.test.ts`: 15/15 pass locally via `pnpm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/milestone-subjective-uat-domain-operation.test.js`. Confirmed the new executor test fails on `main` without the fix.
- [x] `pnpm run typecheck:extensions` passes.
- [x] Manual testing — applied the same change to an installed 1.19.0 and used it to close a real milestone end-to-end: prepare → user chooses via `ask_user_questions` → answer with the printed IDs → `gsd_validate_milestone verdict=pass` → `gsd_complete_milestone`.
- [ ] CI passes

## AI disclosure

- [x] This PR includes AI-assisted code — drafted with GSD/Claude; the fix was validated by the new unit test and by closing a live milestone with it.
