### PR TITLE
fix(gsd): embed effective config in /gsd settings prompt

### DIFF
--- a/src/resources/extensions/gsd/commands-gsd-core.ts
+++ b/src/resources/extensions/gsd/commands-gsd-core.ts
@@ -1134,8 +1134,19 @@ export async function handleProfileUser(args: string, ctx: ExtensionCommandConte
 
 /** /gsd settings */
 export async function handleSettings(_args: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
+  const { formatConfigText, buildCollectConfigOptions } = await import("./config-overlay.js");
+  const { getPreferencesReferencePath } = await import("./prompt-loader.js");
+  const configOptions = buildCollectConfigOptions(ctx, projectRoot());
   dispatchPrompt(
-    { prompt: "settings", customType: "gsd-settings", verb: "Settings" },
+    {
+      prompt: "settings",
+      customType: "gsd-settings",
+      verb: "Settings",
+      vars: {
+        effectiveConfig: formatConfigText(configOptions),
+        preferencesReferencePath: getPreferencesReferencePath(),
+      },
+    },
     ctx,
     pi,
   );

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 
 import { computeProgressScore, formatProgressLine } from "../../progress-score.js";
 import { isRepositoryDirty } from "../../git-service.js";
-import { loadEffectiveGSDPreferences, getGlobalGSDPreferencesPath, getProjectGSDPreferencesPath, availableModelIdsFromRegistry, modelIdsForProfileResolution, resolveProfileAnchorProvider, resolveDisabledModelProvidersFromPreferences } from "../../preferences.js";
+import { loadEffectiveGSDPreferences, getGlobalGSDPreferencesPath, getProjectGSDPreferencesPath } from "../../preferences.js";
 import { createRepositoryRegistryFromPreferences } from "../../repository-registry.js";
 import { ensurePreferencesFile, handlePrefs, handlePrefsMode, handlePrefsWizard, handleLanguage } from "../../commands-prefs-wizard.js";
 import { runEnvironmentChecks } from "../../doctor-environment.js";
@@ -586,16 +586,8 @@ export async function handleCoreCommand(
     return true;
   }
   if (trimmed === "show-config") {
-    const { GSDConfigOverlay, formatConfigText } = await import("../../config-overlay.js");
-    const basePath = projectRoot();
-    const anchorProvider = resolveProfileAnchorProvider(ctx.model?.provider);
-    const disabledProviders = resolveDisabledModelProvidersFromPreferences();
-    const availableModelIds = modelIdsForProfileResolution(ctx.modelRegistry, anchorProvider, disabledProviders);
-    const configOptions = {
-      basePath,
-      ...(availableModelIds && availableModelIds.length > 0 ? { availableModelIds } : {}),
-      ...(ctx.model ? { preferredModelId: `${ctx.model.provider}/${ctx.model.id}` } : {}),
-    };
+    const { GSDConfigOverlay, formatConfigText, buildCollectConfigOptions } = await import("../../config-overlay.js");
+    const configOptions = buildCollectConfigOptions(ctx, projectRoot());
     const result = await ctx.ui.custom<boolean>(
       (tui, theme, _kb, done) => new GSDConfigOverlay(tui, theme, () => done(true), configOptions),
       {

--- a/src/resources/extensions/gsd/config-overlay.ts
+++ b/src/resources/extensions/gsd/config-overlay.ts
@@ -7,6 +7,7 @@
  * Opened via `/gsd show-config` or `/gsd config`.
  */
 
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import type { Theme } from "@gsd/pi-coding-agent";
 import { matchesKey, Key, truncateToWidth } from "@gsd/pi-tui";
 
@@ -21,6 +22,9 @@ import {
   resolveEffectiveProfile,
   resolveModelWithFallbacksForUnit,
   resolveAutoSupervisorConfig,
+  modelIdsForProfileResolution,
+  resolveProfileAnchorProvider,
+  resolveDisabledModelProvidersFromPreferences,
 } from "./preferences.js";
 
 const DEFAULT_WIDGET_MODE = "small";
@@ -36,6 +40,21 @@ export interface CollectConfigOptions {
   basePath?: string;
   availableModelIds?: string[];
   preferredModelId?: string;
+}
+
+/** Build overlay/text config options from the active session context. */
+export function buildCollectConfigOptions(
+  ctx: Pick<ExtensionCommandContext, "modelRegistry" | "model">,
+  basePath?: string,
+): CollectConfigOptions {
+  const anchorProvider = resolveProfileAnchorProvider(ctx.model?.provider);
+  const disabledProviders = resolveDisabledModelProvidersFromPreferences();
+  const availableModelIds = modelIdsForProfileResolution(ctx.modelRegistry, anchorProvider, disabledProviders);
+  return {
+    ...(basePath ? { basePath } : {}),
+    ...(availableModelIds && availableModelIds.length > 0 ? { availableModelIds } : {}),
+    ...(ctx.model ? { preferredModelId: `${ctx.model.provider}/${ctx.model.id}` } : {}),
+  };
 }
 
 function collectConfigSections(options?: CollectConfigOptions): ConfigSection[] {

--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -89,6 +89,11 @@ export function getTemplatesDir(): string {
   return templatesDir;
 }
 
+/** Shipped preferences field guide (exists under the resolved extension dir). */
+export function getPreferencesReferencePath(): string {
+  return join(__extensionDir, "docs", "preferences-reference.md");
+}
+
 // Cache all templates from a startup snapshot — a running session uses the
 // template versions that were on disk near startup, immune to later overwrites.
 const templateCache = new Map<string, string>();

--- a/src/resources/extensions/gsd/prompts/settings.md
+++ b/src/resources/extensions/gsd/prompts/settings.md
@@ -1,10 +1,20 @@
 You are running the GSD **settings** workflow — configure GSD workflow toggles and the model profile.
 
+## Effective configuration (authoritative)
+
+The current effective configuration is embedded below. Use this block as the source of truth — do not search for or read package docs under `pkg/README.md`, `pkg/docs`, or `pkg/examples` (those paths are not shipped in the published npm package).
+
+```
+{{effectiveConfig}}
+```
+
+For preference field documentation, read `{{preferencesReferencePath}}` only when you need to explain a specific key.
+
 ## Process
 
 This is the settings flow: present the current effective configuration and let the developer change it.
 
-1. **Show effective settings.** Display the current configuration: active provider/model, model profile, auto-mode toggles, commit granularity, review depth, isolation mode, language, and any feature flags. Pull these from gsd-pi's config overlay, not memory.
+1. **Show effective settings.** Display the embedded configuration above: active provider/model, model profile, auto-mode toggles, commit granularity, review depth, isolation mode, language, and any feature flags.
 
 2. **Offer changes**, grouped:
    - **LLM**: provider, model, default tier — `/gsd setup llm` / `/gsd model`.

--- a/src/resources/extensions/gsd/tests/commands-gsd-core.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-gsd-core.test.ts
@@ -859,9 +859,15 @@ describe("Batch 5 handlers dispatch", () => {
     await handleProfileUser("--questionnaire", ctx as any, pi as any);
     assert.match(pi.sent[0].content, /`--questionnaire` — ON/);
   });
-  test("handleSettings dispatches", async () => {
-    const pi = createMockPi(); const ctx = createMockCtx();
+  test("handleSettings dispatches with embedded effective config", async () => {
+    const pi = createMockPi();
+    const ctx = {
+      ...createMockCtx(),
+      modelRegistry: { getAvailable: () => [] },
+      model: { provider: "anthropic", id: "claude-sonnet-4" },
+    };
     await handleSettings("", ctx as any, pi as any);
     assert.equal(pi.sent[0].customType, "gsd-settings");
+    assert.match(pi.sent[0].content, /GSD Configuration/);
   });
 });

--- a/src/resources/extensions/gsd/tests/gsd-core-parity-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-core-parity-routing.test.ts
@@ -31,6 +31,10 @@ function createMockCtx(cwd?: string) {
   return {
     cwd,
     notifications,
+    modelRegistry: {
+      getAvailable: () => [],
+    },
+    model: { provider: "anthropic", id: "claude-sonnet-4" },
     ui: {
       notify(message: string, level: string) {
         notifications.push({ message, level });

--- a/src/resources/extensions/gsd/tests/settings-command.test.ts
+++ b/src/resources/extensions/gsd/tests/settings-command.test.ts
@@ -1,0 +1,92 @@
+/**
+ * /gsd settings command behavior tests.
+ *
+ * Regression coverage for issue #2249: settings must not depend on unshipped
+ * pkg/README.md, pkg/docs, or pkg/examples paths from PI_PACKAGE_DIR.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { handleSettings } from "../commands-gsd-core.ts";
+import { getPreferencesReferencePath } from "../prompt-loader.ts";
+
+function createMockPi() {
+  const sent: Array<{ customType?: string; content: string }> = [];
+  return {
+    sent,
+    sendMessage(message: { customType?: string; content: string }) {
+      sent.push(message);
+    },
+  };
+}
+
+function createMockCtx() {
+  const notifications: Array<{ message: string; level: string }> = [];
+  return {
+    notifications,
+    modelRegistry: {
+      getAvailable: () => [],
+    },
+    model: { provider: "anthropic", id: "claude-sonnet-4" },
+    ui: {
+      notify(message: string, level: string) {
+        notifications.push({ message, level });
+      },
+    },
+  };
+}
+
+function createMinimalPublishedPkgLayout(): string {
+  const pkgDir = mkdtempSync(join(tmpdir(), "gsd-settings-pkg-"));
+  mkdirSync(join(pkgDir, "dist"), { recursive: true });
+  writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: "@opengsd/gsd-pi", version: "1.19.0" }));
+  return pkgDir;
+}
+
+test("handleSettings embeds effective config and points at shipped preferences reference", async () => {
+  const pi = createMockPi();
+  const ctx = createMockCtx();
+
+  await handleSettings("", ctx as any, pi as any);
+
+  assert.equal(pi.sent.length, 1);
+  assert.equal(pi.sent[0]?.customType, "gsd-settings");
+
+  const content = pi.sent[0]?.content ?? "";
+  assert.match(content, /GSD Configuration/);
+  assert.match(content, /SOURCES/);
+  assert.match(content, /do not search for or read package docs under `pkg\/README\.md`/);
+  assert.ok(content.includes(getPreferencesReferencePath()));
+});
+
+test("handleSettings completes when PI_PACKAGE_DIR is minimal published pkg layout", async () => {
+  const pkgDir = createMinimalPublishedPkgLayout();
+  const originalPiPackageDir = process.env.PI_PACKAGE_DIR;
+
+  process.env.PI_PACKAGE_DIR = pkgDir;
+  try {
+    assert.equal(existsSync(join(pkgDir, "README.md")), false);
+    assert.equal(existsSync(join(pkgDir, "docs")), false);
+    assert.equal(existsSync(join(pkgDir, "examples")), false);
+
+    const pi = createMockPi();
+    const ctx = createMockCtx();
+
+    await handleSettings("", ctx as any, pi as any);
+
+    assert.equal(pi.sent.length, 1);
+    assert.match(pi.sent[0]?.content ?? "", /GSD Configuration/);
+    assert.equal(ctx.notifications.some((n) => n.level === "error"), false);
+  } finally {
+    if (originalPiPackageDir === undefined) {
+      delete process.env.PI_PACKAGE_DIR;
+    } else {
+      process.env.PI_PACKAGE_DIR = originalPiPackageDir;
+    }
+    rmSync(pkgDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2249.

`/gsd settings` dispatched a prompt-only workflow that told the agent to read effective configuration from the config overlay, but did not include any config data. Agents then searched for documentation under `PI_PACKAGE_DIR` (`pkg/README.md`, `pkg/docs`, `pkg/examples`), which are **not shipped** in the published npm package (only `pkg/dist` + `pkg/package.json`). This caused ENOENT errors, repeated `rg` searches, and settings never completing.

## Approach

Per maintainer triage: make `/gsd settings` show effective configuration from real config sources / shipped paths — do **not** depend on unshipped `pkg/` docs.

- **Embed effective config** at dispatch time via `formatConfigText(buildCollectConfigOptions(ctx))`, same data source as `/gsd show-config`.
- **Point field docs** at the shipped `preferences-reference.md` under the resolved extension dir (`getPreferencesReferencePath()`).
- **Update `settings.md`** to treat the embedded block as authoritative and explicitly avoid `pkg/README.md|docs|examples`.
- **Extract `buildCollectConfigOptions()`** for reuse by `/gsd show-config` and `/gsd settings`.

## Tests

- `settings-command.test.ts`: verifies embedded config + preferences reference path in prompt.
- Regression fixture: minimal published `pkg/` layout (`dist/` + `package.json` only) with `PI_PACKAGE_DIR` set — settings dispatch completes without error.

## Test plan

- [x] `node --test src/resources/extensions/gsd/tests/settings-command.test.ts`
- [x] `node --test src/resources/extensions/gsd/tests/show-config-command.test.ts`
- [x] Updated `commands-gsd-core.test.ts` handleSettings assertion
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe7dab43-97f4-57b1-a7ca-c89d7a56a4cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe7dab43-97f4-57b1-a7ca-c89d7a56a4cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

