### PR TITLE
fix(hermes): mark MCP sidecar GSD_MCP_CLIENT_MANAGED to survive executor spawn

### DIFF
--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -70,6 +70,9 @@ class GsdMcpClient:
         # project-relative path that hangs gsd_execute until timeout.
         resolved = shutil.which(self._config.cli_path) or self._config.cli_path
         env["GSD_CLI_PATH"] = resolved
+        # Keep this sidecar out of gsd-mcp-server's singleton PID registry so an
+        # executor-spawned workflow MCP server cannot SIGTERM it (open-gsd/gsd-pi#2291).
+        env["GSD_MCP_CLIENT_MANAGED"] = "1"
         return env
 
     def ensure_version(self) -> None:

--- a/integrations/hermes/tests/test_gsd_client_process_cwd.py
+++ b/integrations/hermes/tests/test_gsd_client_process_cwd.py
@@ -20,3 +20,9 @@ def test_ensure_process_starts_server_in_project_cwd(tmp_path) -> None:
     assert proc is fake_proc
     initialize.assert_called_once_with()
     assert popen.call_args.kwargs["cwd"] == str(tmp_path)
+    assert popen.call_args.kwargs["env"]["GSD_MCP_CLIENT_MANAGED"] == "1"
+
+
+def test_env_marks_mcp_sidecar_client_managed() -> None:
+    client = GsdMcpClient(GsdConfig())
+    assert client._env()["GSD_MCP_CLIENT_MANAGED"] == "1"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #2291.

## Problem

When auto-mode starts a Claude Code executor, the workflow MCP server it injects calls `registerMcpInstance`, which SIGTERMs any existing `gsd-mcp-server` for the same project. The Hermes plugin's `GsdMcpClient` sidecar is such an instance (same `cwd`, not client-managed), so the executor kills the sidecar a few seconds after it started the auto session — session cancelled with "Auto-mode process received a termination signal".

## Fix

Set `GSD_MCP_CLIENT_MANAGED=1` in `GsdMcpClient._env()`. `cli-runner.ts` already honours this flag to keep the sidecar out of the singleton PID registry.

## Tests

```bash
cd integrations/hermes && pip install -e ".[dev]" && pytest tests/test_gsd_client_process_cwd.py -q
```

## Verification on Pi

After merge, restart Hermes gateway and re-run `/gsd auto` via Slack — sidecar should survive executor spawn. **Do not conflict with the other GLM bot**; coordinate with Jeremy for Pi validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-193eddf9-69da-53f8-9f8f-ab51f4f8d399?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-193eddf9-69da-53f8-9f8f-ab51f4f8d399&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

