### PR TITLE
test(hermes): widen stall-test notification fakes for the target parameter

### DIFF
--- a/integrations/hermes/tests/test_supervisor_stall.py
+++ b/integrations/hermes/tests/test_supervisor_stall.py
@@ -38,16 +38,16 @@ class FakeNotifications:
         self.blockers: list[SessionStatus] = []
         self.terminals: list[tuple[str, str | None]] = []
 
-    def notify_stall(self, where: str, idle_minutes: int, doctor_head: str = "") -> None:
+    def notify_stall(self, where: str, idle_minutes: int, doctor_head: str = "", target=None) -> None:
         self.stalls.append((where, idle_minutes, doctor_head))
 
-    def notify_transition(self, message: str) -> None:
+    def notify_transition(self, message: str, target=None) -> None:
         self.transitions.append(message)
 
-    def notify_blocker(self, status) -> None:
+    def notify_blocker(self, status, target=None) -> None:
         self.blockers.append(status)
 
-    def notify_terminal(self, status, error=None) -> None:
+    def notify_terminal(self, status, error=None, target=None) -> None:
         self.terminals.append((status, error))
 
 


### PR DESCRIPTION
## TL;DR

**What:** the `FakeNotifications` doubles in `test_supervisor_stall.py` accept the `target` keyword that supervisor notify calls now pass.
**Why:** #2293 made supervisor notify calls pass the per-run delivery target; #2287 then added `test_supervisor_stall.py` against the pre-target signature, so the v1.20.0 release branch's contract tests fail with `TypeError: ... unexpected keyword argument 'target'` on every stall/blocker/transition notification.
**How:** widen the four fake signatures with `target=None`, mirroring the widening already applied to the other notification test doubles in #2293.

## What

Four one-line signature widenings in `FakeNotifications` (`notify_stall`, `notify_transition`, `notify_blocker`, `notify_terminal`). No production code, no assertions changed.

## Why

Unblocks the v1.20.0 release PR (#2305), whose contract-tests job fails on exactly this cross-PR integration (my #2293 test-doubles widening vs #2287's new tests written against the older API).

## How

Full hermes suite green: 111 passed, 1 skipped (including #2287's stall tests). Release maintainers should merge main (or cherry-pick) into `release/v1.20.0` after this lands.

AI-assisted: this change was implemented with AI assistance (per repo policy, disclosed here; the commit has a human author).