### PR TITLE
fix(gsd): omit legacy verdict override from adopted milestone blockers

### DIFF
--- a/src/resources/extensions/gsd/state/derive/from-db.ts
+++ b/src/resources/extensions/gsd/state/derive/from-db.ts
@@ -49,6 +49,7 @@ import {
   getRequestedMilestoneLock,
 } from './db-open.js';
 import { resolveMilestoneValidationVerdict } from '../../milestone-validation-verdict.js';
+import { isMilestoneLifecycleAdopted } from '../../db/milestone-closeout-readiness.js';
 
 const isStatusDone = isClosedStatus;
 
@@ -370,12 +371,14 @@ async function handleAllSlicesDone(
   // All roadmap slices are done (enforced by caller) and verdict is
   // needs-remediation — remediation cannot progress without new slices.
   // Return blocked instead of re-dispatching validate-milestone (#4506).
+  const allowLegacyVerdictOverride = !isMilestoneLifecycleAdopted(activeMilestone.id);
+
   if (verdict === 'needs-attention') {
     return buildDerivedState(
       context,
       'blocked',
       `Resolve ${activeMilestone.id} validation attention before proceeding.`,
-      { blockers: [formatNeedsAttentionBlocker(activeMilestone.id)] },
+      { blockers: [formatNeedsAttentionBlocker(activeMilestone.id, allowLegacyVerdictOverride)] },
     );
   }
 
@@ -384,7 +387,7 @@ async function handleAllSlicesDone(
       context,
       'blocked',
       `Resolve ${activeMilestone.id} remediation before proceeding.`,
-      { blockers: [formatNeedsRemediationBlocker(activeMilestone.id)] },
+      { blockers: [formatNeedsRemediationBlocker(activeMilestone.id, allowLegacyVerdictOverride)] },
     );
   }
 

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -25,6 +25,9 @@ import {
   setMilestoneQueueOrder,
   transaction,
   updateTaskStatus,
+  adoptOrTransitionLifecycle,
+  executeDomainOperation,
+  readDomainOperationFence,
 } from '../gsd-db.ts';
 
 // ─── Fixture Helpers ───────────────────────────────────────────────────────
@@ -624,6 +627,39 @@ describe('derive-state-helpers', () => {
     }
   });
 
+  function adoptMilestoneForTest(milestoneId: string): void {
+    const fence = readDomainOperationFence();
+    executeDomainOperation({
+      operationType: 'test.milestone.adopt',
+      idempotencyKey: `test/${milestoneId}/adopt`,
+      expectedRevision: fence.revision,
+      expectedAuthorityEpoch: fence.authorityEpoch,
+      actorType: 'test',
+      sourceTransport: 'test',
+      payload: { milestoneId },
+    }, (context) => {
+      adoptOrTransitionLifecycle(context, {
+        itemKind: 'milestone',
+        milestoneId,
+        lifecycleStatus: 'ready',
+      });
+      return {
+        events: [{
+          eventType: 'test.milestone.adopted',
+          entityType: 'milestone',
+          entityId: milestoneId,
+          payload: { milestoneId },
+          destinations: ['test'],
+        }],
+        projections: [{
+          projectionKey: `test/${milestoneId}/adopt`.toLowerCase(),
+          projectionKind: 'test',
+          rendererVersion: '1',
+        }],
+      };
+    });
+  }
+
   // ─── handleAllSlicesDone: needs-remediation + all slices done → blocked (#4506) ──
   test('handleAllSlicesDone: needs-remediation with all slices done returns blocked', async () => {
     const base = createFixtureBase();
@@ -662,6 +698,51 @@ describe('derive-state-helpers', () => {
         'remediation-stuck: blocker message does not expose the internal tool name',
       );
     } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('handleAllSlicesDone: adopted needs-attention blocker omits legacy /gsd verdict override', async () => {
+    const base = createFixtureBase();
+    const previousCwd = process.cwd();
+    try {
+      const doneRoadmap = `# M001: Attention Test\n\n**Vision:** Test.\n\n## Slices\n\n- [x] **S01: Done** \`risk:low\` \`depends:[]\`\n  > Done.\n`;
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', doneRoadmap);
+      writeFile(base, 'milestones/M001/M001-VALIDATION.md',
+        '---\nverdict: needs-attention\n---\n\n# Validation\nNeeds attention.');
+
+      process.chdir(base);
+      openDatabase(join(base, '.gsd', 'gsd.db'));
+      insertMilestone({ id: 'M001', title: 'Attention Test', status: 'active' });
+      insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Done', status: 'complete', risk: 'low', depends: [] });
+      insertAssessment({
+        path: 'milestones/M001/M001-VALIDATION.md',
+        milestoneId: 'M001',
+        status: 'needs-attention',
+        scope: 'milestone-validation',
+        fullContent: 'verdict: needs-attention',
+      });
+      adoptMilestoneForTest('M001');
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+
+      assert.equal(state.phase, 'blocked');
+      assert.ok(
+        state.blockers.some((b) => b.includes('needs-attention') && b.includes('M001')),
+        'blocker mentions milestone and verdict',
+      );
+      assert.ok(
+        state.blockers.every((b) => !b.includes('/gsd verdict')),
+        'adopted milestone blockers must not advertise legacy verdict override',
+      );
+      assert.ok(
+        state.blockers.some((b) => b.includes('current structured evidence')),
+        'blocker should point to canonical re-validation',
+      );
+    } finally {
+      process.chdir(previousCwd);
       closeDatabase();
       cleanup(base);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #2294 (notice-accuracy). Persistence on re-run was addressed in #2264 (post-1.19.0).

## Problem

When derived state blocks on `needs-attention` or `needs-remediation`, `handleAllSlicesDone` always called `needsAttentionBlockerGuidance(milestoneId)` with the default `allowLegacyOverride=true`. That advertises `/gsd verdict pass`, but `commands-verdict.ts` rejects overrides for adopted (canonical) milestones — the pause notice lied.

`auto-verification.ts` already prints the correct stderr guidance for adopted milestones; derived blockers did not.

## Fix

Pass `allowLegacyOverride: !isMilestoneLifecycleAdopted(activeMilestone.id)` into both blocker formatters in `state/derive/from-db.ts`.

## Tests

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
  --experimental-strip-types --test \
  src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
```

New case: adopted milestone + needs-attention → blocker has no `/gsd verdict`, points to canonical re-validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-193eddf9-69da-53f8-9f8f-ab51f4f8d399?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-193eddf9-69da-53f8-9f8f-ab51f4f8d399&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

