### PR TITLE
release: v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,56 @@ This changelog starts from the `open-gsd/gsd-pi` ownership baseline. Earlier pro
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-09-12
+
+### Added
+- **hermes**: notify on a stalled running session (#2210)
+- **gsd**: preserve effective model and routing provenance on assistant messages (#2285)
+- **gsd**: show current dispatched model in the AUTO status strip (#2262)
+
+### Fixed
+- **gsd**: scope external skill activation reads
+- **gsd**: embed effective config in /gsd settings prompt (#2303)
+- **gsd**: tolerate "Provider error:" prefix on status-only 400 (wedge W-a8123253)
+- **gsd**: classify status-only '400 Bad Request' as transient network error
+- **gsd**: omit legacy verdict override from adopted milestone blockers
+- **hermes**: mark MCP sidecar GSD_MCP_CLIENT_MANAGED to survive executor spawn
+- **gsd**: render the subjective UAT answer binding in the prepare tool text (#2298)
+- **hermes**: capture the delivery target per run so async notifications arrive (#2293)
+- **gsd**: quoted shell arguments no longer feed the verify prose heuristic (#2292)
+- **gsd**: stop launch cleanup from deleting user-owned skill directories (#2289)
+- **github-sync**: honor git.merge_strategy when merging slice PRs (#2280)
+- **gsd**: stop emitting trailing whitespace in summary frontmatter (#2254)
+- **gsd**: pause recovery-exhausted validate-milestone instead of clobbering VALIDATION.md (#2252)
+- **gsd**: surface quarantined bytes in self-heal message
+- **gsd**: surface unresolved recover diagnoses with file/line
+- **gsd**: surface foreign-key violations in recover errors
+- **gsd**: explain missing-PLAN lifecycle recover failures
+- **gsd**: add consistent baseline formatting for legacy-import errors
+- **mcp**: verify DB values against mismatched projections
+- **tui**: stop pinned zone mirroring text still visible in the transcript
+- **gsd**: add blocker-accepted closeout disposition with no-rerun replan (#2284)
+- **gsd**: converge journaled exchange replay before replaying identities (#2283)
+- **gsd**: surface the recovery action id on blocker receipts (#2271)
+- **gsd**: parse flags out of the /gsd park milestone id (#2270)
+- **gsd**: surface park DB-sync failures and make failed parks retryable (#2269)
+- **mcp**: match smoke counts to producer contract
+- **mcp**: tighten smoke probe payload validation
+- **mcp**: validate canonical read evidence in host smoke probe
+- **gsd**: make plan-slice re-dispatch idempotent over existing pending rows (#2266)
+- preserve abort origins and record timeout dispatch failures (#2265)
+- **gsd**: let milestone.validate persist non-pass verdicts (V49) (#2264)
+- **gsd**: accept UAT in gsd_summary_save (#2263)
+- **gsd**: actionable error when test resolver hits an unbuilt workspace dist (#2261)
+- **gsd**: accept decorated and descriptive verdict strings at the gate (#2260)
+- **gsd**: disable _desiredSegmentsCache to fix streaming regression
+
+### Changed
+- **deps**: bump sharp to 0.35.4 and vitest to 4.1.11
+- **models**: reconcile model-router registry with the 2026-09 catalog refresh
+- **models**: refresh generated model catalog
+- **deps**: bump next from 16.2.11 to 16.3.3
+
 ## [1.19.0] - 2026-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ See [CHANGELOG.md](./CHANGELOG.md) for release-by-release fixes and [Legacy Rele
 ## Latest Release Highlights
 
 <!-- release-highlights:start -->
-Latest release: **v1.19.0**
+Latest release: **v1.20.0**
 
-- **vscode:** Add Copilot project read tools.
-- **gsd:** Expose progress read metadata.
-- **mcp:** GSD-side smoke probe and per-host checklist for canonical read tools (#2174).
-- **vscode:** Show DB-authoritative project progress in sidebar (#2136) (#2143).
-- **gsd:** Add gsd_project_snapshot canonical DB read tool (#2170).
-- **gsd:** Delete dead planner-handoff module (#2149).
-- **gsd:** Stop husk-task gates from wedging milestone closeout.
-- **gsd:** Rebuild markdown projections at the invocation root.
+- **hermes:** Notify on a stalled running session (#2210).
+- **gsd:** Preserve effective model and routing provenance on assistant messages (#2285).
+- **gsd:** Show current dispatched model in the AUTO status strip (#2262).
+- **deps:** Bump sharp to 0.35.4 and vitest to 4.1.11.
+- **models:** Reconcile model-router registry with the 2026-09 catalog refresh.
+- **models:** Refresh generated model catalog.
+- **deps:** Bump next from 16.2.11 to 16.3.3.
+- **gsd:** Scope external skill activation reads.
 
 <!-- release-highlights:end -->
 

--- a/extensions/google-search/package.json
+++ b/extensions/google-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-extensions/google-search",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Web search via Google with AI-synthesized answers and source citations",
   "type": "module",
   "keywords": [

--- a/integrations/hermes/open_gsd_hermes/gsd_client.py
+++ b/integrations/hermes/open_gsd_hermes/gsd_client.py
@@ -219,7 +219,7 @@ class GsdMcpClient:
                 "params": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.19.0"},
+                    "clientInfo": {"name": "open-gsd-hermes", "version": "1.20.0"},
                 },
             }
         )

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-gsd-hermes"
-version = "1.19.0"
+version = "1.20.0"
 description = "Hermes Agent plugin — GSD structured delivery engine integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-ast"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "ast-grep-core",
  "globset",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-engine"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "arboard",
  "dashmap",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "gsd-grep"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "grep-matcher",
  "grep-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "1.19.0"
+version = "1.20.0"
 edition = "2021"
 license = "MIT"
 authors = ["GSD Contributors"]

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-arm64",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-darwin-x64",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-arm64-gnu",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-linux-x64-gnu",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/engine-win32-x64-msvc",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/gsd-pi",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "GSD Pi local-first coding agent",
   "license": "MIT",
   "repository": {
@@ -210,11 +210,11 @@
   },
   "optionalDependencies": {
     "@mariozechner/clipboard": "0.3.6",
-    "@opengsd/engine-darwin-arm64": "1.19.0",
-    "@opengsd/engine-darwin-x64": "1.19.0",
-    "@opengsd/engine-linux-arm64-gnu": "1.19.0",
-    "@opengsd/engine-linux-x64-gnu": "1.19.0",
-    "@opengsd/engine-win32-x64-msvc": "1.19.0",
+    "@opengsd/engine-darwin-arm64": "1.20.0",
+    "@opengsd/engine-darwin-x64": "1.20.0",
+    "@opengsd/engine-linux-arm64-gnu": "1.20.0",
+    "@opengsd/engine-linux-x64-gnu": "1.20.0",
+    "@opengsd/engine-win32-x64-msvc": "1.20.0",
     "fsevents": "~2.3.3",
     "koffi": "^2.9.0",
     "node-pty": "^1.1.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/contracts",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Shared public contracts for GSD workspace boundaries",
   "license": "MIT",
   "gsd": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/daemon",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "GSD daemon — background process for project monitoring and Discord integration",
   "license": "MIT",
   "repository": {

--- a/packages/gsd-agent-core/package.json
+++ b/packages/gsd-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-core",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "GSD session orchestration layer on top of @gsd/pi-coding-agent",
   "type": "module",
   "gsd": {

--- a/packages/gsd-agent-modes/package.json
+++ b/packages/gsd-agent-modes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/agent-modes",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "GSD run modes and CLI layer",
   "type": "module",
   "gsd": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/mcp-server",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "MCP server exposing GSD orchestration tools for compatible clients",
   "license": "MIT",
   "gsd": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/native",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Native Rust bindings for GSD — high-performance native modules via N-API",
   "type": "commonjs",
   "gsd": {

--- a/packages/pi-agent-core/package.json
+++ b/packages/pi-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-agent-core",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "General-purpose agent with transport abstraction, state management, and attachment support",
   "type": "module",
   "gsd": {

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-ai",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Unified LLM API with automatic model discovery and provider configuration",
   "type": "module",
   "gsd": {

--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-coding-agent",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Coding agent CLI (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-tui",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Terminal UI library (vendored from earendil-works/pi)",
   "type": "module",
   "gsd": {

--- a/packages/rpc-client/package.json
+++ b/packages/rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsd/rpc-client",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Standalone RPC client SDK for GSD — zero internal dependencies",
   "license": "MIT",
   "gsd": {

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glittercowboy/gsd",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "piConfig": {
     "name": "gsd",
     "configDir": ".gsd"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,20 +169,20 @@ importers:
         specifier: 0.3.6
         version: 0.3.6
       '@opengsd/engine-darwin-arm64':
-        specifier: 1.19.0
-        version: 1.19.0
+        specifier: 1.20.0
+        version: 1.20.0
       '@opengsd/engine-darwin-x64':
-        specifier: 1.19.0
-        version: 1.19.0
+        specifier: 1.20.0
+        version: 1.20.0
       '@opengsd/engine-linux-arm64-gnu':
-        specifier: 1.19.0
-        version: 1.19.0
+        specifier: 1.20.0
+        version: 1.20.0
       '@opengsd/engine-linux-x64-gnu':
-        specifier: 1.19.0
-        version: 1.19.0
+        specifier: 1.20.0
+        version: 1.20.0
       '@opengsd/engine-win32-x64-msvc':
-        specifier: 1.19.0
-        version: 1.19.0
+        specifier: 1.20.0
+        version: 1.20.0
       fsevents:
         specifier: ~2.3.3
         version: 2.3.3
@@ -2119,28 +2119,28 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@opengsd/engine-darwin-arm64@1.19.0':
-    resolution: {integrity: sha512-vsJJqqyTTrERP11AP0Xhi+87Td0n6Ps9Ew2dk/HYyLq2W06Mh35+agc8edEjsxh+V3uthGWu3WC8T7MEWRxOrQ==}
+  '@opengsd/engine-darwin-arm64@1.20.0':
+    resolution: {integrity: sha512-1p9bdnpv3JNOYkNLhe9R5as9PjgAFHrIt/OmBWU33nGO+JQ/aZexBc3/4NNFtAfO9bh6+vYjF1+FOBPbxB9Fiw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@opengsd/engine-darwin-x64@1.19.0':
-    resolution: {integrity: sha512-/nLNYQC6TnxduKZQJn4/rLLJqV7tMoSNHgR635kQFHv/EC2TYpAqNT7R/kvE2gp5ObeBgaR7R2Nh+tSuN88Lzw==}
+  '@opengsd/engine-darwin-x64@1.20.0':
+    resolution: {integrity: sha512-gdHdX2FtP/8ijPMb3iCvK6p33Yr65r1WZC3DJexV7UtHDf2g8Ctv1rX4706OL8ojEWVFCn2/VRss/n9L9L/NtQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@opengsd/engine-linux-arm64-gnu@1.19.0':
-    resolution: {integrity: sha512-lsZKyI3ZMf/k+nuRoA2TNPSu/ElR5A4hgqH2dAsOoZuOYAsPBxPzhwJvLTdzn5Ti21R5Ls9rUophQvHFpylFTw==}
+  '@opengsd/engine-linux-arm64-gnu@1.20.0':
+    resolution: {integrity: sha512-1rXapqxba1mRxPhtVRwkRrMgAMDWlSMZMAlBk7a/NZ6N2DjZ73xOSy6F/IJ28pWuE2eOl8o9bmBaYp3ScXzoCA==}
     cpu: [arm64]
     os: [linux]
 
-  '@opengsd/engine-linux-x64-gnu@1.19.0':
-    resolution: {integrity: sha512-L69Mc/9Q+k9dqvyR9zwvBTzir5zROFRdfWg3najnGSHx/ITShFa4k8x8rJfdR4P7fqFvrjaWuDvItFC3112x3g==}
+  '@opengsd/engine-linux-x64-gnu@1.20.0':
+    resolution: {integrity: sha512-Mg2oQphXAIYsQU51b2b5pDgIi3xsqN9oikn2E/tJvvlL//6riE5H9+/neqnVzk7hZSa8qMWxuktwvVrQhCsfig==}
     cpu: [x64]
     os: [linux]
 
-  '@opengsd/engine-win32-x64-msvc@1.19.0':
-    resolution: {integrity: sha512-AC6de8k3AOhzpPvBlsSXhv/vPpKmQ/bUcbceC7TMcvSPn3v3445eBMvLZ+G1IWzK3sJo4jNMBHk9G60u1tgCMA==}
+  '@opengsd/engine-win32-x64-msvc@1.20.0':
+    resolution: {integrity: sha512-lWxNyF1+VRQIXl095UQr9BrAciGJVjDkjxj3DBcGjjDhxrgjakpUDVKcuqCYuri9psFFpYuadH3LdWemMUF1Ow==}
     cpu: [x64]
     os: [win32]
 
@@ -7885,19 +7885,19 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@opengsd/engine-darwin-arm64@1.19.0':
+  '@opengsd/engine-darwin-arm64@1.20.0':
     optional: true
 
-  '@opengsd/engine-darwin-x64@1.19.0':
+  '@opengsd/engine-darwin-x64@1.20.0':
     optional: true
 
-  '@opengsd/engine-linux-arm64-gnu@1.19.0':
+  '@opengsd/engine-linux-arm64-gnu@1.20.0':
     optional: true
 
-  '@opengsd/engine-linux-x64-gnu@1.19.0':
+  '@opengsd/engine-linux-x64-gnu@1.20.0':
     optional: true
 
-  '@opengsd/engine-win32-x64-msvc@1.19.0':
+  '@opengsd/engine-win32-x64-msvc@1.20.0':
     optional: true
 
   '@opengsd/gsd-browser@0.2.2': {}
@@ -10015,7 +10015,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -10048,7 +10048,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -10063,7 +10063,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
Version bump for v1.20.0. Direct push to main was rejected by branch rules, so the release commit lands through the merge queue. npm, the `v1.20.0` tag and the GitHub release are already published.